### PR TITLE
Optimize number of calls to CloudBlobStore::findKey()

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/store/Store.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/Store.java
@@ -96,14 +96,6 @@ public interface Store {
   Set<StoreKey> findMissingKeys(List<StoreKey> keys) throws StoreException;
 
   /**
-   * Return {@link MessageInfo} of given key. This method will only be used in replication thread.
-   * @param key The key of which blob to return {@link MessageInfo}.
-   * @return The {@link MessageInfo}.
-   * @throws StoreException
-   */
-  MessageInfo findKey(StoreKey key) throws StoreException;
-
-  /**
    * Return a {@link Map} of {@code storeKeys} to {@link MessageInfo} of the keys.
    * This method will only be used in replication thread, and the map returned will contain message infos for only those
    * keys that are found in the local store.

--- a/ambry-api/src/main/java/com/github/ambry/store/Store.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/Store.java
@@ -17,6 +17,7 @@ import com.github.ambry.clustermap.ReplicaState;
 import com.github.ambry.replication.FindToken;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 
@@ -101,6 +102,16 @@ public interface Store {
    * @throws StoreException
    */
   MessageInfo findKey(StoreKey key) throws StoreException;
+
+  /**
+   * Return a {@link Map} of {@code storeKeys} to {@link MessageInfo} of the keys.
+   * This method will only be used in replication thread, and the map returned will contain message infos for only those
+   * keys that are found in the local store.
+   * @param storeKeys The list of keys for which to return {@link MessageInfo}s.
+   * @return The {@link Map} of key to {@link MessageInfo}.
+   * @throws StoreException
+   */
+  Map<StoreKey, MessageInfo> findKeys(List<? extends StoreKey> storeKeys) throws StoreException;
 
   /**
    * Get the corresponding {@link StoreStats} instance for this store.

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobStore.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobStore.java
@@ -779,26 +779,6 @@ class CloudBlobStore implements Store {
   }
 
   @Override
-  public MessageInfo findKey(StoreKey key) throws StoreException {
-    try {
-      Map<String, CloudBlobMetadata> cloudBlobMetadataListMap =
-          requestAgent.doWithRetries(() -> cloudDestination.getBlobMetadata(Collections.singletonList((BlobId) key)),
-              "FindKey", partitionId.toPathString());
-      CloudBlobMetadata cloudBlobMetadata = cloudBlobMetadataListMap.get(key.getID());
-      if (cloudBlobMetadata != null) {
-        return new MessageInfo(key, cloudBlobMetadata.getSize(), cloudBlobMetadata.isDeleted(),
-            cloudBlobMetadata.isExpired(), cloudBlobMetadata.isUndeleted(), cloudBlobMetadata.getExpirationTime(), null,
-            (short) cloudBlobMetadata.getAccountId(), (short) cloudBlobMetadata.getContainerId(),
-            cloudBlobMetadata.getLastUpdateTime(), cloudBlobMetadata.getLifeVersion());
-      } else {
-        throw new StoreException(String.format("FindKey couldn't find key: %s", key), StoreErrorCodes.ID_Not_Found);
-      }
-    } catch (CloudStorageException e) {
-      throw new StoreException(e, StoreErrorCodes.IOError);
-    }
-  }
-
-  @Override
   public Map<StoreKey, MessageInfo> findKeys(List<? extends StoreKey> storeKeys) throws StoreException {
     Map<StoreKey, MessageInfo> map = new HashMap<>();
     try {

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobStore.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobStore.java
@@ -47,6 +47,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -795,6 +796,28 @@ class CloudBlobStore implements Store {
     } catch (CloudStorageException e) {
       throw new StoreException(e, StoreErrorCodes.IOError);
     }
+  }
+
+  @Override
+  public Map<StoreKey, MessageInfo> findKeys(List<? extends StoreKey> storeKeys) throws StoreException {
+    Map<StoreKey, MessageInfo> map = new HashMap<>();
+    try {
+      Map<String, CloudBlobMetadata> cloudBlobMetadataMap =
+          requestAgent.doWithRetries(() -> cloudDestination.getBlobMetadata((List<BlobId>) storeKeys), "FindKeys",
+              partitionId.toPathString());
+      for (StoreKey key : storeKeys) {
+        CloudBlobMetadata cloudBlobMetadata = cloudBlobMetadataMap.get(key.getID());
+        if (cloudBlobMetadata != null) {
+          map.put(key, new MessageInfo(key, cloudBlobMetadata.getSize(), cloudBlobMetadata.isDeleted(),
+              cloudBlobMetadata.isExpired(), cloudBlobMetadata.isUndeleted(), cloudBlobMetadata.getExpirationTime(),
+              null, (short) cloudBlobMetadata.getAccountId(), (short) cloudBlobMetadata.getContainerId(),
+              cloudBlobMetadata.getLastUpdateTime(), cloudBlobMetadata.getLifeVersion()));
+        }
+      }
+    } catch (CloudStorageException e) {
+      throw new StoreException(e, StoreErrorCodes.IOError);
+    }
+    return map;
   }
 
   @Override

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -890,6 +890,7 @@ public class ReplicaThread implements Runnable {
           // all the keys being processed are missing in local store.
           localMessageInfoMap = remoteReplicaInfo.getLocalStore()
               .findKeys(messageInfoList.stream()
+                  .filter(msgInfo -> !missingRemoteStoreMessages.contains(msgInfo))
                   .map(msgInfo -> (BlobId) remoteKeyToLocalKeyMap.get(msgInfo.getStoreKey()))
                   .filter(key -> key != null)
                   .collect(Collectors.toList()));
@@ -917,7 +918,8 @@ public class ReplicaThread implements Runnable {
   public void applyUpdatesToBlobInLocalStore(MessageInfo messageInfo, RemoteReplicaInfo remoteReplicaInfo,
       BlobId localKey, MessageInfo localMessageInfo) throws StoreException {
     if (localMessageInfo == null) {
-      throw new StoreException("Key " + localKey + " not found in store.", StoreErrorCodes.ID_Not_Found);
+      throw new StoreException(String.format("Key %s not found in store.", localKey.getID()),
+          StoreErrorCodes.ID_Not_Found);
     }
     boolean deletedLocally = localMessageInfo.isDeleted();
     boolean ttlUpdatedLocally = localMessageInfo.isTtlUpdated();

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -885,7 +885,7 @@ public class ReplicaThread implements Runnable {
             messageInfo)) {
           continue;
         }
-        if(localMessageInfoMap == null) {
+        if (localMessageInfoMap == null) {
           // This makes sure that the potentially expensive findKeys() method isn't called for a replication loop, if
           // all the keys being processed are missing in local store.
           localMessageInfoMap = remoteReplicaInfo.getLocalStore()

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -839,6 +839,7 @@ public class ReplicaThread implements Runnable {
       DataNodeId remoteNode, Map<StoreKey, StoreKey> remoteKeyToLocalKeyMap) throws StoreException {
     long startTime = time.milliseconds();
     List<MessageInfo> messageInfoList = replicaMetadataResponseInfo.getMessageInfoList();
+    Map<StoreKey, MessageInfo> localMessageInfoMap = null;
     for (MessageInfo messageInfo : messageInfoList) {
       BlobId blobId = (BlobId) messageInfo.getStoreKey();
       if (remoteReplicaInfo.getLocalReplicaId().getPartitionId().compareTo(blobId.getPartition()) != 0) {
@@ -880,10 +881,20 @@ public class ReplicaThread implements Runnable {
         // it is deleted in the remote store and not deleted yet locally.
 
         // if the blob is from deprecated container, then nothing needs to be done.
-        if (replicationConfig.replicationContainerDeletionEnabled && skipPredicate != null && skipPredicate.test(messageInfo)) {
+        if (replicationConfig.replicationContainerDeletionEnabled && skipPredicate != null && skipPredicate.test(
+            messageInfo)) {
           continue;
         }
-        applyUpdatesToBlobInLocalStore(messageInfo, remoteReplicaInfo, localKey);
+        if(localMessageInfoMap == null) {
+          // This makes sure that the potentially expensive findKeys() method isn't called for a replication loop, if
+          // all the keys being processed are missing in local store.
+          localMessageInfoMap = remoteReplicaInfo.getLocalStore()
+              .findKeys(messageInfoList.stream()
+                  .map(msgInfo -> (BlobId) remoteKeyToLocalKeyMap.get(msgInfo.getStoreKey()))
+                  .filter(key -> key != null)
+                  .collect(Collectors.toList()));
+        }
+        applyUpdatesToBlobInLocalStore(messageInfo, remoteReplicaInfo, localKey, localMessageInfoMap.get(localKey));
       }
     }
     if (replicatingFromRemoteColo) {
@@ -900,11 +911,14 @@ public class ReplicaThread implements Runnable {
    * @param messageInfo message information of the blob from remote replica
    * @param remoteReplicaInfo remote replica information
    * @param localKey local blob information
+   * @param localMessageInfo message information of the blob from the local replica
    * @throws StoreException
    */
   public void applyUpdatesToBlobInLocalStore(MessageInfo messageInfo, RemoteReplicaInfo remoteReplicaInfo,
-      BlobId localKey) throws StoreException {
-    MessageInfo localMessageInfo = remoteReplicaInfo.getLocalStore().findKey(localKey);
+      BlobId localKey, MessageInfo localMessageInfo) throws StoreException {
+    if (localMessageInfo == null) {
+      throw new StoreException("Key " + localKey + " not found in store.", StoreErrorCodes.ID_Not_Found);
+    }
     boolean deletedLocally = localMessageInfo.isDeleted();
     boolean ttlUpdatedLocally = localMessageInfo.isTtlUpdated();
     short localLifeVersion = localMessageInfo.getLifeVersion();
@@ -1376,6 +1390,13 @@ public class ReplicaThread implements Runnable {
             exchangeMetadataResponse.getReceivedStoreMessagesWithUpdatesPending();
         Set<MessageInfo> receivedMessagesWithUpdatesCompleted = new HashSet<>();
 
+        Map<StoreKey, MessageInfo> localMessageInfoMap = remoteReplicaInfo.getLocalStore()
+            .findKeys(receivedStoreMessagesWithUpdatesPending.stream()
+                .map(messageInfo -> (BlobId) exchangeMetadataResponse.remoteKeyToLocalKeyMap.get(
+                    messageInfo.getStoreKey()))
+                .filter(localKey -> localKey != null)
+                .collect(Collectors.toList()));
+
         // 1. Go through messages for this replica whose keys were previously missing in local store and are now received
         // (via other replica threads) and compare the message infos with message infos of keys in local store to apply
         // updates to them (if needed) to reconcile delete, ttl_update and undelete states.
@@ -1383,7 +1404,8 @@ public class ReplicaThread implements Runnable {
           BlobId localStoreKey =
               (BlobId) exchangeMetadataResponse.remoteKeyToLocalKeyMap.get(messageInfo.getStoreKey());
           if (localStoreKey != null) {
-            applyUpdatesToBlobInLocalStore(messageInfo, remoteReplicaInfo, localStoreKey);
+            applyUpdatesToBlobInLocalStore(messageInfo, remoteReplicaInfo, localStoreKey,
+                localMessageInfoMap.get(localStoreKey));
           }
           receivedMessagesWithUpdatesCompleted.add(messageInfo);
         }

--- a/ambry-replication/src/test/java/com/github/ambry/replication/InMemoryStore.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/InMemoryStore.java
@@ -44,8 +44,10 @@ import java.nio.channels.WritableByteChannel;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static com.github.ambry.replication.ReplicationTest.*;
@@ -404,6 +406,15 @@ class InMemoryStore implements Store {
   @Override
   public MessageInfo findKey(StoreKey key) throws StoreException {
     return getMergedMessageInfo(key, messageInfos);
+  }
+
+  @Override
+  public Map<StoreKey, MessageInfo> findKeys(List<? extends StoreKey> storeKeys) throws StoreException {
+    Map<StoreKey, MessageInfo> map = new HashMap<>();
+    for (StoreKey storeKey : storeKeys) {
+      map.put(storeKey, findKey(storeKey));
+    }
+    return map;
   }
 
   @Override

--- a/ambry-replication/src/test/java/com/github/ambry/replication/InMemoryStore.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/InMemoryStore.java
@@ -404,15 +404,10 @@ class InMemoryStore implements Store {
   }
 
   @Override
-  public MessageInfo findKey(StoreKey key) throws StoreException {
-    return getMergedMessageInfo(key, messageInfos);
-  }
-
-  @Override
   public Map<StoreKey, MessageInfo> findKeys(List<? extends StoreKey> storeKeys) throws StoreException {
     Map<StoreKey, MessageInfo> map = new HashMap<>();
     for (StoreKey storeKey : storeKeys) {
-      map.put(storeKey, findKey(storeKey));
+      map.put(storeKey, getMergedMessageInfo(storeKey, messageInfos));
     }
     return map;
   }

--- a/ambry-server/src/test/java/com/github/ambry/server/MockStorageManager.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/MockStorageManager.java
@@ -225,15 +225,10 @@ class MockStorageManager extends StorageManager {
     }
 
     @Override
-    public MessageInfo findKey(StoreKey key) throws StoreException {
-      return new MessageInfo(key, 1, Utils.Infinite_Time, (short) 0, (short) 0, 0);
-    }
-
-    @Override
     public Map<StoreKey, MessageInfo> findKeys(List<? extends StoreKey> storeKeys) throws StoreException {
       Map<StoreKey, MessageInfo> map = new HashMap<>();
       for (StoreKey storeKey : storeKeys) {
-        map.put(storeKey, findKey(storeKey));
+        map.put(storeKey, new MessageInfo(storeKey, 1, Utils.Infinite_Time, (short) 0, (short) 0, 0));
       }
       return map;
     }

--- a/ambry-server/src/test/java/com/github/ambry/server/MockStorageManager.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/MockStorageManager.java
@@ -195,7 +195,7 @@ class MockStorageManager extends StorageManager {
       try {
         MessageFormatInputStream stream =
             new UndeleteMessageFormatInputStream(info.getStoreKey(), info.getAccountId(), info.getContainerId(),
-                info.getOperationTimeMs(), (short) returnValueOfUndelete);
+                info.getOperationTimeMs(), returnValueOfUndelete);
         // Update info to add stream size;
         info = new MessageInfo(info.getStoreKey(), stream.getSize(), false, false, true, Utils.Infinite_Time, null,
             info.getAccountId(), info.getContainerId(), info.getOperationTimeMs(), returnValueOfUndelete);
@@ -226,7 +226,16 @@ class MockStorageManager extends StorageManager {
 
     @Override
     public MessageInfo findKey(StoreKey key) throws StoreException {
-      return new MessageInfo(key, 1, Utils.Infinite_Time, (short) 0, (short) 0, (long) 0);
+      return new MessageInfo(key, 1, Utils.Infinite_Time, (short) 0, (short) 0, 0);
+    }
+
+    @Override
+    public Map<StoreKey, MessageInfo> findKeys(List<? extends StoreKey> storeKeys) throws StoreException {
+      Map<StoreKey, MessageInfo> map = new HashMap<>();
+      for (StoreKey storeKey : storeKeys) {
+        map.put(storeKey, findKey(storeKey));
+      }
+      return map;
     }
 
     @Override

--- a/ambry-server/src/test/java/com/github/ambry/server/StatsManagerTest.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/StatsManagerTest.java
@@ -730,6 +730,11 @@ public class StatsManagerTest {
     }
 
     @Override
+    public Map<StoreKey, MessageInfo> findKeys(List<? extends StoreKey> storeKeys) throws StoreException {
+      throw new IllegalStateException("Not implemented");
+    }
+
+    @Override
     public StoreStats getStoreStats() {
       isCollected = true;
       getStatsCountdown.countDown();

--- a/ambry-server/src/test/java/com/github/ambry/server/StatsManagerTest.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/StatsManagerTest.java
@@ -725,11 +725,6 @@ public class StatsManagerTest {
     }
 
     @Override
-    public MessageInfo findKey(StoreKey key) throws StoreException {
-      throw new IllegalStateException("Not implemented");
-    }
-
-    @Override
     public Map<StoreKey, MessageInfo> findKeys(List<? extends StoreKey> storeKeys) throws StoreException {
       throw new IllegalStateException("Not implemented");
     }

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -911,7 +911,12 @@ public class BlobStore implements Store {
     }
   }
 
-  @Override
+  /**
+   * Return {@link MessageInfo} of given key. This method will only be used in replication thread.
+   * @param key The key of which blob to return {@link MessageInfo}.
+   * @return The {@link MessageInfo}.
+   * @throws StoreException
+   */
   public MessageInfo findKey(StoreKey key) throws StoreException {
     checkStarted();
     final Timer.Context context = metrics.findKeyResponse.time();
@@ -939,6 +944,8 @@ public class BlobStore implements Store {
     Map<StoreKey, MessageInfo> messageInfoMap = new HashMap<>();
     for (StoreKey storeKey : storeKeys) {
       try {
+        // TODO: Need to look into the possibility if its more efficient to not call findKey() multiple times in a loop,
+        // and instead search the index once for all the blobs in the list.
         messageInfoMap.put(storeKey, findKey(storeKey));
       } catch (StoreException stEx) {
         logger.info("Key %s not found in findKey", storeKey.getID());

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -935,6 +935,19 @@ public class BlobStore implements Store {
   }
 
   @Override
+  public Map<StoreKey, MessageInfo> findKeys(List<? extends StoreKey> storeKeys) {
+    Map<StoreKey, MessageInfo> messageInfoMap = new HashMap<>();
+    for (StoreKey storeKey : storeKeys) {
+      try {
+        messageInfoMap.put(storeKey, findKey(storeKey));
+      } catch (StoreException stEx) {
+        logger.info("Key %s not found in findKey", storeKey.getID());
+      }
+    }
+    return messageInfoMap;
+  }
+
+  @Override
   public StoreStats getStoreStats() {
     return blobStoreStats;
   }

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -949,6 +949,7 @@ public class BlobStore implements Store {
         messageInfoMap.put(storeKey, findKey(storeKey));
       } catch (StoreException e) {
         logger.error("findKey failed for key {} with reason {}", storeKey.getID(), e.getErrorCode().toString());
+        throw e;
       }
     }
     return messageInfoMap;

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -940,15 +940,15 @@ public class BlobStore implements Store {
   }
 
   @Override
-  public Map<StoreKey, MessageInfo> findKeys(List<? extends StoreKey> storeKeys) {
+  public Map<StoreKey, MessageInfo> findKeys(List<? extends StoreKey> storeKeys) throws StoreException {
     Map<StoreKey, MessageInfo> messageInfoMap = new HashMap<>();
     for (StoreKey storeKey : storeKeys) {
+      // TODO: Need to look into the possibility if its more efficient to not call findKey() multiple times in a loop,
+      // and instead search the index once for all the blobs in the list.
       try {
-        // TODO: Need to look into the possibility if its more efficient to not call findKey() multiple times in a loop,
-        // and instead search the index once for all the blobs in the list.
         messageInfoMap.put(storeKey, findKey(storeKey));
-      } catch (StoreException stEx) {
-        logger.info("Key %s not found in findKey", storeKey.getID());
+      } catch (StoreException e) {
+        logger.error("findKey failed for key {} with reason {}", storeKey.getID(), e.getErrorCode().toString());
       }
     }
     return messageInfoMap;


### PR DESCRIPTION
`CloudBlobStore::findKey()` is called multiple times in `ReplicaThread::processReplicaMetadataResponse` inside the `ReplicaThread::replicate()` loop. Since `CloudBlobStore::findKey()` internally calls cosmos db, which is an expensive call, this change batches all the calls to `findKey()` at one place. This will minimize the calls to cosmos db, while keeping the number of `findKey()` calls in case of `BlobStore` same as before.