### PR TITLE
[StorageQuota]Add monthly base account reports in aggregation task

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
@@ -296,6 +296,15 @@ public class ClusterMapConfig {
   @Config("clustermap.retry.disable.partition.completion.backoff.ms")
   public final int clustermapRetryDisablePartitionCompletionBackoffMs;
 
+  public static final String ENABLE_AGGREGATED_MONTHLY_ACCOUNT_REPORT =
+      "clustermap.enable.aggregated.monthly.account.report";
+  /**
+   * True to enable aggregation task to generate a base account report for each month.
+   */
+  @Config(ENABLE_AGGREGATED_MONTHLY_ACCOUNT_REPORT)
+  @Default("false")
+  public final boolean clustermapEnableAggregatedMonthlyAccountReport;
+
   public ClusterMapConfig(VerifiableProperties verifiableProperties) {
     clusterMapFixedTimeoutDatanodeErrorThreshold =
         verifiableProperties.getIntInRange("clustermap.fixedtimeout.datanode.error.threshold", 3, 1, 100);
@@ -361,5 +370,7 @@ public class ClusterMapConfig {
     clustermapRetryDisablePartitionCompletionBackoffMs =
         verifiableProperties.getIntInRange("clustermap.retry.disable.partition.completion.backoff.ms", 10 * 1000, 1,
             Integer.MAX_VALUE);
+    clustermapEnableAggregatedMonthlyAccountReport =
+        verifiableProperties.getBoolean(ENABLE_AGGREGATED_MONTHLY_ACCOUNT_REPORT, false);
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
@@ -31,6 +31,8 @@ public class ClusterMapConfig {
   public static final String AMBRY_STATE_MODEL_DEF = "AmbryLeaderStandby";
   public static final String OLD_STATE_MODEL_DEF = "LeaderStandby";
   public static final String DEFAULT_STATE_MODEL_DEF = AMBRY_STATE_MODEL_DEF;
+  public static final String ENABLE_AGGREGATED_MONTHLY_ACCOUNT_REPORT =
+      "clustermap.enable.aggregated.monthly.account.report";
   private static final String MAX_REPLICAS_ALL_DATACENTERS = "max-replicas-all-datacenters";
 
   /**
@@ -296,8 +298,6 @@ public class ClusterMapConfig {
   @Config("clustermap.retry.disable.partition.completion.backoff.ms")
   public final int clustermapRetryDisablePartitionCompletionBackoffMs;
 
-  public static final String ENABLE_AGGREGATED_MONTHLY_ACCOUNT_REPORT =
-      "clustermap.enable.aggregated.monthly.account.report";
   /**
    * True to enable aggregation task to generate a base account report for each month.
    */

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixHealthReportAggregatorTask.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixHealthReportAggregatorTask.java
@@ -134,20 +134,20 @@ class HelixHealthReportAggregatorTask extends UserContentStore implements Task {
             String.format("%s%s%s", AGGREGATED_REPORT_PREFIX, healthReportName, AGGREGATED_MONTHLY_REPORT_SUFFIX);
         path = String.format("/%s", resultId);
         Stat stat = new Stat();
-        ZNRecord monthBaseReportZNRecord = manager.getHelixPropertyStore().get(path, stat, AccessOption.PERSISTENT);
+        ZNRecord monthlyReportZNRecord = manager.getHelixPropertyStore().get(path, stat, AccessOption.PERSISTENT);
         String currentMonthValue =
             LocalDateTime.ofEpochSecond(time.seconds(), 0, zoneOffset).format(TIMESTAMP_FORMATTER);
-        if (monthBaseReportZNRecord == null || !currentMonthValue.equals(
-            monthBaseReportZNRecord.getSimpleField(MONTH_NAME))) {
-          monthBaseReportZNRecord = new ZNRecord(resultId);
-          monthBaseReportZNRecord.setSimpleField(MONTH_NAME, currentMonthValue);
-          monthBaseReportZNRecord.setSimpleField(RAW_VALID_SIZE_FIELD_NAME,
-              mapper.writeValueAsString(results.getFirst()));
-          monthBaseReportZNRecord.setSimpleField(VALID_SIZE_FIELD_NAME, mapper.writeValueAsString(results.getSecond()));
-          monthBaseReportZNRecord.setSimpleField(TIMESTAMP_FIELD_NAME, String.valueOf(time.milliseconds()));
-          monthBaseReportZNRecord.setListField(ERROR_OCCURRED_INSTANCES_FIELD_NAME,
+        if (monthlyReportZNRecord == null || !currentMonthValue.equals(
+            monthlyReportZNRecord.getSimpleField(MONTH_NAME))) {
+          monthlyReportZNRecord = new ZNRecord(resultId);
+          monthlyReportZNRecord.setSimpleField(MONTH_NAME, currentMonthValue);
+          monthlyReportZNRecord.setSimpleField(RAW_VALID_SIZE_FIELD_NAME,
+              znRecord.getSimpleField(RAW_VALID_SIZE_FIELD_NAME));
+          monthlyReportZNRecord.setSimpleField(VALID_SIZE_FIELD_NAME, znRecord.getSimpleField(VALID_SIZE_FIELD_NAME));
+          monthlyReportZNRecord.setSimpleField(TIMESTAMP_FIELD_NAME, String.valueOf(time.milliseconds()));
+          monthlyReportZNRecord.setListField(ERROR_OCCURRED_INSTANCES_FIELD_NAME,
               clusterAggregator.getExceptionOccurredInstances(statsReportType));
-          manager.getHelixPropertyStore().set(path, monthBaseReportZNRecord, AccessOption.PERSISTENT);
+          manager.getHelixPropertyStore().set(path, monthlyReportZNRecord, AccessOption.PERSISTENT);
         }
       }
       return new TaskResult(TaskResult.Status.COMPLETED, "Aggregation success");

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixHealthReportAggregatorTask.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixHealthReportAggregatorTask.java
@@ -20,6 +20,11 @@ import com.github.ambry.server.StatsReportType;
 import com.github.ambry.server.StatsSnapshot;
 import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.SystemTime;
+import com.github.ambry.utils.Time;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -33,6 +38,7 @@ import org.apache.helix.task.TaskCallbackContext;
 import org.apache.helix.task.TaskResult;
 import org.apache.helix.task.UserContentStore;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.zookeeper.data.Stat;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,18 +48,24 @@ import org.slf4j.LoggerFactory;
  * Helix task to aggregate health reports across all storage nodes and update the helix property store with the result
  */
 class HelixHealthReportAggregatorTask extends UserContentStore implements Task {
+  static final String AGGREGATED_REPORT_PREFIX = "Aggregated_";
+  static final String AGGREGATED_MONTHLY_REPORT_SUFFIX = "_Month_Base";
+  static final String RAW_VALID_SIZE_FIELD_NAME = "raw_valid_data_size";
+  static final String VALID_SIZE_FIELD_NAME = "valid_data_size";
+  static final String MONTH_NAME = "month";
   public static final String TASK_COMMAND_PREFIX = "aggregate";
-  private static final String RAW_VALID_SIZE_FIELD_NAME = "raw_valid_data_size";
-  private static final String VALID_SIZE_FIELD_NAME = "valid_data_size";
   private static final String TIMESTAMP_FIELD_NAME = "timestamp";
   private static final String ERROR_OCCURRED_INSTANCES_FIELD_NAME = "error_occurred_instances";
+  private static final ZoneOffset zoneOffset = ZoneId.systemDefault().getRules().getOffset(LocalDateTime.now());
+  static final DateTimeFormatter TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM");
   private final HelixManager manager;
   private final HelixClusterAggregator clusterAggregator;
   private final String healthReportName;
   private final String statsFieldName;
   private final StatsReportType statsReportType;
   private final ClusterMapConfig clusterMapConfig;
-  public final Callback<StatsSnapshot> callback;
+  private final Callback<StatsSnapshot> callback;
+  private final Time time;
   private static final Logger logger = LoggerFactory.getLogger(HelixHealthReportAggregatorTask.class);
 
   /**
@@ -70,13 +82,21 @@ class HelixHealthReportAggregatorTask extends UserContentStore implements Task {
   HelixHealthReportAggregatorTask(TaskCallbackContext context, long relevantTimePeriodInMs, String healthReportName,
       String statsFieldName, StatsReportType statsReportType, Callback<StatsSnapshot> callback,
       ClusterMapConfig clusterMapConfig) {
-    manager = context.getManager();
+    this(context.getManager(), relevantTimePeriodInMs, healthReportName, statsFieldName, statsReportType, callback,
+        clusterMapConfig, SystemTime.getInstance());
+  }
+
+  HelixHealthReportAggregatorTask(HelixManager manager, long relevantTimePeriodInMs, String healthReportName,
+      String statsFieldName, StatsReportType statsReportType, Callback<StatsSnapshot> callback,
+      ClusterMapConfig clusterMapConfig, Time time) {
+    this.manager = manager;
     clusterAggregator = new HelixClusterAggregator(relevantTimePeriodInMs);
     this.healthReportName = healthReportName;
     this.statsFieldName = statsFieldName;
     this.statsReportType = statsReportType;
     this.callback = callback;
     this.clusterMapConfig = clusterMapConfig;
+    this.time = time;
   }
 
   @Override
@@ -96,15 +116,40 @@ class HelixHealthReportAggregatorTask extends UserContentStore implements Task {
       }
       ObjectMapper mapper = new ObjectMapper();
       results = clusterAggregator.doWork(statsWrappersJSON, statsReportType);
-      String resultId = String.format("Aggregated_%s", healthReportName);
+      String resultId = String.format("%s%s", AGGREGATED_REPORT_PREFIX, healthReportName);
       ZNRecord znRecord = new ZNRecord(resultId);
       znRecord.setSimpleField(RAW_VALID_SIZE_FIELD_NAME, mapper.writeValueAsString(results.getFirst()));
       znRecord.setSimpleField(VALID_SIZE_FIELD_NAME, mapper.writeValueAsString(results.getSecond()));
-      znRecord.setSimpleField(TIMESTAMP_FIELD_NAME, String.valueOf(SystemTime.getInstance().milliseconds()));
+      znRecord.setSimpleField(TIMESTAMP_FIELD_NAME, String.valueOf(time.milliseconds()));
       znRecord.setListField(ERROR_OCCURRED_INSTANCES_FIELD_NAME,
           clusterAggregator.getExceptionOccurredInstances(statsReportType));
       String path = String.format("/%s", resultId);
       manager.getHelixPropertyStore().set(path, znRecord, AccessOption.PERSISTENT);
+
+      // Create a base report at the beginning of each month.
+      // Check if there is a base report for this month or not.
+      if (clusterMapConfig.clustermapEnableAggregatedMonthlyAccountReport
+          && statsReportType == StatsReportType.ACCOUNT_REPORT) {
+        resultId =
+            String.format("%s%s%s", AGGREGATED_REPORT_PREFIX, healthReportName, AGGREGATED_MONTHLY_REPORT_SUFFIX);
+        path = String.format("/%s", resultId);
+        Stat stat = new Stat();
+        ZNRecord monthBaseReportZNRecord = manager.getHelixPropertyStore().get(path, stat, AccessOption.PERSISTENT);
+        String currentMonthValue =
+            LocalDateTime.ofEpochSecond(time.seconds(), 0, zoneOffset).format(TIMESTAMP_FORMATTER);
+        if (monthBaseReportZNRecord == null || !currentMonthValue.equals(
+            monthBaseReportZNRecord.getSimpleField(MONTH_NAME))) {
+          monthBaseReportZNRecord = new ZNRecord(resultId);
+          monthBaseReportZNRecord.setSimpleField(MONTH_NAME, currentMonthValue);
+          monthBaseReportZNRecord.setSimpleField(RAW_VALID_SIZE_FIELD_NAME,
+              mapper.writeValueAsString(results.getFirst()));
+          monthBaseReportZNRecord.setSimpleField(VALID_SIZE_FIELD_NAME, mapper.writeValueAsString(results.getSecond()));
+          monthBaseReportZNRecord.setSimpleField(TIMESTAMP_FIELD_NAME, String.valueOf(time.milliseconds()));
+          monthBaseReportZNRecord.setListField(ERROR_OCCURRED_INSTANCES_FIELD_NAME,
+              clusterAggregator.getExceptionOccurredInstances(statsReportType));
+          manager.getHelixPropertyStore().set(path, monthBaseReportZNRecord, AccessOption.PERSISTENT);
+        }
+      }
       return new TaskResult(TaskResult.Status.COMPLETED, "Aggregation success");
     } catch (Exception e) {
       logger.error("Exception thrown while aggregating stats from health reports across all nodes ", e);

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixHealthReportAggregationTaskTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixHealthReportAggregationTaskTest.java
@@ -1,0 +1,252 @@
+/**
+ * Copyright 2020 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.clustermap;
+
+import com.github.ambry.config.ClusterMapConfig;
+import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.server.StatsReportType;
+import com.github.ambry.server.StatsSnapshot;
+import com.github.ambry.server.StatsWrapper;
+import com.github.ambry.utils.MockTime;
+import com.github.ambry.utils.SystemTime;
+import com.github.ambry.utils.TestUtils;
+import com.github.ambry.utils.Time;
+import java.io.File;
+import java.io.IOException;
+import java.net.BindException;
+import java.nio.file.Files;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+import java.util.Random;
+import org.apache.helix.AccessOption;
+import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.HelixProperty;
+import org.apache.helix.InstanceType;
+import org.apache.helix.PropertyKey;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.zookeeper.data.Stat;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+
+/**
+ * Unit test class for {@link HelixHealthReportAggregatorTask}.
+ */
+@RunWith(Parameterized.class)
+public class HelixHealthReportAggregationTaskTest {
+  private static final String CLUSTER_NAME = "Ambry-prod";
+  private static final String INSTANCE_NAME = "helix.ambry.com";
+  private static final long RELEVANT_PERIOD_IN_MINUTES = 60;
+  private static final String HEALTH_REPORT_NAME_ACCOUNT = "AccountReport";
+  private static final String STATS_FIELD_NAME_ACCOUNT = "AccountStats";
+  private static final String HEALTH_REPORT_NAME_PARTITION = "PartitionClassReport";
+  private static final String STATS_FIELD_NAME_PARTITION = "PartitionClassStats";
+  private MockHelixManager mockHelixManager;
+  private HelixHealthReportAggregatorTask task;
+  private MockTime mockTime;
+  private MockHelixAdmin mockHelixAdmin;
+  private ClusterMapConfig clusterMapConfig;
+  private TestUtils.ZkInfo zkInfo;
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  private final boolean enableAggregatedMonthlyAccountReport;
+
+  @Parameterized.Parameters
+  public static List<Object[]> data() {
+    return Arrays.asList(new Object[][]{{false}, {true}});
+  }
+
+  public HelixHealthReportAggregationTaskTest(boolean enableAggregatedMonthlyAccountReport) throws IOException {
+    this.enableAggregatedMonthlyAccountReport = enableAggregatedMonthlyAccountReport;
+    File tempDir = Files.createTempDirectory("HelixHealthReportAggregationTask-" + new Random().nextInt(1000)).toFile();
+    String tempDirPath = tempDir.getAbsolutePath();
+    int zkPort = 13188;
+    int maxRetries = 1000;
+    int numRetries = 0;
+    while (true) {
+      if (numRetries > maxRetries) {
+        throw new IOException("No ports are available to start zookeeper server");
+      }
+      try {
+        zkInfo = new TestUtils.ZkInfo(tempDirPath, "DC1", (byte) 0, zkPort, true);
+        break;
+      } catch (Exception e) {
+        if (e instanceof BindException || e.getCause() instanceof BindException) {
+          System.out.println("Port " + zkPort + " already in use, try " + (zkPort + 1) + " instead");
+          zkPort++;
+          numRetries++;
+        } else {
+          throw new RuntimeException(e);
+        }
+      }
+    }
+    String zkAddr = "localhost:" + String.valueOf(zkInfo.getPort());
+
+    mockHelixAdmin = new MockHelixAdminFactory().getHelixAdmin(zkAddr);
+    mockHelixManager =
+        new MockHelixManager(INSTANCE_NAME, InstanceType.PARTICIPANT, zkAddr, CLUSTER_NAME, mockHelixAdmin, null, null);
+    mockTime = new MockTime(SystemTime.getInstance().milliseconds());
+  }
+
+  @After
+  public void after() {
+    zkInfo.shutdown();
+  }
+
+  private ClusterMapConfig makeClusterMapConfig() {
+    Properties props = new Properties();
+    props.setProperty("clustermap.host.name", INSTANCE_NAME);
+    props.setProperty("clustermap.cluster.name", CLUSTER_NAME);
+    props.setProperty("clustermap.datacenter.name", "DC1");
+    props.setProperty(ClusterMapConfig.ENABLE_AGGREGATED_MONTHLY_ACCOUNT_REPORT,
+        Boolean.toString(this.enableAggregatedMonthlyAccountReport));
+    return new ClusterMapConfig(new VerifiableProperties(props));
+  }
+
+  /**
+   * Test {@link HelixHealthReportAggregatorTask#run()} method.
+   * @throws Exception
+   */
+  @Test
+  public void testAggregationTask() throws Exception {
+    int port = 10000;
+    int numNode = 3;
+    for (StatsReportType type : StatsReportType.values()) {
+      initializeNodeReports(type, numNode, port);
+
+      String healthReportName =
+          type == StatsReportType.ACCOUNT_REPORT ? HEALTH_REPORT_NAME_ACCOUNT : HEALTH_REPORT_NAME_PARTITION;
+      String statsFieldName =
+          type == StatsReportType.ACCOUNT_REPORT ? STATS_FIELD_NAME_ACCOUNT : STATS_FIELD_NAME_PARTITION;
+      clusterMapConfig = makeClusterMapConfig();
+      task = new HelixHealthReportAggregatorTask(mockHelixManager, RELEVANT_PERIOD_IN_MINUTES, healthReportName,
+          statsFieldName, type, null, clusterMapConfig, mockTime);
+      task.run();
+
+      // Verify the targeted znode has value, don't worry about the correctness of the value, it's verified by other tests.
+      Stat stat = new Stat();
+      ZNRecord record = mockHelixManager.getHelixPropertyStore()
+          .get(String.format("/%s%s", HelixHealthReportAggregatorTask.AGGREGATED_REPORT_PREFIX, healthReportName), stat,
+              AccessOption.PERSISTENT);
+      Assert.assertNotNull(record);
+      Assert.assertNotNull(record.getSimpleField(HelixHealthReportAggregatorTask.VALID_SIZE_FIELD_NAME));
+      Assert.assertNotNull(record.getSimpleField(HelixHealthReportAggregatorTask.RAW_VALID_SIZE_FIELD_NAME));
+
+      if (type == StatsReportType.ACCOUNT_REPORT && this.enableAggregatedMonthlyAccountReport) {
+        record = mockHelixManager.getHelixPropertyStore()
+            .get(String.format("/%s%s%s", HelixHealthReportAggregatorTask.AGGREGATED_REPORT_PREFIX, healthReportName,
+                HelixHealthReportAggregatorTask.AGGREGATED_MONTHLY_REPORT_SUFFIX), stat, AccessOption.PERSISTENT);
+        Assert.assertNotNull(record);
+        Assert.assertNotNull(record.getSimpleField(HelixHealthReportAggregatorTask.VALID_SIZE_FIELD_NAME));
+        Assert.assertNotNull(record.getSimpleField(HelixHealthReportAggregatorTask.RAW_VALID_SIZE_FIELD_NAME));
+        Assert.assertNotNull(record.getSimpleField(HelixHealthReportAggregatorTask.MONTH_NAME));
+      }
+    }
+  }
+
+  /**
+   * Test aggregation task on different month to verify if the new monthly account reports are generated.
+   * @throws Exception
+   */
+  @Test
+  public void testAggregationOnNewMonth() throws Exception {
+    Assume.assumeTrue(enableAggregatedMonthlyAccountReport);
+    initializeNodeReports(StatsReportType.ACCOUNT_REPORT, 3, 1000);
+
+    clusterMapConfig = makeClusterMapConfig();
+    task = new HelixHealthReportAggregatorTask(mockHelixManager, RELEVANT_PERIOD_IN_MINUTES, HEALTH_REPORT_NAME_ACCOUNT,
+        STATS_FIELD_NAME_ACCOUNT, StatsReportType.ACCOUNT_REPORT, null, clusterMapConfig, mockTime);
+    task.run();
+
+    Stat stat = new Stat();
+    ZNRecord record = mockHelixManager.getHelixPropertyStore()
+        .get(String.format("/%s%s%s", HelixHealthReportAggregatorTask.AGGREGATED_REPORT_PREFIX,
+            HEALTH_REPORT_NAME_ACCOUNT, HelixHealthReportAggregatorTask.AGGREGATED_MONTHLY_REPORT_SUFFIX), stat,
+            AccessOption.PERSISTENT);
+    Assert.assertNotNull(record);
+    Assert.assertNotNull(record.getSimpleField(HelixHealthReportAggregatorTask.VALID_SIZE_FIELD_NAME));
+    Assert.assertNotNull(record.getSimpleField(HelixHealthReportAggregatorTask.RAW_VALID_SIZE_FIELD_NAME));
+    Assert.assertNotNull(record.getSimpleField(HelixHealthReportAggregatorTask.MONTH_NAME));
+
+    String previousMonth = record.getSimpleField(HelixHealthReportAggregatorTask.MONTH_NAME);
+
+    // Moving timestamp to next month, we should get a different ZNRecord with different month value.
+    ZoneOffset zoneOffset = ZoneId.systemDefault().getRules().getOffset(LocalDateTime.now());
+    LocalDateTime dateTime = LocalDateTime.ofEpochSecond(mockTime.seconds(), 0, zoneOffset);
+    long secondsNextMonth = dateTime.plusMonths(1).atOffset(zoneOffset).toEpochSecond();
+    mockTime.sleep(secondsNextMonth * Time.MsPerSec - mockTime.milliseconds());
+    // Now it's should be a month later
+
+    task.run();
+
+    record = mockHelixManager.getHelixPropertyStore()
+        .get(String.format("/%s%s%s", HelixHealthReportAggregatorTask.AGGREGATED_REPORT_PREFIX,
+            HEALTH_REPORT_NAME_ACCOUNT, HelixHealthReportAggregatorTask.AGGREGATED_MONTHLY_REPORT_SUFFIX), stat,
+            AccessOption.PERSISTENT);
+    Assert.assertNotNull(record);
+    Assert.assertNotNull(record.getSimpleField(HelixHealthReportAggregatorTask.MONTH_NAME));
+    String currentMonth = record.getSimpleField(HelixHealthReportAggregatorTask.MONTH_NAME);
+    Assert.assertFalse(previousMonth.equals(currentMonth));
+  }
+
+  /**
+   * Initialize the reports and create instances in helix if not exists.
+   * @param type The type of reports to create
+   * @param numNode The number of nodes to initiate.
+   * @param startingPort The starting port number, which will then be incremented to represent different nodes.
+   * @throws IOException
+   */
+  private void initializeNodeReports(StatsReportType type, int numNode, int startingPort) throws IOException {
+    String healthReportName =
+        type == StatsReportType.ACCOUNT_REPORT ? HEALTH_REPORT_NAME_ACCOUNT : HEALTH_REPORT_NAME_PARTITION;
+    String statsFieldName =
+        type == StatsReportType.ACCOUNT_REPORT ? STATS_FIELD_NAME_ACCOUNT : STATS_FIELD_NAME_PARTITION;
+    List<StatsSnapshot> storeSnapshots = new ArrayList<>();
+    Random random = new Random();
+    for (int i = 3; i < 6; i++) {
+      storeSnapshots.add(TestUtils.generateStoreStats(i, 3, random, type));
+    }
+    StatsWrapper nodeStats = TestUtils.generateNodeStats(storeSnapshots, 1000, type);
+    String nodeStatsJSON = mapper.writeValueAsString(nodeStats);
+
+    HelixDataAccessor dataAccessor = mockHelixManager.getHelixDataAccessor();
+    for (int i = 0; i < numNode; i++) {
+      String instanceName = ClusterMapUtils.getInstanceName("localhost", startingPort);
+      InstanceConfig instanceConfig = new InstanceConfig(instanceName);
+      instanceConfig.setHostName("localhost");
+      instanceConfig.setPort(Integer.toString(startingPort));
+      mockHelixAdmin.addInstance(CLUSTER_NAME, instanceConfig);
+
+      PropertyKey key = dataAccessor.keyBuilder().healthReport(instanceName, healthReportName);
+      ZNRecord znRecord = new ZNRecord(instanceName);
+      // Set the same reports for all instances
+      znRecord.setSimpleField(statsFieldName, nodeStatsJSON);
+      HelixProperty helixProperty = new HelixProperty(znRecord);
+      dataAccessor.setProperty(key, helixProperty);
+
+      startingPort++;
+    }
+  }
+}

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixDataAccessor.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixDataAccessor.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.helix.BaseDataAccessor;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixProperty;
@@ -45,6 +46,7 @@ public class MockHelixDataAccessor implements HelixDataAccessor {
   private final String clusterName;
   private final PropertyKey.Builder propertyKeyBuilder;
   private final MockHelixAdmin mockHelixAdmin;
+  private Map<PropertyKey, HelixProperty> properties = new ConcurrentHashMap<>();
 
   MockHelixDataAccessor(String clusterName, MockHelixAdmin mockHelixAdmin) {
     this.clusterName = clusterName;
@@ -81,7 +83,8 @@ public class MockHelixDataAccessor implements HelixDataAccessor {
 
   @Override
   public <T extends HelixProperty> boolean setProperty(PropertyKey key, T value) {
-    throw new UnsupportedOperationException("Unsupported in MockHelixDataAccessor");
+    properties.put(key, value);
+    return true;
   }
 
   @Override
@@ -96,8 +99,7 @@ public class MockHelixDataAccessor implements HelixDataAccessor {
 
   @Override
   public <T extends HelixProperty> T getProperty(PropertyKey key) {
-    //return (T) (new HelixProperty("id"));
-    throw new UnsupportedOperationException("Unsupported in MockHelixDataAccessor");
+    return (T) getProperty(Collections.singletonList(key), false).get(0);
   }
 
   @Override
@@ -134,6 +136,8 @@ public class MockHelixDataAccessor implements HelixDataAccessor {
             .findFirst()
             .get();
         result.add((T) instanceConfig);
+      } else {
+        result.add((T) properties.get(key));
       }
     }
     return result;


### PR DESCRIPTION
In order for frontend to know each container's usage of current month, we have to create a monthly account report as the base value. The logic works like this:
1. Aggregation task creates a base report to each month, for example, April.
2. Every 10 minutes, the aggregation task creates a report of current storage usage of each container.
3. Frontend receives this current report and subtract it from monthly base report, so frontend would know the storage usage of each container for this month.
4. Frontend has a quota source to fetch the monthly quota for all containers.
5. Frontend compares the usage against the quota.