### PR TITLE
HelixBootstrapTool changes to support InstanceConfig-To-PropertyStore migration

### DIFF
--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DataNodeConfig.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DataNodeConfig.java
@@ -185,6 +185,29 @@ class DataNodeConfig {
         that.disabledReplicas) && diskConfigs.equals(that.diskConfigs);
   }
 
+  /**
+   * Conditional equivalency check between two {@link DataNodeConfig}.
+   * @param other the other {@link DataNodeConfig} to compare with current config.
+   * @param ignoreReplicaStatusFields whether to ignore replica status fields (i.e Sealed/Stopped/Disabled) in comparison.
+   * @return {@code true} if two {@link DataNodeConfig}s are conditionally equivalent.
+   */
+  public boolean equals(DataNodeConfig other, boolean ignoreReplicaStatusFields){
+    if (ignoreReplicaStatusFields) {
+      // @formatter:off
+      return Objects.equals(instanceName, other.getInstanceName())
+          && Objects.equals(hostName, other.getHostName())
+          && Objects.equals(datacenterName, other.getDatacenterName())
+          && port == other.getPort()
+          && Objects.equals(sslPort, other.getSslPort())
+          && Objects.equals(http2Port, other.getHttp2Port())
+          && Objects.equals(rackId, other.getRackId())
+          && diskConfigs.equals(other.getDiskConfigs());
+      // @formatter:on
+    } else {
+      return this.equals(other);
+    }
+  }
+
   @Override
   public int hashCode() {
     return instanceName.hashCode();

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DataNodeConfig.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DataNodeConfig.java
@@ -20,6 +20,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TreeMap;
 
 
 /**
@@ -37,7 +38,7 @@ class DataNodeConfig {
   private final Set<String> sealedReplicas = new HashSet<>();
   private final Set<String> stoppedReplicas = new HashSet<>();
   private final Set<String> disabledReplicas = new HashSet<>();
-  private final Map<String, DiskConfig> diskConfigs = new HashMap<>();
+  private final Map<String, DiskConfig> diskConfigs = new TreeMap<>();
   private final Map<String, Map<String, String>> extraMapFields = new HashMap<>();
 
   /**
@@ -195,7 +196,7 @@ class DataNodeConfig {
   static class DiskConfig {
     private final HardwareState state;
     private final long diskCapacityInBytes;
-    private final Map<String, ReplicaConfig> replicaConfigs = new HashMap<>();
+    private final Map<String, ReplicaConfig> replicaConfigs = new TreeMap<>();
 
     /**
      * @param state the configured {@link HardwareState} of the disk.

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
@@ -366,7 +366,7 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
       newReplicaInfoAdded = true;
     }
     if (newReplicaInfoAdded) {
-      //logger.info("Updating config: {} in Helix by adding partition {}", dataNodeConfig, partitionName);
+      logger.info("Updating config: {} in Helix by adding partition {}", dataNodeConfig, partitionName);
       additionResult = dataNodeConfigSource.set(dataNodeConfig);
     }
     return additionResult;

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
@@ -366,7 +366,7 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
       newReplicaInfoAdded = true;
     }
     if (newReplicaInfoAdded) {
-      logger.info("Updating config: {} in Helix by adding partition {}", dataNodeConfig, partitionName);
+      //logger.info("Updating config: {} in Helix by adding partition {}", dataNodeConfig, partitionName);
       additionResult = dataNodeConfigSource.set(dataNodeConfig);
     }
     return additionResult;

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PropertyStoreToDataNodeConfigAdapter.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PropertyStoreToDataNodeConfigAdapter.java
@@ -91,9 +91,10 @@ class PropertyStoreToDataNodeConfigAdapter implements DataNodeConfigSource {
   /**
    * Remove data config from property store
    * @param instanceName the name of instance
+   * @return {@code true} if the config was successfully removed.
    */
-  public void remove(String instanceName) {
-    propertyStore.remove(CONFIG_PATH + "/" + instanceName, AccessOption.PERSISTENT);
+  public boolean remove(String instanceName) {
+    return propertyStore.remove(CONFIG_PATH + "/" + instanceName, AccessOption.PERSISTENT);
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PropertyStoreToDataNodeConfigAdapter.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PropertyStoreToDataNodeConfigAdapter.java
@@ -88,6 +88,22 @@ class PropertyStoreToDataNodeConfigAdapter implements DataNodeConfigSource {
     propertyStore.stop();
   }
 
+  /**
+   * Remove data config from property store
+   * @param instanceName the name of instance
+   */
+  public void remove(String instanceName) {
+    propertyStore.remove(CONFIG_PATH + "/" + instanceName, AccessOption.PERSISTENT);
+  }
+
+  /**
+   * @return all data node names in the property store.
+   */
+  public List<String> getAllDataNodeNames() {
+    List<String> names = propertyStore.getChildNames(CONFIG_PATH, AccessOption.PERSISTENT);
+    return names == null ? Collections.emptyList() : names;
+  }
+
   private class Subscription implements HelixPropertyListener {
     private final DataNodeConfigChangeListener listener;
     private final CompletableFuture<Void> initFuture = new CompletableFuture<>();

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PropertyStoreToDataNodeConfigAdapter.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PropertyStoreToDataNodeConfigAdapter.java
@@ -203,8 +203,8 @@ class PropertyStoreToDataNodeConfigAdapter implements DataNodeConfigSource {
    * Convert between {@link DataNodeConfig}s and {@link ZNRecord}s.
    */
   static class Converter {
+    public static final String MOUNT_PREFIX = "mount-";
     private static final int VERSION_0 = 0;
-    private static final String MOUNT_PREFIX = "mount-";
     private static final String HOSTNAME_FIELD = "hostname";
     private static final String PORT_FIELD = "port";
     private final String defaultPartitionClass;

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixCluster.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixCluster.java
@@ -59,7 +59,7 @@ public class MockHelixCluster {
     dataCenterToZkAddress = parseDcJsonAndPopulateDcInfo(jsonString);
     HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterName,
         "all", MAX_PARTITIONS_IN_ONE_RESOURCE, false, false, helixAdminFactory, false,
-        ClusterMapConfig.DEFAULT_STATE_MODEL_DEF, BootstrapCluster);
+        ClusterMapConfig.DEFAULT_STATE_MODEL_DEF, BootstrapCluster, DataNodeConfigSourceType.INSTANCE_CONFIG, false);
     this.clusterName = clusterName;
   }
 
@@ -71,7 +71,7 @@ public class MockHelixCluster {
   void upgradeWithNewHardwareLayout(String hardwareLayoutPath) throws Exception {
     HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterName,
         "all", MAX_PARTITIONS_IN_ONE_RESOURCE, false, false, helixAdminFactory, false,
-        ClusterMapConfig.DEFAULT_STATE_MODEL_DEF, BootstrapCluster);
+        ClusterMapConfig.DEFAULT_STATE_MODEL_DEF, BootstrapCluster, DataNodeConfigSourceType.INSTANCE_CONFIG, false);
     triggerInstanceConfigChangeNotification();
   }
 
@@ -84,7 +84,8 @@ public class MockHelixCluster {
   void upgradeWithNewPartitionLayout(String partitionLayoutPath,
       HelixBootstrapUpgradeUtil.HelixAdminOperation adminOperation) throws Exception {
     HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterName,
-        "all", 3, false, false, helixAdminFactory, false, ClusterMapConfig.DEFAULT_STATE_MODEL_DEF, adminOperation);
+        "all", 3, false, false, helixAdminFactory, false, ClusterMapConfig.DEFAULT_STATE_MODEL_DEF, adminOperation,
+        DataNodeConfigSourceType.INSTANCE_CONFIG, false);
     triggerInstanceConfigChangeNotification();
   }
 

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/TestUtils.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/TestUtils.java
@@ -440,30 +440,28 @@ public class TestUtils {
   }
 
   /**
-   * Verify updated {@link InstanceConfig}. If {@param shouldExist} is true, verify that replica is present in InstanceConfig.
+   * Verify updated {@link DataNodeConfig}. If {@param shouldExist} is true, verify that replica is present in InstanceConfig.
    * If false, InstanceConfig should not contain given replica info.
-   * @param instanceConfig the updated {@link InstanceConfig} to verify.
-   * @param replicaId the replica whose info should/shouldn't exist in InstanceConfig
-   * @param shouldExist whether given replica should exist in InstanceConfig.
+   * @param dataNodeConfig the updated {@link DataNodeConfig} to verify.
+   * @param replicaId the replica whose info should/shouldn't exist in dataNodeConfig
+   * @param shouldExist whether given replica should exist in dataNodeConfig.
    */
-  public static void verifyReplicaInfoInInstanceConfig(InstanceConfig instanceConfig, ReplicaId replicaId,
+  public static void verifyReplicaInfoInDataNodeConfig(DataNodeConfig dataNodeConfig, ReplicaId replicaId,
       boolean shouldExist) {
-    Map<String, Map<String, String>> mountPathToDiskInfos = instanceConfig.getRecord().getMapFields();
-    Map<String, String> diskInfo = mountPathToDiskInfos.get(replicaId.getMountPath());
-    Set<String> replicasOnDisk = new HashSet<>();
-    for (String replicaInfo : diskInfo.get(REPLICAS_STR).split(REPLICAS_DELIM_STR)) {
-      replicasOnDisk.add(replicaInfo.split(REPLICAS_STR_SEPARATOR)[0]);
-    }
-    List<String> sealedList = getSealedReplicas(instanceConfig);
-    List<String> stoppedList = getStoppedReplicas(instanceConfig);
+    DataNodeConfig.DiskConfig diskInfo = dataNodeConfig.getDiskConfigs().get(replicaId.getMountPath());
+    Set<String> replicasOnDisk = new HashSet<>(diskInfo.getReplicaConfigs().keySet());
+    Set<String> sealedList = dataNodeConfig.getSealedReplicas();
+    Set<String> stoppedList = dataNodeConfig.getStoppedReplicas();
+    Set<String> disabledList = dataNodeConfig.getDisabledReplicas();
     String partitionName = replicaId.getPartitionId().toPathString();
     if (shouldExist) {
-      assertTrue("New replica is not found in InstanceConfig", replicasOnDisk.contains(partitionName));
+      assertTrue("New replica is not found in DataNodeConfig", replicasOnDisk.contains(partitionName));
     } else {
-      assertFalse("Old replica should not exist in InstanceConfig", replicasOnDisk.contains(partitionName));
+      assertFalse("Old replica should not exist in DataNodeConfig", replicasOnDisk.contains(partitionName));
       // make sure the replica is not present in sealed/stopped list
       assertFalse("Old replica should not exist in sealed/stopped list",
-          sealedList.contains(partitionName) || stoppedList.contains(partitionName));
+          sealedList.contains(partitionName) || stoppedList.contains(partitionName) || disabledList.contains(
+              partitionName));
     }
   }
 

--- a/ambry-tools/src/integration-test/java/com/github/ambry/clustermap/HelixBootstrapUpgradeToolTest.java
+++ b/ambry-tools/src/integration-test/java/com/github/ambry/clustermap/HelixBootstrapUpgradeToolTest.java
@@ -84,6 +84,7 @@ public class HelixBootstrapUpgradeToolTest {
   private static final String CLUSTER_NAME_PREFIX = "Ambry-";
   private static final String ROOT_PATH =
       "/" + CLUSTER_NAME_PREFIX + CLUSTER_NAME_IN_STATIC_CLUSTER_MAP + "/" + ClusterMapUtils.PROPERTYSTORE_STR;
+  private static final DataNodeConfigSourceType DEFAULT_DATA_NODE_CONFIG_SOURCE = DataNodeConfigSourceType.INSTANCE_CONFIG;
   private static HelixPropertyStoreConfig propertyStoreConfig;
 
   /**
@@ -197,7 +198,7 @@ public class HelixBootstrapUpgradeToolTest {
     // bootstrap a cluster
     HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
         CLUSTER_NAME_PREFIX, dcStr, DEFAULT_MAX_PARTITIONS_PER_RESOURCE, false, false, new HelixAdminFactory(), false,
-        ClusterMapConfig.OLD_STATE_MODEL_DEF, BootstrapCluster);
+        ClusterMapConfig.OLD_STATE_MODEL_DEF, BootstrapCluster, DEFAULT_DATA_NODE_CONFIG_SOURCE, false);
     // add new state model def
     HelixBootstrapUpgradeUtil.addStateModelDef(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
         CLUSTER_NAME_PREFIX, dcStr, ClusterMapConfig.AMBRY_STATE_MODEL_DEF);
@@ -236,7 +237,7 @@ public class HelixBootstrapUpgradeToolTest {
       try {
         HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
             CLUSTER_NAME_PREFIX, dcStr, DEFAULT_MAX_PARTITIONS_PER_RESOURCE, false, false, new HelixAdminFactory(),
-            false, ClusterMapConfig.DEFAULT_STATE_MODEL_DEF, BootstrapCluster);
+            false, ClusterMapConfig.DEFAULT_STATE_MODEL_DEF, BootstrapCluster, DEFAULT_DATA_NODE_CONFIG_SOURCE, false);
         fail("Should have thrown IllegalArgumentException as a zk host is missing for one of the dcs");
       } catch (IllegalArgumentException e) {
         // OK
@@ -578,7 +579,7 @@ public class HelixBootstrapUpgradeToolTest {
     // upgrade Helix by updating IdealState: AdminOperation = UpdateIdealState
     HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
         CLUSTER_NAME_PREFIX, dcStr, DEFAULT_MAX_PARTITIONS_PER_RESOURCE, false, false, new HelixAdminFactory(), false,
-        ClusterMapConfig.DEFAULT_STATE_MODEL_DEF, UpdateIdealState);
+        ClusterMapConfig.DEFAULT_STATE_MODEL_DEF, UpdateIdealState, DEFAULT_DATA_NODE_CONFIG_SOURCE, false);
     verifyResourceCount(testHardwareLayout.getHardwareLayout(), expectedResourceCount);
 
     // verify IdealState has been updated
@@ -652,7 +653,7 @@ public class HelixBootstrapUpgradeToolTest {
         // Upgrade Helix by updating IdealState: AdminOperation = DisablePartition
         HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
             CLUSTER_NAME_PREFIX, dcStr, DEFAULT_MAX_PARTITIONS_PER_RESOURCE, false, false, new HelixAdminFactory(),
-            false, ClusterMapConfig.DEFAULT_STATE_MODEL_DEF, DisablePartition);
+            false, ClusterMapConfig.DEFAULT_STATE_MODEL_DEF, DisablePartition, DEFAULT_DATA_NODE_CONFIG_SOURCE, false);
         bootstrapCompletionLatch.countDown();
       } catch (Exception e) {
         // do nothing, if there is any exception subsequent test should fail.
@@ -816,7 +817,7 @@ public class HelixBootstrapUpgradeToolTest {
     writeBootstrapOrUpgrade(expectedResourceCount, false);
     Set<String> sealedPartitions =
         HelixBootstrapUpgradeUtil.listSealedPartition(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
-            CLUSTER_NAME_PREFIX, dcStr);
+            CLUSTER_NAME_PREFIX, dcStr, DEFAULT_DATA_NODE_CONFIG_SOURCE);
     assertEquals("Sealed partition set should be empty initially", Collections.emptySet(), sealedPartitions);
     // randomly choose 20 partitions to mark as sealed
     int[] intArray = new Random().ints(0, 100).distinct().limit(20).toArray();
@@ -845,7 +846,7 @@ public class HelixBootstrapUpgradeToolTest {
     // query sealed partition in Helix again
     sealedPartitions =
         HelixBootstrapUpgradeUtil.listSealedPartition(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
-            CLUSTER_NAME_PREFIX, dcStr);
+            CLUSTER_NAME_PREFIX, dcStr, DEFAULT_DATA_NODE_CONFIG_SOURCE);
     assertEquals("Mismatch in sealed partition set", selectedSealedPartitionSet, sealedPartitions);
   }
 
@@ -1022,7 +1023,7 @@ public class HelixBootstrapUpgradeToolTest {
     // This updates and verifies that the information in Helix is consistent with the one in the static cluster map.
     HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
         CLUSTER_NAME_PREFIX, dcStr, DEFAULT_MAX_PARTITIONS_PER_RESOURCE, false, forceRemove, new HelixAdminFactory(),
-        false, ClusterMapConfig.DEFAULT_STATE_MODEL_DEF, BootstrapCluster);
+        false, ClusterMapConfig.DEFAULT_STATE_MODEL_DEF, BootstrapCluster, DEFAULT_DATA_NODE_CONFIG_SOURCE, false);
     verifyResourceCount(testHardwareLayout.getHardwareLayout(), expectedResourceCount);
   }
 


### PR DESCRIPTION
Ambry will eventually migrate datanode info (i.e. disk, replica) from InstanceConfig to PropertyStore in Helix. This PR makes several changes in HelixBootstrapUpgradeTool to support both. User should be able to specify which DataNodeConfigSource type to use and the tool will update Helix accordingly.