### PR TITLE
Do ttlUpdate for named blob without TTL

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/FrontendConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/FrontendConfig.java
@@ -66,6 +66,14 @@ public class FrontendConfig {
   public final long optionsValiditySeconds;
 
   /**
+   * For permanent named blob, the put procedure is put, database insert and then ttlUpdate. This config is the ttl used
+   * in the initial put. This value should be greater than {@link StoreConfig#storeTtlUpdateBufferTimeSeconds}
+   */
+  @Config("permanent.named.blob.initial.put.ttl")
+  @Default("25 * 60 * 60")
+  public final long permanentNamedBlobInitialPutTtl;
+
+  /**
    * Value of "Access-Control-Allow-Methods" in response headers for OPTIONS requests.
    */
   @Config("frontend.options.allow.methods")
@@ -232,6 +240,7 @@ public class FrontendConfig {
   public FrontendConfig(VerifiableProperties verifiableProperties) {
     cacheValiditySeconds = verifiableProperties.getLong("frontend.cache.validity.seconds", 365 * 24 * 60 * 60);
     optionsValiditySeconds = verifiableProperties.getLong("frontend.options.validity.seconds", 24 * 60 * 60);
+    permanentNamedBlobInitialPutTtl = verifiableProperties.getLong("permanent.named.blob.initial.put.ttl", 25 * 60 * 60);
     optionsAllowMethods =
         verifiableProperties.getString("frontend.options.allow.methods", "POST, GET, OPTIONS, HEAD, DELETE");
     idConverterFactory = verifiableProperties.getString("frontend.id.converter.factory",

--- a/ambry-api/src/main/java/com/github/ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com/github/ambry/rest/RestUtils.java
@@ -396,6 +396,22 @@ public class RestUtils {
     String contentEncoding = getHeader(args, Headers.AMBRY_CONTENT_ENCODING, false);
     String filename = getHeader(args, Headers.AMBRY_FILENAME, false);
 
+    long ttl = getTtlFromRequestHeader(args);
+
+    // This field should not matter on newly created blobs, because all privacy/cacheability decisions should be made
+    // based on the container properties and ACLs. For now, BlobProperties still includes this field, though.
+    boolean isPrivate = !container.isCacheable();
+    return new BlobProperties(-1, serviceId, ownerId, contentType, isPrivate, ttl, account.getId(), container.getId(),
+        container.isEncrypted(), externalAssetTag, contentEncoding, filename);
+  }
+
+  /**
+   * An util method to get ttl from arguments associated with a request.
+   * @param args the arguments associated with the request. Cannot be {@code null}.
+   * @return the ttl extracted from the arguments.
+   * @throws RestServiceException if required arguments aren't present or if they aren't in the format expected.
+   */
+  public static long getTtlFromRequestHeader(Map<String, Object> args) throws RestServiceException {
     long ttl = Utils.Infinite_Time;
     Long ttlFromHeader = getLongHeader(args, Headers.TTL, false);
     if (ttlFromHeader != null) {
@@ -405,12 +421,7 @@ public class RestUtils {
       }
       ttl = ttlFromHeader;
     }
-
-    // This field should not matter on newly created blobs, because all privacy/cacheability decisions should be made
-    // based on the container properties and ACLs. For now, BlobProperties still includes this field, though.
-    boolean isPrivate = !container.isCacheable();
-    return new BlobProperties(-1, serviceId, ownerId, contentType, isPrivate, ttl, account.getId(), container.getId(),
-        container.isEncrypted(), externalAssetTag, contentEncoding, filename);
+    return ttl;
   }
 
   /**

--- a/ambry-commons/src/main/java/com/github/ambry/commons/RetryExecutor.java
+++ b/ambry-commons/src/main/java/com/github/ambry/commons/RetryExecutor.java
@@ -1,0 +1,74 @@
+package com.github.ambry.commons;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Retries is a library that can be used to execute retry operations or functions with user-specified policy.
+ * A {@link Consumer} call with a {@link Callback} is needed to provide the execution logic for retry,
+ * when execution may not be successful with exception. You can provide a user-{@link Callback},
+ * which will be executed after all policy defined retry executions are done successfully or not.
+ */
+public class RetryExecutor {
+  private final ScheduledExecutorService scheduler;
+  private static final Logger logger = LoggerFactory.getLogger(RetryExecutor.class);
+
+  /**
+   * Constructor for {@link RetryExecutor}.
+   * @param scheduler The executor of function call with specific wait time provided by policy.
+   */
+  public RetryExecutor(ScheduledExecutorService scheduler) {
+    this.scheduler = scheduler;
+  }
+
+  /**
+   * Starts retriable function call with specific {@link RetryPolicy} and callback function.
+   * @param policy The {@link RetryPolicy} to schedule retry.
+   * @param call The function call that will be executed and retried with failure.
+   * @param userCallback The user defined {@link Callback} to be executed after success or if all retry attempts failed.
+   */
+  public <T> void runWithRetries(RetryPolicy policy, Consumer<Callback<T>> call, Callback<T> userCallback) {
+    recursiveAsyncRetry(call, policy, userCallback, 0);
+  }
+
+  /**
+   * Recursively retrying on the task call with specific policy and user defined callback.
+   * @param call The function call will be executed and retried with failure.
+   * @param policy The {@link RetryPolicy} to schedule retrying.
+   * @param userCallback The user defined {@link Callback} to be executed after all retry attempts failed.
+   * @param attempts The number of retries has been attempted.
+   */
+  private <T> void recursiveAsyncRetry(Consumer<Callback<T>> call, RetryPolicy policy, Callback<T> userCallback,
+      int attempts) {
+    call.accept((result, exception) -> {
+      if (exception != null) {
+        int currAttempts = attempts + 1;
+        if (currAttempts < policy.maxAttempts() && isRetriable(exception)) {
+          int waitTimeMs = policy.waitTimeMs(currAttempts);
+          logger.info("{} of {} attempts failed, will keep retrying after a {} ms backoff. exception='{}'",
+              currAttempts, policy.maxAttempts(), waitTimeMs, exception);
+          scheduler.schedule(() -> recursiveAsyncRetry(call, policy, userCallback, currAttempts), waitTimeMs,
+              TimeUnit.MILLISECONDS);
+        } else {
+          logger.info("{} of {} attempts failed, completing operation. exception='{}'", currAttempts,
+              policy.maxAttempts(), exception);
+          userCallback.onCompletion(null, exception);
+        }
+      } else {
+        userCallback.onCompletion(result, null);
+      }
+    });
+  }
+
+  /**
+   * Decide on a specific {@link Throwable} can be retried or not.
+   * @param throwable The {@link Throwable} thrown in execution of retrying.
+   */
+  private static boolean isRetriable(Throwable throwable) {
+    return true;
+  }
+}

--- a/ambry-commons/src/main/java/com/github/ambry/commons/RetryExecutor.java
+++ b/ambry-commons/src/main/java/com/github/ambry/commons/RetryExecutor.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
 package com.github.ambry.commons;
 
 import java.util.concurrent.ScheduledExecutorService;

--- a/ambry-commons/src/main/java/com/github/ambry/commons/RetryPolicies.java
+++ b/ambry-commons/src/main/java/com/github/ambry/commons/RetryPolicies.java
@@ -1,0 +1,158 @@
+package com.github.ambry.commons;
+
+import java.util.Objects;
+
+
+/**
+ * Various common {@link RetryPolicy} implementations that can be used by customers.
+ */
+public class RetryPolicies {
+  private static final RetryPolicy DEFAULT_POLICY = exponentialPolicy(3, 100);
+
+  private RetryPolicies() {
+  }
+
+  /**
+   * @return a retry policy with sane defaults: exponential policy with 4 attempts and an initial backoff time of 100 ms
+   */
+  public static RetryPolicy defaultPolicy() {
+    return DEFAULT_POLICY;
+  }
+
+  /**
+   * @param maxAttempts The maximum attempts.
+   * @param initialWaitTimeMs The initial wait time in milliseconds, wait time will grow exponentially with number of
+   *                          attempts.
+   * @return an exponential retry policy with the provided parameters.
+   */
+  public static RetryPolicy exponentialPolicy(int maxAttempts, int initialWaitTimeMs) {
+    return new ExponentialPolicy(maxAttempts, initialWaitTimeMs);
+  }
+
+  /**
+   * @param maxAttempts The maximum attempts.
+   * @param waitTimeMs The wait time in milliseconds, wait time will not change with time.
+   * @return a fixed-backoff retry policy with the provided parameters.
+   */
+  public static RetryPolicy fixedBackoffPolicy(int maxAttempts, int waitTimeMs) {
+    return new FixedBackoffPolicy(maxAttempts, waitTimeMs);
+  }
+
+  /**
+   * @param attempts  the number of attempts provided as an argument to {@link RetryPolicy#waitTimeMs}.
+   * @param maxAttempts the maximum number of attempts for the policy
+   * @throws IllegalArgumentException if {@code attempts} is not in the range {@code [1, maxAttempts)}
+   */
+  private static void checkWaitTimeMsArgs(int attempts, int maxAttempts) {
+    if (attempts < 1 || attempts >= maxAttempts) {
+      throw new IllegalArgumentException(
+          "Number of attempts (" + attempts + ") must be in the range [1," + maxAttempts + ")");
+    }
+  }
+
+  /**
+   * The example {@link RetryPolicy} with wait time that grows exponentially with number of attempts.
+   */
+  private static class ExponentialPolicy implements RetryPolicy {
+
+    private final int maxAttempts;
+    private final int initialWaitTimeMs;
+
+    /**
+     * Constructor for {@link ExponentialPolicy}.
+     * @param maxAttempts The maximum attempts.
+     * @param initialWaitTimeMs The initial wait time in milliseconds, wait time will grow exponentially with it.
+     */
+    ExponentialPolicy(int maxAttempts, int initialWaitTimeMs) {
+      this.maxAttempts = maxAttempts;
+      this.initialWaitTimeMs = initialWaitTimeMs;
+    }
+
+    @Override
+    public int maxAttempts() {
+      return maxAttempts;
+    }
+
+    @Override
+    public int waitTimeMs(int attempts) {
+      checkWaitTimeMsArgs(attempts, maxAttempts);
+      return initialWaitTimeMs * (1 << (attempts - 1));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      ExponentialPolicy other = (ExponentialPolicy) o;
+      return maxAttempts == other.maxAttempts && initialWaitTimeMs == other.initialWaitTimeMs;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(maxAttempts, initialWaitTimeMs);
+    }
+
+    @Override
+    public String toString() {
+      return "ExponentialPolicy{" + "maxAttempts=" + maxAttempts + ", initialWaitTimeMs=" + initialWaitTimeMs + '}';
+    }
+  }
+
+  /**
+   * The example {@link RetryPolicy} with fixed wait time for each attempt.
+   */
+  private static class FixedBackoffPolicy implements RetryPolicy {
+
+    private final int maxAttempts;
+    private final int waitTimeMs;
+
+    /**
+     * Constructor for {@link FixedBackoffPolicy}.
+     * @param maxAttempts The maximum attempts.
+     * @param waitTimeMs The wait time in milliseconds, wait time will not change with time.
+     */
+    FixedBackoffPolicy(int maxAttempts, int waitTimeMs) {
+      this.maxAttempts = maxAttempts;
+      this.waitTimeMs = waitTimeMs;
+    }
+
+    @Override
+    public int maxAttempts() {
+      return maxAttempts;
+    }
+
+    @Override
+    public int waitTimeMs(int attempts) {
+      checkWaitTimeMsArgs(attempts, maxAttempts);
+      return waitTimeMs;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      FixedBackoffPolicy other = (FixedBackoffPolicy) o;
+      return maxAttempts == other.maxAttempts && waitTimeMs == other.waitTimeMs;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(maxAttempts, waitTimeMs);
+    }
+
+    @Override
+    public String toString() {
+      return "FixedBackoffPolicy{" + "maxAttempts=" + maxAttempts + ", waitTimeMs=" + waitTimeMs + '}';
+    }
+  }
+}

--- a/ambry-commons/src/main/java/com/github/ambry/commons/RetryPolicies.java
+++ b/ambry-commons/src/main/java/com/github/ambry/commons/RetryPolicies.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
 package com.github.ambry.commons;
 
 import java.util.Objects;

--- a/ambry-commons/src/main/java/com/github/ambry/commons/RetryPolicy.java
+++ b/ambry-commons/src/main/java/com/github/ambry/commons/RetryPolicy.java
@@ -1,9 +1,22 @@
+/*
+ * Copyright 2020 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
 package com.github.ambry.commons;
 
 /**
  * The {@link RetryPolicy} defines the specific number of  maximum attempts, wait time in milliseconds and maximum
  * time in milliseconds for timeout. Users can provide their own implementations of policy for different
- * needs. Two implementations: {@link RetryPolicies.ExponentialPolicy} and {@link RetryPolicies.FixedBackoffPolicy} are
+ * needs. Two implementations: {@link RetryPolicies#exponentialPolicy} and {@link RetryPolicies#fixedBackoffPolicy}} are
  * provided for users.
  */
 public interface RetryPolicy {

--- a/ambry-commons/src/main/java/com/github/ambry/commons/RetryPolicy.java
+++ b/ambry-commons/src/main/java/com/github/ambry/commons/RetryPolicy.java
@@ -1,0 +1,20 @@
+package com.github.ambry.commons;
+
+/**
+ * The {@link RetryPolicy} defines the specific number of  maximum attempts, wait time in milliseconds and maximum
+ * time in milliseconds for timeout. Users can provide their own implementations of policy for different
+ * needs. Two implementations: {@link RetryPolicies.ExponentialPolicy} and {@link RetryPolicies.FixedBackoffPolicy} are
+ * provided for users.
+ */
+public interface RetryPolicy {
+  /**
+   * Provide the maximum attempts for Retries to decide retry or not.
+   */
+  int maxAttempts();
+
+  /**
+   * Provide the wait time in milliseconds for current attempt for Retries.
+   * @param attempts The number of tries that have been attempted.
+   */
+  int waitTimeMs(int attempts);
+}

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
@@ -33,12 +33,17 @@ import com.github.ambry.router.ChunkInfo;
 import com.github.ambry.router.PutBlobOptions;
 import com.github.ambry.router.PutBlobOptionsBuilder;
 import com.github.ambry.router.Router;
+import com.github.ambry.router.RouterErrorCode;
+import com.github.ambry.router.RouterException;
 import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.Utils;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import org.json.JSONObject;
@@ -46,6 +51,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static com.github.ambry.frontend.FrontendUtils.*;
+import static com.github.ambry.router.RouterErrorCode.*;
 
 
 /**
@@ -79,6 +85,8 @@ public class NamedBlobPutHandler {
   private final String clusterName;
   private final RetryPolicy retryPolicy = RetryPolicies.defaultPolicy();
   private final RetryExecutor retryExecutor = new RetryExecutor(Executors.newScheduledThreadPool(2));
+  private final Set<RouterErrorCode> retriableRouterError = new HashSet<RouterErrorCode>(
+      Arrays.asList(AmbryUnavailable, ChannelClosed, UnexpectedInternalError, OperationTimedOut));
 
   /**
    * Constructs a handler for handling requests for uploading or stitching blobs.
@@ -178,7 +186,7 @@ public class NamedBlobPutHandler {
           restRequest.readInto(channel, fetchStitchRequestBodyCallback(channel, blobInfo));
         } else {
           PutBlobOptions options = getPutBlobOptionsFromRequest();
-          if (RestUtils.getTtlFromRequestHeader(restRequest.getArgs()) == Utils.Infinite_Time) {
+          if (blobInfo.getBlobProperties().getTimeToLiveInSeconds() == Utils.Infinite_Time) {
             // For blob with infinite time, the procedure is putBlob, record insert to database, and ttlUpdate.
             blobInfo.getBlobProperties().setTimeToLiveInSeconds(frontendConfig.permanentNamedBlobInitialPutTtl);
           }
@@ -236,12 +244,34 @@ public class NamedBlobPutHandler {
     private Callback<String> idConverterCallback(BlobInfo blobInfo) {
       return buildCallback(frontendMetrics.putIdConversionMetrics, blobId -> {
         if (RestUtils.getTtlFromRequestHeader(restRequest.getArgs()) == Utils.Infinite_Time) {
+          // Do ttl update with retryExecutor
           String serviceId = RestUtils.getHeader(restRequest.getArgs(), RestUtils.Headers.SERVICE_ID, true);
-          router.updateBlobTtl(blobId, serviceId, Utils.Infinite_Time, routerTtlUpdateCallback(blobInfo));
+          retryExecutor.runWithRetries(retryPolicy, callback -> updateBlobTtl(blobId, serviceId, callback),
+              throwable -> throwable instanceof RouterException && retriableRouterError.contains(
+                  ((RouterException) throwable).getErrorCode()), routerTtlUpdateCallback(blobInfo));
         } else {
           securityService.processResponse(restRequest, restResponseChannel, blobInfo,
               securityProcessResponseCallback());
         }
+      }, uri, LOGGER, finalCallback);
+    }
+
+    /*
+     * Wrapper method to call {@link Router#updateBlobTtl}.
+     */
+    private void updateBlobTtl(String blobId, String serviceId, Callback<Void> callback) {
+      router.updateBlobTtl(blobId, serviceId, Utils.Infinite_Time, callback);
+    }
+
+    /**
+     * After TTL update finishes, call {@link SecurityService#postProcessRequest} to perform
+     * request time security checks that rely on the request being fully parsed and any additional arguments set.
+     * @param blobInfo the {@link BlobInfo} to use for security checks.
+     * @return a {@link Callback} to be used with {@link Router#updateBlobTtl(String, String, long)}.
+     */
+    private Callback<Void> routerTtlUpdateCallback(BlobInfo blobInfo) {
+      return buildCallback(frontendMetrics.updateBlobTtlRouterMetrics, blobId -> {
+        securityService.processResponse(restRequest, restResponseChannel, blobInfo, securityProcessResponseCallback());
       }, uri, LOGGER, finalCallback);
     }
 
@@ -378,18 +408,6 @@ public class NamedBlobPutHandler {
             + stitchedBlobProperties.getAccountId() + ", " + stitchedBlobProperties.getContainerId() + ")",
             RestServiceErrorCode.BadRequest);
       }
-    }
-
-    /**
-     * After TTL update finishes, call {@link SecurityService#postProcessRequest} to perform
-     * request time security checks that rely on the request being fully parsed and any additional arguments set.
-     * @param blobInfo the {@link BlobInfo} to use for security checks.
-     * @return a {@link Callback} to be used with {@link Router#updateBlobTtl(String, String, long)}.
-     */
-    private Callback<Void> routerTtlUpdateCallback(BlobInfo blobInfo) {
-      return buildCallback(frontendMetrics.updateBlobTtlRouterMetrics, blobId -> {
-        securityService.processResponse(restRequest, restResponseChannel, blobInfo, securityProcessResponseCallback());
-      }, uri, LOGGER, finalCallback);
     }
   }
 }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
@@ -17,6 +17,9 @@ import com.github.ambry.account.Container;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.Callback;
 import com.github.ambry.commons.RetainingAsyncWritableChannel;
+import com.github.ambry.commons.RetryExecutor;
+import com.github.ambry.commons.RetryPolicies;
+import com.github.ambry.commons.RetryPolicy;
 import com.github.ambry.config.FrontendConfig;
 import com.github.ambry.messageformat.BlobInfo;
 import com.github.ambry.messageformat.BlobProperties;
@@ -36,6 +39,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -73,6 +77,8 @@ public class NamedBlobPutHandler {
   private final FrontendConfig frontendConfig;
   private final FrontendMetrics frontendMetrics;
   private final String clusterName;
+  private final RetryPolicy retryPolicy = RetryPolicies.defaultPolicy();
+  private final RetryExecutor retryExecutor = new RetryExecutor(Executors.newScheduledThreadPool(2));
 
   /**
    * Constructs a handler for handling requests for uploading or stitching blobs.

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/NamedBlobPutHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/NamedBlobPutHandlerTest.java
@@ -130,7 +130,9 @@ public class NamedBlobPutHandlerTest {
    */
   @Test
   public void putNamedBlobTest() throws Exception {
-    putBlobAndVerify(null);
+    idConverterFactory.returnInputIfTranslationNull = true;
+    putBlobAndVerify(null, TestUtils.TTL_SECS);
+    putBlobAndVerify(null, Utils.Infinite_Time);
   }
 
   /**
@@ -414,12 +416,13 @@ public class NamedBlobPutHandlerTest {
    * Make a stitch blob call using {@link PostBlobHandler} and verify the result of the operation.
    * @param errorChecker if non-null, expect an exception to be thrown by the post flow and verify it using this
    *                     {@link ThrowingConsumer}.
+   * @param ttl the ttl used for the blob
    * @throws Exception
    */
-  private void putBlobAndVerify(ThrowingConsumer<ExecutionException> errorChecker) throws Exception {
+  private void putBlobAndVerify(ThrowingConsumer<ExecutionException> errorChecker, long ttl) throws Exception {
     JSONObject headers = new JSONObject();
-    FrontendRestRequestServiceTest.setAmbryHeadersForPut(headers, TestUtils.TTL_SECS, !REF_CONTAINER.isCacheable(),
-        SERVICE_ID, CONTENT_TYPE, OWNER_ID, null, null, null);
+    FrontendRestRequestServiceTest.setAmbryHeadersForPut(headers, ttl, !REF_CONTAINER.isCacheable(), SERVICE_ID,
+        CONTENT_TYPE, OWNER_ID, null, null, null);
     byte[] content = TestUtils.getRandomBytes(1024);
     RestRequest request = getRestRequest(headers, request_path, content);
     RestResponseChannel restResponseChannel = new MockRestResponseChannel();


### PR DESCRIPTION
For named blob without TTL, the put procedure is change to: put with a temp ttl, insert record and ttlUpdate().
This PR also introduces an RetryExecutor for retry.