### PR TITLE
[build] Set '--release 8' compiler option

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,11 +44,19 @@ subprojects {
     apply plugin: 'java'
 
     if (!project.hasProperty('disableShipkit')) {
-      apply from: "$rootDir/gradle/java-publishing.gradle"
+        apply from: "$rootDir/gradle/java-publishing.gradle"
     }
 
     sourceCompatibility = 1.8
     targetCompatibility = 1.8
+
+    if (JavaVersion.current().java9Compatible) {
+        // Our consumers still run on java 8, so this flag ensures that our builds are backwards compatible at runtime
+        // with java 8 platform APIs.
+        compileJava {
+            options.compilerArgs.addAll(['--release', '8'])
+        }
+    }
 
     sourceSets {
         // separate source set for integration tests


### PR DESCRIPTION
Without this option, building with java 11 can cause issues at runtime
when depending on ambry on a java 8 app due to platform API changes in
java 11.

Using the "--release 8" option on new JVMs will ensure that
ambry is built against java 8 standard library APIs.
(https://stackoverflow.com/a/61267496)