### PR TITLE
Introduce tool for migrating instance configs to property store

### DIFF
--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeUtil.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeUtil.java
@@ -740,7 +740,7 @@ public class HelixBootstrapUpgradeUtil {
         HelixPropertyStore<ZNRecord> propertyStore = createHelixPropertyStore(dcName);
         try {
           PropertyStoreToDataNodeConfigAdapter propertyStoreAdapter =
-              new PropertyStoreToDataNodeConfigAdapter(propertyStore, config, dcName);
+              new PropertyStoreToDataNodeConfigAdapter(propertyStore, config);
           List<String> instanceNames = helixAdmin.getInstancesInCluster(clusterName);
           logger.info("Found {} instances in cluster", instanceNames.size());
           instanceNames.forEach(instanceName -> {

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeUtil.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeUtil.java
@@ -156,7 +156,8 @@ public class HelixBootstrapUpgradeUtil {
     DisablePartition,
     EnablePartition,
     ResetPartition,
-    ListSealedPartition
+    ListSealedPartition,
+    MigrateToPropertyStore
   }
 
   /**
@@ -356,6 +357,26 @@ public class HelixBootstrapUpgradeUtil {
   }
 
   /**
+   * Copy the legacy custom InstanceConfig properties to the DataNodeConfigs tree in the property store.
+   * @param hardwareLayoutPath the path to the hardware layout file.
+   * @param partitionLayoutPath the path to the partition layout file.
+   * @param zkLayoutPath the path to the zookeeper layout file.
+   * @param clusterNamePrefix the prefix that when combined with the cluster name in the static cluster map files
+   *                          will give the cluster name in Helix to bootstrap or upgrade.
+   * @param dcs the comma-separated list of data centers that needs to be migrated
+   * @throws Exception
+   */
+  static void migrateToPropertyStore(String hardwareLayoutPath, String partitionLayoutPath, String zkLayoutPath,
+      String clusterNamePrefix, String dcs) throws Exception {
+
+    HelixBootstrapUpgradeUtil helixBootstrapUpgradeUtil =
+        new HelixBootstrapUpgradeUtil(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterNamePrefix, dcs,
+            DEFAULT_MAX_PARTITIONS_PER_RESOURCE, false, false, null, null, null, null, null,
+            HelixAdminOperation.MigrateToPropertyStore);
+    helixBootstrapUpgradeUtil.migrateToPropertyStore();
+  }
+
+  /**
    * Drop a cluster from Helix.
    * @param zkLayoutPath the path to the zookeeper layout file.
    * @param clusterName the name of the cluster in Helix.
@@ -466,10 +487,7 @@ public class HelixBootstrapUpgradeUtil {
     dataCenterToZkAddress = parseAndUpdateDcInfoFromArg(dcs, zkLayoutPath);
     Properties props = new Properties();
     // The following properties are immaterial for the tool, but the ClusterMapConfig mandates their presence.
-    props.setProperty("clustermap.host.name", "localhost");
-    props.setProperty("clustermap.cluster.name", "");
-    props.setProperty("clustermap.datacenter.name", "");
-    ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
+    ClusterMapConfig clusterMapConfig = getClusterMapConfig("", "", null);
     if (new File(partitionLayoutPath).exists()) {
       staticClusterMap =
           (new StaticClusterAgentsFactory(clusterMapConfig, hardwareLayoutPath, partitionLayoutPath)).getClusterMap();
@@ -700,18 +718,45 @@ public class HelixBootstrapUpgradeUtil {
    * @param adminConfigZNodePath the znode path of admin config.
    */
   private void deleteClusterAdminInfos(String clusterAdminType, String adminConfigZNodePath) {
-    Properties storeProps = new Properties();
-    storeProps.setProperty("helix.property.store.root.path", "/" + clusterName + "/" + PROPERTYSTORE_STR);
-    HelixPropertyStoreConfig propertyStoreConfig = new HelixPropertyStoreConfig(new VerifiableProperties(storeProps));
     for (Map.Entry<String, ClusterMapUtils.DcZkInfo> entry : dataCenterToZkAddress.entrySet()) {
       info("Deleting {} infos for datacenter {}.", clusterAdminType, entry.getKey());
-      HelixPropertyStore<ZNRecord> helixPropertyStore =
-          CommonUtils.createHelixPropertyStore(entry.getValue().getZkConnectStrs().get(0), propertyStoreConfig, null);
+      HelixPropertyStore<ZNRecord> helixPropertyStore = createHelixPropertyStore(entry.getKey());
       if (!helixPropertyStore.remove(adminConfigZNodePath, AccessOption.PERSISTENT)) {
         logger.error("Failed to remove {} infos from datacenter {}", clusterAdminType, entry.getKey());
       }
       helixPropertyStore.stop();
     }
+  }
+
+  /**
+   * Convert instance configs to the new DataNodeConfig format and persist them in the property store.
+   */
+  private void migrateToPropertyStore() {
+    adminForDc.forEach((dcName, helixAdmin) -> {
+      logger.info("Starting property store migration in {}", dcName);
+      ClusterMapConfig config = getClusterMapConfig(clusterName, dcName, null);
+      InstanceConfigToDataNodeConfigAdapter.Converter instanceConfigConverter =
+          new InstanceConfigToDataNodeConfigAdapter.Converter(config);
+      HelixPropertyStore<ZNRecord> propertyStore = createHelixPropertyStore(dcName);
+      try {
+        PropertyStoreToDataNodeConfigAdapter propertyStoreAdapter =
+            new PropertyStoreToDataNodeConfigAdapter(propertyStore, config, dcName);
+        List<String> instanceNames = helixAdmin.getInstancesInCluster(clusterName);
+        logger.info("Found {} instances in cluster", instanceNames.size());
+        instanceNames.forEach(instanceName -> {
+          logger.info("Copying config for node {}", instanceName);
+          InstanceConfig instanceConfig = helixAdmin.getInstanceConfig(clusterName, instanceName);
+          DataNodeConfig dataNodeConfig = instanceConfigConverter.convert(instanceConfig);
+          logger.debug("Writing {} to property store in {}", dataNodeConfig, dcName);
+          if (!propertyStoreAdapter.set(dataNodeConfig)) {
+            logger.error("Failed to persist config for node {} in the property store.",
+                dataNodeConfig.getInstanceName());
+          }
+        });
+      } finally {
+        propertyStore.stop();
+      }
+    });
   }
 
   /**
@@ -1155,6 +1200,20 @@ public class HelixBootstrapUpgradeUtil {
   }
 
   /**
+   * @param dcName the datacenter to check in.
+   * @return true if the cluster is present and set up in this datacenter.
+   */
+  private boolean isClusterPresent(String dcName) {
+    if (zkClientForDc.get(dcName) == null) {
+      return Objects.requireNonNull(adminForDc.get(dcName), () -> "no admin for " + dcName)
+          .getClusters()
+          .contains(clusterName);
+    } else {
+      return ZKUtil.isClusterSetup(clusterName, zkClientForDc.get(dcName));
+    }
+  }
+
+  /**
    * Add new state model def to ambry cluster in enabled datacenter(s).
    */
   private void addStateModelDef() {
@@ -1162,9 +1221,7 @@ public class HelixBootstrapUpgradeUtil {
       // Add a cluster entry in every enabled DC
       String dcName = entry.getKey();
       HelixAdmin admin = entry.getValue();
-      boolean isClusterPresent = zkClientForDc.get(dcName) == null ? admin.getClusters().contains(clusterName)
-          : ZKUtil.isClusterSetup(clusterName, zkClientForDc.get(dcName));
-      if (!isClusterPresent) {
+      if (!isClusterPresent(dcName)) {
         throw new IllegalStateException("Cluster " + clusterName + " in " + dcName + " doesn't exist!");
       }
       if (!admin.getStateModelDefs(clusterName).contains(stateModelDef)) {
@@ -1273,9 +1330,7 @@ public class HelixBootstrapUpgradeUtil {
       // Add a cluster entry in every DC
       String dcName = entry.getKey();
       HelixAdmin admin = entry.getValue();
-      boolean isClusterPresent = zkClientForDc.get(dcName) == null ? admin.getClusters().contains(clusterName)
-          : ZKUtil.isClusterSetup(clusterName, zkClientForDc.get(dcName));
-      if (!isClusterPresent) {
+      if (!isClusterPresent(dcName)) {
         info("Adding cluster {} in {}", clusterName, dcName);
         admin.addCluster(clusterName);
         admin.addStateModelDef(clusterName, stateModelDef, getStateModelDefinition(stateModelDef));
@@ -1308,14 +1363,32 @@ public class HelixBootstrapUpgradeUtil {
    * @throws IOException if there was an error instantiating the cluster manager.
    */
   private void startClusterManager() throws IOException {
+    ClusterMapConfig clusterMapConfig =
+        getClusterMapConfig(clusterName, adminForDc.keySet().iterator().next(), zkLayoutPath);
+    HelixClusterAgentsFactory helixClusterAgentsFactory = new HelixClusterAgentsFactory(clusterMapConfig, null, null);
+    validatingHelixClusterManager = helixClusterAgentsFactory.getClusterMap();
+  }
+
+  /**
+   * Exposed for test use.
+   * @param clusterName cluster name to use in the config
+   * @param dcName datacenter name to use in the config
+   * @param zkLayoutPath if non-null, read ZK connection configs from the file at this path.
+   * @return the {@link ClusterMapConfig}
+   */
+  static ClusterMapConfig getClusterMapConfig(String clusterName, String dcName, String zkLayoutPath) {
     Properties props = new Properties();
     props.setProperty("clustermap.host.name", "localhost");
     props.setProperty("clustermap.cluster.name", clusterName);
-    props.setProperty("clustermap.datacenter.name", adminForDc.keySet().iterator().next());
-    props.setProperty("clustermap.dcs.zk.connect.strings", Utils.readStringFromFile(zkLayoutPath));
-    ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
-    HelixClusterAgentsFactory helixClusterAgentsFactory = new HelixClusterAgentsFactory(clusterMapConfig, null, null);
-    validatingHelixClusterManager = helixClusterAgentsFactory.getClusterMap();
+    props.setProperty("clustermap.datacenter.name", dcName);
+    if (zkLayoutPath != null) {
+      try {
+        props.setProperty("clustermap.dcs.zk.connect.strings", Utils.readStringFromFile(zkLayoutPath));
+      } catch (IOException e) {
+        throw new RuntimeException("Could not read zk layout file", e);
+      }
+    }
+    return new ClusterMapConfig(new VerifiableProperties(props));
   }
 
   /**
@@ -1367,8 +1440,7 @@ public class HelixBootstrapUpgradeUtil {
         info("Skipping {}", dc.getName());
         continue;
       }
-      ensureOrThrow(zkClientForDc.get(dc.getName()) == null ? admin.getClusters().contains(clusterName)
-              : ZKUtil.isClusterSetup(clusterName, zkClientForDc.get(dc.getName())),
+      ensureOrThrow(isClusterPresent(dc.getName()),
           "Cluster not found in ZK " + dataCenterToZkAddress.get(dc.getName()));
       Utils.newThread(() -> {
         try {
@@ -1456,8 +1528,7 @@ public class HelixBootstrapUpgradeUtil {
         info("Skipping {}", dc.getName());
         continue;
       }
-      ensureOrThrow(zkClientForDc.get(dc.getName()) == null ? admin.getClusters().contains(clusterName)
-              : ZKUtil.isClusterSetup(clusterName, zkClientForDc.get(dc.getName())),
+      ensureOrThrow(isClusterPresent(dc.getName()),
           "Cluster not found in ZK " + dataCenterToZkAddress.get(dc.getName()));
       Utils.newThread(() -> {
         try {
@@ -1487,11 +1558,7 @@ public class HelixBootstrapUpgradeUtil {
   private void verifyDataNodeAndDiskEquivalencyInDc(Datacenter dc, String clusterName,
       PartitionLayout partitionLayout) {
     // The following properties are immaterial for the tool, but the ClusterMapConfig mandates their presence.
-    Properties props = new Properties();
-    props.setProperty("clustermap.host.name", "localhost");
-    props.setProperty("clustermap.cluster.name", clusterName);
-    props.setProperty("clustermap.datacenter.name", dc.getName());
-    ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
+    ClusterMapConfig clusterMapConfig = getClusterMapConfig(clusterName, dc.getName(), null);
     StaticClusterManager staticClusterMap =
         (new StaticClusterAgentsFactory(clusterMapConfig, partitionLayout)).getClusterMap();
     String dcName = dc.getName();

--- a/ambry-tools/src/integration-test/java/com/github/ambry/clustermap/HelixBootstrapUpgradeToolTest.java
+++ b/ambry-tools/src/integration-test/java/com/github/ambry/clustermap/HelixBootstrapUpgradeToolTest.java
@@ -874,7 +874,7 @@ public class HelixBootstrapUpgradeToolTest {
         PropertyStoreToDataNodeConfigAdapter propertyStoreAdapter =
             new PropertyStoreToDataNodeConfigAdapter(propertyStore,
                 HelixBootstrapUpgradeUtil.getClusterMapConfig(CLUSTER_NAME_PREFIX + CLUSTER_NAME_IN_STATIC_CLUSTER_MAP,
-                    dcName, null), dcName);
+                    dcName, null));
         Map<DataNodeId, Set<String>> dataNodeToReplicas = testPartitionLayout.getPartitionLayout()
             .getPartitions(null)
             .stream()

--- a/ambry-tools/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeTool.java
+++ b/ambry-tools/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeTool.java
@@ -96,14 +96,14 @@ public class HelixBootstrapUpgradeTool {
   public static void main(String[] args) throws Exception {
     OptionParser parser = new OptionParser();
 
-    OptionSpec dropClusterOpt = parser.accepts("dropCluster",
+    OptionSpec<Void> dropClusterOpt = parser.accepts("dropCluster",
         "Drops the given Ambry cluster from Helix. Use this option with care. If present, must be accompanied with and "
             + "only with the clusterName argument");
 
-    OptionSpec forceRemove = parser.accepts("forceRemove",
+    OptionSpec<Void> forceRemove = parser.accepts("forceRemove",
         "Specifies that any instances or partitions absent in the json files be removed from Helix. Use this with care");
 
-    OptionSpec addStateModel = parser.accepts("addStateModel",
+    OptionSpec<Void> addStateModel = parser.accepts("addStateModel",
         "Attempt to add new state model to Helix StateModelDefs if it doesn't exist. This option will not touch instanceConfig");
 
     ArgumentAcceptingOptionSpec<String> hardwareLayoutPathOpt =
@@ -174,13 +174,14 @@ public class HelixBootstrapUpgradeTool {
 
     ArgumentAcceptingOptionSpec<String> adminOperationOpt = parser.accepts("adminOperation",
         "(Optional argument) Perform admin operations to manage resources in cluster. For example: "
-            + " '--adminOperation UpdateIdealState'     # Update IdealState based on static clustermap. This won't change InstanceConfig"
-            + " '--adminOperation DisablePartition'     # Disable partition on certain node. Usually used as first step to decommission replica(s)"
-            + " '--adminOperation EnablePartition'      # Enable partition on certain node (if partition is previously disabled)"
-            + " '--adminOperation ResetPartition'       # Reset partition on certain node (if partition is previously in error state)"
-            + " '--adminOperation ListSealedPartition'  # List all sealed partitions in Helix cluster (aggregated across all datacenters)"
-            + " '--adminOperation ValidateCluster'      # Validates the information in static clustermap is consistent with the information in Helix"
-            + " '--adminOperation BootstrapCluster'     # (Default operation if not specified) Bootstrap cluster based on static clustermap")
+            + " '--adminOperation UpdateIdealState' # Update IdealState based on static clustermap. This won't change InstanceConfig"
+            + " '--adminOperation DisablePartition' # Disable partition on certain node. Usually used as first step to decommission replica(s)"
+            + " '--adminOperation EnablePartition' # Enable partition on certain node (if partition is previously disabled)"
+            + " '--adminOperation ResetPartition' # Reset partition on certain node (if partition is previously in error state)"
+            + " '--adminOperation ListSealedPartition' # List all sealed partitions in Helix cluster (aggregated across all datacenters)"
+            + " '--adminOperation ValidateCluster' # Validates the information in static clustermap is consistent with the information in Helix"
+            + " '--adminOperation MigrateToPropertyStore' # Migrate custom instance config properties to DataNodeConfigs in the property store"
+            + " '--adminOperation BootstrapCluster' # (Default operation if not specified) Bootstrap cluster based on static clustermap")
         .withRequiredArg()
         .describedAs("admin_operation")
         .ofType(String.class);
@@ -271,6 +272,10 @@ public class HelixBootstrapUpgradeTool {
           break;
         case ListSealedPartition:
           HelixBootstrapUpgradeUtil.listSealedPartition(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
+              clusterNamePrefix, dcs);
+          break;
+        case MigrateToPropertyStore:
+          HelixBootstrapUpgradeUtil.migrateToPropertyStore(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
               clusterNamePrefix, dcs);
           break;
         case ResetPartition:


### PR DESCRIPTION
This HelixBootstrapUpgradeTool operation will fetch all instance configs
for a cluster, convert them into the new format, and then persist them
in the property store.