### PR TITLE
Fix illegal character in Azure container name when using container layout strategy

### DIFF
--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureBlobLayoutStrategy.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureBlobLayoutStrategy.java
@@ -29,7 +29,6 @@ import com.github.ambry.utils.Utils;
 public class AzureBlobLayoutStrategy {
 
   private static final String DASH = "-";
-  private static final String UNDERSCORE = "_";
   private static final String BLOB_NAME_SEPARATOR = DASH;
   // Note: Azure container name needs to be lower case
   private static final String TOKEN_CONTAINER_NAME = "replicatokens";
@@ -84,9 +83,11 @@ public class AzureBlobLayoutStrategy {
     this.clusterName = clusterName;
     currentVersion = azureCloudConfig.azureNameSchemeVersion;
     blobContainerStrategy = BlobContainerStrategy.get(azureCloudConfig.azureBlobContainerStrategy);
-    // Since account and container Ids can technically be negative numbers, use underscore instead of dash
-    // to avoid confusion.
-    containerNameSeparator = (blobContainerStrategy == BlobContainerStrategy.CONTAINER) ? UNDERSCORE : DASH;
+    // Note: for ancient blobs (pre-container), account and container ids can be -1.  For that reason,
+    // when using container layout, we would prefer to use a different separator like underscore instead of dash,
+    // but Azure container names allow only alphanumerics and single dashes.
+    // TODO: translate ids of -1 to special string like "unknown"
+    containerNameSeparator = DASH;
   }
 
   /** Test constructor */

--- a/ambry-cloud/src/test/java/com/github/ambry/cloud/azure/AzureBlobLayoutStrategyTest.java
+++ b/ambry-cloud/src/test/java/com/github/ambry/cloud/azure/AzureBlobLayoutStrategyTest.java
@@ -71,7 +71,7 @@ public class AzureBlobLayoutStrategyTest {
     BlobLayout layout = strategy.getDataBlobLayout(blobId);
     // Container name should be main-101-5
     String expectedContainerName =
-        String.format("%s_%d_%d", clusterName, AzureTestUtils.accountId, AzureTestUtils.containerId);
+        String.format("%s-%d-%d", clusterName, AzureTestUtils.accountId, AzureTestUtils.containerId);
     String blobIdStr = blobId.getID();
     String expectedBlobName = blobIdStr.substring(blobIdStr.length() - 4) + "-" + blobIdStr;
     checkLayout(layout, expectedContainerName, expectedBlobName);
@@ -81,7 +81,7 @@ public class AzureBlobLayoutStrategyTest {
 
     // Tokens should go in their own container: main_replicaTokens
     layout = strategy.getTokenBlobLayout(partitionPath, tokenFileName);
-    expectedContainerName = clusterName + "_" + tokenFileName.toLowerCase();
+    expectedContainerName = clusterName + "-" + tokenFileName.toLowerCase();
     expectedBlobName = partitionPath + "/" + tokenFileName;
     checkLayout(layout, expectedContainerName, expectedBlobName);
   }


### PR DESCRIPTION
Note: I have tested AzureIntegrationTest locally with container layout to verify the fix, and will make a separate PR that runs a few test cases with both layout options.