### PR TITLE
 Introduce CompositeDataNodeConfigSource

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/clustermap/DataNodeConfigSourceType.java
+++ b/ambry-api/src/main/java/com/github/ambry/clustermap/DataNodeConfigSourceType.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ */
+
+package com.github.ambry.clustermap;
+
+/**
+ * Represent the type of {@code DataNodeConfigSource} implementation to use.
+ */
+public enum DataNodeConfigSourceType {
+  INSTANCE_CONFIG, PROPERTY_STORE, COMPOSITE_INSTANCE_CONFIG_PRIMARY, COMPOSITE_PROPERTY_STORE_PRIMARY
+}

--- a/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.config;
 
+import com.github.ambry.clustermap.DataNodeConfigSourceType;
 import org.apache.helix.model.LeaderStandbySMD;
 import org.json.JSONObject;
 
@@ -27,6 +28,7 @@ public class ClusterMapConfig {
   public static final String CLUSTERMAP_HOST_NAME = "clustermap.host.name";
   public static final String CLUSTERMAP_PORT = "clustermap.port";
   public static final String CLUSTERMAP_MAX_DISK_CAPACITY_IN_BYTES = "clustermap.max.disk.capacity.in.bytes";
+  public static final String CLUSTERMAP_DATA_NODE_CONFIG_SOURCE_TYPE = "clustermap.data.node.config.source.type";
   public static final String AMBRY_STATE_MODEL_DEF = "AmbryLeaderStandby";
   public static final String OLD_STATE_MODEL_DEF = LeaderStandbySMD.name;
   public static final String DEFAULT_STATE_MODEL_DEF = AMBRY_STATE_MODEL_DEF;
@@ -101,6 +103,13 @@ public class ClusterMapConfig {
   @Config("clustermap.cluster.change.handler.type")
   @Default("SimpleClusterChangeHandler")
   public final String clusterMapClusterChangeHandlerType;
+
+  /**
+   * The {@code DataNodeConfigSource} implementation to use with the Helix-based Cluster Map.
+   */
+  @Config(CLUSTERMAP_DATA_NODE_CONFIG_SOURCE_TYPE)
+  @Default("INSTANCE_CONFIG")
+  public final DataNodeConfigSourceType clusterMapDataNodeConfigSourceType;
 
   /**
    * Serialized json containing the information about all the zk hosts that the Helix based cluster manager should
@@ -311,6 +320,9 @@ public class ClusterMapConfig {
         "com.github.ambry.clustermap.StaticClusterAgentsFactory");
     clusterMapClusterChangeHandlerType =
         verifiableProperties.getString("clustermap.cluster.change.handler.type", "SimpleClusterChangeHandler");
+    clusterMapDataNodeConfigSourceType =
+        verifiableProperties.getEnum(CLUSTERMAP_DATA_NODE_CONFIG_SOURCE_TYPE, DataNodeConfigSourceType.class,
+            DataNodeConfigSourceType.INSTANCE_CONFIG);
     clusterMapDcsZkConnectStrings = verifiableProperties.getString("clustermap.dcs.zk.connect.strings", "");
     clusterMapClusterName = verifiableProperties.getString(CLUSTERMAP_CLUSTER_NAME);
     clusterMapDatacenterName = verifiableProperties.getString(CLUSTERMAP_DATACENTER_NAME);

--- a/ambry-api/src/main/java/com/github/ambry/config/VerifiableProperties.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/VerifiableProperties.java
@@ -234,6 +234,7 @@ public class VerifiableProperties {
   public <E extends Enum<E>> E getEnum(String name, Class<E> type, E defaultVal) {
     return containsKey(name) ? Enum.valueOf(type, getProperty(name)) : defaultVal;
   }
+
   /**
    * Get a string property, or, if no such property is defined, return the given default value
    */

--- a/ambry-api/src/main/java/com/github/ambry/config/VerifiableProperties.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/VerifiableProperties.java
@@ -226,6 +226,15 @@ public class VerifiableProperties {
   }
 
   /**
+   * @param name The property name.
+   * @param type The type of enum to parse.
+   * @param defaultVal The default value to use if the property is not found.
+   * @return The enum value.
+   */
+  public <E extends Enum<E>> E getEnum(String name, Class<E> type, E defaultVal) {
+    return containsKey(name) ? Enum.valueOf(type, getProperty(name)) : defaultVal;
+  }
+  /**
    * Get a string property, or, if no such property is defined, return the given default value
    */
   public String getString(String name, String defaultVal) {

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
@@ -283,7 +283,16 @@ public class ClusterMapUtils {
    * @return the datacenter name associated with the given instance.
    */
   public static String getDcName(InstanceConfig instanceConfig) {
-    return instanceConfig.getRecord().getSimpleField(DATACENTER_STR);
+    return getDcName(instanceConfig.getRecord());
+  }
+
+  /**
+   * Get the datacenter name associated with the given instance.
+   * @param znRecord the {@link ZNRecord} associated with the interested instance.
+   * @return the datacenter name associated with the given instance.
+   */
+  public static String getDcName(ZNRecord znRecord) {
+    return znRecord.getSimpleField(DATACENTER_STR);
   }
 
   /**
@@ -358,25 +367,24 @@ public class ClusterMapUtils {
    * Get an instance of a {@link DataNodeConfigSource} based on settings in the provided {@link ClusterMapConfig}
    * @param clusterMapConfig the config to use.
    * @param helixManager the manager instance to use.
-   * @param dcName the name of the datacenter that the returned source should be configured for.
    * @param metrics the metrics instance that the returned source should use.
    * @return the {@link DataNodeConfigSource} instance.
    */
   static DataNodeConfigSource getDataNodeConfigSource(ClusterMapConfig clusterMapConfig, HelixManager helixManager,
-      String dcName, DataNodeConfigSourceMetrics metrics) {
+      DataNodeConfigSourceMetrics metrics) {
     switch (clusterMapConfig.clusterMapDataNodeConfigSourceType) {
       case INSTANCE_CONFIG:
         return new InstanceConfigToDataNodeConfigAdapter(helixManager, clusterMapConfig);
       case PROPERTY_STORE:
-        return new PropertyStoreToDataNodeConfigAdapter(helixManager.getHelixPropertyStore(), clusterMapConfig, dcName);
+        return new PropertyStoreToDataNodeConfigAdapter(helixManager.getHelixPropertyStore(), clusterMapConfig);
       case COMPOSITE_INSTANCE_CONFIG_PRIMARY:
         return new CompositeDataNodeConfigSource(
             new InstanceConfigToDataNodeConfigAdapter(helixManager, clusterMapConfig),
-            new PropertyStoreToDataNodeConfigAdapter(helixManager.getHelixPropertyStore(), clusterMapConfig, dcName),
+            new PropertyStoreToDataNodeConfigAdapter(helixManager.getHelixPropertyStore(), clusterMapConfig),
             SystemTime.getInstance(), metrics);
       case COMPOSITE_PROPERTY_STORE_PRIMARY:
         return new CompositeDataNodeConfigSource(
-            new PropertyStoreToDataNodeConfigAdapter(helixManager.getHelixPropertyStore(), clusterMapConfig, dcName),
+            new PropertyStoreToDataNodeConfigAdapter(helixManager.getHelixPropertyStore(), clusterMapConfig),
             new InstanceConfigToDataNodeConfigAdapter(helixManager, clusterMapConfig), SystemTime.getInstance(),
             metrics);
       default:

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
@@ -13,7 +13,9 @@
  */
 package com.github.ambry.clustermap;
 
+import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.network.Port;
+import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.Utils;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -33,6 +35,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.apache.helix.HelixAdmin;
+import org.apache.helix.HelixManager;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
@@ -349,6 +352,36 @@ public class ClusterMapUtils {
       }
     }
     return result;
+  }
+
+  /**
+   * Get an instance of a {@link DataNodeConfigSource} based on settings in the provided {@link ClusterMapConfig}
+   * @param clusterMapConfig the config to use.
+   * @param helixManager the manager instance to use.
+   * @param dcName the name of the datacenter that the returned source should be configured for.
+   * @param metrics the metrics instance that the returned source should use.
+   * @return the {@link DataNodeConfigSource} instance.
+   */
+  static DataNodeConfigSource getDataNodeConfigSource(ClusterMapConfig clusterMapConfig, HelixManager helixManager,
+      String dcName, DataNodeConfigSourceMetrics metrics) {
+    switch (clusterMapConfig.clusterMapDataNodeConfigSourceType) {
+      case INSTANCE_CONFIG:
+        return new InstanceConfigToDataNodeConfigAdapter(helixManager, clusterMapConfig);
+      case PROPERTY_STORE:
+        return new PropertyStoreToDataNodeConfigAdapter(helixManager.getHelixPropertyStore(), clusterMapConfig, dcName);
+      case COMPOSITE_INSTANCE_CONFIG_PRIMARY:
+        return new CompositeDataNodeConfigSource(
+            new InstanceConfigToDataNodeConfigAdapter(helixManager, clusterMapConfig),
+            new PropertyStoreToDataNodeConfigAdapter(helixManager.getHelixPropertyStore(), clusterMapConfig, dcName),
+            SystemTime.getInstance(), metrics);
+      case COMPOSITE_PROPERTY_STORE_PRIMARY:
+        return new CompositeDataNodeConfigSource(
+            new PropertyStoreToDataNodeConfigAdapter(helixManager.getHelixPropertyStore(), clusterMapConfig, dcName),
+            new InstanceConfigToDataNodeConfigAdapter(helixManager, clusterMapConfig), SystemTime.getInstance(),
+            metrics);
+      default:
+        throw new IllegalArgumentException("Unknown type: " + clusterMapConfig.clusterMapDataNodeConfigSourceType);
+    }
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/CompositeDataNodeConfigSource.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/CompositeDataNodeConfigSource.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2020 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ */
+
+package com.github.ambry.clustermap;
+
+import com.github.ambry.utils.Time;
+import com.github.ambry.utils.Utils;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * An implementation of {@link DataNodeConfigSource} that combines two sources. The "primary" acts as the source of
+ * truth for users of this class, but results obtained are compared against the "secondary" source. This class can be
+ * useful for safe migrations between different backing stores.
+ */
+public class CompositeDataNodeConfigSource implements DataNodeConfigSource {
+  private static final Logger LOGGER = LoggerFactory.getLogger(CompositeDataNodeConfigSource.class);
+  static final long CHECK_PERIOD_MS = TimeUnit.MINUTES.toMillis(5);
+  static final int MAX_PERIODS_WITH_INCONSISTENCY = 3;
+  private final DataNodeConfigSource primarySource;
+  private final DataNodeConfigSource secondarySource;
+  private final DataNodeConfigSourceMetrics metrics;
+  private final Time time;
+  private final AtomicBoolean recordingListenersRegistered = new AtomicBoolean(false);
+
+  /**
+   * @param primarySource the source of truth for users of this class.
+   * @param secondarySource all operations are also attempted against this source, but if the results of the operation
+   *                        differ from the primary, inconsistencies are just recorded with logs and metrics.
+   * @param time a {@link Time} instance used for consistency verification.
+   * @param metrics a {@link DataNodeConfigSourceMetrics} instance to use.
+   */
+  public CompositeDataNodeConfigSource(DataNodeConfigSource primarySource, DataNodeConfigSource secondarySource,
+      Time time, DataNodeConfigSourceMetrics metrics) {
+    this.primarySource = primarySource;
+    this.secondarySource = secondarySource;
+    this.time = time;
+    this.metrics = metrics;
+  }
+
+  @Override
+  public void addDataNodeConfigChangeListener(DataNodeConfigChangeListener userListener) throws Exception {
+    if (recordingListenersRegistered.compareAndSet(false, true)) {
+      RecordingListener primaryListener = new RecordingListener(userListener);
+      RecordingListener secondaryListener = new RecordingListener(null);
+      primarySource.addDataNodeConfigChangeListener(primaryListener);
+      try {
+        secondarySource.addDataNodeConfigChangeListener(secondaryListener);
+      } catch (Exception e) {
+        LOGGER.error("Error from secondarySource.addDataNodeConfigChangeListener({})", userListener, e);
+      }
+      Utils.newThread("DataNodeConfigConsistencyChecker",
+          new ConsistencyChecker(time, metrics, primaryListener, secondaryListener), false).start();
+    } else {
+      // only set up consistency checking for the first listener. Other listeners will just use with the primary src
+      primarySource.addDataNodeConfigChangeListener(userListener);
+    }
+  }
+
+  @Override
+  public boolean set(DataNodeConfig config) {
+    boolean primaryResult = primarySource.set(config);
+    try {
+      boolean secondaryResult = secondarySource.set(config);
+      if (primaryResult != secondaryResult) {
+        metrics.setInconsistentCount.inc();
+        LOGGER.error("Results differ for set({}). sourceOfTruth={}, secondarySource={}", config, primaryResult,
+            secondaryResult);
+      }
+    } catch (Exception e) {
+      metrics.setInconsistentCount.inc();
+      LOGGER.error("Error from secondarySource.set({})", config, e);
+    }
+    return primaryResult;
+  }
+
+  @Override
+  public DataNodeConfig get(String instanceName) {
+    DataNodeConfig primaryResult = primarySource.get(instanceName);
+    try {
+      DataNodeConfig secondaryResult = secondarySource.get(instanceName);
+      if (!Objects.equals(primaryResult, secondaryResult)) {
+        metrics.getInconsistentCount.inc();
+        LOGGER.error("Results differ for get({}). sourceOfTruth={}, secondarySource={}", instanceName, primaryResult,
+            secondaryResult);
+      }
+    } catch (Exception e) {
+      metrics.getInconsistentCount.inc();
+      LOGGER.error("Error from secondarySource.get({})", instanceName, e);
+    }
+    return primaryResult;
+  }
+
+  /**
+   * Long running background task to periodically check for consistency between two listeners.
+   */
+  private static class ConsistencyChecker implements Runnable {
+    private final Time time;
+    private final DataNodeConfigSourceMetrics metrics;
+    private final RecordingListener primaryListener;
+    private final RecordingListener secondaryListener;
+
+    /**
+     * @param time {@link Time} instance.
+     * @param metrics {@link DataNodeConfigSourceMetrics} instance.
+     * @param primaryListener the first {@link RecordingListener} to compare.
+     * @param secondaryListener the second {@link RecordingListener} to compare.
+     */
+    public ConsistencyChecker(Time time, DataNodeConfigSourceMetrics metrics, RecordingListener primaryListener,
+        RecordingListener secondaryListener) {
+      this.time = time;
+      this.metrics = metrics;
+      this.primaryListener = primaryListener;
+      this.secondaryListener = secondaryListener;
+    }
+
+    @Override
+    public void run() {
+      long lastSuccessTimeMs = time.milliseconds();
+      while (!Thread.currentThread().isInterrupted()) {
+        try {
+          time.sleep(CHECK_PERIOD_MS);
+        } catch (InterruptedException e) {
+          LOGGER.warn("ConsistencyChecker sleep interrupted, shutting down");
+          Thread.currentThread().interrupt();
+          break;
+        }
+        long currentTimeMs = time.milliseconds();
+        Map<String, DataNodeConfig> primaryConfigsSeen = primaryListener.configsSeen;
+        Map<String, DataNodeConfig> secondaryConfigsSeen = secondaryListener.configsSeen;
+        if (primaryConfigsSeen.equals(secondaryConfigsSeen)) {
+          lastSuccessTimeMs = currentTimeMs;
+          metrics.listenerConsistentCount.inc();
+          LOGGER.debug("Sources consistent at {}", currentTimeMs);
+        } else if ((currentTimeMs - CHECK_PERIOD_MS * MAX_PERIODS_WITH_INCONSISTENCY) >= lastSuccessTimeMs) {
+          metrics.listenerInconsistentCount.inc();
+          LOGGER.warn("Inconsistency detected for multiple periods. primary={}, secondary={}", primaryConfigsSeen,
+              secondaryConfigsSeen);
+        } else {
+          metrics.listenerTrendingInconsistentCount.inc();
+          LOGGER.debug("Inconsistency detected at {}, waiting to see if state converges. primary={}, secondary={}",
+              currentTimeMs, primaryConfigsSeen, secondaryConfigsSeen);
+        }
+      }
+    }
+  }
+
+  /**
+   * A listener that keeps a map of all of the configs it has seen that can be used for checking consistency.
+   */
+  private static class RecordingListener implements DataNodeConfigChangeListener {
+    final Map<String, DataNodeConfig> configsSeen = new ConcurrentHashMap<>();
+    private final DataNodeConfigChangeListener userListener;
+
+    /**
+     * @param userListener if non-null, this listener will be notified on any change.
+     */
+    public RecordingListener(DataNodeConfigChangeListener userListener) {
+      this.userListener = userListener;
+    }
+
+    @Override
+    public void onDataNodeConfigChange(Iterable<DataNodeConfig> configs) {
+      if (userListener != null) {
+        userListener.onDataNodeConfigChange(configs);
+      }
+      for (DataNodeConfig config : configs) {
+        configsSeen.put(config.getInstanceName(), config);
+      }
+    }
+  }
+}

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DataNodeConfig.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DataNodeConfig.java
@@ -162,11 +162,14 @@ class DataNodeConfig {
     return "DataNodeConfig{" + "instanceName='" + instanceName + '\'' + ", hostName='" + hostName + '\'' + ", port="
         + port + ", datacenterName='" + datacenterName + '\'' + ", sslPort=" + sslPort + ", http2Port=" + http2Port
         + ", rackId='" + rackId + '\'' + ", xid=" + xid + ", sealedReplicas=" + sealedReplicas + ", stoppedReplicas="
-        + stoppedReplicas + ", disabledReplicas=" + disabledReplicas + ", diskConfigs=" + diskConfigs + '}';
+        + stoppedReplicas + ", disabledReplicas=" + disabledReplicas + ", diskConfigs=" + diskConfigs
+        + ", extraMapFields=" + extraMapFields + '}';
   }
 
   @Override
   public boolean equals(Object o) {
+    // xid and extraMapFields are ignored in this equality check. They are unique to specific DataNodeConfigSource
+    // implementations for legacy compatibility only. Comparison between configs from different sources is required.
     if (this == o) {
       return true;
     }
@@ -176,9 +179,9 @@ class DataNodeConfig {
     DataNodeConfig that = (DataNodeConfig) o;
     return Objects.equals(instanceName, that.instanceName) && Objects.equals(hostName, that.hostName) && Objects.equals(
         datacenterName, that.datacenterName) && port == that.port && Objects.equals(sslPort, that.sslPort)
-        && Objects.equals(http2Port, that.http2Port) && Objects.equals(rackId, that.rackId) && xid == that.xid
-        && sealedReplicas.equals(that.sealedReplicas) && stoppedReplicas.equals(that.stoppedReplicas)
-        && disabledReplicas.equals(that.disabledReplicas) && diskConfigs.equals(that.diskConfigs);
+        && Objects.equals(http2Port, that.http2Port) && Objects.equals(rackId, that.rackId) && sealedReplicas.equals(
+        that.sealedReplicas) && stoppedReplicas.equals(that.stoppedReplicas) && disabledReplicas.equals(
+        that.disabledReplicas) && diskConfigs.equals(that.diskConfigs);
   }
 
   @Override

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DataNodeConfigSourceMetrics.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DataNodeConfigSourceMetrics.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ */
+
+package com.github.ambry.clustermap;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.MetricRegistry;
+
+
+/**
+ * Metrics for {@link DataNodeConfigSource} implementations
+ */
+class DataNodeConfigSourceMetrics {
+  final Counter setInconsistentCount;
+  final Counter getInconsistentCount;
+  final Counter listenerInconsistentCount;
+  final Counter listenerTrendingInconsistentCount;
+  final Counter listenerConsistentCount;
+
+  DataNodeConfigSourceMetrics(MetricRegistry registry) {
+    setInconsistentCount =
+        registry.counter(MetricRegistry.name(CompositeDataNodeConfigSource.class, "SetInconsistentCount"));
+    getInconsistentCount =
+        registry.counter(MetricRegistry.name(CompositeDataNodeConfigSource.class, "GetInconsistentCount"));
+    listenerInconsistentCount =
+        registry.counter(MetricRegistry.name(CompositeDataNodeConfigSource.class, "ListenerInconsistentCount"));
+    listenerTrendingInconsistentCount =
+        registry.counter(MetricRegistry.name(CompositeDataNodeConfigSource.class, "ListenerTrendingInconsistentCount"));
+    listenerConsistentCount =
+        registry.counter(MetricRegistry.name(CompositeDataNodeConfigSource.class, "ListenerConsistentCount"));
+  }
+}

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DataNodeConfigSourceMetrics.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DataNodeConfigSourceMetrics.java
@@ -23,22 +23,22 @@ import com.codahale.metrics.MetricRegistry;
  * Metrics for {@link DataNodeConfigSource} implementations
  */
 class DataNodeConfigSourceMetrics {
-  final Counter setInconsistentCount;
-  final Counter getInconsistentCount;
-  final Counter listenerInconsistentCount;
-  final Counter listenerTrendingInconsistentCount;
-  final Counter listenerConsistentCount;
+  final Counter setSwallowedErrorCount;
+  final Counter getSwallowedErrorCount;
+  final Counter addListenerSwallowedErrorCount;
+  final Counter listenerInconsistencyCount;
+  final Counter listenerTransientInconsistencyCount;
 
   DataNodeConfigSourceMetrics(MetricRegistry registry) {
-    setInconsistentCount =
-        registry.counter(MetricRegistry.name(CompositeDataNodeConfigSource.class, "SetInconsistentCount"));
-    getInconsistentCount =
-        registry.counter(MetricRegistry.name(CompositeDataNodeConfigSource.class, "GetInconsistentCount"));
-    listenerInconsistentCount =
-        registry.counter(MetricRegistry.name(CompositeDataNodeConfigSource.class, "ListenerInconsistentCount"));
-    listenerTrendingInconsistentCount =
-        registry.counter(MetricRegistry.name(CompositeDataNodeConfigSource.class, "ListenerTrendingInconsistentCount"));
-    listenerConsistentCount =
-        registry.counter(MetricRegistry.name(CompositeDataNodeConfigSource.class, "ListenerConsistentCount"));
+    setSwallowedErrorCount =
+        registry.counter(MetricRegistry.name(CompositeDataNodeConfigSource.class, "SetSwallowedErrorCount"));
+    getSwallowedErrorCount =
+        registry.counter(MetricRegistry.name(CompositeDataNodeConfigSource.class, "GetSwallowedErrorCount"));
+    addListenerSwallowedErrorCount =
+        registry.counter(MetricRegistry.name(CompositeDataNodeConfigSource.class, "AddListenerSwallowedErrorCount"));
+    listenerInconsistencyCount =
+        registry.counter(MetricRegistry.name(CompositeDataNodeConfigSource.class, "ListenerInconsistencyCount"));
+    listenerTransientInconsistencyCount = registry.counter(
+        MetricRegistry.name(CompositeDataNodeConfigSource.class, "ListenerTransientInconsistencyCount"));
   }
 }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DatacenterInitializer.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DatacenterInitializer.java
@@ -53,6 +53,7 @@ class DatacenterInitializer {
   private final HelixClusterManager.ClusterChangeHandlerCallback clusterChangeHandlerCallback;
   private final HelixClusterManager.HelixClusterManagerCallback helixClusterManagerCallback;
   private final HelixClusterManagerMetrics helixClusterManagerMetrics;
+  private final DataNodeConfigSourceMetrics dataNodeConfigSourceMetrics;
   private final AtomicLong sealedStateChangeCounter;
   // Fields to pass into only SimpleClusterChangeHandler (These can be removed if SimpleClusterChangeHandler is removed)
   private final ConcurrentHashMap<ByteBuffer, AmbryPartition> partitionMap;
@@ -69,6 +70,7 @@ class DatacenterInitializer {
    * @param clusterChangeHandlerCallback a call back that allows current handler to update cluster-wide info.
    * @param helixClusterManagerCallback a help class to get cluster state from all DCs.
    * @param helixClusterManagerMetrics metrics that help track of cluster changes and infos.
+   * @param dataNodeConfigSourceMetrics metrics related to {@link DataNodeConfigSource}.
    * @param sealedStateChangeCounter a counter that records event when replica is sealed or unsealed
    * @param partitionMap a map from serialized bytes to corresponding partition.
    * @param partitionNameToAmbryPartition a map from partition name to {@link AmbryPartition} object.
@@ -79,8 +81,8 @@ class DatacenterInitializer {
       Map<String, Map<String, String>> partitionOverrideInfoMap,
       HelixClusterManager.ClusterChangeHandlerCallback clusterChangeHandlerCallback,
       HelixClusterManager.HelixClusterManagerCallback helixClusterManagerCallback,
-      HelixClusterManagerMetrics helixClusterManagerMetrics, AtomicLong sealedStateChangeCounter,
-      ConcurrentHashMap<ByteBuffer, AmbryPartition> partitionMap,
+      HelixClusterManagerMetrics helixClusterManagerMetrics, DataNodeConfigSourceMetrics dataNodeConfigSourceMetrics,
+      AtomicLong sealedStateChangeCounter, ConcurrentHashMap<ByteBuffer, AmbryPartition> partitionMap,
       ConcurrentHashMap<String, AmbryPartition> partitionNameToAmbryPartition,
       ConcurrentHashMap<AmbryPartition, Set<AmbryReplica>> ambryPartitionToAmbryReplicas) {
     this.clusterMapConfig = clusterMapConfig;
@@ -92,6 +94,7 @@ class DatacenterInitializer {
     this.clusterChangeHandlerCallback = clusterChangeHandlerCallback;
     this.helixClusterManagerCallback = helixClusterManagerCallback;
     this.helixClusterManagerMetrics = helixClusterManagerMetrics;
+    this.dataNodeConfigSourceMetrics = dataNodeConfigSourceMetrics;
     this.sealedStateChangeCounter = sealedStateChangeCounter;
     this.partitionMap = partitionMap;
     this.partitionNameToAmbryPartition = partitionNameToAmbryPartition;
@@ -197,7 +200,8 @@ class DatacenterInitializer {
     // notification for a change from within the same thread that adds the listener, in the context of the add
     // call. Therefore, when the call to add a listener returns, the initial notification will have been
     // received and handled.
-    DataNodeConfigSource dataNodeConfigSource = new InstanceConfigToDataNodeConfigAdapter(manager, clusterMapConfig);
+    DataNodeConfigSource dataNodeConfigSource =
+        ClusterMapUtils.getDataNodeConfigSource(clusterMapConfig, manager, dcName, dataNodeConfigSourceMetrics);
     dataNodeConfigSource.addDataNodeConfigChangeListener(clusterChangeHandler);
     logger.info("Registered instance config change listeners for Helix manager at {}", zkConnectStr);
     manager.addIdealStateChangeListener(clusterChangeHandler);

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DatacenterInitializer.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DatacenterInitializer.java
@@ -201,7 +201,7 @@ class DatacenterInitializer {
     // call. Therefore, when the call to add a listener returns, the initial notification will have been
     // received and handled.
     DataNodeConfigSource dataNodeConfigSource =
-        ClusterMapUtils.getDataNodeConfigSource(clusterMapConfig, manager, dcName, dataNodeConfigSourceMetrics);
+        ClusterMapUtils.getDataNodeConfigSource(clusterMapConfig, manager, dataNodeConfigSourceMetrics);
     dataNodeConfigSource.addDataNodeConfigChangeListener(clusterChangeHandler);
     logger.info("Registered instance config change listeners for Helix manager at {}", zkConnectStr);
     manager.addIdealStateChangeListener(clusterChangeHandler);

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
@@ -113,13 +113,14 @@ public class HelixClusterManager implements ClusterMap {
     }
     if (initializationFailureMap.get(clusterMapConfig.clusterMapDatacenterName) == null) {
       List<DatacenterInitializer> initializers = new ArrayList<>();
+      DataNodeConfigSourceMetrics dataNodeConfigSourceMetrics = new DataNodeConfigSourceMetrics(metricRegistry);
       for (DcZkInfo dcZkInfo : dataCenterToZkAddress.values()) {
         // Initialize from every remote datacenter in a separate thread to speed things up.
         DatacenterInitializer initializer =
             new DatacenterInitializer(clusterMapConfig, localManager, helixFactory, dcZkInfo, selfInstanceName,
                 partitionOverrideInfoMap, clusterChangeHandlerCallback, helixClusterManagerCallback,
-                helixClusterManagerMetrics, sealedStateChangeCounter, partitionMap, partitionNameToAmbryPartition,
-                ambryPartitionToAmbryReplicas);
+                helixClusterManagerMetrics, dataNodeConfigSourceMetrics, sealedStateChangeCounter, partitionMap,
+                partitionNameToAmbryPartition, ambryPartitionToAmbryReplicas);
         initializer.start();
         initializers.add(initializer);
       }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixFactory.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixFactory.java
@@ -13,6 +13,8 @@
  */
 package com.github.ambry.clustermap;
 
+import com.github.ambry.config.ClusterMapConfig;
+import com.github.ambry.utils.SystemTime;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixFactory.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixFactory.java
@@ -13,8 +13,6 @@
  */
 package com.github.ambry.clustermap;
 
-import com.github.ambry.config.ClusterMapConfig;
-import com.github.ambry.utils.SystemTime;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
@@ -104,8 +104,7 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
           helixFactory.getZkHelixManagerAndConnect(clusterName, instanceName, InstanceType.SPECTATOR, zkConnectStr);
       helixAdmin = spectatorManager.getClusterManagmentTool();
       dataNodeConfigSource =
-          getDataNodeConfigSource(clusterMapConfig, spectatorManager, clusterMapConfig.clusterMapDatacenterName,
-              new DataNodeConfigSourceMetrics(metricRegistry));
+          getDataNodeConfigSource(clusterMapConfig, spectatorManager, new DataNodeConfigSourceMetrics(metricRegistry));
     } catch (Exception exception) {
       throw new IllegalStateException("Error setting up administration facilities", exception);
     }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipantMetrics.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipantMetrics.java
@@ -29,6 +29,7 @@ class HelixParticipantMetrics {
   private final Map<String, ReplicaState> localPartitionAndState;
   // no need to record exact number of "dropped" partition, a counter to track partition-dropped events would suffice
   final Counter partitionDroppedCount;
+  final Counter setReplicaDisabledStateErrorCount;
 
   HelixParticipantMetrics(MetricRegistry metricRegistry, String zkConnectStr,
       Map<String, ReplicaState> localPartitionAndState) {
@@ -55,6 +56,8 @@ class HelixParticipantMetrics {
         errorStatePartitionCount);
     partitionDroppedCount =
         metricRegistry.counter(MetricRegistry.name(HelixParticipant.class, "partitionDroppedCount" + zkSuffix));
+    setReplicaDisabledStateErrorCount = metricRegistry.counter(
+        MetricRegistry.name(HelixParticipant.class, "setReplicaDisabledStateErrorCount" + zkSuffix));
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PropertyStoreToDataNodeConfigAdapter.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PropertyStoreToDataNodeConfigAdapter.java
@@ -53,12 +53,11 @@ public class PropertyStoreToDataNodeConfigAdapter implements DataNodeConfigSourc
   /**
    * @param propertyStore the {@link HelixPropertyStore} instance to use to interact with zookeeper.
    * @param clusterMapConfig the {@link ClusterMapConfig} to use.
-   * @param dcName the datacenter name for for the property store.
    */
   public PropertyStoreToDataNodeConfigAdapter(HelixPropertyStore<ZNRecord> propertyStore,
-      ClusterMapConfig clusterMapConfig, String dcName) {
+      ClusterMapConfig clusterMapConfig) {
     this.propertyStore = propertyStore;
-    this.converter = new Converter(clusterMapConfig.clusterMapDefaultPartitionClass, dcName);
+    this.converter = new Converter(clusterMapConfig.clusterMapDefaultPartitionClass);
     this.eventExecutor = Executors.newSingleThreadExecutor();
   }
 
@@ -184,15 +183,12 @@ public class PropertyStoreToDataNodeConfigAdapter implements DataNodeConfigSourc
     private static final String HOSTNAME_FIELD = "hostname";
     private static final String PORT_FIELD = "port";
     private final String defaultPartitionClass;
-    private final String dcName;
 
     /**
      * @param defaultPartitionClass the default partition class for these nodes.
-     * @param dcName the datacenter name for these nodes.
      */
-    Converter(String defaultPartitionClass, String dcName) {
+    Converter(String defaultPartitionClass) {
       this.defaultPartitionClass = defaultPartitionClass;
-      this.dcName = dcName;
     }
 
     /**
@@ -208,7 +204,7 @@ public class PropertyStoreToDataNodeConfigAdapter implements DataNodeConfigSourc
       }
 
       DataNodeConfig dataNodeConfig = new DataNodeConfig(record.getId(), record.getSimpleField(HOSTNAME_FIELD),
-          record.getIntField(PORT_FIELD, DataNodeId.UNKNOWN_PORT), dcName, getSslPortStr(record),
+          record.getIntField(PORT_FIELD, DataNodeId.UNKNOWN_PORT), getDcName(record), getSslPortStr(record),
           getHttp2PortStr(record), getRackId(record), DEFAULT_XID);
       dataNodeConfig.getSealedReplicas().addAll(getSealedReplicas(record));
       dataNodeConfig.getStoppedReplicas().addAll(getStoppedReplicas(record));
@@ -247,6 +243,7 @@ public class PropertyStoreToDataNodeConfigAdapter implements DataNodeConfigSourc
       record.setIntField(SCHEMA_VERSION_STR, VERSION_0);
       record.setSimpleField(HOSTNAME_FIELD, dataNodeConfig.getHostName());
       record.setIntField(PORT_FIELD, dataNodeConfig.getPort());
+      record.setSimpleField(DATACENTER_STR, dataNodeConfig.getDatacenterName());
       if (dataNodeConfig.getSslPort() != null) {
         record.setIntField(SSL_PORT_STR, dataNodeConfig.getSslPort());
       }

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/CompositeDataNodeConfigSourceTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/CompositeDataNodeConfigSourceTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2020 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ */
+
+package com.github.ambry.clustermap;
+
+import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.utils.MockTime;
+import com.github.ambry.utils.TestUtils;
+import java.util.Collections;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+
+public class CompositeDataNodeConfigSourceTest extends DataNodeConfigSourceTestBase {
+  DataNodeConfigSourceMetrics metrics = new DataNodeConfigSourceMetrics(new MetricRegistry());
+  DataNodeConfigSource primarySource = mock(DataNodeConfigSource.class);
+  DataNodeConfigSource secondarySource = mock(DataNodeConfigSource.class);
+  MockTime time = new MockTime();
+  CompositeDataNodeConfigSource compositeSource =
+      new CompositeDataNodeConfigSource(primarySource, secondarySource, time, metrics);
+
+  @Test
+  public void testListener() throws Exception {
+    time.allowSleepCalls(0);
+    DataNodeConfigChangeListener listener = mock(DataNodeConfigChangeListener.class);
+    compositeSource.addDataNodeConfigChangeListener(listener);
+    DataNodeConfigChangeListener primaryListener = captureRegisteredListener(primarySource);
+    DataNodeConfigChangeListener secondaryListener = captureRegisteredListener(secondarySource);
+    // create an inconsistency (this should not make the metric fire until 3*5 mock seconds have passed)
+    DataNodeConfig configOne = createConfig(1, 1);
+    primaryListener.onDataNodeConfigChange(Collections.singleton(configOne));
+    verify(listener).onDataNodeConfigChange(Collections.singleton(configOne));
+    time.allowSleepCalls(1);
+    assertTrue("Expected 0 inconsistencies so far",
+        TestUtils.checkAndSleep(0L, metrics.listenerInconsistentCount::getCount, 500));
+    time.allowSleepCalls(2);
+    assertTrue("Expected 1 inconsistency so far",
+        TestUtils.checkAndSleep(1L, metrics.listenerInconsistentCount::getCount, 500));
+    assertEquals("Expected 0 consistent checks at this point", 0, metrics.listenerConsistentCount.getCount());
+
+    // fix the inconsistency
+    secondaryListener.onDataNodeConfigChange(Collections.singleton(configOne));
+    time.allowSleepCalls(1);
+    assertTrue("Expected inconsistency to be resolved",
+        TestUtils.checkAndSleep(1L, metrics.listenerConsistentCount::getCount, 500));
+
+    // add a second listener, this should only be attached to the primary
+    DataNodeConfigChangeListener newListener = mock(DataNodeConfigChangeListener.class);
+    compositeSource.addDataNodeConfigChangeListener(newListener);
+    verify(primarySource).addDataNodeConfigChangeListener(newListener);
+    verify(secondarySource, never()).addDataNodeConfigChangeListener(newListener);
+  }
+
+  /**
+   * Test composite set with both sources returning the same result.
+   */
+  @Test
+  public void testSetBothSuccess() {
+    when(primarySource.set(any())).thenReturn(true);
+    when(secondarySource.set(any())).thenReturn(true);
+    DataNodeConfig config = createConfig(1, 1);
+    assertTrue("Expected success response", compositeSource.set(config));
+    verify(primarySource).set(config);
+    verify(secondarySource).set(config);
+  }
+
+  /**
+   * Test composite set when one source returns a different result.
+   */
+  @Test
+  public void testSetResultsDifferent() {
+    when(primarySource.set(any())).thenReturn(true);
+    when(secondarySource.set(any())).thenReturn(false);
+    DataNodeConfig config = createConfig(1, 1);
+    assertTrue("Expected response from primary", compositeSource.set(config));
+    verify(primarySource).set(config);
+    verify(secondarySource).set(config);
+    assertEquals("Expected one inconsistency", 1, metrics.setInconsistentCount.getCount());
+  }
+
+  /**
+   * Test exceptions thrown in the composite set method.
+   */
+  @Test
+  public void testSetException() throws Exception {
+    // exception in primary should be thrown
+    when(primarySource.set(any())).thenThrow(new RuntimeException());
+    DataNodeConfig config = createConfig(1, 1);
+    TestUtils.assertException(RuntimeException.class, () -> compositeSource.set(config), null);
+    verify(primarySource).set(config);
+    verify(secondarySource, never()).set(any());
+
+    // exception in secondary should be swallowed
+    reset(primarySource, secondarySource);
+    when(primarySource.set(any())).thenReturn(true);
+    when(secondarySource.set(any())).thenThrow(new RuntimeException());
+    assertTrue("Expected response from primary", compositeSource.set(config));
+    verify(primarySource).set(config);
+    verify(secondarySource).set(config);
+    assertEquals("Expected one inconsistency", 1, metrics.setInconsistentCount.getCount());
+  }
+
+  /**
+   * Test composite get with both sources returning the same result.
+   */
+  @Test
+  public void testGetBothSuccess() {
+    DataNodeConfig config = createConfig(1, 1);
+    when(primarySource.get(any())).thenReturn(config);
+    when(secondarySource.get(any())).thenReturn(config);
+    assertEquals("Unexpected response", config, compositeSource.get(config.getInstanceName()));
+    verify(primarySource).get(config.getInstanceName());
+    verify(secondarySource).get(config.getInstanceName());
+  }
+
+  /**
+   * Test composite get when one source returns a different result.
+   */
+  @Test
+  public void testGetResultsDifferent() {
+    DataNodeConfig config = createConfig(1, 1);
+    when(primarySource.get(any())).thenReturn(config);
+    when(secondarySource.get(any())).thenReturn(createConfig(1, 1));
+    assertEquals("Expected response from primary", config, compositeSource.get(config.getInstanceName()));
+    verify(primarySource).get(config.getInstanceName());
+    verify(secondarySource).get(config.getInstanceName());
+    assertEquals("Expected one inconsistency", 1, metrics.getInconsistentCount.getCount());
+  }
+
+  /**
+   * Test exceptions thrown in the composite get method.
+   */
+  @Test
+  public void testGetException() throws Exception {
+    // exception in primary should be thrown
+    when(primarySource.get(any())).thenThrow(new RuntimeException());
+    DataNodeConfig config = createConfig(1, 1);
+    TestUtils.assertException(RuntimeException.class, () -> compositeSource.get(config.getInstanceName()), null);
+    verify(primarySource).get(config.getInstanceName());
+    verify(secondarySource, never()).get(any());
+
+    // exception in secondary should be swallowed
+    reset(primarySource, secondarySource);
+    when(primarySource.get(any())).thenReturn(config);
+    when(secondarySource.get(any())).thenThrow(new RuntimeException());
+    assertEquals("Expected response from primary", config, compositeSource.get(config.getInstanceName()));
+    verify(primarySource).get(config.getInstanceName());
+    verify(secondarySource).get(config.getInstanceName());
+    assertEquals("Expected one inconsistency", 1, metrics.getInconsistentCount.getCount());
+  }
+
+  /**
+   * @param source the mock source to get the registered listener from
+   * @return the {@link DataNodeConfigChangeListener} captured.
+   */
+  private static DataNodeConfigChangeListener captureRegisteredListener(DataNodeConfigSource source) throws Exception {
+    ArgumentCaptor<DataNodeConfigChangeListener> listenerCaptor =
+        ArgumentCaptor.forClass(DataNodeConfigChangeListener.class);
+    verify(source).addDataNodeConfigChangeListener(listenerCaptor.capture());
+    return listenerCaptor.getValue();
+  }
+}

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/PropertyStoreToDataNodeConfigAdapterTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/PropertyStoreToDataNodeConfigAdapterTest.java
@@ -34,7 +34,7 @@ public class PropertyStoreToDataNodeConfigAdapterTest extends DataNodeConfigSour
 
   private final MockHelixPropertyStore<ZNRecord> propertyStore = new MockHelixPropertyStore<>();
   private final DataNodeConfigSource source =
-      new PropertyStoreToDataNodeConfigAdapter(propertyStore, TestUtils.getDummyConfig(), DC_NAME);
+      new PropertyStoreToDataNodeConfigAdapter(propertyStore, TestUtils.getDummyConfig());
 
   /**
    * Test {@link DataNodeConfigSource} methods.

--- a/ambry-test-utils/src/main/java/com/github/ambry/utils/TestUtils.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/utils/TestUtils.java
@@ -410,7 +410,7 @@ public class TestUtils {
    * @param timeoutInMs the time out in millisecond.
    * @return true if value match.
    */
-  public static <T> boolean checkAndSleep(T expectedValue, Supplier expressionToCheck, int timeoutInMs) {
+  public static <T> boolean checkAndSleep(T expectedValue, Supplier<T> expressionToCheck, int timeoutInMs) {
     long startTime = System.currentTimeMillis();
     try {
       while (!Objects.equals(expectedValue, expressionToCheck.get())) {


### PR DESCRIPTION
- Add CompositeDataNodeConfigSource that can be used to verify that two
  config sources are consistent with each other during a migration. Only
  the primary config source will be used as the source of truth for
  other components.
- Add config to allow switching between different config source impls.