### PR TITLE
Several minor changes in operation tracker and ambry partition

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/clustermap/ClusterMapSnapshotConstants.java
+++ b/ambry-api/src/main/java/com/github/ambry/clustermap/ClusterMapSnapshotConstants.java
@@ -56,7 +56,7 @@ public class ClusterMapSnapshotConstants {
   // partitions
   public static final String PARTITION_ID = "id";
   public static final String PARTITION_CLASS = "class";
-  public static final String PARTITION_RESOURCE_ID = "resourceId";
+  public static final String PARTITION_RESOURCE_NAME = "resourceName";
   public static final String PARTITION_WRITE_STATE = "writeState";
   public static final String PARTITION_REPLICAS = "replicas";
 

--- a/ambry-api/src/main/java/com/github/ambry/clustermap/ClusterMapSnapshotConstants.java
+++ b/ambry-api/src/main/java/com/github/ambry/clustermap/ClusterMapSnapshotConstants.java
@@ -56,6 +56,7 @@ public class ClusterMapSnapshotConstants {
   // partitions
   public static final String PARTITION_ID = "id";
   public static final String PARTITION_CLASS = "class";
+  public static final String PARTITION_RESOURCE_ID = "resourceId";
   public static final String PARTITION_WRITE_STATE = "writeState";
   public static final String PARTITION_REPLICAS = "replicas";
 

--- a/ambry-api/src/main/java/com/github/ambry/clustermap/PartitionId.java
+++ b/ambry-api/src/main/java/com/github/ambry/clustermap/PartitionId.java
@@ -73,4 +73,11 @@ public interface PartitionId extends Resource, Comparable<PartitionId> {
    * @return the partition class that this partition belongs to
    */
   String getPartitionClass();
+
+  /**
+   * @return the resource name which this partition belongs to. Can be null if resource is not defined or applicable.
+   */
+  default String getResourceName() {
+    return null;
+  }
 }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryPartition.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryPartition.java
@@ -138,11 +138,17 @@ public class AmbryPartition implements PartitionId {
   }
 
   @Override
+  public String getResourceName() {
+    return clusterManagerCallback.getResourceNameForPartition(this);
+  }
+
+  @Override
   public JSONObject getSnapshot() {
     JSONObject snapshot = new JSONObject();
     snapshot.put(PARTITION_ID, toPathString());
     snapshot.put(PARTITION_WRITE_STATE, getPartitionState().name());
     snapshot.put(PARTITION_CLASS, getPartitionClass());
+    snapshot.put(PARTITION_RESOURCE_ID, getResourceName());
     JSONArray replicas = new JSONArray();
     getReplicaIds().forEach(replica -> replicas.put(replica.getSnapshot()));
     snapshot.put(PARTITION_REPLICAS, replicas);

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryPartition.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryPartition.java
@@ -148,7 +148,7 @@ public class AmbryPartition implements PartitionId {
     snapshot.put(PARTITION_ID, toPathString());
     snapshot.put(PARTITION_WRITE_STATE, getPartitionState().name());
     snapshot.put(PARTITION_CLASS, getPartitionClass());
-    snapshot.put(PARTITION_RESOURCE_ID, getResourceName());
+    snapshot.put(PARTITION_RESOURCE_NAME, getResourceName());
     JSONArray replicas = new JSONArray();
     getReplicaIds().forEach(replica -> replicas.put(replica.getSnapshot()));
     snapshot.put(PARTITION_REPLICAS, replicas);

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterManagerCallback.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterManagerCallback.java
@@ -30,6 +30,15 @@ interface ClusterManagerCallback<R extends ReplicaId, D extends DiskId, P extend
   List<R> getReplicaIdsForPartition(P partition);
 
   /**
+   * Get resource name associated with given partition.
+   * @param partition the {@link PartitionId} for which to get the resource name.
+   * @return the resource name associated with given partition.
+   */
+  default String getResourceNameForPartition(P partition) {
+    return null;
+  }
+
+  /**
    * Get replicas of given partition from specified datacenter that are in required state
    * @param partition the {@link PartitionId} for which to get the list of replicas.
    * @param state {@link ReplicaState} associated with replica

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
@@ -668,6 +668,20 @@ public class HelixClusterManager implements ClusterMap {
       return new ArrayList<>(ambryPartitionToAmbryReplicas.get(partition));
     }
 
+    @Override
+    public String getResourceNameForPartition(AmbryPartition partition) {
+      String result = null;
+      // go through all datacenters in case that partition resides in one datacenter only
+      for (DcInfo dcInfo : dcToDcInfo.values()) {
+        String resourceName = dcInfo.clusterChangeHandler.getPartitionToResourceMap().get(partition.toPathString());
+        if (resourceName != null) {
+          result = resourceName;
+          break;
+        }
+      }
+      return result;
+    }
+
     /**
      * {@inheritDoc}
      * If dcName is null, then get replicas by given state from all datacenters.

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/ClusterChangeHandlerTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/ClusterChangeHandlerTest.java
@@ -425,6 +425,10 @@ public class ClusterChangeHandlerTest {
     Set<String> partitionNames = partitionIds.stream().map(PartitionId::toPathString).collect(Collectors.toSet());
     assertEquals("Some partitions are not present in partition-to-resource map", partitionNames,
         partitionNameToResource.keySet());
+    // verify all partitions are able to get their resource name
+    helixClusterManager.getAllPartitionIds(DEFAULT_PARTITION_CLASS)
+        .forEach(partitionId -> assertEquals("Resource name is not expected",
+            partitionNameToResource.get(partitionId.toPathString()), partitionId.getResourceName()));
     helixClusterManager.close();
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -152,12 +152,7 @@ project(':ambry-utils') {
         compile "org.json:json:$jsonVersion"
         compile "net.sf.jopt-simple:jopt-simple:$joptSimpleVersion"
         compile "io.netty:netty-buffer:$nettyVersion"
-        testCompile ("org.apache.helix:helix-core:$helixVersion") {
-            // TODO Once new release is out, we can remove this
-            exclude group: "org.apache.helix", module: "helix-common"
-        }
-        // TODO remove zookeeper dependency once Helix open source fix is out
-        testCompile "org.apache.zookeeper:zookeeper:3.4.13"
+        testCompile "org.apache.helix:helix-core:$helixVersion"
         testCompile project(":ambry-test-utils")
     }
 }
@@ -178,12 +173,7 @@ project(':ambry-api') {
         compile project(':ambry-utils')
         compile ("org.apache.helix:helix-core:$helixVersion") {
             exclude group: "log4j", module: "log4j"
-            // This is a workaround for https://github.com/apache/helix/issues/1022.
-            // TODO Once new release is out, we can remove this
-            exclude group: "org.apache.helix", module: "helix-common"
         }
-        // TODO remove zookeeper dependency once Helix open source fix is out
-        compile "org.apache.zookeeper:zookeeper:3.4.13"
         compile "io.dropwizard.metrics:metrics-core:$metricsVersion"
         compile "org.codehaus.jackson:jackson-core-asl:$jacksonVersion"
         compile "org.codehaus.jackson:jackson-mapper-asl:$jacksonVersion"
@@ -198,12 +188,7 @@ project(':ambry-account') {
         compile project(':ambry-api'),
                 project(':ambry-utils'),
                 project(':ambry-commons')
-        compile ("org.apache.helix:helix-core:$helixVersion") {
-            // TODO remove this once Helix open source fix is out
-            exclude group: "org.apache.helix", module: "helix-common"
-        }
-        // TODO remove zookeeper dependency once Helix open source fix is out
-        compile "org.apache.zookeeper:zookeeper:3.4.13"
+        compile "org.apache.helix:helix-core:$helixVersion"
         compile "io.dropwizard.metrics:metrics-core:$metricsVersion"
         compile "org.json:json:$jsonVersion"
         testCompile project(':ambry-test-utils')
@@ -216,12 +201,7 @@ project(':ambry-clustermap') {
     dependencies {
         compile project(':ambry-api'),
                 project(':ambry-utils')
-        compile ("org.apache.helix:helix-core:$helixVersion") {
-            // TODO remove this once Helix open source fix is out
-            exclude group: "org.apache.helix", module: "helix-common"
-        }
-        // TODO remove zookeeper dependency once Helix open source fix is out
-        compile "org.apache.zookeeper:zookeeper:3.4.13"
+        compile "org.apache.helix:helix-core:$helixVersion"
         compile "io.dropwizard.metrics:metrics-core:$metricsVersion"
         compile "org.json:json:$jsonVersion"
         testCompile project(':ambry-commons')

--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -19,7 +19,7 @@ ext {
     javaxVersion = "3.0.1"
     nettyVersion = "4.1.42.Final"
     nettyTcnativeVersion = "2.0.26.Final"
-    helixVersion = "1.0.0"
+    helixVersion = "1.0.1"
     jacksonVersion = "1.8.5"
     jaydioVersion = "0.1"
     azureStorageVersion = "12.2.0"


### PR DESCRIPTION
1. allow replica in OFFLINE state to be added to replica pool for GET operation
2. support getting resource name associated with ambry partition (if Helix is adopted)
3. upgrade helix library to version 1.0.1