### PR TITLE
Use ByteBuf in decrypt job

### DIFF
--- a/ambry-router/src/main/java/com/github/ambry/router/GCMCryptoService.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/GCMCryptoService.java
@@ -124,7 +124,6 @@ public class GCMCryptoService implements CryptoService<SecretKeySpec> {
       encrypter.init(Cipher.ENCRYPT_MODE, key, new IvParameterSpec(iv));
       int outputSize = encrypter.getOutputSize(toEncrypt.readableBytes());
 
-      // stick with heap memory for now so to compare with the java.nio.ByteBuffer.
       encryptedContent = PooledByteBufAllocator.DEFAULT.ioBuffer(IVRecord_Format_V1.getIVRecordSize(iv) + outputSize);
       IVRecord_Format_V1.serializeIVRecord(encryptedContent, iv);
 

--- a/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
@@ -692,6 +692,7 @@ class GetBlobOperation extends GetOperation {
       if (isInProgress() && progressTracker.isCryptoJobRequired() && decryptCallbackResultInfo.decryptJobComplete) {
         if (decryptCallbackResultInfo.result != null) {
           decryptCallbackResultInfo.result.getDecryptedBlobContent().release();
+          decryptCallbackResultInfo.result = null;
         }
       }
     }

--- a/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
@@ -648,8 +648,7 @@ class GetBlobOperation extends GetOperation {
     }
 
     /**
-     * Maybe process callbacks if applicable. This is a no-op for blobs that do not need
-     * any async processing. As of now, decryption is the only async processing that could happen if applicable.
+     * Process decryption callback.
      */
     protected void processCallbacks() {
       logger.trace("Processing decrypt callback stored result for data chunk {}", chunkBlobId);

--- a/ambry-router/src/main/java/com/github/ambry/router/ProgressTracker.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/ProgressTracker.java
@@ -33,7 +33,7 @@ class ProgressTracker {
   /**
    * Initializes the {@link CryptoJobStatusTracker}
    */
-  synchronized void initializeCryptoJobTracker(CryptoJobType cryptoJobType) {
+  void initializeCryptoJobTracker(CryptoJobType cryptoJobType) {
     cryptoJobStatusTracker = new CryptoJobStatusTracker();
     this.cryptoJobType = cryptoJobType;
   }
@@ -41,14 +41,14 @@ class ProgressTracker {
   /**
    * @return {@code true} if crypto job is required. {@code false} otherwise
    */
-  synchronized boolean isCryptoJobRequired() {
+  boolean isCryptoJobRequired() {
     return cryptoJobStatusTracker != null;
   }
 
   /**
    * Sets crypto job as succeeded
    */
-  synchronized void setCryptoJobSuccess() {
+  void setCryptoJobSuccess() {
     if (cryptoJobStatusTracker == null) {
       throw new IllegalStateException("No crypto job.");
     }
@@ -58,7 +58,7 @@ class ProgressTracker {
   /**
    * Sets crypto job as failed
    */
-  synchronized void setCryptoJobFailed() {
+  void setCryptoJobFailed() {
     if (cryptoJobStatusTracker == null) {
       throw new IllegalStateException("No crypto job.");
     }
@@ -70,7 +70,7 @@ class ProgressTracker {
    *
    * @return {@code true} if the operation has completed.
    */
-  synchronized boolean isDone() {
+  boolean isDone() {
     return operationTracker.isDone() && (cryptoJobStatusTracker == null || cryptoJobStatusTracker.isDone());
   }
 

--- a/ambry-router/src/main/java/com/github/ambry/router/ProgressTracker.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/ProgressTracker.java
@@ -33,7 +33,7 @@ class ProgressTracker {
   /**
    * Initializes the {@link CryptoJobStatusTracker}
    */
-  void initializeCryptoJobTracker(CryptoJobType cryptoJobType) {
+  synchronized void initializeCryptoJobTracker(CryptoJobType cryptoJobType) {
     cryptoJobStatusTracker = new CryptoJobStatusTracker();
     this.cryptoJobType = cryptoJobType;
   }
@@ -41,14 +41,14 @@ class ProgressTracker {
   /**
    * @return {@code true} if crypto job is required. {@code false} otherwise
    */
-  boolean isCryptoJobRequired() {
+  synchronized boolean isCryptoJobRequired() {
     return cryptoJobStatusTracker != null;
   }
 
   /**
    * Sets crypto job as succeeded
    */
-  void setCryptoJobSuccess() {
+  synchronized void setCryptoJobSuccess() {
     if (cryptoJobStatusTracker == null) {
       throw new IllegalStateException("No crypto job.");
     }
@@ -58,7 +58,7 @@ class ProgressTracker {
   /**
    * Sets crypto job as failed
    */
-  void setCryptoJobFailed() {
+  synchronized void setCryptoJobFailed() {
     if (cryptoJobStatusTracker == null) {
       throw new IllegalStateException("No crypto job.");
     }
@@ -70,7 +70,7 @@ class ProgressTracker {
    *
    * @return {@code true} if the operation has completed.
    */
-  boolean isDone() {
+  synchronized boolean isDone() {
     return operationTracker.isDone() && (cryptoJobStatusTracker == null || cryptoJobStatusTracker.isDone());
   }
 

--- a/ambry-router/src/test/java/com/github/ambry/router/ChunkFillTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/ChunkFillTest.java
@@ -198,7 +198,8 @@ public class ChunkFillTest {
           Assert.assertTrue("Chunk should be Building or Ready.", putChunk.getState() == PutOperation.ChunkState.Ready
               || putChunk.getState() == PutOperation.ChunkState.Building);
           if (putChunk.getState() == PutOperation.ChunkState.Ready) {
-            Assert.assertEquals("Chunk size should be the last chunk size", lastChunkSize, putChunk.buf.readableBytes());
+            Assert.assertEquals("Chunk size should be the last chunk size", lastChunkSize,
+                putChunk.buf.readableBytes());
             Assert.assertTrue("Chunk Filling should be complete at this time", op.isChunkFillingDone());
             fillingComplete = true;
           }
@@ -321,7 +322,7 @@ public class ChunkFillTest {
       ByteBuffer dest = ByteBuffer.allocate(totalSizeWritten);
       for (ByteBuf buf : compositeBuffers) {
         Assert.assertNotNull("All chunks should have come in", buf);
-        for (ByteBuffer buffer: buf.nioBuffers()) {
+        for (ByteBuffer buffer : buf.nioBuffers()) {
           dest.put(buffer);
         }
       }
@@ -335,9 +336,11 @@ public class ChunkFillTest {
             new DecryptJob(compositeBlobIds[i], compositeEncryptionKeys[i], compositeBuffers[i], null, cryptoService,
                 kms, new CryptoJobMetricsTracker(routerMetrics.decryptJobMetrics), (result, exception) -> {
               Assert.assertNull("Exception shouldn't have been thrown", exception);
-              int chunkSize = result.getDecryptedBlobContent().remaining();
-              result.getDecryptedBlobContent().get(content, offset.get(), chunkSize);
+              ByteBuf decryptedBlobContent = result.getDecryptedBlobContent();
+              int chunkSize = decryptedBlobContent.readableBytes();
+              decryptedBlobContent.readBytes(content, offset.get(), chunkSize);
               offset.addAndGet(chunkSize);
+              decryptedBlobContent.release();
             });
         decryptJob.run();
       }

--- a/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTest.java
@@ -343,6 +343,7 @@ public class NonBlockingRouterTest {
       router.deleteBlob(blobId, null).get();
       try {
         router.getBlob(blobId, new GetBlobOptionsBuilder().build()).get();
+        fail("Get blob should fail");
       } catch (ExecutionException e) {
         RouterException r = (RouterException) e.getCause();
         Assert.assertEquals("BlobDeleted error is expected", RouterErrorCode.BlobDeleted, r.getErrorCode());


### PR DESCRIPTION
Before this PR, in GetBlobOperation, we use java ByteBuffer as the byte container to store decrypted blob content.
This PR switches to netty ByteBuf.
It also switches to use ioBuffer (direct memory) for encryption and decryption.