### PR TITLE
[BlobStoreCompaction] Always enable target index duplicate checking to ignore duplicate PUTs

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -356,6 +356,12 @@ public class StoreConfig {
   @Default("false")
   public final boolean storeEnableBucketForLogSegmentReports;
 
+  @Config(storeAlwaysEnableTargetIndexDuplicateCheckingName)
+  @Default("false")
+  public final boolean storeAlwaysEnableTargetIndexDuplicateChecking;
+  public static final String storeAlwaysEnableTargetIndexDuplicateCheckingName =
+      "store.always.enable.target.index.duplicate.checking";
+
   public StoreConfig(VerifiableProperties verifiableProperties) {
 
     storeKeyFactory = verifiableProperties.getString("store.key.factory", "com.github.ambry.commons.BlobIdFactory");
@@ -434,5 +440,7 @@ public class StoreConfig {
         verifiableProperties.getBoolean("store.set.local.partition.state.enabled", false);
     storeEnableBucketForLogSegmentReports =
         verifiableProperties.getBoolean("store.enable.bucket.for.log.segment.reports", false);
+    storeAlwaysEnableTargetIndexDuplicateChecking =
+        verifiableProperties.getBoolean(storeAlwaysEnableTargetIndexDuplicateCheckingName, false);
   }
 }

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
@@ -563,8 +563,8 @@ class BlobStoreCompactor {
     logger.debug("Copying data from {}", indexSegmentToCopy.getFile());
     // call into diskIOScheduler to make sure we can proceed (assuming it won't be 0).
     diskIOScheduler.getSlice(INDEX_SEGMENT_READ_JOB_NAME, INDEX_SEGMENT_READ_JOB_NAME, 1);
-    boolean checkAlreadyCopied =
-        recoveryStartToken != null && recoveryStartToken.getOffset().equals(indexSegmentToCopy.getStartOffset());
+    boolean checkAlreadyCopied = config.storeAlwaysEnableTargetIndexDuplicateChecking || (recoveryStartToken != null
+        && recoveryStartToken.getOffset().equals(indexSegmentToCopy.getStartOffset()));
     logger.trace("Should check already copied for {}: {} ", indexSegmentToCopy.getFile(), checkAlreadyCopied);
 
     List<IndexEntry> indexEntriesToCopy =

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
@@ -39,6 +39,8 @@ import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Properties;
 import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -69,6 +71,7 @@ public class BlobStoreCompactorTest {
   private final boolean doDirectIO;
   private final boolean withUndelete;
   private final StoreConfig config;
+  private boolean alwaysEnableTargetIndexDuplicateChecking = false;
 
   private CuratedLogIndexState state = null;
   private BlobStoreCompactor compactor = null;
@@ -369,6 +372,55 @@ public class BlobStoreCompactorTest {
           tempDir.listFiles(BlobStoreCompactor.TEMP_LOG_SEGMENTS_FILTER).length);
       verifySavedBytesCount(logSegmentsBeforeCompaction, 0);
     }
+  }
+
+  @Test
+  public void testDuplicatePuts() throws Exception {
+    testDuplicatePutsHelper();
+    alwaysEnableTargetIndexDuplicateChecking = true;
+    try {
+      testDuplicatePutsHelper();
+    } finally {
+      alwaysEnableTargetIndexDuplicateChecking = false;
+    }
+  }
+
+  private void testDuplicatePutsHelper() throws Exception {
+    // Construct a blob store, where there is a duplicate PUT indexValue in different log segment.
+    refreshState(false, false);
+    writeDataToMeetRequiredSegmentCount(1, Collections.singletonList(Utils.Infinite_Time));
+    // we know all the IndexEntries are PUT entries.
+    TreeMap<MockId, TreeSet<IndexValue>> lastEntry = state.referenceIndex.lastEntry().getValue();
+    MockId id = lastEntry.firstKey();
+    IndexValue value = lastEntry.get(id).first();
+    byte[] bytes = state.logOrder.get(value.getOffset()).getSecond().buffer;
+
+    // Delete some PUT entries, so we know the first log segment will be compacted
+    for (MockId toDelete : state.referenceIndex.firstEntry().getValue().keySet()) {
+      state.addDeleteEntry(toDelete);
+    }
+    state.forceAddPutEntry(id, value, bytes);
+    writeDataToMeetRequiredSegmentCount(3, Collections.singletonList(Utils.Infinite_Time));
+
+    // Now compact the blobstore, it will fail because of duplicate puts
+    state.reloadIndex(true, false);
+    long deleteReferenceTimeMs = state.time.milliseconds();
+    List<String> segmentsUnderCompaction = getLogSegments(0, state.index.getLogSegmentCount() - 1);
+    CompactionDetails details = new CompactionDetails(deleteReferenceTimeMs, segmentsUnderCompaction);
+    compactor = getCompactor(state.log, DISK_IO_SCHEDULER);
+    compactor.initialize(state.index);
+    if (alwaysEnableTargetIndexDuplicateChecking) {
+      compactor.compact(details, bundleReadBuffer);
+    } else {
+      try {
+        compactor.compact(details, bundleReadBuffer);
+        fail("Should fail with duplicate put");
+      } catch (StoreException e) {
+        assertEquals(StoreErrorCodes.Unknown_Error, e.getErrorCode());
+        assertTrue(e.getMessage().contains("duplicate PUT"));
+      }
+    }
+    compactor.close(0);
   }
 
   /**
@@ -2392,6 +2444,11 @@ public class BlobStoreCompactorTest {
     }
     if (withUndelete) {
       state.properties.put("store.compaction.filter", "IndexSegmentValidEntryWithUndelete");
+    }
+    if (alwaysEnableTargetIndexDuplicateChecking) {
+      state.properties.put(StoreConfig.storeAlwaysEnableTargetIndexDuplicateCheckingName, "true");
+    } else {
+      state.properties.put(StoreConfig.storeAlwaysEnableTargetIndexDuplicateCheckingName, "false");
     }
     StoreConfig config = new StoreConfig(new VerifiableProperties(state.properties));
     metricRegistry = new MetricRegistry();

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
@@ -2445,11 +2445,8 @@ public class BlobStoreCompactorTest {
     if (withUndelete) {
       state.properties.put("store.compaction.filter", "IndexSegmentValidEntryWithUndelete");
     }
-    if (alwaysEnableTargetIndexDuplicateChecking) {
-      state.properties.put(StoreConfig.storeAlwaysEnableTargetIndexDuplicateCheckingName, "true");
-    } else {
-      state.properties.put(StoreConfig.storeAlwaysEnableTargetIndexDuplicateCheckingName, "false");
-    }
+    state.properties.put(StoreConfig.storeAlwaysEnableTargetIndexDuplicateCheckingName,
+        Boolean.toString(alwaysEnableTargetIndexDuplicateChecking));
     StoreConfig config = new StoreConfig(new VerifiableProperties(state.properties));
     metricRegistry = new MetricRegistry();
     StoreMetrics metrics = new StoreMetrics(metricRegistry);


### PR DESCRIPTION
We experienced a compaction error due to duplicate PUTs in log. This is a weird error since there shouldn't be any duplicate PUTs in the log. However, it takes too long to figure out why it happened. Before we fully understand the root cause, this is a bandage to temporarily fix the issue.

We can always check the duplicates in target persistent index while we are check if a IndexValue is a valid one or not. If it's a duplicate of certain IndexValue in target persistent index, then it's not a valid one. This logic would ignore the duplicate PUT and mark it as invalid.