### PR TITLE
Return 413 when router returns BlobTooLarge

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/rest/RestServiceErrorCode.java
+++ b/ambry-api/src/main/java/com/github/ambry/rest/RestServiceErrorCode.java
@@ -182,7 +182,6 @@ public enum RestServiceErrorCode {
    */
   public static RestServiceErrorCode getRestServiceErrorCode(RouterErrorCode routerErrorCode) {
     switch (routerErrorCode) {
-      case BlobTooLarge:
       case InvalidBlobId:
       case InvalidPutArgument:
       case BadInputChannel:
@@ -196,6 +195,8 @@ public enum RestServiceErrorCode {
         return NotFound;
       case BlobUpdateNotAllowed:
         return NotAllowed;
+      case BlobTooLarge:
+        return RequestTooLarge;
       case RangeNotSatisfiable:
         return RangeNotSatisfiable;
       case OperationTimedOut:

--- a/ambry-rest/src/main/java/com/github/ambry/rest/NettyResponseChannel.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/NettyResponseChannel.java
@@ -13,11 +13,11 @@
  */
 package com.github.ambry.rest;
 
+import com.github.ambry.commons.Callback;
 import com.github.ambry.commons.PerformanceIndex;
 import com.github.ambry.commons.Thresholds;
 import com.github.ambry.config.NettyConfig;
 import com.github.ambry.config.PerformanceConfig;
-import com.github.ambry.commons.Callback;
 import com.github.ambry.router.FutureResult;
 import com.github.ambry.utils.Utils;
 import io.netty.buffer.ByteBuf;
@@ -611,7 +611,8 @@ class NettyResponseChannel implements RestResponseChannel {
   }
 
   private boolean shouldSendFailureReason(HttpResponseStatus status, RestServiceException exception) {
-    if (status == HttpResponseStatus.BAD_REQUEST || exception.shouldIncludeExceptionMessageInResponse()) {
+    if (status == HttpResponseStatus.BAD_REQUEST || status == HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE
+        || exception.shouldIncludeExceptionMessageInResponse()) {
       return true;
     }
     return request != null && request.getArgs().containsKey(RestUtils.InternalKeys.SEND_FAILURE_REASON)

--- a/ambry-rest/src/test/java/com/github/ambry/rest/NettyResponseChannelTest.java
+++ b/ambry-rest/src/test/java/com/github/ambry/rest/NettyResponseChannelTest.java
@@ -14,10 +14,10 @@
 package com.github.ambry.rest;
 
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.commons.Callback;
 import com.github.ambry.config.NettyConfig;
 import com.github.ambry.config.PerformanceConfig;
 import com.github.ambry.config.VerifiableProperties;
-import com.github.ambry.commons.Callback;
 import com.github.ambry.utils.NettyByteBufLeakHelper;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
@@ -538,7 +538,8 @@ public class NettyResponseChannelTest {
         HttpResponseStatus expectedStatus = getExpectedHttpResponseStatus(errorCode);
         assertEquals("Unexpected response status", expectedStatus, response.status());
         boolean containsFailureReasonHeader = response.headers().contains(NettyResponseChannel.FAILURE_REASON_HEADER);
-        if (expectedStatus == HttpResponseStatus.BAD_REQUEST || expectedStatus == HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE || includeExceptionMessageInResponse) {
+        if (expectedStatus == HttpResponseStatus.BAD_REQUEST
+            || expectedStatus == HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE || includeExceptionMessageInResponse) {
           assertTrue("Could not find failure reason header.", containsFailureReasonHeader);
         } else {
           assertFalse("Should not have found failure reason header.", containsFailureReasonHeader);

--- a/ambry-rest/src/test/java/com/github/ambry/rest/NettyResponseChannelTest.java
+++ b/ambry-rest/src/test/java/com/github/ambry/rest/NettyResponseChannelTest.java
@@ -538,7 +538,7 @@ public class NettyResponseChannelTest {
         HttpResponseStatus expectedStatus = getExpectedHttpResponseStatus(errorCode);
         assertEquals("Unexpected response status", expectedStatus, response.status());
         boolean containsFailureReasonHeader = response.headers().contains(NettyResponseChannel.FAILURE_REASON_HEADER);
-        if (expectedStatus == HttpResponseStatus.BAD_REQUEST || includeExceptionMessageInResponse) {
+        if (expectedStatus == HttpResponseStatus.BAD_REQUEST || expectedStatus == HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE || includeExceptionMessageInResponse) {
           assertTrue("Could not find failure reason header.", containsFailureReasonHeader);
         } else {
           assertFalse("Should not have found failure reason header.", containsFailureReasonHeader);


### PR DESCRIPTION
Previously, RouterErrorCode.BlobTooLarge was mapped to 400 bad request,
even though we already supported the 413 request entity too large status
code. Returning 413 lets our customers programatically respond to such
errors without having to disambiguate the more general class of 400 errors.

Note to reviewers: I believe this is safe to change for java ambry-client users as ambry-client has had an error code and related handling for 413 since the library was created in 2014. 413 was already used in some similar cases but was missed in the RouterErrorCode to RestServiceErrorCode converter.