### PR TITLE
Ignore version mismatch temporarily in MySqlAccountService while updating Accounts and Containers

### DIFF
--- a/ambry-account/src/main/java/com/github/ambry/account/AbstractAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/AbstractAccountService.java
@@ -131,6 +131,7 @@ abstract class AbstractAccountService implements AccountService {
         }
       } else {
         // existing container
+        //TODO: Include condition to check version as well after moving to MySql only.
         Container existingContainer = existingContainersInAccount.get(container.getName());
         if (existingContainer == null) {
           throw new AccountServiceException(
@@ -140,11 +141,6 @@ abstract class AbstractAccountService implements AccountService {
           throw new AccountServiceException(
               "In account " + accountName + ", container " + container.getName() + " has containerId "
                   + existingContainer.getId() + " (" + container.getId() + " was supplied)",
-              AccountServiceErrorCode.ResourceConflict);
-        } else if (existingContainer.getSnapshotVersion() != container.getSnapshotVersion()) {
-          throw new AccountServiceException(
-              "In account " + accountName + ", container " + container.getName() + " has version "
-                  + existingContainer.getSnapshotVersion() + " (" + container.getSnapshotVersion() + " was supplied)",
               AccountServiceErrorCode.ResourceConflict);
         } else {
           resolvedContainers.add(container);

--- a/ambry-account/src/main/java/com/github/ambry/account/AbstractAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/AbstractAccountService.java
@@ -131,7 +131,6 @@ abstract class AbstractAccountService implements AccountService {
         }
       } else {
         // existing container
-        //TODO: Include condition to check version as well after moving to MySql only.
         Container existingContainer = existingContainersInAccount.get(container.getName());
         if (existingContainer == null) {
           throw new AccountServiceException(
@@ -141,6 +140,12 @@ abstract class AbstractAccountService implements AccountService {
           throw new AccountServiceException(
               "In account " + accountName + ", container " + container.getName() + " has containerId "
                   + existingContainer.getId() + " (" + container.getId() + " was supplied)",
+              AccountServiceErrorCode.ResourceConflict);
+        } else if (!config.ignoreVersionMismatch
+            && existingContainer.getSnapshotVersion() != container.getSnapshotVersion()) {
+          throw new AccountServiceException(
+              "In account " + accountName + ", container " + container.getName() + " has version "
+                  + existingContainer.getSnapshotVersion() + " (" + container.getSnapshotVersion() + " was supplied)",
               AccountServiceErrorCode.ResourceConflict);
         } else {
           resolvedContainers.add(container);

--- a/ambry-account/src/main/java/com/github/ambry/account/AccountInfoMap.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/AccountInfoMap.java
@@ -163,6 +163,7 @@ class AccountInfoMap {
    * conflicting with each other if they have different account Ids but the same account name.
    *
    * @param accountsToSet The collection of {@link Account}s to check conflict.
+   * @param ignoreVersion {@code true} if mismatch in account version can be ignored.
    * @return {@code true} if there is at least one {@link Account} in {@code accountPairs} conflicts with the existing
    *                      {@link Account}s in {@link AccountInfoMap}, {@code false} otherwise.
    */
@@ -195,6 +196,7 @@ class AccountInfoMap {
    * different {@link Container} Ids but the same {@link Container} name.
    * @param containersToSet {@link Container}s to check for conflict
    * @param parentAccountId parent {@link Account} id of the {@link Container}.
+   * @param ignoreVersion {@code true} if mismatch in account version can be ignored.
    * @return true if there is any container under given parent account with same name but different id.
    */
   boolean hasConflictingContainer(Collection<Container> containersToSet, short parentAccountId, boolean ignoreVersion) {

--- a/ambry-account/src/main/java/com/github/ambry/account/AccountInfoMap.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/AccountInfoMap.java
@@ -166,11 +166,11 @@ class AccountInfoMap {
    * @return {@code true} if there is at least one {@link Account} in {@code accountPairs} conflicts with the existing
    *                      {@link Account}s in {@link AccountInfoMap}, {@code false} otherwise.
    */
-  boolean hasConflictingAccount(Collection<Account> accountsToSet) {
+  boolean hasConflictingAccount(Collection<Account> accountsToSet, boolean ignoreVersion) {
     for (Account account : accountsToSet) {
       // if the account already exists, check that the snapshot version matches the expected value.
       Account accountInMap = getAccountById(account.getId());
-      if (accountInMap != null && account.getSnapshotVersion() != accountInMap.getSnapshotVersion()) {
+      if (!ignoreVersion && accountInMap != null && account.getSnapshotVersion() != accountInMap.getSnapshotVersion()) {
         logger.error(
             "Account to update (accountId={} accountName={}) has an unexpected snapshot version in store (expected={}, encountered={})",
             account.getId(), account.getName(), account.getSnapshotVersion(), accountInMap.getSnapshotVersion());
@@ -197,11 +197,12 @@ class AccountInfoMap {
    * @param parentAccountId parent {@link Account} id of the {@link Container}.
    * @return true if there is any container under given parent account with same name but different id.
    */
-  boolean hasConflictingContainer(Collection<Container> containersToSet, short parentAccountId) {
+  boolean hasConflictingContainer(Collection<Container> containersToSet, short parentAccountId, boolean ignoreVersion) {
     for (Container container : containersToSet) {
       // if the container already exists, check that the snapshot version matches the expected value.
       Container containerInMap = getContainerByNameForAccount(container.getParentAccountId(), container.getName());
-      if (containerInMap != null && container.getSnapshotVersion() != containerInMap.getSnapshotVersion()) {
+      if (!ignoreVersion && containerInMap != null
+          && container.getSnapshotVersion() != containerInMap.getSnapshotVersion()) {
         logger.error(
             "Container to update in AccountId {} (containerId={} containerName={}) has an unexpected snapshot version in store (expected={}, encountered={})",
             parentAccountId, container.getId(), container.getName(), container.getSnapshotVersion(),

--- a/ambry-account/src/main/java/com/github/ambry/account/HelixAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/HelixAccountService.java
@@ -136,10 +136,10 @@ public class HelixAccountService extends AbstractAccountService implements Accou
         new BackupFileManager(this.accountServiceMetrics, config.backupDir, config.maxBackupFileCount);
     if (config.useNewZNodePath) {
       accountMetadataStore = new RouterStore(this.accountServiceMetrics, backupFileManager, helixStore, router, false,
-          config.totalNumberOfVersionToKeep);
+          config.totalNumberOfVersionToKeep, config);
       // postpone initializeFetchAndSchedule to setupRouter function.
     } else {
-      accountMetadataStore = new LegacyMetadataStore(this.accountServiceMetrics, backupFileManager, helixStore);
+      accountMetadataStore = new LegacyMetadataStore(this.accountServiceMetrics, backupFileManager, helixStore, config);
       initialFetchAndSchedule();
     }
   }
@@ -289,7 +289,7 @@ public class HelixAccountService extends AbstractAccountService implements Accou
     // update operation for all the accounts if any conflict exists. There is a slight chance that the account to update
     // conflicts with the accounts in the local cache, but does not conflict with those in the helixPropertyStore. This
     // will happen if some accounts are updated but the local cache is not refreshed.
-    if (accountInfoMapRef.get().hasConflictingAccount(accounts, false)) {
+    if (accountInfoMapRef.get().hasConflictingAccount(accounts, config.ignoreVersionMismatch)) {
       logger.debug("Accounts={} conflict with the accounts in local cache. Cancel the update operation.", accounts);
       accountServiceMetrics.updateAccountErrorCount.inc();
       throw new AccountServiceException("Input accounts conflict with the accounts in local cache",

--- a/ambry-account/src/main/java/com/github/ambry/account/HelixAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/HelixAccountService.java
@@ -289,7 +289,7 @@ public class HelixAccountService extends AbstractAccountService implements Accou
     // update operation for all the accounts if any conflict exists. There is a slight chance that the account to update
     // conflicts with the accounts in the local cache, but does not conflict with those in the helixPropertyStore. This
     // will happen if some accounts are updated but the local cache is not refreshed.
-    if (accountInfoMapRef.get().hasConflictingAccount(accounts)) {
+    if (accountInfoMapRef.get().hasConflictingAccount(accounts, false)) {
       logger.debug("Accounts={} conflict with the accounts in local cache. Cancel the update operation.", accounts);
       accountServiceMetrics.updateAccountErrorCount.inc();
       throw new AccountServiceException("Input accounts conflict with the accounts in local cache",

--- a/ambry-account/src/main/java/com/github/ambry/account/LegacyMetadataStore.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/LegacyMetadataStore.java
@@ -110,7 +110,7 @@ class LegacyMetadataStore extends AccountMetadataStore {
 
       // if there is any conflict with the existing record, fail the update. Exception thrown in this updater will
       // be caught by Helix and helixStore#update will return false.
-      if (remoteAccountInfoMap.hasConflictingAccount(accountsToUpdate)) {
+      if (remoteAccountInfoMap.hasConflictingAccount(accountsToUpdate, false)) {
         // Throw exception, so that helixStore can capture and terminate the update operation
         errorMessage = "Updating accounts failed because one account to update conflicts with existing accounts";
         logger.error(errorMessage);

--- a/ambry-account/src/main/java/com/github/ambry/account/LegacyMetadataStore.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/LegacyMetadataStore.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.account;
 
+import com.github.ambry.config.HelixAccountServiceConfig;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -38,6 +39,7 @@ class LegacyMetadataStore extends AccountMetadataStore {
   static final String FULL_ACCOUNT_METADATA_PATH = "/account_metadata/full_data";
   private static final String ZN_RECORD_ID = "full_account_metadata";
   private static final Logger logger = LoggerFactory.getLogger(LegacyMetadataStore.class);
+  private final HelixAccountServiceConfig config;
 
   /**
    * Constructor to create a {@link LegacyMetadataStore}.
@@ -46,8 +48,9 @@ class LegacyMetadataStore extends AccountMetadataStore {
    * @param helixStore The {@link HelixPropertyStore} to fetch and update data.
    */
   LegacyMetadataStore(AccountServiceMetrics accountServiceMetrics, BackupFileManager backupFileManager,
-      HelixPropertyStore<ZNRecord> helixStore) {
+      HelixPropertyStore<ZNRecord> helixStore, HelixAccountServiceConfig config) {
     super(accountServiceMetrics, backupFileManager, helixStore, FULL_ACCOUNT_METADATA_PATH);
+    this.config = config;
   }
 
   @Override
@@ -110,7 +113,7 @@ class LegacyMetadataStore extends AccountMetadataStore {
 
       // if there is any conflict with the existing record, fail the update. Exception thrown in this updater will
       // be caught by Helix and helixStore#update will return false.
-      if (remoteAccountInfoMap.hasConflictingAccount(accountsToUpdate, false)) {
+      if (remoteAccountInfoMap.hasConflictingAccount(accountsToUpdate, config.ignoreVersionMismatch)) {
         // Throw exception, so that helixStore can capture and terminate the update operation
         errorMessage = "Updating accounts failed because one account to update conflicts with existing accounts";
         logger.error(errorMessage);

--- a/ambry-account/src/main/java/com/github/ambry/account/MySqlAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/MySqlAccountService.java
@@ -341,23 +341,6 @@ public class MySqlAccountService extends AbstractAccountService {
   @Override
   protected void updateResolvedContainers(Account account, Collection<Container> resolvedContainers)
       throws AccountServiceException {
-
-    // Check for name/id/version conflicts for containers being updated with those in local cache.
-    infoMapLock.readLock().lock();
-    try {
-      if (accountInfoMapRef.get()
-          .hasConflictingContainer(resolvedContainers, account.getId(), config.ignoreVersionMismatch)) {
-        logger.error(
-            "Containers={} under Account={} conflict with the containers in local cache. Cancel the update operation.",
-            account.getAllContainers(), account.getId());
-        accountServiceMetrics.updateAccountErrorCount.inc();
-        throw new AccountServiceException("Containers in account " + account.getId() + " conflict with local cache",
-            AccountServiceErrorCode.ResourceConflict);
-      }
-    } finally {
-      infoMapLock.readLock().unlock();
-    }
-
     try {
       updateContainersWithMySqlStore(account.getId(), resolvedContainers);
     } catch (SQLException e) {

--- a/ambry-account/src/main/java/com/github/ambry/account/MySqlAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/MySqlAccountService.java
@@ -249,14 +249,16 @@ public class MySqlAccountService extends AbstractAccountService {
     infoMapLock.readLock().lock();
     try {
       AccountInfoMap accountInfoMap = accountInfoMapRef.get();
-      if (accountInfoMap.hasConflictingAccount(accounts)) {
+      //TODO: Temporarily disabling version check with CompositeAccountService enabled. Remove it after moving to MySql only.
+      if (accountInfoMap.hasConflictingAccount(accounts, true)) {
         logger.error("Accounts={} conflict with the accounts in local cache. Cancel the update operation.", accounts);
         accountServiceMetrics.updateAccountErrorCount.inc();
         throw new AccountServiceException("Input accounts conflict with the accounts in local cache",
             AccountServiceErrorCode.ResourceConflict);
       }
       for (Account account : accounts) {
-        if (accountInfoMap.hasConflictingContainer(account.getAllContainers(), account.getId())) {
+        //TODO: Temporarily disabling version check with CompositeAccountService enabled. Remove it after moving to MySql only.
+        if (accountInfoMap.hasConflictingContainer(account.getAllContainers(), account.getId(), true)) {
           logger.error(
               "Containers={} under Account={} conflict with the containers in local cache. Cancel the update operation.",
               account.getAllContainers(), account.getId());

--- a/ambry-account/src/main/java/com/github/ambry/account/RouterStore.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/RouterStore.java
@@ -15,6 +15,7 @@ package com.github.ambry.account;
 
 import com.github.ambry.commons.ByteBufferReadableStreamChannel;
 import com.github.ambry.commons.ReadableStreamChannelInputStream;
+import com.github.ambry.config.HelixAccountServiceConfig;
 import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.router.GetBlobOptionsBuilder;
 import com.github.ambry.router.GetBlobResult;
@@ -73,6 +74,7 @@ class RouterStore extends AccountMetadataStore {
   // If forBackFill is true, then when updating the account metadata, we don't create backup files and we don't merge
   // accounts from ambry-server with the provided accounts set.
   private final boolean forBackFill;
+  private final HelixAccountServiceConfig config;
 
   /**
    * Constructor to create the RouterStore.
@@ -85,11 +87,12 @@ class RouterStore extends AccountMetadataStore {
    */
   RouterStore(AccountServiceMetrics accountServiceMetrics, BackupFileManager backupFileManager,
       HelixPropertyStore<ZNRecord> helixStore, AtomicReference<Router> router, boolean forBackFill,
-      int totalNumberOfVersionToKeep) {
+      int totalNumberOfVersionToKeep, HelixAccountServiceConfig config) {
     super(accountServiceMetrics, backupFileManager, helixStore, ACCOUNT_METADATA_BLOB_IDS_PATH);
     this.router = router;
     this.forBackFill = forBackFill;
     this.totalNumberOfVersionToKeep = totalNumberOfVersionToKeep;
+    this.config = config;
   }
 
   @Override
@@ -329,7 +332,7 @@ class RouterStore extends AccountMetadataStore {
 
         // If there is any conflict with the existing record, fail the update. Exception thrown in this updater will
         // be caught by Helix and helixStore#update will return false.
-        if (localAccountInfoMap.hasConflictingAccount(this.accounts, false)) {
+        if (localAccountInfoMap.hasConflictingAccount(this.accounts, config.ignoreVersionMismatch)) {
           // Throw exception, so that helixStore can capture and terminate the update operation
           logAndThrowIllegalStateException(
               "Updating accounts failed because one account to update conflicts with existing accounts", null);

--- a/ambry-account/src/main/java/com/github/ambry/account/RouterStore.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/RouterStore.java
@@ -329,7 +329,7 @@ class RouterStore extends AccountMetadataStore {
 
         // If there is any conflict with the existing record, fail the update. Exception thrown in this updater will
         // be caught by Helix and helixStore#update will return false.
-        if (localAccountInfoMap.hasConflictingAccount(this.accounts)) {
+        if (localAccountInfoMap.hasConflictingAccount(this.accounts, false)) {
           // Throw exception, so that helixStore can capture and terminate the update operation
           logAndThrowIllegalStateException(
               "Updating accounts failed because one account to update conflicts with existing accounts", null);

--- a/ambry-account/src/test/java/com/github/ambry/account/HelixAccountServiceTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/HelixAccountServiceTest.java
@@ -468,7 +468,7 @@ public class HelixAccountServiceTest {
       assertEquals("Mismatch in error code", AccountServiceErrorCode.NotFound, e.getErrorCode());
     }
 
-    // 2. Update container with valid name and wrong id
+    // 3. Update container with valid name and wrong id
     badContainer = new ContainerBuilder(refContainer).setId((short) (refContainerId + 7)).build();
     try {
       accountService.updateContainers(refAccountName, Collections.singleton(badContainer));
@@ -476,6 +476,17 @@ public class HelixAccountServiceTest {
     } catch (AccountServiceException e) {
       assertEquals("Mismatch in error code", AccountServiceErrorCode.ResourceConflict, e.getErrorCode());
     }
+
+    // 4. Update container with valid name and id but with invalid version.
+    //TODO: Temporarily tolerating version mismatch with CompositeAccountService enabled due to difference in versioning
+    // between HelixAccountService and MySqlAccountService. Update expectation to throw conflict due to version check later
+    // after moving to MySql only.
+    modifiedContainer = new ContainerBuilder(modifiedContainer).setStatus(ContainerStatus.INACTIVE)
+        .setSnapshotVersion(modifiedContainer.getSnapshotVersion() + 1)
+        .build();
+    updatedContainers = accountService.updateContainers(refAccountName, Collections.singleton(modifiedContainer));
+    assertEquals("Mismatch in return count", 1, updatedContainers.size());
+    assertEquals("Mismatch in container data", modifiedContainer, updatedContainers.iterator().next());
   }
 
   /**

--- a/ambry-account/src/test/java/com/github/ambry/account/HelixAccountServiceTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/HelixAccountServiceTest.java
@@ -476,17 +476,6 @@ public class HelixAccountServiceTest {
     } catch (AccountServiceException e) {
       assertEquals("Mismatch in error code", AccountServiceErrorCode.ResourceConflict, e.getErrorCode());
     }
-
-    // 4. Update container with valid name and id but with invalid version.
-    //TODO: Temporarily tolerating version mismatch with CompositeAccountService enabled due to difference in versioning
-    // between HelixAccountService and MySqlAccountService. Update expectation to throw conflict due to version check later
-    // after moving to MySql only.
-    modifiedContainer = new ContainerBuilder(modifiedContainer).setStatus(ContainerStatus.INACTIVE)
-        .setSnapshotVersion(modifiedContainer.getSnapshotVersion() + 1)
-        .build();
-    updatedContainers = accountService.updateContainers(refAccountName, Collections.singleton(modifiedContainer));
-    assertEquals("Mismatch in return count", 1, updatedContainers.size());
-    assertEquals("Mismatch in container data", modifiedContainer, updatedContainers.iterator().next());
   }
 
   /**

--- a/ambry-account/src/test/java/com/github/ambry/account/MySqlAccountServiceTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/MySqlAccountServiceTest.java
@@ -321,15 +321,16 @@ public class MySqlAccountServiceTest {
     assertEquals("UpdateAccountErrorCount in metrics should be 2", 2,
         accountServiceMetrics.updateAccountErrorCount.getCount());
 
-    // case F: verify updating account (1, "c") with incorrect version throws resource conflict
+    // case F: verify updating account (1, "c") with incorrect version is successful and throws no resource conflict
+    //TODO: Temporarily tolerating version mismatch with CompositeAccountService enabled due to difference in versioning
+    // between HelixAccountService and MySqlAccountService. Update expectation to throw conflict due to version check later
+    // after moving to MySql only.
     accountToUpdate =
         new AccountBuilder(mySqlAccountService.getAccountById((short) 1)).status(Account.AccountStatus.INACTIVE)
             .snapshotVersion(mySqlAccountService.getAccountById((short) 1).getSnapshotVersion() + 1)
             .build();
-    assertUpdateAccountsFails(Collections.singletonList(accountToUpdate), AccountServiceErrorCode.ResourceConflict,
-        mySqlAccountService);
-    assertEquals("UpdateAccountErrorCount in metrics should be 3", 3,
-        accountServiceMetrics.updateAccountErrorCount.getCount());
+    mySqlAccountService.updateAccounts(Collections.singletonList(accountToUpdate));
+    assertEquals("Mismatch in account information", accountToUpdate, mySqlAccountService.getAccountById((short) 1));
 
     // verify there should be 3 accounts (1, "c), (2, "b) and (3, "d) at the end of operation
     assertEquals("Mismatch in number of accounts", 3, mySqlAccountService.getAllAccounts().size());
@@ -393,16 +394,18 @@ public class MySqlAccountServiceTest {
     assertEquals("UpdateAccountErrorCount in metrics should be 2", 2,
         accountServiceMetrics.updateAccountErrorCount.getCount());
 
-    // case E: Verify updating container (3,c4) with incorrect version throws resource conflict
+    // case E: Verify updating container (3,c4) with incorrect version throws no resource conflict
+    //TODO: Temporarily tolerating version mismatch with CompositeAccountService enabled due to difference in versioning
+    // between HelixAccountService and MySqlAccountService. Update expectation to throw conflict due to version check later
+    // after moving to MySql only.
     containerToUpdate = mySqlAccountService.getAccountById((short) 1).getContainerById((short) 3);
     containerToUpdate = new ContainerBuilder(containerToUpdate).setStatus(Container.ContainerStatus.INACTIVE)
         .setSnapshotVersion(containerToUpdate.getSnapshotVersion() + 1)
         .build();
     accountToUpdate = new AccountBuilder(accountToUpdate).addOrUpdateContainer(containerToUpdate).build();
-    assertUpdateAccountsFails(Collections.singletonList(accountToUpdate), AccountServiceErrorCode.ResourceConflict,
-        mySqlAccountService);
-    assertEquals("UpdateAccountErrorCount in metrics should be 3", 3,
-        accountServiceMetrics.updateAccountErrorCount.getCount());
+    mySqlAccountService.updateAccounts(Collections.singletonList(accountToUpdate));
+    assertEquals("Mismatch in container information", containerToUpdate,
+        mySqlAccountService.getAccountById((short) 1).getContainerById((short) 3));
   }
 
   /**

--- a/ambry-account/src/test/java/com/github/ambry/account/RouterStoreTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/RouterStoreTest.java
@@ -114,7 +114,7 @@ public class RouterStoreTest {
   public void testUpdateAndFetch() throws Exception {
     RouterStore store =
         new RouterStore(accountServiceMetrics, backup, helixStore, new AtomicReference<>(router), forBackfill,
-            TOTAL_NUMBER_OF_VERSION_TO_KEEP);
+            TOTAL_NUMBER_OF_VERSION_TO_KEEP, config);
     Map<Short, Account> idToRefAccountMap = new HashMap<>();
     Map<Short, Map<Short, Container>> idtoRefContainerMap = new HashMap<>();
     Set<Short> accountIDSet = new HashSet<>();
@@ -158,7 +158,7 @@ public class RouterStoreTest {
     assumeTrue(!forBackfill);
     RouterStore store =
         new RouterStore(accountServiceMetrics, backup, helixStore, new AtomicReference<>(router), forBackfill,
-            TOTAL_NUMBER_OF_VERSION_TO_KEEP);
+            TOTAL_NUMBER_OF_VERSION_TO_KEEP, config);
     Map<Short, Account> idToRefAccountMap = new HashMap<>();
     Map<Short, Map<Short, Container>> idtoRefContainerMap = new HashMap<>();
     Set<Short> accountIDSet = new HashSet<>();
@@ -186,7 +186,7 @@ public class RouterStoreTest {
   public void testSizeLimitInList() throws Exception {
     RouterStore store =
         new RouterStore(accountServiceMetrics, backup, helixStore, new AtomicReference<>(router), forBackfill,
-            TOTAL_NUMBER_OF_VERSION_TO_KEEP);
+            TOTAL_NUMBER_OF_VERSION_TO_KEEP, config);
 
     Map<Short, Account> idToRefAccountMap = new HashMap<>();
     Map<Short, Map<Short, Container>> idtoRefContainerMap = new HashMap<>();

--- a/ambry-api/src/main/java/com/github/ambry/config/AccountServiceConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/AccountServiceConfig.java
@@ -22,6 +22,7 @@ public class AccountServiceConfig {
   public static final String MAX_RETRY_COUNT_ON_UPDATE_FAILURE =
       ACCOUNT_SERVICE_PREFIX + "max.retry.count.on.update.failure";
   public static final String RETRY_DELAY_MS = ACCOUNT_SERVICE_PREFIX + "retry.delay.ms";
+  public static final String IGNORE_VERSION_MISMATCH = ACCOUNT_SERVICE_PREFIX + "ignore.version.mismatch";
 
   /** The numeric container Id to be used for the first container created within an account. */
   @Config(CONTAINER_ID_START_NUMBER)
@@ -42,10 +43,18 @@ public class AccountServiceConfig {
   @Default("1000")
   public final long retryDelayMs;
 
+  /**
+   * If true, AccountService would ignore version mismatch while updating Accounts and Containers.
+   */
+  @Config(IGNORE_VERSION_MISMATCH)
+  @Default("false")
+  public final boolean ignoreVersionMismatch;
+
   public AccountServiceConfig(VerifiableProperties verifiableProperties) {
     containerIdStartNumber =
         verifiableProperties.getShortInRange(CONTAINER_ID_START_NUMBER, (short) 1, (short) 0, Short.MAX_VALUE);
     maxRetryCountOnUpdateFailure = verifiableProperties.getIntInRange(MAX_RETRY_COUNT_ON_UPDATE_FAILURE, 10, 1, 100);
     retryDelayMs = verifiableProperties.getLongInRange(RETRY_DELAY_MS, 1000, 1, Long.MAX_VALUE);
+    ignoreVersionMismatch = verifiableProperties.getBoolean(IGNORE_VERSION_MISMATCH, false);
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/config/MySqlAccountServiceConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/MySqlAccountServiceConfig.java
@@ -26,7 +26,6 @@ public class MySqlAccountServiceConfig extends AccountServiceConfig {
   public static final String BACKUP_DIRECTORY_KEY = MYSQL_ACCOUNT_SERVICE_PREFIX + "backup.dir";
   public static final String UPDATE_DISABLED = MYSQL_ACCOUNT_SERVICE_PREFIX + "update.disabled";
   private static final String MAX_BACKUP_FILE_COUNT = MYSQL_ACCOUNT_SERVICE_PREFIX + "max.backup.file.count";
-  public static final String IGNORE_VERSION_MISMATCH = MYSQL_ACCOUNT_SERVICE_PREFIX + "ignore.version.mismatch";
 
   /**
    * Serialized json containing the information about all mysql end points. This information should be of the following form:
@@ -98,13 +97,6 @@ public class MySqlAccountServiceConfig extends AccountServiceConfig {
   @Default("false")
   public final boolean updateDisabled;
 
-  /**
-   * If true, MySqlAccountService would ignore version mismatch while updating Accounts and Containers.
-   */
-  @Config(IGNORE_VERSION_MISMATCH)
-  @Default("false")
-  public final boolean ignoreVersionMismatch;
-
   public MySqlAccountServiceConfig(VerifiableProperties verifiableProperties) {
     super(verifiableProperties);
     dbInfo = verifiableProperties.getString(DB_INFO);
@@ -115,6 +107,5 @@ public class MySqlAccountServiceConfig extends AccountServiceConfig {
     backupDir = verifiableProperties.getString(BACKUP_DIRECTORY_KEY, "");
     updateDisabled = verifiableProperties.getBoolean(UPDATE_DISABLED, false);
     maxBackupFileCount = verifiableProperties.getIntInRange(MAX_BACKUP_FILE_COUNT, 10, 1, Integer.MAX_VALUE);
-    ignoreVersionMismatch = verifiableProperties.getBoolean(IGNORE_VERSION_MISMATCH, false);
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/config/MySqlAccountServiceConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/MySqlAccountServiceConfig.java
@@ -26,6 +26,7 @@ public class MySqlAccountServiceConfig extends AccountServiceConfig {
   public static final String BACKUP_DIRECTORY_KEY = MYSQL_ACCOUNT_SERVICE_PREFIX + "backup.dir";
   public static final String UPDATE_DISABLED = MYSQL_ACCOUNT_SERVICE_PREFIX + "update.disabled";
   private static final String MAX_BACKUP_FILE_COUNT = MYSQL_ACCOUNT_SERVICE_PREFIX + "max.backup.file.count";
+  public static final String IGNORE_VERSION_MISMATCH = MYSQL_ACCOUNT_SERVICE_PREFIX + "ignore.version.mismatch";
 
   /**
    * Serialized json containing the information about all mysql end points. This information should be of the following form:
@@ -97,6 +98,13 @@ public class MySqlAccountServiceConfig extends AccountServiceConfig {
   @Default("false")
   public final boolean updateDisabled;
 
+  /**
+   * If true, MySqlAccountService would ignore version mismatch while updating Accounts and Containers.
+   */
+  @Config(IGNORE_VERSION_MISMATCH)
+  @Default("false")
+  public final boolean ignoreVersionMismatch;
+
   public MySqlAccountServiceConfig(VerifiableProperties verifiableProperties) {
     super(verifiableProperties);
     dbInfo = verifiableProperties.getString(DB_INFO);
@@ -107,5 +115,6 @@ public class MySqlAccountServiceConfig extends AccountServiceConfig {
     backupDir = verifiableProperties.getString(BACKUP_DIRECTORY_KEY, "");
     updateDisabled = verifiableProperties.getBoolean(UPDATE_DISABLED, false);
     maxBackupFileCount = verifiableProperties.getIntInRange(MAX_BACKUP_FILE_COUNT, 10, 1, Integer.MAX_VALUE);
+    ignoreVersionMismatch = verifiableProperties.getBoolean(IGNORE_VERSION_MISMATCH, false);
   }
 }

--- a/ambry-tools/src/main/java/com/github/ambry/account/AccountTool.java
+++ b/ambry-tools/src/main/java/com/github/ambry/account/AccountTool.java
@@ -579,7 +579,7 @@ public class AccountTool {
    */
   private RouterStore getRouterStore() throws Exception {
     return new RouterStore(new AccountServiceMetrics(registry), backupFileManager, helixStore,
-        new AtomicReference<>(getRouter()), true, 100);
+        new AtomicReference<>(getRouter()), true, 100, accountServiceConfig);
   }
 
   /**


### PR DESCRIPTION
Since HelixAccountService and MySqlAccountService handles versioning of Accounts and Containers differently, this causes mismatch between Accounts when compared in CompositeAccountService. This PR temporarily ignores version mismatch during Account/Container updates in MySqlAccountService.  