### PR TITLE
Drop http2 request in two cases

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/Http2ClientConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/Http2ClientConfig.java
@@ -28,6 +28,9 @@ public class Http2ClientConfig {
   public static final String HTTP2_INITIAL_WINDOW_SIZE = "http2.initial.window.size";
   public static final String NETTY_RECEIVE_BUFFER_SIZE = "netty.receive.buffer.size";
   public static final String NETTY_SEND_BUFFER_SIZE = "netty.send.buffer.size";
+  public static final String HTTP2_WRITE_AND_FLUSH_TIMEOUT_MS = "http2.write.and.flush.timeout.ms";
+  public static final String HTTP2_DROP_REQUEST_ON_WRITE_AND_FLUSH_TIMEOUT =
+      "http2.drop.request.on.write.and.flush.timeout";
   public static final String HTTP2_BLOCKING_CHANNEL_ACQUIRE_TIMEOUT_MS = "http2.blocking.channel.acquire.timeout.ms";
   public static final String HTTP2_BLOCKING_CHANNEL_SEND_TIMEOUT_MS = "http2.blocking.channel.send.timeout.ms";
   public static final String HTTP2_BLOCKING_CHANNEL_RECEIVE_TIMEOUT_MS = "http2.blocking.channel.receive.timeout.ms";
@@ -106,6 +109,20 @@ public class Http2ClientConfig {
   public final int nettySendBufferSize;
 
   /**
+   * Show warn message if waiting time longer than this threshold.
+   */
+  @Config(HTTP2_WRITE_AND_FLUSH_TIMEOUT_MS)
+  @Default("1000")
+  public final int http2WriteAndFlushTimeoutMs;
+
+  /**
+   * Drop request if waiting time longer than http2WriteAndFlushTimeoutMs.
+   */
+  @Config(HTTP2_DROP_REQUEST_ON_WRITE_AND_FLUSH_TIMEOUT)
+  @Default("false")
+  public final boolean http2DropRequestOnWriteAndFlushTimeout;
+
+  /**
    * Maximum time allowed for acquire a stream channel from http2 connection.
    */
   @Config(HTTP2_BLOCKING_CHANNEL_ACQUIRE_TIMEOUT_MS)
@@ -147,6 +164,9 @@ public class Http2ClientConfig {
 
     nettyReceiveBufferSize = verifiableProperties.getInt(NETTY_RECEIVE_BUFFER_SIZE, 1024 * 1024);
     nettySendBufferSize = verifiableProperties.getInt(NETTY_SEND_BUFFER_SIZE, 1024 * 1024);
+    http2WriteAndFlushTimeoutMs = verifiableProperties.getInt(HTTP2_WRITE_AND_FLUSH_TIMEOUT_MS, 1000);
+    http2DropRequestOnWriteAndFlushTimeout =
+        verifiableProperties.getBoolean(HTTP2_DROP_REQUEST_ON_WRITE_AND_FLUSH_TIMEOUT, false);
     http2BlockingChannelAcquireTimeoutMs = verifiableProperties.getInt(HTTP2_BLOCKING_CHANNEL_ACQUIRE_TIMEOUT_MS, 1000);
     http2BlockingChannelSendTimeoutMs = verifiableProperties.getInt(HTTP2_BLOCKING_CHANNEL_SEND_TIMEOUT_MS, 2000);
     http2BlockingChannelReceiveTimeoutMs = verifiableProperties.getInt(HTTP2_BLOCKING_CHANNEL_RECEIVE_TIMEOUT_MS, 5000);

--- a/ambry-api/src/main/java/com/github/ambry/network/NetworkClientErrorCode.java
+++ b/ambry-api/src/main/java/com/github/ambry/network/NetworkClientErrorCode.java
@@ -26,5 +26,10 @@ public enum NetworkClientErrorCode {
    * A network error was encountered.
    */
   NetworkError,
+
+  /**
+   * Request timed out.
+   */
+  TimeoutError,
 }
 

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ChannelPoolHandler.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ChannelPoolHandler.java
@@ -71,6 +71,7 @@ public class Http2ChannelPoolHandler extends AbstractChannelPoolHandler {
         .frameLogger(new Http2FrameLogger(LogLevel.DEBUG, "client"))
         .build());
     pipeline.addLast(new Http2MultiplexHandler(new ChannelInboundHandlerAdapter()));
+    pipeline.addLast(connectionInboundExceptionHandler);
   }
 
   @ChannelHandler.Sharable
@@ -79,8 +80,8 @@ public class Http2ChannelPoolHandler extends AbstractChannelPoolHandler {
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
       if (cause instanceof Http2Exception.StreamException) {
-        // This usually happens when server returns response which from a dropped request.
-        logger.info(cause.getMessage());
+        // This usually happens when server returns response for a request which was already dropped.
+        logger.info("StreamException: {}", cause.getMessage());
       } else {
         logger.warn("Connection inbound exception:", cause);
       }

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ClientMetrics.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ClientMetrics.java
@@ -36,6 +36,7 @@ public class Http2ClientMetrics {
   public final Histogram http2ClientSendTime;
   public final Histogram http2ClientSendAndPollTime;
   public final Histogram http2ResponseFrameCount;
+  public final Histogram requestToNetworkClientLatencyMs;
 
   public final Counter http2NewPoolCount;
   public final Counter http2NewConnectionCount;
@@ -76,6 +77,8 @@ public class Http2ClientMetrics {
         registry.histogram(MetricRegistry.name(Http2NetworkClient.class, "Http2ClientSendAndPollTime"));
     http2ResponseFrameCount =
         registry.histogram(MetricRegistry.name(Http2NetworkClient.class, "Http2ResponseFrameCount"));
+    requestToNetworkClientLatencyMs =
+        registry.histogram(MetricRegistry.name(Http2NetworkClient.class, "RequestToNetworkClientLatencyMs"));
 
     http2NewPoolCount = registry.counter(MetricRegistry.name(Http2NetworkClient.class, "Http2NewPoolCount"));
     http2NewConnectionCount =

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ClientResponseHandler.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ClientResponseHandler.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.network.http2;
 
+import com.github.ambry.network.NetworkClientErrorCode;
 import com.github.ambry.utils.BatchBlockingQueue;
 import com.github.ambry.network.RequestInfo;
 import com.github.ambry.network.ResponseInfo;
@@ -67,8 +68,11 @@ class Http2ClientResponseHandler extends SimpleChannelInboundHandler<FullHttpRes
   @Override
   public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
     http2ClientMetrics.http2StreamExceptionCount.inc();
-    logger.info("Exception caught from in Http2ClientResponseHandler {} {}. Closing stream channel. Cause: ",
+    logger.info("Exception caught in Http2ClientResponseHandler {} {}. Closing stream channel. Cause: ",
         ctx.channel().hashCode(), ctx.channel(), cause);
-    releaseAndCloseStreamChannel(ctx.channel());
+    RequestInfo requestInfo = releaseAndCloseStreamChannel(ctx.channel());
+    if (requestInfo != null) {
+      responseInfoQueue.put(new ResponseInfo(requestInfo, NetworkClientErrorCode.NetworkError, null));
+    }
   }
 }

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2MultiplexedChannelPool.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2MultiplexedChannelPool.java
@@ -118,9 +118,10 @@ public class Http2MultiplexedChannelPool implements ChannelPool {
         .option(ChannelOption.SO_KEEPALIVE, true)
         // To honor http2 window size, WriteBufferWaterMark.high() should be greater or equal to http2 window size.
         // Also see: https://github.com/netty/netty/issues/10193
+        // Use reasonable WaterMark, because channel.isWriteable() depends on WriteBufferWaterMark.
         .option(ChannelOption.WRITE_BUFFER_WATER_MARK,
-            new WriteBufferWaterMark(http2ClientConfig.http2InitialWindowSize,
-                2 * http2ClientConfig.http2InitialWindowSize))
+            new WriteBufferWaterMark(http2ClientConfig.http2InitialWindowSize / 2,
+                http2ClientConfig.http2InitialWindowSize))
         .remoteAddress(inetSocketAddress);
     if (http2ClientConfig.nettyReceiveBufferSize != -1) {
       b.option(ChannelOption.SO_RCVBUF, http2ClientConfig.nettyReceiveBufferSize);

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2NetworkClient.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2NetworkClient.java
@@ -96,7 +96,7 @@ public class Http2NetworkClient implements NetworkClient {
       logger.warn("Number of requestsToDrop: {}", requestsToDrop.size());
       http2ClientMetrics.http2RequestsToDropCount.inc(requestsToDrop.size());
       for (int correlationId : requestsToDrop) {
-        Channel streamChannel = correlationIdInFlightToChannelMap.get(correlationId);
+        Channel streamChannel = correlationIdInFlightToChannelMap.remove(correlationId);
         if (streamChannel != null) {
           logger.warn("Drop request on streamChannel: {}", streamChannel);
           RequestInfo requestInfo = releaseAndCloseStreamChannel(streamChannel);

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2Utils.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2Utils.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.network.http2;
 
+import com.github.ambry.network.RequestInfo;
 import io.netty.channel.Channel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,12 +26,13 @@ public class Http2Utils {
 
   private static final Logger logger = LoggerFactory.getLogger(Http2ClientResponseHandler.class);
 
-  static void releaseAndCloseStreamChannel(Channel streamChannel) {
+  static RequestInfo releaseAndCloseStreamChannel(Channel streamChannel) {
     logger.info("Stream channel is being closed. Stream: {}, Parent: {}", streamChannel, streamChannel.parent());
-    streamChannel.attr(Http2NetworkClient.REQUEST_INFO).set(null);
+    RequestInfo requestInfo = streamChannel.attr(Http2NetworkClient.REQUEST_INFO).getAndSet(null);
     streamChannel.parent()
         .attr(Http2MultiplexedChannelPool.HTTP2_MULTIPLEXED_CHANNEL_POOL)
         .get()
         .release(streamChannel);
+    return requestInfo;
   }
 }

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2Utils.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2Utils.java
@@ -27,12 +27,15 @@ public class Http2Utils {
   private static final Logger logger = LoggerFactory.getLogger(Http2ClientResponseHandler.class);
 
   static RequestInfo releaseAndCloseStreamChannel(Channel streamChannel) {
-    logger.info("Stream channel is being closed. Stream: {}, Parent: {}", streamChannel, streamChannel.parent());
+    logger.debug("Stream channel is being closed. Stream: {}, Parent: {}", streamChannel, streamChannel.parent());
     RequestInfo requestInfo = streamChannel.attr(Http2NetworkClient.REQUEST_INFO).getAndSet(null);
-    streamChannel.parent()
-        .attr(Http2MultiplexedChannelPool.HTTP2_MULTIPLEXED_CHANNEL_POOL)
-        .get()
-        .release(streamChannel);
+    if (requestInfo != null) {
+      //REQUEST_INFO is used to indicate if a streamChannel has been released before.
+      streamChannel.parent()
+          .attr(Http2MultiplexedChannelPool.HTTP2_MULTIPLEXED_CHANNEL_POOL)
+          .get()
+          .release(streamChannel);
+    }
     return requestInfo;
   }
 }

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/MultiplexedChannelRecord.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/MultiplexedChannelRecord.java
@@ -268,18 +268,21 @@ public class MultiplexedChannelRecord {
     for (int attempt = 0; attempt < 5; ++attempt) {
 
       if (state != RecordState.OPEN) {
+        log.warn("claimStream fail because state is closed. ");
         return false;
       }
 
       int currentlyAvailable = numOfAvailableStreams.get();
 
       if (currentlyAvailable <= 0) {
+        log.warn("claimStream fail because currentlyAvailable: {}. ", currentlyAvailable);
         return false;
       }
       if (numOfAvailableStreams.compareAndSet(currentlyAvailable, currentlyAvailable - 1)) {
         return true;
       }
     }
+    log.warn("claimStream fail because attempt failed. ");
 
     return false;
   }

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/RequestOrResponse.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/RequestOrResponse.java
@@ -40,6 +40,7 @@ public abstract class RequestOrResponse extends AbstractByteBufHolder<RequestOrR
   protected ByteBuf bufferToSend;
   protected ByteBuffer byteBufferToSend;
   protected static final Logger logger = LoggerFactory.getLogger(RequestOrResponse.class);
+  public final long requestCreateTime;
 
   private static final int Request_Response_Size_In_Bytes = 8;
   private static final int Request_Response_Type_Size_In_Bytes = 2;
@@ -53,6 +54,7 @@ public abstract class RequestOrResponse extends AbstractByteBufHolder<RequestOrR
     this.correlationId = correlationId;
     this.clientId = clientId;
     this.bufferToSend = null;
+    this.requestCreateTime = System.currentTimeMillis();
   }
 
   public RequestOrResponseType getRequestType() {

--- a/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
@@ -1357,11 +1357,11 @@ class PutOperation {
         requestRegistrationCallback.registerRequestToSend(PutOperation.this, request);
         replicaIterator.remove();
         if (RouterUtils.isRemoteReplica(routerConfig, replicaId)) {
-          logger.debug("Making request with correlationId {} to a remote replica {} in {} ", correlationId,
+          logger.debug("Making request with correlationId {} to a remote replica {} in {}", correlationId,
               replicaId.getDataNodeId(), replicaId.getDataNodeId().getDatacenterName());
           routerMetrics.crossColoRequestCount.inc();
         } else {
-          logger.trace("Making request with correlationId {} to a local replica {} ", correlationId,
+          logger.trace("Making request with correlationId {} to a local replica {}", correlationId,
               replicaId.getDataNodeId());
         }
         routerMetrics.getDataNodeBasedMetrics(replicaId.getDataNodeId()).putRequestRate.mark();

--- a/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
@@ -1323,8 +1323,8 @@ class PutOperation {
         ChunkPutRequestInfo info = entry.getValue();
         if (time.milliseconds() - info.startTimeMs > routerConfig.routerRequestTimeoutMs) {
           onErrorResponse(info.replicaId, TrackedRequestFinalState.FAILURE);
-          logger.debug("PutRequest with correlationId {} in flight has expired for replica {} ", correlationId,
-              info.replicaId.getDataNodeId());
+          logger.warn("PutRequest with correlationId {} in flight has expired for replica {} {}", correlationId,
+              info.replicaId.getDataNodeId(), info);
           // Do not notify this as a failure to the response handler, as this timeout could simply be due to
           // connection unavailability. If there is indeed a network error, the NetworkClient will provide an error
           // response and the response handler will be notified accordingly.
@@ -1357,7 +1357,7 @@ class PutOperation {
         requestRegistrationCallback.registerRequestToSend(PutOperation.this, request);
         replicaIterator.remove();
         if (RouterUtils.isRemoteReplica(routerConfig, replicaId)) {
-          logger.trace("Making request with correlationId {} to a remote replica {} in {} ", correlationId,
+          logger.debug("Making request with correlationId {} to a remote replica {} in {} ", correlationId,
               replicaId.getDataNodeId(), replicaId.getDataNodeId().getDatacenterName());
           routerMetrics.crossColoRequestCount.inc();
         } else {

--- a/ambry-server/src/main/java/com/github/ambry/server/StorageServerNettyChannelInitializer.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/StorageServerNettyChannelInitializer.java
@@ -84,8 +84,8 @@ public class StorageServerNettyChannelInitializer extends ChannelInitializer<Soc
     ch.config()
         .setSendBufferSize(http2ClientConfig.nettySendBufferSize)
         .setReceiveBufferSize(http2ClientConfig.nettyReceiveBufferSize)
-        .setWriteBufferWaterMark(new WriteBufferWaterMark(http2ClientConfig.http2InitialWindowSize,
-            2 * http2ClientConfig.http2InitialWindowSize));
+        .setWriteBufferWaterMark(new WriteBufferWaterMark(http2ClientConfig.http2InitialWindowSize / 2,
+            http2ClientConfig.http2InitialWindowSize));
     // If channel handler implementations are not annotated with @Sharable, Netty creates a new instance of every class
     // in the pipeline for every connection.
     // i.e. if there are a 1000 active connections there will be a 1000 NettyMessageProcessor instances.

--- a/build.gradle
+++ b/build.gradle
@@ -248,7 +248,8 @@ project(':ambry-network') {
         compile project(':ambry-api'),
                 project(':ambry-utils'),
                 project(':ambry-commons'),
-                project(':ambry-clustermap')
+                project(':ambry-clustermap'),
+                project(':ambry-protocol')
         compile "io.netty:netty-all:$nettyVersion"
         compile "io.netty:netty-tcnative-boringssl-static:$nettyTcnativeVersion"
         compile "io.netty:netty-transport-native-epoll:$nettyVersion"


### PR DESCRIPTION
Drop request on router requests to drop a request.
Drop request on writeAndFlush exceeds threshold.
Adjusted Netty High and Low WaterMark for isWriteable() tracking. 
There was an assumption that a stream channel can be released twice. This is wrong because MultiplexedChannelRecord maintains a counter for streams on it. This PR fixs it by checking if RESPONSE_INFO attr null or not.