### PR TITLE
Increase timeout on some tests

### DIFF
--- a/ambry-router/src/test/java/com/github/ambry/router/PutManagerTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/PutManagerTest.java
@@ -85,7 +85,7 @@ import static org.junit.Assert.*;
 @RunWith(Parameterized.class)
 public class PutManagerTest {
   static final GeneralSecurityException GSE = new GeneralSecurityException("Exception to throw for tests");
-  private static final long MAX_WAIT_MS = 5000;
+  private static final long MAX_WAIT_MS = 10000;
   private final boolean testEncryption;
   private final int metadataContentVersion;
   private final MockServerLayout mockServerLayout;

--- a/ambry-server/src/integration-test/java/com/github/ambry/server/RouterServerTestFramework.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/RouterServerTestFramework.java
@@ -64,7 +64,7 @@ import org.junit.Assert;
  * {@link RouterServerSSLTest} for example usage.
  */
 class RouterServerTestFramework {
-  static final int AWAIT_TIMEOUT = 50;
+  static final int AWAIT_TIMEOUT = 120;
   static final int CHUNK_SIZE = 1024 * 1024;
 
   private final MockClusterMap clusterMap;


### PR DESCRIPTION
This should ease the test failures on PutManagerTest and ambry-server integration tests.