### PR TITLE
Create a MessageInfo.Builder to help build MessageInfo

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/store/MessageInfo.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/MessageInfo.java
@@ -167,8 +167,8 @@ public class MessageInfo {
     this.key = key;
     this.size = size;
     this.isDeleted = deleted;
-    isTtlUpdated = ttlUpdated;
-    isUndeleted = undeleted;
+    this.isTtlUpdated = ttlUpdated;
+    this.isUndeleted = undeleted;
     this.expirationTimeInMs = expirationTimeInMs;
     this.crc = crc;
     this.accountId = accountId;
@@ -294,5 +294,63 @@ public class MessageInfo {
         .append(lifeVersion)
         .append("]");
     return stringBuilder.toString();
+  }
+
+  public static class Builder {
+    private final StoreKey key;
+    private final long size;
+    private final short accountId;
+    private final short containerId;
+    private final long operationTimeMs;
+
+    private long expirationTimeInMs = Utils.Infinite_Time;
+    private boolean isDeleted = false;
+    private boolean isTtlUpdated = false;
+    private boolean isUndeleted = false;
+    private Long crc = null;
+    private short lifeVersion = 0;
+
+    public Builder(StoreKey key, long size, short accountId, short containerId, long operationTimeMs) {
+      this.key = key;
+      this.size = size;
+      this.accountId = accountId;
+      this.containerId = containerId;
+      this.operationTimeMs = operationTimeMs;
+    }
+
+    public MessageInfo build() {
+      return new MessageInfo(key, size, isDeleted, isTtlUpdated, isUndeleted, expirationTimeInMs, crc, accountId,
+          containerId, operationTimeMs, lifeVersion);
+    }
+
+    public Builder expirationTimeInMs(long expirationTimeInMs) {
+      this.expirationTimeInMs = expirationTimeInMs;
+      return this;
+    }
+
+    public Builder isDeleted(boolean isDeleted) {
+      this.isDeleted = isDeleted;
+      return this;
+    }
+
+    public Builder isTtlUpdated(boolean isTtlUpdated) {
+      this.isTtlUpdated = isTtlUpdated;
+      return this;
+    }
+
+    public Builder isUndeleted(boolean isUndeleted) {
+      this.isUndeleted = isUndeleted;
+      return this;
+    }
+
+    public Builder crc(Long crc) {
+      this.crc = crc;
+      return this;
+    }
+
+    public Builder lifeVersion(short lifeVersion) {
+      this.lifeVersion = lifeVersion;
+      return this;
+    }
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/store/MessageInfo.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/MessageInfo.java
@@ -296,12 +296,15 @@ public class MessageInfo {
     return stringBuilder.toString();
   }
 
+  /**
+   * A builder class for {@link MessageInfo}.
+   */
   public static class Builder {
-    private final StoreKey key;
-    private final long size;
-    private final short accountId;
-    private final short containerId;
-    private final long operationTimeMs;
+    private StoreKey key;
+    private short accountId;
+    private short containerId;
+    private long operationTimeMs;
+    private long size;
 
     private long expirationTimeInMs = Utils.Infinite_Time;
     private boolean isDeleted = false;
@@ -310,6 +313,14 @@ public class MessageInfo {
     private Long crc = null;
     private short lifeVersion = 0;
 
+    /**
+     * Constructor to create a builder.
+     * @param key The {@link StoreKey} associated with {@link MessageInfo}.
+     * @param size The size of this this message in bytes.
+     * @param accountId accountId of the blob.
+     * @param containerId containerId of the blob.
+     * @param operationTimeMs operation time in ms.
+     */
     public Builder(StoreKey key, long size, short accountId, short containerId, long operationTimeMs) {
       this.key = key;
       this.size = size;
@@ -318,36 +329,138 @@ public class MessageInfo {
       this.operationTimeMs = operationTimeMs;
     }
 
+    /**
+     * Constructor to create a builder from {@link MessageInfo}.
+     * @param info The {@link MessageInfo} to build from.
+     */
+    public Builder(final MessageInfo info) {
+      this.key = info.getStoreKey();
+      this.accountId = info.getAccountId();
+      this.containerId = info.getContainerId();
+      this.operationTimeMs = info.getOperationTimeMs();
+      this.size = info.getSize();
+      this.expirationTimeInMs = info.getExpirationTimeInMs();
+      this.isDeleted = info.isDeleted();
+      this.isTtlUpdated = info.isTtlUpdated();
+      this.isUndeleted = info.isUndeleted();
+      this.crc = info.getCrc();
+      this.lifeVersion = info.getLifeVersion();
+    }
+
+    /**
+     * Builds a {@link MessageInfo} object.
+     * @return A {@link MessageInfo} object.
+     */
     public MessageInfo build() {
       return new MessageInfo(key, size, isDeleted, isTtlUpdated, isUndeleted, expirationTimeInMs, crc, accountId,
           containerId, operationTimeMs, lifeVersion);
     }
 
+    /**
+     * Sets the key of the {@link MessageInfo} to build.
+     * @param key the key to set.
+     * @return This builder.
+     */
+    public Builder storeKey(StoreKey key) {
+      this.key = key;
+      return this;
+    }
+
+    /**
+     * Sets the accountId of the {@link MessageInfo} to build.
+     * @param accountId the accountId to set.
+     * @return This builder.
+     */
+    public Builder accountId(short accountId) {
+      this.accountId = accountId;
+      return this;
+    }
+
+    /**
+     * Sets the containerId of the {@link MessageInfo} to build.
+     * @param containerId the containerId to set.
+     * @return This builder.
+     */
+    public Builder containerId(short containerId) {
+      this.containerId = containerId;
+      return this;
+    }
+
+    /**
+     * Sets the operationTime in ms of the {@link MessageInfo} to build.
+     * @param operationTimeMs the operationTime to set.
+     * @return This builder.
+     */
+    public Builder operationTimeMs(long operationTimeMs) {
+      this.operationTimeMs = operationTimeMs;
+      return this;
+    }
+
+    /**
+     * Sets the size of the {@link MessageInfo} to build.
+     * @param size the size to set.
+     * @return This builder.
+     */
+    public Builder size(long size) {
+      this.size = size;
+      return this;
+    }
+
+    /**
+     * Sets expirationTime in ms of the {@link MessageInfo} to build.
+     * @param expirationTimeInMs the expirationTime to set
+     * @return This builder.
+     */
     public Builder expirationTimeInMs(long expirationTimeInMs) {
       this.expirationTimeInMs = expirationTimeInMs;
       return this;
     }
 
+    /**
+     * Sets isDeleted flag of the {@link MessageInfo} to build.
+     * @param isDeleted the isDeleted to set.
+     * @return This builder.
+     */
     public Builder isDeleted(boolean isDeleted) {
       this.isDeleted = isDeleted;
       return this;
     }
 
+    /**
+     * Sets isTtlUpdated flag of the {@link MessageInfo} to build.
+     * @param isTtlUpdated the isTtlUpdated to set.
+     * @return This builder.
+     */
     public Builder isTtlUpdated(boolean isTtlUpdated) {
       this.isTtlUpdated = isTtlUpdated;
       return this;
     }
 
+    /**
+     * Sets isUndeleted flag of the {@link MessageInfo} to build.
+     * @param isUndeleted the isUndeleted to set.
+     * @return This builder.
+     */
     public Builder isUndeleted(boolean isUndeleted) {
       this.isUndeleted = isUndeleted;
       return this;
     }
 
+    /**
+     * Sets crc of the {@link MessageInfo} to build.
+     * @param crc the crc to set.
+     * @return
+     */
     public Builder crc(Long crc) {
       this.crc = crc;
       return this;
     }
 
+    /**
+     * Sets the lifeVersion of the {@link MessageInfo} to build.
+     * @param lifeVersion the lifeVersion to set.
+     * @return This builder.
+     */
     public Builder lifeVersion(short lifeVersion) {
       this.lifeVersion = lifeVersion;
       return this;

--- a/ambry-api/src/main/java/com/github/ambry/store/MessageInfo.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/MessageInfo.java
@@ -316,7 +316,7 @@ public class MessageInfo {
     /**
      * Constructor to create a builder.
      * @param key The {@link StoreKey} associated with {@link MessageInfo}.
-     * @param size The size of this this message in bytes.
+     * @param size The size of this message in bytes.
      * @param accountId accountId of the blob.
      * @param containerId containerId of the blob.
      * @param operationTimeMs operation time in ms.
@@ -449,7 +449,7 @@ public class MessageInfo {
     /**
      * Sets crc of the {@link MessageInfo} to build.
      * @param crc the crc to set.
-     * @return
+     * @return This builder.
      */
     public Builder crc(Long crc) {
       this.crc = crc;

--- a/ambry-api/src/test/java/com/github/ambry/store/MessageInfoTest.java
+++ b/ambry-api/src/test/java/com/github/ambry/store/MessageInfoTest.java
@@ -82,6 +82,89 @@ public class MessageInfoTest {
   }
 
   /**
+   * Tests for MessageInfo.Builder.
+   */
+  @Test
+  public void testBuilder() {
+    short accountId = 100, containerId = 1000;
+    StoreKey key = new MockId(TestUtils.getRandomString(10), accountId, containerId);
+    long size = 12345;
+    long expirationTime = SystemTime.getInstance().milliseconds() - 1;
+    long operationTime = SystemTime.getInstance().milliseconds() + 300;
+    Long crc = 1000L;
+    short lifeVersion = 5;
+    MessageInfo origin =
+        new MessageInfo(key, size, false, false, false, expirationTime, crc, accountId, containerId, operationTime,
+            lifeVersion);
+
+    MessageInfo.Builder builder = new MessageInfo.Builder(origin);
+    MessageInfo info = builder.build();
+    checkGetters(info, origin.getStoreKey(), origin.getSize(), origin.isDeleted(), origin.isTtlUpdated(),
+        origin.isUndeleted(), origin.getExpirationTimeInMs(), origin.getCrc(), origin.getAccountId(),
+        origin.getContainerId(), origin.getOperationTimeMs(), origin.getLifeVersion());
+
+    StoreKey newKey = new MockId(TestUtils.getRandomString(10), accountId, containerId);
+    info = builder.storeKey(newKey).build();
+    checkGetters(info, newKey, origin.getSize(), origin.isDeleted(), origin.isTtlUpdated(), origin.isUndeleted(),
+        origin.getExpirationTimeInMs(), origin.getCrc(), origin.getAccountId(), origin.getContainerId(),
+        origin.getOperationTimeMs(), origin.getLifeVersion());
+
+    long newSize = size + 1000L;
+    info = builder.size(newSize).build();
+    checkGetters(info, newKey, newSize, origin.isDeleted(), origin.isTtlUpdated(), origin.isUndeleted(),
+        origin.getExpirationTimeInMs(), origin.getCrc(), origin.getAccountId(), origin.getContainerId(),
+        origin.getOperationTimeMs(), origin.getLifeVersion());
+
+    info = builder.isDeleted(true).build();
+    checkGetters(info, newKey, newSize, true, origin.isTtlUpdated(), origin.isUndeleted(),
+        origin.getExpirationTimeInMs(), origin.getCrc(), origin.getAccountId(), origin.getContainerId(),
+        origin.getOperationTimeMs(), origin.getLifeVersion());
+
+    info = builder.isTtlUpdated(true).build();
+    checkGetters(info, newKey, newSize, true, true, origin.isUndeleted(), origin.getExpirationTimeInMs(),
+        origin.getCrc(), origin.getAccountId(), origin.getContainerId(), origin.getOperationTimeMs(),
+        origin.getLifeVersion());
+
+    info = builder.isUndeleted(true).build();
+    checkGetters(info, newKey, newSize, true, true, true, origin.getExpirationTimeInMs(), origin.getCrc(),
+        origin.getAccountId(), origin.getContainerId(), origin.getOperationTimeMs(), origin.getLifeVersion());
+
+    long newExpirationTime = expirationTime + 1000L;
+    info = builder.expirationTimeInMs(newExpirationTime).build();
+    checkGetters(info, newKey, newSize, true, true, true, newExpirationTime, origin.getCrc(), origin.getAccountId(),
+        origin.getContainerId(), origin.getOperationTimeMs(), origin.getLifeVersion());
+
+    Long newCrc = null;
+    info = builder.crc(newCrc).build();
+    checkGetters(info, newKey, newSize, true, true, true, newExpirationTime, newCrc, origin.getAccountId(),
+        origin.getContainerId(), origin.getOperationTimeMs(), origin.getLifeVersion());
+
+    short newAccountId = 101;
+    info = builder.accountId(newAccountId).build();
+    checkGetters(info, newKey, newSize, true, true, true, newExpirationTime, newCrc, newAccountId,
+        origin.getContainerId(), origin.getOperationTimeMs(), origin.getLifeVersion());
+
+    short newContainerId = 10001;
+    info = builder.containerId(newContainerId).build();
+    checkGetters(info, newKey, newSize, true, true, true, newExpirationTime, newCrc, newAccountId, newContainerId,
+        origin.getOperationTimeMs(), origin.getLifeVersion());
+
+    long newOperationTime = operationTime - 1000L;
+    info = builder.operationTimeMs(newOperationTime).build();
+    checkGetters(info, newKey, newSize, true, true, true, newExpirationTime, newCrc, newAccountId, newContainerId,
+        newOperationTime, origin.getLifeVersion());
+
+    short newLifeVersion = (short) (lifeVersion + 1);
+    info = builder.lifeVersion(newLifeVersion).build();
+    checkGetters(info, newKey, newSize, true, true, true, newExpirationTime, newCrc, newAccountId, newContainerId,
+        newOperationTime, newLifeVersion);
+
+    info = new MessageInfo.Builder(newKey, newSize, newAccountId, newContainerId, newOperationTime).build();
+    checkGetters(info, newKey, newSize, false, false, false, Utils.Infinite_Time, null, newAccountId, newContainerId,
+        newOperationTime, (short) 0);
+  }
+
+  /**
    * Checks getters of {@code info}
    * @param info the {@link MessageInfo} whose props need to checked
    * @param key the expected {@link StoreKey} in {@code info}.

--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/ValidatingTransformer.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/ValidatingTransformer.java
@@ -88,10 +88,10 @@ public class ValidatingTransformer implements Transformer {
             new PutMessageFormatInputStream(keyInStream, encryptionKey, props, metadata,
                 new ByteBufInputStream(blobData.content(), true), blobData.getSize(), blobData.getBlobType(),
                 msgInfo.getLifeVersion());
-        MessageInfo transformedMsgInfo =
-            new MessageInfo(keyInStream, transformedStream.getSize(), false, msgInfo.isTtlUpdated(),
-                false, msgInfo.getExpirationTimeInMs(), msgInfo.getCrc(), msgInfo.getAccountId(),
-                msgInfo.getContainerId(), msgInfo.getOperationTimeMs(), msgInfo.getLifeVersion());
+        MessageInfo transformedMsgInfo = new MessageInfo.Builder(msgInfo).size(transformedStream.getSize())
+            .isDeleted(false)
+            .isUndeleted(false)
+            .build();
         transformationOutput = new TransformationOutput(new Message(transformedMsgInfo, transformedStream));
       } else {
         throw new IllegalStateException(

--- a/ambry-messageformat/src/test/java/com/github/ambry/messageformat/MessageSievingInputStreamTest.java
+++ b/ambry-messageformat/src/test/java/com/github/ambry/messageformat/MessageSievingInputStreamTest.java
@@ -1138,10 +1138,10 @@ class ValidatingKeyConvertingTransformer implements Transformer {
               new PutMessageFormatInputStream(newKey, encryptionKey, props, metadata,
                   new ByteBufInputStream(blobData.content(), true), blobData.getSize(), blobData.getBlobType(),
                   msgInfo.getLifeVersion());
-          transformedMsgInfo =
-              new MessageInfo(newKey, transformedStream.getSize(), msgInfo.isDeleted(), msgInfo.isTtlUpdated(), false,
-                  msgInfo.getExpirationTimeInMs(), msgInfo.getCrc(), msgInfo.getAccountId(), msgInfo.getContainerId(),
-                  msgInfo.getOperationTimeMs(), msgInfo.getLifeVersion());
+          transformedMsgInfo = new MessageInfo.Builder(msgInfo).storeKey(newKey)
+              .size(transformedStream.getSize())
+              .isUndeleted(false)
+              .build();
           transformationOutput = new TransformationOutput(new Message(transformedMsgInfo, transformedStream));
         }
       } else {

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/AmbryRequests.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/AmbryRequests.java
@@ -171,7 +171,7 @@ public class AmbryRequests implements RequestAPI {
                 receivedRequest.getBlobSize(), receivedRequest.getBlobType());
         BlobProperties properties = receivedRequest.getBlobProperties();
         long expirationTime = Utils.addSecondsToEpochTime(receivedRequest.getBlobProperties().getCreationTimeInMs(),
-            receivedRequest.getBlobProperties().getTimeToLiveInSeconds());
+            properties.getTimeToLiveInSeconds());
         MessageInfo info =
             new MessageInfo.Builder(receivedRequest.getBlobId(), stream.getSize(), properties.getAccountId(),
                 properties.getContainerId(), properties.getCreationTimeInMs()).expirationTimeInMs(expirationTime)

--- a/ambry-replication/src/main/java/com/github/ambry/replication/BlobIdTransformer.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/BlobIdTransformer.java
@@ -263,9 +263,13 @@ public class BlobIdTransformer implements Transformer {
       // same after conversion.
       Long originalCrc = oldMessageInfo.getStoreKey().getID().equals(newKey.getID()) ? oldMessageInfo.getCrc() : null;
       MessageInfo info =
-          new MessageInfo(newKey, putMessageFormatInputStream.getSize(), false, oldMessageInfo.isTtlUpdated(), false,
-              oldMessageInfo.getExpirationTimeInMs(), originalCrc, newProperties.getAccountId(),
-              newProperties.getContainerId(), oldMessageInfo.getOperationTimeMs(), oldMessageInfo.getLifeVersion());
+          new MessageInfo.Builder(newKey, putMessageFormatInputStream.getSize(), newProperties.getAccountId(),
+              newProperties.getContainerId(), oldMessageInfo.getOperationTimeMs()).isTtlUpdated(
+              oldMessageInfo.isTtlUpdated())
+              .expirationTimeInMs(oldMessageInfo.getExpirationTimeInMs())
+              .crc(originalCrc)
+              .lifeVersion(oldMessageInfo.getLifeVersion())
+              .build();
       return new Message(info, putMessageFormatInputStream);
     } else {
       throw new IllegalArgumentException("Only 'put' records are valid");

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -1222,10 +1222,7 @@ public class ReplicaThread implements Runnable {
       // committed), then we have a bad situation where only a TTL update exists in the store. This problem has to be
       // addressed. This can only happen if replication is far behind (for e.g due to a server being down for a long
       // time). Won't happen if a server is being recreated.
-      messageInfo = new MessageInfo(messageInfo.getStoreKey(), messageInfo.getSize(), messageInfo.isDeleted(), true,
-          messageInfo.isUndeleted(), messageInfo.getExpirationTimeInMs(), messageInfo.getCrc(),
-          messageInfo.getAccountId(), messageInfo.getContainerId(), messageInfo.getOperationTimeMs(),
-          messageInfo.getLifeVersion());
+      messageInfo = new MessageInfo.Builder(messageInfo).isTtlUpdated(true).build();
       remoteReplicaInfo.getLocalStore().updateTtl(Collections.singletonList(messageInfo));
       logger.trace("Remote node: {} Thread name: {} Remote replica: {} Key ttl updated id: {}", remoteNode, threadName,
           remoteReplicaInfo.getReplicaId(), messageInfo.getStoreKey());
@@ -1255,10 +1252,7 @@ public class ReplicaThread implements Runnable {
   private void applyUndelete(MessageInfo messageInfo, RemoteReplicaInfo remoteReplicaInfo) throws StoreException {
     DataNodeId remoteNode = remoteReplicaInfo.getReplicaId().getDataNodeId();
     try {
-      messageInfo = new MessageInfo(messageInfo.getStoreKey(), messageInfo.getSize(), messageInfo.isDeleted(),
-          messageInfo.isTtlUpdated(), true, messageInfo.getExpirationTimeInMs(), messageInfo.getCrc(),
-          messageInfo.getAccountId(), messageInfo.getContainerId(), messageInfo.getOperationTimeMs(),
-          messageInfo.getLifeVersion());
+      messageInfo = new MessageInfo.Builder(messageInfo).isUndeleted(true).isDeleted(false).build();
       remoteReplicaInfo.getLocalStore().undelete(messageInfo);
       logger.trace("Remote node: {} Thread name: {} Remote replica: {} Key undelete id: {}", remoteNode, threadName,
           remoteReplicaInfo.getReplicaId(), messageInfo.getStoreKey());
@@ -1289,10 +1283,7 @@ public class ReplicaThread implements Runnable {
   private void applyDelete(MessageInfo messageInfo, RemoteReplicaInfo remoteReplicaInfo) throws StoreException {
     DataNodeId remoteNode = remoteReplicaInfo.getReplicaId().getDataNodeId();
     try {
-      messageInfo =
-          new MessageInfo(messageInfo.getStoreKey(), messageInfo.getSize(), true, messageInfo.isTtlUpdated(), false,
-              messageInfo.getExpirationTimeInMs(), messageInfo.getCrc(), messageInfo.getAccountId(),
-              messageInfo.getContainerId(), messageInfo.getOperationTimeMs(), messageInfo.getLifeVersion());
+      messageInfo = new MessageInfo.Builder(messageInfo).isDeleted(true).isUndeleted(false).build();
       remoteReplicaInfo.getLocalStore().delete(Collections.singletonList(messageInfo));
       logger.trace("Remote node: {} Thread name: {} Remote replica: {} Key delete: {}", remoteNode, threadName,
           remoteReplicaInfo.getReplicaId(), messageInfo.getStoreKey());

--- a/ambry-store/src/main/java/com/github/ambry/store/ScanResults.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/ScanResults.java
@@ -193,7 +193,9 @@ class ScanResults {
     if (!nestedMap.containsKey(firstKey)) {
       nestedMap.put(firstKey, new HashMap<String, Long>());
     }
-    updateMapHelper(nestedMap.get(firstKey), secondKey, v
+    updateMapHelper(nestedMap.get(firstKey), secondKey, value);
+  }
+
   /**
    * Helper function to update map data structure.
    * @param map {@link Map} to be updated

--- a/ambry-store/src/main/java/com/github/ambry/store/ScanResults.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/ScanResults.java
@@ -193,9 +193,7 @@ class ScanResults {
     if (!nestedMap.containsKey(firstKey)) {
       nestedMap.put(firstKey, new HashMap<String, Long>());
     }
-    updateMapHelper(nestedMap.get(firstKey), secondKey, value);
-  }
-
+    updateMapHelper(nestedMap.get(firstKey), secondKey, v
   /**
    * Helper function to update map data structure.
    * @param map {@link Map} to be updated


### PR DESCRIPTION
There has been too many MessageInfo constructors due to new fields being added to MessageInfo. This PR adds a Builder for MessageInfo in hope that later those constructors can be replaced by this builder.