### PR TITLE
Mysql error handling and retries

### DIFF
--- a/ambry-account/src/integration-test/java/com/github/ambry/account/MySqlAccountServiceIntegrationTest.java
+++ b/ambry-account/src/integration-test/java/com/github/ambry/account/MySqlAccountServiceIntegrationTest.java
@@ -41,6 +41,7 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.github.ambry.account.AccountTestUtils.*;
 import static com.github.ambry.account.Container.*;
 import static com.github.ambry.account.mysql.MySqlUtils.*;
 import static com.github.ambry.config.MySqlAccountServiceConfig.*;
@@ -380,15 +381,15 @@ public class MySqlAccountServiceIntegrationTest {
 
     // case D: verify adding new account (4, "c") conflicts in name with (1, "c")
     accountToUpdate = new AccountBuilder((short) 4, "c", Account.AccountStatus.ACTIVE).build();
-    assertFalse("Account update should fail due to name conflict",
-        mySqlAccountService.updateAccounts(Collections.singletonList(accountToUpdate)));
+    assertUpdateAccountsFails(Collections.singletonList(accountToUpdate), AccountServiceErrorCode.ResourceConflict,
+        mySqlAccountService);
     assertEquals("UpdateAccountErrorCount in metrics should be 1", 1,
         accountServiceMetrics.updateAccountErrorCount.getCount());
 
     // case E: verify updating name of account  (1, "c") to (1, "b") conflicts in name with (2, "b")
     accountToUpdate = new AccountBuilder(mySqlAccountService.getAccountById((short) 1)).name("b").build();
-    assertFalse("Account update should fail due to name conflict",
-        mySqlAccountService.updateAccounts(Collections.singletonList(accountToUpdate)));
+    assertUpdateAccountsFails(Collections.singletonList(accountToUpdate), AccountServiceErrorCode.ResourceConflict,
+        mySqlAccountService);
     assertEquals("UpdateAccountErrorCount in metrics should be 2", 2,
         accountServiceMetrics.updateAccountErrorCount.getCount());
 
@@ -427,8 +428,8 @@ public class MySqlAccountServiceIntegrationTest {
     containerToUpdate = new ContainerBuilder((short) 3, "c3", ContainerStatus.ACTIVE, "c3", (short) 1).build();
     accountToUpdate =
         new AccountBuilder(accountToUpdate).containers(Collections.singletonList(containerToUpdate)).build();
-    assertFalse("Account update should fail due to name conflict in containers",
-        mySqlAccountService.updateAccounts(Collections.singletonList(accountToUpdate)));
+    assertUpdateAccountsFails(Collections.singletonList(accountToUpdate), AccountServiceErrorCode.ResourceConflict,
+        mySqlAccountService);
     accountToUpdate = new AccountBuilder(accountToUpdate).removeContainer(containerToUpdate).build();
     assertEquals("UpdateAccountErrorCount in metrics should be 1", 1,
         accountServiceMetrics.updateAccountErrorCount.getCount());
@@ -445,8 +446,8 @@ public class MySqlAccountServiceIntegrationTest {
         new ContainerBuilder(mySqlAccountService.getAccountById((short) 1).getContainerById((short) 3)).setName("c2")
             .build();
     accountToUpdate = new AccountBuilder(accountToUpdate).addOrUpdateContainer(containerToUpdate).build();
-    assertFalse("Account update should fail due to name conflict in containers",
-        mySqlAccountService.updateAccounts(Collections.singletonList(accountToUpdate)));
+    assertUpdateAccountsFails(Collections.singletonList(accountToUpdate), AccountServiceErrorCode.ResourceConflict,
+        mySqlAccountService);
     assertEquals("UpdateAccountErrorCount in metrics should be 2", 2,
         accountServiceMetrics.updateAccountErrorCount.getCount());
   }

--- a/ambry-account/src/integration-test/java/com/github/ambry/account/MySqlAccountServiceIntegrationTest.java
+++ b/ambry-account/src/integration-test/java/com/github/ambry/account/MySqlAccountServiceIntegrationTest.java
@@ -41,10 +41,10 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static com.github.ambry.account.AccountTestUtils.*;
 import static com.github.ambry.account.Container.*;
 import static com.github.ambry.account.mysql.MySqlUtils.*;
 import static com.github.ambry.config.MySqlAccountServiceConfig.*;
+import static com.github.ambry.utils.AccountTestUtils.*;
 import static com.github.ambry.utils.TestUtils.*;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;

--- a/ambry-account/src/main/java/com/github/ambry/account/AbstractAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/AbstractAccountService.java
@@ -165,12 +165,7 @@ abstract class AbstractAccountService implements AccountService {
     AccountBuilder accountBuilder = new AccountBuilder(account);
     resolvedContainers.forEach(accountBuilder::addOrUpdateContainer);
     Account updatedAccount = accountBuilder.build();
-    boolean hasSucceeded = updateAccounts(Collections.singletonList(updatedAccount));
-    // TODO: updateAccounts should throw exception with specific error code
-    if (!hasSucceeded) {
-      throw new AccountServiceException("Account update failed for " + account.getName(),
-          AccountServiceErrorCode.InternalError);
-    }
+    updateAccounts(Collections.singletonList(updatedAccount));
   }
 
   @Override

--- a/ambry-account/src/main/java/com/github/ambry/account/AccountServiceMetrics.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/AccountServiceMetrics.java
@@ -38,6 +38,7 @@ public class AccountServiceMetrics {
   public final Counter unrecognizedMessageErrorCount;
   public final Counter notifyAccountDataChangeErrorCount;
   public final Counter updateAccountErrorCount;
+  public final Counter conflictRetryCount;
   public final Counter fetchRemoteAccountErrorCount;
   public final Counter remoteDataCorruptionErrorCount;
   public final Counter backupErrorCount;
@@ -71,7 +72,9 @@ public class AccountServiceMetrics {
     notifyAccountDataChangeErrorCount =
             metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "NotifyAccountDataChangeErrorCount"));
     updateAccountErrorCount =
-            metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "UpdateAccountErrorCount"));
+        metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "UpdateAccountErrorCount"));
+    conflictRetryCount =
+        metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "ConflictRetryCount"));
     accountUpdatesToZkErrorCount =
             metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "AccountUpdatesToZkErrorCount"));
     fetchRemoteAccountErrorCount =

--- a/ambry-account/src/main/java/com/github/ambry/account/HelixAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/HelixAccountService.java
@@ -252,7 +252,7 @@ public class HelixAccountService extends AbstractAccountService implements Accou
    * </p>
    */
   @Override
-  public boolean updateAccounts(Collection<Account> accounts) {
+  public boolean updateAccounts(Collection<Account> accounts) throws AccountServiceException {
     return updateAccountsWithAccountMetadataStore(accounts, accountMetadataStore);
   }
 
@@ -263,7 +263,7 @@ public class HelixAccountService extends AbstractAccountService implements Accou
    * @return True when the update operation succeeds.
    */
   boolean updateAccountsWithAccountMetadataStore(Collection<Account> accounts,
-      AccountMetadataStore accountMetadataStore) {
+      AccountMetadataStore accountMetadataStore) throws AccountServiceException {
     checkOpen();
     Objects.requireNonNull(accounts, "accounts cannot be null");
     if (accounts.isEmpty()) {
@@ -275,9 +275,9 @@ public class HelixAccountService extends AbstractAccountService implements Accou
       return false;
     }
     if (hasDuplicateAccountIdOrName(accounts)) {
-      logger.debug("Duplicate account id or name exist in the accounts to update");
       accountServiceMetrics.updateAccountErrorCount.inc();
-      return false;
+      throw new AccountServiceException("Duplicate account id or name exist in the accounts to update",
+          AccountServiceErrorCode.ResourceConflict);
     }
     long startTimeMs = System.currentTimeMillis();
     logger.trace("Start updating to HelixPropertyStore with accounts={}", accounts);
@@ -289,9 +289,11 @@ public class HelixAccountService extends AbstractAccountService implements Accou
     if (accountInfoMapRef.get().hasConflictingAccount(accounts)) {
       logger.debug("Accounts={} conflict with the accounts in local cache. Cancel the update operation.", accounts);
       accountServiceMetrics.updateAccountErrorCount.inc();
-    } else {
-      hasSucceeded = accountMetadataStore.updateAccounts(accounts);
+      throw new AccountServiceException("Input accounts conflict with the accounts in local cache",
+          AccountServiceErrorCode.ResourceConflict);
     }
+
+    hasSucceeded = accountMetadataStore.updateAccounts(accounts);
     long timeForUpdate = System.currentTimeMillis() - startTimeMs;
     if (hasSucceeded) {
       logger.trace("Completed updating accounts, took time={} ms", timeForUpdate);
@@ -305,11 +307,13 @@ public class HelixAccountService extends AbstractAccountService implements Accou
         logger.error("Failed to send notification for account metadata change");
         accountServiceMetrics.notifyAccountDataChangeErrorCount.inc();
       }
+      return true;
     } else {
       logger.error("Failed updating accounts={}, took {} ms", accounts, timeForUpdate);
       accountServiceMetrics.updateAccountErrorCount.inc();
+      throw new AccountServiceException("Failed updating accounts to Helix property store",
+          AccountServiceErrorCode.InternalError);
     }
-    return hasSucceeded;
   }
 
   @Override
@@ -400,6 +404,7 @@ public class HelixAccountService extends AbstractAccountService implements Accou
   void markContainerInactiveOnZk(Set<Container> inactiveContainerCandidateSet) throws InterruptedException {
     if (inactiveContainerCandidateSet != null) {
       boolean success = false;
+      Exception updateException = null;
       int retry = 0;
       while (!success && retry < config.maxRetryCountOnUpdateFailure) {
         Map<Short, Account> accountToUpdateMap = new HashMap<>();
@@ -414,15 +419,17 @@ public class HelixAccountService extends AbstractAccountService implements Accou
           accountToUpdateMap.put(accountId,
               new AccountBuilder(accountToEdit).addOrUpdateContainer(editedContainer).build());
         });
-        success = updateAccounts(accountToUpdateMap.values());
-        if (!success) {
+        try {
+          success = updateAccounts(accountToUpdateMap.values());
+        } catch (AccountServiceException ase) {
+          updateException = ase;
           retry++;
           Thread.sleep(config.retryDelayMs);
         }
       }
-      if (!success) {
+      if (updateException != null) {
         logger.error("Failed to mark containers INACTIVE in set : {}  after {} retries", inactiveContainerCandidateSet,
-            config.maxRetryCountOnUpdateFailure);
+            config.maxRetryCountOnUpdateFailure, updateException);
         accountServiceMetrics.accountUpdatesToZkErrorCount.inc();
       }
     }

--- a/ambry-account/src/main/java/com/github/ambry/account/InMemoryUnknownAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/InMemoryUnknownAccountService.java
@@ -63,10 +63,9 @@ class InMemoryUnknownAccountService implements AccountService {
   }
 
   @Override
-  public boolean updateAccounts(Collection<Account> accounts) {
+  public void updateAccounts(Collection<Account> accounts) {
     checkOpen();
     Objects.requireNonNull(accounts, "accounts cannot be null");
-    return false;
   }
 
   @Override

--- a/ambry-account/src/main/java/com/github/ambry/account/JsonAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/JsonAccountService.java
@@ -119,11 +119,10 @@ final class JsonAccountService extends AbstractAccountService {
    * for all nodes. Therefor calling this method will always throw an {@link UnsupportedOperationException}.
    *
    * @param accounts The collection of {@link Account}s to update. Cannot be {@code null}.
-   * @return
    * @throws UnsupportedOperationException Always thrown when this method is invoked.
    */
   @Override
-  public boolean updateAccounts(Collection<Account> accounts) {
+  public void updateAccounts(Collection<Account> accounts) {
     throw new UnsupportedOperationException(
         "Service does not support updating of accountsById via API. Modify account JSON files on all nodes instead.");
   }

--- a/ambry-account/src/main/java/com/github/ambry/account/MySqlAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/MySqlAccountService.java
@@ -156,7 +156,7 @@ public class MySqlAccountService extends AbstractAccountService {
         } finally {
           infoMapLock.writeLock().unlock();
         }
-        // At this point we can safely say cash is refreshed
+        // At this point we can safely say cache is refreshed
         needRefresh = false;
 
         // Persist account metadata in cache to back up file on disk.
@@ -199,20 +199,17 @@ public class MySqlAccountService extends AbstractAccountService {
   }
 
   @Override
-  public boolean updateAccounts(Collection<Account> accounts) throws AccountServiceException {
+  public void updateAccounts(Collection<Account> accounts) throws AccountServiceException {
     Objects.requireNonNull(accounts, "accounts cannot be null");
     if (accounts.isEmpty()) {
-      logger.debug("Empty account collection to update.");
-      return false;
+      throw new IllegalArgumentException("Empty account collection to update.");
     }
-
     if (mySqlAccountStore == null) {
       throw new AccountServiceException("MySql Account store is not accessible", AccountServiceErrorCode.InternalError);
     }
 
     if (config.updateDisabled) {
-      logger.info("Updates have been disabled");
-      return false;
+      throw new AccountServiceException("Updates have been disabled", AccountServiceErrorCode.UpdateDisabled);
     }
 
     if (hasDuplicateAccountIdOrName(accounts)) {
@@ -262,8 +259,6 @@ public class MySqlAccountService extends AbstractAccountService {
     } finally {
       infoMapLock.writeLock().unlock();
     }
-
-    return true;
   }
 
   @Override

--- a/ambry-account/src/main/java/com/github/ambry/account/MySqlAccountServiceFactory.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/MySqlAccountServiceFactory.java
@@ -20,6 +20,7 @@ import com.github.ambry.config.VerifiableProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+
 /**
  * MySql based implementation of {@link AccountServiceFactory}.
  * <p/>

--- a/ambry-account/src/main/java/com/github/ambry/account/mysql/AccountDao.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/mysql/AccountDao.java
@@ -66,9 +66,7 @@ public class AccountDao {
       insertStatement.setInt(2, account.getSnapshotVersion());
       insertStatement.executeUpdate();
     } catch (SQLException e) {
-      // TODO: record failure, parse exception to figure out what we did wrong (eg. id or name collision)
-      // For now, assume connection issue.
-      dataAccessor.reset();
+      dataAccessor.onException(e);
       throw e;
     }
   }
@@ -86,9 +84,7 @@ public class AccountDao {
     try (ResultSet rs = getSinceStatement.executeQuery()) {
       return convertResultSet(rs);
     } catch (SQLException e) {
-      // TODO: record failure, parse exception to figure out what we did wrong (eg. id or name collision)
-      // For now, assume connection issue.
-      dataAccessor.reset();
+      dataAccessor.onException(e);
       throw e;
     }
   }
@@ -106,9 +102,7 @@ public class AccountDao {
       updateStatement.setInt(3, account.getId());
       updateStatement.executeUpdate();
     } catch (SQLException e) {
-      // TODO: record failure, parse exception to figure out what we did wrong (eg. id or name collision)
-      // For now, assume connection issue.
-      dataAccessor.reset();
+      dataAccessor.onException(e);
       throw e;
     }
   }

--- a/ambry-account/src/main/java/com/github/ambry/account/mysql/ContainerDao.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/mysql/ContainerDao.java
@@ -13,14 +13,11 @@
  */
 package com.github.ambry.account.mysql;
 
-import com.github.ambry.account.AccountCollectionSerde;
 import com.github.ambry.account.Container;
 import com.github.ambry.account.ContainerBuilder;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.SQLIntegrityConstraintViolationException;
-import java.sql.SQLTransientException;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
@@ -48,9 +45,8 @@ public class ContainerDao {
 
   public ContainerDao(MySqlDataAccessor dataAccessor) {
     this.dataAccessor = dataAccessor;
-    insertSql =
-        String.format("insert into %s (%s, %s, %s, %s, %s) values (?, ?, 1, now(3), now(3))", CONTAINER_TABLE, ACCOUNT_ID,
-            CONTAINER_INFO, VERSION, CREATION_TIME, LAST_MODIFIED_TIME);
+    insertSql = String.format("insert into %s (%s, %s, %s, %s, %s) values (?, ?, 1, now(3), now(3))", CONTAINER_TABLE,
+        ACCOUNT_ID, CONTAINER_INFO, VERSION, CREATION_TIME, LAST_MODIFIED_TIME);
     getSinceSql =
         String.format("select %s, %s, %s from %s where %s > ?", ACCOUNT_ID, CONTAINER_INFO, LAST_MODIFIED_TIME,
             CONTAINER_TABLE, LAST_MODIFIED_TIME);

--- a/ambry-account/src/main/java/com/github/ambry/account/mysql/ContainerDao.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/mysql/ContainerDao.java
@@ -19,6 +19,8 @@ import com.github.ambry.account.ContainerBuilder;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.SQLIntegrityConstraintViolationException;
+import java.sql.SQLTransientException;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
@@ -74,9 +76,7 @@ public class ContainerDao {
       insertStatement.setString(2, container.toJson().toString());
       insertStatement.executeUpdate();
     } catch (SQLException e) {
-      // TODO: record failure, parse exception to figure out what we did wrong (eg. id or name collision)
-      // For now, assume connection issue.
-      dataAccessor.reset();
+      dataAccessor.onException(e);
       throw e;
     }
   }
@@ -96,9 +96,7 @@ public class ContainerDao {
       updateStatement.setInt(3, container.getId());
       updateStatement.executeUpdate();
     } catch (SQLException e) {
-      // TODO: record failure, parse exception to figure out what we did wrong (eg. id or name collision)
-      // For now, assume connection issue.
-      dataAccessor.reset();
+      dataAccessor.onException(e);
       throw e;
     }
   }
@@ -115,8 +113,7 @@ public class ContainerDao {
     try (ResultSet rs = getByAccountStatement.executeQuery()) {
       return convertResultSet(rs);
     } catch (SQLException e) {
-      // record failure, parse exception, ...
-      dataAccessor.reset();
+      dataAccessor.onException(e);
       throw e;
     }
   }
@@ -134,8 +131,7 @@ public class ContainerDao {
     try (ResultSet rs = getSinceStatement.executeQuery()) {
       return convertResultSet(rs);
     } catch (SQLException e) {
-      // record failure, parse exception, ...
-      dataAccessor.reset();
+      dataAccessor.onException(e);
       throw e;
     }
   }

--- a/ambry-account/src/main/java/com/github/ambry/account/mysql/MySqlAccountStore.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/mysql/MySqlAccountStore.java
@@ -45,8 +45,17 @@ public class MySqlAccountStore {
    */
   public void addAccounts(Collection<Account> accounts) throws SQLException {
     for (Account account : accounts) {
-      accountDao.addAccount(account);
+      addAccount(account);
     }
+  }
+
+  /**
+   * Adds new {@link Account} to Account table in MySql DB
+   * @param account {@link Account} to be inserted
+   * @throws SQLException
+   */
+  public void addAccount(Account account) throws SQLException {
+      accountDao.addAccount(account);
   }
 
   /**
@@ -56,8 +65,17 @@ public class MySqlAccountStore {
    */
   public void addContainers(Collection<Container> containers) throws SQLException {
     for (Container container : containers) {
-      containerDao.addContainer(container.getParentAccountId(), container);
+      addContainer(container);
     }
+  }
+
+  /**
+   * Adds new {@link Container} to Container table in MySql DB
+   * @param container {@link Container} to be inserted
+   * @throws SQLException
+   */
+  public void addContainer(Container container) throws SQLException {
+    containerDao.addContainer(container.getParentAccountId(), container);
   }
 
   /**
@@ -72,14 +90,32 @@ public class MySqlAccountStore {
   }
 
   /**
+   * Updates existing {@link Account} in Account table in MySql DB
+   * @param account {@link Account} to be updated
+   * @throws SQLException
+   */
+  public void updateAccount(Account account) throws SQLException {
+    accountDao.updateAccount(account);
+  }
+
+  /**
    * Updates existing {@link Container}s in Container table in MySql DB
-   * @param containers collection of {@link Account}s to be updated
+   * @param containers collection of {@link Container}s to be updated
    * @throws SQLException
    */
   public void updateContainers(Collection<Container> containers) throws SQLException {
     for (Container container : containers) {
       containerDao.updateContainer(container.getParentAccountId(), container);
     }
+  }
+
+  /**
+   * Updates existing {@link Container} in Container table in MySql DB
+   * @param container {@link Container} to be updated
+   * @throws SQLException
+   */
+  public void updateContainer(Container container) throws SQLException {
+    containerDao.updateContainer(container.getParentAccountId(), container);
   }
 
   /**

--- a/ambry-account/src/main/java/com/github/ambry/account/mysql/MySqlDataAccessor.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/mysql/MySqlDataAccessor.java
@@ -13,12 +13,15 @@
  */
 package com.github.ambry.account.mysql;
 
+import com.github.ambry.account.AccountServiceErrorCode;
+import com.github.ambry.account.AccountServiceException;
 import com.mysql.cj.exceptions.MysqlErrorNumbers;
 import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.sql.SQLIntegrityConstraintViolationException;
 import java.sql.SQLTransientConnectionException;
 import java.util.HashMap;
 import java.util.Map;
@@ -33,6 +36,8 @@ import org.slf4j.LoggerFactory;
 public class MySqlDataAccessor {
 
   private static final Logger logger = LoggerFactory.getLogger(MySqlDataAccessor.class);
+  private static final String INDEX_ACCOUNT_CONTAINER = "containers.accountContainer";
+  private static final String INDEX_CONTAINER_NAME = "containers.uniqueName";
   private final String mysqlUrl;
   private final String mysqlUser;
   private final String mysqlPassword;
@@ -101,14 +106,48 @@ public class MySqlDataAccessor {
     return statement;
   }
 
+  /**
+   * Translate a {@link SQLException} to a {@link AccountServiceException}.
+   * @param e the input exception.
+   * @return the corresponding {@link AccountServiceException}.
+   */
+  public static AccountServiceException translateSQLException(SQLException e) {
+    if (e instanceof SQLIntegrityConstraintViolationException) {
+      SQLIntegrityConstraintViolationException icve = (SQLIntegrityConstraintViolationException) e;
+      String message;
+      if (icve.getMessage().contains(INDEX_ACCOUNT_CONTAINER)) {
+        // Example: Duplicate entry '101-5' for key 'containers.accountContainer'
+        message = "Duplicate containerId";
+      } else if (icve.getMessage().contains(INDEX_CONTAINER_NAME)) {
+        // duplicate container name: need to update cache but retry may fail
+        message = "Duplicate container name";
+      } else {
+        message = "Constraint violation";
+      }
+      return new AccountServiceException(message, AccountServiceErrorCode.ResourceConflict);
+    } else if (MySqlDataAccessor.isCredentialError(e)) {
+      return new AccountServiceException("Invalid database credentials", AccountServiceErrorCode.InternalError);
+    } else {
+      return new AccountServiceException(e.getMessage(), AccountServiceErrorCode.InternalError);
+    }
+  }
+
+  /**
+   * @return true if the exception indicates invalid database credentials.
+   * @param e the {@link SQLException}
+   */
+  public static boolean isCredentialError(SQLException e) {
+    return e.getErrorCode() == MysqlErrorNumbers.ER_ACCESS_DENIED_ERROR;
+  }
+
+  /**
+   * Handle a SQL exception on a database operation.
+   * @param e the {@link SQLException} encountered.
+   */
   void onException(SQLException e) {
     if (e instanceof SQLTransientConnectionException) {
       reset();
     }
-  }
-
-  public static boolean isCredentialError(SQLException e) {
-    return e.getErrorCode() == MysqlErrorNumbers.ER_ACCESS_DENIED_ERROR;
   }
 
   /**

--- a/ambry-account/src/test/java/com/github/ambry/account/AccountTestUtils.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/AccountTestUtils.java
@@ -85,6 +85,23 @@ class AccountTestUtils {
   }
 
   /**
+   * Updates a collection of {@link Account}s and verifies that an {@link AccountServiceException} with the expected
+   * error code is thrown.
+   * @param accounts the accounts to update.
+   * @param expectedErrorCode the {@link AccountServiceErrorCode} expected.
+   * @param accountService The {@link AccountService} to update.
+   */
+  static void assertUpdateAccountsFails(Collection<Account> accounts, AccountServiceErrorCode expectedErrorCode,
+      AccountService accountService) {
+    try {
+      accountService.updateAccounts(accounts);
+      fail("Expected update to fail");
+    } catch (AccountServiceException ase) {
+      assertEquals("Unexpected error code", expectedErrorCode, ase.getErrorCode());
+    }
+  }
+
+  /**
    * Randomly generates a collection of {@link Account}s, which do not have the same id or name. The {@link Container}s
    * of the same {@link Account} also do not have the same id or name.
    * @param idToRefAccountMap A map from id to {@link Account} to populate with the generated {@link Account}s.

--- a/ambry-account/src/test/java/com/github/ambry/account/HelixAccountServiceTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/HelixAccountServiceTest.java
@@ -194,7 +194,7 @@ public class HelixAccountServiceTest {
    * exists on the {@code ZooKeeper}.
    */
   @Test
-  public void testCreateAccount() {
+  public void testCreateAccount() throws Exception {
     accountService = mockHelixAccountServiceFactory.getAccountService();
     assertEquals("The number of account in HelixAccountService is incorrect", 0,
         accountService.getAllAccounts().size());
@@ -689,7 +689,7 @@ public class HelixAccountServiceTest {
    * Tests a number of bad inputs.
    */
   @Test
-  public void testNullInputs() throws IOException {
+  public void testNullInputs() throws Exception {
     try {
       new MockHelixAccountServiceFactory(null, new MetricRegistry(), notifier, null, mockRouter).getAccountService();
       fail("should have thrown");
@@ -1049,7 +1049,7 @@ public class HelixAccountServiceTest {
    * account update request should be rejected.
    */
   @Test
-  public void testUpdateDisabled() {
+  public void testUpdateDisabled() throws Exception {
     helixConfigProps.setProperty(HelixAccountServiceConfig.UPDATE_DISABLED, "true");
     vHelixConfigProps = new VerifiableProperties(helixConfigProps);
     storeConfig = new HelixPropertyStoreConfig(vHelixConfigProps);

--- a/ambry-account/src/test/java/com/github/ambry/account/InMemoryUnknownAccountServiceTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/InMemoryUnknownAccountServiceTest.java
@@ -71,7 +71,7 @@ public class InMemoryUnknownAccountServiceTest {
    * Tests {@code null} inputs.
    */
   @Test
-  public void testNullInputs() {
+  public void testNullInputs() throws Exception {
     try {
       accountService.updateAccounts(null);
       fail("should have thrown");
@@ -90,7 +90,7 @@ public class InMemoryUnknownAccountServiceTest {
    * Tests adding/removing {@link Consumer}.
    */
   @Test
-  public void testAddRemoveConsumer() {
+  public void testAddRemoveConsumer() throws Exception {
     List<Collection<Account>> updatedAccountsReceivedByConsumers = new ArrayList<>();
     // add consumers
     Consumer<Collection<Account>> accountUpdateConsumer = updatedAccounts -> {

--- a/ambry-account/src/test/java/com/github/ambry/account/InMemoryUnknownAccountServiceTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/InMemoryUnknownAccountServiceTest.java
@@ -55,8 +55,7 @@ public class InMemoryUnknownAccountServiceTest {
     assertEquals("Wrong size of account collection", 1, accountService.getAllAccounts().size());
     // updating the InMemoryUnknownAccountService should fail.
     Account account = new AccountBuilder((short) 1, "a", Account.AccountStatus.INACTIVE).build();
-    assertFalse("Wrong return value from an unsuccessful update operation",
-        accountService.updateAccounts(Collections.singletonList(account)));
+    accountService.updateAccounts(Collections.singletonList(account));
     assertEquals("Wrong size of account collection", 1, accountService.getAllAccounts().size());
     try {
       accountService.getAllAccounts().add(account);

--- a/ambry-account/src/test/java/com/github/ambry/account/MySqlAccountServiceTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/MySqlAccountServiceTest.java
@@ -62,7 +62,7 @@ public class MySqlAccountServiceTest {
   }
 
   // TODO: parametrize to use mock or real store (maybe blank url = test)
-  private MySqlAccountService getAccountService() throws IOException {
+  private MySqlAccountService getAccountService() throws IOException, SQLException {
     return new MySqlAccountService(accountServiceMetrics,
         new MySqlAccountServiceConfig(new VerifiableProperties(mySqlConfigProps)), mockMySqlAccountStoreFactory);
   }
@@ -124,7 +124,7 @@ public class MySqlAccountServiceTest {
    * 2. update existing {@link Account} by adding new {@link Container} to an existing {@link Account};
    */
   @Test
-  public void testUpdateAccounts() throws SQLException, IOException {
+  public void testUpdateAccounts() throws Exception {
 
     when(mockMySqlAccountStore.getNewAccounts(0)).thenReturn(new ArrayList<>());
     Container testContainer =
@@ -159,7 +159,7 @@ public class MySqlAccountServiceTest {
     testAccount = new AccountBuilder(testAccount).addOrUpdateContainer(testContainer).build();
     mySqlAccountService.updateAccounts(Collections.singletonList(testAccount));
     verify(mockMySqlAccountStore, never()).updateAccounts(Collections.singletonList(testAccount));
-    verify(mockMySqlAccountStore, atLeastOnce()).updateContainers(Collections.singletonList(testContainer));
+    verify(mockMySqlAccountStore, atLeastOnce()).updateContainer(testContainer);
     assertEquals("Mismatch in account retrieved by ID", testAccount,
         mySqlAccountService.getAccountById(testAccount.getId()));
   }
@@ -202,7 +202,7 @@ public class MySqlAccountServiceTest {
    * Tests disabling of background updater by setting {@link MySqlAccountServiceConfig#UPDATER_POLLING_INTERVAL_SECONDS} to 0.
    */
   @Test
-  public void testDisableBackgroundUpdater() throws IOException {
+  public void testDisableBackgroundUpdater() throws IOException, SQLException {
 
     mySqlConfigProps.setProperty(UPDATER_POLLING_INTERVAL_SECONDS, "0");
     mySqlAccountService = getAccountService();
@@ -214,7 +214,7 @@ public class MySqlAccountServiceTest {
    * Tests disabling account updates by setting {@link MySqlAccountServiceConfig#UPDATE_DISABLED} to true.
    */
   @Test
-  public void testUpdateDisabled() throws IOException {
+  public void testUpdateDisabled() throws Exception {
 
     mySqlConfigProps.setProperty(UPDATE_DISABLED, "true");
     mySqlAccountService = getAccountService();
@@ -230,7 +230,7 @@ public class MySqlAccountServiceTest {
    * in name.
    */
   @Test
-  public void testUpdateNameConflictingAccounts() throws IOException {
+  public void testUpdateNameConflictingAccounts() throws Exception {
     List<Account> conflictAccounts = new ArrayList<>();
     conflictAccounts.add(new AccountBuilder((short) 1, "a", Account.AccountStatus.INACTIVE).build());
     conflictAccounts.add(new AccountBuilder((short) 2, "a", Account.AccountStatus.INACTIVE).build());
@@ -244,7 +244,7 @@ public class MySqlAccountServiceTest {
    * in id.
    */
   @Test
-  public void testUpdateIdConflictingAccounts() throws IOException {
+  public void testUpdateIdConflictingAccounts() throws Exception {
     List<Account> conflictAccounts = new ArrayList<>();
     conflictAccounts.add(new AccountBuilder((short) 1, "a", Account.AccountStatus.INACTIVE).build());
     conflictAccounts.add(new AccountBuilder((short) 1, "b", Account.AccountStatus.INACTIVE).build());
@@ -257,7 +257,7 @@ public class MySqlAccountServiceTest {
    * Tests updating a collection of {@link Account}s, where there are duplicate {@link Account}s in id and name.
    */
   @Test
-  public void testUpdateDuplicateAccounts() throws IOException {
+  public void testUpdateDuplicateAccounts() throws Exception {
     List<Account> conflictAccounts = new ArrayList<>();
     conflictAccounts.add(new AccountBuilder((short) 1, "a", Account.AccountStatus.INACTIVE).build());
     conflictAccounts.add(new AccountBuilder((short) 1, "a", Account.AccountStatus.INACTIVE).build());
@@ -285,7 +285,7 @@ public class MySqlAccountServiceTest {
    *
    */
   @Test
-  public void testConflictingUpdatesWithAccounts() throws IOException {
+  public void testConflictingUpdatesWithAccounts() throws Exception {
 
     // write two accounts (1, "a") and (2, "b")
     List<Account> existingAccounts = new ArrayList<>();
@@ -335,7 +335,7 @@ public class MySqlAccountServiceTest {
    * Tests name/id conflicts in Containers
    */
   @Test
-  public void testConflictingUpdatesWithContainers() throws IOException {
+  public void testConflictingUpdatesWithContainers() throws Exception {
     List<Container> containersList = new ArrayList<>();
     containersList.add(
         new ContainerBuilder((short) 1, "c1", Container.ContainerStatus.ACTIVE, "c1", (short) 1).build());

--- a/ambry-account/src/test/java/com/github/ambry/account/MySqlAccountServiceTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/MySqlAccountServiceTest.java
@@ -33,8 +33,8 @@ import java.util.Map;
 import java.util.Properties;
 import org.junit.Test;
 
-import static com.github.ambry.account.AccountTestUtils.*;
 import static com.github.ambry.config.MySqlAccountServiceConfig.*;
+import static com.github.ambry.utils.AccountTestUtils.*;
 import static com.github.ambry.utils.TestUtils.*;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;

--- a/ambry-account/src/test/java/com/github/ambry/account/MySqlAccountServiceTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/MySqlAccountServiceTest.java
@@ -222,8 +222,12 @@ public class MySqlAccountServiceTest {
 
     // Verify account update is disabled
     Account testAccount = new AccountBuilder((short) 1, "testAccount1", Account.AccountStatus.ACTIVE).build();
-    assertFalse("Update accounts should be disabled",
-        mySqlAccountService.updateAccounts(Collections.singletonList(testAccount)));
+    try {
+      mySqlAccountService.updateAccounts(Collections.singletonList(testAccount));
+      fail("Update accounts should be disabled");
+    } catch (AccountServiceException e) {
+      assertEquals("Mismatch in error code", AccountServiceErrorCode.UpdateDisabled, e.getErrorCode());
+    }
   }
 
   /**

--- a/ambry-account/src/test/java/com/github/ambry/account/MySqlAccountServiceTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/MySqlAccountServiceTest.java
@@ -135,7 +135,7 @@ public class MySqlAccountServiceTest {
 
     // 1. Addition of new account. Verify account is added to cache.
     mySqlAccountService.updateAccounts(Collections.singletonList(testAccount));
-    verify(mockMySqlAccountStore, atLeastOnce()).addAccounts(Collections.singletonList(testAccount));
+    verify(mockMySqlAccountStore, atLeastOnce()).addAccount(testAccount);
     List<Account> accounts = new ArrayList<>(mySqlAccountService.getAllAccounts());
     assertEquals("Mismatch in number of accounts", 1, accounts.size());
     assertEquals("Mismatch in account retrieved by ID", testAccount,
@@ -149,8 +149,8 @@ public class MySqlAccountServiceTest {
             .build();
     testAccount = new AccountBuilder(testAccount).addOrUpdateContainer(testContainer2).build();
     mySqlAccountService.updateAccounts(Collections.singletonList(testAccount));
-    verify(mockMySqlAccountStore, never()).updateAccounts(Collections.singletonList(testAccount));
-    verify(mockMySqlAccountStore, atLeastOnce()).addContainers(Collections.singletonList(testContainer2));
+    verify(mockMySqlAccountStore, never()).updateAccount(testAccount);
+    verify(mockMySqlAccountStore, atLeastOnce()).addContainer(testContainer2);
     assertEquals("Mismatch in account retrieved by ID", testAccount,
         mySqlAccountService.getAccountById(testAccount.getId()));
 
@@ -158,7 +158,7 @@ public class MySqlAccountServiceTest {
     testContainer = new ContainerBuilder(testContainer).setMediaScanDisabled(true).setCacheable(true).build();
     testAccount = new AccountBuilder(testAccount).addOrUpdateContainer(testContainer).build();
     mySqlAccountService.updateAccounts(Collections.singletonList(testAccount));
-    verify(mockMySqlAccountStore, never()).updateAccounts(Collections.singletonList(testAccount));
+    verify(mockMySqlAccountStore, never()).updateAccount(testAccount);
     verify(mockMySqlAccountStore, atLeastOnce()).updateContainer(testContainer);
     assertEquals("Mismatch in account retrieved by ID", testAccount,
         mySqlAccountService.getAccountById(testAccount.getId()));

--- a/ambry-account/src/test/resources/mysql.properties
+++ b/ambry-account/src/test/resources/mysql.properties
@@ -9,4 +9,4 @@
 # under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 # CONDITIONS OF ANY KIND, either express or implied.
 #
-mysql.account.service.db.info=[{"url":"jdbc:mysql://localhost/AccountMetadata?serverTimezone=UTC","datacenter":"dc1","isWriteable":"true","username":"travis","password":""}]
+mysql.account.service.db.info=[{"url":"jdbc:mysql://localhost/AccountMetadata?serverTimezone=UTC","datacenter":"dc1","isWriteable":"true","username":"ambry","password":"ambry"}]

--- a/ambry-account/src/test/resources/mysql.properties
+++ b/ambry-account/src/test/resources/mysql.properties
@@ -9,4 +9,4 @@
 # under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 # CONDITIONS OF ANY KIND, either express or implied.
 #
-mysql.account.service.db.info=[{"url":"jdbc:mysql://localhost/AccountMetadata?serverTimezone=UTC","datacenter":"dc1","isWriteable":"true","username":"ambry","password":"ambry"}]
+mysql.account.service.db.info=[{"url":"jdbc:mysql://localhost/AccountMetadata?serverTimezone=UTC","datacenter":"dc1","isWriteable":"true","username":"travis","password":""}]

--- a/ambry-api/src/main/java/com/github/ambry/account/AccountService.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/AccountService.java
@@ -79,11 +79,10 @@ public interface AccountService extends Closeable {
    * E      1           "b"           yes            fail update                  conflicts with existing name.
    * </pre>
    * @param accounts The collection of {@link Account}s to update. Cannot be {@code null}.
-   * @return {@code true} indicates that the accounts have been successfully updated, {@code false} indicates the
-   *                      operation has failed, and none of the account has been updated. This is an either succeed-all
-   *                      or fail-all operation.
+   * @throws AccountServiceException if the operation has failed, and none of the account has been updated.
+   *         This is an either succeed-all or fail-all operation.
    */
-  boolean updateAccounts(Collection<Account> accounts) throws AccountServiceException;
+  void updateAccounts(Collection<Account> accounts) throws AccountServiceException;
 
   /**
    * Gets all the {@link Account}s in this {@code AccountService}. The {@link Account}s <em>MUST</em> have their

--- a/ambry-api/src/main/java/com/github/ambry/account/AccountService.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/AccountService.java
@@ -83,7 +83,7 @@ public interface AccountService extends Closeable {
    *                      operation has failed, and none of the account has been updated. This is an either succeed-all
    *                      or fail-all operation.
    */
-  public boolean updateAccounts(Collection<Account> accounts);
+  public boolean updateAccounts(Collection<Account> accounts) throws AccountServiceException;
 
   /**
    * Gets all the {@link Account}s in this {@code AccountService}. The {@link Account}s <em>MUST</em> have their

--- a/ambry-api/src/main/java/com/github/ambry/account/AccountServiceErrorCode.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/AccountServiceErrorCode.java
@@ -32,5 +32,9 @@ public enum AccountServiceErrorCode {
   /**
    * Account service experienced an internal error.
    */
-  InternalError
+  InternalError,
+  /**
+   * Updates to the account service are disabled.
+   */
+  UpdateDisabled
 }

--- a/ambry-api/src/main/java/com/github/ambry/rest/RestServiceErrorCode.java
+++ b/ambry-api/src/main/java/com/github/ambry/rest/RestServiceErrorCode.java
@@ -230,6 +230,8 @@ public enum RestServiceErrorCode {
         return Conflict;
       case BadRequest:
         return BadRequest;
+      case UpdateDisabled:
+        return ServiceUnavailable;
       default:
         return InternalServerError;
     }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/PostAccountsHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/PostAccountsHandler.java
@@ -213,9 +213,9 @@ class PostAccountsHandler {
       }
       try {
         accountService.updateAccounts(accountsToUpdate);
-      } catch (AccountServiceException ex) {
-        throw new RestServiceException("Account update failed",
-            RestServiceErrorCode.getRestServiceErrorCode(ex.getErrorCode()));
+      } catch (AccountServiceException ase) {
+        throw new RestServiceException("Account update failed: " + ase.getMessage(),
+            RestServiceErrorCode.getRestServiceErrorCode(ase.getErrorCode()));
       }
     }
   }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/PostAccountsHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/PostAccountsHandler.java
@@ -211,8 +211,11 @@ class PostAccountsHandler {
       } catch (JSONException e) {
         throw new RestServiceException("Bad account update request body", e, RestServiceErrorCode.BadRequest);
       }
-      if (!accountService.updateAccounts(accountsToUpdate)) {
-        throw new RestServiceException("Account update failed", RestServiceErrorCode.BadRequest);
+      try {
+        accountService.updateAccounts(accountsToUpdate);
+      } catch (AccountServiceException ex) {
+        throw new RestServiceException("Account update failed",
+            RestServiceErrorCode.getRestServiceErrorCode(ex.getErrorCode()));
       }
     }
   }

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendIntegrationTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendIntegrationTest.java
@@ -135,7 +135,7 @@ public class FrontendIntegrationTest {
       FRONTEND_CONFIG = new FrontendConfig(FRONTEND_VERIFIABLE_PROPS);
       ACCOUNT_SERVICE.clear();
       ACCOUNT_SERVICE.updateAccounts(Collections.singletonList(InMemAccountService.UNKNOWN_ACCOUNT));
-    } catch (IOException | GeneralSecurityException e) {
+    } catch (Exception e) {
       throw new IllegalStateException(e);
     }
   }

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
@@ -18,6 +18,7 @@ import com.github.ambry.account.Account;
 import com.github.ambry.account.AccountBuilder;
 import com.github.ambry.account.AccountCollectionSerde;
 import com.github.ambry.account.AccountService;
+import com.github.ambry.account.AccountServiceException;
 import com.github.ambry.account.Container;
 import com.github.ambry.account.ContainerBuilder;
 import com.github.ambry.account.InMemAccountService;
@@ -2348,7 +2349,7 @@ public class FrontendRestRequestServiceTest {
   /**
    * Prepopulates the {@link AccountService} with a reference {@link Account} and {@link InMemAccountService#UNKNOWN_ACCOUNT}.
    */
-  private void populateAccountService() {
+  private void populateAccountService() throws AccountServiceException {
     accountService.clear();
     accountService.updateAccounts(Lists.newArrayList(refAccount, InMemAccountService.UNKNOWN_ACCOUNT));
   }

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/PostAccountsHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/PostAccountsHandlerTest.java
@@ -111,7 +111,7 @@ public class PostAccountsHandlerTest {
     // AccountService update failure
     accountService.setShouldUpdateSucceed(false);
     testAction.accept(AccountCollectionSerde.accountsToJson(Collections.emptyList()).toString(),
-        RestServiceErrorCode.BadRequest);
+        RestServiceErrorCode.InternalServerError);
   }
 
   /**

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/PostBlobHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/PostBlobHandlerTest.java
@@ -93,19 +93,17 @@ public class PostBlobHandlerTest {
   static {
     try {
       CLUSTER_MAP = new MockClusterMap();
-    } catch (IOException e) {
+      Account account = ACCOUNT_SERVICE.createAndAddRandomAccount();
+      Container publicContainer = account.getContainerById(Container.DEFAULT_PUBLIC_CONTAINER_ID);
+      Container ttlRequiredContainer = new ContainerBuilder(publicContainer).setTtlRequired(true).build();
+      Account newAccount = new AccountBuilder(account).addOrUpdateContainer(ttlRequiredContainer).build();
+      ACCOUNT_SERVICE.updateAccounts(Collections.singleton(newAccount));
+      REF_ACCOUNT = ACCOUNT_SERVICE.getAccountById(newAccount.getId());
+      REF_CONTAINER = REF_ACCOUNT.getContainerById(Container.DEFAULT_PRIVATE_CONTAINER_ID);
+      REF_CONTAINER_WITH_TTL_REQUIRED = REF_ACCOUNT.getContainerById(Container.DEFAULT_PUBLIC_CONTAINER_ID);
+    } catch (Exception e) {
       throw new IllegalStateException(e);
     }
-    Account account = ACCOUNT_SERVICE.createAndAddRandomAccount();
-    Container publicContainer = account.getContainerById(Container.DEFAULT_PUBLIC_CONTAINER_ID);
-    Container ttlRequiredContainer = new ContainerBuilder(publicContainer).setTtlRequired(true).build();
-    Account newAccount = new AccountBuilder(account).addOrUpdateContainer(ttlRequiredContainer).build();
-    if (!ACCOUNT_SERVICE.updateAccounts(Collections.singleton(newAccount))) {
-      throw new IllegalStateException("Account could not be created");
-    }
-    REF_ACCOUNT = ACCOUNT_SERVICE.getAccountById(newAccount.getId());
-    REF_CONTAINER = REF_ACCOUNT.getContainerById(Container.DEFAULT_PRIVATE_CONTAINER_ID);
-    REF_CONTAINER_WITH_TTL_REQUIRED = REF_ACCOUNT.getContainerById(Container.DEFAULT_PUBLIC_CONTAINER_ID);
   }
 
   private final MockTime time = new MockTime();

--- a/ambry-router/src/test/java/com/github/ambry/router/RouterUtilsTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/RouterUtilsTest.java
@@ -16,6 +16,7 @@ package com.github.ambry.router;
 import com.github.ambry.account.Account;
 import com.github.ambry.account.AccountBuilder;
 import com.github.ambry.account.AccountService;
+import com.github.ambry.account.AccountServiceException;
 import com.github.ambry.account.Container;
 import com.github.ambry.account.ContainerBuilder;
 import com.github.ambry.account.InMemAccountService;
@@ -117,7 +118,7 @@ public class RouterUtilsTest {
    * Test {@link RouterUtils#getAccountContainer(AccountService, short, short)}.
    */
   @Test
-  public void testGetAccountContainer() {
+  public void testGetAccountContainer() throws AccountServiceException {
     AccountService accountService = new InMemAccountService(false, false);
     // Both accountId and containerId are not tracked by AccountService.
     Pair<Account, Container> accountContainer =

--- a/ambry-test-utils/src/main/java/com/github/ambry/account/InMemAccountService.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/account/InMemAccountService.java
@@ -73,7 +73,7 @@ public class InMemAccountService implements AccountService {
   }
 
   @Override
-  public synchronized boolean updateAccounts(Collection<Account> accounts) throws AccountServiceException {
+  public synchronized void updateAccounts(Collection<Account> accounts) throws AccountServiceException {
     if (!shouldUpdateSucceed) {
       throw new AccountServiceException("Update failed", AccountServiceErrorCode.InternalError);
     }
@@ -86,7 +86,6 @@ public class InMemAccountService implements AccountService {
         accountUpdateConsumer.accept(accounts);
       }
     }
-    return true;
   }
 
   @Override
@@ -115,11 +114,7 @@ public class InMemAccountService implements AccountService {
       ++nextContainerId;
     }
     account.updateContainerMap(createdContainers);
-    boolean hasSucceeded = updateAccounts(Collections.singletonList(account));
-    if (!hasSucceeded) {
-      throw new AccountServiceException("Account update failed for " + accountName,
-          AccountServiceErrorCode.InternalError);
-    }
+    updateAccounts(Collections.singletonList(account));
     return createdContainers;
   }
 
@@ -220,7 +215,8 @@ public class InMemAccountService implements AccountService {
     Container newContainer = new ContainerBuilder(container).setReplicationPolicy(replicationPolicy).build();
     Account account = getAccountById(container.getParentAccountId());
     Account newAccount = new AccountBuilder(account).addOrUpdateContainer(newContainer).build();
-    return updateAccounts(Collections.singleton(newAccount)) ? newContainer : null;
+    updateAccounts(Collections.singleton(newAccount));
+    return newContainer;
   }
 
   /**

--- a/ambry-test-utils/src/main/java/com/github/ambry/utils/AccountTestUtils.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/utils/AccountTestUtils.java
@@ -16,6 +16,8 @@ package com.github.ambry.utils;
 import com.github.ambry.account.Account;
 import com.github.ambry.account.AccountBuilder;
 import com.github.ambry.account.AccountService;
+import com.github.ambry.account.AccountServiceErrorCode;
+import com.github.ambry.account.AccountServiceException;
 import com.github.ambry.account.Container;
 import com.github.ambry.account.ContainerBuilder;
 import java.util.ArrayList;
@@ -95,7 +97,7 @@ public class AccountTestUtils {
    * @param expectedErrorCode the {@link AccountServiceErrorCode} expected.
    * @param accountService The {@link AccountService} to update.
    */
-  static void assertUpdateAccountsFails(Collection<Account> accounts, AccountServiceErrorCode expectedErrorCode,
+  public static void assertUpdateAccountsFails(Collection<Account> accounts, AccountServiceErrorCode expectedErrorCode,
       AccountService accountService) {
     try {
       accountService.updateAccounts(accounts);

--- a/ambry-tools/src/main/java/com/github/ambry/account/AccountTool.java
+++ b/ambry-tools/src/main/java/com/github/ambry/account/AccountTool.java
@@ -362,19 +362,21 @@ public class AccountTool {
           }
           break;
         case ROLLBACK:
-          succeeded = accountTool.rollback(version);
-          if (succeeded) {
+          try {
+            accountTool.rollback(version);
             System.out.println("Successfully rollback account metadata to version " + version);
-          } else {
+          } catch (Exception e) {
             System.out.println("Fail to rollback account metadata to version " + version);
+            throw e;
           }
           break;
         case UPDATE:
-          succeeded = accountTool.updateFromFile(accountJsonPath);
-          if (succeeded) {
+          try {
+            accountTool.updateFromFile(accountJsonPath);
             System.out.println("Successfully update account metadata from file " + accountJsonPath);
-          } else {
+          } catch (Exception e) {
             System.out.println("Fail to update account metadata from file " + accountJsonPath);
+            throw e;
           }
           break;
       }
@@ -446,9 +448,9 @@ public class AccountTool {
    * Overwrite the current {@link Account} metadata with the given {@link Collection} and publish the new {@link Account}
    * metadata if the update succeeds.
    * @param accounts The new {@link Account} metadata.
-   * @return True if the update succeeds.
+   * @throws AccountServiceException if the update fails.
    */
-  private boolean updateAccounts(Collection<Account> accounts) throws AccountServiceException {
+  private void updateAccounts(Collection<Account> accounts) throws AccountServiceException {
     Collection<Account> existingAccounts = accountService.getAllAccounts();
     Map<Short, Account> existingAccountsMap = new HashMap<>();
     for (Account account : existingAccounts) {
@@ -464,7 +466,7 @@ public class AccountTool {
         newAccounts.add(account);
       }
     }
-    return accountService.updateAccountsWithAccountMetadataStore(newAccounts, routerStore);
+    accountService.updateAccountsWithAccountMetadataStore(newAccounts, routerStore);
   }
 
   /**
@@ -474,11 +476,10 @@ public class AccountTool {
    * a file, then a new version 11 will be created with teh same content in the file.
    * It will publish the new {@link Account} metadata to all the listener if the rollback operation succeeds.
    * @param accountJsonPath The file to read the {@link Account} metadata from.
-   * @return True if the update operation succeeds.
-   * @throws Exception Andy unexpected error.
+   * @throws Exception Any unexpected error.
    */
-  public boolean updateFromFile(String accountJsonPath) throws Exception {
-    return updateAccounts(getAccountsFromJson(accountJsonPath));
+  public void updateFromFile(String accountJsonPath) throws Exception {
+    updateAccounts(getAccountsFromJson(accountJsonPath));
   }
 
   /**
@@ -488,16 +489,15 @@ public class AccountTool {
    * with the same content of version 8.
    * It will publish the new {@link Account} metadata to all the listener if the rollback operation succeeds.
    * @param version The version to roll back to.
-   * @return True if the rollback operation succeeds.
-   * @throws Exception Andy unexpected error.
+   * @throws Exception Any unexpected error.
    */
-  public boolean rollback(int version) throws Exception {
+  public void rollback(int version) throws Exception {
     Collection<String> accountJsons = viewAccountMetadata(version);
     Collection<Account> accounts = new ArrayList<>();
     for (String accountJson : accountJsons) {
       accounts.add(Account.fromJson(new JSONObject(accountJson)));
     }
-    return updateAccounts(accounts);
+    updateAccounts(accounts);
   }
 
   /**

--- a/ambry-tools/src/main/java/com/github/ambry/account/AccountTool.java
+++ b/ambry-tools/src/main/java/com/github/ambry/account/AccountTool.java
@@ -136,6 +136,7 @@ import org.json.JSONObject;
  *   </pre>
  * </p>
  */
+// TODO: only works with HelixAccountService, not MySql
 public class AccountTool {
   private final MetricRegistry registry;
   private final BackupFileManager backupFileManager;
@@ -447,7 +448,7 @@ public class AccountTool {
    * @param accounts The new {@link Account} metadata.
    * @return True if the update succeeds.
    */
-  private boolean updateAccounts(Collection<Account> accounts) {
+  private boolean updateAccounts(Collection<Account> accounts) throws AccountServiceException {
     Collection<Account> existingAccounts = accountService.getAllAccounts();
     Map<Short, Account> existingAccountsMap = new HashMap<>();
     for (Account account : existingAccounts) {


### PR DESCRIPTION
* When container update fails with conflict error, refresh cache and retry operation.
* AccountService.updateAccounts() now throws AccountServiceException.
* Fail creation of MySqlAccountService if bad DB credentials are supplied.