### PR TITLE
[Container API] Check status of existing container before creating same container

### DIFF
--- a/ambry-account/src/main/java/com/github/ambry/account/AbstractAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/AbstractAccountService.java
@@ -115,12 +115,12 @@ abstract class AbstractAccountService implements AccountService {
         if (existingContainer != null) {
           switch (existingContainer.getStatus()) {
             case INACTIVE:
-              throw new AccountServiceException("The container has gone and cannot be restored",
+              throw new AccountServiceException(
+                  "The container " + container.getName() + " has gone and cannot be restored",
                   AccountServiceErrorCode.ResourceHasGone);
             case DELETE_IN_PROGRESS:
-              throw new AccountServiceException(
-                  "Create method is not allowed on container with Delete_In_Progress state",
-                  AccountServiceErrorCode.MethodNotAllowed);
+              throw new AccountServiceException("Create method is not allowed on container " + container.getName()
+                  + " as it's in Delete_In_Progress state", AccountServiceErrorCode.MethodNotAllowed);
             case ACTIVE:
               // make sure there is no conflicting container (conflicting means a container with same name but different attributes already exists).
               if (existingContainer.isSameContainer(container)) {

--- a/ambry-account/src/test/java/com/github/ambry/account/HelixAccountServiceTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/HelixAccountServiceTest.java
@@ -45,6 +45,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.regex.Matcher;
@@ -380,9 +381,16 @@ public class HelixAccountServiceTest {
     Container inactiveContainer =
         new ContainerBuilder((short) (refContainer.getId() + 2), "inactive", Container.ContainerStatus.INACTIVE, "",
             refAccount.getId()).build();
-    Container deleteInProgressContainer = new ContainerBuilder((short) (refContainer.getId() + 3), "delete-in-progress",
-        ContainerStatus.DELETE_IN_PROGRESS, "", refAccount.getId()).build();
-    refAccount.updateContainerMap(Arrays.asList(activeContainer, inactiveContainer, deleteInProgressContainer));
+    Container deleteInProgressContainer1 =
+        new ContainerBuilder((short) (refContainer.getId() + 3), "within-retention-period",
+            ContainerStatus.DELETE_IN_PROGRESS, "", refAccount.getId()).setDeleteTriggerTime(System.currentTimeMillis())
+            .build();
+    Container deleteInProgressContainer2 =
+        new ContainerBuilder((short) (refContainer.getId() + 4), "past-retention-period",
+            ContainerStatus.DELETE_IN_PROGRESS, "", refAccount.getId()).setDeleteTriggerTime(
+            System.currentTimeMillis() - TimeUnit.DAYS.toMillis(15)).build();
+    refAccount.updateContainerMap(
+        Arrays.asList(activeContainer, inactiveContainer, deleteInProgressContainer1, deleteInProgressContainer2));
     // add an account with single container
     accountService.updateAccounts(Collections.singletonList(refAccount));
 
@@ -410,8 +418,10 @@ public class HelixAccountServiceTest {
 
     // 3. test containers already exist with INACTIVE and DELETE_IN_PROGRESS state
     Container duplicateInactiveContainer = new ContainerBuilder(inactiveContainer).setId(UNKNOWN_CONTAINER_ID).build();
-    Container duplicateDeleteInProgressContainer =
-        new ContainerBuilder(deleteInProgressContainer).setId(UNKNOWN_CONTAINER_ID).build();
+    Container duplicateDeleteInProgressContainer1 =
+        new ContainerBuilder(deleteInProgressContainer1).setId(UNKNOWN_CONTAINER_ID).build();
+    Container duplicateDeleteInProgressContainer2 =
+        new ContainerBuilder(deleteInProgressContainer2).setId(UNKNOWN_CONTAINER_ID).build();
     try {
       accountService.updateContainers(refAccountName, Collections.singleton(duplicateInactiveContainer));
       fail("Should fail because the existing container has been marked INACTIVE.");
@@ -419,10 +429,16 @@ public class HelixAccountServiceTest {
       assertEquals("Mismatch in error code", AccountServiceErrorCode.ResourceHasGone, ase.getErrorCode());
     }
     try {
-      accountService.updateContainers(refAccountName, Collections.singleton(duplicateDeleteInProgressContainer));
+      accountService.updateContainers(refAccountName, Collections.singleton(duplicateDeleteInProgressContainer1));
       fail("Should fail because the existing container has been marked DELETE_IN_PROGRESS.");
     } catch (AccountServiceException ase) {
       assertEquals("Mismatch in error code", AccountServiceErrorCode.MethodNotAllowed, ase.getErrorCode());
+    }
+    try {
+      accountService.updateContainers(refAccountName, Collections.singleton(duplicateDeleteInProgressContainer2));
+      fail("Should fail because the existing container has been marked DELETE_IN_PROGRESS and past retention time");
+    } catch (AccountServiceException ase) {
+      assertEquals("Mismatch in error code", AccountServiceErrorCode.ResourceHasGone, ase.getErrorCode());
     }
     // 4. test conflict container (new container with existing name but different attributes)
     Container conflictContainer = new ContainerBuilder(brandNewContainer).setBackupEnabled(true).build();
@@ -433,7 +449,7 @@ public class HelixAccountServiceTest {
       assertEquals("Mismatch in error code", AccountServiceErrorCode.ResourceConflict, e.getErrorCode());
     }
 
-    // 4. test adding same container twice, should be no-op and return result should include container with id
+    // 5. test adding same container twice, should be no-op and return result should include container with id
     Collection<Container> addedContainers =
         accountService.updateContainers(refAccountName, Collections.singleton(brandNewContainer));
     assertEquals("Mismatch in return count", 1, addedContainers.size());
@@ -443,7 +459,7 @@ public class HelixAccountServiceTest {
       assertEquals("Mismatch in container name", activeContainer.getName(), container.getName());
     }
 
-    // 5. test adding a different container (failure case due to ZK update failure)
+    // 6. test adding a different container (failure case due to ZK update failure)
     MockHelixPropertyStore<ZNRecord> mockHelixStore =
         mockHelixAccountServiceFactory.getHelixStore(ZK_CONNECT_STRING, storeConfig);
     mockHelixStore.setExceptionDuringUpdater(true);
@@ -455,7 +471,7 @@ public class HelixAccountServiceTest {
     }
     mockHelixStore.setExceptionDuringUpdater(false);
 
-    // 6. test adding 2 different containers (success case)
+    // 7. test adding 2 different containers (success case)
     Container containerToAdd2 =
         new ContainerBuilder(UNKNOWN_CONTAINER_ID, "newContainer2", ContainerStatus.ACTIVE, "description",
             refParentAccountId).build();

--- a/ambry-account/src/test/java/com/github/ambry/account/MySqlAccountServiceTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/MySqlAccountServiceTest.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import org.junit.Test;
 
@@ -499,15 +500,19 @@ public class MySqlAccountServiceTest {
     AccountService mySqlAccountService = getAccountService();
     String accountName = "test-account";
     String inactiveContainer = "inactive-container";
-    String deleteInProgressContainer = "delete-in-progress-container";
+    String deleteInProgressContainer1 = "delete-in-progress-container1";
+    String deleteInProgressContainer2 = "delete-in-progress-container2";
     // create a testing account with inactive and delete-in-progress container.
     Account accountToUpdate =
         new AccountBuilder((short) 1, accountName, Account.AccountStatus.ACTIVE).addOrUpdateContainer(
             new ContainerBuilder((short) 1, inactiveContainer, Container.ContainerStatus.INACTIVE, "",
                 (short) 1).build())
-            .addOrUpdateContainer(
-                new ContainerBuilder((short) 2, deleteInProgressContainer, Container.ContainerStatus.DELETE_IN_PROGRESS,
-                    "", (short) 1).build())
+            .addOrUpdateContainer(new ContainerBuilder((short) 2, deleteInProgressContainer1,
+                Container.ContainerStatus.DELETE_IN_PROGRESS, "", (short) 1).setDeleteTriggerTime(
+                System.currentTimeMillis()).build())
+            .addOrUpdateContainer(new ContainerBuilder((short) 3, deleteInProgressContainer2,
+                Container.ContainerStatus.DELETE_IN_PROGRESS, "", (short) 1).setDeleteTriggerTime(
+                System.currentTimeMillis() - TimeUnit.DAYS.toMillis(15)).build())
             .build();
     mySqlAccountService.updateAccounts(Collections.singletonList(accountToUpdate));
 
@@ -522,14 +527,24 @@ public class MySqlAccountServiceTest {
       assertEquals("Mismatch in error code", AccountServiceErrorCode.ResourceHasGone, ase.getErrorCode());
     }
 
-    // Attempting to create an existing container with DELETE_IN_PROGRESS state should fail
-    containerToCreate = new ContainerBuilder(Container.UNKNOWN_CONTAINER_ID, deleteInProgressContainer,
+    // Attempting to create an existing container with DELETE_IN_PROGRESS state (within retention time) should fail
+    containerToCreate = new ContainerBuilder(Container.UNKNOWN_CONTAINER_ID, deleteInProgressContainer1,
         Container.ContainerStatus.ACTIVE, "", (short) 1).build();
     try {
       mySqlAccountService.updateContainers(accountName, Collections.singletonList(containerToCreate));
       fail("should fail because container to create is in DELETE_IN_PROGRESS state");
     } catch (AccountServiceException ase) {
       assertEquals("Mismatch in error code", AccountServiceErrorCode.MethodNotAllowed, ase.getErrorCode());
+    }
+
+    // Attempting to create an existing container with DELETE_IN_PROGRESS state (past retention time) should fail
+    containerToCreate = new ContainerBuilder(Container.UNKNOWN_CONTAINER_ID, deleteInProgressContainer2,
+        Container.ContainerStatus.ACTIVE, "", (short) 1).build();
+    try {
+      mySqlAccountService.updateContainers(accountName, Collections.singletonList(containerToCreate));
+      fail("should fail because container to create is in DELETE_IN_PROGRESS state and past retention time");
+    } catch (AccountServiceException ase) {
+      assertEquals("Mismatch in error code", AccountServiceErrorCode.ResourceHasGone, ase.getErrorCode());
     }
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/account/AccountServiceErrorCode.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/AccountServiceErrorCode.java
@@ -30,6 +30,14 @@ public enum AccountServiceErrorCode {
    */
   ResourceConflict,
   /**
+   * The account or container has gone and cannot be restored.
+   */
+  ResourceHasGone,
+  /**
+   * Method in request is not allowed on account or container.
+   */
+  MethodNotAllowed,
+  /**
    * Account service experienced an internal error.
    */
   InternalError,

--- a/ambry-api/src/main/java/com/github/ambry/account/Container.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/Container.java
@@ -535,7 +535,9 @@ public class Container {
         && Objects.equals(this.isTtlRequired(), containerToCompare.isTtlRequired())
         && Objects.equals(this.getReplicationPolicy(), containerToCompare.getReplicationPolicy())
         && Objects.equals(this.isSecurePathRequired(), containerToCompare.isSecurePathRequired())
-        && Objects.equals(this.isBackupEnabled(), containerToCompare.isBackupEnabled());
+        && Objects.equals(this.isBackupEnabled(), containerToCompare.isBackupEnabled())
+        && Objects.equals(this.getContentTypeWhitelistForFilenamesOnDownload(),
+                          containerToCompare.getContentTypeWhitelistForFilenamesOnDownload());
     //@formatter:on
   }
 

--- a/ambry-api/src/main/java/com/github/ambry/config/AccountServiceConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/AccountServiceConfig.java
@@ -23,6 +23,7 @@ public class AccountServiceConfig {
       ACCOUNT_SERVICE_PREFIX + "max.retry.count.on.update.failure";
   public static final String RETRY_DELAY_MS = ACCOUNT_SERVICE_PREFIX + "retry.delay.ms";
   public static final String IGNORE_VERSION_MISMATCH = ACCOUNT_SERVICE_PREFIX + "ignore.version.mismatch";
+  public static final String CONTAINER_DEPRECATION_RETENTION_DAYS = ACCOUNT_SERVICE_PREFIX + "container.deprecation.retention.days";
 
   /** The numeric container Id to be used for the first container created within an account. */
   @Config(CONTAINER_ID_START_NUMBER)
@@ -50,11 +51,19 @@ public class AccountServiceConfig {
   @Default("false")
   public final boolean ignoreVersionMismatch;
 
+  /**
+   * The period of time during which the deprecated container can be restored. After retention time, compaction starts
+   * to compact blobs in this container.
+   */
+  @Config(CONTAINER_DEPRECATION_RETENTION_DAYS)
+  public final int containerDeprecationRetentionDays;
+
   public AccountServiceConfig(VerifiableProperties verifiableProperties) {
     containerIdStartNumber =
         verifiableProperties.getShortInRange(CONTAINER_ID_START_NUMBER, (short) 1, (short) 0, Short.MAX_VALUE);
     maxRetryCountOnUpdateFailure = verifiableProperties.getIntInRange(MAX_RETRY_COUNT_ON_UPDATE_FAILURE, 10, 1, 100);
     retryDelayMs = verifiableProperties.getLongInRange(RETRY_DELAY_MS, 1000, 1, Long.MAX_VALUE);
     ignoreVersionMismatch = verifiableProperties.getBoolean(IGNORE_VERSION_MISMATCH, false);
+    containerDeprecationRetentionDays = verifiableProperties.getIntInRange(CONTAINER_DEPRECATION_RETENTION_DAYS, 13, 0, Integer.MAX_VALUE);
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/rest/RestServiceErrorCode.java
+++ b/ambry-api/src/main/java/com/github/ambry/rest/RestServiceErrorCode.java
@@ -232,6 +232,10 @@ public enum RestServiceErrorCode {
         return BadRequest;
       case UpdateDisabled:
         return ServiceUnavailable;
+      case ResourceHasGone:
+        return Deleted;
+      case MethodNotAllowed:
+        return NotAllowed;
       default:
         return InternalServerError;
     }


### PR DESCRIPTION
This PR fixes an edge case where user may attempt to create same container even though the container is already deprecated.
There are two posssible states to handle:
1. if existing container is INACTIVE, Ambry throws ResourceHasGone exception indicating the container is unrecoverable.
2. if existing container is DELETE_IN_PROGRESS, Ambry throws MethodNotAllowed exception. User is able to cancel deprecation to restore the whole container.