### PR TITLE
[Container scalability] Implementation of backup file logic for MySqlAccountService and addition of LMT field to Accounts/Containers

### DIFF
--- a/ambry-account/src/main/java/com/github/ambry/account/AccountInfoMap.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/AccountInfoMap.java
@@ -16,7 +16,6 @@ package com.github.ambry.account;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -40,6 +39,8 @@ class AccountInfoMap {
   private final static Logger logger = LoggerFactory.getLogger(AccountInfoMap.class);
   private final Map<String, Account> nameToAccountMap;
   private final Map<Short, Account> idToAccountMap;
+  // used to track last modified time of the accounts and containers in this cache
+  private long lastModifiedTime = 0;
 
   /**
    * Constructor for an empty {@code AccountInfoMap}.
@@ -73,13 +74,13 @@ class AccountInfoMap {
       if (idKey == null) {
         accountServiceMetrics.remoteDataCorruptionErrorCount.inc();
         throw new IllegalStateException(
-            "Invalid account record when reading accountMap in ZNRecord because idKey=null");
+            "Invalid account record when reading accountMap because idKey=null");
       }
       account = Account.fromJson(accountJson);
       if (account.getId() != Short.parseShort(idKey)) {
         accountServiceMetrics.remoteDataCorruptionErrorCount.inc();
         throw new IllegalStateException(
-            "Invalid account record when reading accountMap in ZNRecord because idKey and accountId do not match. idKey="
+            "Invalid account record when reading accountMap because idKey and accountId do not match. idKey="
                 + idKey + " accountId=" + account.getId());
       }
       if (idToAccountMap.containsKey(account.getId()) || nameToAccountMap.containsKey(account.getName())) {
@@ -121,22 +122,6 @@ class AccountInfoMap {
       idToAccountMap.put(account.getId(), account);
       nameToAccountMap.put(account.getName(), account);
     }
-  }
-
-  /**
-   * <p>
-   *   Constructs an {@code AccountInfoMap} from a group of {@link Account}s.
-   * </p>
-   * <p>
-   *   This is used when source {@link Account}s is a relational database. We won't need to check for duplicate IDs or names
-   *   since they are ensured by applying unique key constraints in the DB.
-   * </p>
-   * @param accounts A list of {@link Account}s.
-   */
-  AccountInfoMap(List<Account> accounts) {
-    nameToAccountMap = new HashMap<>();
-    idToAccountMap = new HashMap<>();
-    addOrUpdateAccounts(accounts);
   }
 
   /**
@@ -304,5 +289,26 @@ class AccountInfoMap {
   Container getContainerByNameForAccount(Short accountId, String name) {
     Account parentAccount = idToAccountMap.get(accountId);
     return parentAccount == null ? null : parentAccount.getContainerByName(name);
+  }
+
+  /**
+   * Gets the last modified time of {@link Account}s and {@link Container}s in the cache
+   * @return last modified time.
+   */
+  public long getLastModifiedTime() {
+    return lastModifiedTime;
+  }
+
+  /**
+   * Refreshes the lastModifiedTime of {@link Account}s and {@link Container}s in the cache. This is expected to be
+   * called after account metadata is fetched from db periodically.
+   */
+  public void refreshLastModifiedTime() {
+    for (Account account : idToAccountMap.values()) {
+      lastModifiedTime = Math.max(lastModifiedTime, account.getLastModifiedTime());
+      for (Container container : account.getAllContainers()) {
+        lastModifiedTime = Math.max(lastModifiedTime, container.getLastModifiedTime());
+      }
+    }
   }
 }

--- a/ambry-account/src/main/java/com/github/ambry/account/AccountMetadataStore.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/AccountMetadataStore.java
@@ -95,7 +95,7 @@ abstract class AccountMetadataStore {
     }
     Map<String, String> newAccountMap = fetchAccountMetadataFromZNRecord(znRecord);
     if (newAccountMap != null) {
-      backupFileManager.persistAccountMap(newAccountMap, stat);
+      backupFileManager.persistAccountMap(newAccountMap, stat.getVersion(), stat.getMtime() / 1000);
     }
     return newAccountMap;
   }

--- a/ambry-account/src/main/java/com/github/ambry/account/BackupFileManager.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/BackupFileManager.java
@@ -114,7 +114,7 @@ class BackupFileManager {
     File[] files = backupDir.listFiles(tempFileFilter);
     if (files != null) {
       for (File file : files) {
-        logger.trace("Delete temp file " + file.getName());
+        logger.trace("Delete temp file {}", file.getName());
         tryDeleteFile(file);
       }
     }
@@ -126,7 +126,7 @@ class BackupFileManager {
       for (File file : files) {
         Matcher m = versionFilenamePattern.matcher(file.getName());
         m.find();
-        logger.trace("Starting processing version backup file " + file.getName());
+        logger.trace("Starting processing version backup file {}", file.getName());
         int version = Integer.parseInt(m.group(1));
         long modifiedTimeInSecond = LocalDateTime.parse(m.group(2), TIMESTAMP_FORMATTER).toEpochSecond(zoneOffset);
         BackupFileInfo currentBackup = new BackupFileInfo(version, file.getName(), modifiedTimeInSecond);
@@ -158,7 +158,7 @@ class BackupFileManager {
     files = backupDir.listFiles(oldStateFileFilter);
     if (files != null) {
       for (File file : files) {
-        logger.trace("Delete old state file " + file.getName());
+        logger.trace("Delete old state file {}", file.getName());
         tryDeleteFile(file);
       }
     }
@@ -172,7 +172,7 @@ class BackupFileManager {
         logger.trace("More than {} versioned backup found, remove all the backup files in old format",
             maxBackupFileCount);
         for (File file : allNewStateFiles) {
-          logger.trace("Delete new state file " + file.getName());
+          logger.trace("Delete new state file {}", file.getName());
           tryDeleteFile(file);
         }
       } else {
@@ -188,7 +188,7 @@ class BackupFileManager {
         for (int i = 0; i < size; i++) {
           File file = allNewStateFiles[i];
           if (i < startIndexToPreserveBackupFile) {
-            logger.trace("Delete new state file " + file.getName());
+            logger.trace("Delete new state file {}", file.getName());
             tryDeleteFile(file);
           } else {
             Matcher m = newStateFilenamePattern.matcher(file.getName());
@@ -234,7 +234,7 @@ class BackupFileManager {
       writeAccountMapToFile(tempFilePath, accountMap);
       Files.move(tempFilePath, filePath);
     } catch (IOException e) {
-      logger.error("Failed to persist state to file: " + fileName, e);
+      logger.error("Failed to persist state to file: {}", fileName, e);
       accountServiceMetrics.backupErrorCount.inc();
       return;
     }
@@ -304,7 +304,7 @@ class BackupFileManager {
       return deserializeAccountMap(bytes);
     } catch (IOException e) {
       accountServiceMetrics.backupErrorCount.inc();
-      logger.error("Failed to read all bytes out from file " + filepath + " " + e.getMessage());
+      logger.error("Failed to read all bytes out from file {} {}", filepath, e.getMessage());
       return null;
     }
   }
@@ -334,11 +334,11 @@ class BackupFileManager {
     try {
       Files.delete(toDelete);
     } catch (NoSuchFileException e) {
-      logger.error("File doesn't exist while deleting: " + toDelete.toString(), e);
+      logger.error("File doesn't exist while deleting: {}", toDelete.toString(), e);
     } catch (IOException e) {
-      logger.error("Encounter an I/O error while deleting file: " + toDelete.toString(), e);
+      logger.error("Encounter an I/O error while deleting file: {}", toDelete.toString(), e);
     } catch (Exception e) {
-      logger.error("Encounter an unexpected error while deleting file: " + toDelete.toString(), e);
+      logger.error("Encounter an unexpected error while deleting file: {}", toDelete.toString(), e);
     }
   }
 
@@ -366,7 +366,7 @@ class BackupFileManager {
       channel.write(buffer);
     } catch (IOException e) {
       // Failed to persist file
-      logger.error("Failed to persist account map to file " + filepath, e);
+      logger.error("Failed to persist account map to file {}", filepath, e);
       throw e;
     }
   }
@@ -400,7 +400,7 @@ class BackupFileManager {
       }
       return result;
     } catch (JSONException e) {
-      logger.error("Failed to deserialized bytes to account map: " + e.getMessage());
+      logger.error("Failed to deserialized bytes to account map: {}", e.getMessage());
       return null;
     }
   }

--- a/ambry-account/src/main/java/com/github/ambry/account/mysql/AccountDao.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/mysql/AccountDao.java
@@ -14,6 +14,7 @@
 package com.github.ambry.account.mysql;
 
 import com.github.ambry.account.Account;
+import com.github.ambry.account.AccountBuilder;
 import com.github.ambry.account.AccountSerdeUtils;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -21,6 +22,7 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
+import org.json.JSONObject;
 
 
 /**
@@ -123,7 +125,7 @@ public class AccountDao {
       String accountJson = resultSet.getString(ACCOUNT_INFO);
       Timestamp lastModifiedTime = resultSet.getTimestamp(LAST_MODIFIED_TIME);
       Account account = AccountSerdeUtils.accountFromJson(accountJson);
-      //account.setLastModifiedTime(lastModifiedTime);
+      account = new AccountBuilder(account).lastModifiedTime(lastModifiedTime.getTime()).build();
       accounts.add(account);
     }
     return accounts;

--- a/ambry-account/src/main/java/com/github/ambry/account/mysql/ContainerDao.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/mysql/ContainerDao.java
@@ -15,6 +15,7 @@ package com.github.ambry.account.mysql;
 
 import com.github.ambry.account.AccountSerdeUtils;
 import com.github.ambry.account.Container;
+import com.github.ambry.account.ContainerBuilder;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -149,8 +150,9 @@ public class ContainerDao {
     while (resultSet.next()) {
       int accountId = resultSet.getInt(ACCOUNT_ID);
       String containerJson = resultSet.getString(CONTAINER_INFO);
+      Timestamp lastModifiedTime = resultSet.getTimestamp(LAST_MODIFIED_TIME);
       Container container = AccountSerdeUtils.containerFromJson(containerJson, (short) accountId);
-      // TODO: container.setLastModifiedTime(resultSet.getTimestamp(LAST_MODIFIED_TIME));
+      container = new ContainerBuilder(container).setLastModifiedTime(lastModifiedTime.getTime()).build();
       containers.add(container);
     }
     return containers;

--- a/ambry-account/src/test/java/com/github/ambry/account/BackupFileManagerTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/BackupFileManagerTest.java
@@ -16,7 +16,6 @@ package com.github.ambry.account;
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.config.HelixAccountServiceConfig;
 import com.github.ambry.config.VerifiableProperties;
-import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
 import java.io.File;

--- a/ambry-account/src/test/java/com/github/ambry/account/BackupFileManagerTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/BackupFileManagerTest.java
@@ -16,6 +16,7 @@ package com.github.ambry.account;
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.config.HelixAccountServiceConfig;
 import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
 import java.io.File;
@@ -90,7 +91,8 @@ public class BackupFileManagerTest {
     helixConfigProps.remove(HelixAccountServiceConfig.BACKUP_DIRECTORY_KEY);
     VerifiableProperties vHelixConfigProps = new VerifiableProperties(helixConfigProps);
     HelixAccountServiceConfig config = new HelixAccountServiceConfig(vHelixConfigProps);
-    BackupFileManager backup = new BackupFileManager(accountServiceMetrics, config);
+    BackupFileManager backup =
+        new BackupFileManager(accountServiceMetrics, config.backupDir, config.maxBackupFileCount);
 
     // getLatestAccountMap should return null
     assertNull("Disabled backup shouldn't have any state", backup.getLatestAccountMap(0));
@@ -100,7 +102,7 @@ public class BackupFileManagerTest {
     stat.setVersion(1);
     stat.setMtime(System.currentTimeMillis());
 
-    backup.persistAccountMap(new HashMap<String, String>(), stat);
+    backup.persistAccountMap(new HashMap<String, String>(), stat.getVersion(), stat.getMtime() / 1000);
     assertTrue("Disabled backup shouldn't add any backup", backup.isEmpty());
   }
 
@@ -121,7 +123,8 @@ public class BackupFileManagerTest {
     Map<String, String> expected = new HashMap<>();
     expected.put(String.valueOf(refAccount.getId()), refAccount.toJson(true).toString());
 
-    BackupFileManager backup = new BackupFileManager(accountServiceMetrics, config);
+    BackupFileManager backup =
+        new BackupFileManager(accountServiceMetrics, config.backupDir, config.maxBackupFileCount);
     Map<String, String> obtained = backup.getLatestAccountMap(0);
     assertTwoStringMapsEqual(expected, obtained);
     assertFalse("There are backup files", backup.isEmpty());
@@ -143,7 +146,8 @@ public class BackupFileManagerTest {
     String[] filenames = createBackupFilesWithoutVersion(accountBackupDir, count, baseModifiedTime, interval, false);
     saveAccountsToFile(Collections.singleton(refAccount), accountBackupDir.resolve(filenames[filenames.length - 1]));
 
-    BackupFileManager backup = new BackupFileManager(accountServiceMetrics, config);
+    BackupFileManager backup =
+        new BackupFileManager(accountServiceMetrics, config.backupDir, config.maxBackupFileCount);
     Map<String, String> obtained = backup.getLatestAccountMap(0);
     assertNull("No state should be loaded from backup file from old format", obtained);
     assertFalse("Backup should not be empty since there are files from old format", backup.isEmpty());
@@ -170,7 +174,8 @@ public class BackupFileManagerTest {
     Map<String, String> expected = new HashMap<>();
     expected.put(String.valueOf(refAccount.getId()), refAccount.toJson(true).toString());
 
-    BackupFileManager backup = new BackupFileManager(accountServiceMetrics, config);
+    BackupFileManager backup =
+        new BackupFileManager(accountServiceMetrics, config.backupDir, config.maxBackupFileCount);
     Map<String, String> obtained = backup.getLatestAccountMap(0);
     assertTwoStringMapsEqual(expected, obtained);
     assertFalse("There are backup files", backup.isEmpty());
@@ -200,7 +205,8 @@ public class BackupFileManagerTest {
     createBackupFilesWithoutVersion(accountBackupDir, 10, baseModifiedTime, interval, false);
     createBackupFilesWithoutVersion(accountBackupDir, 10, baseModifiedTime, interval, true);
 
-    BackupFileManager backup = new BackupFileManager(accountServiceMetrics, config);
+    BackupFileManager backup =
+        new BackupFileManager(accountServiceMetrics, config.backupDir, config.maxBackupFileCount);
     assertEquals("Number of backup files mismatch", backup.size(), maxBackupFile);
 
     File[] remainingFiles = accountBackupDir.toFile().listFiles();
@@ -235,7 +241,8 @@ public class BackupFileManagerTest {
         baseModifiedTime + 2 * backupFileNoVersionCount * interval, interval, false);
     saveAccountsToFile(Collections.singleton(refAccount), accountBackupDir.resolve(filenames[filenames.length - 1]));
 
-    BackupFileManager backup = new BackupFileManager(accountServiceMetrics, config);
+    BackupFileManager backup =
+        new BackupFileManager(accountServiceMetrics, config.backupDir, config.maxBackupFileCount);
     assertEquals("Number of backup files mismatch", backup.size(), maxBackupFile);
 
     File[] remainingFiles = accountBackupDir.toFile().listFiles();
@@ -255,12 +262,13 @@ public class BackupFileManagerTest {
   }
 
   /**
-   * Test {@link BackupFileManager#persistAccountMap(Map, Stat)} and then recover {@link BackupFileManager} from the same backup directory.
+   * Test {@link BackupFileManager#persistAccountMap(Map, int, long)} and then recover {@link BackupFileManager} from the same backup directory.
    * @throws IOException if I/O error occurs
    */
   @Test
   public void testPersistAccountMapAndRecover() throws IOException {
-    BackupFileManager backup = new BackupFileManager(accountServiceMetrics, config);
+    BackupFileManager backup =
+        new BackupFileManager(accountServiceMetrics, config.backupDir, config.maxBackupFileCount);
     final int numberAccounts = maxBackupFile * 2;
     final Map<String, String> accounts = new HashMap<>(numberAccounts);
     final Stat stat = new Stat();
@@ -271,7 +279,7 @@ public class BackupFileManagerTest {
       accounts.put(String.valueOf(account.getId()), account.toJson(true).toString());
       stat.setVersion(i + 1);
       stat.setMtime(modifiedTime * 1000);
-      backup.persistAccountMap(accounts, stat);
+      backup.persistAccountMap(accounts, stat.getVersion(), stat.getMtime() / 1000);
       modifiedTime += interval;
     }
 
@@ -283,7 +291,7 @@ public class BackupFileManagerTest {
       assertEquals("Remaining backup mismatch", maxBackupFile, remaingingFiles.length);
 
       // Recover BackupFileManager from the same backup dir
-      backup = new BackupFileManager(accountServiceMetrics, config);
+      backup = new BackupFileManager(accountServiceMetrics, config.backupDir, config.maxBackupFileCount);
     }
   }
 
@@ -336,7 +344,7 @@ public class BackupFileManagerTest {
       Stat stat = new Stat();
       stat.setVersion(i);
       stat.setMtime((baseModifiedTime + (i - startVersion) * interval) * 1000);
-      String filename = BackupFileManager.getBackupFilenameFromStat(stat);
+      String filename = BackupFileManager.getBackupFilename(stat.getVersion(), stat.getMtime() / 1000);
       if (isTemp) {
         filename = filename + BackupFileManager.SEP + BackupFileManager.TEMP_FILE_SUFFIX;
       }

--- a/ambry-account/src/test/java/com/github/ambry/account/MySqlAccountServiceTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/MySqlAccountServiceTest.java
@@ -48,7 +48,7 @@ public class MySqlAccountServiceTest {
    * Tests in-memory cache is updated with accounts from mysql db store on start up
    */
   @Test
-  public void testInitCacheOnStartUp() throws SQLException {
+  public void testInitCacheOnStartUp() throws SQLException, IOException {
     Container testContainer =
         new ContainerBuilder((short) 1, "testContainer", Container.ContainerStatus.ACTIVE, "testContainer",
             (short) 1).build();
@@ -72,7 +72,7 @@ public class MySqlAccountServiceTest {
    * 2. update existing {@link Account} by adding new {@link Container} to an existing {@link Account};
    */
   @Test
-  public void testUpdateAccounts() throws SQLException {
+  public void testUpdateAccounts() throws SQLException, IOException {
 
     MySqlAccountStore mockMySqlAccountStore = mock(MySqlAccountStore.class);
     when(mockMySqlAccountStore.getNewAccounts(0)).thenReturn(new ArrayList<>());
@@ -145,6 +145,10 @@ public class MySqlAccountServiceTest {
     // verify that close() stops the background updater thread
     mySqlAccountService.close();
 
+    // force shutdown background updater thread. As the default timeout value is 1 minute, it is possible that thread is
+    // present after close() due to actively executing task.
+    ((MySqlAccountService) mySqlAccountService).getScheduler().shutdownNow();
+
     assertEquals("Background account updater thread should be stopped", 0,
         numThreadsByThisName(MySqlAccountService.MYSQL_ACCOUNT_UPDATER_PREFIX));
   }
@@ -153,7 +157,7 @@ public class MySqlAccountServiceTest {
    * Tests disabling of background updater by setting {@link MySqlAccountServiceConfig#UPDATER_POLLING_INTERVAL_SECONDS} to 0.
    */
   @Test
-  public void testDisableBackgroundUpdater() {
+  public void testDisableBackgroundUpdater() throws IOException {
 
     mySqlConfigProps.setProperty(UPDATER_POLLING_INTERVAL_SECONDS, "0");
     mySqlAccountService = new MySqlAccountService(new AccountServiceMetrics(new MetricRegistry()),
@@ -166,7 +170,7 @@ public class MySqlAccountServiceTest {
    * Tests disabling account updates by setting {@link MySqlAccountServiceConfig#UPDATE_DISABLED} to true.
    */
   @Test
-  public void testUpdateDisabled() {
+  public void testUpdateDisabled() throws IOException {
 
     mySqlConfigProps.setProperty(UPDATE_DISABLED, "true");
     MySqlAccountStore mockMySqlAccountStore = mock(MySqlAccountStore.class);
@@ -184,7 +188,7 @@ public class MySqlAccountServiceTest {
    * in name.
    */
   @Test
-  public void testUpdateNameConflictingAccounts() {
+  public void testUpdateNameConflictingAccounts() throws IOException {
     AccountServiceMetrics accountServiceMetrics = new AccountServiceMetrics(new MetricRegistry());
     mySqlAccountService = new MySqlAccountService(accountServiceMetrics,
         new MySqlAccountServiceConfig(new VerifiableProperties(mySqlConfigProps)), mock(MySqlAccountStore.class));
@@ -201,7 +205,7 @@ public class MySqlAccountServiceTest {
    * in id.
    */
   @Test
-  public void testUpdateIdConflictingAccounts() {
+  public void testUpdateIdConflictingAccounts() throws IOException {
     AccountServiceMetrics accountServiceMetrics = new AccountServiceMetrics(new MetricRegistry());
     mySqlAccountService = new MySqlAccountService(accountServiceMetrics,
         new MySqlAccountServiceConfig(new VerifiableProperties(mySqlConfigProps)), mock(MySqlAccountStore.class));
@@ -217,7 +221,7 @@ public class MySqlAccountServiceTest {
    * Tests updating a collection of {@link Account}s, where there are duplicate {@link Account}s in id and name.
    */
   @Test
-  public void testUpdateDuplicateAccounts() {
+  public void testUpdateDuplicateAccounts() throws IOException {
     AccountServiceMetrics accountServiceMetrics = new AccountServiceMetrics(new MetricRegistry());
     mySqlAccountService = new MySqlAccountService(accountServiceMetrics,
         new MySqlAccountServiceConfig(new VerifiableProperties(mySqlConfigProps)), mock(MySqlAccountStore.class));
@@ -248,7 +252,7 @@ public class MySqlAccountServiceTest {
    *
    */
   @Test
-  public void testConflictingUpdatesWithAccounts() {
+  public void testConflictingUpdatesWithAccounts() throws IOException {
     AccountServiceMetrics accountServiceMetrics = new AccountServiceMetrics(new MetricRegistry());
     mySqlAccountService = new MySqlAccountService(accountServiceMetrics,
         new MySqlAccountServiceConfig(new VerifiableProperties(mySqlConfigProps)), mock(MySqlAccountStore.class));
@@ -301,7 +305,7 @@ public class MySqlAccountServiceTest {
    * Tests name/id conflicts in Containers
    */
   @Test
-  public void testConflictingUpdatesWithContainers() {
+  public void testConflictingUpdatesWithContainers() throws IOException {
     AccountServiceMetrics accountServiceMetrics = new AccountServiceMetrics(new MetricRegistry());
     mySqlAccountService = new MySqlAccountService(accountServiceMetrics,
         new MySqlAccountServiceConfig(new VerifiableProperties(mySqlConfigProps)), mock(MySqlAccountStore.class));

--- a/ambry-account/src/test/java/com/github/ambry/account/MySqlAccountServiceTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/MySqlAccountServiceTest.java
@@ -16,12 +16,18 @@ package com.github.ambry.account;
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.config.MySqlAccountServiceConfig;
 import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.utils.SystemTime;
+import com.github.ambry.utils.TestUtils;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import org.junit.Before;
 import org.junit.Test;
@@ -42,6 +48,40 @@ public class MySqlAccountServiceTest {
 
   public MySqlAccountServiceTest() {
 
+  }
+
+  /**
+   * Tests in-memory cache is initialized with metadata from local file on start up
+   * @throws IOException
+   */
+  @Test
+  public void testInitCacheFromDisk() throws IOException, SQLException {
+    Path accountBackupDir = Paths.get(TestUtils.getTempDir("account-backup")).toAbsolutePath();
+    mySqlConfigProps.setProperty(MySqlAccountServiceConfig.BACKUP_DIRECTORY_KEY, accountBackupDir.toString());
+
+    // write test account to backup file
+    long lastModifiedTime = 100;
+    Account testAccount =
+        new AccountBuilder((short) 1, "testAccount", Account.AccountStatus.ACTIVE).lastModifiedTime(lastModifiedTime)
+            .build();
+    Map<String, String> accountMap = new HashMap<>();
+    accountMap.put(Short.toString(testAccount.getId()), testAccount.toJson(false).toString());
+    String filename = BackupFileManager.getBackupFilename(1, SystemTime.getInstance().seconds());
+    Path filePath = accountBackupDir.resolve(filename);
+    BackupFileManager.writeAccountMapToFile(filePath, accountMap);
+
+    MySqlAccountStore mockMySqlAccountStore = mock(MySqlAccountStore.class);
+    mySqlAccountService = new MySqlAccountService(new AccountServiceMetrics(new MetricRegistry()),
+        new MySqlAccountServiceConfig(new VerifiableProperties(mySqlConfigProps)), mockMySqlAccountStore);
+
+    // verify cache is initialized on startup with test account from backup file
+    assertEquals("Mismatch in number of accounts in cache", 1, mySqlAccountService.getAllAccounts().size());
+    assertEquals("Mismatch in account info in cache", testAccount,
+        mySqlAccountService.getAllAccounts().iterator().next());
+
+    // verify that mySqlAccountStore.getNewAccounts() is called with input argument "lastModifiedTime" value as 100
+    verify(mockMySqlAccountStore, atLeastOnce()).getNewAccounts(lastModifiedTime);
+    verify(mockMySqlAccountStore, atLeastOnce()).getNewContainers(lastModifiedTime);
   }
 
   /**

--- a/ambry-account/src/test/java/com/github/ambry/account/RouterStoreTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/RouterStoreTest.java
@@ -84,7 +84,7 @@ public class RouterStoreTest {
     properties.setProperty(HelixAccountServiceConfig.ZK_CLIENT_CONNECT_STRING_KEY, "1000");
     VerifiableProperties verifiableProperties = new VerifiableProperties(properties);
     config = new HelixAccountServiceConfig(verifiableProperties);
-    backup = new BackupFileManager(accountServiceMetrics, config);
+    backup = new BackupFileManager(accountServiceMetrics, config.backupDir, config.maxBackupFileCount);
     helixStore = new MockHelixPropertyStore<>();
     router = new MockRouter();
   }

--- a/ambry-account/src/test/java/com/github/ambry/account/mysql/AccountDaoTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/mysql/AccountDaoTest.java
@@ -18,11 +18,13 @@ import com.github.ambry.account.AccountBuilder;
 import com.github.ambry.account.AccountSerdeUtils;
 import com.github.ambry.config.MySqlAccountServiceConfig;
 import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.utils.SystemTime;
 import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Timestamp;
 import java.util.List;
 import java.util.Properties;
 import org.junit.Test;
@@ -57,6 +59,8 @@ public class AccountDaoTest {
     ResultSet mockResultSet = mock(ResultSet.class);
     when(mockResultSet.next()).thenReturn(true).thenReturn(false);
     when(mockResultSet.getString(eq(AccountDao.ACCOUNT_INFO))).thenReturn(accountJson);
+    when(mockResultSet.getTimestamp(eq(AccountDao.LAST_MODIFIED_TIME))).thenReturn(
+        new Timestamp(SystemTime.getInstance().milliseconds()));
     when(mockQueryStatement.executeQuery()).thenReturn(mockResultSet);
     dataAccessor = getDataAccessor(mockConnection);
     accountDao = new AccountDao(dataAccessor);

--- a/ambry-account/src/test/java/com/github/ambry/account/mysql/ContainerDaoTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/mysql/ContainerDaoTest.java
@@ -16,10 +16,12 @@ package com.github.ambry.account.mysql;
 import com.github.ambry.account.AccountSerdeUtils;
 import com.github.ambry.account.Container;
 import com.github.ambry.account.ContainerBuilder;
+import com.github.ambry.utils.SystemTime;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Timestamp;
 import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -58,6 +60,8 @@ public class ContainerDaoTest {
     when(mockResultSet.next()).thenReturn(true).thenReturn(false);
     when(mockResultSet.getInt(eq(ContainerDao.ACCOUNT_ID))).thenReturn((int) accountId);
     when(mockResultSet.getString(eq(ContainerDao.CONTAINER_INFO))).thenReturn(containerJson);
+    when(mockResultSet.getTimestamp(eq(ContainerDao.LAST_MODIFIED_TIME))).thenReturn(
+        new Timestamp(SystemTime.getInstance().milliseconds()));
     dataAccessor = AccountDaoTest.getDataAccessor(mockConnection);
     containerDao = new ContainerDao(dataAccessor);
   }

--- a/ambry-api/src/main/java/com/github/ambry/account/Account.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/Account.java
@@ -81,9 +81,11 @@ public class Account {
   static final String STATUS_KEY = "status";
   static final String SNAPSHOT_VERSION_KEY = "snapshotVersion";
   static final String CONTAINERS_KEY = "containers";
+  static final String LAST_MODIFIED_TIME_KEY = "lastModifiedTime";
   static final short JSON_VERSION_1 = 1;
   static final short CURRENT_JSON_VERSION = JSON_VERSION_1;
   static final int SNAPSHOT_VERSION_DEFAULT_VALUE = 0;
+  static final long LAST_MODIFIED_TIME_DEFAULT_VALUE = 0;
 
   /**
    * The id of unknown account.
@@ -110,6 +112,7 @@ public class Account {
   private final String name;
   private AccountStatus status;
   private final int snapshotVersion;
+  private final long lastModifiedTime;
   // internal data structure
   private final Map<Short, Container> containerIdToContainerMap = new HashMap<>();
   private final Map<String, Container> containerNameToContainerMap = new HashMap<>();
@@ -130,6 +133,7 @@ public class Account {
         name = metadata.getString(ACCOUNT_NAME_KEY);
         status = AccountStatus.valueOf(metadata.getString(STATUS_KEY));
         snapshotVersion = metadata.optInt(SNAPSHOT_VERSION_KEY, SNAPSHOT_VERSION_DEFAULT_VALUE);
+        lastModifiedTime = metadata.optLong(LAST_MODIFIED_TIME_KEY, LAST_MODIFIED_TIME_DEFAULT_VALUE);
         checkRequiredFieldsForBuild();
         JSONArray containerArray = metadata.optJSONArray(CONTAINERS_KEY);
         if (containerArray != null) {
@@ -155,10 +159,25 @@ public class Account {
    * @param containers A collection of {@link Container}s to be part of this account.
    */
   Account(short id, String name, AccountStatus status, int snapshotVersion, Collection<Container> containers) {
+    this(id, name, status, snapshotVersion, containers, LAST_MODIFIED_TIME_DEFAULT_VALUE);
+  }
+
+  /**
+   * Constructor that takes individual arguments.
+   * @param id The id of the account. Cannot be null.
+   * @param name The name of the account. Cannot be null.
+   * @param status The status of the account. Cannot be null.
+   * @param snapshotVersion the expected snapshot version for the account record.
+   * @param containers A collection of {@link Container}s to be part of this account.
+   * @param lastModifiedTime created/modified time of this Account
+   */
+  Account(short id, String name, AccountStatus status, int snapshotVersion, Collection<Container> containers,
+      long lastModifiedTime) {
     this.id = id;
     this.name = name;
     this.status = status;
     this.snapshotVersion = snapshotVersion;
+    this.lastModifiedTime = lastModifiedTime;
     checkRequiredFieldsForBuild();
     if (containers != null) {
       updateContainerMap(containers);
@@ -179,6 +198,7 @@ public class Account {
     metadata.put(ACCOUNT_NAME_KEY, name);
     metadata.put(STATUS_KEY, status.name());
     metadata.put(SNAPSHOT_VERSION_KEY, incrementSnapshotVersion ? snapshotVersion + 1 : snapshotVersion);
+    metadata.put(LAST_MODIFIED_TIME_KEY, lastModifiedTime);
     JSONArray containerArray = new JSONArray();
     for (Container container : containerIdToContainerMap.values()) {
       containerArray.put(container.toJson());
@@ -226,6 +246,14 @@ public class Account {
    */
   public int getSnapshotVersion() {
     return snapshotVersion;
+  }
+
+  /**
+   * Get the created/modified time of this Account
+   * @return epoch time in milliseconds
+   */
+  public long getLastModifiedTime() {
+    return lastModifiedTime;
   }
 
   /**

--- a/ambry-api/src/main/java/com/github/ambry/account/AccountBuilder.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/AccountBuilder.java
@@ -31,6 +31,7 @@ public class AccountBuilder {
   private String name;
   private AccountStatus status;
   private int snapshotVersion = Account.SNAPSHOT_VERSION_DEFAULT_VALUE;
+  private long lastModifiedTime = LAST_MODIFIED_TIME_DEFAULT_VALUE;
   private Map<Short, Container> idToContainerMetadataMap = new HashMap<>();
 
   /**
@@ -46,6 +47,7 @@ public class AccountBuilder {
     name = origin.getName();
     status = origin.getStatus();
     snapshotVersion = origin.getSnapshotVersion();
+    lastModifiedTime = origin.getLastModifiedTime();
     for (Container container : origin.getAllContainers()) {
       idToContainerMetadataMap.put(container.getId(), container);
     }
@@ -107,6 +109,16 @@ public class AccountBuilder {
   }
 
   /**
+   * Sets the created/modified time of the {@link Account} to build.
+   * @param lastModifiedTime time in milliseconds.
+   * @return This builder.
+   */
+  public AccountBuilder lastModifiedTime(long lastModifiedTime) {
+    this.lastModifiedTime = lastModifiedTime;
+    return this;
+  }
+
+  /**
    * Clear the set of containers for the {@link Account} to build and add the provided ones.
    * @param containers A collection of {@link Container}s to use. Can be {@code null} to just remove all containers.
    * @return This builder.
@@ -152,12 +164,12 @@ public class AccountBuilder {
   }
 
   /**
-   * Builds an {@link Account} object. {@code id}, {@code name}, {@code status}, and {@code containers} (if any)
-   * must be set before building.
+   * Builds an {@link Account} object. {@code id}, {@code name}, {@code status}, {@code lastModifiedTime} and
+   * {@code containers} (if any) must be set before building.
    * @return An {@link Account} object.
    * @throws IllegalStateException If any required fields is not set or there is inconsistency in containers.
    */
   public Account build() {
-    return new Account(id, name, status, snapshotVersion, idToContainerMetadataMap.values());
+    return new Account(id, name, status, snapshotVersion, idToContainerMetadataMap.values(), lastModifiedTime);
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/account/ContainerBuilder.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/ContainerBuilder.java
@@ -44,6 +44,7 @@ public class ContainerBuilder {
   private Set<String> contentTypeWhitelistForFilenamesOnDownload =
       CONTENT_TYPE_WHITELIST_FOR_FILENAMES_ON_DOWNLOAD_DEFAULT_VALUE;
   private boolean backupEnabled = BACKUP_ENABLED_DEFAULT_VALUE;
+  private long lastModifiedTime = LAST_MODIFIED_TIME_DEFAULT_VALUE;
 
   /**
    * Constructor. This will allow building a new {@link Container} from an existing {@link Container}. The builder will
@@ -70,6 +71,7 @@ public class ContainerBuilder {
     securePathRequired = origin.isSecurePathRequired();
     contentTypeWhitelistForFilenamesOnDownload = origin.getContentTypeWhitelistForFilenamesOnDownload();
     backupEnabled = origin.isBackupEnabled();
+    lastModifiedTime = origin.getLastModifiedTime();
   }
 
   /**
@@ -239,6 +241,16 @@ public class ContainerBuilder {
   }
 
   /**
+   * Sets the created/modified time of the {@link Container}
+   * @param lastModifiedTime epoch time in milliseconds.
+   * @return This builder.
+   */
+  public ContainerBuilder setLastModifiedTime(long lastModifiedTime) {
+    this.lastModifiedTime = lastModifiedTime;
+    return this;
+  }
+
+  /**
    * Builds a {@link Container} object. {@code id}, {@code name}, {@code status}, {@code isPrivate}, and
    * {@code parentAccountId} are required before build.
    * @return A {@link Container} object.
@@ -247,6 +259,7 @@ public class ContainerBuilder {
   public Container build() {
     return new Container(id, name, status, description, encrypted, previouslyEncrypted || encrypted, cacheable,
         mediaScanDisabled, replicationPolicy, ttlRequired, securePathRequired,
-        contentTypeWhitelistForFilenamesOnDownload, backupEnabled, parentAccountId, deleteTriggerTime);
+        contentTypeWhitelistForFilenamesOnDownload, backupEnabled, parentAccountId, deleteTriggerTime,
+        lastModifiedTime);
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/config/MySqlAccountServiceConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/MySqlAccountServiceConfig.java
@@ -79,7 +79,7 @@ public class MySqlAccountServiceConfig {
    * a new backup file, it will remove the oldest one.
    */
   @Config(MAX_BACKUP_FILE_COUNT)
-  @Default("100")
+  @Default("10")
   public final int maxBackupFileCount;
 
   /**

--- a/ambry-api/src/main/java/com/github/ambry/config/MySqlAccountServiceConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/MySqlAccountServiceConfig.java
@@ -27,6 +27,7 @@ public class MySqlAccountServiceConfig {
       MYSQL_ACCOUNT_SERVICE_PREFIX + "updater.shut.down.timeout.minutes";
   public static final String BACKUP_DIRECTORY_KEY = MYSQL_ACCOUNT_SERVICE_PREFIX + "backup.dir";
   public static final String UPDATE_DISABLED = MYSQL_ACCOUNT_SERVICE_PREFIX + "update.disabled";
+  private static final String MAX_BACKUP_FILE_COUNT = MYSQL_ACCOUNT_SERVICE_PREFIX + "max.backup.file.count";
 
   // TODO: Might need to take an array of URLs which would have one write (master) and multiple read urls (backup)
   /**
@@ -74,6 +75,14 @@ public class MySqlAccountServiceConfig {
   public final String backupDir;
 
   /**
+   * The maximum number of local backup files kept in disk. When account service exceeds this count, every time it creates
+   * a new backup file, it will remove the oldest one.
+   */
+  @Config(MAX_BACKUP_FILE_COUNT)
+  @Default("100")
+  public final int maxBackupFileCount;
+
+  /**
    * If true, MySqlAccountService would reject all the requests to update accounts.
    */
   @Config(UPDATE_DISABLED)
@@ -90,5 +99,6 @@ public class MySqlAccountServiceConfig {
         verifiableProperties.getIntInRange(UPDATER_SHUT_DOWN_TIMEOUT_MINUTES, 2, 1, Integer.MAX_VALUE);
     backupDir = verifiableProperties.getString(BACKUP_DIRECTORY_KEY, "");
     updateDisabled = verifiableProperties.getBoolean(UPDATE_DISABLED, false);
+    maxBackupFileCount = verifiableProperties.getIntInRange(MAX_BACKUP_FILE_COUNT, 10, 1, Integer.MAX_VALUE);
   }
 }

--- a/ambry-api/src/test/java/com/github/ambry/account/AccountContainerTest.java
+++ b/ambry-api/src/test/java/com/github/ambry/account/AccountContainerTest.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.account;
 
+import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
 import java.util.ArrayList;
@@ -34,6 +35,7 @@ import org.junit.runners.Parameterized;
 
 import static com.github.ambry.account.Account.*;
 import static com.github.ambry.account.Container.*;
+import static com.github.ambry.account.Container.LAST_MODIFIED_TIME_KEY;
 import static org.junit.Assert.*;
 
 
@@ -99,6 +101,7 @@ public class AccountContainerTest {
     refAccountJson.put(Account.STATUS_KEY, refAccountStatus.name());
     refAccountJson.put(SNAPSHOT_VERSION_KEY, refAccountSnapshotVersion);
     refAccountJson.put(CONTAINERS_KEY, containerJsonList);
+    refAccountJson.put(Account.LAST_MODIFIED_TIME_KEY, 0);
   }
 
   /**
@@ -996,7 +999,7 @@ public class AccountContainerTest {
       }
       refContainerTtlRequiredValues.add(random.nextBoolean());
       refContainerSignedPathRequiredValues.add(random.nextBoolean());
-      refContainerDeleteTriggerTime.add((long)0);
+      refContainerDeleteTriggerTime.add((long) 0);
       if (i == 0) {
         refContainerContentTypeWhitelistForFilenamesOnDownloadValues.add(null);
       } else if (i == 1) {
@@ -1041,6 +1044,7 @@ public class AccountContainerTest {
         containerJson.put(DESCRIPTION_KEY, container.getDescription());
         containerJson.put(IS_PRIVATE_KEY, !container.isCacheable());
         containerJson.put(PARENT_ACCOUNT_ID_KEY, container.getParentAccountId());
+        containerJson.put(LAST_MODIFIED_TIME_KEY, container.getLastModifiedTime());
         break;
       case Container.JSON_VERSION_2:
         containerJson.put(Container.JSON_VERSION_KEY, Container.JSON_VERSION_2);
@@ -1057,6 +1061,7 @@ public class AccountContainerTest {
         containerJson.putOpt(REPLICATION_POLICY_KEY, container.getReplicationPolicy());
         containerJson.put(TTL_REQUIRED_KEY, container.isTtlRequired());
         containerJson.put(SECURE_PATH_REQUIRED_KEY, container.isSecurePathRequired());
+        containerJson.put(LAST_MODIFIED_TIME_KEY, container.getLastModifiedTime());
         if (container.getContentTypeWhitelistForFilenamesOnDownload() != null
             && !container.getContentTypeWhitelistForFilenamesOnDownload().isEmpty()) {
           containerJson.put(CONTENT_TYPE_WHITELIST_FOR_FILENAMES_ON_DOWNLOAD,

--- a/ambry-tools/src/main/java/com/github/ambry/account/AccountTool.java
+++ b/ambry-tools/src/main/java/com/github/ambry/account/AccountTool.java
@@ -412,7 +412,8 @@ public class AccountTool {
     accountServiceConfig = new HelixAccountServiceConfig(verifiableProperties);
     storeConfig = new HelixPropertyStoreConfig(verifiableProperties);
     registry = new MetricRegistry();
-    backupFileManager = new BackupFileManager(new AccountServiceMetrics(registry), accountServiceConfig);
+    backupFileManager = new BackupFileManager(new AccountServiceMetrics(registry), accountServiceConfig.backupDir,
+        accountServiceConfig.maxBackupFileCount);
     helixStore = CommonUtils.createHelixPropertyStore(accountServiceConfig.zkClientConnectString, storeConfig, null);
     routerStore = getRouterStore();
   }


### PR DESCRIPTION
Changes to:
1. Persist account and container metadata to local file on disk after syncing recent updates from db.   
2. Retrieve metadata from local file on start up and initialize cache.
3. Add 'lastModifiedTime' field to Account and Container class, update it from timestamp column in DB records and use the max LMT as reference timestamp during next db sync.
