### PR TITLE
Mark container status inactive in Zk

### DIFF
--- a/ambry-account/src/main/java/com/github/ambry/account/AccountServiceMetrics.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/AccountServiceMetrics.java
@@ -46,44 +46,47 @@ public class AccountServiceMetrics {
   public final Counter accountUpdatesToAmbryServerErrorCount;
   public final Counter accountDeletesToAmbryServerErrorCount;
   public final Counter accountFetchFromAmbryServerErrorCount;
+  public final Counter accountUpdatesToZkErrorCount;
 
   public AccountServiceMetrics(MetricRegistry metricRegistry) {
     // Histogram
     startupTimeInMs = metricRegistry.histogram(MetricRegistry.name(HelixAccountService.class, "StartupTimeInMs"));
     updateAccountTimeInMs =
-        metricRegistry.histogram(MetricRegistry.name(HelixAccountService.class, "UpdateAccountTimeInMs"));
+            metricRegistry.histogram(MetricRegistry.name(HelixAccountService.class, "UpdateAccountTimeInMs"));
     fetchRemoteAccountTimeInMs =
-        metricRegistry.histogram(MetricRegistry.name(HelixAccountService.class, "FetchRemoteAccountTimeInMs"));
+            metricRegistry.histogram(MetricRegistry.name(HelixAccountService.class, "FetchRemoteAccountTimeInMs"));
     accountUpdateConsumerTimeInMs =
-        metricRegistry.histogram(MetricRegistry.name(HelixAccountService.class, "AccountUpdateConsumerTimeInMs"));
+            metricRegistry.histogram(MetricRegistry.name(HelixAccountService.class, "AccountUpdateConsumerTimeInMs"));
     accountUpdateToAmbryTimeInMs =
-        metricRegistry.histogram(MetricRegistry.name(HelixAccountService.class, "AccountUpdateToAmbryTimeInMs"));
+            metricRegistry.histogram(MetricRegistry.name(HelixAccountService.class, "AccountUpdateToAmbryTimeInMs"));
     accountFetchFromAmbryTimeInMs =
-        metricRegistry.histogram(MetricRegistry.name(HelixAccountService.class, "AccountFetchFromAmbryTimeInMs"));
+            metricRegistry.histogram(MetricRegistry.name(HelixAccountService.class, "AccountFetchFromAmbryTimeInMs"));
     backupWriteTimeInMs =
-        metricRegistry.histogram(MetricRegistry.name(HelixAccountService.class, "BackupWriteTimeInMs"));
+            metricRegistry.histogram(MetricRegistry.name(HelixAccountService.class, "BackupWriteTimeInMs"));
     backupReadTimeInMs = metricRegistry.histogram(MetricRegistry.name(HelixAccountService.class, "BackupReadTimeInMs"));
 
     // Counter
     unrecognizedMessageErrorCount =
-        metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "UnrecognizedMessageErrorCount"));
+            metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "UnrecognizedMessageErrorCount"));
     notifyAccountDataChangeErrorCount =
-        metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "NotifyAccountDataChangeErrorCount"));
+            metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "NotifyAccountDataChangeErrorCount"));
     updateAccountErrorCount =
-        metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "UpdateAccountErrorCount"));
+            metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "UpdateAccountErrorCount"));
+    accountUpdatesToZkErrorCount =
+            metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "AccountUpdatesToZkErrorCount"));
     fetchRemoteAccountErrorCount =
-        metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "FetchRemoteAccountErrorCount"));
+            metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "FetchRemoteAccountErrorCount"));
     remoteDataCorruptionErrorCount =
-        metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "RemoteDataCorruptionErrorCount"));
+            metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "RemoteDataCorruptionErrorCount"));
     backupErrorCount = metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "BackupErrorCount"));
     nullNotifierCount = metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "NullNotifierCount"));
     accountUpdatesCapturedByScheduledUpdaterCount = metricRegistry.counter(
-        MetricRegistry.name(HelixAccountService.class, "AccountUpdatesCapturedByScheduledUpdaterCount"));
+            MetricRegistry.name(HelixAccountService.class, "AccountUpdatesCapturedByScheduledUpdaterCount"));
     accountUpdatesToAmbryServerErrorCount =
-        metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "AccountUpdatesToAmbryServerErrorCount"));
+            metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "AccountUpdatesToAmbryServerErrorCount"));
     accountDeletesToAmbryServerErrorCount =
-        metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "AccountDeletesToAmbryServerErrorCount"));
+            metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "AccountDeletesToAmbryServerErrorCount"));
     accountFetchFromAmbryServerErrorCount =
-        metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "AccountFetchFromAmbryServerErrorCount"));
+            metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "AccountFetchFromAmbryServerErrorCount"));
   }
 }

--- a/ambry-account/src/main/java/com/github/ambry/account/HelixAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/HelixAccountService.java
@@ -375,15 +375,44 @@ public class HelixAccountService extends AbstractAccountService implements Accou
    */
   public void selectInactiveContainersAndMarkInZK(StatsSnapshot statsSnapshot) {
     Set<Container> inactiveContainerCandidateSet = selectInactiveContainerCandidates(statsSnapshot);
-    markContainerInactiveOnZk(inactiveContainerCandidateSet);
+    try {
+      markContainerInactiveOnZk(inactiveContainerCandidateSet);
+    } catch (InterruptedException e) {
+      logger.error("Mark inactive container in zookeeper is interrupted", e);
+    }
   }
 
   /**
    * Mark the given {@link Container}s status to INACTIVE in zookeeper.
    * @param inactiveContainerCandidateSet DELETE_IN_PROGRESS {@link Container} set which has been deleted successfully during compaction.
    */
-  private void markContainerInactiveOnZk(Set<Container> inactiveContainerCandidateSet) {
-    // TODO: mark the given containers status to INACTIVE in zookeeper.
+  void markContainerInactiveOnZk(Set<Container> inactiveContainerCandidateSet) throws InterruptedException {
+    if (inactiveContainerCandidateSet != null) {
+      boolean successful = false;
+      int retry = 0;
+      while (!successful && retry < config.retryCount) {
+        Map<Short, Account> accountToUpdateMap = new HashMap<>();
+        inactiveContainerCandidateSet.forEach(container -> {
+          // start by getting account, and then get container from account to make sure that we are editing the most
+          // recent snapshot
+          short accountId = container.getParentAccountId();
+          Account accountToEdit = accountToUpdateMap.computeIfAbsent(accountId, this::getAccountById);
+          Container containerToEdit = accountToEdit.getContainerById(container.getId());
+          Container editedContainer =
+                  new ContainerBuilder(containerToEdit).setStatus(Container.ContainerStatus.INACTIVE).build();
+          accountToUpdateMap.put(accountId,
+                  new AccountBuilder(accountToEdit).addOrUpdateContainer(editedContainer).build());
+        });
+        successful = updateAccounts(accountToUpdateMap.values());
+        if (!successful) {
+          retry++;
+          Thread.sleep(config.retryDelay);
+        }
+      }
+      if (!successful) {
+        logger.error("Container failed to be marked as INACTIVE in inactiveContainerCandidateSet : {}", inactiveContainerCandidateSet);
+      }
+    }
   }
 
   /**

--- a/ambry-account/src/main/java/com/github/ambry/account/HelixAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/HelixAccountService.java
@@ -388,9 +388,9 @@ public class HelixAccountService extends AbstractAccountService implements Accou
    */
   void markContainerInactiveOnZk(Set<Container> inactiveContainerCandidateSet) throws InterruptedException {
     if (inactiveContainerCandidateSet != null) {
-      boolean successful = false;
+      boolean success = false;
       int retry = 0;
-      while (!successful && retry < config.maxRetryCountOnUpdateFailure) {
+      while (!success && retry < config.maxRetryCountOnUpdateFailure) {
         Map<Short, Account> accountToUpdateMap = new HashMap<>();
         inactiveContainerCandidateSet.forEach(container -> {
           // start by getting account, and then get container from account to make sure that we are editing the most
@@ -403,13 +403,13 @@ public class HelixAccountService extends AbstractAccountService implements Accou
           accountToUpdateMap.put(accountId,
                   new AccountBuilder(accountToEdit).addOrUpdateContainer(editedContainer).build());
         });
-        successful = updateAccounts(accountToUpdateMap.values());
-        if (!successful) {
+        success = updateAccounts(accountToUpdateMap.values());
+        if (!success) {
           retry++;
           Thread.sleep(config.retryDelayMs);
         }
       }
-      if (!successful) {
+      if (!success) {
         logger.error("Failed to mark containers INACTIVE in set : {}  after {} retries", inactiveContainerCandidateSet, config.maxRetryCountOnUpdateFailure);
         accountServiceMetrics.accountUpdatesToZkErrorCount.inc();
       }

--- a/ambry-account/src/test/java/com/github/ambry/account/HelixAccountServiceTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/HelixAccountServiceTest.java
@@ -248,6 +248,15 @@ public class HelixAccountServiceTest {
     Set<Container> inactiveContainerSet =
         ((HelixAccountService) accountService).selectInactiveContainerCandidates(statsSnapshot);
     assertTrue("Mismatch in container Set after detect", expectContainerSet.equals(inactiveContainerSet));
+    ((HelixAccountService) accountService).markContainerInactiveOnZk(inactiveContainerSet);
+    Account testAccount0 = accountService.getAccountById((short) 0);
+    for (Container container : testAccount0.getAllContainers()) {
+      assertEquals("Based on the stats report, container has not been compacted yet", ContainerStatus.DELETE_IN_PROGRESS, container.getStatus());
+    }
+    Account testAccount1 = accountService.getAccountById((short) 1);
+    for (Container container : testAccount1.getAllContainers()) {
+      assertEquals("Based on the stats report, inactive container status needs to be set as INACTIVE", ContainerStatus.INACTIVE, container.getStatus());
+    }
   }
 
   /**

--- a/ambry-api/src/main/java/com/github/ambry/config/HelixAccountServiceConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/HelixAccountServiceConfig.java
@@ -30,8 +30,8 @@ public class HelixAccountServiceConfig {
   public static final String ENABLE_SERVE_FROM_BACKUP = HELIX_ACCOUNT_SERVICE_PREFIX + "enable.serve.from.backup";
   public static final String TOTAL_NUMBER_OF_VERSION_TO_KEEP =
       HELIX_ACCOUNT_SERVICE_PREFIX + "total.number.of.version.to.keep";
-  public static final String RETRY_COUNT = HELIX_ACCOUNT_SERVICE_PREFIX + "retry.count";
-  public static final String RETRY_DELAY = HELIX_ACCOUNT_SERVICE_PREFIX + "retry.delay";
+  public static final String MAX_RETRY_COUNT_ON_UPDATE_FAILURE = HELIX_ACCOUNT_SERVICE_PREFIX + "retry.count.on.update.failure";
+  public static final String RETRY_DELAY_MS = HELIX_ACCOUNT_SERVICE_PREFIX + "retry.delay.ms";
   /**
    * The ZooKeeper server address. This config is required when using {@code HelixAccountService}.
    */
@@ -103,16 +103,16 @@ public class HelixAccountServiceConfig {
   /**
    * The number of retry times when the update accounts fails by marking delete_in_progress container status to inactive;
    */
-  @Config(RETRY_COUNT)
+  @Config(MAX_RETRY_COUNT_ON_UPDATE_FAILURE)
   @Default("10")
-  public final int retryCount;
+  public final int maxRetryCountOnUpdateFailure;
 
   /**
    * The sleep time between each retry action when the update accounts fails by marking delete_in_progress container status to inactive;
    */
-  @Config(RETRY_DELAY)
+  @Config(RETRY_DELAY_MS)
   @Default("1000")
-  public final long retryDelay;
+  public final long retryDelayMs;
 
   public HelixAccountServiceConfig(VerifiableProperties verifiableProperties) {
     zkClientConnectString = verifiableProperties.getString(ZK_CLIENT_CONNECT_STRING_KEY);
@@ -127,7 +127,7 @@ public class HelixAccountServiceConfig {
     enableServeFromBackup = verifiableProperties.getBoolean(ENABLE_SERVE_FROM_BACKUP, false);
     totalNumberOfVersionToKeep =
         verifiableProperties.getIntInRange(TOTAL_NUMBER_OF_VERSION_TO_KEEP, 100, 1, Integer.MAX_VALUE);
-    retryCount = verifiableProperties.getIntInRange(RETRY_COUNT, 10, 1, 100);
-    retryDelay = verifiableProperties.getLongInRange(RETRY_DELAY, 1000, 1, Long.MAX_VALUE);
+    maxRetryCountOnUpdateFailure = verifiableProperties.getIntInRange(MAX_RETRY_COUNT_ON_UPDATE_FAILURE, 10, 1, 100);
+    retryDelayMs = verifiableProperties.getLongInRange(RETRY_DELAY_MS, 1000, 1, Long.MAX_VALUE);
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/config/HelixAccountServiceConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/HelixAccountServiceConfig.java
@@ -30,7 +30,8 @@ public class HelixAccountServiceConfig {
   public static final String ENABLE_SERVE_FROM_BACKUP = HELIX_ACCOUNT_SERVICE_PREFIX + "enable.serve.from.backup";
   public static final String TOTAL_NUMBER_OF_VERSION_TO_KEEP =
       HELIX_ACCOUNT_SERVICE_PREFIX + "total.number.of.version.to.keep";
-
+  public static final String RETRY_COUNT = HELIX_ACCOUNT_SERVICE_PREFIX + "retry.count";
+  public static final String RETRY_DELAY = HELIX_ACCOUNT_SERVICE_PREFIX + "retry.delay";
   /**
    * The ZooKeeper server address. This config is required when using {@code HelixAccountService}.
    */
@@ -99,6 +100,20 @@ public class HelixAccountServiceConfig {
   @Default("100")
   public final int totalNumberOfVersionToKeep;
 
+  /**
+   * The number of retry times when the update accounts fails by marking delete_in_progress container status to inactive;
+   */
+  @Config(RETRY_COUNT)
+  @Default("10")
+  public final int retryCount;
+
+  /**
+   * The sleep time between each retry action when the update accounts fails by marking delete_in_progress container status to inactive;
+   */
+  @Config(RETRY_DELAY)
+  @Default("1000")
+  public final long retryDelay;
+
   public HelixAccountServiceConfig(VerifiableProperties verifiableProperties) {
     zkClientConnectString = verifiableProperties.getString(ZK_CLIENT_CONNECT_STRING_KEY);
     updaterPollingIntervalMs =
@@ -112,5 +127,7 @@ public class HelixAccountServiceConfig {
     enableServeFromBackup = verifiableProperties.getBoolean(ENABLE_SERVE_FROM_BACKUP, false);
     totalNumberOfVersionToKeep =
         verifiableProperties.getIntInRange(TOTAL_NUMBER_OF_VERSION_TO_KEEP, 100, 1, Integer.MAX_VALUE);
+    retryCount = verifiableProperties.getIntInRange(RETRY_COUNT, 10, 1, 100);
+    retryDelay = verifiableProperties.getLongInRange(RETRY_DELAY, 1000, 1, Long.MAX_VALUE);
   }
 }


### PR DESCRIPTION
Mark status inactive for all the containers in inactiveContainerCandidateSet. The set is generated based on aggregation stats report, all the delete_in_progress containers which have been fully compacted will be included in the set.