### PR TITLE
Fix null replica in HelixClusterMap when decommissioning replicas.

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/clustermap/ReplicaSyncUpManager.java
+++ b/ambry-api/src/main/java/com/github/ambry/clustermap/ReplicaSyncUpManager.java
@@ -37,14 +37,18 @@ public interface ReplicaSyncUpManager {
   void waitBootstrapCompleted(String partitionName) throws InterruptedException;
 
   /**
-   * Update replica lag (in byte) between two replicas (local and peer replica)
+   * Update replica lag (in byte) between two replicas (local and peer replica) and check sync-up status.
    * @param localReplica the replica that resides on current node
    * @param peerReplica the peer replica of local one.
    * @param lagInBytes replica lag bytes
-   * @return whether the lag is updated or not. If {@code false}, it means the local replica is not tracked in this service.
-   *         Either the replica has caught up and removed from service or it is an existing replica that doesn't need catchup.
+   * @param targetState the target state the replica will transit to after sync-up completes.
+   * @return whether sync-up is completed by this update. If {@code false}, it means either the local replica is not
+   *         tracked by this manager or the sync-up has not finished yet. For the former case, there are also two cases:
+   *         (1) the replica has caught up and removed from manager already
+   *         (2) it is an existing replica that doesn't need catchup.
    */
-  boolean updateLagBetweenReplicas(ReplicaId localReplica, ReplicaId peerReplica, long lagInBytes);
+  boolean updateReplicaLagAndCheckSyncStatus(ReplicaId localReplica, ReplicaId peerReplica, long lagInBytes,
+      ReplicaState targetState);
 
   /**
    * Whether given replica has synced up with its peers.

--- a/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
@@ -250,11 +250,12 @@ public class RouterConfig {
   public final boolean routerGetCrossDcEnabled;
 
   /**
-   * Whether to
+   * Whether to include down(offline) replicas in replicas pool within operation tracker.
    */
   @Config(ROUTER_OPERATION_TRACKER_INCLUDE_DOWN_REPLICAS)
   @Default("true")
   public final boolean routerOperationTrackerIncludeDownReplicas;
+
   /**
    * The OperationTracker to use for GET operations.
    */

--- a/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
@@ -58,9 +58,8 @@ public class RouterConfig {
   public static final String ROUTER_GET_REQUEST_PARALLELISM = "router.get.request.parallelism";
   public static final String ROUTER_GET_SUCCESS_TARGET = "router.get.success.target";
   public static final String ROUTER_GET_CROSS_DC_ENABLED = "router.get.cross.dc.enabled";
-  public static final String ROUTER_GET_INCLUDE_NON_ORIGINATING_DC_REPLICAS =
-      "router.get.include.non.originating.dc.replicas";
-  public static final String ROUTER_GET_REPLICAS_REQUIRED = "router.get.replicas.required";
+  public static final String ROUTER_OPERATION_TRACKER_INCLUDE_DOWN_REPLICAS =
+      "router.operation.tracker.include.down.replicas";
   public static final String ROUTER_GET_OPERATION_TRACKER_TYPE = "router.get.operation.tracker.type";
   public static final String ROUTER_LATENCY_TOLERANCE_QUANTILE = "router.latency.tolerance.quantile";
   public static final String ROUTER_BLOBID_CURRENT_VERSION = "router.blobid.current.version";
@@ -251,20 +250,11 @@ public class RouterConfig {
   public final boolean routerGetCrossDcEnabled;
 
   /**
-   * Indicates whether get operations are allowed to make requests to nodes in non-originating remote data centers.
+   * Whether to
    */
-  @Config(ROUTER_GET_INCLUDE_NON_ORIGINATING_DC_REPLICAS)
+  @Config(ROUTER_OPERATION_TRACKER_INCLUDE_DOWN_REPLICAS)
   @Default("true")
-  public final boolean routerGetIncludeNonOriginatingDcReplicas;
-
-  /**
-   * Number of replicas required for GET OperationTracker when routerGetIncludeNonOriginatingDcReplicas is False.
-   * Please note routerGetReplicasRequired is 6 because total number of local and originating replicas is always <= 6.
-   * This may no longer be true with partition classes and flexible replication.
-   */
-  @Config(ROUTER_GET_REPLICAS_REQUIRED)
-  @Default("6")
-  public final int routerGetReplicasRequired;
+  public final boolean routerOperationTrackerIncludeDownReplicas;
   /**
    * The OperationTracker to use for GET operations.
    */
@@ -546,10 +536,8 @@ public class RouterConfig {
         verifiableProperties.getIntInRange(ROUTER_GET_REQUEST_PARALLELISM, 2, 1, Integer.MAX_VALUE);
     routerGetSuccessTarget = verifiableProperties.getIntInRange(ROUTER_GET_SUCCESS_TARGET, 1, 1, Integer.MAX_VALUE);
     routerGetCrossDcEnabled = verifiableProperties.getBoolean(ROUTER_GET_CROSS_DC_ENABLED, true);
-    routerGetIncludeNonOriginatingDcReplicas =
-        verifiableProperties.getBoolean(ROUTER_GET_INCLUDE_NON_ORIGINATING_DC_REPLICAS, true);
-    routerGetReplicasRequired =
-        verifiableProperties.getIntInRange(ROUTER_GET_REPLICAS_REQUIRED, 6, 1, Integer.MAX_VALUE);
+    routerOperationTrackerIncludeDownReplicas =
+        verifiableProperties.getBoolean(ROUTER_OPERATION_TRACKER_INCLUDE_DOWN_REPLICAS, true);
     routerGetOperationTrackerType =
         verifiableProperties.getString(ROUTER_GET_OPERATION_TRACKER_TYPE, "SimpleOperationTracker");
     routerLatencyToleranceQuantile =

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterChangeHandler.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterChangeHandler.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.clustermap;
 
+import java.util.Objects;
 import java.util.stream.Stream;
 import org.apache.helix.api.listeners.IdealStateChangeListener;
 import org.apache.helix.api.listeners.LiveInstanceChangeListener;
@@ -51,6 +52,6 @@ interface HelixClusterChangeHandler
     return getRoutingTableSnapshot().getInstancesForResource(resourceName, partition.toPathString(), state.name())
         .stream()
         .map(instanceConfig -> getDataNode(instanceConfig.getInstanceName()))
-        .map(dataNode -> getReplicaId(dataNode, partition.toPathString()));
+        .map(dataNode -> getReplicaId(dataNode, partition.toPathString())).filter(Objects::nonNull);
   }
 }

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/ClusterChangeHandlerTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/ClusterChangeHandlerTest.java
@@ -76,6 +76,11 @@ public class ClusterChangeHandlerTest {
   private final HelixClusterManagerTest.MockHelixManagerFactory helixManagerFactory;
   private final Properties props = new Properties();
 
+  @Parameterized.Parameters
+  public static List<Object[]> data() {
+    return Arrays.asList(new Object[][]{{false}, {true}});
+  }
+
   // set up a mock helix cluster, create separate HelixClusterManager with both Simple and Dynamic cluster change handler
   public ClusterChangeHandlerTest(boolean overrideEnabled) throws Exception {
     this.overrideEnabled = overrideEnabled;
@@ -124,11 +129,6 @@ public class ClusterChangeHandlerTest {
     helixCluster =
         new MockHelixCluster(clusterNamePrefixInHelix, hardwareLayoutPath, partitionLayoutPath, zkLayoutPath);
     helixManagerFactory = new HelixClusterManagerTest.MockHelixManagerFactory(helixCluster, znRecordMap, null);
-  }
-
-  @Parameterized.Parameters
-  public static List<Object[]> data() {
-    return Arrays.asList(new Object[][]{{false}, {true}});
   }
 
   /**

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixClusterManagerTest.java
@@ -290,7 +290,8 @@ public class HelixClusterManagerTest {
     partitionToTest.addReplica(new Replica(partitionToTest, diskOnNewNode, testHardwareLayout1.clusterMapConfig));
     Utils.writeJsonObjectToFile(testPartitionLayout1.getPartitionLayout().toJSONObject(), testPartitionLayoutPath);
     testCluster.upgradeWithNewHardwareLayout(testHardwareLayoutPath);
-    testCluster.upgradeWithNewPartitionLayout(testPartitionLayoutPath);
+    testCluster.upgradeWithNewPartitionLayout(testPartitionLayoutPath,
+        HelixBootstrapUpgradeUtil.HelixAdminOperation.BootstrapCluster);
 
     // reset hardware/partition layout, this also resets replica capacity of partitionToTest. However, it won't touch
     // instanceConfig of new added node because it is not in hardware layout. So, replica on new added node still has
@@ -302,7 +303,8 @@ public class HelixClusterManagerTest {
     Utils.writeJsonObjectToFile(testHardwareLayout1.getHardwareLayout().toJSONObject(), testHardwareLayoutPath);
     Utils.writeJsonObjectToFile(testPartitionLayout1.getPartitionLayout().toJSONObject(), testPartitionLayoutPath);
     testCluster.upgradeWithNewHardwareLayout(testHardwareLayoutPath);
-    testCluster.upgradeWithNewPartitionLayout(testPartitionLayoutPath);
+    testCluster.upgradeWithNewPartitionLayout(testPartitionLayoutPath,
+        HelixBootstrapUpgradeUtil.HelixAdminOperation.BootstrapCluster);
 
     Properties props = new Properties();
     props.setProperty("clustermap.host.name", hostname);
@@ -941,7 +943,8 @@ public class HelixClusterManagerTest {
       // Following test re-initializes clusterManager with new partitionLayout and then triggers instanceConfig change on new added partition
       testPartitionLayout.addNewPartitions(1, DEFAULT_PARTITION_CLASS, PartitionState.READ_WRITE, helixDcs[0]);
       Utils.writeJsonObjectToFile(testPartitionLayout.getPartitionLayout().toJSONObject(), partitionLayoutPath);
-      helixCluster.upgradeWithNewPartitionLayout(partitionLayoutPath);
+      helixCluster.upgradeWithNewPartitionLayout(partitionLayoutPath,
+          HelixBootstrapUpgradeUtil.HelixAdminOperation.BootstrapCluster);
       clusterManager.close();
       Map<String, ZNRecord> znRecordMap = new HashMap<>();
       znRecordMap.put(PARTITION_OVERRIDE_ZNODE_PATH, znRecord);

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixAdmin.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixAdmin.java
@@ -446,14 +446,14 @@ public class MockHelixAdmin implements HelixAdmin {
     return setInstanceConfigCallCount;
   }
 
+  // ***************************************
+  // Not implemented. Implement as required.
+  // ***************************************
+
   @Override
   public List<String> getResourcesInClusterWithTag(String clusterName, String tag) {
     throw new IllegalStateException("Not implemented");
   }
-
-  // ***************************************
-  // Not implemented. Implement as required.
-  // ***************************************
 
   @Override
   public boolean addCluster(String clusterName, boolean recreateIfExists) {

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixAdmin.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixAdmin.java
@@ -161,6 +161,9 @@ public class MockHelixAdmin implements HelixAdmin {
    * @param instanceConfig the instanceConfig to check.
    */
   private void removeDisabledReplicasIfNeeded(InstanceConfig instanceConfig) {
+    if (instanceConfig == null) {
+      return;
+    }
     Map<String, List<String>> disabledReplicasByResource = instanceConfig.getDisabledPartitionsMap();
     if (!disabledReplicasByResource.isEmpty()) {
       // if disabled replica map is not empty, we remove those replicas from InstanceConfig to mock replica decommission

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixAdmin.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixAdmin.java
@@ -35,18 +35,20 @@ import org.apache.helix.model.MaintenanceSignal;
 import org.apache.helix.model.ResourceConfig;
 import org.apache.helix.model.StateModelDefinition;
 
+import static com.github.ambry.clustermap.ClusterMapUtils.*;
+
 
 /**
  * Mock implementation of {@link HelixAdmin} which stores all information internally.
  */
 public class MockHelixAdmin implements HelixAdmin {
-  private String clusterName;
   private final Map<String, InstanceConfig> instanceNameToinstanceConfigs = new HashMap<>();
   private final Map<String, IdealState> resourcesToIdealStates = new HashMap<>();
   private final Set<String> upInstances = new HashSet<>();
   private final Set<String> downInstances = new HashSet<>();
-  private long totalDiskCount = 0;
   private final List<MockHelixManager> helixManagersForThisAdmin = new ArrayList<>();
+  private String clusterName;
+  private long totalDiskCount = 0;
   private Map<String, Set<String>> partitionToInstances = new HashMap<>();
   private Map<String, PartitionState> partitionToPartitionStates = new HashMap<>();
   // A map of instanceName to state infos of all replicas on this instance
@@ -148,8 +150,42 @@ public class MockHelixAdmin implements HelixAdmin {
   @Override
   public boolean setInstanceConfig(String clusterName, String instanceName, InstanceConfig instanceConfig) {
     setInstanceConfigCallCount++;
+    removeDisabledReplicasIfNeeded(instanceConfig);
     instanceNameToinstanceConfigs.put(instanceName, instanceConfig);
     return true;
+  }
+
+  /**
+   * Remove disabled replicas from InstanceConfig if needed. This is to mock last step of disabling replica, which will
+   * remove the replica entry from InstanceConfig.
+   * @param instanceConfig the instanceConfig to check.
+   */
+  private void removeDisabledReplicasIfNeeded(InstanceConfig instanceConfig) {
+    Map<String, List<String>> disabledReplicasByResource = instanceConfig.getDisabledPartitionsMap();
+    if (!disabledReplicasByResource.isEmpty()) {
+      // if disabled replica map is not empty, we remove those replicas from InstanceConfig to mock replica decommission
+      Set<String> replicasToRemove = new HashSet<>();
+      disabledReplicasByResource.values().forEach(replicasToRemove::addAll);
+      Map<String, Map<String, String>> newMapFields = new HashMap<>();
+      Map<String, Map<String, String>> mapFields = instanceConfig.getRecord().getMapFields();
+      for (Map.Entry<String, Map<String, String>> entry : mapFields.entrySet()) {
+        if (entry.getKey().startsWith("/mnt")) {
+          String replicasStr = entry.getValue().get(REPLICAS_STR);
+          if (!replicasStr.isEmpty()) {
+            String[] replicaArray = replicasStr.split(REPLICAS_DELIM_STR);
+            StringBuilder sb = new StringBuilder();
+            for (String replicaStr : replicaArray) {
+              if (!replicasToRemove.contains(replicaStr.split(REPLICAS_STR_SEPARATOR)[0])) {
+                sb.append(replicaStr).append(REPLICAS_DELIM_STR);
+              }
+            }
+            entry.getValue().put(REPLICAS_STR, sb.toString());
+          }
+          newMapFields.put(entry.getKey(), entry.getValue());
+        }
+      }
+      instanceConfig.getRecord().setMapFields(newMapFields);
+    }
   }
 
   /**
@@ -407,35 +443,14 @@ public class MockHelixAdmin implements HelixAdmin {
     return setInstanceConfigCallCount;
   }
 
-  /**
-   * Private class that holds partition state infos from one data node.
-   */
-  class ReplicaStateInfos {
-    Map<String, Map<String, String>> replicaStateMap;
-
-    ReplicaStateInfos() {
-      replicaStateMap = new HashMap<>();
-    }
-
-    void setReplicaState(String partition, String state) {
-      Map<String, String> stateMap = new HashMap<>();
-      stateMap.put(CurrentState.CurrentStateProperty.CURRENT_STATE.name(), state);
-      replicaStateMap.put(partition, stateMap);
-    }
-
-    Map<String, Map<String, String>> getReplicaStateMap() {
-      return replicaStateMap;
-    }
+  @Override
+  public List<String> getResourcesInClusterWithTag(String clusterName, String tag) {
+    throw new IllegalStateException("Not implemented");
   }
 
   // ***************************************
   // Not implemented. Implement as required.
   // ***************************************
-
-  @Override
-  public List<String> getResourcesInClusterWithTag(String clusterName, String tag) {
-    throw new IllegalStateException("Not implemented");
-  }
 
   @Override
   public boolean addCluster(String clusterName, boolean recreateIfExists) {
@@ -768,5 +783,26 @@ public class MockHelixAdmin implements HelixAdmin {
   @Override
   public Map<String, Boolean> validateInstancesForWagedRebalance(String clusterName, List<String> instancesNames) {
     return null;
+  }
+
+  /**
+   * Private class that holds partition state infos from one data node.
+   */
+  class ReplicaStateInfos {
+    Map<String, Map<String, String>> replicaStateMap;
+
+    ReplicaStateInfos() {
+      replicaStateMap = new HashMap<>();
+    }
+
+    void setReplicaState(String partition, String state) {
+      Map<String, String> stateMap = new HashMap<>();
+      stateMap.put(CurrentState.CurrentStateProperty.CURRENT_STATE.name(), state);
+      replicaStateMap.put(partition, stateMap);
+    }
+
+    Map<String, Map<String, String>> getReplicaStateMap() {
+      return replicaStateMap;
+    }
   }
 }

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixCluster.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixCluster.java
@@ -78,11 +78,13 @@ public class MockHelixCluster {
   /**
    * Upgrade based on the partitionLayout.
    * @param partitionLayoutPath the new partition layout.
+   * @param adminOperation the admin operation associated with this upgrade.
    * @throws Exception
    */
-  void upgradeWithNewPartitionLayout(String partitionLayoutPath) throws Exception {
+  void upgradeWithNewPartitionLayout(String partitionLayoutPath,
+      HelixBootstrapUpgradeUtil.HelixAdminOperation adminOperation) throws Exception {
     HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterName,
-        "all", 3, false, false, helixAdminFactory, false, ClusterMapConfig.DEFAULT_STATE_MODEL_DEF, BootstrapCluster);
+        "all", 3, false, false, helixAdminFactory, false, ClusterMapConfig.DEFAULT_STATE_MODEL_DEF, adminOperation);
     triggerInstanceConfigChangeNotification();
   }
 

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -601,14 +601,13 @@ public class ReplicaThread implements Runnable {
                     && remoteReplicaInfo.getLocalStore().getCurrentState() == ReplicaState.BOOTSTRAP) {
                   ReplicaId localReplica = remoteReplicaInfo.getLocalReplicaId();
                   ReplicaId remoteReplica = remoteReplicaInfo.getReplicaId();
-                  boolean updated = replicaSyncUpManager.updateLagBetweenReplicas(localReplica, remoteReplica,
-                      exchangeMetadataResponse.localLagFromRemoteInBytes);
-                  // if updated is false, it means local replica is not found in replicaSyncUpManager and is therefore not
-                  // in bootstrap state.
-                  if (updated && replicaSyncUpManager.isSyncUpComplete(localReplica)) {
+                  boolean isSyncCompleted =
+                      replicaSyncUpManager.updateReplicaLagAndCheckSyncStatus(localReplica, remoteReplica,
+                          exchangeMetadataResponse.localLagFromRemoteInBytes, ReplicaState.STANDBY);
+                  // if catchup is completed by this update call, we can complete bootstrap in local store
+                  if (isSyncCompleted) {
                     // complete BOOTSTRAP -> STANDBY transition
                     remoteReplicaInfo.getLocalStore().setCurrentState(ReplicaState.STANDBY);
-                    replicaSyncUpManager.onBootstrapComplete(localReplica);
                     remoteReplicaInfo.getLocalStore().completeBootstrap();
                   }
                 }

--- a/ambry-replication/src/test/java/com/github/ambry/replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/ReplicationTest.java
@@ -517,9 +517,10 @@ public class ReplicationTest extends ReplicationTestHelper {
     List<RemoteReplicaInfo> remoteReplicaInfos =
         replicationManager.partitionToPartitionInfo.get(existingPartition).getRemoteReplicaInfos();
     ReplicaId peerReplica1 = remoteReplicaInfos.get(0).getReplicaId();
-    // we purposely update lag to verify that local replica is present in ReplicaSyncUpManager.
-    assertTrue("Updating lag between local replica and peer replica should succeed",
-        mockHelixParticipant.getReplicaSyncUpManager().updateLagBetweenReplicas(localReplica, peerReplica1, 10L));
+
+    assertFalse("Sync up should not complete because not enough replicas have caught up",
+        mockHelixParticipant.getReplicaSyncUpManager()
+            .updateReplicaLagAndCheckSyncStatus(localReplica, peerReplica1, 10L, ReplicaState.INACTIVE));
     // pick another remote replica to update the replication lag
     ReplicaId peerReplica2 = remoteReplicaInfos.get(1).getReplicaId();
     replicationManager.updateTotalBytesReadByRemoteReplica(existingPartition,
@@ -536,7 +537,8 @@ public class ReplicationTest extends ReplicationTestHelper {
     // we purposely update lag against local replica to verify local replica is no longer in ReplicaSyncUpManager because
     // deactivation is complete and local replica should be removed from "replicaToLagInfos" map.
     assertFalse("Sync up should complete (2 replicas have caught up), hence updated should be false",
-        mockHelixParticipant.getReplicaSyncUpManager().updateLagBetweenReplicas(localReplica, peerReplica2, 0L));
+        mockHelixParticipant.getReplicaSyncUpManager()
+            .updateReplicaLagAndCheckSyncStatus(localReplica, peerReplica2, 0L, ReplicaState.INACTIVE));
     storageManager.shutdown();
   }
 

--- a/ambry-router/src/main/java/com/github/ambry/router/SimpleOperationTracker.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/SimpleOperationTracker.java
@@ -68,6 +68,7 @@ import org.slf4j.LoggerFactory;
  *
  */
 class SimpleOperationTracker implements OperationTracker {
+  private static final Logger logger = LoggerFactory.getLogger(SimpleOperationTracker.class);
   protected final String datacenterName;
   protected final String originatingDcName;
   protected final int diskReplicaSuccessTarget;
@@ -81,7 +82,10 @@ class SimpleOperationTracker implements OperationTracker {
   protected final int originatingDcNotFoundFailureThreshold;
   protected final int totalReplicaCount;
   protected final LinkedList<ReplicaId> replicaPool = new LinkedList<>();
-
+  private final OpTrackerIterator otIterator;
+  private final RouterOperation routerOperation;
+  private final RouterConfig routerConfig;
+  private final boolean crossColoEnabled;
   protected int inflightCount = 0;
   protected int diskReplicaSuccessCount = 0;
   protected int cloudReplicaSuccessCount = 0;
@@ -94,14 +98,8 @@ class SimpleOperationTracker implements OperationTracker {
   protected int diskDownCount = 0;
   protected ReplicaId lastReturnedByIterator = null;
   protected ReplicaType inFlightReplicaType;
-
-  private final OpTrackerIterator otIterator;
-  private final RouterOperation routerOperation;
-  private final RouterConfig routerConfig;
-  private final boolean crossColoEnabled;
   private Iterator<ReplicaId> replicaIterator;
   private String reassignedOriginDc = null;
-  private static final Logger logger = LoggerFactory.getLogger(SimpleOperationTracker.class);
 
   /**
    * Constructor for an {@code SimpleOperationTracker}. In constructor, there is a config allowing operation tracker to
@@ -139,8 +137,6 @@ class SimpleOperationTracker implements OperationTracker {
   SimpleOperationTracker(RouterConfig routerConfig, RouterOperation routerOperation, PartitionId partitionId,
       String originatingDcName, boolean shuffleReplicas) {
     // populate tracker parameters based on operation type
-    boolean includeNonOriginatingDcReplicas = true;
-    int numOfReplicasRequired = Integer.MAX_VALUE;
     this.routerConfig = routerConfig;
     this.routerOperation = routerOperation;
     this.originatingDcName = originatingDcName;
@@ -154,11 +150,8 @@ class SimpleOperationTracker implements OperationTracker {
         diskReplicaSuccessTarget = routerConfig.routerGetSuccessTarget;
         diskReplicaParallelism = routerConfig.routerGetRequestParallelism;
         crossColoEnabled = routerConfig.routerGetCrossDcEnabled;
-        includeNonOriginatingDcReplicas = routerConfig.routerGetIncludeNonOriginatingDcReplicas;
-        numOfReplicasRequired = routerConfig.routerGetReplicasRequired;
         eligibleReplicas = getEligibleReplicas(partitionId, null,
-            EnumSet.of(ReplicaState.BOOTSTRAP, ReplicaState.STANDBY, ReplicaState.LEADER, ReplicaState.INACTIVE,
-                ReplicaState.OFFLINE));
+            EnumSet.of(ReplicaState.BOOTSTRAP, ReplicaState.STANDBY, ReplicaState.LEADER, ReplicaState.INACTIVE));
         break;
       case PutOperation:
         eligibleReplicas =
@@ -265,19 +258,29 @@ class SimpleOperationTracker implements OperationTracker {
     }
     List<ReplicaId> backupReplicasToCheck = new ArrayList<>(backupReplicas);
     List<ReplicaId> downReplicasToCheck = new ArrayList<>(downReplicas);
-    if (includeNonOriginatingDcReplicas || this.originatingDcName == null) {
-      backupReplicas.forEach(this::addToEndOfPool);
+
+    // Add replicas that are neither in local dc nor in originating dc.
+    backupReplicas.forEach(this::addToEndOfPool);
+
+    if (routerConfig.routerOperationTrackerIncludeDownReplicas) {
+      // Add those replicas deemed by native failure detector to be down
       downReplicas.forEach(this::addToEndOfPool);
-    } else {
-      // This is for get request only. Take replicasRequired copy of replicas to do the request
-      // Please note replicasRequired is 6 because total number of local and originating replicas is always <= 6.
-      // This may no longer be true with partition classes and flexible replication.
-      // Don't do this if originatingDcName is unknown.
-      while (replicaPool.size() < numOfReplicasRequired && backupReplicas.size() > 0) {
-        addToEndOfPool(backupReplicas.pollFirst());
-      }
-      while (replicaPool.size() < numOfReplicasRequired && downReplicas.size() > 0) {
-        addToEndOfPool(downReplicas.pollFirst());
+      // Add those replicas deemed by Helix to be down (offline). This only applies to GET operation.
+      // Adding this logic to mitigate situation where one or more Zookeeper clusters are suddenly unavailable while
+      // ambry servers are still up.
+      if (routerOperation == RouterOperation.GetBlobOperation
+          || routerOperation == RouterOperation.GetBlobInfoOperation) {
+        Set<ReplicaId> offlineReplicas =
+            new HashSet<>(getEligibleReplicas(partitionId, null, EnumSet.of(ReplicaState.OFFLINE)));
+        Set<ReplicaId> originatingReplicas = offlineReplicas.stream().filter(r -> r.getDataNodeId().getDatacenterName().equals(this.originatingDcName)).collect(
+            Collectors.toSet());
+        numReplicasInOriginatingDc += originatingReplicas.size();
+        Set<ReplicaId> localOfflineReplicas = offlineReplicas.stream()
+            .filter(r -> r.getDataNodeId().getDatacenterName().equals(datacenterName))
+            .collect(Collectors.toSet());
+        offlineReplicas.removeAll(localOfflineReplicas);
+        localOfflineReplicas.forEach(this::addToEndOfPool);
+        offlineReplicas.forEach(this::addToEndOfPool);
       }
     }
     totalReplicaCount = replicaPool.size();


### PR DESCRIPTION
Ambry frontend now allows GET operation to try on OFFLINE replicas. During replica decommission, the first step is to
disable replica. This will eventually bring replica to OFFLINE state and remove its entry from DataNodeConfig. All listeners
(both frontends and servers) will receive the DataNodeConfig change and remove this replica from in-mem clustermap. However, at this point of time, the IdealState in Helix hasn't been changed and this replica still exists in external view. So when router calls getReplicaIdByState(), the RoutingTableProvider still returns instance(server) associated with this replica. This causes a null replica when router queries in-mem clustermap by this instance and our code doesn't invalidate the null value in the return result, which triggers NPEs in the end.
This PR makes following changes:
1. Add a config to control whether to add down replicas to the replica pool in operation tracker. If yes, down(offline) replicas
   will be added to the end.
2. Preclude null replicas in the method of getReplicaIdsByState().
3. Make "update replication lag" in ReplicaSyncUpManager atomic. Added lock to avoid race condition in the process of  updateLag-checkStatus-completeSyncUp. (We saw two threads concurrently attempting to count the same latch in production. The loser threw IllegalStateException because latch was already removed.)