### PR TITLE
Reduce stats report size, remove all 0-value snapshots, use v to replace value

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/server/StatsSnapshot.java
+++ b/ambry-api/src/main/java/com/github/ambry/server/StatsSnapshot.java
@@ -138,6 +138,9 @@ public class StatsSnapshot {
     value = subMap.values().stream().mapToLong(StatsSnapshot::getValue).sum();
   }
 
+  /**
+   * Remove all 0-value snapshots in the sub map.
+   */
   public void removeZeroValueSnapshots() {
     if (value == 0) {
       // we know that all values are positive, if the <pre>value</prev> is 0, then all the StatsSnapshots in the subMap

--- a/ambry-api/src/main/java/com/github/ambry/server/StatsSnapshot.java
+++ b/ambry-api/src/main/java/com/github/ambry/server/StatsSnapshot.java
@@ -14,11 +14,15 @@
 
 package com.github.ambry.server;
 
-import java.util.HashMap;
-import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 
 /**
@@ -29,8 +33,10 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * {@link StatsSnapshot}'s subMap will contain all the containers in the account that is mapped with. At the leaf level
  * {@link StatsSnapshot}'s subMap will be null.
  */
-@JsonPropertyOrder({"value", "subMap"})
+@JsonPropertyOrder({"v", "subMap"})
 public class StatsSnapshot {
+  @JsonAlias({"value", "v"})
+  @JsonProperty("v")
   private long value;
   private Map<String, StatsSnapshot> subMap;
 
@@ -130,5 +136,27 @@ public class StatsSnapshot {
     }
     subMap.values().forEach(StatsSnapshot::updateValue);
     value = subMap.values().stream().mapToLong(StatsSnapshot::getValue).sum();
+  }
+
+  public void removeZeroValueSnapshots() {
+    if (value == 0) {
+      // we know that all values are positive, if the <pre>value</prev> is 0, then all the StatsSnapshots in the subMap
+      // will have value 0 too.
+      subMap = null;
+      return;
+    }
+    // if we are here, then value is not 0, we can examine all the StatsSnapshots in the subMap and remove the 0-value
+    // StatsSnapshot.
+    if (subMap != null) {
+      List<String> keysToRemove = new ArrayList<>();
+      for (Map.Entry<String, StatsSnapshot> ent : subMap.entrySet()) {
+        if (ent.getValue().getValue() == 0) {
+          keysToRemove.add(ent.getKey());
+        } else {
+          ent.getValue().removeZeroValueSnapshots();
+        }
+      }
+      keysToRemove.forEach(k -> subMap.remove(k));
+    }
   }
 }

--- a/ambry-api/src/test/java/com/github/ambry/server/StatsSnapshotTest.java
+++ b/ambry-api/src/test/java/com/github/ambry/server/StatsSnapshotTest.java
@@ -80,7 +80,7 @@ public class StatsSnapshotTest {
 
   @Test
   public void testCopyConstructor() {
-    // Anonymous class with static block initialization, not a good way to create map, it's only for map.
+    // Anonymous class with static block initialization, not a good way to create map, it's only for testing.
     StatsSnapshot original = new StatsSnapshot(60L, new HashMap<String, StatsSnapshot>() {
       {
         put("L1_K1", new StatsSnapshot(30L, new HashMap<String, StatsSnapshot>() {
@@ -93,10 +93,10 @@ public class StatsSnapshotTest {
       }
     });
     StatsSnapshot copy = new StatsSnapshot(original);
-    assertTrue(copy != original);
+    assertNotSame(copy, original);
     assertEquals(original, copy);
 
-    assertTrue(copy.getSubMap() != original.getSubMap());
+    assertNotSame(copy.getSubMap(), original.getSubMap());
     assertEquals(original.getSubMap(), copy.getSubMap());
   }
 
@@ -105,7 +105,7 @@ public class StatsSnapshotTest {
    */
   @Test
   public void testUpdateValue() {
-    // Anonymous class with static block initialization, not a good way to create map, it's only for map.
+    // Anonymous class with static block initialization, not a good way to create map, it's only for testing.
     StatsSnapshot snapshot = new StatsSnapshot(0L, new HashMap<String, StatsSnapshot>() {
       {
         put("L1_K1", new StatsSnapshot(0L, new HashMap<String, StatsSnapshot>() {
@@ -146,8 +146,8 @@ public class StatsSnapshotTest {
    */
   @Test
   public void testRemoveZeroValueSnapshots() {
-    // Anonymous class with static block initialization, not a good way to create map, it's only for map.
-    StatsSnapshot snapshot = new StatsSnapshot(0L, new HashMap<String, StatsSnapshot>() {
+    // Anonymous class with static block initialization, not a good way to create map, it's only for testing.
+    StatsSnapshot snapshot = new StatsSnapshot(370L, new HashMap<String, StatsSnapshot>() {
       {
         put("L1_K1", new StatsSnapshot(0L, new HashMap<String, StatsSnapshot>() {
           {
@@ -155,15 +155,15 @@ public class StatsSnapshotTest {
             put("L2_K2", new StatsSnapshot(0L, null));
           }
         }));
-        put("L1_K2", new StatsSnapshot(0L, new HashMap<String, StatsSnapshot>() {
+        put("L1_K2", new StatsSnapshot(70L, new HashMap<String, StatsSnapshot>() {
           {
             put("L2_K3", new StatsSnapshot(70L, null));
             put("L2_K4", new StatsSnapshot(0L, null));
           }
         }));
-        put("L1_K3", new StatsSnapshot(0L, new HashMap<String, StatsSnapshot>() {
+        put("L1_K3", new StatsSnapshot(300L, new HashMap<String, StatsSnapshot>() {
           {
-            put("L2_K5", new StatsSnapshot(20L, new HashMap<String, StatsSnapshot>() {
+            put("L2_K5", new StatsSnapshot(0L, new HashMap<String, StatsSnapshot>() {
               {
                 put("L3_K1", new StatsSnapshot(0L, null));
                 put("L3_K2", new StatsSnapshot(0L, null));
@@ -174,9 +174,8 @@ public class StatsSnapshotTest {
         }));
       }
     });
-    snapshot.updateValue();
     snapshot.removeZeroValueSnapshots();
-    /* it will be trimed to :
+    /* it will be trimmed to :
        {
          "value": 370,
          "L1_K2": {
@@ -189,7 +188,6 @@ public class StatsSnapshotTest {
          }
        }
      */
-    assertEquals(370, snapshot.getValue());
     assertEquals(2, snapshot.getSubMap().size());
     assertTrue(snapshot.getSubMap().containsKey("L1_K2"));
     assertTrue(snapshot.getSubMap().containsKey("L1_K3"));

--- a/ambry-api/src/test/java/com/github/ambry/server/StatsSnapshotTest.java
+++ b/ambry-api/src/test/java/com/github/ambry/server/StatsSnapshotTest.java
@@ -66,5 +66,147 @@ public class StatsSnapshotTest {
     assertEquals("Mismatch in aggregated value for second account", 60L, snapshot.getSubMap().get("second").getValue());
     assertEquals("The subMap in first account should be null", null, snapshot.getSubMap().get("first").getSubMap());
     assertEquals("The subMap in second account should be null", null, snapshot.getSubMap().get("second").getSubMap());
+
+    jsonAsString = "{\"v\":100,\"first\":{\"v\":40},\"second\":{\"v\":60}}";
+
+    snapshot = new ObjectMapper().readValue(jsonAsString, StatsSnapshot.class);
+
+    assertEquals("Mismatch in total aggregated value for StatsSnapshot", 100L, snapshot.getValue());
+    assertEquals("Mismatch in aggregated value for first account", 40L, snapshot.getSubMap().get("first").getValue());
+    assertEquals("Mismatch in aggregated value for second account", 60L, snapshot.getSubMap().get("second").getValue());
+    assertEquals("The subMap in first account should be null", null, snapshot.getSubMap().get("first").getSubMap());
+    assertEquals("The subMap in second account should be null", null, snapshot.getSubMap().get("second").getSubMap());
+  }
+
+  @Test
+  public void testCopyConstructor() {
+    // Anonymous class with static block initialization, not a good way to create map, it's only for map.
+    StatsSnapshot original = new StatsSnapshot(60L, new HashMap<String, StatsSnapshot>() {
+      {
+        put("L1_K1", new StatsSnapshot(30L, new HashMap<String, StatsSnapshot>() {
+          {
+            put("L2_K1", new StatsSnapshot(10L, null));
+            put("L2_K2", new StatsSnapshot(20L, null));
+          }
+        }));
+        put("L1_K2", new StatsSnapshot(30L, null));
+      }
+    });
+    StatsSnapshot copy = new StatsSnapshot(original);
+    assertTrue(copy != original);
+    assertEquals(original, copy);
+
+    assertTrue(copy.getSubMap() != original.getSubMap());
+    assertEquals(original.getSubMap(), copy.getSubMap());
+  }
+
+  /**
+   * Test {@link StatsSnapshot#updateValue()}.
+   */
+  @Test
+  public void testUpdateValue() {
+    // Anonymous class with static block initialization, not a good way to create map, it's only for map.
+    StatsSnapshot snapshot = new StatsSnapshot(0L, new HashMap<String, StatsSnapshot>() {
+      {
+        put("L1_K1", new StatsSnapshot(0L, new HashMap<String, StatsSnapshot>() {
+          {
+            put("L2_K1", new StatsSnapshot(40L, null));
+            put("L2_K2", new StatsSnapshot(60L, null));
+          }
+        }));
+        put("L1_K2", new StatsSnapshot(0L, new HashMap<String, StatsSnapshot>() {
+          {
+            put("L2_K3", new StatsSnapshot(70L, null));
+            put("L2_K4", new StatsSnapshot(90L, null));
+          }
+        }));
+        put("L1_K3", new StatsSnapshot(0L, new HashMap<String, StatsSnapshot>() {
+          {
+            put("L2_K5", new StatsSnapshot(20L, new HashMap<String, StatsSnapshot>() {
+              {
+                put("L3_K1", new StatsSnapshot(100L, null));
+                put("L3_K2", new StatsSnapshot(200L, null));
+              }
+            }));
+            put("L2_K6", new StatsSnapshot(300L, null));
+          }
+        }));
+      }
+    });
+    snapshot.updateValue();
+    assertEquals(40 + 60 + 70 + 90 + 100 + 200 + 300, snapshot.getValue());
+    assertEquals(40 + 60, snapshot.getSubMap().get("L1_K1").getValue());
+    assertEquals(70 + 90, snapshot.getSubMap().get("L1_K2").getValue());
+    assertEquals(100 + 200 + 300, snapshot.getSubMap().get("L1_K3").getValue());
+    assertEquals(100 + 200, snapshot.getSubMap().get("L1_K3").getSubMap().get("L2_K5").getValue());
+  }
+
+  /**
+   * Test {@link StatsSnapshot#removeZeroValueSnapshots()}
+   */
+  @Test
+  public void testRemoveZeroValueSnapshots() {
+    // Anonymous class with static block initialization, not a good way to create map, it's only for map.
+    StatsSnapshot snapshot = new StatsSnapshot(0L, new HashMap<String, StatsSnapshot>() {
+      {
+        put("L1_K1", new StatsSnapshot(0L, new HashMap<String, StatsSnapshot>() {
+          {
+            put("L2_K1", new StatsSnapshot(0L, null));
+            put("L2_K2", new StatsSnapshot(0L, null));
+          }
+        }));
+        put("L1_K2", new StatsSnapshot(0L, new HashMap<String, StatsSnapshot>() {
+          {
+            put("L2_K3", new StatsSnapshot(70L, null));
+            put("L2_K4", new StatsSnapshot(0L, null));
+          }
+        }));
+        put("L1_K3", new StatsSnapshot(0L, new HashMap<String, StatsSnapshot>() {
+          {
+            put("L2_K5", new StatsSnapshot(20L, new HashMap<String, StatsSnapshot>() {
+              {
+                put("L3_K1", new StatsSnapshot(0L, null));
+                put("L3_K2", new StatsSnapshot(0L, null));
+              }
+            }));
+            put("L2_K6", new StatsSnapshot(300L, null));
+          }
+        }));
+      }
+    });
+    snapshot.updateValue();
+    snapshot.removeZeroValueSnapshots();
+    /* it will be trimed to :
+       {
+         "value": 370,
+         "L1_K2": {
+           "value": 70,
+           "L2_K3": { "value": 70 }
+         },
+         "L1_K3": {
+           "value": 300,
+           "L2_K6": { "value": 300 }
+         }
+       }
+     */
+    assertEquals(370, snapshot.getValue());
+    assertEquals(2, snapshot.getSubMap().size());
+    assertTrue(snapshot.getSubMap().containsKey("L1_K2"));
+    assertTrue(snapshot.getSubMap().containsKey("L1_K3"));
+    assertFalse(snapshot.getSubMap().containsKey("L1_K1"));
+
+    assertEquals(70, snapshot.getSubMap().get("L1_K2").getValue());
+    assertEquals(1, snapshot.getSubMap().get("L1_K2").getSubMap().size());
+    assertTrue(snapshot.getSubMap().get("L1_K2").getSubMap().containsKey("L2_K3"));
+    assertFalse(snapshot.getSubMap().get("L1_K2").getSubMap().containsKey("L2_K4"));
+    assertEquals(70, snapshot.getSubMap().get("L1_K2").getSubMap().get("L2_K3").getValue());
+    assertNull(snapshot.getSubMap().get("L1_K2").getSubMap().get("L2_K3").getSubMap());
+
+    assertEquals(300, snapshot.getSubMap().get("L1_K3").getValue());
+    assertEquals(1, snapshot.getSubMap().get("L1_K3").getSubMap().size());
+    assertTrue(snapshot.getSubMap().get("L1_K3").getSubMap().containsKey("L2_K6"));
+    assertFalse(snapshot.getSubMap().get("L1_K3").getSubMap().containsKey("L2_K5"));
+    assertEquals(300, snapshot.getSubMap().get("L1_K3").getSubMap().get("L2_K6").getValue());
+    assertNull(snapshot.getSubMap().get("L1_K3").getSubMap().get("L2_K6").getSubMap());
   }
 }

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreStats.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreStats.java
@@ -217,6 +217,7 @@ class BlobStoreStats implements StoreStats, Closeable {
           logger.error("Unrecognized stats report type: {}", reportType);
       }
     }
+    statsSnapshotsByType.forEach((k, v) -> v.removeZeroValueSnapshots());
     return statsSnapshotsByType;
   }
 


### PR DESCRIPTION
There are a couple low hanging fruits to reduce the size of the stats report to helix
1) remove all the 0-value snapshots
2) use "v" to replace "value" so the key would be shorter.

Hopefully this would make report a bit smaller.