### PR TITLE
[named_blobs] Avoid bad affected row count assumptions

### DIFF
--- a/ambry-named-mysql/src/main/java/com/github/ambry/named/MySqlNamedBlobDbFactory.java
+++ b/ambry-named-mysql/src/main/java/com/github/ambry/named/MySqlNamedBlobDbFactory.java
@@ -60,9 +60,6 @@ public class MySqlNamedBlobDbFactory implements NamedBlobDbFactory {
     hikariConfig.addDataSourceProperty("prepStmtCacheSize", "250");
     hikariConfig.addDataSourceProperty("prepStmtCacheSqlLimit", "2048");
     hikariConfig.addDataSourceProperty("useServerPrepStmts", "true");
-    // Checking if a row was actually changed in an update requires the DataSource to be configured with the
-    // useAffectedRows option, otherwise the number of rows visited will be returned, even if they are not changed.
-    hikariConfig.addDataSourceProperty("useAffectedRows", "true");
     hikariConfig.setMetricRegistry(metricRegistry);
     return new HikariDataSource(hikariConfig);
   }

--- a/ambry-named-mysql/src/test/resources/mysql.properties
+++ b/ambry-named-mysql/src/test/resources/mysql.properties
@@ -9,4 +9,4 @@
 # under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 # CONDITIONS OF ANY KIND, either express or implied.
 #
-mysql.named.blob.db.info=[{"url":"jdbc:mysql://localhost/AmbryNamedBlobs?serverTimezone=UTC","datacenter":"dc1","isWriteable":"true","username":"travis","password":""}]
+mysql.named.blob.db.info=[{"url":"jdbc:mysql://localhost/AmbryNamedBlobs","datacenter":"dc1","isWriteable":"true","username":"travis","password":""}]


### PR DESCRIPTION
Previously, the put code used an "insert on duplicate key" expression
with conditional assignments. However, this required using the affected
rows to count how many rows actually changed. If the DB is set up to use
triggers that assign other metadata columns, the row may change even if
the specific fields set in the update call did not.

As an alternative, we can switch to the default "found rows" jdbc
behavior and use an optimistic insert followed by a conditional update.