### PR TITLE
Fix reference counter exception when closing SocketNetworkClient

### DIFF
--- a/ambry-network/src/main/java/com/github/ambry/network/SocketNetworkClient.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/SocketNetworkClient.java
@@ -393,7 +393,11 @@ public class SocketNetworkClient implements NetworkClient {
     if (pendingConnectionsToAssociatedRequests != null) {
       requestMetadataToRelease.addAll(pendingConnectionsToAssociatedRequests.values());
     }
-    requestMetadataToRelease.forEach(requestMetadata -> requestMetadata.requestInfo.getRequest().release());
+    requestMetadataToRelease.forEach(requestMetadata -> {
+      if (!requestMetadata.requestInfo.getRequest().isSendComplete()) {
+        requestMetadata.requestInfo.getRequest().release();
+      }
+    });
     logger.trace("Closing the SocketNetworkClient");
     selector.close();
     closed = true;


### PR DESCRIPTION
When closing SocketNetworkClient, we release all the dangling requests. But some requests already released by the selector when it finished sending bytes to the server. Skip those requests to avoid the IllegalReferenceCounterException.