### PR TITLE
Collect stats for delete tombstones and token reset events

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/store/StoreStats.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/StoreStats.java
@@ -25,6 +25,9 @@ import java.util.Set;
  * Exposes important stats related to a {@link Store}.
  */
 public interface StoreStats {
+  String EXPIRED_DELETE_TOMBSTONE = "ExpiredDeleteTombstone";
+  String PERMANENT_DELETE_TOMBSTONE = "PermanentDeleteTombstone";
+
   /**
    * Gets the size of valid data at a particular point in time. The caller specifies a reference time and acceptable
    * resolution for the stats in the form of a {@link TimeRange}. The store will return valid data size for a point
@@ -52,4 +55,12 @@ public interface StoreStats {
    */
   Map<StatsReportType, StatsSnapshot> getStatsSnapshots(Set<StatsReportType> statsReportTypes, long referenceTimeInMs)
       throws StoreException;
+
+  /**
+   * Fetches delete tombstone stats grouped by different types, i.e. {@link StoreStats#EXPIRED_DELETE_TOMBSTONE},
+   * {@link StoreStats#PERMANENT_DELETE_TOMBSTONE}.
+   * @return a map whose key specifies delete tombstone type and value is a {@link Pair} representing the delete
+   * tombstone count and total size
+   */
+  Map<String, Pair<Long, Long>> getDeleteTombstoneStats();
 }

--- a/ambry-server/src/main/java/com/github/ambry/server/StatsManager.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/StatsManager.java
@@ -376,7 +376,7 @@ class StatsManager {
     Pair<Long, Long> aggregatedExpiredDeleteTombstoneStats;
     Pair<Long, Long> aggregatedPermanentDeleteTombstoneStats;
 
-    AggregatedDeleteTombstoneStats(){
+    AggregatedDeleteTombstoneStats() {
       this(0, 0, 0, 0);
     }
 
@@ -386,19 +386,19 @@ class StatsManager {
       aggregatedPermanentDeleteTombstoneStats = new Pair<>(permanentDeleteCount, permanentDeleteSize);
     }
 
-    long getExpiredDeleteTombstoneCount(){
+    long getExpiredDeleteTombstoneCount() {
       return aggregatedExpiredDeleteTombstoneStats.getFirst();
     }
 
-    long getExpiredDeleteTombstoneSize(){
+    long getExpiredDeleteTombstoneSize() {
       return aggregatedExpiredDeleteTombstoneStats.getSecond();
     }
 
-    long getPermanentDeleteTombstoneCount(){
+    long getPermanentDeleteTombstoneCount() {
       return aggregatedPermanentDeleteTombstoneStats.getFirst();
     }
 
-    long getPermanentDeleteTombstoneSize(){
+    long getPermanentDeleteTombstoneSize() {
       return aggregatedPermanentDeleteTombstoneStats.getSecond();
     }
   }

--- a/ambry-server/src/main/java/com/github/ambry/server/StatsManagerMetrics.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/StatsManagerMetrics.java
@@ -47,22 +47,22 @@ class StatsManagerMetrics {
 
   void initDeleteStatsGaugesIfNeeded() {
     if (deleteStatsGaugeInitialized.compareAndSet(false, true)) {
-      Gauge<Long> deleteTombstoneWithTtlCount =
-          () -> aggregatedDeleteTombstoneStats.get().getDeleteTombstoneWithTtlCount();
-      registry.register(MetricRegistry.name(StatsManager.class, "DeleteTombstoneWithTtlCount"),
-          deleteTombstoneWithTtlCount);
-      Gauge<Long> deleteTombstoneWithTtlSize =
-          () -> aggregatedDeleteTombstoneStats.get().getDeleteTombstoneWithTtlSize();
-      registry.register(MetricRegistry.name(StatsManager.class, "DeleteTombstoneWithTtlSize"),
-          deleteTombstoneWithTtlSize);
-      Gauge<Long> deleteTombstoneWithoutTtlCount =
-          () -> aggregatedDeleteTombstoneStats.get().getDeleteTombstoneWithoutTtlCount();
-      registry.register(MetricRegistry.name(StatsManager.class, "DeleteTombstoneWithoutTtlCount"),
-          deleteTombstoneWithoutTtlCount);
-      Gauge<Long> deleteTombstoneWithoutTtlSize =
-          () -> aggregatedDeleteTombstoneStats.get().getDeleteTombstoneWithoutTtlSize();
-      registry.register(MetricRegistry.name(StatsManager.class, "DeleteTombstoneWithoutTtlSize"),
-          deleteTombstoneWithoutTtlSize);
+      Gauge<Long> expiredDeleteTombstoneCount =
+          () -> aggregatedDeleteTombstoneStats.get().getExpiredDeleteTombstoneCount();
+      registry.register(MetricRegistry.name(StatsManager.class, "ExpiredDeleteTombstoneCount"),
+          expiredDeleteTombstoneCount);
+      Gauge<Long> expiredDeleteTombstoneSize =
+          () -> aggregatedDeleteTombstoneStats.get().getExpiredDeleteTombstoneSize();
+      registry.register(MetricRegistry.name(StatsManager.class, "ExpiredDeleteTombstoneSize"),
+          expiredDeleteTombstoneSize);
+      Gauge<Long> permanentDeleteTombstoneCount =
+          () -> aggregatedDeleteTombstoneStats.get().getPermanentDeleteTombstoneCount();
+      registry.register(MetricRegistry.name(StatsManager.class, "PermanentDeleteTombstoneCount"),
+          permanentDeleteTombstoneCount);
+      Gauge<Long> permanentDeleteTombstoneSize =
+          () -> aggregatedDeleteTombstoneStats.get().getPermanentDeleteTombstoneSize();
+      registry.register(MetricRegistry.name(StatsManager.class, "PermanentDeleteTombstoneSize"),
+          permanentDeleteTombstoneSize);
     }
   }
 }

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreStats.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreStats.java
@@ -53,7 +53,7 @@ import org.slf4j.LoggerFactory;
  * a forecast boundary. Stats related requests are either served via these buckets or a separate scan that will walk
  * through the entire index if the request is outside of the forecast boundary.
  */
-public class BlobStoreStats implements StoreStats, Closeable {
+class BlobStoreStats implements StoreStats, Closeable {
   static final String IO_SCHEDULER_JOB_TYPE = "BlobStoreStats";
   static final String IO_SCHEDULER_JOB_ID = "indexSegment_read";
   // Max blob size that's encountered while generating stats
@@ -220,12 +220,12 @@ public class BlobStoreStats implements StoreStats, Closeable {
     return statsSnapshotsByType;
   }
 
-  public Pair<Long, Long> getExpiredDeleteTombstoneStats() {
-    return expiredDeleteTombstoneStats.get();
-  }
-
-  public Pair<Long, Long> getPermanentDeleteTombstoneStats() {
-    return permanentDeleteTombstoneStats.get();
+  @Override
+  public Map<String, Pair<Long, Long>> getDeleteTombstoneStats() {
+    Map<String, Pair<Long, Long>> deleteTombstoneStats = new HashMap<>();
+    deleteTombstoneStats.put(EXPIRED_DELETE_TOMBSTONE, expiredDeleteTombstoneStats.get());
+    deleteTombstoneStats.put(PERMANENT_DELETE_TOMBSTONE, permanentDeleteTombstoneStats.get());
+    return deleteTombstoneStats;
   }
 
   /**

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreStats.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreStats.java
@@ -17,10 +17,10 @@ package com.github.ambry.store;
 import com.github.ambry.server.StatsReportType;
 import com.github.ambry.server.StatsSnapshot;
 import com.github.ambry.utils.Pair;
-import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
 import java.io.Closeable;
+import java.util.Collection;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -53,7 +53,7 @@ import org.slf4j.LoggerFactory;
  * a forecast boundary. Stats related requests are either served via these buckets or a separate scan that will walk
  * through the entire index if the request is outside of the forecast boundary.
  */
-class BlobStoreStats implements StoreStats, Closeable {
+public class BlobStoreStats implements StoreStats, Closeable {
   static final String IO_SCHEDULER_JOB_TYPE = "BlobStoreStats";
   static final String IO_SCHEDULER_JOB_ID = "indexSegment_read";
   // Max blob size that's encountered while generating stats
@@ -78,6 +78,10 @@ class BlobStoreStats implements StoreStats, Closeable {
   private final Condition waitCondition = scanLock.newCondition();
   private final Queue<EntryContext> recentEntryQueue = new LinkedBlockingQueue<>();
   private final AtomicInteger queueEntryCount = new AtomicInteger(0);
+  private final AtomicReference<Pair<Long, Long>> deleteTombstoneWithTtlStats =
+      new AtomicReference<>(new Pair<>(0L, 0L));
+  private final AtomicReference<Pair<Long, Long>> deleteTombstoneWithoutTtlStats =
+      new AtomicReference<>(new Pair<>(0L, 0L));
   private final AtomicBoolean enabled = new AtomicBoolean(true);
 
   private volatile boolean isScanning = false;
@@ -214,6 +218,14 @@ class BlobStoreStats implements StoreStats, Closeable {
       }
     }
     return statsSnapshotsByType;
+  }
+
+  public Pair<Long, Long> getDeleteTombstoneWithTtlStats() {
+    return deleteTombstoneWithTtlStats.get();
+  }
+
+  public Pair<Long, Long> getDeleteTombstoneWithoutTtlStats() {
+    return deleteTombstoneWithoutTtlStats.get();
   }
 
   /**
@@ -484,6 +496,8 @@ class BlobStoreStats implements StoreStats, Closeable {
             indexSegment.getFile().getName(), storeId);
       }
     }
+    // The remaining index entries in keyFinalStates are DELETE tombstones left by compaction (whose associated PUT is not found)
+    updateDeleteTombstoneStats(keyFinalStates.values());
     metrics.statsOnDemandScanTotalTimeMs.update(time.milliseconds() - startTimeMs, TimeUnit.MILLISECONDS);
     return validDataSizePerContainer;
   }
@@ -521,6 +535,8 @@ class BlobStoreStats implements StoreStats, Closeable {
             indexSegment.getFile().getName(), storeId);
       }
     }
+    // The remaining index entries in keyFinalStates are DELETE tombstones left by compaction (whose associated PUT is not found)
+    updateDeleteTombstoneStats(keyFinalStates.values());
     metrics.statsOnDemandScanTotalTimeMs.update(time.milliseconds() - startTimeMs, TimeUnit.MILLISECONDS);
     if (validSizePerLogSegment.isEmpty()) {
       validSizePerLogSegment.put(index.getStartOffset().getName(), 0L);
@@ -565,7 +581,8 @@ class BlobStoreStats implements StoreStats, Closeable {
               indexValue.getOperationTimeInMs() == Utils.Infinite_Time ? indexSegment.getLastModifiedTimeMs()
                   : indexValue.getOperationTimeInMs();
           keyFinalStates.put(indexEntry.getKey(),
-              new IndexFinalState(indexValue.getFlags(), operationTimeInMs, indexValue.getLifeVersion()));
+              new IndexFinalState(indexValue.getFlags(), operationTimeInMs, indexValue.getLifeVersion(),
+                  indexValue.getSize(), indexValue.getExpiresAtMs()));
         }
         validIndexEntryAction.accept(indexEntry);
       } else if (indexValue.isUndelete()) {
@@ -585,7 +602,8 @@ class BlobStoreStats implements StoreStats, Closeable {
               indexValue.getOperationTimeInMs() == Utils.Infinite_Time ? indexSegment.getLastModifiedTimeMs()
                   : indexValue.getOperationTimeInMs();
           keyFinalStates.put(indexEntry.getKey(),
-              new IndexFinalState(indexValue.getFlags(), operationTimeInMs, indexValue.getLifeVersion()));
+              new IndexFinalState(indexValue.getFlags(), operationTimeInMs, indexValue.getLifeVersion(),
+                  indexValue.getSize(), indexValue.getExpiresAtMs()));
         }
         if (!isExpired(indexValue.getExpiresAtMs(), expiryReferenceTimeInMs)) {
           validIndexEntryAction.accept(indexEntry);
@@ -646,7 +664,8 @@ class BlobStoreStats implements StoreStats, Closeable {
     }
     if (valid && !keyFinalStates.containsKey(key)) {
       keyFinalStates.put(key, new IndexFinalState(ttlUpdateValue.getFlags(), ttlUpdateValue.
-          getOperationTimeInMs(), ttlUpdateValue.getLifeVersion()));
+          getOperationTimeInMs(), ttlUpdateValue.getLifeVersion(), ttlUpdateValue.getSize(),
+          ttlUpdateValue.getExpiresAtMs()));
     }
     // else, valid = true because a ttl update entry with a put in another log segment is considered valid as long as
     // the put still exists (regardless of its validity)
@@ -1012,6 +1031,30 @@ class BlobStoreStats implements StoreStats, Closeable {
   }
 
   /**
+   * A helper method to update stats about DELETE tombstones with/without TtlUpdate flag separately.
+   * @param indexFinalStates a collection of {@link IndexFinalState} containing DELETE tombstone index value only
+   */
+  private void updateDeleteTombstoneStats(Collection<IndexFinalState> indexFinalStates) {
+    long deleteWithTtlCount = 0;
+    long deleteWithoutTtlCount = 0;
+    long deleteWithTtlTotalSize = 0;
+    long deleteWithoutTtlTotalSize = 0;
+    for (IndexFinalState finalState : indexFinalStates) {
+      if (finalState.isDelete()) {
+        if (finalState.getExpirationTime() != -1) {
+          deleteWithTtlCount++;
+          deleteWithTtlTotalSize += finalState.getRecordSize();
+        } else {
+          deleteWithoutTtlCount++;
+          deleteWithoutTtlTotalSize += finalState.getRecordSize();
+        }
+      }
+    }
+    deleteTombstoneWithTtlStats.set(new Pair<>(deleteWithTtlCount, deleteWithTtlTotalSize));
+    deleteTombstoneWithoutTtlStats.set(new Pair<>(deleteWithoutTtlCount, deleteWithoutTtlTotalSize));
+  }
+
+  /**
    * Runner that processes new entries buffered in the recentEntryQueue and make appropriate updates to keep the current
    * {@link ScanResults} relevant.
    */
@@ -1138,6 +1181,8 @@ class BlobStoreStats implements StoreStats, Closeable {
               }
             }
           }
+          // The remaining index entries in keyFinalStates are DELETE tombstones left by compaction (whose associated PUT is not found)
+          updateDeleteTombstoneStats(keyFinalStates.values());
         } else {
           newScanResults.updateLogSegmentBaseBucket(index.getStartOffset().getName(), 0L);
         }
@@ -1303,17 +1348,23 @@ class BlobStoreStats implements StoreStats, Closeable {
     private final byte flags;
     private final long operationTime;
     private final short lifeVersion;
+    private final long recordSize;
+    private final long expirationTime;
 
     /**
      * Constructor to construct an {@link IndexFinalState}.
-     * @param flags
-     * @param operationTime
-     * @param lifeVersion
+     * @param flags the {@link IndexValue.Flags} of final {@link IndexValue}
+     * @param operationTime the operation time in ms of final {@link IndexValue}
+     * @param lifeVersion the life version associated with final {@link IndexValue}
+     * @param recordSize the size of message record in the log that associated with final {@link IndexValue}
+     * @param expirationTime the expiration time in ms of final {@link IndexValue}
      */
-    IndexFinalState(byte flags, long operationTime, short lifeVersion) {
+    IndexFinalState(byte flags, long operationTime, short lifeVersion, long recordSize, long expirationTime) {
       this.flags = flags;
       this.operationTime = operationTime;
       this.lifeVersion = lifeVersion;
+      this.recordSize = recordSize;
+      this.expirationTime = expirationTime;
     }
 
     /**
@@ -1328,6 +1379,20 @@ class BlobStoreStats implements StoreStats, Closeable {
      */
     public short getLifeVersion() {
       return lifeVersion;
+    }
+
+    /**
+     * @return size of record in log that associated with final {@link IndexValue}.
+     */
+    public long getRecordSize() {
+      return recordSize;
+    }
+
+    /**
+     * @return the expiration time of the final {@link IndexValue}.
+     */
+    public long getExpirationTime() {
+      return expirationTime;
     }
 
     /**

--- a/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
@@ -1968,6 +1968,7 @@ class PersistentIndex {
         Offset floorOffset = indexSegments.floorKey(offset);
         if (floorOffset == null || !floorOffset.getName().equals(offset.getName())) {
           revalidatedToken = new StoreFindToken();
+          metrics.journalBasedTokenResetCount.inc();
           logger.info("Revalidated token {} because it is invalid for the index segment map", token);
         }
         break;
@@ -1975,6 +1976,7 @@ class PersistentIndex {
         // An index based token, but the offset is not in the segments, might be caused by the compaction
         if (!indexSegments.containsKey(offset)) {
           revalidatedToken = new StoreFindToken();
+          metrics.indexBasedTokenResetCount.inc();
           logger.info("Revalidated token {} because it is invalid for the index segment map", token);
         }
         break;

--- a/ambry-store/src/main/java/com/github/ambry/store/StoreMetrics.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StoreMetrics.java
@@ -49,6 +49,8 @@ public class StoreMetrics {
   public final Counter unsealSetError;
   public final Counter sealDoneCount;
   public final Counter unsealDoneCount;
+  public final Counter indexBasedTokenResetCount;
+  public final Counter journalBasedTokenResetCount;
   public final Timer recoveryTime;
   public final Timer findTime;
   public final Timer indexFlushTime;
@@ -131,6 +133,8 @@ public class StoreMetrics {
     unsealSetError = registry.counter(MetricRegistry.name(BlobStore.class, name + "UnsealSetError"));
     sealDoneCount = registry.counter(MetricRegistry.name(BlobStore.class, name + "SealDoneCount"));
     unsealDoneCount = registry.counter(MetricRegistry.name(BlobStore.class, name + "UnsealDoneCount"));
+    indexBasedTokenResetCount = registry.counter(MetricRegistry.name(PersistentIndex.class, name + "IndexBasedTokenResetCount"));
+    journalBasedTokenResetCount = registry.counter(MetricRegistry.name(PersistentIndex.class, name + "JounralBasedTokenResetCount"));
     recoveryTime = registry.timer(MetricRegistry.name(PersistentIndex.class, name + "IndexRecoveryTime"));
     findTime = registry.timer(MetricRegistry.name(PersistentIndex.class, name + "IndexFindTime"));
     indexFlushTime = registry.timer(MetricRegistry.name(PersistentIndex.class, name + "IndexFlushTime"));

--- a/ambry-store/src/main/java/com/github/ambry/store/StoreMetrics.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StoreMetrics.java
@@ -133,8 +133,10 @@ public class StoreMetrics {
     unsealSetError = registry.counter(MetricRegistry.name(BlobStore.class, name + "UnsealSetError"));
     sealDoneCount = registry.counter(MetricRegistry.name(BlobStore.class, name + "SealDoneCount"));
     unsealDoneCount = registry.counter(MetricRegistry.name(BlobStore.class, name + "UnsealDoneCount"));
-    indexBasedTokenResetCount = registry.counter(MetricRegistry.name(PersistentIndex.class, name + "IndexBasedTokenResetCount"));
-    journalBasedTokenResetCount = registry.counter(MetricRegistry.name(PersistentIndex.class, name + "JounralBasedTokenResetCount"));
+    indexBasedTokenResetCount =
+        registry.counter(MetricRegistry.name(PersistentIndex.class, name + "IndexBasedTokenResetCount"));
+    journalBasedTokenResetCount =
+        registry.counter(MetricRegistry.name(PersistentIndex.class, name + "JournalBasedTokenResetCount"));
     recoveryTime = registry.timer(MetricRegistry.name(PersistentIndex.class, name + "IndexRecoveryTime"));
     findTime = registry.timer(MetricRegistry.name(PersistentIndex.class, name + "IndexFindTime"));
     indexFlushTime = registry.timer(MetricRegistry.name(PersistentIndex.class, name + "IndexFlushTime"));

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
@@ -2503,9 +2503,10 @@ public class BlobStoreCompactorTest {
    */
   private long getValidDataSize(List<String> logSegments, long deleteReferenceTimeMs) {
     long size = 0;
+    Map<String, AtomicLong> deleteTombstoneStats = generateDeleteTombstoneStats();
     for (String segment : logSegments) {
       size += state.getValidDataSizeForLogSegment(state.log.getSegment(segment), deleteReferenceTimeMs,
-          state.time.milliseconds(), getFileSpanForLogSegments(logSegments));
+          state.time.milliseconds(), getFileSpanForLogSegments(logSegments), new HashSet<>(), deleteTombstoneStats);
     }
     return size;
   }
@@ -2932,10 +2933,12 @@ public class BlobStoreCompactorTest {
   private List<LogEntry> getValidLogEntriesInOrder(List<String> logSegmentsUnderConsideration,
       long deleteReferenceTimeMs) {
     List<LogEntry> validLogEntriesInOrder = new ArrayList<>();
+    Map<String, AtomicLong> deleteTombstoneStats = generateDeleteTombstoneStats();
     for (String logSegment : logSegmentsUnderConsideration) {
       List<IndexEntry> validIndexEntries =
           state.getValidIndexEntriesForLogSegment(state.log.getSegment(logSegment), deleteReferenceTimeMs,
-              state.time.milliseconds(), getFileSpanForLogSegments(logSegmentsUnderConsideration));
+              state.time.milliseconds(), getFileSpanForLogSegments(logSegmentsUnderConsideration), new HashSet<>(),
+              deleteTombstoneStats);
       addToLogEntriesInOrder(validIndexEntries, validLogEntriesInOrder);
     }
     return validLogEntriesInOrder;

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
@@ -2503,7 +2503,7 @@ public class BlobStoreCompactorTest {
    */
   private long getValidDataSize(List<String> logSegments, long deleteReferenceTimeMs) {
     long size = 0;
-    Map<String, AtomicLong> deleteTombstoneStats = generateDeleteTombstoneStats();
+    Map<String, Pair<AtomicLong, AtomicLong>> deleteTombstoneStats = generateDeleteTombstoneStats();
     for (String segment : logSegments) {
       size += state.getValidDataSizeForLogSegment(state.log.getSegment(segment), deleteReferenceTimeMs,
           state.time.milliseconds(), getFileSpanForLogSegments(logSegments), new HashSet<>(), deleteTombstoneStats);
@@ -2933,7 +2933,7 @@ public class BlobStoreCompactorTest {
   private List<LogEntry> getValidLogEntriesInOrder(List<String> logSegmentsUnderConsideration,
       long deleteReferenceTimeMs) {
     List<LogEntry> validLogEntriesInOrder = new ArrayList<>();
-    Map<String, AtomicLong> deleteTombstoneStats = generateDeleteTombstoneStats();
+    Map<String, Pair<AtomicLong, AtomicLong>> deleteTombstoneStats = generateDeleteTombstoneStats();
     for (String logSegment : logSegmentsUnderConsideration) {
       List<IndexEntry> validIndexEntries =
           state.getValidIndexEntriesForLogSegment(state.log.getSegment(logSegment), deleteReferenceTimeMs,

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreStatsTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreStatsTest.java
@@ -1275,8 +1275,8 @@ public class BlobStoreStatsTest {
   }
 
   private void verifyDeleteTombstoneStats(BlobStoreStats blobStoreStats, Map<String, AtomicLong> deleteTombstoneStats) {
-    Pair<Long, Long> permanentDeletes = blobStoreStats.getDeleteTombstoneWithoutTtlStats();
-    Pair<Long, Long> expiredDeletes = blobStoreStats.getDeleteTombstoneWithTtlStats();
+    Pair<Long, Long> permanentDeletes = blobStoreStats.getPermanentDeleteTombstoneStats();
+    Pair<Long, Long> expiredDeletes = blobStoreStats.getExpiredDeleteTombstoneStats();
     assertEquals("Mismatch in permanent delete count", deleteTombstoneStats.get(PERMANENT_DELETE_COUNT_STR).get(),
         (long) permanentDeletes.getFirst());
     assertEquals("Mismatch in permanent delete total size", deleteTombstoneStats.get(PERMANENT_DELETE_SIZE_STR).get(),


### PR DESCRIPTION
1. added logic in blobstore stats to count both expired and permanent delete tombstones left by compaction;
2. added metrics to track token reset events in PersistentIndex