### PR TITLE
[Content Encoding] Support serialize for new version of blobProperty

### DIFF
--- a/ambry-messageformat/src/test/java/com/github/ambry/messageformat/BlobPropertiesTest.java
+++ b/ambry-messageformat/src/test/java/com/github/ambry/messageformat/BlobPropertiesTest.java
@@ -84,10 +84,19 @@ public class BlobPropertiesTest {
     String filenameToExpect = filename;
 
     BlobProperties blobProperties = new BlobProperties(blobSize, serviceId, null, null, false, Utils.Infinite_Time,
+        SystemTime.getInstance().milliseconds(), accountId, containerId, isEncrypted, externalAssetTag, null, null);
+    System.out.println(blobProperties.toString()); // Provide example of BlobProperties.toString()
+    ByteBuffer serializedBuffer = serializeBlobPropertiesInVersion(blobProperties);
+    blobProperties = BlobPropertiesSerDe.getBlobPropertiesFromStream(
+        new DataInputStream(new ByteBufferInputStream(serializedBuffer)));
+    verifyBlobProperties(blobProperties, blobSize, serviceId, "", "", false, Utils.Infinite_Time, accountIdToExpect,
+        containerIdToExpect, encryptFlagToExpect, null, null, null);
+
+    blobProperties = new BlobProperties(blobSize, serviceId, null, null, false, Utils.Infinite_Time,
         SystemTime.getInstance().milliseconds(), accountId, containerId, isEncrypted, externalAssetTag, contentEncoding,
         filename);
     System.out.println(blobProperties.toString()); // Provide example of BlobProperties.toString()
-    ByteBuffer serializedBuffer = serializeBlobPropertiesInVersion(blobProperties);
+    serializedBuffer = serializeBlobPropertiesInVersion(blobProperties);
     blobProperties = BlobPropertiesSerDe.getBlobPropertiesFromStream(
         new DataInputStream(new ByteBufferInputStream(serializedBuffer)));
     verifyBlobProperties(blobProperties, blobSize, serviceId, "", "", false, Utils.Infinite_Time, accountIdToExpect,

--- a/ambry-messageformat/src/test/java/com/github/ambry/messageformat/BlobPropertiesTest.java
+++ b/ambry-messageformat/src/test/java/com/github/ambry/messageformat/BlobPropertiesTest.java
@@ -217,20 +217,13 @@ public class BlobPropertiesTest {
         outputBuffer.flip();
         break;
       case BlobPropertiesSerDe.VERSION_3:
-        outputBuffer = ByteBuffer.allocate(BlobPropertiesSerDe.getBlobPropertiesSerDeSize(blobProperties));
-        BlobPropertiesSerDe.serializeBlobProperties(outputBuffer, blobProperties);
-        outputBuffer.flip();
-        break;
-      case BlobPropertiesSerDe.VERSION_4:
-        //will update this part once serialize logic is in.
         size = VERSION_FIELD_SIZE_IN_BYTES + TTL_FIELD_SIZE_IN_BYTES + PRIVATE_FIELD_SIZE_IN_BYTES
             + CREATION_TIME_FIELD_SIZE_IN_BYTES + BLOB_SIZE_FIELD_SIZE_IN_BYTES + Utils.getIntStringLength(
             blobProperties.getContentType()) + Utils.getIntStringLength(blobProperties.getOwnerId())
             + Utils.getIntStringLength(blobProperties.getServiceId()) + Short.BYTES + Short.BYTES
-            + ENCRYPTED_FIELD_SIZE_IN_BYTES + Utils.getIntStringLength(blobProperties.getContentEncoding())
-            + Utils.getIntStringLength(blobProperties.getFilename());
+            + ENCRYPTED_FIELD_SIZE_IN_BYTES;
         outputBuffer = ByteBuffer.allocate(size);
-        outputBuffer.putShort(VERSION_4);
+        outputBuffer.putShort(VERSION_3);
         outputBuffer.putLong(blobProperties.getTimeToLiveInSeconds());
         outputBuffer.put(blobProperties.isPrivate() ? (byte) 1 : (byte) 0);
         outputBuffer.putLong(blobProperties.getCreationTimeInMs());
@@ -241,8 +234,11 @@ public class BlobPropertiesTest {
         outputBuffer.putShort(blobProperties.getAccountId());
         outputBuffer.putShort(blobProperties.getContainerId());
         outputBuffer.put(blobProperties.isEncrypted() ? (byte) 1 : (byte) 0);
-        Utils.serializeNullableString(outputBuffer, blobProperties.getContentEncoding());
-        Utils.serializeNullableString(outputBuffer, blobProperties.getFilename());
+        outputBuffer.flip();
+        break;
+      case BlobPropertiesSerDe.VERSION_4:
+        outputBuffer = ByteBuffer.allocate(BlobPropertiesSerDe.getBlobPropertiesSerDeSize(blobProperties));
+        BlobPropertiesSerDe.serializeBlobProperties(outputBuffer, blobProperties);
         outputBuffer.flip();
         break;
     }

--- a/ambry-server/src/integration-test/java/com/github/ambry/server/CloudAndStoreReplicationTest.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/CloudAndStoreReplicationTest.java
@@ -89,7 +89,7 @@ public class CloudAndStoreReplicationTest {
   private final short containerId = Utils.getRandomShort(TestUtils.RANDOM);
   private final static int FOUR_MB_SZ = 4194304;
   private final String vcrRecoveryPartitionConfig;
-  private static int zkPort = 31997;
+  private static int zkPort = 31990;
   private static final String zkConnectString = "localhost:" + zkPort;
   private static final String vcrClusterName = "vcrTestCluster";
   private static final String cloudDc = "CloudDc";
@@ -306,8 +306,9 @@ public class CloudAndStoreReplicationTest {
     for (PartitionResponseInfo partitionResponseInfo : getResponse.getPartitionResponseInfoList()) {
       assertEquals("Error in getting the recovered blobs", ServerErrorCode.No_Error,
           partitionResponseInfo.getErrorCode());
+      //old value is 272. Adding 8 Bytes due to the two fields added 4 + 4 Blob Property BYTE.
       for (MessageInfo messageInfo : partitionResponseInfo.getMessageInfoList()) {
-        assertEquals(blobIdToSizeMap.get(messageInfo.getStoreKey()) + 272, messageInfo.getSize());
+        assertEquals(blobIdToSizeMap.get(messageInfo.getStoreKey()) + 280, messageInfo.getSize());
       }
     }
   }

--- a/ambry-server/src/integration-test/java/com/github/ambry/server/ServerHardDeleteTest.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/ServerHardDeleteTest.java
@@ -314,7 +314,10 @@ public class ServerHardDeleteTest {
     //
     // Add 14 here when changing message header version to 3, since the message header version went from 2 to 3 and adds
     // a short to every record, which include 6 puts and 1 delete. (last delete is not included).
-    int expectedTokenValueT1 = 198732 + 14;
+
+    // old value is 198732 + 14. Increased by 48 when adding two fields(4 BYTE CRC for each field) in blobProperty when putBlob.
+    // There are 6 * (4 + 4). 6 stands for the times for putBlob, 4 stands for 4 extra blobProperty Bytes for each field.
+    int expectedTokenValueT1 = 198732 + 14 + 48;
     ensureCleanupTokenCatchesUp(chosenPartition.getReplicaIds().get(0).getReplicaPath(), mockClusterMap,
         expectedTokenValueT1);
 
@@ -351,7 +354,7 @@ public class ServerHardDeleteTest {
 
     time.sleep(TimeUnit.DAYS.toMillis(1));
     // For each future change to this offset, add to this variable and write an explanation of why the number changed.
-    int expectedTokenValueT2 = 298416 + 98 + 28;
+    int expectedTokenValueT2 = 298416 + 98 + 28 + 72;
     // old value: 298400. Increased by 16 (4 * 4) to 298416 because the format for delete record went from 2 to 3 which
     // adds 4 bytes (two shorts) extra. The last record is a delete record so its extra 4 bytes are not added
     //
@@ -362,6 +365,9 @@ public class ServerHardDeleteTest {
     // old value is 298416 + 98. Increased by 28 when changing the message header version from 2 to 3, which adds a short
     // to all the records, which includes 9 puts and 5 deletes and 1 undelete. Undelete is not include since it's the last
     // record.
+
+    // old value is 298416 + 98 + 28. Increased by 72 when adding two fields(4 BYTE CRC for each field) in blobProperty when putBlob.
+    // There are 9 * (4 + 4). 9 stands for the times for putBlob, 4 stands for 4 extra blobProperty Bytes.
     ensureCleanupTokenCatchesUp(chosenPartition.getReplicaIds().get(0).getReplicaPath(), mockClusterMap,
         expectedTokenValueT2);
 

--- a/ambry-server/src/integration-test/java/com/github/ambry/server/VcrRecoveryTest.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/VcrRecoveryTest.java
@@ -189,8 +189,9 @@ public class VcrRecoveryTest {
     for (PartitionResponseInfo partitionResponseInfo : getResponse.getPartitionResponseInfoList()) {
       assertEquals("Error in getting the recovered blobs", ServerErrorCode.No_Error,
           partitionResponseInfo.getErrorCode());
+      //old value is 272. Adding 8 Bytes due to the two fields added 4 + 4 Blob Property BYTE.
       for (MessageInfo messageInfo : partitionResponseInfo.getMessageInfoList()) {
-        assertEquals(blobIdToSizeMap.get(messageInfo.getStoreKey()) + 272, messageInfo.getSize());
+        assertEquals(blobIdToSizeMap.get(messageInfo.getStoreKey()) + 280, messageInfo.getSize());
       }
     }
   }

--- a/ambry-utils/src/main/java/com/github/ambry/utils/Utils.java
+++ b/ambry-utils/src/main/java/com/github/ambry/utils/Utils.java
@@ -149,13 +149,15 @@ public class Utils {
     return readIntString(input, StandardCharsets.UTF_8);
   }
 
+  /**
+   * Reads a nullable String whose length is an int from the given input stream
+   * @param input The input stream from which to read the String from
+   * @return The String read from the stream
+   * @throws IOException
+   */
   public static String readNullableIntString(DataInputStream input) throws IOException {
     String tmp = readIntString(input, StandardCharsets.UTF_8);
-    if (tmp.length() == 0) {
-      return null;
-    } else {
-      return tmp;
-    }
+    return tmp.isEmpty() ? null : tmp;
   }
 
   /**

--- a/ambry-utils/src/main/java/com/github/ambry/utils/Utils.java
+++ b/ambry-utils/src/main/java/com/github/ambry/utils/Utils.java
@@ -149,6 +149,15 @@ public class Utils {
     return readIntString(input, StandardCharsets.UTF_8);
   }
 
+  public static String readNullableIntString(DataInputStream input) throws IOException {
+    String tmp = readIntString(input, StandardCharsets.UTF_8);
+    if (tmp.length() == 0) {
+      return null;
+    } else {
+      return tmp;
+    }
+  }
+
   /**
    * Reads a String whose length is an int from the given input stream
    * @param input The input stream from which to read the String from


### PR DESCRIPTION
Support serialize for version4 of blobProperty and fix the issue when field is null but after deserialize it's empty.