### PR TITLE
Fix reference counter error in socketNetworkClient

### DIFF
--- a/ambry-network/src/main/java/com/github/ambry/network/SocketNetworkClient.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/SocketNetworkClient.java
@@ -355,7 +355,8 @@ public class SocketNetworkClient implements NetworkClient {
           // No need to call pendingRequests.remove() because it has been removed due to connection unavailability in prepareSends()
         }
       }
-      if (requestMetadata != null) {
+      // if request is send completed, its resource has already been released.
+      if (requestMetadata != null && !requestMetadata.requestInfo.getRequest().isSendComplete()) {
         requestMetadata.requestInfo.getRequest().release();
       }
       networkMetrics.connectionDisconnected.inc();


### PR DESCRIPTION
SocketNetworkClient would throw lots of IllegalReferenceCountException when any ambry-server dies. This is caused by a bug where I released the request twice. When a request is sent to server completed, it will be released by selector. And when it gets disconnected when it's waiting for response, it will be released again. This PR fixes that. It checks if the request is sentCompleted, if not, it will release the request when disconnected.