### PR TITLE
Split travis build into multiple jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,20 @@ branches:
   except: # don't build tags
     - /^v\d/
 install: skip # skips unnecessary ./gradlew assemble (https://docs.travis-ci.com/user/job-lifecycle/#skipping-the-installation-phase) 
-script:
-  - ./travis-build.sh
-after_success:
-  - bash <(curl -s https://codecov.io/bash)
+
+jobs:
+  include:
+    - stage: test
+      name: "Unit Tests"
+      script: ./travis-unit-test.sh
+    - stage: test
+      name: "Integration Tests"
+      script: ./travis-int-test.sh
+    - stage: publish
+      name: "Publish To Bintray"
+      script: ./travis-publish.sh
+
+stages:
+  - name: test
+  - name: publish
+    if: branch = master and type = push

--- a/ambry-api/src/main/java/com/github/ambry/rest/RequestPath.java
+++ b/ambry-api/src/main/java/com/github/ambry/rest/RequestPath.java
@@ -29,9 +29,9 @@ public class RequestPath {
   private final int blobSegmentIdx;
   private final String pathAfterPrefixes;
   private String operationOrBlobIdWithoutLeadingSlash = null;
-  private static char PATH_SEPARATOR_CHAR = '/';
-  private static String PATH_SEPARATOR_STRING = String.valueOf(PATH_SEPARATOR_CHAR);
-  private static String SEGMENT = SubResource.Segment.toString();
+  private static final char PATH_SEPARATOR_CHAR = '/';
+  private static final String PATH_SEPARATOR_STRING = String.valueOf(PATH_SEPARATOR_CHAR);
+  private static final String SEGMENT = SubResource.Segment.toString();
 
   /**
    * Parse the request path (and additional headers in some cases). The path will match the following regex-like

--- a/build.gradle
+++ b/build.gradle
@@ -488,6 +488,8 @@ task allJarVcr(type: Jar, dependsOn: subprojects.assemble) {
 }
 
 task codeCoverageReport(type: JacocoReport) {
+    // This task will compile a report for whatever tests have been run.
+    // Make sure to run the desired test tasks before generating the coverate report.
     executionData fileTree(project.rootDir.absolutePath).include("**/build/jacoco/*.exec")
 
     subprojects.each {
@@ -501,7 +503,6 @@ task codeCoverageReport(type: JacocoReport) {
         csv.enabled true
     }
 }
-codeCoverageReport.dependsOn subprojects*.allTest
 
 if (hasProperty('buildScan')) {
     buildScan {

--- a/travis-int-test.sh
+++ b/travis-int-test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# exit when any command fails
+set -e
+
+echo "Running integration tests"
+./gradlew -s --scan intTest codeCoverageReport
+
+echo "Uploading integration test coverage to codecov"
+bash <(curl -s https://codecov.io/bash)

--- a/travis-publish.sh
+++ b/travis-publish.sh
@@ -1,10 +1,10 @@
-#!/bin/sh
+#!/bin/bash
 
 # exit when any command fails
 set -e
 
-echo "Building and testing artifacts, and creating pom files"
-./gradlew -s --scan build publishToMavenLocal codeCoverageReport
+echo "Building artifacts, and creating pom files"
+./gradlew -s --scan assemble publishToMavenLocal
 
 echo "Testing Bintray publication by uploading in dry run mode"
 ./gradlew -s -i --scan bintrayUploadAll -Pbintray.dryRun
@@ -12,7 +12,7 @@ echo "Testing Bintray publication by uploading in dry run mode"
 echo "Pull request: [$TRAVIS_PULL_REQUEST], Travis branch: [$TRAVIS_BRANCH]"
 # release only from master when no pull request build
 if [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]
-then    
+then
     echo "Releasing (tagging, uploading to Bintray)"
     ./gradlew -s -i --scan ciPerformRelease
 fi

--- a/travis-unit-test.sh
+++ b/travis-unit-test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# exit when any command fails
+set -e
+
+echo "Building and running unit tests"
+./gradlew -s --scan build codeCoverageReport
+
+echo "Uploading unit test coverage to codecov"
+bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Our build on the master branch is occaisionally hitting the 50 minute
travis-ci job timeout. To give more headroom, we can split independent
parts of the build into multiple jobs.
- Integration tests and unit tests will run in parallel jobs. Coverage
  reports are supposed to be merged according to codecov docs.
  (https://docs.codecov.io/docs/merging-reports)
- Publishing to bintray will run after both test jobs pass on the master
  branch.