### PR TITLE
[RANGE_REQUEST] add option for always resolving ranges on empty blobs

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com/github/ambry/rest/RestUtils.java
@@ -221,6 +221,12 @@ public class RestUtils {
      * The lifeVersion of the blob.
      */
     public final static String LIFE_VERSION = "x-ambry-life-version";
+
+    /**
+     * Set to true to indicate that ambry should return a successful response for a range request against an empty
+     * (0 byte) blob instead of returning a 416 error.
+     */
+    public final static String RESOLVE_RANGE_ON_EMPTY_BLOB = "x-ambry-resolve-range-on-empty-blob";
   }
 
   public static final class TrackingHeaders {
@@ -538,12 +544,14 @@ public class RestUtils {
       throw new RestServiceException("Ranges not supported for sub-resources that aren't Segment.",
           RestServiceErrorCode.InvalidArgs);
     }
+    boolean resolveRangeOnEmptyBlob = getBooleanHeader(args, Headers.RESOLVE_RANGE_ON_EMPTY_BLOB, false);
     return new GetBlobOptionsBuilder().operationType(
         subResource == null || subResource == SubResource.Segment ? GetBlobOptions.OperationType.All
             : GetBlobOptions.OperationType.BlobInfo)
         .getOption(getOption)
         .blobSegment(blobSegmentIdx)
         .range(rangeHeaderValue != null ? RestUtils.buildByteRange(rangeHeaderValue) : null)
+        .resolveRangeOnEmptyBlob(resolveRangeOnEmptyBlob)
         .build();
   }
 

--- a/ambry-api/src/main/java/com/github/ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com/github/ambry/rest/RestUtils.java
@@ -557,17 +557,20 @@ public class RestUtils {
 
   /**
    * Build the value for the Content-Range header that corresponds to the provided range and blob size. The returned
-   * Content-Range header value will be in the following format: {@code {a}-{b}/{c}}, where {@code {a}} is the inclusive
-   * start byte offset of the returned range, {@code {b}} is the inclusive end byte offset of the returned range, and
-   * {@code {c}} is the total size of the blob in bytes. This function also generates the range length in bytes.
+   * Content-Range header value will be in the following format: {@code bytes {a}-{b}/{c}}, where {@code {a}} is the
+   * inclusive start byte offset of the returned range, {@code {b}} is the inclusive end byte offset of the returned
+   * range, and {@code {c}} is the total size of the blob in bytes. This function also generates the range length in
+   * bytes.
    * @param range a {@link ByteRange} used to generate the Content-Range header.
    * @param blobSize the total size of the associated blob in bytes.
+   * @param resolveRangeOnEmptyBlob {@code true} to force range resolution to succeed if the blob is empty.
+   *                                In other words, return {@code bytes 1-0/0} if {@code totalSize == 0}.
    * @return a {@link Pair} containing the content range header value and the content length in bytes.
    */
-  public static Pair<String, Long> buildContentRangeAndLength(ByteRange range, long blobSize)
-      throws RestServiceException {
+  public static Pair<String, Long> buildContentRangeAndLength(ByteRange range, long blobSize,
+      boolean resolveRangeOnEmptyBlob) throws RestServiceException {
     try {
-      range = range.toResolvedByteRange(blobSize);
+      range = range.toResolvedByteRange(blobSize, resolveRangeOnEmptyBlob);
     } catch (IllegalArgumentException e) {
       throw new RestServiceException("Range provided was not satisfiable.", e,
           RestServiceErrorCode.RangeNotSatisfiable);

--- a/ambry-api/src/main/java/com/github/ambry/router/ByteRange.java
+++ b/ambry-api/src/main/java/com/github/ambry/router/ByteRange.java
@@ -113,7 +113,20 @@ public abstract class ByteRange {
    * @return the {@link ByteRange} with start and end offsets
    * @throws IllegalArgumentException if the byte range starts past the end of the blob.
    */
-  public abstract ByteRange toResolvedByteRange(long totalSize);
+  public ByteRange toResolvedByteRange(long totalSize) {
+    return toResolvedByteRange(totalSize, false);
+  };
+
+  /**
+   * Given the total size of a blob, generate a new {@link ByteRange} of type {@link ByteRangeType#OFFSET_RANGE} with
+   * defined start and end offsets that are verified to be within the supplied total blob size.
+   * @param totalSize the total size of the blob that this range corresponds to.
+   * @param resolveRangeOnEmptyBlob {@code true} to force range resolution to succeed if the blob is empty.
+   *                                In other words, return an empty range if {@code totalSize == 0}.
+   * @return the {@link ByteRange} with start and end offsets
+   * @throws IllegalArgumentException if the byte range starts past the end of the blob.
+   */
+  public abstract ByteRange toResolvedByteRange(long totalSize, boolean resolveRangeOnEmptyBlob);
 
   @Override
   public abstract String toString();

--- a/ambry-api/src/main/java/com/github/ambry/router/ByteRanges.java
+++ b/ambry-api/src/main/java/com/github/ambry/router/ByteRanges.java
@@ -15,6 +15,7 @@
 package com.github.ambry.router;
 
 public class ByteRanges {
+  private static final ByteRange EMPTY_RANGE = new ClosedRange(0, -1);
 
   /**
    * Construct a range from a start offset to an end offset.
@@ -55,6 +56,14 @@ public class ByteRanges {
       throw new IllegalArgumentException("Invalid range offsets provided for ByteRange; lastNBytes=" + lastNBytes);
     }
     return new SuffixRange(lastNBytes);
+  }
+
+  /**
+   * Return an empty range for internal components that need one. This is represented as the range {@code [0,-1]}
+   * @return a range that contains 0 bytes.
+   */
+  static ByteRange emptyRange() {
+    return EMPTY_RANGE;
   }
 
   /**
@@ -133,7 +142,7 @@ public class ByteRanges {
    * A range from a start offset to the end of an object.
    */
   private static class OpenRange extends ByteRange {
-    private long startOffset;
+    private final long startOffset;
 
     /**
      * @see ByteRanges#fromStartOffset(long)
@@ -187,7 +196,7 @@ public class ByteRanges {
    * A range that represents the last N bytes of an object.
    */
   private static class SuffixRange extends ByteRange {
-    private long lastNBytes;
+    private final long lastNBytes;
 
     /**
      * @see ByteRanges#fromLastNBytes(long)

--- a/ambry-api/src/main/java/com/github/ambry/router/ByteRanges.java
+++ b/ambry-api/src/main/java/com/github/ambry/router/ByteRanges.java
@@ -59,14 +59,6 @@ public class ByteRanges {
   }
 
   /**
-   * Return an empty range for internal components that need one. This is represented as the range {@code [0,-1]}
-   * @return a range that contains 0 bytes.
-   */
-  static ByteRange emptyRange() {
-    return EMPTY_RANGE;
-  }
-
-  /**
    * Only static methods in this class.
    */
   private ByteRanges() {
@@ -108,7 +100,10 @@ public class ByteRanges {
     }
 
     @Override
-    public ByteRange toResolvedByteRange(long totalSize) {
+    public ByteRange toResolvedByteRange(long totalSize, boolean resolveRangeOnEmptyBlob) {
+      if (totalSize == 0 && resolveRangeOnEmptyBlob) {
+        return EMPTY_RANGE;
+      }
       if (getStartOffset() >= totalSize) {
         throw new IllegalArgumentException("Invalid totalSize: " + totalSize + " for range: " + this);
       }
@@ -162,7 +157,10 @@ public class ByteRanges {
     }
 
     @Override
-    public ByteRange toResolvedByteRange(long totalSize) {
+    public ByteRange toResolvedByteRange(long totalSize, boolean resolveRangeOnEmptyBlob) {
+      if (totalSize == 0 && resolveRangeOnEmptyBlob) {
+        return EMPTY_RANGE;
+      }
       if (getStartOffset() >= totalSize) {
         throw new IllegalArgumentException("Invalid totalSize: " + totalSize + " for range: " + this);
       }
@@ -221,7 +219,10 @@ public class ByteRanges {
     }
 
     @Override
-    public ByteRange toResolvedByteRange(long totalSize) {
+    public ByteRange toResolvedByteRange(long totalSize, boolean resolveRangeOnEmptyBlob) {
+      if (totalSize == 0 && resolveRangeOnEmptyBlob) {
+        return EMPTY_RANGE;
+      }
       if (totalSize < 0) {
         throw new IllegalArgumentException("Invalid totalSize: " + totalSize + " for range: " + this);
       }

--- a/ambry-api/src/main/java/com/github/ambry/router/GetBlobOptionsBuilder.java
+++ b/ambry-api/src/main/java/com/github/ambry/router/GetBlobOptionsBuilder.java
@@ -27,6 +27,7 @@ public class GetBlobOptionsBuilder {
   private GetBlobOptions.OperationType operationType = GetBlobOptions.OperationType.All;
   private GetOption getOption = GetOption.None;
   private ByteRange range = null;
+  private boolean resolveRangeOnEmptyBlob = false;
   private boolean rawMode = false;
   private int blobSegmentIdx = NO_BLOB_SEGMENT_IDX_SPECIFIED;
 
@@ -58,6 +59,17 @@ public class GetBlobOptionsBuilder {
   }
 
   /**
+   * @param resolveRangeOnEmptyBlob {@code true} to indicate that the router should a successful response for a range
+   *                                request against an empty (0 byte) blob instead of returning a
+   *                                {@link RouterErrorCode#RangeNotSatisfiable} error.
+   * @return this builder
+   */
+  public GetBlobOptionsBuilder resolveRangeOnEmptyBlob(boolean resolveRangeOnEmptyBlob) {
+    this.resolveRangeOnEmptyBlob = resolveRangeOnEmptyBlob;
+    return this;
+  }
+
+  /**
    * @param rawMode the raw mode flag for this get request.
    * If rawMode is true, the returned {@link GetBlobResult} will contain the raw (unserialized) blob payload in the
    * data channel and null blobInfo.  This option cannot be used in conjunction with a byte range.
@@ -81,6 +93,6 @@ public class GetBlobOptionsBuilder {
    * @return the {@link GetBlobOptions} built.
    */
   public GetBlobOptions build() {
-    return new GetBlobOptions(operationType, getOption, range, rawMode, blobSegmentIdx);
+    return new GetBlobOptions(operationType, getOption, range, resolveRangeOnEmptyBlob, rawMode, blobSegmentIdx);
   }
 }

--- a/ambry-api/src/test/java/com/github/ambry/rest/RestUtilsTest.java
+++ b/ambry-api/src/test/java/com/github/ambry/rest/RestUtilsTest.java
@@ -576,7 +576,7 @@ public class RestUtilsTest {
   }
 
   /**
-   * Test {@link RestUtils#buildContentRangeAndLength(ByteRange, long)}.
+   * Test {@link RestUtils#buildContentRangeAndLength(ByteRange, long, boolean)}.
    */
   @Test
   public void buildContentRangeAndLengthTest() throws RestServiceException {
@@ -992,7 +992,7 @@ public class RestUtilsTest {
   }
 
   /**
-   * Test {@link RestUtils#buildContentRangeAndLength(ByteRange, long)} for a specific {@link ByteRange} and total blob
+   * Test {@link RestUtils#buildContentRangeAndLength(ByteRange, long, boolean)} for a specific {@link ByteRange} and total blob
    * size.
    * @param range the {@link ByteRange} to test for.
    * @param blobSize the total blob size in bytes to test for.
@@ -1004,12 +1004,12 @@ public class RestUtilsTest {
   private void doBuildContentRangeAndLengthTest(ByteRange range, long blobSize, String expectedContentRange,
       long expectedContentLength, boolean shouldSucceed) throws RestServiceException {
     if (shouldSucceed) {
-      Pair<String, Long> rangeAndLength = RestUtils.buildContentRangeAndLength(range, blobSize);
+      Pair<String, Long> rangeAndLength = RestUtils.buildContentRangeAndLength(range, blobSize, false);
       assertEquals(expectedContentRange, rangeAndLength.getFirst());
       assertEquals(expectedContentLength, (long) rangeAndLength.getSecond());
     } else {
       try {
-        RestUtils.buildContentRangeAndLength(range, blobSize);
+        RestUtils.buildContentRangeAndLength(range, blobSize, false);
         fail("Should have encountered exception when building Content-Range");
       } catch (RestServiceException e) {
         assertEquals("Unexpected error code.", RestServiceErrorCode.RangeNotSatisfiable, e.getErrorCode());

--- a/ambry-api/src/test/java/com/github/ambry/router/GetBlobOptionsTest.java
+++ b/ambry-api/src/test/java/com/github/ambry/router/GetBlobOptionsTest.java
@@ -28,10 +28,9 @@ import static org.junit.Assert.*;
 public class GetBlobOptionsTest {
   /**
    * Test that the range option can be assigned and retrieved correctly.
-   * @throws Exception
    */
   @Test
-  public void testRangeOption() throws Exception {
+  public void testRangeOption() {
     long startOffset = 1;
     long endOffset = 2;
     ByteRange range = ByteRanges.fromOffsetRange(startOffset, endOffset);
@@ -41,9 +40,16 @@ public class GetBlobOptionsTest {
     assertEquals("Range from options not as expected.", range, options.getRange());
   }
 
+  @Test
+  public void testResolveRangeOnEmptyBlobOption() {
+    GetBlobOptions options = new GetBlobOptionsBuilder().build();
+    assertFalse("Default value of resolveRangeOnEmptyBlob should be false", options.resolveRangeOnEmptyBlob());
+    options = new GetBlobOptionsBuilder().resolveRangeOnEmptyBlob(true).build();
+    assertTrue("resolveRangeOnEmptyBlob should be set to true", options.resolveRangeOnEmptyBlob());
+  }
+
   /**
    * Test that the OperationType option can be assigned and retrieved correctly.
-   * @throws Exception
    */
   @Test
   public void testOperationTypeOption() {
@@ -54,7 +60,6 @@ public class GetBlobOptionsTest {
 
   /**
    * Test that the {@link GetOption} option can be assigned and retrieved correctly.
-   * @throws Exception
    */
   @Test
   public void testGetOptionOption() {

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbrySecurityService.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbrySecurityService.java
@@ -15,6 +15,7 @@ package com.github.ambry.frontend;
 
 import com.github.ambry.account.Account;
 import com.github.ambry.account.Container;
+import com.github.ambry.commons.Callback;
 import com.github.ambry.config.FrontendConfig;
 import com.github.ambry.messageformat.BlobInfo;
 import com.github.ambry.messageformat.BlobProperties;
@@ -27,7 +28,6 @@ import com.github.ambry.rest.RestResponseChannel;
 import com.github.ambry.rest.RestServiceErrorCode;
 import com.github.ambry.rest.RestServiceException;
 import com.github.ambry.rest.RestUtils;
-import com.github.ambry.commons.Callback;
 import com.github.ambry.router.GetBlobOptions;
 import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.Time;
@@ -265,7 +265,8 @@ class AmbrySecurityService implements SecurityService {
     restResponseChannel.setHeader(RestUtils.Headers.ACCEPT_RANGES, RestUtils.BYTE_RANGE_UNITS);
     long contentLength = blobProperties.getBlobSize();
     if (options.getRange() != null) {
-      Pair<String, Long> rangeAndLength = RestUtils.buildContentRangeAndLength(options.getRange(), contentLength);
+      Pair<String, Long> rangeAndLength =
+          RestUtils.buildContentRangeAndLength(options.getRange(), contentLength, options.resolveRangeOnEmptyBlob());
       restResponseChannel.setHeader(RestUtils.Headers.CONTENT_RANGE, rangeAndLength.getFirst());
       contentLength = rangeAndLength.getSecond();
     }
@@ -289,7 +290,8 @@ class AmbrySecurityService implements SecurityService {
     restResponseChannel.setHeader(RestUtils.Headers.ACCEPT_RANGES, RestUtils.BYTE_RANGE_UNITS);
     long contentLength = blobProperties.getBlobSize();
     if (options.getRange() != null) {
-      Pair<String, Long> rangeAndLength = RestUtils.buildContentRangeAndLength(options.getRange(), contentLength);
+      Pair<String, Long> rangeAndLength =
+          RestUtils.buildContentRangeAndLength(options.getRange(), contentLength, options.resolveRangeOnEmptyBlob());
       restResponseChannel.setHeader(RestUtils.Headers.CONTENT_RANGE, rangeAndLength.getFirst());
       contentLength = rangeAndLength.getSecond();
     }

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/AmbrySecurityServiceTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/AmbrySecurityServiceTest.java
@@ -717,7 +717,7 @@ public class AmbrySecurityServiceTest {
         restResponseChannel.getHeader(RestUtils.Headers.ACCEPT_RANGES));
     long contentLength = blobProperties.getBlobSize();
     if (range != null) {
-      Pair<String, Long> rangeAndLength = RestUtils.buildContentRangeAndLength(range, contentLength);
+      Pair<String, Long> rangeAndLength = RestUtils.buildContentRangeAndLength(range, contentLength, false);
       Assert.assertEquals("Content range header not set correctly for range " + range, rangeAndLength.getFirst(),
           restResponseChannel.getHeader(RestUtils.Headers.CONTENT_RANGE));
       contentLength = rangeAndLength.getSecond();
@@ -765,7 +765,7 @@ public class AmbrySecurityServiceTest {
         restResponseChannel.getHeader(RestUtils.Headers.ACCEPT_RANGES));
     long contentLength = blobProperties.getBlobSize();
     if (range != null) {
-      Pair<String, Long> rangeAndLength = RestUtils.buildContentRangeAndLength(range, contentLength);
+      Pair<String, Long> rangeAndLength = RestUtils.buildContentRangeAndLength(range, contentLength, false);
       Assert.assertEquals("Content range header not set correctly for range " + range, rangeAndLength.getFirst(),
           restResponseChannel.getHeader(RestUtils.Headers.CONTENT_RANGE));
       contentLength = rangeAndLength.getSecond();

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendIntegrationTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendIntegrationTest.java
@@ -425,7 +425,7 @@ public class FrontendIntegrationTest {
     // verify POST
     headers.add(RestUtils.Headers.BLOB_SIZE, content.capacity());
     headers.add(RestUtils.Headers.LIFE_VERSION, "0");
-    getBlobAndVerify(blobId, null, GetOption.None, headers, !container.isCacheable(), content, account.getName(),
+    getBlobAndVerify(blobId, null, GetOption.None, false, headers, !container.isCacheable(), content, account.getName(),
         container.getName());
     getBlobInfoAndVerify(blobId, GetOption.None, headers, !container.isCacheable(), account.getName(),
         container.getName(), null);
@@ -448,7 +448,7 @@ public class FrontendIntegrationTest {
     uri = new URI(signedGetUrl);
     httpRequest = buildRequest(HttpMethod.GET, uri.getPath() + "?" + uri.getQuery(), null, null);
     responseParts = nettyClient.sendRequest(httpRequest, null, null).get();
-    verifyGetBlobResponse(responseParts, null, headers, !container.isCacheable(), content, account.getName(),
+    verifyGetBlobResponse(responseParts, null, false, headers, !container.isCacheable(), content, account.getName(),
         container.getName());
   }
 
@@ -506,6 +506,31 @@ public class FrontendIntegrationTest {
     updateAccountsAndVerify(editedAccount, ACCOUNT_SERVICE.generateRandomAccount());
 
     getAccountsAndVerify();
+  }
+
+  @Test
+  public void emptyBlobRangeHandlingTest() throws Exception {
+    Account refAccount = ACCOUNT_SERVICE.createAndAddRandomAccount();
+    Container refContainer = refAccount.getContainerById(Container.DEFAULT_PUBLIC_CONTAINER_ID);
+    HttpHeaders headers = new DefaultHttpHeaders();
+    setAmbryHeadersForPut(headers, TTL_SECS, !refContainer.isCacheable(), refAccount.getName(),
+        "application/octet-stream", null, refAccount.getName(), refContainer.getName());
+    ByteBuffer content = ByteBuffer.allocate(0);
+    String blobId = postBlobAndVerify(headers, content, content.capacity());
+    ByteRange range = ByteRanges.fromOffsetRange(0, 50);
+    headers.add(RestUtils.Headers.BLOB_SIZE, content.capacity());
+    headers.add(RestUtils.Headers.LIFE_VERSION, "0");
+
+    // Should get a 416 if x-ambry-resolve-range-on-empty-blob is not set
+    HttpRequest httpRequest = buildRequest(HttpMethod.GET, blobId,
+        new DefaultHttpHeaders().add(RestUtils.Headers.RANGE, RestTestUtils.getRangeHeaderString(range)), null);
+    ResponseParts responseParts = nettyClient.sendRequest(httpRequest, null, null).get();
+    HttpResponse response = getHttpResponse(responseParts);
+    assertEquals("Unexpected response status", HttpResponseStatus.REQUESTED_RANGE_NOT_SATISFIABLE, response.status());
+
+    // Should get a 206 if the header is set.
+    getBlobAndVerify(blobId, range, null, true, headers, !refContainer.isCacheable(), content, refAccount.getName(),
+        refContainer.getName());
   }
 
   // helpers
@@ -658,22 +683,26 @@ public class FrontendIntegrationTest {
     }
     headers.add(RestUtils.Headers.BLOB_SIZE, content.capacity());
     headers.add(RestUtils.Headers.LIFE_VERSION, "0");
-    getBlobAndVerify(blobId, null, null, headers, isPrivate, content, expectedAccountName, expectedContainerName);
+    getBlobAndVerify(blobId, null, null, false, headers, isPrivate, content, expectedAccountName,
+        expectedContainerName);
     getHeadAndVerify(blobId, null, null, headers, isPrivate, expectedAccountName, expectedContainerName);
-    getBlobAndVerify(blobId, null, GetOption.None, headers, isPrivate, content, expectedAccountName,
+    getBlobAndVerify(blobId, null, GetOption.None, false, headers, isPrivate, content, expectedAccountName,
         expectedContainerName);
     getHeadAndVerify(blobId, null, GetOption.None, headers, isPrivate, expectedAccountName, expectedContainerName);
     ByteRange range = ByteRanges.fromLastNBytes(ThreadLocalRandom.current().nextLong(content.capacity() + 1));
-    getBlobAndVerify(blobId, range, null, headers, isPrivate, content, expectedAccountName, expectedContainerName);
+    getBlobAndVerify(blobId, range, null, false, headers, isPrivate, content, expectedAccountName,
+        expectedContainerName);
     getHeadAndVerify(blobId, range, null, headers, isPrivate, expectedAccountName, expectedContainerName);
     if (contentSize > 0) {
       range = ByteRanges.fromStartOffset(ThreadLocalRandom.current().nextLong(content.capacity()));
-      getBlobAndVerify(blobId, range, null, headers, isPrivate, content, expectedAccountName, expectedContainerName);
+      getBlobAndVerify(blobId, range, null, false, headers, isPrivate, content, expectedAccountName,
+          expectedContainerName);
       getHeadAndVerify(blobId, range, null, headers, isPrivate, expectedAccountName, expectedContainerName);
       long random1 = ThreadLocalRandom.current().nextLong(content.capacity());
       long random2 = ThreadLocalRandom.current().nextLong(content.capacity());
       range = ByteRanges.fromOffsetRange(Math.min(random1, random2), Math.max(random1, random2));
-      getBlobAndVerify(blobId, range, null, headers, isPrivate, content, expectedAccountName, expectedContainerName);
+      getBlobAndVerify(blobId, range, null, false, headers, isPrivate, content, expectedAccountName,
+          expectedContainerName);
       getHeadAndVerify(blobId, range, null, headers, isPrivate, expectedAccountName, expectedContainerName);
     }
     getNotModifiedBlobAndVerify(blobId, null, isPrivate);
@@ -772,6 +801,8 @@ public class FrontendIntegrationTest {
    * @param blobId the blob ID of the blob to GET.
    * @param range the {@link ByteRange} for the request.
    * @param getOption the options to use while getting the blob.
+   * @param resolveRangeOnEmptyBlob {@code true} to send the {@link RestUtils.Headers#RESOLVE_RANGE_ON_EMPTY_BLOB}
+   *                                header.
    * @param expectedHeaders the expected headers in the response.
    * @param isPrivate {@code true} if the blob is private, {@code false} if not.
    * @param expectedContent the expected content of the blob.
@@ -780,9 +811,9 @@ public class FrontendIntegrationTest {
    * @throws ExecutionException
    * @throws InterruptedException
    */
-  private void getBlobAndVerify(String blobId, ByteRange range, GetOption getOption, HttpHeaders expectedHeaders,
-      boolean isPrivate, ByteBuffer expectedContent, String accountName, String containerName)
-      throws ExecutionException, InterruptedException, RestServiceException {
+  private void getBlobAndVerify(String blobId, ByteRange range, GetOption getOption, boolean resolveRangeOnEmptyBlob,
+      HttpHeaders expectedHeaders, boolean isPrivate, ByteBuffer expectedContent, String accountName,
+      String containerName) throws ExecutionException, InterruptedException, RestServiceException {
     HttpHeaders headers = new DefaultHttpHeaders();
     if (range != null) {
       headers.add(RestUtils.Headers.RANGE, RestTestUtils.getRangeHeaderString(range));
@@ -790,16 +821,21 @@ public class FrontendIntegrationTest {
     if (getOption != null) {
       headers.add(RestUtils.Headers.GET_OPTION, getOption.toString());
     }
+    if (resolveRangeOnEmptyBlob) {
+      headers.add(RestUtils.Headers.RESOLVE_RANGE_ON_EMPTY_BLOB, true);
+    }
     FullHttpRequest httpRequest = buildRequest(HttpMethod.GET, blobId, headers, null);
     ResponseParts responseParts = nettyClient.sendRequest(httpRequest, null, null).get();
-    verifyGetBlobResponse(responseParts, range, expectedHeaders, isPrivate, expectedContent, accountName,
-        containerName);
+    verifyGetBlobResponse(responseParts, range, resolveRangeOnEmptyBlob, expectedHeaders, isPrivate, expectedContent,
+        accountName, containerName);
   }
 
   /**
    * Verifies the GET blob response.
    * @param responseParts the response received from the server.
    * @param range the {@link ByteRange} for the request.
+   * @param resolveRangeOnEmptyBlob {@code true} if the {@link RestUtils.Headers#RESOLVE_RANGE_ON_EMPTY_BLOB} header was
+   *                                sent.
    * @param expectedHeaders the expected headers in the response.
    * @param isPrivate {@code true} if the blob is private, {@code false} if not.
    * @param expectedContent the expected content of the blob.
@@ -807,9 +843,9 @@ public class FrontendIntegrationTest {
    * @param containerName the container name that should be in the response
    * @throws RestServiceException
    */
-  private void verifyGetBlobResponse(ResponseParts responseParts, ByteRange range, HttpHeaders expectedHeaders,
-      boolean isPrivate, ByteBuffer expectedContent, String accountName, String containerName)
-      throws RestServiceException {
+  private void verifyGetBlobResponse(ResponseParts responseParts, ByteRange range, boolean resolveRangeOnEmptyBlob,
+      HttpHeaders expectedHeaders, boolean isPrivate, ByteBuffer expectedContent, String accountName,
+      String containerName) throws RestServiceException {
     HttpResponse response = getHttpResponse(responseParts);
     assertEquals("Unexpected response status",
         range == null ? HttpResponseStatus.OK : HttpResponseStatus.PARTIAL_CONTENT, response.status());
@@ -825,9 +861,9 @@ public class FrontendIntegrationTest {
     if (range != null) {
       long blobSize = Long.parseLong(expectedHeaders.get(RestUtils.Headers.BLOB_SIZE));
       assertEquals("Content-Range header not set correctly",
-          RestUtils.buildContentRangeAndLength(range, blobSize, false).getFirst(),
+          RestUtils.buildContentRangeAndLength(range, blobSize, resolveRangeOnEmptyBlob).getFirst(),
           response.headers().get(RestUtils.Headers.CONTENT_RANGE));
-      ByteRange resolvedRange = range.toResolvedByteRange(blobSize);
+      ByteRange resolvedRange = range.toResolvedByteRange(blobSize, resolveRangeOnEmptyBlob);
       expectedContentArray = Arrays.copyOfRange(expectedContentArray, (int) resolvedRange.getStartOffset(),
           (int) resolvedRange.getEndOffset() + 1);
     } else {
@@ -1193,7 +1229,8 @@ public class FrontendIntegrationTest {
 
     GetOption[] options = {GetOption.Include_Deleted_Blobs, GetOption.Include_All};
     for (GetOption option : options) {
-      getBlobAndVerify(blobId, null, option, expectedHeaders, isPrivate, expectedContent, accountName, containerName);
+      getBlobAndVerify(blobId, null, option, false, expectedHeaders, isPrivate, expectedContent, accountName,
+          containerName);
       getNotModifiedBlobAndVerify(blobId, option, isPrivate);
       getUserMetadataAndVerify(blobId, option, expectedHeaders, usermetadata);
       getBlobInfoAndVerify(blobId, option, expectedHeaders, isPrivate, accountName, containerName, usermetadata);
@@ -1371,7 +1408,7 @@ public class FrontendIntegrationTest {
       expectedGetHeaders.set(RestUtils.Headers.TTL, FRONTEND_CONFIG.chunkUploadInitialChunkTtlSecs);
       expectedGetHeaders.set(RestUtils.Headers.LIFE_VERSION, "0");
       for (String id : new String[]{signedId, idAndMetadata.getFirst()}) {
-        getBlobAndVerify(id, null, GetOption.None, expectedGetHeaders, !container.isCacheable(), content,
+        getBlobAndVerify(id, null, GetOption.None, false, expectedGetHeaders, !container.isCacheable(), content,
             account.getName(), container.getName());
         getBlobInfoAndVerify(id, GetOption.None, expectedGetHeaders, !container.isCacheable(), account.getName(),
             container.getName(), null);
@@ -1415,7 +1452,7 @@ public class FrontendIntegrationTest {
     long random2 = ThreadLocalRandom.current().nextLong(fullContentArray.length);
     ranges.add(ByteRanges.fromOffsetRange(Math.min(random1, random2), Math.max(random1, random2)));
     for (ByteRange range : ranges) {
-      getBlobAndVerify(stitchedBlobId, range, GetOption.None, expectedGetHeaders, !container.isCacheable(),
+      getBlobAndVerify(stitchedBlobId, range, GetOption.None, false, expectedGetHeaders, !container.isCacheable(),
           ByteBuffer.wrap(fullContentArray), account.getName(), container.getName());
       getHeadAndVerify(stitchedBlobId, range, GetOption.None, expectedGetHeaders, !container.isCacheable(),
           account.getName(), container.getName());

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendIntegrationTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendIntegrationTest.java
@@ -825,7 +825,7 @@ public class FrontendIntegrationTest {
     if (range != null) {
       long blobSize = Long.parseLong(expectedHeaders.get(RestUtils.Headers.BLOB_SIZE));
       assertEquals("Content-Range header not set correctly",
-          RestUtils.buildContentRangeAndLength(range, blobSize).getFirst(),
+          RestUtils.buildContentRangeAndLength(range, blobSize, false).getFirst(),
           response.headers().get(RestUtils.Headers.CONTENT_RANGE));
       ByteRange resolvedRange = range.toResolvedByteRange(blobSize);
       expectedContentArray = Arrays.copyOfRange(expectedContentArray, (int) resolvedRange.getStartOffset(),
@@ -974,7 +974,7 @@ public class FrontendIntegrationTest {
     checkCommonGetHeadHeaders(response.headers());
     long contentLength = Long.parseLong(expectedHeaders.get(RestUtils.Headers.BLOB_SIZE));
     if (range != null) {
-      Pair<String, Long> rangeAndLength = RestUtils.buildContentRangeAndLength(range, contentLength);
+      Pair<String, Long> rangeAndLength = RestUtils.buildContentRangeAndLength(range, contentLength, false);
       assertEquals("Content-Range header not set correctly", rangeAndLength.getFirst(),
           response.headers().get(RestUtils.Headers.CONTENT_RANGE));
       contentLength = rangeAndLength.getSecond();

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
@@ -1664,7 +1664,7 @@ public class FrontendRestRequestServiceTest {
     if (range != null) {
       long blobSize = expectedHeaders.getLong(RestUtils.Headers.BLOB_SIZE);
       assertEquals("Content-Range does not match expected",
-          RestUtils.buildContentRangeAndLength(range, blobSize).getFirst(),
+          RestUtils.buildContentRangeAndLength(range, blobSize, false).getFirst(),
           restResponseChannel.getHeader(RestUtils.Headers.CONTENT_RANGE));
       ByteRange resolvedRange = range.toResolvedByteRange(blobSize);
       expectedContentArray = Arrays.copyOfRange(expectedContentArray, (int) resolvedRange.getStartOffset(),
@@ -1790,7 +1790,7 @@ public class FrontendRestRequestServiceTest {
         restResponseChannel.getHeader(RestUtils.Headers.ACCEPT_RANGES));
     long contentLength = expectedHeaders.getLong(RestUtils.Headers.BLOB_SIZE);
     if (range != null) {
-      Pair<String, Long> rangeAndLength = RestUtils.buildContentRangeAndLength(range, contentLength);
+      Pair<String, Long> rangeAndLength = RestUtils.buildContentRangeAndLength(range, contentLength, false);
       assertEquals("Content-Range does not match expected", rangeAndLength.getFirst(),
           restResponseChannel.getHeader(RestUtils.Headers.CONTENT_RANGE));
       contentLength = rangeAndLength.getSecond();

--- a/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
@@ -1469,7 +1469,11 @@ class GetBlobOperation extends GetOperation {
       boolean failure = false;
       try {
         if (options != null && options.getBlobOptions.getRange() != null) {
-          resolvedByteRange = options.getBlobOptions.getRange().toResolvedByteRange(totalSize);
+          if (options.getBlobOptions.resolveRangeOnEmptyBlob() && totalSize == 0) {
+            resolvedByteRange = ByteRanges.emptyRange();
+          } else {
+            resolvedByteRange = options.getBlobOptions.getRange().toResolvedByteRange(totalSize);
+          }
         }
       } catch (IllegalArgumentException e) {
         onInvalidRange(e);

--- a/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
@@ -1469,11 +1469,8 @@ class GetBlobOperation extends GetOperation {
       boolean failure = false;
       try {
         if (options != null && options.getBlobOptions.getRange() != null) {
-          if (options.getBlobOptions.resolveRangeOnEmptyBlob() && totalSize == 0) {
-            resolvedByteRange = ByteRanges.emptyRange();
-          } else {
-            resolvedByteRange = options.getBlobOptions.getRange().toResolvedByteRange(totalSize);
-          }
+          resolvedByteRange = options.getBlobOptions.getRange()
+              .toResolvedByteRange(totalSize, options.getBlobOptions.resolveRangeOnEmptyBlob());
         }
       } catch (IllegalArgumentException e) {
         onInvalidRange(e);

--- a/ambry-router/src/test/java/com/github/ambry/router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/GetBlobOperationTest.java
@@ -1559,8 +1559,8 @@ public class GetBlobOperationTest {
         && !options.getBlobOptions.isRawMode() && !options.getChunkIdsOnly) {
       int sizeWritten = blobSize;
       if (options.getBlobOptions.getRange() != null) {
-        ByteRange range = options.getBlobOptions.resolveRangeOnEmptyBlob() && blobSize == 0 ? ByteRanges.emptyRange()
-            : options.getBlobOptions.getRange().toResolvedByteRange(blobSize);
+        ByteRange range = options.getBlobOptions.getRange()
+            .toResolvedByteRange(blobSize, options.getBlobOptions.resolveRangeOnEmptyBlob());
         sizeWritten = (int) range.getRangeSize();
       }
       Assert.assertEquals("Size read must equal size written", sizeWritten, readCompleteResult.get());
@@ -1643,8 +1643,7 @@ public class GetBlobOperationTest {
       } else {
         // If a range is set, compare the result against the specified byte range.
         if (options != null && options.getRange() != null) {
-          ByteRange range = options.resolveRangeOnEmptyBlob() && putContent.length == 0 ? ByteRanges.emptyRange()
-              : options.getRange().toResolvedByteRange(blobSize);
+          ByteRange range = options.getRange().toResolvedByteRange(blobSize, options.resolveRangeOnEmptyBlob());
           putContentBuf = ByteBuffer.wrap(putContent, (int) range.getStartOffset(), (int) range.getRangeSize());
         } else {
           putContentBuf = ByteBuffer.wrap(putContent);

--- a/ambry-router/src/test/java/com/github/ambry/router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/GetBlobOperationTest.java
@@ -1084,34 +1084,9 @@ public class GetBlobOperationTest {
    */
   @Test
   public void testRangeRequestSimpleBlob() throws Exception {
-    // Random valid ranges
-    for (int i = 0; i < 5; i++) {
-      blobSize = random.nextInt(maxChunkSize) + 1;
-      int randomOne = random.nextInt(blobSize);
-      int randomTwo = random.nextInt(blobSize);
-      testRangeRequestOffsetRange(Math.min(randomOne, randomTwo), Math.max(randomOne, randomTwo), true);
-    }
-    blobSize = random.nextInt(maxChunkSize) + 1;
-    // Entire blob
-    testRangeRequestOffsetRange(0, blobSize - 1, true);
-    // Range that extends to end of blob
-    testRangeRequestFromStartOffset(random.nextInt(blobSize), true);
-    // Last n bytes of the blob
-    testRangeRequestLastNBytes(random.nextInt(blobSize) + 1, true);
-    // Last blobSize + 1 bytes
-    testRangeRequestLastNBytes(blobSize + 1, true);
-    // Range over the end of the blob
-    testRangeRequestOffsetRange(random.nextInt(blobSize), blobSize + 5, true);
-    // Ranges that start past the end of the blob (should not succeed)
-    testRangeRequestFromStartOffset(blobSize, false);
-    testRangeRequestOffsetRange(blobSize, blobSize + 20, false);
-    // 0 byte range
-    testRangeRequestLastNBytes(0, true);
-    // 1 byte ranges
-    testRangeRequestOffsetRange(0, 0, true);
-    testRangeRequestOffsetRange(blobSize - 1, blobSize - 1, true);
-    testRangeRequestFromStartOffset(blobSize - 1, true);
-    testRangeRequestLastNBytes(1, true);
+    // the resolveRangeOnEmptyBlob setting should not change behavior for non-empty blobs
+    testRangeRequestSimpleBlob(false);
+    testRangeRequestSimpleBlob(true);
   }
 
   /**
@@ -1120,45 +1095,34 @@ public class GetBlobOperationTest {
    */
   @Test
   public void testRangeRequestCompositeBlob() throws Exception {
-    // Random valid ranges
-    for (int i = 0; i < 5; i++) {
-      blobSize = random.nextInt(maxChunkSize) + maxChunkSize * random.nextInt(10);
-      int randomOne = random.nextInt(blobSize);
-      int randomTwo = random.nextInt(blobSize);
-      testRangeRequestOffsetRange(Math.min(randomOne, randomTwo), Math.max(randomOne, randomTwo), true);
-    }
+    // the resolveRangeOnEmptyBlob setting should not change behavior for non-empty blobs
+    testRangeRequestCompositeBlob(false);
+    testRangeRequestCompositeBlob(true);
+  }
 
-    blobSize = random.nextInt(maxChunkSize) + maxChunkSize * random.nextInt(10);
-    // Entire blob
-    testRangeRequestOffsetRange(0, blobSize - 1, true);
-    // Range that extends to end of blob
-    testRangeRequestFromStartOffset(random.nextInt(blobSize), true);
-    // Last n bytes of the blob
-    testRangeRequestLastNBytes(random.nextInt(blobSize) + 1, true);
-    // Last blobSize + 1 bytes
-    testRangeRequestLastNBytes(blobSize + 1, true);
-    // Range over the end of the blob
-    testRangeRequestOffsetRange(random.nextInt(blobSize), blobSize + 5, true);
-    // Ranges that start past the end of the blob (should not succeed)
-    testRangeRequestFromStartOffset(blobSize, false);
-    testRangeRequestOffsetRange(blobSize, blobSize + 20, false);
-    // 1 byte ranges
-    testRangeRequestOffsetRange(0, 0, true);
-    testRangeRequestOffsetRange(blobSize / 2, blobSize / 2, true);
-    testRangeRequestOffsetRange(blobSize - 1, blobSize - 1, true);
-    testRangeRequestFromStartOffset(blobSize - 1, true);
-    testRangeRequestLastNBytes(1, true);
+  /**
+   * Test range request behavior with 0-byte blobs.
+   * @throws Exception
+   */
+  @Test
+  public void testRangeRequestEmptyBlob() throws Exception {
+    blobSize = 0;
+    // only a last n bytes request should succeed. Any other request should fail if resolveRangeOnEmptyBlob is false,
+    // since offset 0 is past the end of the blob.
+    testRangeRequest(ByteRanges.fromStartOffset(0), false, false);
+    testRangeRequest(ByteRanges.fromStartOffset(1), false, false);
+    testRangeRequest(ByteRanges.fromOffsetRange(0, 15), false, false);
+    testRangeRequest(ByteRanges.fromOffsetRange(2, 15), false, false);
+    testRangeRequest(ByteRanges.fromLastNBytes(20), false, true);
+    testRangeRequest(ByteRanges.fromLastNBytes(0), false, true);
 
-    blobSize = maxChunkSize * 2 + random.nextInt(maxChunkSize) + 1;
-    // Single start chunk
-    testRangeRequestOffsetRange(0, maxChunkSize - 1, true);
-    // Single intermediate chunk
-    testRangeRequestOffsetRange(maxChunkSize, maxChunkSize * 2 - 1, true);
-    // Single end chunk
-    testRangeRequestOffsetRange(maxChunkSize * 2, blobSize - 1, true);
-    // Over chunk boundaries
-    testRangeRequestOffsetRange(maxChunkSize / 2, maxChunkSize + maxChunkSize / 2, true);
-    testRangeRequestFromStartOffset(maxChunkSize + maxChunkSize / 2, true);
+    // all types of range requests should succeed if resolveRangeOnEmptyBlob is true.
+    testRangeRequest(ByteRanges.fromStartOffset(0), true, true);
+    testRangeRequest(ByteRanges.fromStartOffset(1), true, true);
+    testRangeRequest(ByteRanges.fromOffsetRange(0, 15), true, true);
+    testRangeRequest(ByteRanges.fromOffsetRange(2, 15), true, true);
+    testRangeRequest(ByteRanges.fromLastNBytes(20), true, true);
+    testRangeRequest(ByteRanges.fromLastNBytes(0), true, true);
   }
 
   /**
@@ -1306,48 +1270,103 @@ public class GetBlobOperationTest {
   }
 
   /**
+   * Test range requests on a single chunk blob.
+   * @param resolveRangeOnEmptyBlob the value of {@link GetBlobOptions#resolveRangeOnEmptyBlob()} to set.
+   */
+  private void testRangeRequestSimpleBlob(boolean resolveRangeOnEmptyBlob) throws Exception {
+    // Random valid ranges
+    for (int i = 0; i < 5; i++) {
+      blobSize = random.nextInt(maxChunkSize) + 1;
+      int randomOne = random.nextInt(blobSize);
+      int randomTwo = random.nextInt(blobSize);
+      testRangeRequest(ByteRanges.fromOffsetRange(Math.min(randomOne, randomTwo), Math.max(randomOne, randomTwo)),
+          resolveRangeOnEmptyBlob, true);
+    }
+    blobSize = random.nextInt(maxChunkSize) + 1;
+    // Entire blob
+    testRangeRequest(ByteRanges.fromOffsetRange(0, blobSize - 1), resolveRangeOnEmptyBlob, true);
+    // Range that extends to end of blob
+    testRangeRequest(ByteRanges.fromStartOffset(random.nextInt(blobSize)), resolveRangeOnEmptyBlob, true);
+    // Last n bytes of the blob
+    testRangeRequest(ByteRanges.fromLastNBytes(random.nextInt(blobSize) + 1), resolveRangeOnEmptyBlob, true);
+    // Last blobSize + 1 bytes
+    testRangeRequest(ByteRanges.fromLastNBytes(blobSize + 1), resolveRangeOnEmptyBlob, true);
+    // Range over the end of the blob
+    testRangeRequest(ByteRanges.fromOffsetRange(random.nextInt(blobSize), blobSize + 5), resolveRangeOnEmptyBlob, true);
+    // Ranges that start past the end of the blob (should not succeed)
+    testRangeRequest(ByteRanges.fromStartOffset(blobSize), resolveRangeOnEmptyBlob, false);
+    testRangeRequest(ByteRanges.fromOffsetRange(blobSize, blobSize + 20), resolveRangeOnEmptyBlob, false);
+    // 0 byte range
+    testRangeRequest(ByteRanges.fromLastNBytes(0), resolveRangeOnEmptyBlob, true);
+    // 1 byte ranges
+    testRangeRequest(ByteRanges.fromOffsetRange(0, 0), resolveRangeOnEmptyBlob, true);
+    testRangeRequest(ByteRanges.fromOffsetRange(blobSize - 1, blobSize - 1), resolveRangeOnEmptyBlob, true);
+    testRangeRequest(ByteRanges.fromStartOffset(blobSize - 1), resolveRangeOnEmptyBlob, true);
+    testRangeRequest(ByteRanges.fromLastNBytes(1), resolveRangeOnEmptyBlob, true);
+  }
+
+  /**
+   * Test range requests on a composite blob
+   * @param resolveRangeOnEmptyBlob the value of {@link GetBlobOptions#resolveRangeOnEmptyBlob()} to set.
+   */
+  private void testRangeRequestCompositeBlob(boolean resolveRangeOnEmptyBlob) throws Exception {
+    // Random valid ranges
+    for (int i = 0; i < 5; i++) {
+      blobSize = random.nextInt(maxChunkSize) + maxChunkSize * random.nextInt(10);
+      int randomOne = random.nextInt(blobSize);
+      int randomTwo = random.nextInt(blobSize);
+      testRangeRequest(ByteRanges.fromOffsetRange(Math.min(randomOne, randomTwo), Math.max(randomOne, randomTwo)),
+          resolveRangeOnEmptyBlob, true);
+    }
+
+    blobSize = random.nextInt(maxChunkSize) + maxChunkSize * random.nextInt(10);
+    // Entire blob
+    testRangeRequest(ByteRanges.fromOffsetRange(0, blobSize - 1), resolveRangeOnEmptyBlob, true);
+    // Range that extends to end of blob
+    testRangeRequest(ByteRanges.fromStartOffset(random.nextInt(blobSize)), resolveRangeOnEmptyBlob, true);
+    // Last n bytes of the blob
+    testRangeRequest(ByteRanges.fromLastNBytes(random.nextInt(blobSize) + 1), resolveRangeOnEmptyBlob, true);
+    // Last blobSize + 1 bytes
+    testRangeRequest(ByteRanges.fromLastNBytes(blobSize + 1), resolveRangeOnEmptyBlob, true);
+    // Range over the end of the blob
+    testRangeRequest(ByteRanges.fromOffsetRange(random.nextInt(blobSize), blobSize + 5), resolveRangeOnEmptyBlob, true);
+    // Ranges that start past the end of the blob (should not succeed)
+    testRangeRequest(ByteRanges.fromStartOffset(blobSize), resolveRangeOnEmptyBlob, false);
+    testRangeRequest(ByteRanges.fromOffsetRange(blobSize, blobSize + 20), resolveRangeOnEmptyBlob, false);
+    // 1 byte ranges
+    testRangeRequest(ByteRanges.fromOffsetRange(0, 0), resolveRangeOnEmptyBlob, true);
+    testRangeRequest(ByteRanges.fromOffsetRange(blobSize / 2, blobSize / 2), resolveRangeOnEmptyBlob, true);
+    testRangeRequest(ByteRanges.fromOffsetRange(blobSize - 1, blobSize - 1), resolveRangeOnEmptyBlob, true);
+    testRangeRequest(ByteRanges.fromStartOffset(blobSize - 1), resolveRangeOnEmptyBlob, true);
+    testRangeRequest(ByteRanges.fromLastNBytes(1), resolveRangeOnEmptyBlob, true);
+
+    blobSize = maxChunkSize * 2 + random.nextInt(maxChunkSize) + 1;
+    // Single start chunk
+    testRangeRequest(ByteRanges.fromOffsetRange(0, maxChunkSize - 1), resolveRangeOnEmptyBlob, true);
+    // Single intermediate chunk
+    testRangeRequest(ByteRanges.fromOffsetRange(maxChunkSize, maxChunkSize * 2 - 1), resolveRangeOnEmptyBlob, true);
+    // Single end chunk
+    testRangeRequest(ByteRanges.fromOffsetRange(maxChunkSize * 2, blobSize - 1), resolveRangeOnEmptyBlob, true);
+    // Over chunk boundaries
+    testRangeRequest(ByteRanges.fromOffsetRange(maxChunkSize / 2, maxChunkSize + maxChunkSize / 2),
+        resolveRangeOnEmptyBlob, true);
+    testRangeRequest(ByteRanges.fromStartOffset(maxChunkSize + maxChunkSize / 2), resolveRangeOnEmptyBlob, true);
+  }
+
+  /**
    * Send a range request and test that it either completes successfully or fails with a
    * {@link RouterErrorCode#RangeNotSatisfiable} error.
-   * @param startOffset The start byte offset for the range request.
-   * @param endOffset The end byte offset for the range request
+   * @param range The {@link ByteRange} to set in {@link GetBlobOptions}.
+   * @param resolveRangeOnEmptyBlob the value of {@link GetBlobOptions#resolveRangeOnEmptyBlob()} to set.
    * @param rangeSatisfiable {@code true} if the range request should succeed.
    * @throws Exception
    */
-  private void testRangeRequestOffsetRange(long startOffset, long endOffset, boolean rangeSatisfiable)
+  private void testRangeRequest(ByteRange range, boolean resolveRangeOnEmptyBlob, boolean rangeSatisfiable)
       throws Exception {
     doPut();
     options = new GetBlobOptionsInternal(new GetBlobOptionsBuilder().operationType(GetBlobOptions.OperationType.All)
-        .range(ByteRanges.fromOffsetRange(startOffset, endOffset))
-        .build(), false, routerMetrics.ageAtGet);
-    getErrorCodeChecker.testAndAssert(rangeSatisfiable ? null : RouterErrorCode.RangeNotSatisfiable);
-  }
-
-  /**
-   * Send a range request from a {@code startOffset} on and test that it either completes successfully or fails with a
-   * {@link RouterErrorCode#RangeNotSatisfiable} error.
-   * @param startOffset The start byte offset for the range request.
-   * @param rangeSatisfiable {@code true} if the range request should succeed.
-   * @throws Exception
-   */
-  private void testRangeRequestFromStartOffset(long startOffset, boolean rangeSatisfiable) throws Exception {
-    doPut();
-    options = new GetBlobOptionsInternal(new GetBlobOptionsBuilder().operationType(GetBlobOptions.OperationType.All)
-        .range(ByteRanges.fromStartOffset(startOffset))
-        .build(), false, routerMetrics.ageAtGet);
-    getErrorCodeChecker.testAndAssert(rangeSatisfiable ? null : RouterErrorCode.RangeNotSatisfiable);
-  }
-
-  /**
-   * Send a range request for the {@code lastNBytes} of an object and test that it either completes successfully or
-   * fails with a {@link RouterErrorCode#RangeNotSatisfiable} error.
-   * @param lastNBytes The start byte offset for the range request.
-   * @param rangeSatisfiable {@code true} if the range request should succeed.
-   * @throws Exception
-   */
-  private void testRangeRequestLastNBytes(long lastNBytes, boolean rangeSatisfiable) throws Exception {
-    doPut();
-    options = new GetBlobOptionsInternal(new GetBlobOptionsBuilder().operationType(GetBlobOptions.OperationType.All)
-        .range(ByteRanges.fromLastNBytes(lastNBytes))
+        .range(range)
+        .resolveRangeOnEmptyBlob(resolveRangeOnEmptyBlob)
         .build(), false, routerMetrics.ageAtGet);
     getErrorCodeChecker.testAndAssert(rangeSatisfiable ? null : RouterErrorCode.RangeNotSatisfiable);
   }
@@ -1540,8 +1559,9 @@ public class GetBlobOperationTest {
         && !options.getBlobOptions.isRawMode() && !options.getChunkIdsOnly) {
       int sizeWritten = blobSize;
       if (options.getBlobOptions.getRange() != null) {
-        ByteRange range = options.getBlobOptions.getRange().toResolvedByteRange(blobSize);
-        sizeWritten = (int) (range.getEndOffset() - range.getStartOffset() + 1);
+        ByteRange range = options.getBlobOptions.resolveRangeOnEmptyBlob() && blobSize == 0 ? ByteRanges.emptyRange()
+            : options.getBlobOptions.getRange().toResolvedByteRange(blobSize);
+        sizeWritten = (int) range.getRangeSize();
       }
       Assert.assertEquals("Size read must equal size written", sizeWritten, readCompleteResult.get());
     }
@@ -1621,11 +1641,13 @@ public class GetBlobOperationTest {
         putContentBuf = getBlobBuffer();
         Assert.assertNotNull("Did not find server with blob: " + blobIdStr, putContentBuf);
       } else {
-        putContentBuf = ByteBuffer.wrap(putContent);
         // If a range is set, compare the result against the specified byte range.
         if (options != null && options.getRange() != null) {
-          ByteRange range = options.getRange().toResolvedByteRange(blobSize);
+          ByteRange range = options.resolveRangeOnEmptyBlob() && putContent.length == 0 ? ByteRanges.emptyRange()
+              : options.getRange().toResolvedByteRange(blobSize);
           putContentBuf = ByteBuffer.wrap(putContent, (int) range.getStartOffset(), (int) range.getRangeSize());
+        } else {
+          putContentBuf = ByteBuffer.wrap(putContent);
         }
       }
 

--- a/ambry-test-utils/src/main/java/com/github/ambry/router/InMemoryRouter.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/router/InMemoryRouter.java
@@ -144,18 +144,19 @@ public class InMemoryRouter implements Router {
     }
 
     /**
-     * @param range the {@link ByteRange} for the blob, or null.
+     * @param options any options specified for fetching the blob.
      * @return the blob content within the provided range, or the entire blob, if the range is null.
      * @throws RouterException if the range was non-null, but could not be resolved.
      */
-    public ByteBuffer getBlob(ByteRange range) throws RouterException {
+    public ByteBuffer getBlob(GetBlobOptions options) throws RouterException {
       ByteBuffer buf;
-      if (range == null) {
+      if (options.getRange() == null) {
         buf = getBlob();
       } else {
         ByteRange resolvedRange;
         try {
-          resolvedRange = range.toResolvedByteRange(blob.array().length);
+          resolvedRange =
+              options.getRange().toResolvedByteRange(blob.array().length, options.resolveRangeOnEmptyBlob());
         } catch (IllegalArgumentException e) {
           throw new RouterException("Invalid range for blob", e, RouterErrorCode.RangeNotSatisfiable);
         }
@@ -210,13 +211,13 @@ public class InMemoryRouter implements Router {
             || ALLOW_EXPIRED_BLOB_GET.contains(options.getGetOption())) {
           switch (options.getOperationType()) {
             case Data:
-              blobDataChannel = new ByteBufferRSC(blob.getBlob(options.getRange()));
+              blobDataChannel = new ByteBufferRSC(blob.getBlob(options));
               break;
             case BlobInfo:
               blobInfo = new BlobInfo(blob.getBlobProperties(), blob.getUserMetadata());
               break;
             case All:
-              blobDataChannel = new ByteBufferRSC(blob.getBlob(options.getRange()));
+              blobDataChannel = new ByteBufferRSC(blob.getBlob(options));
               blobInfo = new BlobInfo(blob.getBlobProperties(), blob.getUserMetadata());
               break;
           }


### PR DESCRIPTION
Some clients make preemptive range requests against blobs. Since the
client does not know the blob size without making at least one request,
they could be making a range request against an empty (0-byte) blob. All
range types with a start offset will fail with a 416 since byte 0 is
already past the end of an empty blob.

To keep this behavior for most users (since changing range request
behavior can cause CDN interaction challenges), this PR introduces an
optional request header that allows the client to tell ambry-frontend to
that it wants a success response when any range request is made against
an empty blob.