### PR TITLE
[SEGMENTED_GET_FIX] Return correct size in headers for segmented blobs.

### DIFF
--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbrySecurityService.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbrySecurityService.java
@@ -15,6 +15,7 @@ package com.github.ambry.frontend;
 
 import com.github.ambry.account.Account;
 import com.github.ambry.account.Container;
+import com.github.ambry.commons.Callback;
 import com.github.ambry.config.FrontendConfig;
 import com.github.ambry.messageformat.BlobInfo;
 import com.github.ambry.messageformat.BlobProperties;
@@ -27,7 +28,6 @@ import com.github.ambry.rest.RestResponseChannel;
 import com.github.ambry.rest.RestServiceErrorCode;
 import com.github.ambry.rest.RestServiceException;
 import com.github.ambry.rest.RestUtils;
-import com.github.ambry.commons.Callback;
 import com.github.ambry.router.GetBlobOptions;
 import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.Time;
@@ -49,7 +49,9 @@ import static com.github.ambry.router.GetBlobOptions.*;
  */
 class AmbrySecurityService implements SecurityService {
 
-  static final Set<String> OPERATIONS;
+  static final Set<String> OPERATIONS = Collections.unmodifiableSet(
+      Utils.getStaticFieldValuesAsStrings(Operations.class)
+          .collect(Collectors.toCollection(() -> new TreeSet<>(String.CASE_INSENSITIVE_ORDER))));
   private final FrontendConfig frontendConfig;
   private final FrontendMetrics frontendMetrics;
   private final UrlSigningService urlSigningService;
@@ -383,10 +385,5 @@ class AmbrySecurityService implements SecurityService {
             RestServiceErrorCode.AccessDenied);
       }
     }
-  }
-
-  static {
-    OPERATIONS = Collections.unmodifiableSet(Utils.getStaticFieldValuesAsStrings(Operations.class)
-        .collect(Collectors.toCollection(() -> new TreeSet<>(String.CASE_INSENSITIVE_ORDER))));
   }
 }

--- a/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
@@ -222,7 +222,7 @@ class GetBlobOperation extends GetOperation {
           }
           if (e == null) {
             if (blobInfo != null) {
-              // For segmented blob we have already filtered out not required chunks by now. So the first chunk is the segment we need.
+              // For segmented blob we have already filtered out not-required chunks by now. So the first chunk is the segment we need.
               fixBlobSizeIfRequired(blobInfo.getBlobProperties().getBlobSize(),
                   options.getBlobOptions.hasBlobSegmentIdx() ? firstChunk.getChunkMetadataList().get(0).getSize()
                       : totalSize);
@@ -250,13 +250,13 @@ class GetBlobOperation extends GetOperation {
 
   /**
    * In order to mitigate impact of replication logic that set the size field in BlobProperties incorrectly,
-   * replace the field with the size from inside of the metadata content.
+   * and in case of GET for segment of a blob, replace the field with the size from inside of the metadata content.
    * @param blobSizeFromProperties blob size obtained from blob properties.
    * @param blobSizeFromMetadata blob size obtained from metadata of the given blob or its composite blob.
    */
   private void fixBlobSizeIfRequired(long blobSizeFromProperties, long blobSizeFromMetadata) {
     // In order to mitigate impact of replication logic that set the size field in BlobProperties incorrectly,
-    // we will replace the field with the size from inside of the metadata content.
+    // and in case of GET for segment of a blob, we will replace the field with the size from inside of the metadata content.
     if (blobSizeFromProperties != blobSizeFromMetadata) {
       if (compositeBlobInfo != null) {
         routerMetrics.compositeBlobSizeMismatchCount.inc();


### PR DESCRIPTION
The size of the segmented blob can only be determined when the segmented chunk has been fetched. This PR fixes the issue of returning correct for segmented blobs by taking advantage of the fact that for a segmented blob, first chunk will always be a metadata chunk, and subsequently there will be only data chunk that will ever be returned.