### PR TITLE
Separate store tests into separate travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,11 @@ install: skip # skips unnecessary ./gradlew assemble (https://docs.travis-ci.com
 jobs:
   include:
     - stage: test
-      name: "Unit Tests"
+      name: "Unit Tests excluding ambry-store"
       script: ./travis-unit-test.sh
+    - stage: test
+      name: "Unit Tests for ambry-store"
+      script: ./travis-store-test.sh
     - stage: test
       name: "Integration Tests"
       script: ./travis-int-test.sh

--- a/travis-store-test.sh
+++ b/travis-store-test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# exit when any command fails
+set -e
+
+echo "Building and running unit tests for ambry-store"
+./gradlew -s --scan :ambry-store:test codeCoverageReport
+
+echo "Uploading unit test coverage for ambry-store to codecov"
+bash <(curl -s https://codecov.io/bash)

--- a/travis-unit-test.sh
+++ b/travis-unit-test.sh
@@ -3,8 +3,8 @@
 # exit when any command fails
 set -e
 
-echo "Building and running unit tests"
-./gradlew -s --scan build codeCoverageReport
+echo "Building and running unit tests excluding ambry-store"
+./gradlew -s --scan -x :ambry-store:test build codeCoverageReport
 
-echo "Uploading unit test coverage to codecov"
+echo "Uploading unit test coverage excluding ambry-store to codecov"
 bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
ambry-store has the longest running test suite. Separating it out into
its own parallel travis job can help speed up total build time.