### PR TITLE
[Container API] Attach account id to response header for container update

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/account/AccountCollectionSerde.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/AccountCollectionSerde.java
@@ -76,7 +76,7 @@ public class AccountCollectionSerde {
    */
   public static JSONObject containersToJson(Collection<Container> containers) {
     JSONArray containerArray = new JSONArray();
-    containers.stream().map(container -> container.toJson()).forEach(containerArray::put);
+    containers.stream().map(Container::toJson).forEach(containerArray::put);
     return new JSONObject().put(Account.CONTAINERS_KEY, containerArray);
   }
 

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendIntegrationTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendIntegrationTest.java
@@ -1052,8 +1052,8 @@ public class FrontendIntegrationTest {
     assertEquals(RestUtils.Headers.AMBRY_CONTENT_TYPE + " does not match",
         expectedHeaders.get(RestUtils.Headers.AMBRY_CONTENT_TYPE),
         response.headers().get(RestUtils.Headers.AMBRY_CONTENT_TYPE));
-    assertTrue("No " + RestUtils.Headers.CREATION_TIME,
-        response.headers().get(RestUtils.Headers.CREATION_TIME, null) != null);
+    assertNotNull("No " + RestUtils.Headers.CREATION_TIME,
+        response.headers().get(RestUtils.Headers.CREATION_TIME, null));
     if (expectedHeaders.get(RestUtils.Headers.TTL) != null
         && Long.parseLong(expectedHeaders.get(RestUtils.Headers.TTL)) != Utils.Infinite_Time) {
       assertEquals(RestUtils.Headers.TTL + " does not match", expectedHeaders.get(RestUtils.Headers.TTL),
@@ -1254,7 +1254,7 @@ public class FrontendIntegrationTest {
     ResponseParts responseParts = nettyClient.sendRequest(httpRequest, null, null).get();
     HttpResponse response = getHttpResponse(responseParts);
     assertEquals("Unexpected response status", expectedStatusCode, response.status());
-    assertTrue("No Date header", response.headers().get(HttpHeaderNames.DATE, null) != null);
+    assertNotNull("No Date header", response.headers().get(HttpHeaderNames.DATE, null));
     assertNoContent(responseParts.queue, 1);
     assertTrue("Channel should be active", HttpUtil.isKeepAlive(response));
     verifyTrackingHeaders(response);
@@ -1265,8 +1265,8 @@ public class FrontendIntegrationTest {
    * @param receivedHeaders the {@link HttpHeaders} that were received.
    */
   private void checkCommonGetHeadHeaders(HttpHeaders receivedHeaders) {
-    assertTrue("No Date header", receivedHeaders.get(HttpHeaderNames.DATE) != null);
-    assertTrue("No Last-Modified header", receivedHeaders.get(HttpHeaderNames.LAST_MODIFIED) != null);
+    assertNotNull("No Date header", receivedHeaders.get(HttpHeaderNames.DATE));
+    assertNotNull("No Last-Modified header", receivedHeaders.get(HttpHeaderNames.LAST_MODIFIED));
   }
 
   /**
@@ -1505,6 +1505,11 @@ public class FrontendIntegrationTest {
     ResponseParts responseParts = nettyClient.sendRequest(request, null, null).get();
     HttpResponse response = getHttpResponse(responseParts);
     assertEquals("Unexpected response status", HttpResponseStatus.OK, response.status());
+    // verify regular response header
+    assertEquals("Unexpected account id in response header", account.getId(),
+        Short.parseShort(response.headers().get(RestUtils.Headers.TARGET_ACCOUNT_ID)));
+    assertEquals("Unexpected content type in response header", RestUtils.JSON_CONTENT_TYPE,
+        response.headers().get(RestUtils.Headers.CONTENT_TYPE));
     verifyTrackingHeaders(response);
     ByteBuffer content = getContent(responseParts.queue, HttpUtil.getContentLength(response));
     Collection<Container> outputContainers =

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/PostAccountContainersHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/PostAccountContainersHandlerTest.java
@@ -84,6 +84,8 @@ public class PostAccountContainersHandlerTest {
       assertNotNull("Date has not been set", restResponseChannel.getHeader(RestUtils.Headers.DATE));
       assertEquals("Content-length is not as expected", responseChannel.getSize(),
           Integer.parseInt((String) restResponseChannel.getHeader(RestUtils.Headers.CONTENT_LENGTH)));
+      assertEquals("Account id in response header is not as expected", accountId,
+          Short.parseShort((String) restResponseChannel.getHeader(RestUtils.Headers.TARGET_ACCOUNT_ID)));
       Collection<Container> outputContainers =
           AccountCollectionSerde.containersFromJson(RestTestUtils.getJsonizedResponseBody(responseChannel), accountId);
       assertEquals("Unexpected count returned", inputContainers.size(), outputContainers.size());
@@ -105,6 +107,10 @@ public class PostAccountContainersHandlerTest {
     }
     testAction.accept(containerList);
 
+    // add an exactly same container (we reuse the container created in previous case)
+    testAction.accept(Collections.singletonList(
+        new ContainerBuilder(Container.UNKNOWN_CONTAINER_ID, "Test-0", Container.ContainerStatus.ACTIVE, "",
+            accountId).build()));
     // TODO: update existing containers when support is added
   }
 

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/PostAccountContainersHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/PostAccountContainersHandlerTest.java
@@ -107,10 +107,6 @@ public class PostAccountContainersHandlerTest {
     }
     testAction.accept(containerList);
 
-    // add an exactly same container (we reuse the container created in previous case)
-    testAction.accept(Collections.singletonList(
-        new ContainerBuilder(Container.UNKNOWN_CONTAINER_ID, "Test-0", Container.ContainerStatus.ACTIVE, "",
-            accountId).build()));
     // TODO: update existing containers when support is added
   }
 


### PR DESCRIPTION
Previously, container update returns a collecion of updated result in the format of JSON.
To deserialize containers from JSON on client side, account id is needed bub not available
in response. This PR attaches account id to response header which will be returned together
with response body (updated containers).