### PR TITLE
Add a configuration to exclude accounts from stats report

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/StatsManagerConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StatsManagerConfig.java
@@ -14,6 +14,11 @@
 
 package com.github.ambry.config;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+
 /**
  * The configs for stats.
  */
@@ -22,6 +27,8 @@ public class StatsManagerConfig {
   public static final String STATS_PUBLISH_PERIOD_IN_SECS = "stats.publish.period.in.secs";
   public static final String STATS_INITIAL_DELAY_UPPER_BOUND_IN_SECS = "stats.initial.delay.upper.bound.in.secs";
   public static final String STATS_ENABLE_MYSQL_REPORT = "stats.enable.mysql.report";
+  public static final String STATS_HEALTH_REPORT_EXCLUDE_ACCOUNT_NAMES = "stats.health.report.exclude.account.names";
+  public static final String STATS_PUBLISH_EXCLUDE_ACCOUNT_NAMES = "stats.publish.exclude.account.names";
 
   /**
    * The file path (including filename) to be used for publishing the stats.
@@ -45,9 +52,27 @@ public class StatsManagerConfig {
   @Default("600")
   public final int initialDelayUpperBoundInSecs;
 
+  /**
+   * True to enable publishing stats to mysql database
+   */
   @Config(STATS_ENABLE_MYSQL_REPORT)
   @Default("false")
   public final boolean enableMysqlReport;
+
+  /**
+   * The account names to exclude from the health report. Multiple account names should be separated with ",".
+   */
+  @Config(STATS_HEALTH_REPORT_EXCLUDE_ACCOUNT_NAMES)
+  @Default("")
+  public final List<String> healthReportExcludeAccountNames;
+
+  /**
+   * The account names to exclude from publishing to local disk and mysql database. Multiple account names should be
+   * separated with ",".
+   */
+  @Config(STATS_PUBLISH_EXCLUDE_ACCOUNT_NAMES)
+  @Default("")
+  public final List<String> publishExcludeAccountNames;
 
   public StatsManagerConfig(VerifiableProperties verifiableProperties) {
     outputFilePath = verifiableProperties.getString(STATS_OUTPUT_FILE_PATH, "/tmp/stats_output.json");
@@ -55,5 +80,11 @@ public class StatsManagerConfig {
     initialDelayUpperBoundInSecs =
         verifiableProperties.getIntInRange(STATS_INITIAL_DELAY_UPPER_BOUND_IN_SECS, 600, 0, Integer.MAX_VALUE);
     enableMysqlReport = verifiableProperties.getBoolean(STATS_ENABLE_MYSQL_REPORT, false);
+    String excludeNames = verifiableProperties.getString(STATS_HEALTH_REPORT_EXCLUDE_ACCOUNT_NAMES, "").trim();
+    healthReportExcludeAccountNames =
+        excludeNames.isEmpty() ? Collections.EMPTY_LIST : Arrays.asList(excludeNames.split(","));
+    excludeNames = verifiableProperties.getString(STATS_PUBLISH_EXCLUDE_ACCOUNT_NAMES, "").trim();
+    publishExcludeAccountNames =
+        excludeNames.isEmpty() ? Collections.EMPTY_LIST : Arrays.asList(excludeNames.split(","));
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/server/StatsSnapshot.java
+++ b/ambry-api/src/main/java/com/github/ambry/server/StatsSnapshot.java
@@ -154,7 +154,7 @@ public class StatsSnapshot {
           .stream()
           .filter(ent -> ent.getValue().getValue() != 0)
           .peek(ent -> ent.getValue().removeZeroValueSnapshots())
-          .collect(Collectors.toMap(ent -> ent.getKey(), ent -> ent.getValue()));
+          .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/server/StatsSnapshot.java
+++ b/ambry-api/src/main/java/com/github/ambry/server/StatsSnapshot.java
@@ -19,10 +19,9 @@ import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 
 /**
@@ -151,15 +150,11 @@ public class StatsSnapshot {
     // if we are here, then value is not 0, we can examine all the StatsSnapshots in the subMap and remove the 0-value
     // StatsSnapshot.
     if (subMap != null) {
-      List<String> keysToRemove = new ArrayList<>();
-      for (Map.Entry<String, StatsSnapshot> ent : subMap.entrySet()) {
-        if (ent.getValue().getValue() == 0) {
-          keysToRemove.add(ent.getKey());
-        } else {
-          ent.getValue().removeZeroValueSnapshots();
-        }
-      }
-      keysToRemove.forEach(k -> subMap.remove(k));
+      subMap = subMap.entrySet()
+          .stream()
+          .filter(ent -> ent.getValue().getValue() != 0)
+          .peek(ent -> ent.getValue().removeZeroValueSnapshots())
+          .collect(Collectors.toMap(ent -> ent.getKey(), ent -> ent.getValue()));
     }
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/store/StoreStats.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/StoreStats.java
@@ -17,6 +17,7 @@ package com.github.ambry.store;
 import com.github.ambry.server.StatsReportType;
 import com.github.ambry.server.StatsSnapshot;
 import com.github.ambry.utils.Pair;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -50,11 +51,12 @@ public interface StoreStats {
    * value is {@link StatsSnapshot}.
    * @param statsReportTypes the specified {@link StatsReportType} to fetch
    * @param referenceTimeInMs the reference time in ms until which deletes and expiration are relevant
+   * @param accountIdToExclude the list of account id to exclude from the {@link StatsSnapshot}.
    * @return a map of {@link StatsReportType} to {@link StatsSnapshot}
    * @throws StoreException
    */
-  Map<StatsReportType, StatsSnapshot> getStatsSnapshots(Set<StatsReportType> statsReportTypes, long referenceTimeInMs)
-      throws StoreException;
+  Map<StatsReportType, StatsSnapshot> getStatsSnapshots(Set<StatsReportType> statsReportTypes, long referenceTimeInMs,
+      List<Short> accountIdToExclude) throws StoreException;
 
   /**
    * Fetches delete tombstone stats grouped by different types, i.e. {@link StoreStats#EXPIRED_DELETE_TOMBSTONE},

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryServer.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryServer.java
@@ -266,7 +266,7 @@ public class AmbryServer {
           statsConfig.enableMysqlReport ? new AccountStatsMySqlStoreFactory(properties, clusterMapConfig, statsConfig,
               registry).getAccountStatsMySqlStore() : null;
       statsManager = new StatsManager(storageManager, clusterMap.getReplicaIds(nodeId), registry, statsConfig, time,
-          clusterParticipants.get(0), accountStatsMySqlStore);
+          clusterParticipants.get(0), accountStatsMySqlStore, accountService);
       if (serverConfig.serverStatsPublishLocalEnabled) {
         statsManager.start();
       }

--- a/ambry-server/src/main/java/com/github/ambry/server/StatsManager.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/StatsManager.java
@@ -16,6 +16,7 @@ package com.github.ambry.server;
 
 import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.ambry.account.Account;
 import com.github.ambry.account.AccountService;
 import com.github.ambry.accountstats.AccountStatsMySqlStore;
 import com.github.ambry.clustermap.ClusterParticipant;
@@ -35,12 +36,14 @@ import com.github.ambry.utils.Utils;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledExecutorService;
@@ -114,8 +117,8 @@ class StatsManager {
     this.accountStatsMySqlStore = accountStatsMySqlStore;
     Function<List<String>, List<Short>> convertAccountNamesToIds = names -> names.stream()
         .map(name -> accountService.getAccountByName(name))
-        .filter(account -> account != null)
-        .map(account -> account.getId())
+        .filter(Objects::nonNull)
+        .map(Account::getId)
         .collect(Collectors.toList());
     this.healthReportExcludeAccountIds = convertAccountNamesToIds.apply(config.healthReportExcludeAccountNames);
     this.publishExcludeAccountIds = convertAccountNamesToIds.apply(config.publishExcludeAccountNames);
@@ -142,6 +145,22 @@ class StatsManager {
     if (scheduler != null) {
       shutDownExecutorService(scheduler, 30, TimeUnit.SECONDS);
     }
+  }
+
+  /**
+   * Return the {@link #healthReportExcludeAccountIds}. Only for test.
+   * @return
+   */
+  List<Short> getHealthReportExcludeAccountIds() {
+    return Collections.unmodifiableList(healthReportExcludeAccountIds);
+  }
+
+  /**
+   * Return the {@link #publishExcludeAccountIds}. Only for test.
+   * @return
+   */
+  List<Short> getPublishExcludeAccountIds() {
+    return Collections.unmodifiableList(publishExcludeAccountIds);
   }
 
   /**

--- a/ambry-server/src/main/java/com/github/ambry/server/StatsManager.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/StatsManager.java
@@ -16,6 +16,7 @@ package com.github.ambry.server;
 
 import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.ambry.account.AccountService;
 import com.github.ambry.accountstats.AccountStatsMySqlStore;
 import com.github.ambry.clustermap.ClusterParticipant;
 import com.github.ambry.clustermap.PartitionId;
@@ -71,6 +72,8 @@ class StatsManager {
   private final Time time;
   private final ObjectMapper mapper = new ObjectMapper();
   private final AccountStatsMySqlStore accountStatsMySqlStore;
+  private final List<Short> healthReportExcludeAccountIds;
+  private final List<Short> publishExcludeAccountIds;
   private ScheduledExecutorService scheduler = null;
   private StatsAggregator statsAggregator = null;
   private long expiredDeleteTombstoneCount = 0;
@@ -90,10 +93,11 @@ class StatsManager {
    * @param time the {@link Time} instance to be used for reporting
    * @param clusterParticipant the {@link ClusterParticipant} to register state change listener.
    * @param accountStatsMySqlStore the {@link AccountStatsMySqlStore} to publish stats to mysql database.
+   * @param accountService the {@link AccountService} to get account ids from account names.
    */
   StatsManager(StorageManager storageManager, List<? extends ReplicaId> replicaIds, MetricRegistry registry,
       StatsManagerConfig config, Time time, ClusterParticipant clusterParticipant,
-      AccountStatsMySqlStore accountStatsMySqlStore) {
+      AccountStatsMySqlStore accountStatsMySqlStore, AccountService accountService) {
     this.storageManager = storageManager;
     statsOutputFile = new File(config.outputFilePath);
     publishPeriodInSecs = config.publishPeriodInSecs;
@@ -108,6 +112,13 @@ class StatsManager {
       logger.info("Stats Manager's state change listener registered!");
     }
     this.accountStatsMySqlStore = accountStatsMySqlStore;
+    Function<List<String>, List<Short>> convertAccountNamesToIds = names -> names.stream()
+        .map(name -> accountService.getAccountByName(name))
+        .filter(account -> account != null)
+        .map(account -> account.getId())
+        .collect(Collectors.toList());
+    this.healthReportExcludeAccountIds = convertAccountNamesToIds.apply(config.healthReportExcludeAccountNames);
+    this.publishExcludeAccountIds = convertAccountNamesToIds.apply(config.publishExcludeAccountNames);
   }
 
   /**
@@ -167,7 +178,8 @@ class StatsManager {
         long fetchAndAggregatePerStoreStartTimeMs = time.milliseconds();
         StoreStats storeStats = store.getStoreStats();
         Map<StatsReportType, StatsSnapshot> snapshotsByType =
-            storeStats.getStatsSnapshots(EnumSet.of(StatsReportType.ACCOUNT_REPORT), time.milliseconds());
+            storeStats.getStatsSnapshots(EnumSet.of(StatsReportType.ACCOUNT_REPORT), time.milliseconds(),
+                publishExcludeAccountIds);
         aggregatedSnapshot.getSubMap().put(partitionId.toString(), snapshotsByType.get(StatsReportType.ACCOUNT_REPORT));
         metrics.fetchAndAggregateTimePerStoreMs.update(time.milliseconds() - fetchAndAggregatePerStoreStartTimeMs);
         // update delete tombstone stats
@@ -192,8 +204,8 @@ class StatsManager {
       unreachablePartitions.add(partitionId);
     } else {
       try {
-        Map<StatsReportType, StatsSnapshot> snapshotsByType =
-            store.getStoreStats().getStatsSnapshots(EnumSet.of(reportType), time.milliseconds());
+        Map<StatsReportType, StatsSnapshot> snapshotsByType = store.getStoreStats()
+            .getStatsSnapshots(EnumSet.of(reportType), time.milliseconds(), healthReportExcludeAccountIds);
         statsSnapshot = snapshotsByType.get(reportType);
       } catch (StoreException e) {
         String reportTypeStr = reportType.toString();
@@ -332,7 +344,7 @@ class StatsManager {
    * Exposed for testing.
    * @return aggregated delete tombstone stats.
    */
-  AggregatedDeleteTombstoneStats getAggregatedDeleteTombstoneStats(){
+  AggregatedDeleteTombstoneStats getAggregatedDeleteTombstoneStats() {
     return aggregatedDeleteTombstoneStats.get();
   }
 

--- a/ambry-server/src/test/java/com/github/ambry/server/AmbryStatsReportTest.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/AmbryStatsReportTest.java
@@ -15,6 +15,7 @@
 package com.github.ambry.server;
 
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.account.InMemAccountService;
 import com.github.ambry.clustermap.MockDataNodeId;
 import com.github.ambry.config.StatsManagerConfig;
 import com.github.ambry.config.VerifiableProperties;
@@ -42,7 +43,7 @@ public class AmbryStatsReportTest {
     StatsManager testStatsManager = new StatsManager(new MockStorageManager(Collections.emptyMap(),
         new MockDataNodeId(Collections.singletonList(new Port(6667, PortType.PLAINTEXT)),
             Collections.singletonList("/tmp"), "DC1")), Collections.emptyList(), new MetricRegistry(), config,
-        new MockTime(), null, null);
+        new MockTime(), null, null, new InMemAccountService(false, false));
     // test account stats report
     AmbryStatsReport ambryStatsReport =
         new AmbryStatsReport(testStatsManager, AGGREGATE_INTERVAL_MINS, StatsReportType.ACCOUNT_REPORT);

--- a/ambry-server/src/test/java/com/github/ambry/server/MockStatsManager.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/MockStatsManager.java
@@ -14,6 +14,7 @@
 package com.github.ambry.server;
 
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.account.InMemAccountService;
 import com.github.ambry.clustermap.ClusterParticipant;
 import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.config.StatsManagerConfig;
@@ -30,7 +31,8 @@ class MockStatsManager extends StatsManager {
 
   MockStatsManager(StorageManager storageManager, List<? extends ReplicaId> replicaIds, MetricRegistry metricRegistry,
       StatsManagerConfig statsManagerConfig, ClusterParticipant clusterParticipant) {
-    super(storageManager, replicaIds, metricRegistry, statsManagerConfig, new MockTime(), clusterParticipant, null);
+    super(storageManager, replicaIds, metricRegistry, statsManagerConfig, new MockTime(), clusterParticipant, null,
+        new InMemAccountService(false, false));
   }
 
   @Override

--- a/ambry-server/src/test/java/com/github/ambry/server/StatsManagerTest.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/StatsManagerTest.java
@@ -16,6 +16,9 @@ package com.github.ambry.server;
 
 import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.ambry.account.Account;
+import com.github.ambry.account.AccountBuilder;
+import com.github.ambry.account.AccountService;
 import com.github.ambry.account.InMemAccountService;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.MockClusterMap;
@@ -69,9 +72,12 @@ import java.util.Properties;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
+import java.util.stream.Collectors;
 import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import static com.github.ambry.clustermap.StateTransitionException.TransitionErrorCode.*;
 import static com.github.ambry.clustermap.TestUtils.*;
@@ -82,6 +88,7 @@ import static org.junit.Assert.*;
 /**
  * Tests for {@link StatsManager}.
  */
+@RunWith(Parameterized.class)
 public class StatsManagerTest {
   private static final int MAX_ACCOUNT_COUNT = 10;
   private static final int MIN_ACCOUNT_COUNT = 5;
@@ -100,6 +107,8 @@ public class StatsManagerTest {
   private final ObjectMapper mapper = new ObjectMapper();
   private final Map<String, Pair<Long, Long>> storeDeleteTombstoneStats = new HashMap<>();
   private final StatsManagerConfig statsManagerConfig;
+  private final AccountService inMemoryAccountService = new InMemAccountService(false, false);
+  private final boolean enableAccountExclusion;
   private VerifiableProperties verifiableProperties;
   private DataNodeId dataNodeId;
 
@@ -118,7 +127,13 @@ public class StatsManagerTest {
     }
   }
 
-  public StatsManagerTest() throws Exception {
+  @Parameterized.Parameters
+  public static List<Object[]> data() {
+    return Arrays.asList(new Object[][]{{false}, {true}});
+  }
+
+  public StatsManagerTest(boolean enableAccountExclusion) throws Exception {
+    this.enableAccountExclusion = enableAccountExclusion;
     tempDir = Files.createTempDirectory("nodeStatsDir-" + TestUtils.getRandomString(10)).toFile();
     tempDir.deleteOnExit();
     outputFileString = (new File(tempDir.getAbsolutePath(), "stats_output.json")).getAbsolutePath();
@@ -126,7 +141,10 @@ public class StatsManagerTest {
     zkInfoList.add(new com.github.ambry.utils.TestUtils.ZkInfo(null, "DC1", (byte) 0, 2199, false));
     JSONObject zkJson = constructZkLayoutJSON(zkInfoList);
     Properties properties = new Properties();
-    properties.put("stats.output.file.path", outputFileString);
+    String accountNamesToExclude = enableAccountExclusion ? "account0,account" + MAX_ACCOUNT_COUNT : "";
+    properties.put(StatsManagerConfig.STATS_OUTPUT_FILE_PATH, outputFileString);
+    properties.put(StatsManagerConfig.STATS_HEALTH_REPORT_EXCLUDE_ACCOUNT_NAMES, accountNamesToExclude);
+    properties.put(StatsManagerConfig.STATS_PUBLISH_EXCLUDE_ACCOUNT_NAMES, accountNamesToExclude);
     properties.setProperty("clustermap.cluster.name", "test");
     properties.setProperty("clustermap.datacenter.name", "DC1");
     properties.setProperty("clustermap.host.name", "localhost");
@@ -136,7 +154,11 @@ public class StatsManagerTest {
     ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(properties));
     storeMap = new HashMap<>();
     partitionToSnapshot = new HashMap<>();
-    preAggregatedSnapshot = generateRandomSnapshot().get(StatsReportType.ACCOUNT_REPORT);
+    List<Short> accountIdsToExlude = new ArrayList<>();
+    if (enableAccountExclusion) {
+      accountIdsToExlude.add((short) 0);
+    }
+    preAggregatedSnapshot = generateRandomSnapshot(accountIdsToExlude).get(StatsReportType.ACCOUNT_REPORT);
     Pair<StatsSnapshot, StatsSnapshot> baseSliceAndNewSlice = new Pair<>(preAggregatedSnapshot, null);
     storeDeleteTombstoneStats.put(EXPIRED_DELETE_TOMBSTONE,
         new Pair<>((long) random.nextInt(100), (long) random.nextInt(1000)));
@@ -165,9 +187,13 @@ public class StatsManagerTest {
     storageManager = new MockStorageManager(storeMap, dataNodeId);
     MockHelixParticipant.metricRegistry = new MetricRegistry();
     clusterParticipant = new MockHelixParticipant(clusterMapConfig);
+    // prepare account service, we are only going to fetch account0, and account10
+    inMemoryAccountService.updateAccounts(
+        Arrays.asList(new AccountBuilder((short) 0, "account0", Account.AccountStatus.ACTIVE).build(),
+            new AccountBuilder((short) 10, "account10", Account.AccountStatus.ACTIVE).build()));
     statsManager =
-        new StatsManager(storageManager, replicas, new MetricRegistry(), statsManagerConfig, new MockTime(), null,
-            null);
+        new StatsManager(storageManager, replicas, new MetricRegistry(), statsManagerConfig, new MockTime(), null, null,
+            inMemoryAccountService);
   }
 
   /**
@@ -228,7 +254,7 @@ public class StatsManagerTest {
     problematicStoreMap.put(partitionId2, exceptionStore);
     StatsManager testStatsManager = new StatsManager(new MockStorageManager(problematicStoreMap, dataNodeId),
         Arrays.asList(partitionId1.getReplicaIds().get(0), partitionId2.getReplicaIds().get(0)), new MetricRegistry(),
-        statsManagerConfig, new MockTime(), null, null);
+        statsManagerConfig, new MockTime(), null, null, inMemoryAccountService);
     List<PartitionId> unreachablePartitions = new ArrayList<>();
     StatsSnapshot actualSnapshot = new StatsSnapshot(0L, new HashMap<>());
     for (PartitionId partitionId : problematicStoreMap.keySet()) {
@@ -252,7 +278,7 @@ public class StatsManagerTest {
     mixedStoreMap.put(partitionId4, exceptionStore);
     testStatsManager = new StatsManager(new MockStorageManager(mixedStoreMap, dataNodeId),
         Arrays.asList(partitionId3.getReplicaIds().get(0), partitionId4.getReplicaIds().get(0)), new MetricRegistry(),
-        statsManagerConfig, new MockTime(), null, null);
+        statsManagerConfig, new MockTime(), null, null, inMemoryAccountService);
     actualSnapshot = new StatsSnapshot(0L, new HashMap<>());
     for (PartitionId partitionId : mixedStoreMap.keySet()) {
       testStatsManager.collectAndAggregate(actualSnapshot, partitionId, unreachablePartitions);
@@ -265,8 +291,8 @@ public class StatsManagerTest {
       StatsSnapshot snapshot =
           testStatsManager.fetchSnapshot(partitionId, unreachablePartitions, StatsReportType.ACCOUNT_REPORT);
       if (Integer.parseInt(partitionId.toPathString()) < 3) {
-        assertEquals("Actual StatsSnapshot does not match with expected snapshot", snapshot,
-            partitionToSnapshot.get(partitionId));
+        assertEquals("Actual StatsSnapshot does not match with expected snapshot with partition id "
+            + partitionId.toPathString(), snapshot, partitionToSnapshot.get(partitionId));
       }
     }
     assertEquals("Unreachable store count mismatch with expected value", 2, unreachablePartitions.size());
@@ -294,7 +320,7 @@ public class StatsManagerTest {
     StorageManager mockStorageManager = new MockStorageManager(testStoreMap, dataNodeId);
     StatsManager testStatsManager =
         new StatsManager(mockStorageManager, testReplicas, new MetricRegistry(), statsManagerConfig, new MockTime(),
-            null, null);
+            null, null, inMemoryAccountService);
 
     // verify that adding an existing store to StatsManager should fail
     assertFalse("Adding a store which already exists should fail", testStatsManager.addReplica(testReplicas.get(0)));
@@ -486,7 +512,7 @@ public class StatsManagerTest {
       partitionId = new MockPartitionId(i,
           (i % 2 == 0) ? MockClusterMap.DEFAULT_PARTITION_CLASS : MockClusterMap.SPECIAL_PARTITION_CLASS,
           Collections.singletonList((MockDataNodeId) dataNodeId), 0);
-      Map<StatsReportType, StatsSnapshot> allSnapshots = generateRandomSnapshot();
+      Map<StatsReportType, StatsSnapshot> allSnapshots = generateRandomSnapshot(Arrays.asList((short) 0));
       partitionClassSnapshots.add(allSnapshots.get(StatsReportType.PARTITION_CLASS_REPORT));
       accountSnapshots.add(allSnapshots.get(StatsReportType.ACCOUNT_REPORT));
       storeMap.put(partitionId, new MockStore(new MockStoreStats(allSnapshots, false)));
@@ -495,7 +521,7 @@ public class StatsManagerTest {
     StorageManager storageManager = new MockStorageManager(storeMap, dataNodeId);
     StatsManager statsManager =
         new StatsManager(storageManager, replicaIds, new MetricRegistry(), statsManagerConfig, new MockTime(), null,
-            null);
+            null, inMemoryAccountService);
 
     StatsSnapshot expectAccountSnapshot = new StatsSnapshot(0L, new HashMap<>());
     StatsSnapshot expectPartitionClassSnapshot = new StatsSnapshot(0L, new HashMap<>());
@@ -620,10 +646,22 @@ public class StatsManagerTest {
    * @return a map of all types of {@link StatsSnapshot} whose key is the type name and value is corresponding snapshot
    */
   private Map<StatsReportType, StatsSnapshot> generateRandomSnapshot() {
+    return generateRandomSnapshot(Collections.EMPTY_LIST);
+  }
+
+  /**
+   * Generate a random, two levels of nesting (accountId, containerId) {@link StatsSnapshot} for testing aggregation.
+   * @param accountIdToExclude The account id to exclude from the final map.
+   * @return a map of all types of {@link StatsSnapshot} whose key is the type name and value is corresponding snapshot
+   */
+  private Map<StatsReportType, StatsSnapshot> generateRandomSnapshot(List<Short> accountIdToExclude) {
     Map<String, StatsSnapshot> accountMap = new HashMap<>();
     Map<String, StatsSnapshot> accountContainerPairMap = new HashMap<>();
     long totalSize = 0;
     for (int i = 0; i < random.nextInt(MAX_ACCOUNT_COUNT - MIN_ACCOUNT_COUNT + 1) + MIN_ACCOUNT_COUNT; i++) {
+      if (accountIdToExclude.contains((short) i)) {
+        continue;
+      }
       String accountIdStr = "A[".concat(String.valueOf(i)).concat("]");
       Map<String, StatsSnapshot> containerMap = new HashMap<>();
       long subTotalSize = 0;
@@ -851,15 +889,36 @@ public class StatsManagerTest {
 
     @Override
     public Map<StatsReportType, StatsSnapshot> getStatsSnapshots(Set<StatsReportType> statsReportTypes,
-        long referenceTimeInMs) throws StoreException {
+        long referenceTimeInMs, List<Short> accountIdsToExclude) throws StoreException {
       if (throwStoreException) {
         throw new StoreException("Test", StoreErrorCodes.Unknown_Error);
       }
-      return snapshotsByType;
+      if (accountIdsToExclude != null && !accountIdsToExclude.isEmpty()) {
+        Map<StatsReportType, StatsSnapshot> result = new HashMap<>();
+        List<String> accountIdInKeys =
+            accountIdsToExclude.stream().map(id -> "A[" + id + "]").collect(Collectors.toList());
+        for (Map.Entry<StatsReportType, StatsSnapshot> ent : snapshotsByType.entrySet()) {
+          StatsSnapshot newSnapshot = new StatsSnapshot(ent.getValue());
+          if (ent.getKey() == StatsReportType.ACCOUNT_REPORT) {
+            accountIdsToExclude.forEach(id -> newSnapshot.getSubMap().remove("A[" + id + "]"));
+          } else {
+            List<String> keysToRemove = newSnapshot.getSubMap()
+                .keySet()
+                .stream()
+                .filter(key -> accountIdInKeys.stream().anyMatch(ak -> key.contains(ak)))
+                .collect(Collectors.toList());
+            keysToRemove.forEach(key -> newSnapshot.getSubMap().remove(key));
+          }
+          result.put(ent.getKey(), newSnapshot);
+        }
+        return result;
+      } else {
+        return snapshotsByType;
+      }
     }
 
     @Override
-    public Map<String, Pair<Long, Long>> getDeleteTombstoneStats(){
+    public Map<String, Pair<Long, Long>> getDeleteTombstoneStats() {
       return deleteTombstoneStats;
     }
   }

--- a/ambry-server/src/test/java/com/github/ambry/server/StatsManagerTest.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/StatsManagerTest.java
@@ -174,6 +174,10 @@ public class StatsManagerTest {
             inMemoryAccountService);
   }
 
+  /**
+   * Test AccountExclusion configuration.
+   * @throws Exception
+   */
   @Test
   public void testAccountExclusion() throws Exception {
     String excludedAccountNames = "account0,account10";

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreStats.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreStats.java
@@ -200,9 +200,12 @@ class BlobStoreStats implements StoreStats, Closeable {
    */
   @Override
   public Map<StatsReportType, StatsSnapshot> getStatsSnapshots(Set<StatsReportType> statsReportTypes,
-      long referenceTimeInMs) throws StoreException {
+      long referenceTimeInMs, List<Short> accountIdsToExclude) throws StoreException {
     Map<StatsReportType, StatsSnapshot> statsSnapshotsByType = new HashMap<>();
     Map<String, Map<String, Long>> utilizationMap = getValidDataSizeByContainer(referenceTimeInMs);
+    if (accountIdsToExclude != null && !accountIdsToExclude.isEmpty()) {
+      accountIdsToExclude.forEach(id -> utilizationMap.remove("A[" + id + "]"));
+    }
     for (StatsReportType reportType : statsReportTypes) {
       switch (reportType) {
         case ACCOUNT_REPORT:


### PR DESCRIPTION
Add this configuration so we can specify a list of account names to be excluded from health report, to make sure a big account doesn't blow up the health report.