### PR TITLE
Upgrade metrics to 4.1.2, allow custom configuration for JmxReporter

### DIFF
--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrMain.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrMain.java
@@ -42,7 +42,7 @@ public class VcrMain {
           Utils.getObj(clusterMapConfig.clusterMapClusterAgentsFactory, clusterMapConfig,
               options.hardwareLayoutFilePath, options.partitionLayoutFilePath);
       logger.info("Bootstrapping VcrServer");
-      vcrServer = new VcrServer(verifiableProperties, clusterAgentsFactory, new LoggingNotificationSystem());
+      vcrServer = new VcrServer(verifiableProperties, clusterAgentsFactory, new LoggingNotificationSystem(), null);
       // attach shutdown handler to catch control-c
       Runtime.getRuntime().addShutdownHook(new Thread() {
         public void run() {

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrServer.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrServer.java
@@ -50,6 +50,7 @@ import java.util.ArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -74,6 +75,7 @@ public class VcrServer {
   private JmxReporter reporter = null;
   private ConnectionPool connectionPool = null;
   private final NotificationSystem notificationSystem;
+  private final Function<MetricRegistry, JmxReporter> reporterFactory;
   private CloudDestinationFactory cloudDestinationFactory;
   private VcrRequests requests;
   private RequestHandlerPool requestHandlerPool;
@@ -84,12 +86,15 @@ public class VcrServer {
    * @param properties the config properties to use.
    * @param clusterAgentsFactory the {@link ClusterAgentsFactory} to use.
    * @param notificationSystem the {@link NotificationSystem} to use.
+   * @param reporterFactory if non-null, use this function to set up a {@link JmxReporter} with custom settings. If this
+   *                        option is null the default settings for the reporter will be used.
    */
   public VcrServer(VerifiableProperties properties, ClusterAgentsFactory clusterAgentsFactory,
-      NotificationSystem notificationSystem) {
+      NotificationSystem notificationSystem, Function<MetricRegistry, JmxReporter> reporterFactory) {
     this.properties = properties;
     this.clusterAgentsFactory = clusterAgentsFactory;
     this.notificationSystem = notificationSystem;
+    this.reporterFactory = reporterFactory;
   }
 
   /**
@@ -98,10 +103,12 @@ public class VcrServer {
    * @param clusterAgentsFactory the {@link ClusterAgentsFactory} to use.
    * @param notificationSystem the {@link NotificationSystem} to use.
    * @param cloudDestinationFactory the {@link CloudDestinationFactory} to use.
+   * @param reporterFactory
    */
   VcrServer(VerifiableProperties properties, ClusterAgentsFactory clusterAgentsFactory,
-      NotificationSystem notificationSystem, CloudDestinationFactory cloudDestinationFactory) {
-    this(properties, clusterAgentsFactory, notificationSystem);
+      NotificationSystem notificationSystem, CloudDestinationFactory cloudDestinationFactory,
+      Function<MetricRegistry, JmxReporter> reporterFactory) {
+    this(properties, clusterAgentsFactory, notificationSystem, reporterFactory);
     this.cloudDestinationFactory = cloudDestinationFactory;
   }
 
@@ -118,7 +125,7 @@ public class VcrServer {
       logger.info("Setting up JMX.");
       long startTime = SystemTime.getInstance().milliseconds();
       registry = clusterMap.getMetricRegistry();
-      reporter = JmxReporter.forRegistry(registry).build();
+      reporter = reporterFactory != null ? reporterFactory.apply(registry) : JmxReporter.forRegistry(registry).build();
       reporter.start();
 
       logger.info("creating configs");

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrServer.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrServer.java
@@ -103,7 +103,8 @@ public class VcrServer {
    * @param clusterAgentsFactory the {@link ClusterAgentsFactory} to use.
    * @param notificationSystem the {@link NotificationSystem} to use.
    * @param cloudDestinationFactory the {@link CloudDestinationFactory} to use.
-   * @param reporterFactory
+   * @param reporterFactory if non-null, use this function to set up a {@link JmxReporter} with custom settings. If this
+   *                        option is null the default settings for the reporter will be used.
    */
   VcrServer(VerifiableProperties properties, ClusterAgentsFactory clusterAgentsFactory,
       NotificationSystem notificationSystem, CloudDestinationFactory cloudDestinationFactory,

--- a/ambry-cloud/src/test/java/com/github/ambry/cloud/VcrServerTest.java
+++ b/ambry-cloud/src/test/java/com/github/ambry/cloud/VcrServerTest.java
@@ -13,6 +13,10 @@
  */
 package com.github.ambry.cloud;
 
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.jmx.DefaultObjectNameFactory;
+import com.codahale.metrics.jmx.JmxReporter;
+import com.codahale.metrics.jmx.ObjectNameFactory;
 import com.github.ambry.clustermap.MockClusterAgentsFactory;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.config.CloudConfig;
@@ -23,6 +27,7 @@ import com.github.ambry.utils.TestUtils;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Properties;
+import java.util.function.Function;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -58,17 +63,29 @@ public class VcrServerTest {
    */
   @Test
   public void testVCRServerWithStaticCluster() throws Exception {
-    Properties props = VcrTestUtil.createVcrProperties("DC1", "vcrClusterName", "", 12300, 12400, null);
-    props.setProperty(CloudConfig.VCR_ASSIGNED_PARTITIONS, "0,1");
-    props.setProperty(CloudConfig.VIRTUAL_REPLICATOR_CLUSTER_FACTORY_CLASS, StaticVcrClusterFactory.class.getName());
-    // Run this one with compaction disabled
-    props.setProperty(CloudConfig.CLOUD_BLOB_COMPACTION_ENABLED, "false");
-    props.setProperty(CloudConfig.CLOUD_DESTINATION_FACTORY_CLASS,
-        "com.github.ambry.cloud.LatchBasedInMemoryCloudDestinationFactory");
-    VerifiableProperties verifiableProperties = new VerifiableProperties(props);
+    VerifiableProperties verifiableProperties = getStaticClusterVcrProps();
     VcrServer vcrServer = new VcrServer(verifiableProperties, mockClusterAgentsFactory, notificationSystem, null);
     vcrServer.startup();
     Assert.assertNull("Expected null compactor", vcrServer.getVcrReplicationManager().getCloudStorageCompactor());
+    vcrServer.shutdown();
+  }
+
+  /**
+   * Bring up the VCR server and then shut it down with {@link StaticVcrCluster} and a custom {@link JmxReporter}
+   * factory.
+   * @throws Exception
+   */
+  @Test
+  public void testVCRServerWithReporterFactory() throws Exception {
+    VerifiableProperties verifiableProperties = getStaticClusterVcrProps();
+    ObjectNameFactory spyObjectNameFactory = spy(new DefaultObjectNameFactory());
+    Function<MetricRegistry, JmxReporter> reporterFactory =
+        reporter -> JmxReporter.forRegistry(reporter).createsObjectNamesWith(spyObjectNameFactory).build();
+    VcrServer vcrServer =
+        new VcrServer(verifiableProperties, mockClusterAgentsFactory, notificationSystem, reporterFactory);
+    vcrServer.startup();
+    // check that the custom ObjectNameFactory specified in reporterFactory was used.
+    verify(spyObjectNameFactory, atLeastOnce()).createName(anyString(), anyString(), anyString());
     vcrServer.shutdown();
   }
 
@@ -89,11 +106,26 @@ public class VcrServerTest {
         new LatchBasedInMemoryCloudDestination(Collections.emptyList(), mockClusterMap));
     VerifiableProperties verifiableProperties = new VerifiableProperties(props);
     VcrServer vcrServer =
-        new VcrServer(verifiableProperties, mockClusterAgentsFactory, notificationSystem, cloudDestinationFactory, null);
+        new VcrServer(verifiableProperties, mockClusterAgentsFactory, notificationSystem, cloudDestinationFactory,
+            null);
     vcrServer.startup();
     Assert.assertNotNull("Expected compactor", vcrServer.getVcrReplicationManager().getCloudStorageCompactor());
     vcrServer.shutdown();
     helixControllerManager.syncStop();
     zkInfo.shutdown();
+  }
+
+  /**
+   * @return {@link VerifiableProperties} to start a VCR with a static cluster.
+   */
+  private VerifiableProperties getStaticClusterVcrProps() {
+    Properties props = VcrTestUtil.createVcrProperties("DC1", "vcrClusterName", "", 12300, 12400, null);
+    props.setProperty(CloudConfig.VCR_ASSIGNED_PARTITIONS, "0,1");
+    props.setProperty(CloudConfig.VIRTUAL_REPLICATOR_CLUSTER_FACTORY_CLASS, StaticVcrClusterFactory.class.getName());
+    // Run this one with compaction disabled
+    props.setProperty(CloudConfig.CLOUD_BLOB_COMPACTION_ENABLED, "false");
+    props.setProperty(CloudConfig.CLOUD_DESTINATION_FACTORY_CLASS,
+        "com.github.ambry.cloud.LatchBasedInMemoryCloudDestinationFactory");
+    return new VerifiableProperties(props);
   }
 }

--- a/ambry-cloud/src/test/java/com/github/ambry/cloud/VcrServerTest.java
+++ b/ambry-cloud/src/test/java/com/github/ambry/cloud/VcrServerTest.java
@@ -66,7 +66,7 @@ public class VcrServerTest {
     props.setProperty(CloudConfig.CLOUD_DESTINATION_FACTORY_CLASS,
         "com.github.ambry.cloud.LatchBasedInMemoryCloudDestinationFactory");
     VerifiableProperties verifiableProperties = new VerifiableProperties(props);
-    VcrServer vcrServer = new VcrServer(verifiableProperties, mockClusterAgentsFactory, notificationSystem);
+    VcrServer vcrServer = new VcrServer(verifiableProperties, mockClusterAgentsFactory, notificationSystem, null);
     vcrServer.startup();
     Assert.assertNull("Expected null compactor", vcrServer.getVcrReplicationManager().getCloudStorageCompactor());
     vcrServer.shutdown();
@@ -89,7 +89,7 @@ public class VcrServerTest {
         new LatchBasedInMemoryCloudDestination(Collections.emptyList(), mockClusterMap));
     VerifiableProperties verifiableProperties = new VerifiableProperties(props);
     VcrServer vcrServer =
-        new VcrServer(verifiableProperties, mockClusterAgentsFactory, notificationSystem, cloudDestinationFactory);
+        new VcrServer(verifiableProperties, mockClusterAgentsFactory, notificationSystem, cloudDestinationFactory, null);
     vcrServer.startup();
     Assert.assertNotNull("Expected compactor", vcrServer.getVcrReplicationManager().getCloudStorageCompactor());
     vcrServer.shutdown();

--- a/ambry-cloud/src/test/java/com/github/ambry/cloud/VcrTestUtil.java
+++ b/ambry-cloud/src/test/java/com/github/ambry/cloud/VcrTestUtil.java
@@ -63,7 +63,7 @@ public class VcrTestUtil {
    */
   public static VcrServer createVcrServer(VerifiableProperties properties, ClusterAgentsFactory clusterAgentsFactory,
       NotificationSystem notificationSystem, CloudDestinationFactory cloudDestinationFactory) {
-    return new VcrServer(properties, clusterAgentsFactory, notificationSystem, cloudDestinationFactory);
+    return new VcrServer(properties, clusterAgentsFactory, notificationSystem, cloudDestinationFactory, null);
   }
 
   /**

--- a/ambry-server/src/integration-test/java/com/github/ambry/server/MockCluster.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/MockCluster.java
@@ -274,10 +274,10 @@ public class MockCluster {
     if (mockClusterAgentsFactory != null) {
       server =
           new AmbryServer(createInitProperties(dataNodeId, enableHardDeletes, sslProperties), mockClusterAgentsFactory,
-              mockClusterSpectatorFactory, notificationSystem, time);
+              mockClusterSpectatorFactory, notificationSystem, time, null);
     } else {
       server = new AmbryServer(createInitProperties(dataNodeId, enableHardDeletes, sslProperties),
-          this.mockClusterAgentsFactory, mockClusterSpectatorFactory, notificationSystem, time);
+          this.mockClusterAgentsFactory, mockClusterSpectatorFactory, notificationSystem, time, null);
     }
     return server;
   }

--- a/ambry-server/src/test/java/com/github/ambry/server/AmbryServerTest.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/AmbryServerTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ */
+
+package com.github.ambry.server;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.jmx.DefaultObjectNameFactory;
+import com.codahale.metrics.jmx.JmxReporter;
+import com.codahale.metrics.jmx.ObjectNameFactory;
+import com.github.ambry.clustermap.ClusterAgentsFactory;
+import com.github.ambry.clustermap.DataNodeId;
+import com.github.ambry.clustermap.MockClusterAgentsFactory;
+import com.github.ambry.commons.LoggingNotificationSystem;
+import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.utils.SystemTime;
+import java.util.Properties;
+import java.util.function.Function;
+import org.junit.Test;
+
+import static org.mockito.Mockito.*;
+
+
+/**
+ * Test logic in {@link AmbryServer}.
+ */
+public class AmbryServerTest {
+
+  /**
+   * Test starting and shutting down the server with a custom {@link JmxReporter} factory.
+   * @throws Exception
+   */
+  @Test
+  public void testAmbryServerWithReporterFactory() throws Exception {
+    ClusterAgentsFactory clusterAgentsFactory = new MockClusterAgentsFactory(false, false, 1, 1, 1);
+    ObjectNameFactory spyObjectNameFactory = spy(new DefaultObjectNameFactory());
+    Function<MetricRegistry, JmxReporter> reporterFactory =
+        reporter -> JmxReporter.forRegistry(reporter).createsObjectNamesWith(spyObjectNameFactory).build();
+
+    DataNodeId dataNodeId = clusterAgentsFactory.getClusterMap().getDataNodeIds().get(0);
+
+    Properties props = new Properties();
+    props.setProperty("host.name", dataNodeId.getHostname());
+    props.setProperty("port", Integer.toString(dataNodeId.getPort()));
+    props.setProperty("clustermap.cluster.name", "test");
+    props.setProperty("clustermap.datacenter.name", "DC1");
+    props.setProperty("clustermap.host.name", dataNodeId.getHostname());
+
+    AmbryServer ambryServer =
+        new AmbryServer(new VerifiableProperties(props), clusterAgentsFactory, null, new LoggingNotificationSystem(),
+            SystemTime.getInstance(), reporterFactory);
+    ambryServer.startup();
+    verify(spyObjectNameFactory, atLeastOnce()).createName(anyString(), anyString(), anyString());
+    ambryServer.shutdown();
+  }
+}

--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -13,7 +13,7 @@ ext {
     joptSimpleVersion = "4.9"
     log4jVersion = "1.2.17"
     jsonVersion = "20170516"
-    metricsVersion = "4.0.7"
+    metricsVersion = "4.1.2"
     commonsVersion = "1.9"
     bouncycastleVersion = "1.64"
     javaxVersion = "3.0.1"


### PR DESCRIPTION
- Upgrade dropwizard metrics to 4.1.2
- Upgrading to 4.1.2 brings some changes in MBean naming in JmxReporter,
  which can effect users that query these MBeans based on naming patterns.
- To address this, add an optional argument to each "server" class to
  allow users to pass in a factory that produces a JmxReporter with
  non-default configs.