### PR TITLE
Use one EventLoopGroup in all http2NetworkClients

### DIFF
--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2NetworkClientFactory.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2NetworkClientFactory.java
@@ -17,31 +17,43 @@ import com.github.ambry.commons.SSLFactory;
 import com.github.ambry.config.Http2ClientConfig;
 import com.github.ambry.network.NetworkClientFactory;
 import com.github.ambry.utils.Time;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.epoll.Epoll;
+import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
 import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
  * A factory class used to get new instances of a {@link Http2NetworkClient}
  */
 public class Http2NetworkClientFactory implements NetworkClientFactory {
-  protected final Http2ClientMetrics http2ClientMetrics;
-  protected final Http2ClientConfig http2ClientConfig;
-  protected final SSLFactory sslFactory;
-  private final Time time;
+  private static final Logger logger = LoggerFactory.getLogger(Http2NetworkClientFactory.class);
+  private final Http2ClientMetrics http2ClientMetrics;
+  private final Http2ClientConfig http2ClientConfig;
+  private final SSLFactory sslFactory;
+  private final EventLoopGroup eventLoopGroup;
 
   /**
    * Construct a factory using the given parameters.
    * @param http2ClientMetrics the metrics for HTTP/2 Client.
    * @param http2ClientConfig the configs for HTTP/2 Client.
    * @param sslFactory the sslFactory for HTTP/2 Client.
-   * @param time the Time instance to use.
    */
   public Http2NetworkClientFactory(Http2ClientMetrics http2ClientMetrics, Http2ClientConfig http2ClientConfig,
       SSLFactory sslFactory, Time time) {
     this.http2ClientMetrics = http2ClientMetrics;
     this.http2ClientConfig = http2ClientConfig;
     this.sslFactory = sslFactory;
-    this.time = time;
+    if (Epoll.isAvailable()) {
+      logger.info("Create EpollEventLoopGroup in Http2NetworkClientFactory.");
+      this.eventLoopGroup = new EpollEventLoopGroup(http2ClientConfig.http2NettyEventLoopGroupThreads);
+    } else {
+      logger.info("Create NioEventLoopGroup in Http2NetworkClientFactory.");
+      this.eventLoopGroup = new NioEventLoopGroup(http2ClientConfig.http2NettyEventLoopGroupThreads);
+    }
   }
 
   /**
@@ -50,7 +62,7 @@ public class Http2NetworkClientFactory implements NetworkClientFactory {
    */
   @Override
   public Http2NetworkClient getNetworkClient() throws IOException {
-    return new Http2NetworkClient(http2ClientMetrics, http2ClientConfig, sslFactory);
+    return new Http2NetworkClient(http2ClientMetrics, http2ClientConfig, sslFactory, eventLoopGroup);
   }
 }
 

--- a/ambry-server/src/integration-test/java/com/github/ambry/server/Http2NetworkClientTest.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/Http2NetworkClientTest.java
@@ -102,7 +102,6 @@ public class Http2NetworkClientTest {
         "http2-client");
     TestSSLUtils.addHttp2Properties(clientSSLProps, SSLFactory.Mode.CLIENT, false);
     clientSSLConfig = new SSLConfig(new VerifiableProperties(clientSSLProps));
-    eventLoopGroup = new NioEventLoopGroup();
     eventLoopGroup = Epoll.isAvailable() ? new EpollEventLoopGroup() : new NioEventLoopGroup();
 
     // Server


### PR DESCRIPTION
Use one EventLoopGroup in all http2NetworkClients. This is suggested in Netty best practice: The change is based on a best practice of netty: http://normanmaurer.me/presentations/2014-facebook-eng-netty/slides.html#25.0