### PR TITLE
Return copy of Set references in ExchangeMetadataResponse get methods to avoid concurrentModificationException

### DIFF
--- a/ambry-replication/src/main/java/com/github/ambry/replication/RemoteReplicaInfo.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/RemoteReplicaInfo.java
@@ -248,7 +248,7 @@ public class RemoteReplicaInfo {
    */
   synchronized void updateMissingMessagesInMetadataResponse(List<MessageInfo> messagesWrittenToStore) {
     Set<MessageInfo> missingStoreMessages = exchangeMetadataResponse.getMissingStoreMessages();
-    if (missingStoreMessages != null && !missingStoreMessages.isEmpty()) {
+    if (!missingStoreMessages.isEmpty()) {
       Set<StoreKey> keysWrittenToStore =
           messagesWrittenToStore.stream().map(MessageInfo::getStoreKey).collect(Collectors.toSet());
       Set<MessageInfo> missingMessagesFoundInStore = missingStoreMessages.stream()

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -1451,7 +1451,7 @@ public class ReplicaThread implements Runnable {
     ExchangeMetadataResponse exchangeMetadataResponse = remoteReplicaInfo.getExchangeMetadataResponse();
     Set<MessageInfo> missingStoreMessages = exchangeMetadataResponse.getMissingStoreMessages();
 
-    if (missingStoreMessages != null && !missingStoreMessages.isEmpty()) {
+    if (!missingStoreMessages.isEmpty()) {
       Set<MessageInfo> missingStoreMessagesFoundInStore = new HashSet<>();
       try {
         // construct map of message info -> converted non-null local key
@@ -1567,10 +1567,10 @@ public class ReplicaThread implements Runnable {
 
     /**
      * Get missing store messages in this metadata exchange.
-     * @return set of missing store messages
+     * @return set of missing store messages as a new collection.
      */
     synchronized Set<MessageInfo> getMissingStoreMessages() {
-      return missingStoreMessages;
+      return missingStoreMessages == null ? Collections.emptySet() : new HashSet<>(missingStoreMessages);
     }
 
     /**
@@ -1599,10 +1599,11 @@ public class ReplicaThread implements Runnable {
     /**
      * Get remote messages that were previously missing and are now received but whose blob properties (
      * ttl_update, delete, undelete) still needs to be compared to properties of blob in local store and reconciled.
-     * @return set of messages that are now found in store
+     * @return set of messages that are now found in store as a new collection
      */
     synchronized Set<MessageInfo> getReceivedStoreMessagesWithUpdatesPending() {
-      return receivedStoreMessagesWithUpdatesPending;
+      return receivedStoreMessagesWithUpdatesPending == null ? Collections.emptySet()
+          : new HashSet<>(receivedStoreMessagesWithUpdatesPending);
     }
 
     /**
@@ -1629,7 +1630,7 @@ public class ReplicaThread implements Runnable {
     }
 
     /**
-     *  get the keys corresponding to the missing messages in local store
+     *  Get the keys corresponding to the missing messages in local store
      */
     Set<StoreKey> getMissingStoreKeys() {
       return missingStoreMessages == null ? Collections.emptySet()

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -1630,9 +1630,10 @@ public class ReplicaThread implements Runnable {
     }
 
     /**
-     *  Get the keys corresponding to the missing messages in local store
+     * Get the keys corresponding to the missing messages in the local store
+     * @return store keys missing in the local store
      */
-    Set<StoreKey> getMissingStoreKeys() {
+    synchronized Set<StoreKey> getMissingStoreKeys() {
       return missingStoreMessages == null ? Collections.emptySet()
           : missingStoreMessages.stream().map(MessageInfo::getStoreKey).collect(Collectors.toSet());
     }


### PR DESCRIPTION
Due to multiple replica threads referencing same references of ExchangeMetadataResponse Set collection, modification of set by one thread while iterating over it in another thread is resulting in concurrentModificationException. Return copy of set references in get() methods to avoid it.