### PR TITLE
Add configuration to limit the number of concurrent delete operations in background deleter

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
@@ -103,6 +103,8 @@ public class RouterConfig {
   public static final String ROUTER_ENABLE_HTTP2_NETWORK_CLIENT = "router.enable.http2.network.client";
   public static final String ROUTER_CROSS_COLO_REQUEST_TO_DC_WITH_MOST_REPLICAS =
       "router.cross.colo.request.to.dc.with.most.replicas";
+  public static final String ROUTER_BACKGROUND_DELETER_MAX_CONCURRENT_OPERATIONS =
+      "router.background.deleter.max.concurrent.operations";
 
   /**
    * Number of independent scaling units for the router.
@@ -501,6 +503,13 @@ public class RouterConfig {
   public final boolean routerCrossColoRequestToDcWithMostReplicas;
 
   /**
+   * The maximum number of outgoing delete operations in background deleter. 0 means no limit.
+   */
+  @Config(ROUTER_BACKGROUND_DELETER_MAX_CONCURRENT_OPERATIONS)
+  @Default("0")
+  public final int routerBackgroundDeleterMaxConcurrentOperations;
+
+  /**
    * Create a RouterConfig instance.
    * @param verifiableProperties the properties map to refer to.
    */
@@ -607,5 +616,8 @@ public class RouterConfig {
     routerEnableHttp2NetworkClient = verifiableProperties.getBoolean(ROUTER_ENABLE_HTTP2_NETWORK_CLIENT, false);
     routerCrossColoRequestToDcWithMostReplicas =
         verifiableProperties.getBoolean(ROUTER_CROSS_COLO_REQUEST_TO_DC_WITH_MOST_REPLICAS, false);
+    routerBackgroundDeleterMaxConcurrentOperations =
+        verifiableProperties.getIntInRange(ROUTER_BACKGROUND_DELETER_MAX_CONCURRENT_OPERATIONS, 0, 0,
+            Integer.MAX_VALUE);
   }
 }

--- a/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterMetrics.java
@@ -637,13 +637,18 @@ public class NonBlockingRouterMetrics {
    * @param currentOperationsCount The counter of {@code OperationController}.
    * @param currentBackgroundOperationsCount The counter of background operations submitted to the router that are not
    *                                         yet completed.
+   * @param concurrentBackgroundDeleteOperationCount The counter of concurrent background delete operations.
    */
   public void initializeNumActiveOperationsMetrics(final AtomicInteger currentOperationsCount,
-      final AtomicInteger currentBackgroundOperationsCount) {
+      final AtomicInteger currentBackgroundOperationsCount,
+      final AtomicInteger concurrentBackgroundDeleteOperationCount) {
     metricRegistry.register(MetricRegistry.name(NonBlockingRouter.class, "NumActiveOperations"),
         (Gauge<Integer>) currentOperationsCount::get);
     metricRegistry.register(MetricRegistry.name(NonBlockingRouter.class, "NumActiveBackgroundOperations"),
         (Gauge<Integer>) currentBackgroundOperationsCount::get);
+    metricRegistry.register(
+        MetricRegistry.name(NonBlockingRouter.BackgroundDeleter.class, "NumberConcurrentBackgroundDeleteOperations"),
+        (Gauge<Integer>) concurrentBackgroundDeleteOperationCount::get);
   }
 
   /**

--- a/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTest.java
@@ -837,9 +837,28 @@ public class NonBlockingRouterTest {
    */
   @Test
   public void testCompositeBlobDataChunksDelete() throws Exception {
+    // Test when there is no limit on how many concurrent background delete operations
+    testCompositeBlobDataChunksDeleteMaxDeleteOperation(0);
+  }
+
+  /**
+   * Test that if a composite blob is deleted, the data chunks are eventually deleted. Also check the service IDs used
+   * for delete operations. But this time, we limit the number of background delete operations.
+   */
+  @Test
+  public void testCompositeBlobDataChunksDeleteWithMaxBackgroudDeleteOperation() throws Exception {
+    // Test when the maximum number of background delete operations is 2;
+    testCompositeBlobDataChunksDeleteMaxDeleteOperation(2);
+  }
+
+  protected void testCompositeBlobDataChunksDeleteMaxDeleteOperation(int maxDeleteOperation) throws Exception {
     // Ensure there are 4 chunks.
     maxPutChunkSize = PUT_CONTENT_SIZE / 4;
     Properties props = getNonBlockingRouterProperties("DC1");
+    if (maxDeleteOperation != 0) {
+      props.setProperty(RouterConfig.ROUTER_BACKGROUND_DELETER_MAX_CONCURRENT_OPERATIONS,
+          Integer.toString(maxDeleteOperation));
+    }
     VerifiableProperties verifiableProperties = new VerifiableProperties((props));
     RouterConfig routerConfig = new RouterConfig(verifiableProperties);
     MockClusterMap mockClusterMap = new MockClusterMap();


### PR DESCRIPTION
Blobs in delivery cluster are usually pretty huge. When router is trying to delete a blob, router would create delete operations for all the chunks of this blob. The number of chunks which belong to this blob can be huge, and background deleter would flood the network client with delete operations. This might cause connection unavailable error when the servers are not responding to the frontends fast enough. 

Since they are background deletes, we can de-prioritize them by setting a limit on how many concurrent delete operations a router can have. By doing so, we would mitigate the connection unavailable error.

However, this is not an ideal solution. To solve this issue, we should
1. Set a different time out for checking connection from pool for background deletes.
2. De-prioritize background delete requests in the network layer (and maybe retry?) to support better QOS.