### PR TITLE
[memory] fix leak on Selector.write error

### DIFF
--- a/ambry-network/src/main/java/com/github/ambry/network/Selector.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/Selector.java
@@ -779,8 +779,8 @@ public class Selector implements Selectable {
     long startTimeToWriteInMs = time.milliseconds();
     NetworkSend networkSend = null;
     try {
-      boolean sendComplete = transmission.write();
       networkSend = transmission.getNetworkSend();
+      boolean sendComplete = transmission.write();
       if (sendComplete) {
         logger.trace("Finished writing, registering for read on connection {}", transmission.getRemoteSocketAddress());
         // Release the NetworkSend resource here, not in the SocketNetworkClient, because SocketServer uses Selector

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/AmbryRequests.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/AmbryRequests.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 LinkedIn Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -357,9 +357,10 @@ public class AmbryRequests implements RequestAPI {
       long processingTime = SystemTime.getInstance().milliseconds() - startTime;
       totalTimeSpent += processingTime;
       publicAccessLogger.info("{} {} processingTime {}", getRequest, response, processingTime);
+      long responseSize = response != null ? response.sizeInBytes() : 0;
       if (getRequest.getMessageFormatFlag() == MessageFormatFlags.Blob) {
         metrics.getBlobProcessingTimeInMs.update(processingTime);
-        metrics.updateGetBlobProcessingTimeBySize(response.sizeInBytes(), processingTime);
+        metrics.updateGetBlobProcessingTimeBySize(responseSize, processingTime);
       } else if (getRequest.getMessageFormatFlag() == MessageFormatFlags.BlobProperties) {
         metrics.getBlobPropertiesProcessingTimeInMs.update(processingTime);
       } else if (getRequest.getMessageFormatFlag() == MessageFormatFlags.BlobUserMetadata) {
@@ -374,12 +375,12 @@ public class AmbryRequests implements RequestAPI {
           if (clientStrs.length > 1) {
             String clientDc = clientStrs[1].substring(0, clientStrs[1].length() - 1);
             if (!currentNode.getDatacenterName().equals(clientDc)) {
-              metrics.updateCrossColoFetchBytesRate(clientDc, response.sizeInBytes());
+              metrics.updateCrossColoFetchBytesRate(clientDc, responseSize);
             }
           }
         } else {
           metrics.getBlobAllProcessingTimeInMs.update(processingTime);
-          metrics.updateGetBlobProcessingTimeBySize(response.sizeInBytes(), processingTime);
+          metrics.updateGetBlobProcessingTimeBySize(responseSize, processingTime);
         }
       }
     }
@@ -639,7 +640,7 @@ public class AmbryRequests implements RequestAPI {
       if (clientStrs.length > 1) {
         String clientDc = clientStrs[1].substring(0, clientStrs[1].length() - 1);
         if (!currentNode.getDatacenterName().equals(clientDc)) {
-          metrics.updateCrossColoMetadataExchangeBytesRate(clientDc, response.sizeInBytes());
+          metrics.updateCrossColoMetadataExchangeBytesRate(clientDc, response != null ? response.sizeInBytes() : 0L);
         }
       }
     }
@@ -659,8 +660,8 @@ public class AmbryRequests implements RequestAPI {
     metrics.undeleteBlobRequestRate.mark();
     long startTime = SystemTime.getInstance().milliseconds();
     UndeleteResponse response = null;
-    Store storeToUndelete = null;
-    StoreKey convertedStoreKey = null;
+    Store storeToUndelete;
+    StoreKey convertedStoreKey;
     try {
       convertedStoreKey = getConvertedStoreKeys(Collections.singletonList(undeleteRequest.getBlobId())).get(0);
       ServerErrorCode error =


### PR DESCRIPTION
Switch where the networkSend variable is assigned so that it is assigned
prior to the place where the IOException can occur, allowing the catch
block to release it.

Fix NPE in AmbryRequests.