### PR TITLE
[Container API] Support getting single container from given account in ambry-frontend

### DIFF
--- a/ambry-account/src/main/java/com/github/ambry/account/AbstractAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/AbstractAccountService.java
@@ -42,8 +42,8 @@ abstract class AbstractAccountService implements AccountService {
   protected final ReentrantLock lock = new ReentrantLock();
   protected final CopyOnWriteArraySet<Consumer<Collection<Account>>> accountUpdateConsumers =
       new CopyOnWriteArraySet<>();
-  private final AccountServiceConfig config;
   protected final AccountServiceMetrics accountServiceMetrics;
+  private final AccountServiceConfig config;
 
   public AbstractAccountService(AccountServiceConfig config, AccountServiceMetrics accountServiceMetrics) {
     this.config = config;
@@ -114,7 +114,8 @@ abstract class AbstractAccountService implements AccountService {
           if (existingContainer.isSameContainer(container)) {
             // If an exactly same container already exists, treat as no-op (may be retry after partial failure).
             // But include it in the list returned to caller to provide the containerId.
-            logger.info("Request to create container with existing name and properties: {}", existingContainer.toJson().toString());
+            logger.info("Request to create container with existing name and properties: {}",
+                existingContainer.toJson().toString());
             existingUnchangedContainers.add(existingContainer);
           } else {
             throw new AccountServiceException("There is a conflicting container in account " + accountName,
@@ -153,7 +154,7 @@ abstract class AbstractAccountService implements AccountService {
       // TODO: updateAccounts should throw exception with specific error code
       if (!hasSucceeded) {
         throw new AccountServiceException("Account update failed for " + accountName,
-            AccountServiceErrorCode.AccountUpdateError);
+            AccountServiceErrorCode.InternalError);
       }
     }
 
@@ -179,7 +180,7 @@ abstract class AbstractAccountService implements AccountService {
    * Logs and notifies account update {@link Consumer}s about any new account changes/creations.
    * @param newAccountInfoMap the new {@link AccountInfoMap} that has been set.
    * @param oldAccountInfoMap the {@link AccountInfoMap} that was cached before this change.
-   * @param isCalledFromListener {@code true} if the caller is the account update listener, {@@code false} otherwise.
+   * @param isCalledFromListener {@code true} if the caller is the account update listener, {@code false} otherwise.
    */
   protected void notifyAccountUpdateConsumers(AccountInfoMap newAccountInfoMap, AccountInfoMap oldAccountInfoMap,
       boolean isCalledFromListener) {

--- a/ambry-account/src/test/java/com/github/ambry/account/HelixAccountServiceTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/HelixAccountServiceTest.java
@@ -425,7 +425,7 @@ public class HelixAccountServiceTest {
       accountService.updateContainers(refAccountName, Collections.singleton(containerToAdd1));
       fail("should fail because exception occurs when updating ZK");
     } catch (AccountServiceException e) {
-      assertEquals("Mismatch in error code", AccountServiceErrorCode.AccountUpdateError, e.getErrorCode());
+      assertEquals("Mismatch in error code", AccountServiceErrorCode.InternalError, e.getErrorCode());
     }
     mockHelixStore.setExceptionDuringUpdater(false);
 

--- a/ambry-api/src/main/java/com/github/ambry/account/AccountServiceErrorCode.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/AccountServiceErrorCode.java
@@ -30,7 +30,7 @@ public enum AccountServiceErrorCode {
    */
   ResourceConflict,
   /**
-   * Error occurred when updating account in metadata store.
+   * Account service experienced an internal error.
    */
-  AccountUpdateError
+  InternalError
 }

--- a/ambry-api/src/main/java/com/github/ambry/frontend/Operations.java
+++ b/ambry-api/src/main/java/com/github/ambry/frontend/Operations.java
@@ -23,6 +23,6 @@ public class Operations {
   public static final String STITCH = "stitch";
   public static final String GET_CLUSTER_MAP_SNAPSHOT = "getClusterMapSnapshot";
   public static final String ACCOUNTS = "accounts";
-  public static final String UPDATE_ACCOUNT_CONTAINERS = "accounts/updateContainers";
+  public static final String ACCOUNTS_CONTAINERS = "accounts/containers";
   public static final String UNDELETE = "undelete";
 }

--- a/ambry-api/src/main/java/com/github/ambry/rest/RestServiceErrorCode.java
+++ b/ambry-api/src/main/java/com/github/ambry/rest/RestServiceErrorCode.java
@@ -228,8 +228,6 @@ public enum RestServiceErrorCode {
         return NotFound;
       case ResourceConflict:
         return Conflict;
-      case AccountUpdateError:
-        return InternalServerError;
       case BadRequest:
         return BadRequest;
       default:

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/PostAccountsHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/PostAccountsHandler.java
@@ -145,8 +145,8 @@ class PostAccountsHandler {
       return buildCallback(frontendMetrics.postAccountsReadRequestMetrics, bytesRead -> {
         JSONObject jsonPayload = readJsonFromChannel(channel);
         ReadableStreamChannel outputChannel;
-        if (RestUtils.getRequestPath(restRequest).matchesOperation(UPDATE_ACCOUNT_CONTAINERS)) {
-          logger.debug("Got request for {} with payload {}", UPDATE_ACCOUNT_CONTAINERS, jsonPayload);
+        if (RestUtils.getRequestPath(restRequest).matchesOperation(ACCOUNTS_CONTAINERS)) {
+          logger.debug("Got request for {} with payload {}", ACCOUNTS_CONTAINERS, jsonPayload);
           Pair<Account, JSONObject> accountAndUpdatedContainers = updateContainers(jsonPayload);
           outputChannel = serializeJsonToChannel(accountAndUpdatedContainers.getSecond());
           restResponseChannel.setHeader(RestUtils.Headers.TARGET_ACCOUNT_ID,

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/PostAccountContainersHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/PostAccountContainersHandlerTest.java
@@ -156,7 +156,7 @@ public class PostAccountContainersHandlerTest {
   private RestRequest createRestRequest(String requestBody, String accountName, String accountId) throws Exception {
     JSONObject data = new JSONObject();
     data.put(MockRestRequest.REST_METHOD_KEY, RestMethod.POST.name());
-    data.put(MockRestRequest.URI_KEY, Operations.UPDATE_ACCOUNT_CONTAINERS);
+    data.put(MockRestRequest.URI_KEY, Operations.ACCOUNTS_CONTAINERS);
     JSONObject headers = new JSONObject();
     if (accountName != null) {
       headers.put(RestUtils.Headers.TARGET_ACCOUNT_NAME, accountName);

--- a/ambry-test-utils/src/main/java/com/github/ambry/account/InMemAccountService.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/account/InMemAccountService.java
@@ -44,12 +44,12 @@ public class InMemAccountService implements AccountService {
           Account.SNAPSHOT_VERSION_DEFAULT_VALUE,
           Arrays.asList(Container.UNKNOWN_CONTAINER, Container.DEFAULT_PUBLIC_CONTAINER,
               Container.DEFAULT_PRIVATE_CONTAINER));
-  private boolean shouldUpdateSucceed = true;
   private final boolean shouldReturnOnlyUnknown;
   private final boolean notifyConsumers;
   private final Map<Short, Account> idToAccountMap = new HashMap<>();
   private final Map<String, Account> nameToAccountMap = new HashMap<>();
   private final Set<Consumer<Collection<Account>>> accountUpdateConsumers = new HashSet<>();
+  private boolean shouldUpdateSucceed = true;
 
   /**
    * Constructor.
@@ -118,7 +118,7 @@ public class InMemAccountService implements AccountService {
     boolean hasSucceeded = updateAccounts(Collections.singletonList(account));
     if (!hasSucceeded) {
       throw new AccountServiceException("Account update failed for " + accountName,
-          AccountServiceErrorCode.AccountUpdateError);
+          AccountServiceErrorCode.InternalError);
     }
     return createdContainers;
   }


### PR DESCRIPTION
This PR makes changes in GetAccountsHandler to support getting single container if the
request path matches "/accounts/containers". This can avoid transmitting whole account
info when number of containers in this account is super large. The account id is also attached
to response header to help deserialize container.