### PR TITLE
Fix reset partition error when restarting a stopped replica

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/clustermap/ClusterMap.java
+++ b/ambry-api/src/main/java/com/github/ambry/clustermap/ClusterMap.java
@@ -47,7 +47,7 @@ public interface ClusterMap extends AutoCloseable {
   List<? extends PartitionId> getWritablePartitionIds(String partitionClass);
 
   /**
-   * Get a writable partition chosen at random that belongs to given partitionclass.
+   * Get a writable partition chosen at random that belongs to given partition class.
    * @param partitionClass the partition class whose writable partitions are required. Can be {@code null}
    * @param partitionsToExclude list of partitions that shouldn't be considered as a possible partition returned
    * @return chosen random partition. Can be {@code null}

--- a/ambry-api/src/main/java/com/github/ambry/store/Store.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/Store.java
@@ -172,9 +172,9 @@ public interface Store {
   boolean recoverFromDecommission();
 
   /**
-   * @return {@code true} if the store is disabled on error (due to disk I/O issue).
+   * @return {@code true} if the store is disabled due to disk I/O error or by admin operation(i.e. stop replica).
    */
-  boolean disabledOnError();
+  boolean isDisabled();
 
   /**
    * Shuts down the store

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobStore.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobStore.java
@@ -900,7 +900,7 @@ class CloudBlobStore implements Store {
   }
 
   @Override
-  public boolean disabledOnError() {
+  public boolean isDisabled() {
     throw new UnsupportedOperationException("Method not supported");
   }
 

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixParticipant.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixParticipant.java
@@ -19,6 +19,7 @@ import com.github.ambry.commons.Callback;
 import com.github.ambry.server.AmbryHealthReport;
 import com.github.ambry.server.StatsSnapshot;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -145,6 +146,11 @@ public class MockHelixParticipant extends HelixParticipant {
   @Override
   public List<String> getStoppedReplicas() {
     return stoppedReplicas.stream().map(r -> r.getPartitionId().toPathString()).collect(Collectors.toList());
+  }
+
+  @Override
+  public List<String> getDisabledReplicas() {
+    return disabledReplicas.stream().map(r -> r.getPartitionId().toPathString()).collect(Collectors.toList());
   }
 
   @Override

--- a/ambry-replication/src/test/java/com/github/ambry/replication/InMemoryStore.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/InMemoryStore.java
@@ -466,7 +466,7 @@ class InMemoryStore implements Store {
   }
 
   @Override
-  public boolean disabledOnError() {
+  public boolean isDisabled() {
     throw new UnsupportedOperationException("Method not supported");
   }
 

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryServerRequests.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryServerRequests.java
@@ -57,6 +57,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,11 +67,6 @@ import org.slf4j.LoggerFactory;
  * handled by this class
  */
 public class AmbryServerRequests extends AmbryRequests {
-  private final ServerConfig serverConfig;
-  private final StatsManager statsManager;
-  private final ClusterParticipant clusterParticipant;
-  private final ConcurrentHashMap<RequestOrResponseType, Set<PartitionId>> requestsDisableInfo =
-      new ConcurrentHashMap<>();
   // POST requests are allowed on stores states: { LEADER, STANDBY }
   static final Set<ReplicaState> PUT_ALLOWED_STORE_STATES = EnumSet.of(ReplicaState.LEADER, ReplicaState.STANDBY);
   // UPDATE requests (including DELETE, TTLUpdate, UNDELETE) are allowed on stores states: { LEADER, STANDBY, INACTIVE, BOOTSTRAP }
@@ -79,8 +75,12 @@ public class AmbryServerRequests extends AmbryRequests {
   static final Set<RequestOrResponseType> UPDATE_REQUEST_TYPES =
       EnumSet.of(RequestOrResponseType.DeleteRequest, RequestOrResponseType.TtlUpdateRequest,
           RequestOrResponseType.UndeleteRequest);
-
   private static final Logger logger = LoggerFactory.getLogger(AmbryServerRequests.class);
+  private final ServerConfig serverConfig;
+  private final StatsManager statsManager;
+  private final ClusterParticipant clusterParticipant;
+  private final ConcurrentHashMap<RequestOrResponseType, Set<PartitionId>> requestsDisableInfo =
+      new ConcurrentHashMap<>();
 
   AmbryServerRequests(StoreManager storeManager, RequestResponseChannel requestResponseChannel, ClusterMap clusterMap,
       DataNodeId nodeId, MetricRegistry registry, ServerMetrics serverMetrics, FindTokenHelper findTokenHelper,
@@ -434,10 +434,14 @@ public class AmbryServerRequests extends AmbryRequests {
       logger.error("Could not enable replication on {}", partitionIds);
       return ServerErrorCode.Unknown_Error;
     }
-    // startBlobStore should guarantee that store is started, so return value shouldn't be null
-    Store store = storeManager.getStore(partitionId);
-    // 4. reset partition state if it's offline (will trigger state transition)
-    if (store.getCurrentState() == ReplicaState.OFFLINE && clusterParticipant != null) {
+    // 4. reset partition state if it's in error state (will trigger state transition)
+    boolean isLocalStoreInErrorState =
+        partitionId.getReplicaIdsByState(ReplicaState.ERROR, currentNode.getDatacenterName())
+            .stream()
+            .map(r -> r.getDataNodeId().getHostname())
+            .collect(Collectors.toSet())
+            .contains(currentNode.getHostname());
+    if (isLocalStoreInErrorState && clusterParticipant != null) {
       if (!clusterParticipant.resetPartitionState(partitionId.toPathString())) {
         logger.error("Failed to reset partition {}", partitionId);
         return ServerErrorCode.Unknown_Error;
@@ -505,6 +509,16 @@ public class AmbryServerRequests extends AmbryRequests {
         logger.error("Fail to add BlobStore(s) {} to stopped list after stop operation completed",
             failToUpdateList.toArray());
         error = ServerErrorCode.Unknown_Error;
+      }
+      // After store is shut down and stopped state is updated, we also need to temporarily disable this replica if Helix
+      // is adopted. The intention here is to make Helix re-elect leader replica if necessary.
+      if (storeManager instanceof StorageManager && clusterParticipant != null) {
+        // Previous operation has guaranteed the store is not null
+        Store store = ((StorageManager) storeManager).getStore(partitionId, true);
+        // Setting disable state will trigger transition error at the very beginning of STANDBY -> INACTIVE transition.
+        // Thus it doesn't go through decommission process.
+        ((BlobStore) store).setDisableState(true);
+        clusterParticipant.setReplicaDisabledState(storeManager.getReplica(partitionId.toPathString()), true);
       }
     } else {
       error = ServerErrorCode.Unknown_Error;

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryServerRequests.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryServerRequests.java
@@ -57,7 +57,6 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -438,9 +437,7 @@ public class AmbryServerRequests extends AmbryRequests {
     boolean isLocalStoreInErrorState =
         partitionId.getReplicaIdsByState(ReplicaState.ERROR, currentNode.getDatacenterName())
             .stream()
-            .map(r -> r.getDataNodeId().getHostname())
-            .collect(Collectors.toSet())
-            .contains(currentNode.getHostname());
+            .anyMatch(r -> r.getDataNodeId().getHostname().equals(currentNode.getHostname()));
     if (isLocalStoreInErrorState && clusterParticipant != null) {
       if (!clusterParticipant.resetPartitionState(partitionId.toPathString())) {
         logger.error("Failed to reset partition {}", partitionId);

--- a/ambry-server/src/test/java/com/github/ambry/server/StatsManagerTest.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/StatsManagerTest.java
@@ -787,7 +787,7 @@ public class StatsManagerTest {
     }
 
     @Override
-    public boolean disabledOnError() {
+    public boolean isDisabled() {
       throw new IllegalStateException("Not implemented");
     }
 

--- a/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
@@ -562,10 +562,11 @@ public class StorageManager implements StoreManager {
           throw new StateTransitionException("Store " + partitionName + " is not found on current node",
               ReplicaNotFound);
         }
-        if (localStore.disabledOnError()) {
-          // if store is disabled due to disk I/O error, we explicitly throw an exception to mark partition as ERROR state
-          throw new StateTransitionException("Store " + partitionName + " is disabled due to I/O error",
-              ReplicaOperationFailure);
+        if (localStore.isDisabled()) {
+          // if store is disabled due to disk I/O error or by admin operation, we explicitly throw an exception to mark
+          // partition in Helix ERROR state
+          throw new StateTransitionException("Store " + partitionName + " is already disabled due to I/O error or by "
+              + "admin operation", ReplicaOperationFailure);
         }
         // 0. as long as local replica exists, we create a decommission file in its dir
         File decommissionFile = new File(replica.getReplicaPath(), BlobStore.DECOMMISSION_FILE_NAME);

--- a/ambry-store/src/test/java/com/github/ambry/store/StorageManagerTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/StorageManagerTest.java
@@ -394,14 +394,14 @@ public class StorageManagerTest {
     storageManager.startBlobStore(localReplica.getPartitionId());
     // 5. store is disabled due to disk I/O error
     BlobStore localStore = (BlobStore) storageManager.getStore(localReplica.getPartitionId());
-    localStore.setDisabledOnError(true);
+    localStore.setDisableState(true);
     try {
       mockHelixParticipant.onPartitionBecomeInactiveFromStandby(localReplica.getPartitionId().toPathString());
       fail("should fail because store is disabled");
     } catch (StateTransitionException e) {
       assertEquals("Error code doesn't match", ReplicaOperationFailure, e.getErrorCode());
     }
-    localStore.setDisabledOnError(false);
+    localStore.setDisableState(false);
     // 6. success case (verify both replica's state and decommission file)
     mockHelixParticipant.onPartitionBecomeInactiveFromStandby(localReplica.getPartitionId().toPathString());
     assertEquals("local store state should be set to INACTIVE", ReplicaState.INACTIVE,


### PR DESCRIPTION
This PR will fix two issues regarding "stop replica":

1. Previous stop replica method didn't change the state of replica in Helix state engine (only added it to "stopped" list in InstanceConfig). This becomes a problem for leader-based replication when a leader replica is stopped and Helix still believes it's leader, which will block cross-colo replication. 

2. Since replica state doesn't change in Helix while being stopped,  the stopped replica may still stay in STANDBY/LEADER state when we try to restart it. Our code calls "resetPartitionState" at the end of "start replica". This will throw exception because Helix doesn't support resetting a non-error replica. 

To address above issues, this PR makes following changes
(1)  adds logic to explicitly disable replica when stopping a replica (to trigger state transition and potential leader election);
(2) checks if the stopped replica is in ERROR state and decide whether to reset the partition.
