### PR TITLE
[DataNodeConfigSource] use dedicated HPS instance

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/clustermap/DataNodeConfigSourceType.java
+++ b/ambry-api/src/main/java/com/github/ambry/clustermap/DataNodeConfigSourceType.java
@@ -19,5 +19,34 @@ package com.github.ambry.clustermap;
  * Represent the type of {@code DataNodeConfigSource} implementation to use.
  */
 public enum DataNodeConfigSourceType {
-  INSTANCE_CONFIG, PROPERTY_STORE, COMPOSITE_INSTANCE_CONFIG_PRIMARY, COMPOSITE_PROPERTY_STORE_PRIMARY
+  INSTANCE_CONFIG(true, false),
+  PROPERTY_STORE(false, true),
+  COMPOSITE_INSTANCE_CONFIG_PRIMARY(true, true),
+  COMPOSITE_PROPERTY_STORE_PRIMARY(true, true);
+
+  private final boolean instanceConfigAware;
+  private final boolean propertyStoreAware;
+
+  /**
+   * @param instanceConfigAware {@code true} if this type depends on helix instance configs.
+   * @param propertyStoreAware {@code true} if this type depends on the helix property store.
+   */
+  DataNodeConfigSourceType(boolean instanceConfigAware, boolean propertyStoreAware) {
+    this.instanceConfigAware = instanceConfigAware;
+    this.propertyStoreAware = propertyStoreAware;
+  }
+
+  /**
+   * @return {@code true} if this type depends on helix instance configs.
+   */
+  public boolean isInstanceConfigAware() {
+    return instanceConfigAware;
+  }
+
+  /**
+   * @return {@code true} if this type depends on the helix property store.
+   */
+  public boolean isPropertyStoreAware() {
+    return propertyStoreAware;
+  }
 }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
@@ -13,9 +13,7 @@
  */
 package com.github.ambry.clustermap;
 
-import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.network.Port;
-import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.Utils;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -35,7 +33,6 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.apache.helix.HelixAdmin;
-import org.apache.helix.HelixManager;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
@@ -359,35 +356,6 @@ public class ClusterMapUtils {
       }
     }
     return result;
-  }
-
-  /**
-   * Get an instance of a {@link DataNodeConfigSource} based on settings in the provided {@link ClusterMapConfig}
-   * @param clusterMapConfig the config to use.
-   * @param helixManager the manager instance to use.
-   * @param metrics the metrics instance that the returned source should use.
-   * @return the {@link DataNodeConfigSource} instance.
-   */
-  static DataNodeConfigSource getDataNodeConfigSource(ClusterMapConfig clusterMapConfig, HelixManager helixManager,
-      DataNodeConfigSourceMetrics metrics) {
-    switch (clusterMapConfig.clusterMapDataNodeConfigSourceType) {
-      case INSTANCE_CONFIG:
-        return new InstanceConfigToDataNodeConfigAdapter(helixManager, clusterMapConfig);
-      case PROPERTY_STORE:
-        return new PropertyStoreToDataNodeConfigAdapter(helixManager.getHelixPropertyStore(), clusterMapConfig);
-      case COMPOSITE_INSTANCE_CONFIG_PRIMARY:
-        return new CompositeDataNodeConfigSource(
-            new InstanceConfigToDataNodeConfigAdapter(helixManager, clusterMapConfig),
-            new PropertyStoreToDataNodeConfigAdapter(helixManager.getHelixPropertyStore(), clusterMapConfig),
-            SystemTime.getInstance(), metrics);
-      case COMPOSITE_PROPERTY_STORE_PRIMARY:
-        return new CompositeDataNodeConfigSource(
-            new PropertyStoreToDataNodeConfigAdapter(helixManager.getHelixPropertyStore(), clusterMapConfig),
-            new InstanceConfigToDataNodeConfigAdapter(helixManager, clusterMapConfig), SystemTime.getInstance(),
-            metrics);
-      default:
-        throw new IllegalArgumentException("Unknown type: " + clusterMapConfig.clusterMapDataNodeConfigSourceType);
-    }
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/CompositeDataNodeConfigSource.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/CompositeDataNodeConfigSource.java
@@ -110,6 +110,15 @@ public class CompositeDataNodeConfigSource implements DataNodeConfigSource {
     return primaryResult;
   }
 
+  @Override
+  public void close() {
+    try {
+      primarySource.close();
+    } finally {
+      secondarySource.close();
+    }
+  }
+
   /**
    * Long running background task to periodically check for consistency between two listeners.
    */

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DataNodeConfigSource.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DataNodeConfigSource.java
@@ -18,7 +18,7 @@ package com.github.ambry.clustermap;
 /**
  * A source of {@link DataNodeConfig}s for a cluster. Can be used for config change notification and administration.
  */
-interface DataNodeConfigSource {
+interface DataNodeConfigSource extends AutoCloseable {
   /**
    * Attach a listener that will be notified when there are new or updated {@link DataNodeConfig}s.
    * @param listener the {@link DataNodeConfigChangeListener} to attach.
@@ -37,4 +37,7 @@ interface DataNodeConfigSource {
    * @return the {@link DataNodeConfig} for the specified instance.
    */
   DataNodeConfig get(String instanceName);
+
+  @Override
+  void close();
 }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DatacenterInitializer.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DatacenterInitializer.java
@@ -201,7 +201,7 @@ class DatacenterInitializer {
     // call. Therefore, when the call to add a listener returns, the initial notification will have been
     // received and handled.
     DataNodeConfigSource dataNodeConfigSource =
-        ClusterMapUtils.getDataNodeConfigSource(clusterMapConfig, manager, dataNodeConfigSourceMetrics);
+        helixFactory.getDataNodeConfigSource(clusterMapConfig, zkConnectStr, dataNodeConfigSourceMetrics);
     dataNodeConfigSource.addDataNodeConfigChangeListener(clusterChangeHandler);
     logger.info("Registered instance config change listeners for Helix manager at {}", zkConnectStr);
     manager.addIdealStateChangeListener(clusterChangeHandler);
@@ -228,7 +228,7 @@ class DatacenterInitializer {
       logger.info("Stopped listening to cross colo ZK server {}", zkConnectStr);
     }
 
-    return new HelixDcInfo(dcName, dcZkInfo, manager, clusterChangeHandler);
+    return new HelixDcInfo(dcName, dcZkInfo, manager, clusterChangeHandler, dataNodeConfigSource);
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixDcInfo.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixDcInfo.java
@@ -24,6 +24,7 @@ import org.apache.helix.HelixManager;
  */
 class HelixDcInfo extends DcInfo {
   final HelixManager helixManager;
+  private final DataNodeConfigSource dataNodeConfigSource;
 
   /**
    * Construct a HelixDcInfo object with the given parameters.
@@ -32,17 +33,23 @@ class HelixDcInfo extends DcInfo {
    * @param helixManager the associated {@link HelixManager} for this datacenter. This can be null if the datacenter is
    *                     not managed by helix.
    * @param clusterChangeHandler the associated {@link ClusterChangeHandler} for this datacenter.
+   * @param dataNodeConfigSource the {@link DataNodeConfigSource} for this datacenter.
    */
   HelixDcInfo(String dcName, ClusterMapUtils.DcZkInfo dcZkInfo, HelixManager helixManager,
-      ClusterChangeHandler clusterChangeHandler) {
+      ClusterChangeHandler clusterChangeHandler, DataNodeConfigSource dataNodeConfigSource) {
     super(dcName, dcZkInfo, clusterChangeHandler);
     this.helixManager = helixManager;
+    this.dataNodeConfigSource = dataNodeConfigSource;
   }
 
   @Override
   public void close() {
-    if (helixManager.isConnected()) {
-      helixManager.disconnect();
+    try {
+      if (helixManager.isConnected()) {
+        helixManager.disconnect();
+      }
+    } finally {
+      dataNodeConfigSource.close();
     }
   }
 }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
@@ -103,8 +103,8 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
       HelixManager spectatorManager =
           helixFactory.getZkHelixManagerAndConnect(clusterName, instanceName, InstanceType.SPECTATOR, zkConnectStr);
       helixAdmin = spectatorManager.getClusterManagmentTool();
-      dataNodeConfigSource =
-          getDataNodeConfigSource(clusterMapConfig, spectatorManager, new DataNodeConfigSourceMetrics(metricRegistry));
+      dataNodeConfigSource = helixFactory.getDataNodeConfigSource(clusterMapConfig, zkConnectStr,
+          new DataNodeConfigSourceMetrics(metricRegistry));
     } catch (Exception exception) {
       throw new IllegalStateException("Error setting up administration facilities", exception);
     }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/InstanceConfigToDataNodeConfigAdapter.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/InstanceConfigToDataNodeConfigAdapter.java
@@ -75,6 +75,10 @@ public class InstanceConfigToDataNodeConfigAdapter implements DataNodeConfigSour
     return instanceConfig != null ? converter.convert(instanceConfig) : null;
   }
 
+  @Override
+  public void close() {
+  }
+
   static class Converter {
     private final ClusterMapConfig clusterMapConfig;
 

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixClusterManagerTest.java
@@ -1496,23 +1496,13 @@ public class HelixClusterManagerTest {
       this.znRecordMap = znRecordMap;
     }
 
-    /**
-     * Return a {@link MockHelixManager}
-     * @param clusterName the name of the cluster for which the manager is to be gotten.
-     * @param instanceName the name of the instance on whose behalf the manager is to be gotten.
-     * @param instanceType the {@link InstanceType} of the requester.
-     * @param zkAddr the address identifying the zk service to which this request is to be made.
-     * @return the {@link MockHelixManager}
-     */
     @Override
-    public HelixManager getZKHelixManager(String clusterName, String instanceName, InstanceType instanceType,
+    HelixManager buildZKHelixManager(String clusterName, String instanceName, InstanceType instanceType,
         String zkAddr) {
-      if (helixCluster.getZkAddrs().contains(zkAddr)) {
-        return helixManagers.computeIfAbsent(new ManagerKey(clusterName, instanceName, instanceType, zkAddr),
-            key -> new MockHelixManager(instanceName, instanceType, zkAddr, helixCluster, znRecordMap, beBadException));
-      } else {
+      if (!helixCluster.getZkAddrs().contains(zkAddr)) {
         throw new IllegalArgumentException("Invalid ZkAddr");
       }
+      return new MockHelixManager(instanceName, instanceType, zkAddr, helixCluster, znRecordMap, beBadException);
     }
   }
 }

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixClusterManagerTest.java
@@ -1508,7 +1508,8 @@ public class HelixClusterManagerTest {
     public HelixManager getZKHelixManager(String clusterName, String instanceName, InstanceType instanceType,
         String zkAddr) {
       if (helixCluster.getZkAddrs().contains(zkAddr)) {
-        return new MockHelixManager(instanceName, instanceType, zkAddr, helixCluster, znRecordMap, beBadException);
+        return helixManagers.computeIfAbsent(new ManagerKey(clusterName, instanceName, instanceType, zkAddr),
+            key -> new MockHelixManager(instanceName, instanceType, zkAddr, helixCluster, znRecordMap, beBadException));
       } else {
         throw new IllegalArgumentException("Invalid ZkAddr");
       }

--- a/ambry-commons/src/main/java/com/github/ambry/commons/CommonUtils.java
+++ b/ambry-commons/src/main/java/com/github/ambry/commons/CommonUtils.java
@@ -16,12 +16,13 @@ package com.github.ambry.commons;
 
 import com.github.ambry.config.HelixPropertyStoreConfig;
 import java.util.List;
-import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.manager.zk.ZNRecordSerializer;
 import org.apache.helix.manager.zk.ZkBaseDataAccessor;
 import org.apache.helix.manager.zk.ZkClient;
 import org.apache.helix.store.HelixPropertyStore;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.helix.zookeeper.api.client.ZkClientType;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
 
 
 public class CommonUtils {
@@ -41,5 +42,23 @@ public class CommonUtils {
         propertyStoreConfig.zkClientConnectionTimeoutMs, new ZNRecordSerializer());
     return new ZkHelixPropertyStore<>(new ZkBaseDataAccessor<>(zkClient), propertyStoreConfig.rootPath,
         subscribedPaths);
+  }
+
+  /**
+   * Create an instance of {@link HelixPropertyStore}, using non-deprecated APIs.
+   * TODO replace usages of the other method with this one once verified to be stable.
+   * @param zkAddress the ZooKeeper server address.
+   * @param rootPath the root path for this {@link HelixPropertyStore}.
+   * @param subscribedPaths the paths to subscribe to for change notification. Note that these should be absolute paths,
+   *                        not relative paths under {@code rootPath}.
+   * @return the instance of {@link HelixPropertyStore}.
+   */
+  public static HelixPropertyStore<ZNRecord> createHelixPropertyStore(String zkAddress, String rootPath,
+      List<String> subscribedPaths) {
+    ZkBaseDataAccessor<ZNRecord> baseDataAccessor =
+        new ZkBaseDataAccessor.Builder<ZNRecord>().setZkClientType(ZkClientType.DEDICATED)
+            .setZkAddress(zkAddress)
+            .build();
+    return new ZkHelixPropertyStore<>(baseDataAccessor, rootPath, subscribedPaths);
   }
 }

--- a/ambry-commons/src/test/java/com/github/ambry/commons/CommonUtilsTest.java
+++ b/ambry-commons/src/test/java/com/github/ambry/commons/CommonUtilsTest.java
@@ -60,7 +60,8 @@ public class CommonUtilsTest {
     }
 
     try {
-      CommonUtils.createHelixPropertyStore("localhost:" + zkInfo.getPort(), null, Collections.emptyList());
+      CommonUtils.createHelixPropertyStore("localhost:" + zkInfo.getPort(), (HelixPropertyStoreConfig) null,
+          Collections.emptyList());
       fail("create HelixPropertyStore with invalid arguments should fail");
     } catch (IllegalArgumentException e) {
       //expected

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
@@ -66,6 +66,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixManager;
+import org.apache.helix.InstanceType;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
@@ -1933,9 +1934,13 @@ public class BlobStoreTest {
     });
     HelixManager mockHelixManager = mock(HelixManager.class);
     when(mockHelixManager.getClusterManagmentTool()).thenReturn(mockHelixAdmin);
-    HelixFactory mockHelixFactory = mock(HelixFactory.class);
-    when(mockHelixFactory.getZkHelixManagerAndConnect(anyString(), anyString(), any(), anyString())).thenReturn(
-        mockHelixManager);
+    HelixFactory mockHelixFactory = new HelixFactory() {
+      @Override
+      public HelixManager getZKHelixManager(String clusterName, String instanceName, InstanceType instanceType,
+          String zkAddr) {
+        return mockHelixManager;
+      }
+    };
     MockHelixParticipant.metricRegistry = new MetricRegistry();
     MockHelixParticipant mockParticipant = new MockHelixParticipant(clusterMapConfig, mockHelixFactory);
     mockParticipant.overrideDisableReplicaMethod = false;

--- a/ambry-tools/src/integration-test/java/com/github/ambry/clustermap/HelixBootstrapUpgradeToolTest.java
+++ b/ambry-tools/src/integration-test/java/com/github/ambry/clustermap/HelixBootstrapUpgradeToolTest.java
@@ -867,14 +867,9 @@ public class HelixBootstrapUpgradeToolTest {
     // verify that they are present in the property store and that the basic values match expectations
     for (ZkInfo zkInfo : dcsToZkInfo.values()) {
       String dcName = zkInfo.getDcName();
-      HelixPropertyStore<ZNRecord> propertyStore =
-          CommonUtils.createHelixPropertyStore("localhost:" + zkInfo.getPort(), propertyStoreConfig,
-              Collections.singletonList(propertyStoreConfig.rootPath));
-      try {
-        PropertyStoreToDataNodeConfigAdapter propertyStoreAdapter =
-            new PropertyStoreToDataNodeConfigAdapter(propertyStore,
-                HelixBootstrapUpgradeUtil.getClusterMapConfig(CLUSTER_NAME_PREFIX + CLUSTER_NAME_IN_STATIC_CLUSTER_MAP,
-                    dcName, null));
+      try (DataNodeConfigSource source = new PropertyStoreToDataNodeConfigAdapter("localhost:" + zkInfo.getPort(),
+          HelixBootstrapUpgradeUtil.getClusterMapConfig(CLUSTER_NAME_PREFIX + CLUSTER_NAME_IN_STATIC_CLUSTER_MAP,
+              dcName, null))) {
         Map<DataNodeId, Set<String>> dataNodeToReplicas = testPartitionLayout.getPartitionLayout()
             .getPartitions(null)
             .stream()
@@ -884,7 +879,7 @@ public class HelixBootstrapUpgradeToolTest {
         List<DataNode> expectedNodes = testHardwareLayout.getAllDataNodesFromDc(zkInfo.getDcName());
         for (DataNode expectedNode : expectedNodes) {
           String instanceName = getInstanceName(expectedNode);
-          DataNodeConfig config = propertyStoreAdapter.get(instanceName);
+          DataNodeConfig config = source.get(instanceName);
           assertNotNull("Config for " + instanceName + " not found", config);
           assertEquals("Unexpected instance name", instanceName, config.getInstanceName());
           assertEquals("Unexpected host", expectedNode.getHostname(), config.getHostName());
@@ -897,11 +892,6 @@ public class HelixBootstrapUpgradeToolTest {
               .collect(Collectors.toSet());
           assertEquals("Unexpected partitions in config", expectedReplicas, replicasInConfig);
         }
-        assertEquals("Unexpected number of node configs in property store", expectedNodes.size(),
-            propertyStore.getChildren(PropertyStoreToDataNodeConfigAdapter.CONFIG_PATH, null, AccessOption.PERSISTENT)
-                .size());
-      } finally {
-        propertyStore.stop();
       }
     }
   }


### PR DESCRIPTION
The property store provided by the HelixManager.getPropertyStore()
method does not support caching/subscribed paths. As a solution, we can
move the ownership/instantiation of the PropertyStore into the
PropertyStoreToDataNodeConfigAdapter class.

To keep views of the property store consistent between HelixParticipant
and HelixClusterManager, this commit also adds a shared pool of
DataNodeConfigSources so that the same instance (and ZkClient) can be
used by both classes.