### PR TITLE
Revert "FindKey method takes FileSpan as the entire search space. (#1558)"

### DIFF
--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -531,10 +531,18 @@ public class BlobStore implements Store {
       Offset indexEndOffsetBeforeCheck = index.getCurrentEndOffset();
       maybeCallInDeleteBetweenGetEndOffsetAndFindKey();
       for (MessageInfo info : infosToDelete) {
-        IndexValue value =
-            index.findKey(info.getStoreKey(), new FileSpan(index.getStartOffset(), indexEndOffsetBeforeCheck));
-        if (value == null) {
-          throw new StoreException("Cannot delete id " + info.getStoreKey() + " because it is not present in the index",
+        IndexValue value = index.findKey(info.getStoreKey());
+        // TODO: Passing a FileSpan the findKey and change the findKey implementation to fully restrict the index
+        // searching space to be limited within the given FileSpan.
+        if (value == null || (value.getOffset().compareTo(indexEndOffsetBeforeCheck) >= 0 && value.isPut())) {
+          // A temporary fix to deal with this particular corner case.
+          // Between calling index.getCurrentEndOffset and findKey method, there is a Put record of the same blob
+          // is inserted to index.
+          // index.getCurrentEndOffset should create a virtual snapshot for this delete method. Everything happens after
+          // this end offset would be considered as happening outside of the snapshot.
+          String reason =
+              value == null ? "it is not present in the index" : "PUT record is out of current offset before check";
+          throw new StoreException("Cannot delete id " + info.getStoreKey() + " because " + reason,
               StoreErrorCodes.ID_Not_Found);
         }
         if (!info.getStoreKey().isAccountContainerMatch(value.getAccountId(), value.getContainerId())) {
@@ -580,24 +588,16 @@ public class BlobStore implements Store {
           FileSpan fileSpan = new FileSpan(indexEndOffsetBeforeCheck, currentIndexEndOffset);
           int i = 0;
           for (MessageInfo info : infosToDelete) {
-            IndexValue value =
-                index.findKey(info.getStoreKey(), fileSpan, EnumSet.allOf(PersistentIndex.IndexEntryType.class));
-            if (value != null) {
-              // There are several possible cases that can exist here. Delete has to follow either PUT, TTL_UPDATE or UNDELETE.
-              // let EOBC be end offset before check, and [RECORD] means RECORD is optional
-              // 1. PUT [TTL_UPDATE DELETE UNDELETE] EOBC DELETE
-              // 2. PUT EOBC TTL_UPDATE
-              // 3. PUT EOBC DELETE UNDELETE: this is really extreme case
-              // From these cases, we can have value being DELETE, TTL_UPDATE AND UNDELETE, we have to deal with them accordingly.
-              if (value.getLifeVersion() == lifeVersions.get(i)) {
-                if (value.isDelete()) {
-                  throw new StoreException(
-                      "Cannot delete id " + info.getStoreKey() + " since it is already deleted in the index.",
-                      StoreErrorCodes.ID_Deleted);
-                }
-                // value being ttl update is fine, we can just append DELETE to it.
+            IndexValue value = index.findKey(info.getStoreKey(), fileSpan,
+                EnumSet.of(PersistentIndex.IndexEntryType.PUT, PersistentIndex.IndexEntryType.DELETE,
+                    PersistentIndex.IndexEntryType.UNDELETE));
+            if (value != null && value.getOffset().compareTo(indexEndOffsetBeforeCheck) >= 0) {
+              // Make sure the value is actually after the indexEndOffsetBeforeCheck
+              if (value.isDelete() && value.getLifeVersion() == lifeVersions.get(i)) {
+                throw new StoreException(
+                    "Cannot delete id " + info.getStoreKey() + " since it is already deleted in the index.",
+                    StoreErrorCodes.ID_Deleted);
               } else {
-                // For the extreme case, we log it out and throw an exception.
                 logger.warn("Concurrent operation for id " + info.getStoreKey() + " in store " + dataDir
                     + ". Newly added value " + value);
                 throw new StoreException(
@@ -666,8 +666,7 @@ public class BlobStore implements Store {
           throw new StoreException("BlobStore only supports removing the expiration time",
               StoreErrorCodes.Update_Not_Allowed);
         }
-        IndexValue value =
-            index.findKey(info.getStoreKey(), new FileSpan(index.getStartOffset(), indexEndOffsetBeforeCheck));
+        IndexValue value = index.findKey(info.getStoreKey());
         if (value == null) {
           throw new StoreException("Cannot update TTL of " + info.getStoreKey() + " since it's not in the index",
               StoreErrorCodes.ID_Not_Found);
@@ -780,8 +779,7 @@ public class BlobStore implements Store {
       Offset indexEndOffsetBeforeCheck = index.getCurrentEndOffset();
       short lifeVersionFromMessageInfo = info.getLifeVersion();
 
-      List<IndexValue> values =
-          index.findAllIndexValuesForKey(id, new FileSpan(index.getStartOffset(), indexEndOffsetBeforeCheck));
+      List<IndexValue> values = index.findAllIndexValuesForKey(id, null);
       // Check if the undelete record is valid.
       index.validateSanityForUndelete(id, values, lifeVersionFromMessageInfo);
       IndexValue latestValue = values.get(0);
@@ -817,7 +815,8 @@ public class BlobStore implements Store {
           FileSpan fileSpan = new FileSpan(indexEndOffsetBeforeCheck, currentIndexEndOffset);
           IndexValue value = index.findKey(info.getStoreKey(), fileSpan,
               EnumSet.of(PersistentIndex.IndexEntryType.DELETE, PersistentIndex.IndexEntryType.UNDELETE));
-          if (value != null) {
+          if (value != null && value.getOffset().compareTo(indexEndOffsetBeforeCheck) >= 0) {
+            // Make sure the value is actually after the indexEndOffsetBeforeCheck
             if (value.isUndelete() && value.getLifeVersion() == revisedLifeVersion) {
               // Might get an concurrent undelete from both replication and frontend.
               throw new IdUndeletedStoreException(

--- a/ambry-store/src/main/java/com/github/ambry/store/FileSpan.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/FileSpan.java
@@ -14,8 +14,7 @@
 package com.github.ambry.store;
 
 /**
- * Represents a portion of a log. Provides the start and end offset of a log. The start offset is inclusive in the
- * FileSpan, but the end offset is not. When the start offset = end offset, this is an empty FileSpan.
+ * Represents a portion of a log. Provides the start and end offset of a log
  */
 class FileSpan {
   private Offset startOffset;
@@ -54,14 +53,7 @@ class FileSpan {
    * @return {@code true} if {@code offset} is in this {@link FileSpan} (start and end offsets are considered inclusive)
    */
   boolean inSpan(Offset offset) {
-    return offset.compareTo(startOffset) >= 0 && offset.compareTo(endOffset) < 0;
-  }
-
-  /**
-   * @return True when start offset equals to end offset.
-   */
-  boolean isEmpty() {
-    return startOffset.compareTo(endOffset) == 0;
+    return offset.compareTo(startOffset) >= 0 && offset.compareTo(endOffset) <= 0;
   }
 
   @Override

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
@@ -776,54 +776,6 @@ public class BlobStoreTest {
   }
 
   /**
-   * Test the case where a TTL_UPDATE happens while a Delete is doing the preliminary check.
-   * @throws Exception
-   */
-  @Test
-  public void concurrentDeleteAndTtlUpdateTest() throws Exception {
-    MockId id = put(1, PUT_RECORD_SIZE, expiresAtMs).get(0);
-    final CountDownLatch getEndOffsetLatch = new CountDownLatch(1);
-    final CountDownLatch findKeyLatch = new CountDownLatch(1);
-    ((MockBlobStore) store).setInDeleteBetweenGetEndOffsetAndFindKey(() -> {
-      getEndOffsetLatch.countDown();
-      findKeyLatch.await();
-      return null;
-    });
-
-    long logEndOffsetBeforeDelete = store.getLogEndOffsetInBytes();
-    long indexEndOffsetBeforeDelete = store.getSizeInBytes();
-    ExecutorService executorService = Executors.newFixedThreadPool(2);
-    try {
-      Future<Void> deleteFuture = executorService.submit(() -> {
-        delete(id);
-        return null;
-      });
-      Future<Void> ttlUpdateFuture = executorService.submit(() -> {
-        // Now make sure delete already get the index's end offset
-        getEndOffsetLatch.await();
-        updateTtl(id);
-        // Now make sure the put is inserted into the index before continue delete
-        findKeyLatch.countDown();
-        return null;
-      });
-      ttlUpdateFuture.get();
-      deleteFuture.get();
-      long logEndOffsetAfterDelete = store.getLogEndOffsetInBytes();
-      long indexEndOffsetAfterDelete = store.getSizeInBytes();
-      assertEquals((long) TTL_UPDATE_RECORD_SIZE + DELETE_RECORD_SIZE,
-          logEndOffsetAfterDelete - logEndOffsetBeforeDelete);
-      assertEquals((long) TTL_UPDATE_RECORD_SIZE + DELETE_RECORD_SIZE,
-          indexEndOffsetAfterDelete - indexEndOffsetBeforeDelete);
-      StoreInfo storeInfo = store.get(Arrays.asList(id), EnumSet.of(StoreGetOptions.Store_Include_Deleted));
-      assertTrue(storeInfo.getMessageReadSetInfo().get(0).isDeleted());
-      assertTrue(storeInfo.getMessageReadSetInfo().get(0).isTtlUpdated());
-    } finally {
-      ((MockBlobStore) store).setInDeleteBetweenGetEndOffsetAndFindKey(null);
-      executorService.shutdownNow();
-    }
-  }
-
-  /**
    * Tests the case where there are many concurrent ttl updates.
    * @throws Exception
    */

--- a/ambry-store/src/test/java/com/github/ambry/store/CuratedLogIndexState.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CuratedLogIndexState.java
@@ -624,6 +624,15 @@ class CuratedLogIndexState {
       return null;
     }
     TreeSet<IndexValue> indexValues = allKeys.get(id);
+    if (fileSpan != null) {
+      Offset modifiedStart = referenceIndex.floorKey(fileSpan.getStartOffset());
+      Offset modifiedEnd = new Offset(fileSpan.getEndOffset().getName(), fileSpan.getEndOffset().getOffset() + 1);
+      modifiedEnd = referenceIndex.ceilingKey(modifiedEnd);
+      if (modifiedEnd == null) {
+        modifiedEnd = index.getCurrentEndOffset();
+      }
+      fileSpan = new FileSpan(modifiedStart, modifiedEnd);
+    }
     List<IndexValue> toConsider = new ArrayList<>();
     for (IndexValue value : indexValues) {
       if (isWithinFileSpan(value.getOffset(), fileSpan)) {

--- a/ambry-store/src/test/java/com/github/ambry/store/FileSpanTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/FileSpanTest.java
@@ -44,7 +44,7 @@ public class FileSpanTest {
         Offset offset = new Offset(segmentName, offsetInSegment);
         boolean inSpan = segmentName.equals(interveningLogSegmentName) || (segmentName.equals(startLogSegmentName)
             && offsetInSegment >= startOffsetInStartLogSegment) || (segmentName.equals(endLogSegmentName)
-            && offsetInSegment < endOffsetInEndLogSegment);
+            && offsetInSegment <= endOffsetInEndLogSegment);
         assertEquals("inSpan() result not as expected", inSpan, span.inSpan(offset));
       }
     }


### PR DESCRIPTION
This reverts commit ba5f1a20682e48b42eeedf6925c54309d1f54fe4.

This seems to cause some error in compaction.