### PR TITLE
[named_blobs] Add NamedBlobDB interface/MySQL impl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ before_install:
   - mysql -e 'USE AccountMetadata; SOURCE ./ambry-account/src/main/resources/AccountSchema.ddl;'
   - mysql -e 'CREATE DATABASE ambry_container_storage_stats;'
   - mysql -e 'USE ambry_container_storage_stats; SOURCE ./ambry-server/src/main/resources/AmbryContainerStorageStats.ddl;'
+  - mysql -e 'CREATE DATABASE AmbryNamedBlobs;'
+  - mysql -e 'USE AmbryNamedBlobs; SOURCE ./ambry-named-mysql/src/main/resources/NamedBlobsSchema.ddl;'
 branches:
   except: # don't build tags
     - /^v\d/

--- a/ambry-api/src/main/java/com/github/ambry/config/FrontendConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/FrontendConfig.java
@@ -40,6 +40,7 @@ public class FrontendConfig {
   public static final String ENABLE_UNDELETE = PREFIX + "enable.undelete";
   public static final String ENABLE_STORAGE_QUOTA_SERVICE = PREFIX + "enable.storage.quota.service";
   public static final String STORAGE_QUOTA_SERVICE_FACTORY = PREFIX + "storage.quota.service.factory";
+  public static final String NAMED_BLOB_DB_FACTORY = PREFIX + "named.blob.db.factory";
 
   // Default values
   private static final String DEFAULT_ENDPOINT = "http://localhost:1174";
@@ -229,6 +230,14 @@ public class FrontendConfig {
   @Default(DEFAULT_STORAGE_QUOTA_SERVICE_FACTORY)
   public final String storageQuotaServiceFactory;
 
+  /**
+   * Can be set to a classname that implements {@link com.github.ambry.named.NamedBlobDbFactory} to enable named blob
+   * support.
+   */
+  @Config(NAMED_BLOB_DB_FACTORY)
+  @Default("null")
+  public final String namedBlobDbFactory;
+
   public FrontendConfig(VerifiableProperties verifiableProperties) {
     cacheValiditySeconds = verifiableProperties.getLong("frontend.cache.validity.seconds", 365 * 24 * 60 * 60);
     optionsValiditySeconds = verifiableProperties.getLong("frontend.options.validity.seconds", 24 * 60 * 60);
@@ -278,6 +287,8 @@ public class FrontendConfig {
     enableStorageQuotaService = verifiableProperties.getBoolean(ENABLE_STORAGE_QUOTA_SERVICE, false);
     storageQuotaServiceFactory =
         verifiableProperties.getString(STORAGE_QUOTA_SERVICE_FACTORY, DEFAULT_STORAGE_QUOTA_SERVICE_FACTORY);
+    namedBlobDbFactory =
+        verifiableProperties.getString(NAMED_BLOB_DB_FACTORY, null);
   }
 
   /**

--- a/ambry-api/src/main/java/com/github/ambry/config/MySqlAccountServiceConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/MySqlAccountServiceConfig.java
@@ -28,7 +28,8 @@ public class MySqlAccountServiceConfig extends AccountServiceConfig {
   private static final String MAX_BACKUP_FILE_COUNT = MYSQL_ACCOUNT_SERVICE_PREFIX + "max.backup.file.count";
 
   /**
-   * Serialized json containing the information about all mysql end points. This information should be of the following form:
+   * Serialized json array containing the information about all mysql end points.
+   * This information should be of the following form:
    * <pre>
    *   [
    *     {

--- a/ambry-api/src/main/java/com/github/ambry/config/MySqlNamedBlobDbConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/MySqlNamedBlobDbConfig.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ */
+
+package com.github.ambry.config;
+
+public class MySqlNamedBlobDbConfig {
+  private static final String PREFIX = "mysql.named.blob.";
+  public static final String DB_INFO = PREFIX + "db.info";
+  public static final String POOL_SIZE = PREFIX + "pool.size";
+  public static final String  LIST_MAX_RESULTS = PREFIX + "list.max.results";
+
+  /**
+   * Serialized json array containing the information about all mysql end points.
+   * See {@link MySqlAccountServiceConfig#dbInfo} for information about the format of the json array.
+   */
+  @Config(DB_INFO)
+  public final String dbInfo;
+
+  /**
+   * Number of connections and threads to use for executing transactions.
+   */
+  @Config(POOL_SIZE)
+  @Default("10")
+  public final int poolSize;
+
+  /**
+   * The maximum number of entries to return per response page when listing blobs.
+   */
+  @Config(LIST_MAX_RESULTS)
+  @Default("100")
+  public final int listMaxResults;
+
+  public MySqlNamedBlobDbConfig(VerifiableProperties verifiableProperties) {
+    this.dbInfo = verifiableProperties.getString(DB_INFO);
+    this.poolSize = verifiableProperties.getIntInRange(POOL_SIZE, 10, 1, Integer.MAX_VALUE);
+    this.listMaxResults = verifiableProperties.getIntInRange(LIST_MAX_RESULTS, 100, 1, Integer.MAX_VALUE);
+  }
+}

--- a/ambry-api/src/main/java/com/github/ambry/named/DeleteResult.java
+++ b/ambry-api/src/main/java/com/github/ambry/named/DeleteResult.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ */
+
+package com.github.ambry.named;
+
+/**
+ * Class to convey information about a successful deletion from {@link NamedBlobDb}.
+ */
+public class DeleteResult {
+  private final boolean notFoundOrAlreadyDeleted;
+
+  /**
+   * @param notFoundOrAlreadyDeleted {@code true} if a record for the blob was not found in the DB or if the record
+   *                                 indicated that the blob was already deleted.
+   */
+  public DeleteResult(boolean notFoundOrAlreadyDeleted) {
+    this.notFoundOrAlreadyDeleted = notFoundOrAlreadyDeleted;
+  }
+
+  /**
+   * @return {@code true} if a record for the blob was not found in the DB or if the record indicated that the blob was
+   *         already deleted.
+   */
+  public boolean isNotFoundOrAlreadyDeleted() {
+    return notFoundOrAlreadyDeleted;
+  }
+}

--- a/ambry-api/src/main/java/com/github/ambry/named/NamedBlobDb.java
+++ b/ambry-api/src/main/java/com/github/ambry/named/NamedBlobDb.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ */
+
+package com.github.ambry.named;
+
+import java.util.concurrent.CompletableFuture;
+
+
+/**
+ * A layer for interacting with a metadata store that holds mappings between blob names and blob IDs.
+ */
+public interface NamedBlobDb {
+
+  /**
+   * Look up a {@link NamedBlobRecord} by name.
+   * @param accountName the name of the account.
+   * @param containerName the name of the container.
+   * @param blobName the name of the blob.
+   * @return a {@link CompletableFuture} that will eventually contain either the {@link NamedBlobRecord} for the named
+   *         blob or an exception if an error occurred.
+   */
+  CompletableFuture<NamedBlobRecord> get(String accountName, String containerName, String blobName);
+
+  /**
+   * List blobs that start with a provided prefix in a container. This returns paginated results. If there are
+   * additional pages to read, {@link Page#getContinuationToken()} will be non null.
+   * @param accountName the name of the account.
+   * @param containerName the name of the container.
+   * @param blobNamePrefix the name prefix to search for.
+   * @param continuationToken if {@code null}, return the first page of {@link NamedBlobRecord}s that start with
+   *                          {@code blobNamePrefix}. If set, use this as a token to resume reading additional pages
+   *                          of records that start with the prefix.
+   * @return a {@link CompletableFuture} that will eventually contain a {@link Page} of {@link NamedBlobRecord}s
+   *         starting with the specified prefix or an exception if an error occurred.
+   */
+  CompletableFuture<Page<NamedBlobRecord>> list(String accountName, String containerName, String blobNamePrefix,
+      String continuationToken);
+
+  /**
+   * Persist a {@link NamedBlobRecord} in the database.
+   * @param record the {@link NamedBlobRecord}
+   * @return a {@link CompletableFuture} that will eventually contain a {@link PutResult} or an exception if an error
+   *         occurred.
+   */
+  CompletableFuture<PutResult> put(NamedBlobRecord record);
+
+  /**
+   * Delete a record for a blob in the database.
+   * @param accountName the name of the account.
+   * @param containerName the name of the container.
+   * @param blobName the name of the blob.
+   * @return a {@link CompletableFuture} that will eventually contain a {@link DeleteResult} or an exception if an error
+   *         occurred.
+   */
+  CompletableFuture<DeleteResult> delete(String accountName, String containerName, String blobName);
+}

--- a/ambry-api/src/main/java/com/github/ambry/named/NamedBlobDbFactory.java
+++ b/ambry-api/src/main/java/com/github/ambry/named/NamedBlobDbFactory.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ */
+
+package com.github.ambry.named;
+
+/**
+ * A factory to build instances of {@link NamedBlobDb}.
+ */
+public interface NamedBlobDbFactory {
+  /**
+   * @return an instance of {@link NamedBlobDb}.
+   * @throws Exception if there is an error during instantiation.
+   */
+  NamedBlobDb getNamedBlobDb() throws Exception;
+}

--- a/ambry-api/src/main/java/com/github/ambry/named/NamedBlobRecord.java
+++ b/ambry-api/src/main/java/com/github/ambry/named/NamedBlobRecord.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2020 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ */
+
+package com.github.ambry.named;
+
+import java.util.Objects;
+
+
+/**
+ * Represents a metadata record in a {@link NamedBlobDb} implementation.
+ */
+public class NamedBlobRecord {
+  private final String accountName;
+  private final String containerName;
+  private final String blobName;
+  private final String blobId;
+  private final long expirationTimeMs;
+
+  /**
+   * @param accountName the account name.
+   * @param containerName the container name.
+   * @param blobName the blob name within the container.
+   * @param blobId the blob ID for the blob content in ambry storage.
+   * @param expirationTimeMs the expiration time in milliseconds since epoch, or -1 if the blob should be permanent.
+   */
+  public NamedBlobRecord(String accountName, String containerName, String blobName, String blobId,
+      long expirationTimeMs) {
+    this.accountName = accountName;
+    this.containerName = containerName;
+    this.blobName = blobName;
+    this.blobId = blobId;
+    this.expirationTimeMs = expirationTimeMs;
+  }
+
+  /**
+   * @return the account name.
+   */
+  public String getAccountName() {
+    return accountName;
+  }
+
+  /**
+   * @return the container name.
+   */
+  public String getContainerName() {
+    return containerName;
+  }
+
+  /**
+   * @return the blob name within the container.
+   */
+  public String getBlobName() {
+    return blobName;
+  }
+
+  /**
+   * @return the blob ID for the blob content in ambry storage.
+   */
+  public String getBlobId() {
+    return blobId;
+  }
+
+  /**
+   * @return the expiration time in milliseconds since epoch, or -1 if the blob should be permanent.
+   */
+  public long getExpirationTimeMs() {
+    return expirationTimeMs;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    NamedBlobRecord record = (NamedBlobRecord) o;
+    return expirationTimeMs == record.expirationTimeMs && Objects.equals(accountName, record.accountName)
+        && Objects.equals(containerName, record.containerName) && Objects.equals(blobName, record.blobName)
+        && Objects.equals(blobId, record.blobId);
+  }
+}

--- a/ambry-api/src/main/java/com/github/ambry/named/Page.java
+++ b/ambry-api/src/main/java/com/github/ambry/named/Page.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ */
+
+package com.github.ambry.named;
+
+import java.util.Collections;
+import java.util.List;
+
+
+/**
+ * Represents a page of a response.
+ * @param <T> the type of the elements in the page
+ */
+public class Page<T> {
+  private final String continuationToken;
+  private final List<T> elements;
+
+  /**
+   *
+   * @param continuationToken {@code null} if there are no remaining pages to read, or a string that can be used to
+   *                          continue to read additional pages.
+   * @param elements the elements in this response page.
+   */
+  public Page(String continuationToken, List<T> elements) {
+    this.continuationToken = continuationToken;
+    this.elements = Collections.unmodifiableList(elements);
+  }
+
+  /**
+   * @return {@code null} if there are no remaining pages to read, or a string that can be used to continue to read
+   *         additional pages.
+   */
+  public String getContinuationToken() {
+    return continuationToken;
+  }
+
+  /**
+   * @return the elements in this response page.
+   */
+  public List<T> getElements() {
+    return elements;
+  }
+}

--- a/ambry-api/src/main/java/com/github/ambry/named/PutResult.java
+++ b/ambry-api/src/main/java/com/github/ambry/named/PutResult.java
@@ -19,7 +19,7 @@ package com.github.ambry.named;
  * Class to convey information about a successful put in {@link NamedBlobDb}.
  */
 public class PutResult {
-  NamedBlobRecord insertedRecord;
+  private final NamedBlobRecord insertedRecord;
 
   /**
    * @param insertedRecord the new record stored in the DB.

--- a/ambry-api/src/main/java/com/github/ambry/named/PutResult.java
+++ b/ambry-api/src/main/java/com/github/ambry/named/PutResult.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ */
+
+package com.github.ambry.named;
+
+/**
+ * Class to convey information about a successful put in {@link NamedBlobDb}.
+ */
+public class PutResult {
+  NamedBlobRecord insertedRecord;
+
+  /**
+   * @param insertedRecord the new record stored in the DB.
+   */
+  public PutResult(NamedBlobRecord insertedRecord) {
+    this.insertedRecord = insertedRecord;
+  }
+
+  /**
+   * @return the new record stored in the DB.
+   */
+  public NamedBlobRecord getInsertedRecord() {
+    return insertedRecord;
+  }
+}

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbryIdConverterFactory.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbryIdConverterFactory.java
@@ -16,6 +16,7 @@ package com.github.ambry.frontend;
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.named.NamedBlobDb;
 import com.github.ambry.rest.RestMethod;
 import com.github.ambry.rest.RestRequest;
 import com.github.ambry.rest.RestServiceErrorCode;
@@ -38,7 +39,7 @@ public class AmbryIdConverterFactory implements IdConverterFactory {
   private final FrontendMetrics frontendMetrics;
 
   public AmbryIdConverterFactory(VerifiableProperties verifiableProperties, MetricRegistry metricRegistry,
-      IdSigningService idSigningService) {
+      IdSigningService idSigningService, NamedBlobDb namedBlobDb) {
     this.idSigningService = idSigningService;
     frontendMetrics = new FrontendMetrics(metricRegistry);
   }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestServiceFactory.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestServiceFactory.java
@@ -19,6 +19,8 @@ import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.FrontendConfig;
 import com.github.ambry.config.StorageQuotaConfig;
 import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.named.NamedBlobDb;
+import com.github.ambry.named.NamedBlobDbFactory;
 import com.github.ambry.quota.StorageQuotaService;
 import com.github.ambry.quota.StorageQuotaServiceFactory;
 import com.github.ambry.rest.RestRequestService;
@@ -76,9 +78,12 @@ public class FrontendRestRequestServiceFactory implements RestRequestServiceFact
       IdSigningService idSigningService =
           Utils.<IdSigningServiceFactory>getObj(frontendConfig.idSigningServiceFactory, verifiableProperties,
               clusterMap.getMetricRegistry()).getIdSigningService();
+      NamedBlobDb namedBlobDb = Utils.isNullOrEmpty(frontendConfig.namedBlobDbFactory) ? null :
+          Utils.<NamedBlobDbFactory>getObj(frontendConfig.namedBlobDbFactory, verifiableProperties,
+              clusterMap.getMetricRegistry(), accountService).getNamedBlobDb();
       IdConverterFactory idConverterFactory =
           Utils.getObj(frontendConfig.idConverterFactory, verifiableProperties, clusterMap.getMetricRegistry(),
-              idSigningService);
+              idSigningService, namedBlobDb);
       UrlSigningService urlSigningService =
           Utils.<UrlSigningServiceFactory>getObj(frontendConfig.urlSigningServiceFactory, verifiableProperties,
               clusterMap.getMetricRegistry()).getUrlSigningService();

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/AmbryIdConverterFactoryTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/AmbryIdConverterFactoryTest.java
@@ -102,7 +102,7 @@ public class AmbryIdConverterFactoryTest {
     //with named blob
     ClusterMap clusterMap = new MockClusterMap();
     ambryIdConverterFactory =
-        new AmbryIdConverterFactory(verifiableProperties, new MetricRegistry(), idSigningService);
+        new AmbryIdConverterFactory(verifiableProperties, new MetricRegistry(), idSigningService, null);
     idConverter = ambryIdConverterFactory.getIdConverter();
     assertNotNull("No IdConverter returned", idConverter);
     List<String> operations = generateOperations(OPERATION_BASE);
@@ -183,7 +183,7 @@ public class AmbryIdConverterFactoryTest {
     VerifiableProperties verifiableProperties = new VerifiableProperties(properties);
     IdSigningService idSigningService = mock(IdSigningService.class);
     AmbryIdConverterFactory ambryIdConverterFactory =
-        new AmbryIdConverterFactory(verifiableProperties, new MetricRegistry(), idSigningService);
+        new AmbryIdConverterFactory(verifiableProperties, new MetricRegistry(), idSigningService, null);
     IdConverter idConverter = ambryIdConverterFactory.getIdConverter();
     assertNotNull("No IdConverter returned", idConverter);
     PartitionId partitionId = new MockPartitionId(partition, MockClusterMap.DEFAULT_PARTITION_CLASS);

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/AmbryIdConverterFactoryTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/AmbryIdConverterFactoryTest.java
@@ -69,7 +69,7 @@ public class AmbryIdConverterFactoryTest {
     VerifiableProperties verifiableProperties = new VerifiableProperties(properties);
     IdSigningService idSigningService = mock(IdSigningService.class);
     AmbryIdConverterFactory ambryIdConverterFactory =
-        new AmbryIdConverterFactory(verifiableProperties, new MetricRegistry(), idSigningService);
+        new AmbryIdConverterFactory(verifiableProperties, new MetricRegistry(), idSigningService, null);
     IdConverter idConverter = ambryIdConverterFactory.getIdConverter();
     assertNotNull("No IdConverter returned", idConverter);
 

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
@@ -162,7 +162,7 @@ public class FrontendRestRequestServiceTest {
         frontendConfig.urlSignerDefaultMaxUploadSizeBytes, frontendConfig.urlSignerMaxUrlTtlSecs,
         frontendConfig.chunkUploadInitialChunkTtlSecs, 4 * 1024 * 1024, SystemTime.getInstance());
     idSigningService = new AmbryIdSigningService();
-    idConverterFactory = new AmbryIdConverterFactory(verifiableProperties, metricRegistry, idSigningService);
+    idConverterFactory = new AmbryIdConverterFactory(verifiableProperties, metricRegistry, idSigningService, null);
     securityServiceFactory =
         new AmbrySecurityServiceFactory(verifiableProperties, clusterMap, null, urlSigningService, idSigningService,
             accountAndContainerInjector);

--- a/ambry-named-mysql/src/integration-test/java/com/github/ambry/named/MySqlNamedBlobDbIntegrationTest.java
+++ b/ambry-named-mysql/src/integration-test/java/com/github/ambry/named/MySqlNamedBlobDbIntegrationTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2020 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ */
+package com.github.ambry.named;
+
+import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.account.Account;
+import com.github.ambry.account.Container;
+import com.github.ambry.account.InMemAccountService;
+import com.github.ambry.clustermap.MockClusterMap;
+import com.github.ambry.clustermap.PartitionId;
+import com.github.ambry.commons.BlobId;
+import com.github.ambry.config.ClusterMapConfig;
+import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.rest.RestServiceErrorCode;
+import com.github.ambry.rest.RestServiceException;
+import com.github.ambry.utils.TestUtils;
+import com.github.ambry.utils.Utils;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import javax.sql.DataSource;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+/**
+ * Integration tests for {@link MySqlNamedBlobDb}.
+ */
+public class MySqlNamedBlobDbIntegrationTest {
+  private static final String LOCAL_DC = "dc1";
+  private final MySqlNamedBlobDb namedBlobDb;
+  private final InMemAccountService accountService;
+  private final PartitionId partitionId;
+
+  public MySqlNamedBlobDbIntegrationTest() throws Exception {
+    Properties properties = Utils.loadPropsFromResource("mysql.properties");
+    properties.setProperty(ClusterMapConfig.CLUSTERMAP_DATACENTER_NAME, LOCAL_DC);
+    accountService = new InMemAccountService(false, false);
+    for (int i = 0; i < 5; i++) {
+      accountService.createAndAddRandomAccount();
+    }
+    MockClusterMap clusterMap = new MockClusterMap();
+    partitionId = clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0);
+    MySqlNamedBlobDbFactory namedBlobDbFactory =
+        new MySqlNamedBlobDbFactory(new VerifiableProperties(properties), new MetricRegistry(), accountService);
+    namedBlobDb = namedBlobDbFactory.getNamedBlobDb();
+
+    cleanup();
+  }
+
+  /**
+   * Tests sequences of puts, gets, lists, and deletes across multiple containers.
+   * @throws Exception
+   */
+  @Test
+  public void testPutGetListDeleteSequence() throws Exception {
+    int blobsPerContainer = 5;
+
+    List<NamedBlobRecord> records = new ArrayList<>();
+    for (Account account : accountService.getAllAccounts()) {
+      for (Container container : account.getAllContainers()) {
+        for (int i = 0; i < blobsPerContainer; i++) {
+          String blobId = getBlobId(account, container);
+          String blobName = "name/" + i + "/more path segments--";
+          long expirationTime =
+              i % 2 == 0 ? Utils.Infinite_Time : System.currentTimeMillis() + TimeUnit.HOURS.toMillis(1);
+          NamedBlobRecord record =
+              new NamedBlobRecord(account.getName(), container.getName(), blobName, blobId, expirationTime);
+          namedBlobDb.put(record).get();
+          records.add(record);
+        }
+      }
+    }
+
+    // get records just inserted
+    for (NamedBlobRecord record : records) {
+      NamedBlobRecord recordFromStore =
+          namedBlobDb.get(record.getAccountName(), record.getContainerName(), record.getBlobName()).get();
+      assertEquals("Record does not match expectations.", record, recordFromStore);
+    }
+
+    // list records in each container
+    for (Account account : accountService.getAllAccounts()) {
+      for (Container container : account.getAllContainers()) {
+        Page<NamedBlobRecord> page = namedBlobDb.list(account.getName(), container.getName(), "name", null).get();
+        assertNull("No continuation token expected", page.getContinuationToken());
+        assertEquals("Unexpected number of blobs in container", blobsPerContainer, page.getElements().size());
+      }
+    }
+
+    // check that puts to the same keys fail.
+    for (Account account : accountService.getAllAccounts()) {
+      for (Container container : account.getAllContainers()) {
+        for (int i = 0; i < blobsPerContainer; i++) {
+          String blobId = getBlobId(account, container);
+          String blobName = "name/" + i + "/more path segments--";
+          NamedBlobRecord record =
+              new NamedBlobRecord(account.getName(), container.getName(), blobName, blobId, Utils.Infinite_Time);
+          checkErrorCode(() -> namedBlobDb.put(record), RestServiceErrorCode.Conflict);
+        }
+      }
+    }
+
+    // delete the records and check that they cannot be fetched with a get call.
+    for (NamedBlobRecord record : records) {
+      namedBlobDb.delete(record.getAccountName(), record.getContainerName(), record.getBlobName()).get();
+      checkErrorCode(() -> namedBlobDb.get(record.getAccountName(), record.getContainerName(), record.getBlobName()),
+          RestServiceErrorCode.Deleted);
+    }
+
+    // deletes should be idempotent and additional delete calls should succeed
+    for (NamedBlobRecord record : records) {
+      namedBlobDb.delete(record.getAccountName(), record.getContainerName(), record.getBlobName()).get();
+    }
+
+    records.clear();
+    // should be able to put new records again after deletion
+    for (Account account : accountService.getAllAccounts()) {
+      for (Container container : account.getAllContainers()) {
+        for (int i = 0; i < blobsPerContainer; i++) {
+          String blobId = getBlobId(account, container);
+          String blobName = "name/" + i + "/more path segments--";
+          long expirationTime =
+              i % 2 == 1 ? Utils.Infinite_Time : System.currentTimeMillis() + TimeUnit.HOURS.toMillis(1);
+          NamedBlobRecord record =
+              new NamedBlobRecord(account.getName(), container.getName(), blobName, blobId, expirationTime);
+          namedBlobDb.put(record).get();
+          records.add(record);
+        }
+      }
+    }
+  }
+
+  /**
+   * Get a sample blob ID.
+   * @param account the account of the blob.
+   * @param container the container of the blob.
+   * @return the base64 blob ID.
+   */
+  private String getBlobId(Account account, Container container) {
+    return new BlobId(BlobId.BLOB_ID_V6, BlobId.BlobIdType.NATIVE, (byte) 0, account.getId(), container.getId(),
+        partitionId, false, BlobId.BlobDataType.SIMPLE).getID();
+  }
+
+  /**
+   * @param callable an async call, where the {@link Future} is expected to be completed with an exception.
+   * @param errorCode the expected {@link RestServiceErrorCode}.
+   */
+  private void checkErrorCode(Callable<Future<?>> callable, RestServiceErrorCode errorCode) throws Exception {
+    TestUtils.assertException(ExecutionException.class, () -> callable.call().get(), e -> {
+      RestServiceException rse = (RestServiceException) e.getCause();
+      assertEquals("Unexpected error code for get after delete", errorCode, rse.getErrorCode());
+    });
+  }
+
+  /**
+   * Empties the accounts and containers tables.
+   * @throws SQLException
+   */
+  private void cleanup() throws SQLException {
+    for (DataSource dataSource : namedBlobDb.getDataSources().values()) {
+      try (Connection connection = dataSource.getConnection()) {
+        try (Statement statement = connection.createStatement()) {
+          statement.executeUpdate("DELETE FROM named_blobs");
+        }
+      }
+    }
+  }
+}

--- a/ambry-named-mysql/src/main/java/com/github/ambry/named/MySqlNamedBlobDb.java
+++ b/ambry-named-mysql/src/main/java/com/github/ambry/named/MySqlNamedBlobDb.java
@@ -1,0 +1,344 @@
+/*
+ * Copyright 2020 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ */
+
+package com.github.ambry.named;
+
+import com.github.ambry.account.Account;
+import com.github.ambry.account.AccountService;
+import com.github.ambry.account.Container;
+import com.github.ambry.config.MySqlNamedBlobDbConfig;
+import com.github.ambry.mysql.MySqlUtils;
+import com.github.ambry.mysql.MySqlUtils.DbEndpoint;
+import com.github.ambry.rest.RestServiceErrorCode;
+import com.github.ambry.rest.RestServiceException;
+import com.github.ambry.utils.Utils;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Delayed;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+import javax.sql.DataSource;
+import org.apache.commons.codec.binary.Base64;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * An implementation of {@link NamedBlobDb} that uses an active-active MySQL deployment as the source of truth for
+ * named blob mappings.
+ *
+ * It uses the Hikari library for connection pooling, which is a widely used and performant JDBC connection pool
+ * implementation.
+ */
+class MySqlNamedBlobDb implements NamedBlobDb {
+  private static final Logger logger = LoggerFactory.getLogger(MySqlNamedBlobDb.class);
+  // table name
+  private static final String NAMED_BLOBS = "named_blobs";
+  // column names
+  private static final String ACCOUNT_ID = "account_id";
+  private static final String CONTAINER_ID = "container_id";
+  private static final String BLOB_NAME = "blob_name";
+  private static final String BLOB_ID = "blob_id";
+  private static final String DELETED_TS = "deleted_ts";
+  private static final String EXPIRES_TS = "expires_ts";
+  // query building blocks
+  private static final String CURRENT_TIME_COMPARISON = "(%1$s IS NOT NULL AND %1$s <= CURRENT_TIMESTAMP(6))";
+  private static final String IS_DELETED = String.format(CURRENT_TIME_COMPARISON, DELETED_TS);
+  private static final String IS_EXPIRED = String.format(CURRENT_TIME_COMPARISON, EXPIRES_TS);
+  private static final String IS_DELETED_OR_EXPIRED = IS_DELETED + " OR " + IS_EXPIRED;
+  private static final String PK_MATCH = String.format("(%s, %s, %s) = (?, ?, ?)", ACCOUNT_ID, CONTAINER_ID, BLOB_NAME);
+
+  /**
+   * Select a record that matches a blob name (lookup by primary key).
+   */
+  private static final String GET_QUERY =
+      String.format("SELECT %s, %s, %s FROM %s WHERE %s", BLOB_ID, EXPIRES_TS, DELETED_TS, NAMED_BLOBS, PK_MATCH);
+
+  /**
+   * Select records up to a specific limit where the blob name starts with a string prefix. The fourth parameter can
+   * be used for pagination.
+   */
+  private static final String LIST_QUERY = String.format("SELECT %1$s, %2$s, %3$s, %4$s FROM %5$s "
+          + "WHERE (%6$s, %7$s) = (?, ?) AND %1$s LIKE ? AND %1$s >= ? ORDER BY %1$s ASC LIMIT ?", BLOB_NAME, BLOB_ID,
+      EXPIRES_TS, DELETED_TS, NAMED_BLOBS, ACCOUNT_ID, CONTAINER_ID);
+
+  /**
+   * Create a blob name to blob ID mapping if a record for that blob name does not exist.
+   * If there is an existing record but the existing blob was soft deleted or expired, allow it to be overwritten.
+   * If there is an existing record and the existing blob is still valid (not expired or soft deleted), do not
+   * overwrite it.
+   * <p>
+   * Eventually the put operation will support updates to the mapping in the third case above, but that requires other
+   * work around concurrency control.
+   */
+  private static final String PUT_QUERY = String.format(
+      "INSERT INTO %1$s (%2$s, %3$s, %4$s, %5$s, %6$s) VALUES (?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE "
+          + "%5$s = IF(%8$s, VALUES(%5$s), %5$s), %6$s = IF(%8$s, VALUES(%6$s), %6$s), %7$s = IF(%8$s, null, %7$s)",
+      NAMED_BLOBS, ACCOUNT_ID, CONTAINER_ID, BLOB_NAME, BLOB_ID, EXPIRES_TS, DELETED_TS, IS_DELETED_OR_EXPIRED);
+
+  /**
+   * Soft delete a blob by setting the delete timestamp to the current time if the blob is not already deleted.
+   */
+  private static final String DELETE_QUERY =
+      String.format("UPDATE %1$s SET %2$s = IF(%3$s, %2$s, CURRENT_TIMESTAMP(6)) WHERE %4$s", NAMED_BLOBS, DELETED_TS,
+          IS_DELETED, PK_MATCH);
+
+  private final AccountService accountService;
+  private final Map<String, DataSource> dcToDataSource;
+  private final String localDatacenter;
+  private final ExecutorService executorService;
+  private final MySqlNamedBlobDbConfig config;
+
+  MySqlNamedBlobDb(AccountService accountService, MySqlNamedBlobDbConfig config, DataSourceFactory dataSourceFactory,
+      String localDatacenter) {
+    this.accountService = accountService;
+    this.config = config;
+    this.localDatacenter = localDatacenter;
+    this.dcToDataSource = MySqlUtils.getDbEndpointsPerDC(config.dbInfo)
+        .values()
+        .stream()
+        .flatMap(List::stream)
+        .filter(DbEndpoint::isWriteable)
+        .collect(Collectors.toMap(DbEndpoint::getDatacenter, dataSourceFactory::getDataSource));
+    // size this to match the connection pool
+    executorService = Executors.newFixedThreadPool(config.poolSize);
+  }
+
+  @Override
+  public CompletableFuture<NamedBlobRecord> get(String accountName, String containerName, String blobName) {
+    return executeTransactionAsync(accountName, containerName, (accountId, containerId, connection) -> {
+      try (PreparedStatement statement = connection.prepareStatement(GET_QUERY)) {
+        statement.setInt(1, accountId);
+        statement.setInt(2, containerId);
+        statement.setString(3, blobName);
+        try (ResultSet resultSet = statement.executeQuery()) {
+          if (!resultSet.next()) {
+            throw buildException("GET: Blob not found", RestServiceErrorCode.NotFound, accountName, containerName,
+                blobName);
+          }
+          String blobId = Base64.encodeBase64URLSafeString(resultSet.getBytes(1));
+          Timestamp expirationTime = resultSet.getTimestamp(2);
+          Timestamp deletionTime = resultSet.getTimestamp(3);
+          long currentTime = System.currentTimeMillis();
+          if (compareTimestamp(expirationTime, currentTime) <= 0) {
+            throw buildException("GET: Blob expired", RestServiceErrorCode.Deleted, accountName, containerName,
+                blobName);
+          } else if (compareTimestamp(deletionTime, currentTime) <= 0) {
+            throw buildException("GET: Blob deleted", RestServiceErrorCode.Deleted, accountName, containerName,
+                blobName);
+          } else {
+            return new NamedBlobRecord(accountName, containerName, blobName, blobId, timestampToMs(expirationTime));
+          }
+        }
+      }
+    });
+  }
+
+  @Override
+  public CompletableFuture<Page<NamedBlobRecord>> list(String accountName, String containerName, String blobNamePrefix,
+      String continuationToken) {
+    return executeTransactionAsync(accountName, containerName, (accountId, containerId, connection) -> {
+      try (PreparedStatement statement = connection.prepareStatement(LIST_QUERY)) {
+        statement.setInt(1, accountId);
+        statement.setInt(2, containerId);
+        statement.setString(3, blobNamePrefix + "%");
+        statement.setString(4, continuationToken != null ? continuationToken : blobNamePrefix);
+        statement.setInt(5, config.listMaxResults + 1);
+        try (ResultSet resultSet = statement.executeQuery()) {
+          String nextContinuationToken = null;
+          List<NamedBlobRecord> elements = new ArrayList<>();
+          int resultIndex = 0;
+          while (resultSet.next()) {
+            if (resultIndex++ == config.listMaxResults) {
+              nextContinuationToken = resultSet.getString(1);
+              break;
+            }
+            String blobName = resultSet.getString(1);
+            String blobId = Base64.encodeBase64URLSafeString(resultSet.getBytes(2));
+            Timestamp expirationTime = resultSet.getTimestamp(3);
+            Timestamp deletionTime = resultSet.getTimestamp(4);
+            long currentTime = System.currentTimeMillis();
+
+            if (compareTimestamp(expirationTime, currentTime) <= 0) {
+              logger.trace("LIST: Blob expired, ignoring in list response; account='{}', container='{}', name='{}'",
+                  accountName, containerName, blobName);
+            } else if (compareTimestamp(deletionTime, currentTime) <= 0) {
+              logger.trace("LIST: Blob deleted, ignoring in list response; account='{}', container='{}', name='{}'",
+                  accountName, containerName, blobName);
+            } else {
+              elements.add(
+                  new NamedBlobRecord(accountName, containerName, blobName, blobId, timestampToMs(expirationTime)));
+            }
+          }
+          return new Page<>(nextContinuationToken, elements);
+        }
+      }
+    });
+  }
+
+  @Override
+  public CompletableFuture<PutResult> put(NamedBlobRecord record) {
+    return executeTransactionAsync(record.getAccountName(), record.getContainerName(),
+        (accountId, containerId, connection) -> {
+          try (PreparedStatement statement = connection.prepareStatement(PUT_QUERY)) {
+            statement.setInt(1, accountId);
+            statement.setInt(2, containerId);
+            statement.setString(3, record.getBlobName());
+            statement.setBytes(4, Base64.decodeBase64(record.getBlobId()));
+            if (record.getExpirationTimeMs() != Utils.Infinite_Time) {
+              statement.setTimestamp(5, new Timestamp(record.getExpirationTimeMs()));
+            } else {
+              statement.setTimestamp(5, null);
+            }
+            // affectedRows will be 0 if there is currently an entry for this blob name that is
+            // not expired or deleted. Note that for this to return the number of changed rows instead of found rows,
+            // the useAffectedRows connector property has to be set to true.
+            int affectedRows = statement.executeUpdate();
+            if (affectedRows == 0) {
+              throw buildException("PUT: Blob still alive", RestServiceErrorCode.Conflict, record.getAccountName(),
+                  record.getContainerName(), record.getBlobName());
+            }
+          }
+          return new PutResult(record);
+        });
+  }
+
+  @Override
+  public CompletableFuture<DeleteResult> delete(String accountName, String containerName, String blobName) {
+    return executeTransactionAsync(accountName, containerName, (accountId, containerId, connection) -> {
+      boolean notFoundOrAlreadyDeleted;
+      try (PreparedStatement statement = connection.prepareStatement(DELETE_QUERY)) {
+        statement.setInt(1, accountId);
+        statement.setInt(2, containerId);
+        statement.setString(3, blobName);
+        // affectedRows will be 0 if an entry for this blob name is not found or if there is an entry, but it was
+        // already marked deleted. Unfortunately, we cannot tell between these 2 cases with the useAffectedRows option,
+        // but since delete is an idempotent operation and recreation of named blobs after deletes is allowed, returning
+        // success in the not found case is probably okay.
+        notFoundOrAlreadyDeleted = statement.executeUpdate() == 0;
+        if (notFoundOrAlreadyDeleted) {
+          logger.trace("DELETE: Blob does not exist or is already deleted; account='{}', container='{}', name='{}'",
+              accountName, containerName, blobName);
+        }
+      }
+      return new DeleteResult(notFoundOrAlreadyDeleted);
+    });
+  }
+
+  /**
+   * Run a transaction on a thread pool and handle common logic surrounding looking up account metadata and error
+   * handling. Eventually this will handle retries.
+   * @param accountName the account name for the transaction.
+   * @param containerName the container name for the transaction.
+   * @param transaction the {@link Transaction} to run. This can either be a read only query or include DML.
+   * @param <T> the return type of the {@link Transaction}.
+   * @return a {@link CompletableFuture} that will eventually contain the result of the transaction or an exception.
+   */
+  private <T> CompletableFuture<T> executeTransactionAsync(String accountName, String containerName,
+      Transaction<T> transaction) {
+    CompletableFuture<T> future = new CompletableFuture<>();
+
+    // Look up account and container IDs. This is common logic needed for all types of transactions.
+    Account account = accountService.getAccountByName(accountName);
+    if (account == null) {
+      future.completeExceptionally(
+          new RestServiceException("Account not found: " + accountName, RestServiceErrorCode.NotFound));
+      return future;
+    }
+    Container container = account.getContainerByName(containerName);
+    if (container == null) {
+      future.completeExceptionally(
+          new RestServiceException("Container not found: " + containerName, RestServiceErrorCode.NotFound));
+      return future;
+    }
+
+    executorService.submit(() -> {
+      // TODO introduce failover handling (retry on remote datacenters, handle SQL exceptions)
+      try (Connection connection = dcToDataSource.get(localDatacenter).getConnection()) {
+        future.complete(transaction.run(account.getId(), container.getId(), connection));
+      } catch (Exception e) {
+        future.completeExceptionally(e);
+      }
+    });
+    return future;
+  }
+
+  /**
+   * Exposed for integration test usage.
+   * @return a map from datacenter name to {@link DataSource}.
+   */
+  Map<String, DataSource> getDataSources() {
+    return dcToDataSource;
+  }
+
+  /**
+   * Compare a nullable timestamp against {@code otherTimeMs}.
+   * @param timestamp the nullable {@link Timestamp} to compare.
+   * @param otherTimeMs the time value to compare against.
+   * @return -1 if the timestamp is earlier than {@code otherTimeMs}, 0 if the times are equal, and 1 if
+   *         {@code otherTimeMs} is later than the timestamp. {@code null} is considered greater than any other time.
+   */
+  private static int compareTimestamp(Timestamp timestamp, long otherTimeMs) {
+    return Utils.compareTimes(timestampToMs(timestamp), otherTimeMs);
+  }
+
+  /**
+   * @param timestamp a {@link Timestamp}, can be null.
+   * @return the milliseconds since the epoch if {@code timestamp} is non-null, or {@link Utils#Infinite_Time} if null.
+   */
+  private static long timestampToMs(Timestamp timestamp) {
+    return timestamp == null ? Utils.Infinite_Time : timestamp.getTime();
+  }
+
+  private static RestServiceException buildException(String message, RestServiceErrorCode errorCode, String accountName,
+      String containerName, String blobName) {
+    return new RestServiceException(
+        message + "; account='" + accountName + "', container='" + containerName + "', name='" + blobName + "'",
+        errorCode);
+  }
+
+  /**
+   * An interface that represents an action performed on an open database connection.
+   * @param <T> the return type of the action.
+   */
+  private interface Transaction<T> {
+    /**
+     * @param accountId the account ID for this transaction.
+     * @param containerId the container ID for this transaction.
+     * @param connection the database connection to use.
+     * @return the result of this transaction.
+     * @throws Exception if there is an error.
+     */
+    T run(short accountId, short containerId, Connection connection) throws Exception;
+  }
+
+  /**
+   * A factory that produces a configured {@link DataSource} based on supplied configs.
+   */
+  interface DataSourceFactory {
+    /**
+     * @param dbEndpoint {@link DbEndpoint} object containing the database connection settings to use.
+     * @return an instance of {@link DataSource} for the provided {@link DbEndpoint}.
+     */
+    DataSource getDataSource(DbEndpoint dbEndpoint);
+  }
+}

--- a/ambry-named-mysql/src/main/java/com/github/ambry/named/MySqlNamedBlobDbFactory.java
+++ b/ambry-named-mysql/src/main/java/com/github/ambry/named/MySqlNamedBlobDbFactory.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ */
+
+package com.github.ambry.named;
+
+import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.account.AccountService;
+import com.github.ambry.mysql.MySqlUtils.DbEndpoint;
+import com.github.ambry.config.ClusterMapConfig;
+import com.github.ambry.config.MySqlNamedBlobDbConfig;
+import com.github.ambry.config.VerifiableProperties;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+
+
+public class MySqlNamedBlobDbFactory implements NamedBlobDbFactory {
+  private final MySqlNamedBlobDbConfig config;
+  private final String localDatacenter;
+  private final MetricRegistry metricRegistry;
+  private final AccountService accountService;
+
+  public MySqlNamedBlobDbFactory(VerifiableProperties verifiableProperties, MetricRegistry metricRegistry,
+      AccountService accountService) {
+    config = new MySqlNamedBlobDbConfig(verifiableProperties);
+    localDatacenter = verifiableProperties.getString(ClusterMapConfig.CLUSTERMAP_DATACENTER_NAME);
+    this.metricRegistry = metricRegistry;
+    this.accountService = accountService;
+  }
+
+  @Override
+  public MySqlNamedBlobDb getNamedBlobDb() {
+    return new MySqlNamedBlobDb(accountService, config, this::buildDataSource, localDatacenter);
+  }
+
+  /**
+   * @param dbEndpoint struct containing JDBC connection information.
+   * @return the {@link HikariDataSource} for the {@link DbEndpoint}.
+   */
+  private HikariDataSource buildDataSource(DbEndpoint dbEndpoint) {
+    HikariConfig hikariConfig = new HikariConfig();
+    hikariConfig.setJdbcUrl(dbEndpoint.getUrl());
+    hikariConfig.setUsername(dbEndpoint.getUsername());
+    hikariConfig.setPassword(dbEndpoint.getPassword());
+    hikariConfig.setMaximumPoolSize(config.poolSize);
+    // Recommended properties for automatic prepared statement caching
+    // https://github.com/brettwooldridge/HikariCP/wiki/MySQL-Configuration
+    hikariConfig.addDataSourceProperty("cachePrepStmts", "true");
+    hikariConfig.addDataSourceProperty("prepStmtCacheSize", "250");
+    hikariConfig.addDataSourceProperty("prepStmtCacheSqlLimit", "2048");
+    hikariConfig.addDataSourceProperty("useServerPrepStmts", "true");
+    // Checking if a row was actually changed in an update requires the DataSource to be configured with the
+    // useAffectedRows option, otherwise the number of rows visited will be returned, even if they are not changed.
+    hikariConfig.addDataSourceProperty("useAffectedRows", "true");
+    hikariConfig.setMetricRegistry(metricRegistry);
+    return new HikariDataSource(hikariConfig);
+  }
+}

--- a/ambry-named-mysql/src/main/resources/NamedBlobsSchema.ddl
+++ b/ambry-named-mysql/src/main/resources/NamedBlobsSchema.ddl
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS named_blobs (
+    account_id int NOT NULL,
+    container_id int NOT NULL,
+    blob_name varchar(191) NOT NULL,
+    blob_id varbinary(50) NOT NULL,
+    deleted_ts datetime(6) DEFAULT NULL,
+    expires_ts datetime(6) DEFAULT NULL,
+    PRIMARY KEY (account_id, container_id, blob_name)
+)
+ENGINE=InnoDB
+DEFAULT CHARSET=utf8mb4
+COLLATE=utf8mb4_bin
+COMMENT='Holds mappings between blob names and blob IDs';
+
+/* Soft Delete Index */
+CREATE INDEX named_blobs_dt ON named_blobs(deleted_ts);
+
+/* Expired Index */
+CREATE INDEX named_blobs_et ON named_blobs(expires_ts);
+
+/* Reverse Lookup Index */
+CREATE INDEX named_blobs_id ON named_blobs(blob_id);

--- a/ambry-named-mysql/src/test/java/com/github/ambry/named/MySqlNamedBlobDbTest.java
+++ b/ambry-named-mysql/src/test/java/com/github/ambry/named/MySqlNamedBlobDbTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2020 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ */
+
+package com.github.ambry.named;
+
+import com.github.ambry.account.Account;
+import com.github.ambry.account.Container;
+import com.github.ambry.account.InMemAccountService;
+import com.github.ambry.config.MySqlNamedBlobDbConfig;
+import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.mysql.MySqlUtils;
+import com.github.ambry.utils.TestUtils;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import javax.sql.DataSource;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.mockito.Mockito.*;
+
+
+/**
+ * Tests for {@link MySqlNamedBlobDb} that require a mocked data source.
+ */
+public class MySqlNamedBlobDbTest {
+  private final List<String> datacenters = Arrays.asList("dc1", "dc2", "dc3");
+  private final String localDatacenter = datacenters.get(0);
+  private final MockDataSourceFactory dataSourceFactory = new MockDataSourceFactory();
+  private final InMemAccountService accountService = new InMemAccountService(false, false);
+  private final MySqlNamedBlobDb namedBlobDb;
+  private final Account account;
+  private final Container container;
+
+  public MySqlNamedBlobDbTest() {
+    Properties properties = new Properties();
+    JSONArray dbInfo = new JSONArray();
+    for (String datacenter : datacenters) {
+      dbInfo.put(new JSONObject().put("url", "jdbc:mysql://" + datacenter)
+          .put("datacenter", datacenter)
+          .put("isWriteable", true)
+          .put("username", "test")
+          .put("password", "password"));
+    }
+    properties.setProperty(MySqlNamedBlobDbConfig.DB_INFO, dbInfo.toString());
+    namedBlobDb = new MySqlNamedBlobDb(accountService, new MySqlNamedBlobDbConfig(new VerifiableProperties(properties)),
+        dataSourceFactory, localDatacenter);
+    account = accountService.createAndAddRandomAccount();
+    container = account.getAllContainers().iterator().next();
+  }
+
+  /**
+   * Test connection failure.
+   */
+  @Test
+  public void testConnectionFailure() throws Exception {
+    SQLException sqlException = new SQLException("bad");
+    dataSourceFactory.triggerConnectionError(localDatacenter, sqlException);
+    TestUtils.assertException(ExecutionException.class,
+        () -> namedBlobDb.get(account.getName(), container.getName(), "blobName").get(),
+        e -> Assert.assertEquals(sqlException, e.getCause()));
+  }
+
+  /**
+   * Test query execution failure
+   */
+  @Test
+  public void testQueryExecutionFailure() throws Exception {
+    SQLException sqlException = new SQLException("bad");
+    dataSourceFactory.triggerQueryExecutionError(localDatacenter, sqlException);
+    TestUtils.assertException(ExecutionException.class,
+        () -> namedBlobDb.get(account.getName(), container.getName(), "blobName").get(),
+        e -> Assert.assertEquals(sqlException, e.getCause()));
+  }
+
+  private static class MockDataSourceFactory implements MySqlNamedBlobDb.DataSourceFactory {
+    private final Map<String, DataSource> dataSources = new HashMap<>();
+
+    @Override
+    public DataSource getDataSource(MySqlUtils.DbEndpoint dbEndpoint) {
+      return dataSources.computeIfAbsent(dbEndpoint.getDatacenter(), k -> mock(DataSource.class));
+    }
+
+    private void triggerConnectionError(String datacenter, SQLException connectionError) {
+      try {
+        DataSource dataSource = dataSources.get(datacenter);
+        reset(dataSource);
+        when(dataSource.getConnection()).thenThrow(connectionError);
+      } catch (SQLException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    private void triggerQueryExecutionError(String datacenter, SQLException executionError) {
+      try {
+        DataSource dataSource = dataSources.get(datacenter);
+        reset(dataSource);
+        PreparedStatement statement = mock(PreparedStatement.class);
+        when(statement.executeQuery()).thenThrow(executionError);
+        when(statement.executeUpdate()).thenThrow(executionError);
+        when(statement.execute()).thenThrow(executionError);
+        Connection connection = mock(Connection.class);
+        when(connection.prepareStatement(any())).thenReturn(statement);
+        when(dataSource.getConnection()).thenReturn(connection);
+      } catch (SQLException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+}
+

--- a/ambry-named-mysql/src/test/resources/mysql.properties
+++ b/ambry-named-mysql/src/test/resources/mysql.properties
@@ -1,0 +1,12 @@
+#
+# Copyright (C) 2014-2020 LinkedIn Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy of the
+# License at  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied.
+#
+mysql.named.blob.db.info=[{"url":"jdbc:mysql://localhost/AmbryNamedBlobs?serverTimezone=UTC","datacenter":"dc1","isWriteable":"true","username":"travis","password":""}]

--- a/build.gradle
+++ b/build.gradle
@@ -439,8 +439,8 @@ project(':ambry-named-mysql') {
     dependencies {
         compile project(':ambry-api')
         compile project(':ambry-commons')
-        compile 'mysql:mysql-connector-java:8.0.21'
-        compile 'com.zaxxer:HikariCP:3.4.5'
+        compile "mysql:mysql-connector-java:$mysqlConnectorVersion"
+        compile "com.zaxxer:HikariCP:$hikariVersion"
         testCompile project(':ambry-test-utils')
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -435,6 +435,16 @@ project(':ambry-cloud') {
     }
 }
 
+project(':ambry-named-mysql') {
+    dependencies {
+        compile project(':ambry-api')
+        compile project(':ambry-commons')
+        compile 'mysql:mysql-connector-java:8.0.21'
+        compile 'com.zaxxer:HikariCP:3.4.5'
+        testCompile project(':ambry-test-utils')
+    }
+}
+
 project(':ambry-quota') {
     dependencies {
         compile project(':ambry-api'),
@@ -455,6 +465,7 @@ project(':ambry-all') {
         compile project(':ambry-server')
         compile project(':ambry-tools')
         compile project(':ambry-cloud')
+        compile project(':ambry-named-mysql')
         compile project(':ambry-test-utils')
     }
 }

--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -29,4 +29,5 @@ ext {
     conscryptVersion = "2.2.1"
     jimFsVersion = "1.1"
     mysqlConnectorVersion = "8.0.21"
+    hikariVersion = "3.4.5"
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -24,6 +24,7 @@ include 'ambry-api',
         'ambry-router',
         'ambry-frontend',
         'ambry-cloud',
+        'ambry-named-mysql',
         'log4j-test-config',
         'ambry-all',
         'ambry-quota'


### PR DESCRIPTION
Add an interface and a MySQL implementation of NamedBlobDB.
This interface will enable interaction with a mutable mapping layer for
named blobs.

Add a mysql based implementation that supports the put/get/list/delete
APIs. For the first iteration, this does not include retry and failover to
other active databases. This implementation uses Hikari for connection
pooling and built-in mysql connector options for prepared statement
caching.
