### PR TITLE
[StorageQuota] Fix a mysql query error when parsing month from empty set

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/server/AccountStatsStore.java
+++ b/ambry-api/src/main/java/com/github/ambry/server/AccountStatsStore.java
@@ -83,7 +83,7 @@ public interface AccountStatsStore {
   /**
    * Return the month value of the current container storage snapshot.
    * @param clusterName The clusterName.
-   * @return The month value for current snapshot, like "2020-01"
+   * @return The month value for current snapshot, like "2020-01". Empty string will be returned if there is no record.
    * @throws Exception
    */
   String queryRecordedMonth(String clusterName) throws Exception;

--- a/ambry-mysql/src/integration-test/java/com/github/ambry/accountstats/AccountStatsMySqlStoreIntegrationTest.java
+++ b/ambry-mysql/src/integration-test/java/com/github/ambry/accountstats/AccountStatsMySqlStoreIntegrationTest.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Random;
 import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -139,6 +140,8 @@ public class AccountStatsMySqlStoreIntegrationTest {
       mySqlStore.storeAggregatedStats(snapshot);
       currentContainerStorageUsages = mySqlStore.queryAggregatedStats(clusterName1);
     }
+    // fetch the month and it should return emtpy string
+    Assert.assertEquals("", mySqlStore.queryRecordedMonth(clusterName1));
     mySqlStore.takeSnapshotOfAggregatedStatsAndUpdateMonth(clusterName1, monthValue);
     Map<String, Map<String, Long>> monthlyContainerStorageUsages = mySqlStore.queryMonthlyAggregatedStats(clusterName1);
     TestUtils.assertContainerMap(currentContainerStorageUsages, monthlyContainerStorageUsages);

--- a/ambry-mysql/src/main/java/com/github/ambry/accountstats/AccountReportsDao.java
+++ b/ambry-mysql/src/main/java/com/github/ambry/accountstats/AccountReportsDao.java
@@ -108,15 +108,13 @@ public class AccountReportsDao {
       queryStatement.setString(1, clusterName);
       queryStatement.setString(2, hostname);
       ResultSet resultSet = queryStatement.executeQuery();
-      if (resultSet != null) {
-        while (resultSet.next()) {
-          int partitionId = resultSet.getInt(PARTITION_ID_COLUMN);
-          int accountId = resultSet.getInt(ACCOUNT_ID_COLUMN);
-          int containerId = resultSet.getInt(CONTAINER_ID_COLUMN);
-          long storageUsage = resultSet.getLong(STORAGE_USAGE_COLUMN);
-          long updatedAtMs = resultSet.getTimestamp(UPDATED_AT_COLUMN).getTime();
-          func.apply((short) partitionId, (short) accountId, (short) containerId, storageUsage, updatedAtMs);
-        }
+      while (resultSet.next()) {
+        int partitionId = resultSet.getInt(PARTITION_ID_COLUMN);
+        int accountId = resultSet.getInt(ACCOUNT_ID_COLUMN);
+        int containerId = resultSet.getInt(CONTAINER_ID_COLUMN);
+        long storageUsage = resultSet.getLong(STORAGE_USAGE_COLUMN);
+        long updatedAtMs = resultSet.getTimestamp(UPDATED_AT_COLUMN).getTime();
+        func.apply((short) partitionId, (short) accountId, (short) containerId, storageUsage, updatedAtMs);
       }
       dataAccessor.onSuccess(Read, System.currentTimeMillis() - startTimeMs);
     } catch (SQLException e) {

--- a/ambry-mysql/src/main/java/com/github/ambry/accountstats/AggregatedAccountReportsDao.java
+++ b/ambry-mysql/src/main/java/com/github/ambry/accountstats/AggregatedAccountReportsDao.java
@@ -151,13 +151,11 @@ public class AggregatedAccountReportsDao {
       PreparedStatement queryStatement = dataAccessor.getPreparedStatement(sqlStatement, false);
       queryStatement.setString(1, clusterName);
       ResultSet resultSet = queryStatement.executeQuery();
-      if (resultSet != null) {
-        while (resultSet.next()) {
-          int accountId = resultSet.getInt(ACCOUNT_ID_COLUMN);
-          int containerId = resultSet.getInt(CONTAINER_ID_COLUMN);
-          long storageUsage = resultSet.getLong(STORAGE_USAGE_COLUMN);
-          func.apply((short) accountId, (short) containerId, storageUsage);
-        }
+      while (resultSet.next()) {
+        int accountId = resultSet.getInt(ACCOUNT_ID_COLUMN);
+        int containerId = resultSet.getInt(CONTAINER_ID_COLUMN);
+        long storageUsage = resultSet.getLong(STORAGE_USAGE_COLUMN);
+        func.apply((short) accountId, (short) containerId, storageUsage);
       }
       dataAccessor.onSuccess(Read, System.currentTimeMillis() - startTimeMs);
     } catch (SQLException e) {
@@ -202,8 +200,7 @@ public class AggregatedAccountReportsDao {
       queryStatement.setString(1, clusterName);
       ResultSet resultSet = queryStatement.executeQuery();
       dataAccessor.onSuccess(Read, System.currentTimeMillis() - startTimeMs);
-      if (resultSet != null) {
-        resultSet.next();
+      if (resultSet.next()) {
         return resultSet.getString(MONTH_COLUMN);
       }
       return "";


### PR DESCRIPTION
When there is no data in the table, AccountStatsMysqlStore should return empty string for month query. This PR fixes that.