### PR TITLE
Add LogSegmentName class

### DIFF
--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
@@ -59,7 +59,7 @@ class BlobStoreCompactor {
   static final String TARGET_INDEX_CLEAN_SHUTDOWN_FILE_NAME = "compactor_clean_shutdown";
   static final String TEMP_LOG_SEGMENT_NAME_SUFFIX = BlobStore.SEPARATOR + "temp";
   static final FilenameFilter TEMP_LOG_SEGMENTS_FILTER = new FilenameFilter() {
-    private final String SUFFIX = LogSegmentNameHelper.SUFFIX + TEMP_LOG_SEGMENT_NAME_SUFFIX;
+    private final String SUFFIX = LogSegmentName.SUFFIX + TEMP_LOG_SEGMENT_NAME_SUFFIX;
 
     @Override
     public boolean accept(File dir, String name) {

--- a/ambry-store/src/main/java/com/github/ambry/store/LogSegmentName.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/LogSegmentName.java
@@ -85,9 +85,16 @@ class LogSegmentName implements Comparable<LogSegmentName> {
    * @param name the name string to parse.
    */
   private LogSegmentName(String name) {
-    int separatorIndex = name.indexOf(BlobStore.SEPARATOR);
-    this.position = Long.parseLong(name.substring(0, separatorIndex));
-    this.generation = Long.parseLong(name.substring(name.indexOf(BlobStore.SEPARATOR) + 1));
+    try {
+      int separatorIndex = name.indexOf(BlobStore.SEPARATOR);
+      if (separatorIndex == -1) {
+        throw new IllegalArgumentException("Separator char not found");
+      }
+      this.position = Long.parseLong(name.substring(0, separatorIndex));
+      this.generation = Long.parseLong(name.substring(name.indexOf(BlobStore.SEPARATOR) + 1));
+    } catch (RuntimeException e) {
+      throw new IllegalArgumentException("Could not parse " + name + " as a log segment name", e);
+    }
     this.name = name;
   }
 

--- a/ambry-store/src/main/java/com/github/ambry/store/LogSegmentName.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/LogSegmentName.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2021 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ */
+
+package com.github.ambry.store;
+
+import java.util.Objects;
+
+
+class LogSegmentName implements Comparable<LogSegmentName> {
+  static final String SUFFIX = BlobStore.SEPARATOR + "log";
+  // for backwards compatibility, if the log contains only a single segment, the segment will have a special name.
+  static final String SINGLE_SEGMENT_LOG_FILE_NAME = "log_current";
+  private static final LogSegmentName SINGLE_SEGMENT_LOG_NAME = new LogSegmentName(-1, -1);
+
+  private String name = null;
+  private final long position;
+  private final long generation;
+
+  /**
+   * @param isLogSegmented {@code true} if the log is segmented, {@code false} otherwise.
+   * @return what should be the name of the first segment.
+   */
+  static LogSegmentName generateFirstSegmentName(boolean isLogSegmented) {
+    return isLogSegmented ? new LogSegmentName(0, 0) : SINGLE_SEGMENT_LOG_NAME;
+  }
+
+  /**
+   * @param filename the name of the file that backs the log segment.
+   * @return the {@link LogSegmentName}.
+   */
+  static LogSegmentName fromFilename(String filename) {
+    if (filename.equals(SINGLE_SEGMENT_LOG_FILE_NAME)) {
+      return SINGLE_SEGMENT_LOG_NAME;
+    }
+    if (!filename.endsWith(SUFFIX)) {
+      throw new IllegalArgumentException("The filename of the log segment does not end with [" + SUFFIX + "]");
+    }
+    String name = filename.substring(0, filename.length() - SUFFIX.length());
+    return new LogSegmentName(name);
+  }
+
+  /**
+   * Parse the string form of a log segment name.
+   * @param name the name string to parse.
+   * @return the {@link LogSegmentName}.
+   */
+  static LogSegmentName fromString(String name) {
+    if (name.isEmpty()) {
+      return SINGLE_SEGMENT_LOG_NAME;
+    }
+    return new LogSegmentName(name);
+  }
+
+  /**
+   * @param position the relative position of the log segment.
+   * @param generation the generation of the log segment.
+   * @return the {@link LogSegmentName}.
+   */
+  static LogSegmentName fromPositionAndGeneration(long position, long generation) {
+    return new LogSegmentName(position, generation);
+  }
+
+  /**
+   * @param position the relative position of the log segment.
+   * @param generation the generation of the log segment.
+   */
+  private LogSegmentName(long position, long generation) {
+    this.position = position;
+    this.generation = generation;
+  }
+
+  /**
+   * @param name the name string to parse.
+   */
+  private LogSegmentName(String name) {
+    int separatorIndex = name.indexOf(BlobStore.SEPARATOR);
+    this.position = Long.parseLong(name.substring(0, separatorIndex));
+    this.generation = Long.parseLong(name.substring(name.indexOf(BlobStore.SEPARATOR) + 1));
+    this.name = name;
+  }
+
+  /**
+   * @return what should be the name of the log segment that is exactly one position higher than this one. The
+   * generation of the returned name will start from the lowest generation number.
+   */
+  LogSegmentName getNextPositionName() {
+    checkSegmented();
+    return new LogSegmentName(position + 1, 0);
+  }
+
+  /**
+   * @return what should be the name of the log segment that is exactly one generation higher than this one.
+   */
+  LogSegmentName getNextGenerationName() {
+    checkSegmented();
+    return new LogSegmentName(position, generation + 1);
+  }
+
+  /**
+   * @return the name of the file that backs the log segment.
+   */
+  String toFilename() {
+    if (isSingleSegment()) {
+      return SINGLE_SEGMENT_LOG_FILE_NAME;
+    }
+    return toString() + SUFFIX;
+  }
+
+  @Override
+  public String toString() {
+    if (name == null) {
+      name = isSingleSegment() ? "" : position + BlobStore.SEPARATOR + generation;
+    }
+    return name;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    LogSegmentName that = (LogSegmentName) o;
+    return position == that.position && generation == that.generation;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(position, generation);
+  }
+
+  @Override
+  public int compareTo(LogSegmentName o) {
+    // special case for log_current (one segment logs)
+    if (isSingleSegment() && o.isSingleSegment()) {
+      return 0;
+    }
+    int compare = Long.compare(position, o.position);
+    if (compare == 0) {
+      compare = Long.compare(generation, o.generation);
+    }
+    return compare;
+  }
+
+  /**
+   * @return {@code true} if this is a single segment log.
+   */
+  private boolean isSingleSegment() {
+    return this == SINGLE_SEGMENT_LOG_NAME;
+  }
+
+  /**
+   * @throws IllegalArgumentException if this is a single segment log.
+   */
+  private void checkSegmented() {
+    if (isSingleSegment()) {
+      throw new IllegalArgumentException("Cannot call for single segment logs");
+    }
+  }
+}

--- a/ambry-store/src/main/java/com/github/ambry/store/Offset.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/Offset.java
@@ -24,7 +24,7 @@ import java.nio.charset.StandardCharsets;
  * Denotes an offset inside the log.
  */
 public class Offset implements Comparable<Offset> {
-  private final String name;
+  private final LogSegmentName name;
   private final long offset;
 
   private static final short CURRENT_VERSION = 0;
@@ -42,7 +42,7 @@ public class Offset implements Comparable<Offset> {
     if (name == null || offset < 0) {
       throw new IllegalArgumentException("Name [" + name + "] is null or offset [" + offset + "] < 0");
     }
-    this.name = name;
+    this.name = LogSegmentName.fromString(name);
     this.offset = offset;
   }
 
@@ -73,7 +73,7 @@ public class Offset implements Comparable<Offset> {
    * be non-null and non-empty.
    */
   public String getName() {
-    return name;
+    return name.toString();
   }
 
   /**
@@ -88,7 +88,7 @@ public class Offset implements Comparable<Offset> {
    * @return the byte representation of this object.
    */
   byte[] toBytes() {
-    byte[] nameBytes = name.getBytes(StandardCharsets.UTF_8);
+    byte[] nameBytes = name.toString().getBytes(StandardCharsets.UTF_8);
     int size = VERSION_SIZE + NAME_LENGTH_SIZE + nameBytes.length + OFFSET_SIZE;
     byte[] bytes = new byte[size];
     ByteBuffer buf = ByteBuffer.wrap(bytes);
@@ -101,7 +101,7 @@ public class Offset implements Comparable<Offset> {
 
   @Override
   public int compareTo(Offset o) {
-    int compare = LogSegmentNameHelper.COMPARATOR.compare(name, o.name);
+    int compare = name.compareTo(o.name);
     return compare == 0 ? Long.compare(offset, o.offset) : compare;
   }
 
@@ -120,7 +120,7 @@ public class Offset implements Comparable<Offset> {
 
   @Override
   public int hashCode() {
-    int result = LogSegmentNameHelper.hashcode(name);
+    int result = name.hashCode();
     result = 31 * result + (int) (offset ^ (offset >>> 32));
     return result;
   }

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
@@ -1781,7 +1781,7 @@ public class BlobStoreTest {
 
     // try adding fake swap segment log segment.
     File tempFile = File.createTempFile("sample-swap",
-        LogSegmentNameHelper.SUFFIX + BlobStoreCompactor.TEMP_LOG_SEGMENT_NAME_SUFFIX, tempDir);
+        LogSegmentName.SUFFIX + BlobStoreCompactor.TEMP_LOG_SEGMENT_NAME_SUFFIX, tempDir);
     doDiskSpaceRequirementsTest(segmentsAllocated, 1);
     assertTrue("Could not delete temp file", tempFile.delete());
 
@@ -1789,9 +1789,9 @@ public class BlobStoreTest {
     segmentsAllocated += 1;
     doDiskSpaceRequirementsTest(segmentsAllocated, 0);
 
-    File.createTempFile("sample-swap", LogSegmentNameHelper.SUFFIX + BlobStoreCompactor.TEMP_LOG_SEGMENT_NAME_SUFFIX,
+    File.createTempFile("sample-swap", LogSegmentName.SUFFIX + BlobStoreCompactor.TEMP_LOG_SEGMENT_NAME_SUFFIX,
         tempDir).deleteOnExit();
-    File.createTempFile("sample-swap", LogSegmentNameHelper.SUFFIX + BlobStoreCompactor.TEMP_LOG_SEGMENT_NAME_SUFFIX,
+    File.createTempFile("sample-swap", LogSegmentName.SUFFIX + BlobStoreCompactor.TEMP_LOG_SEGMENT_NAME_SUFFIX,
         tempDir).deleteOnExit();
     addCuratedData(SEGMENT_CAPACITY, true);
     segmentsAllocated += 1;
@@ -2128,7 +2128,7 @@ public class BlobStoreTest {
 
     // put a swap segment into store dir
     File tempFile = File.createTempFile("sample-swap",
-        LogSegmentNameHelper.SUFFIX + BlobStoreCompactor.TEMP_LOG_SEGMENT_NAME_SUFFIX, storeDir);
+        LogSegmentName.SUFFIX + BlobStoreCompactor.TEMP_LOG_SEGMENT_NAME_SUFFIX, storeDir);
     // test success case (swap segment is returned and store dir is correctly deleted)
     assertEquals("Swap reserve dir should be empty initially", 0,
         diskAllocator.getSwapReserveFileMap().getFileSizeSet().size());

--- a/ambry-store/src/test/java/com/github/ambry/store/IndexSegmentTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/IndexSegmentTest.java
@@ -1307,7 +1307,7 @@ public class IndexSegmentTest {
       IndexValue value;
       if (values == null) {
         // create an index value with a random log segment name
-        value = IndexValueTest.getIndexValue(1, new Offset(TestUtils.getRandomString(1), 0), Utils.Infinite_Time,
+        value = IndexValueTest.getIndexValue(1, new Offset(generateRandomLogSegmentName(), 0), Utils.Infinite_Time,
             time.milliseconds(), id.getAccountId(), id.getContainerId(), (short) 1, formatVersion);
       } else if (values.last().isDelete()) {
         throw new IllegalArgumentException(id + " is deleted");
@@ -1343,7 +1343,7 @@ public class IndexSegmentTest {
       IndexValue value;
       if (values == null) {
         // create an index value with a random log segment name
-        value = IndexValueTest.getIndexValue(1, new Offset(TestUtils.getRandomString(1), 0), Utils.Infinite_Time,
+        value = IndexValueTest.getIndexValue(1, new Offset(generateRandomLogSegmentName(), 0), Utils.Infinite_Time,
             time.milliseconds(), Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM),
             (short) 0, formatVersion);
       } else if (values.last().isDelete()) {

--- a/ambry-store/src/test/java/com/github/ambry/store/LogSegmentNameHelperTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/LogSegmentNameHelperTest.java
@@ -97,7 +97,7 @@ public class LogSegmentNameHelperTest {
             filename = filename + "_index";
             break;
           case 1:
-            filename = filename + LogSegmentNameHelper.SUFFIX + "_temp";
+            filename = filename + LogSegmentName.SUFFIX + "_temp";
             break;
           default:
             break;
@@ -214,8 +214,8 @@ public class LogSegmentNameHelperTest {
 
     // bad file names
     String badNameBase = TestUtils.getRandomString(10);
-    String[] badNames = {badNameBase, badNameBase + LogSegmentNameHelper.SUFFIX,
-        name + BlobStore.SEPARATOR + "123" + LogSegmentNameHelper.SUFFIX};
+    String[] badNames =
+        {badNameBase, badNameBase + LogSegmentName.SUFFIX, name + BlobStore.SEPARATOR + "123" + LogSegmentName.SUFFIX};
     for (String badName : badNames) {
       try {
         LogSegmentNameHelper.nameFromFilename(badName);
@@ -232,8 +232,8 @@ public class LogSegmentNameHelperTest {
   @Test
   public void nameToFilenameTest() {
     assertEquals("Did not get expected file name", "log_current", LogSegmentNameHelper.nameToFilename(""));
-    String name = TestUtils.getRandomString(10);
-    assertEquals("Did not get expected file name", name + LogSegmentNameHelper.SUFFIX,
+    String name = LogSegmentName.fromPositionAndGeneration(3, 1).toString();
+    assertEquals("Did not get expected file name", name + LogSegmentName.SUFFIX,
         LogSegmentNameHelper.nameToFilename(name));
   }
 

--- a/ambry-store/src/test/java/com/github/ambry/store/OffsetTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/OffsetTest.java
@@ -63,9 +63,9 @@ public class OffsetTest {
   @Test
   public void offsetBadInputTest() throws IOException {
     doBadOffsetInputTest(null, 10);
-    doBadOffsetInputTest("1_11_log", -1);
+    doBadOffsetInputTest("1_11", -1);
 
-    Offset offset = new Offset("1_11_log", 10);
+    Offset offset = new Offset("1_11", 10);
     byte[] serialized = offset.toBytes();
     // mess with a version byte
     serialized[0] = serialized[0] == (byte) 1 ? (byte) 2 : (byte) 1;


### PR DESCRIPTION
Parsing the log segment name to find the position and generation becomes
expensive when used as a comparator in frequently used index data
structures. This commit adds a class that represents a parsed log
segment name with a lighter weight compareTo method.

It is a significant refactoring to replace all usages of log segment
name strings with this class, so I only adopted the new class in Offset,
which should help in the frequently used
PersistentIndex.validIndexSegments and Journal data structures.