### PR TITLE
Use copy of ExchangeMetadataResponse while fetching missing keys for timed out standby replicas

### DIFF
--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -1550,23 +1550,23 @@ public class ReplicaThread implements Runnable {
     /**
      * Shallow copy Constructor for {@link ExchangeMetadataResponse}, which copies all field references with exception
      * of 'missingStoreMessages' for which it creates new Set object.
-     * @param old old {@link ExchangeMetadataResponse} object.
+     * @param other other {@link ExchangeMetadataResponse} object.
      */
-    ExchangeMetadataResponse(ExchangeMetadataResponse old) {
+    ExchangeMetadataResponse(ExchangeMetadataResponse other) {
       // Create a copy of 'missingStoreMessages' since it is mutable and sharing between multiple ExchangeMetadataResponses
       // can make operations on it such as size(), isEmpty(), etc. hard to track.
       // For example, an inter-colo thread could be fetching missing store messages from its copy of exchangeMetadataResponse
       // in fixMissingKeys() method while an intra-colo thread could be emptying the missing store messages in
       // exchangeMetadataResponse stored in RemoteReplicaInfo. Referencing same object of missingStoreMessages could
       // lead to race conditions and is avoided for simplicity.
-      this.missingStoreMessages = old.missingStoreMessages == null ? null : new HashSet<>(old.missingStoreMessages);
-      this.remoteKeyToLocalKeyMap = old.remoteKeyToLocalKeyMap;
-      this.remoteToken = old.remoteToken;
-      this.localLagFromRemoteInBytes = old.localLagFromRemoteInBytes;
-      this.serverErrorCode = old.serverErrorCode;
-      this.time = old.time;
-      this.lastMissingMessageReceivedTimeSec = old.lastMissingMessageReceivedTimeSec;
-      this.receivedStoreMessagesWithUpdatesPending = old.receivedStoreMessagesWithUpdatesPending;
+      this.missingStoreMessages = other.missingStoreMessages == null ? null : new HashSet<>(other.missingStoreMessages);
+      this.remoteKeyToLocalKeyMap = other.remoteKeyToLocalKeyMap;
+      this.remoteToken = other.remoteToken;
+      this.localLagFromRemoteInBytes = other.localLagFromRemoteInBytes;
+      this.serverErrorCode = other.serverErrorCode;
+      this.time = other.time;
+      this.lastMissingMessageReceivedTimeSec = other.lastMissingMessageReceivedTimeSec;
+      this.receivedStoreMessagesWithUpdatesPending = other.receivedStoreMessagesWithUpdatesPending;
     }
 
     /**

--- a/ambry-utils/src/main/java/com/github/ambry/utils/Utils.java
+++ b/ambry-utils/src/main/java/com/github/ambry/utils/Utils.java
@@ -250,6 +250,9 @@ public class Utils {
    * @throws IOException Unexpected IO errors.
    */
   public static ByteBuffer getByteBufferFromInputStream(InputStream stream, int dataSize) throws IOException {
+    if (dataSize < 0) {
+      throw new IllegalArgumentException("Input size of stream is " + dataSize);
+    }
     ByteBuffer output = ByteBuffer.allocate(dataSize);
     int read = 0;
     ReadableByteChannel readableByteChannel = Channels.newChannel(stream);
@@ -707,6 +710,7 @@ public class Utils {
       serializeString(outputBuf, value, Charset.defaultCharset());
     }
   }
+
   /**
    * Serializes a string into byte buffer
    * @param outputBuffer The output buffer to serialize the value to
@@ -730,6 +734,7 @@ public class Utils {
     outputBuf.writeInt(valueArray.length);
     outputBuf.writeBytes(valueArray);
   }
+
   /**
    * Deserializes a string from byte buffer
    * @param inputBuffer The input buffer to deserialize the value from
@@ -1222,5 +1227,4 @@ public class Utils {
       return currentSize.getAsInt();
     }
   }
-
 }


### PR DESCRIPTION
Issues:
 1. IllegalStateException thrown in writeMessagesToLocalStoreAndAdvanceTokens() due to mismatch in partition ID in partitionResponseInfo with remoteReplicaInfo
 2. IllegalArgumentException thrown in getReplicaMetadataResponse() when trying to read from connectionChannel inputStream (size of the stream from first 8 bytes is incorrect)

Explanation: We are using references of ExchangeMetadataResponse stored in RemoteReplicaInfo while fetching the missing keys for standby(blocked) replicas. Due to that, it is possible that while an
inter-colo thread is fetching missing store messages present in ExchangeMetadaResponse::missingStoreMessages set, other threads receive these messages and "modify/empty the same set reference".

This will lead to mismatch in state of missingStoreMessages tracked for a partition before and after fetching the keys. That is, before fetch, we would find missingStoreMessages is non-empty and send PartitionRequestInfo in
GET request but when we receive the response,  we will skip/ignore the PartitionResponseInfo since missingStoreMessages is empty were emptied. This could lead to two kinds of issues during iteration of received responses in
writeMessagesToLocalStoreAndAdvanceTokens:
 1. If we skip/ignore such partitions in middle of iteration, indexes of replica list and partition response list mismatch. This causes IllegalStateException.
 2. If we skip/ignore such partitions at end of iteration, the inputStream is not read completely resulting in left over bytes for next replication cycle. This causes IllegalArgumentException.

Fix: Create a copy of ExchangeMetadataResponse (and its missingStoreMessages set) while fetching missing keys.