### PR TITLE
Fix a NullPointerException in PutOperation's fillChunk method

### DIFF
--- a/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
@@ -444,7 +444,7 @@ class PutOperation {
     }
   }
 
-  private void setOperationCompleted() {
+  void setOperationCompleted() {
     operationCompleted = true;
     releaseResource();
   }
@@ -592,6 +592,8 @@ class PutOperation {
         if (lastChunk != null) {
           if (chunkCounter != 0 && lastChunk.buf.readableBytes() == 0) {
             logger.trace("The last buffer(s) received from chunkFillerChannel have no data, discarding them.");
+            lastChunk.releaseBlobContent();
+            lastChunk.state = ChunkState.Free;
           } else {
             lastChunk.onFillComplete(true);
             updateChunkFillerWaitTimeMetrics();


### PR DESCRIPTION
There is a NPE in the ChunkFiller thread in PutOperation. The root cause of this NPE is a race condition and state misconfiguration.
The data flow that causes NPE
1 Last chunkReadBuf from chunkFillerChannel is an empty chunk
2 Reading this empty chunk would create a PutChunk at BUILDING state.
3 At line 593, when finish reading chunks from ReadableStreamChannel, the lastChunk's readable bytes' length is 0
4 Without change the lastChunk' state to free, the program logic move on to link 606 to check whether operation is completed or not.
5 If somehow the operation is completed, (by error, or any other reason), it will call lastChunk.releaseBlobContent. This will set `buf` to null in lastChunk.
6 Since chunkFiller is in a different thread, it doesn't know the operation is finished, it still calls fillChunks and this time, it will directly go to line 593 and fail with a NPE.

This PR fixes this issue, by setting the last chunk's state to FREE, so step 6 will never happen.