### PR TITLE
[HTTP2] use ReferenceCountUtil.safeRelease to avoid setting refCnt to negative number

### DIFF
--- a/ambry-network/src/main/java/com/github/ambry/network/NettyServerRequestResponseChannel.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/NettyServerRequestResponseChannel.java
@@ -18,6 +18,7 @@ import com.github.ambry.server.EmptyRequest;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.ReferenceCountUtil;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.nio.channels.ClosedChannelException;
@@ -61,10 +62,7 @@ public class NettyServerRequestResponseChannel implements RequestResponseChannel
       @Override
       public void operationComplete(ChannelFuture future) throws Exception {
         if (!future.isSuccess()) {
-          if (!(future.cause() instanceof ClosedChannelException)) {
-            // TODO: a round solution is needed. For now, use same logic as Http2NetworkClient in frontend.
-            payloadToSend.release();
-          }
+          ReferenceCountUtil.safeRelease(payloadToSend);
         }
       }
     };

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2NetworkClient.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2NetworkClient.java
@@ -31,6 +31,7 @@ import io.netty.channel.pool.ChannelPoolMap;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http2.Http2StreamFrameToHttpObjectCodec;
 import io.netty.util.AttributeKey;
+import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 import java.net.InetSocketAddress;
@@ -156,11 +157,7 @@ public class Http2NetworkClient implements NetworkClient {
                       http2ClientResponseHandler.getResponseInfoQueue()
                           .put(new ResponseInfo(requestInfoFromChannelAttr, NetworkClientErrorCode.NetworkError, null));
                     }
-                    if (!(future.cause() instanceof ClosedChannelException)) {
-                      // If it's ClosedChannelException caused by drop request, it's probably refCnt has been decreased.
-                      // TODO: a round solution is needed.
-                      requestInfo.getRequest().release();
-                    }
+                    ReferenceCountUtil.safeRelease(requestInfo.getRequest());
                   }
                 }
               });

--- a/ambry-store/src/main/java/com/github/ambry/store/IndexSegment.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/IndexSegment.java
@@ -266,6 +266,9 @@ class IndexSegment implements Iterable<IndexEntry> {
    */
   int size() {
     if (sealed.get()) {
+      if (serEntries == null) {
+        return 0;
+      }
       return numberOfEntries(serEntries);
     } else {
       return getNumberOfItems();


### PR DESCRIPTION
We've seen some refCnt being set to negative number errors. This PR should fix that.