### PR TITLE
Convert (and cache) remote keys in replication GET response for timed out standby replicas in leader-based replication

### DIFF
--- a/ambry-replication/src/test/java/com/github/ambry/replication/ReplicationTestHelper.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/ReplicationTestHelper.java
@@ -280,7 +280,10 @@ public class ReplicationTestHelper {
     StoreConfig storeConfig = new StoreConfig(verifiableProperties);
     DataNodeId dataNodeId = clusterMap.getDataNodeIds().get(0);
 
-    StoreKeyConverterFactory storeKeyConverterFactory = new StoreKeyConverterFactoryImpl(null, null);
+    MockStoreKeyConverterFactory storeKeyConverterFactory = new MockStoreKeyConverterFactory(null, null);
+    storeKeyConverterFactory.setConversionMap(new HashMap<>());
+    storeKeyConverterFactory.setReturnInputIfAbsent(true);
+
     StoreKeyFactory storeKeyFactory = new BlobIdFactory(clusterMap);
 
     StorageManager storageManager =


### PR DESCRIPTION
During replication, as of part of legacy GDPR requirements, remote keys are converted (and cached) to local keys using StoreKeyConverter during metadata exchange. These converted/cached keys are used for validation and transformation after the missing blobs are fetched for them. In case of leader-based replication, when we are fetching missing blobs for standby replicas (timed out waiting for their keys to arrive from leaders), StoreKeyConverter would have cleared these keys from its cache as it is replicating with other replicas before time out happened. This fix is to re-convert remote keys and fill the cache when we fetch missing blobs for timed out standby replicas.