### PR TITLE
Add config to disable helix task when container deletion is not enabled.

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/CloudConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/CloudConfig.java
@@ -60,6 +60,7 @@ public class CloudConfig {
   public static final String VCR_SOURCE_DATACENTERS = "vcr.source.datacenters";
   public static final String CLOUD_COMPACTION_NUM_THREADS = "cloud.compaction.num.threads";
   public static final String VCR_HELIX_STATE_MODEL_FACTORY_CLASS = "vcr.helix.state.model.factory.class";
+  public static final String CLOUD_CONTAINER_COMPACTION_ENABLED = "cloud.container.compaction.enabled";
 
   public static final String DEFAULT_VIRTUAL_REPLICATOR_CLUSTER_FACTORY_CLASS =
       "com.github.ambry.cloud.StaticVcrClusterFactory";
@@ -336,6 +337,13 @@ public class CloudConfig {
   @Default(DEFAULT_VCR_HELIX_STATE_MODEL_FACTORY_CLASS)
   public final String vcrHelixStateModelFactoryClass;
 
+  /**
+   * Whether deprecated container compaction is enabled.
+   */
+  @Config(CLOUD_CONTAINER_COMPACTION_ENABLED)
+  @Default("false")
+  public final boolean cloudContainerCompactionEnabled;
+
   public CloudConfig(VerifiableProperties verifiableProperties) {
 
     cloudIsVcr = verifiableProperties.getBoolean(CLOUD_IS_VCR, false);
@@ -392,5 +400,6 @@ public class CloudConfig {
         Utils.splitString(verifiableProperties.getString(VCR_SOURCE_DATACENTERS, ""), ",", HashSet::new);
     vcrHelixStateModelFactoryClass = verifiableProperties.getString(VCR_HELIX_STATE_MODEL_FACTORY_CLASS,
         DEFAULT_VCR_HELIX_STATE_MODEL_FACTORY_CLASS);
+    cloudContainerCompactionEnabled = verifiableProperties.getBoolean(CLOUD_CONTAINER_COMPACTION_ENABLED, false);
   }
 }

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/HelixVcrCluster.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/HelixVcrCluster.java
@@ -162,7 +162,9 @@ public class HelixVcrCluster implements VirtualReplicatorCluster {
         cloudConfig.vcrClusterZkConnectString);
     VcrStateModelFactory stateModelFactory = Utils.getObj(cloudConfig.vcrHelixStateModelFactoryClass, this);
     manager.getStateMachineEngine().registerStateModelFactory(stateModelFactory.getStateModelName(), stateModelFactory);
-    registerContainerDeletionSyncTask(manager.getStateMachineEngine());
+    if (cloudConfig.cloudContainerCompactionEnabled) {
+      registerContainerDeletionSyncTask(manager.getStateMachineEngine());
+    }
     manager.connect();
     helixAdmin = manager.getClusterManagmentTool();
     logger.info("Participated in HelixVcrCluster successfully.");
@@ -173,6 +175,7 @@ public class HelixVcrCluster implements VirtualReplicatorCluster {
    * @param engine the {@link StateMachineEngine} to register the task state model.
    */
   private void registerContainerDeletionSyncTask(StateMachineEngine engine) {
+
     Map<String, TaskFactory> taskFactoryMap = new HashMap<>();
     taskFactoryMap.put(DeprecatedContainerCloudSyncTask.class.getSimpleName(), new TaskFactory() {
       @Override

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudConfig.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudConfig.java
@@ -168,7 +168,7 @@ public class AzureCloudConfig {
     azureStorageConnectionString = verifiableProperties.getString(AZURE_STORAGE_CONNECTION_STRING, "");
     cosmosEndpoint = verifiableProperties.getString(COSMOS_ENDPOINT);
     cosmosCollectionLink = verifiableProperties.getString(COSMOS_COLLECTION_LINK);
-    cosmosDeletedContainerCollectionLink = verifiableProperties.getString(COSMOS_DELETED_CONTAINER_COLLECTION_LINK);
+    cosmosDeletedContainerCollectionLink = verifiableProperties.getString(COSMOS_DELETED_CONTAINER_COLLECTION_LINK, "");
     cosmosKey = verifiableProperties.getString(COSMOS_KEY);
     azureStorageAuthority = verifiableProperties.getString(AZURE_STORAGE_AUTHORITY, "");
     azureStorageClientId = verifiableProperties.getString(AZURE_STORAGE_CLIENTID, "");


### PR DESCRIPTION
- Add config to disable helix task when container deletion is not enabled.
- Make cosmos deprecated container collection link as not mandatory.