### PR TITLE
[HTTP2] use safeRelease method to release GetResponse and PutRequest

### DIFF
--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/GetResponse.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/GetResponse.java
@@ -22,6 +22,7 @@ import com.github.ambry.utils.Utils;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.util.ReferenceCountUtil;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -201,11 +202,11 @@ public class GetResponse extends Response {
   @Override
   public boolean release() {
     if (bufferToSend != null) {
-      bufferToSend.release();
+      ReferenceCountUtil.safeRelease(bufferToSend);
       bufferToSend = null;
     }
     if (toSend != null) {
-      toSend.release();
+      ReferenceCountUtil.safeRelease(toSend);
       toSend = null;
     }
     return false;

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/PutRequest.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/PutRequest.java
@@ -25,6 +25,7 @@ import com.github.ambry.utils.Utils;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.util.ReferenceCountUtil;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -260,15 +261,16 @@ public class PutRequest extends RequestOrResponse {
   @Override
   public boolean release() {
     if (blob != null) {
-      blob.release();
+      ReferenceCountUtil.safeRelease(blob);
       blob = null;
     }
     if (crcByteBuf != null) {
-      crcByteBuf.release();
+      ReferenceCountUtil.safeRelease(crcByteBuf);
       crcByteBuf = null;
     }
     if (bufferToSend != null) {
-      bufferToSend.release();
+      ReferenceCountUtil.safeRelease(bufferToSend);
+      bufferToSend = null;
     }
     return false;
   }


### PR DESCRIPTION
Just minor change to safely release the buffers in GetResponse and PutRequest.