### PR TITLE
Compact expired delete tombstones

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -125,6 +125,13 @@ public class StoreConfig {
   public final boolean storeCompactionEnableDirectIO;
 
   /**
+   * Whether to purge expired delete tombstone in compaction.
+   */
+  @Config("store.compaction.purge.expired.delete.tombstone")
+  @Default("false")
+  public final boolean storeCompactionPurgeExpiredDeleteTombstone;
+
+  /**
    * The minimum buffer size for compaction copy phase.
    */
   @Config("store.compaction.min.buffer.size")
@@ -387,6 +394,8 @@ public class StoreConfig {
         verifiableProperties.getIntInRange("store.compaction.operations.bytes.per.sec", 1 * 1024 * 1024, 1,
             Integer.MAX_VALUE);
     storeCompactionEnableDirectIO = verifiableProperties.getBoolean("store.compaction.enable.direct.io", false);
+    storeCompactionPurgeExpiredDeleteTombstone =
+        verifiableProperties.getBoolean("store.compaction.purge.expired.delete.tombstone", false);
     storeCompactionMinBufferSize =
         verifiableProperties.getIntInRange("store.compaction.min.buffer.size", 10 * 1024 * 1024, 0, Integer.MAX_VALUE);
     storeCompactionFilter =

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
@@ -1218,7 +1218,6 @@ class BlobStoreCompactor {
             // DELETE entry without corresponding PUT (may be left by previous compaction). Check if this delete
             // tombstone is removable.
             if (isDeleteTombstoneRemovable(value)) {
-//              System.out.println("Delete key in compaction: " + indexEntry.getKey());
               logger.debug(
                   "Delete tombstone of {} (with expiration time {} ms) is removable and won't be copied to target log segment",
                   indexEntry.getKey(), value.getExpiresAtMs());
@@ -1244,7 +1243,6 @@ class BlobStoreCompactor {
                 // Add all values in this index segment (to account for the presence of TTL updates)
                 addAllEntriesForKeyInSegment(validEntries, indexSegment, indexEntry);
               } else {
-//                System.out.println("Found deleted PUT and is compacted in compaction: " + indexEntry.getKey());
                 logger.trace("{} in index segment with start offset {} in {} is not valid because it is a deleted PUT",
                     indexEntry, indexSegment.getStartOffset(), storeId);
               }
@@ -1254,7 +1252,6 @@ class BlobStoreCompactor {
               addAllEntriesForKeyInSegment(validEntries, indexSegment, indexEntry);
             }
           } else {
-//            System.out.println("Found expired PUT and is compacted in compaction: " + indexEntry.getKey() + ", expiry = " + valueFromIdx.getExpiresAtMs() + ", current time = " + time.milliseconds());
             logger.trace("{} in index segment with start offset {} in {} is not valid because it is an expired PUT",
                 indexEntry, indexSegment.getStartOffset(), storeId);
           }

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
@@ -1218,7 +1218,7 @@ class BlobStoreCompactor {
             // DELETE entry without corresponding PUT (may be left by previous compaction). Check if this delete
             // tombstone is removable.
             if (isDeleteTombstoneRemovable(value)) {
-              System.out.println("Delete key in compaction: " + indexEntry.getKey());
+//              System.out.println("Delete key in compaction: " + indexEntry.getKey());
               logger.debug(
                   "Delete tombstone of {} (with expiration time {} ms) is removable and won't be copied to target log segment",
                   indexEntry.getKey(), value.getExpiresAtMs());

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
@@ -1217,7 +1217,7 @@ class BlobStoreCompactor {
           } else {
             // DELETE entry without corresponding PUT (may be left by previous compaction). Check if this delete
             // tombstone is removable.
-            if (isDeleteTombstoneRemovable(value)) {
+            if (config.storeCompactionPurgeExpiredDeleteTombstone && isDeleteTombstoneRemovable(value)) {
               logger.debug(
                   "Delete tombstone of {} (with expiration time {} ms) is removable and won't be copied to target log segment",
                   indexEntry.getKey(), value.getExpiresAtMs());
@@ -1487,7 +1487,8 @@ class BlobStoreCompactor {
           if (currentLatestState.isDelete() && currentLatestState.getLifeVersion() == currentValue.getLifeVersion()) {
             // check if this is a removable delete tombstone.
             IndexValue putValue = getPutValueFromSrc(currentKey, currentValue, indexSegment);
-            if (putValue == null && isDeleteTombstoneRemovable(currentValue)) {
+            if (putValue == null && config.storeCompactionPurgeExpiredDeleteTombstone && isDeleteTombstoneRemovable(
+                currentValue)) {
               logger.debug(
                   "Delete tombstone of {} (with expiration time {} ms) is removable and won't be copied to target log segment",
                   currentKey, currentValue.getExpiresAtMs());

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreStats.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreStats.java
@@ -546,10 +546,16 @@ class BlobStoreStats implements StoreStats, Closeable {
     return validSizePerLogSegment;
   }
 
-  private void removeDeleteTombStonesFromValidSize(Collection<IndexFinalState> indexFinalStates, NavigableMap<String, Long> validSizePerLogSegment){
-    for(IndexFinalState finalState : indexFinalStates){
-      if(finalState.isDelete()){
-        if(finalState.getExpirationTime() != Utils.Infinite_Time ){
+  /**
+   * Remove expired delete tombstones from valid data size per log segment.
+   * @param indexFinalStates the {@link IndexFinalState} that contains delete tombstones.
+   * @param validSizePerLogSegment a {@link NavigableMap} of log segment name to valid data size.
+   */
+  private void removeDeleteTombStonesFromValidSize(Collection<IndexFinalState> indexFinalStates,
+      NavigableMap<String, Long> validSizePerLogSegment) {
+    for (IndexFinalState finalState : indexFinalStates) {
+      if (finalState.isDelete()) {
+        if (finalState.getExpirationTime() != Utils.Infinite_Time) {
           // expired delete tombstone should be considered invalid
           String logSegmentName = finalState.getOffset().getName();
           validSizePerLogSegment.computeIfPresent(logSegmentName, (k, v) -> {
@@ -1201,8 +1207,8 @@ class BlobStoreStats implements StoreStats, Closeable {
           // The remaining index entries in keyFinalStates are DELETE tombstones left by compaction (whose associated PUT is not found)
           updateDeleteTombstoneStats(keyFinalStates.values());
           // Remove delete tombstones from scan results
-          for(IndexFinalState state: keyFinalStates.values()){
-            if(state.isDelete() && state.getExpirationTime() != Utils.Infinite_Time){
+          for (IndexFinalState state : keyFinalStates.values()) {
+            if (state.isDelete() && state.getExpirationTime() != Utils.Infinite_Time) {
               newScanResults.updateLogSegmentBaseBucket(state.getOffset().getName(), -1 * state.getRecordSize());
             }
           }
@@ -1374,7 +1380,6 @@ class BlobStoreStats implements StoreStats, Closeable {
     private final long recordSize;
     private final long expirationTime;
     private final Offset offset;
-    // TODO add offset here to help identify the log segment delete refers to.
 
     /**
      * Constructor to construct an {@link IndexFinalState}.
@@ -1422,6 +1427,7 @@ class BlobStoreStats implements StoreStats, Closeable {
     public Offset getOffset() {
       return offset;
     }
+
     /**
      * @return the expiration time of the final {@link IndexValue}.
      */

--- a/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
@@ -1075,9 +1075,11 @@ class PersistentIndex {
     IndexValue value = findKey(id);
     BlobReadOptions readOptions;
     if (value == null) {
+//      System.out.println(id + " is not found");
       throw new StoreException("Id " + id + " not present in index " + dataDir, StoreErrorCodes.ID_Not_Found);
     } else if (value.isDelete()) {
       if (!getOptions.contains(StoreGetOptions.Store_Include_Deleted)) {
+//        System.out.println(id + " is deleted and expiration time: " + value.getExpiresAtMs());
         throw new StoreException("Id " + id + " has been deleted in index " + dataDir, StoreErrorCodes.ID_Deleted);
       } else {
         readOptions = getDeletedBlobReadOptions(value, id, indexSegments);

--- a/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
@@ -1075,11 +1075,9 @@ class PersistentIndex {
     IndexValue value = findKey(id);
     BlobReadOptions readOptions;
     if (value == null) {
-//      System.out.println(id + " is not found");
       throw new StoreException("Id " + id + " not present in index " + dataDir, StoreErrorCodes.ID_Not_Found);
     } else if (value.isDelete()) {
       if (!getOptions.contains(StoreGetOptions.Store_Include_Deleted)) {
-//        System.out.println(id + " is deleted and expiration time: " + value.getExpiresAtMs());
         throw new StoreException("Id " + id + " has been deleted in index " + dataDir, StoreErrorCodes.ID_Deleted);
       } else {
         readOptions = getDeletedBlobReadOptions(value, id, indexSegments);

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
@@ -2591,8 +2591,8 @@ public class BlobStoreCompactorTest {
     Set<MockId> idsInCompactedLogSegments = getIdsWithPutInSegments(segmentsUnderCompaction);
     // "compactedDeletes" are those tombstones that should be compacted in single run (if no exception occurs);
     // "deletesWithPuts" are those tombstones temporarily with PUTs but may be eligible to be compacted in subsequent cycle
-    Set<MockId> compactedDeletes = purgeExpiredDelete ? expiredDeletes.getFirst() : new HashSet<>();
-    Set<MockId> deletesWithPuts = purgeExpiredDelete ? expiredDeletes.getSecond() : new HashSet<>();
+    Set<MockId> compactedDeletes = expiredDeletes.getFirst();
+    Set<MockId> deletesWithPuts = expiredDeletes.getSecond();
 
     compactor = getCompactor(state.log, DISK_IO_SCHEDULER);
     compactor.initialize(state.index);
@@ -2667,8 +2667,8 @@ public class BlobStoreCompactorTest {
     // get valid log entries including deletes as a backup (in case exception occurred in the middle of compaction)
     List<LogEntry> validLogEntriesInOrder =
         getValidLogEntriesInOrder(segmentsUnderCompaction, deleteReferenceTimeMs, expiredDeletes, purgeExpiredDelete);
-    Set<MockId> compactedDeletes = purgeExpiredDelete ? expiredDeletes.getFirst() : new HashSet<>();
-    Set<MockId> deletesWithPuts = purgeExpiredDelete ? expiredDeletes.getSecond() : new HashSet<>();
+    Set<MockId> compactedDeletes = expiredDeletes.getFirst();
+    Set<MockId> deletesWithPuts = expiredDeletes.getSecond();
     Set<MockId> idsInCompactedLogSegments = getIdsWithPutInSegments(segmentsUnderCompaction);
     compactor = getCompactor(log, diskIOScheduler);
     compactor.initialize(index);

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreStatsTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreStatsTest.java
@@ -1206,6 +1206,7 @@ public class BlobStoreStatsTest {
     long expectedTotalLogSegmentValidSize = 0L;
     LogSegment logSegment = state.log.getFirstSegment();
     Set<MockId> seenPuts = new HashSet<>();
+    Pair<Set<MockId>, Set<MockId>> expiredDeletes = new Pair<>(new HashSet<>(), new HashSet<>());
     Map<String, Pair<AtomicLong, AtomicLong>> deleteTombstoneStats = generateDeleteTombstoneStats();
     while (logSegment != null) {
       String logSegmentName = logSegment.getName();
@@ -1214,7 +1215,7 @@ public class BlobStoreStatsTest {
 
       long expectedLogSegmentValidSize =
           state.getValidDataSizeForLogSegment(logSegment, timeRange.getEndTimeInMs(), expiryReferenceTime, null,
-              seenPuts, deleteTombstoneStats);
+              seenPuts, deleteTombstoneStats, expiredDeletes);
       long actualLogSegmentValidSize = actualLogSegmentValidSizeMap.getSecond().get(logSegmentName);
       assertEquals("Valid data size mismatch for log segment: " + logSegmentName + " in TimeRange " + timeRange,
           expectedLogSegmentValidSize, actualLogSegmentValidSize);
@@ -1249,10 +1250,11 @@ public class BlobStoreStatsTest {
       long expiryReferenceTimeInMs, Map<String, Pair<AtomicLong, AtomicLong>> deleteTombstoneStats) {
     Map<String, Map<String, Long>> containerValidSizeMap = new HashMap<>();
     Set<MockId> seenPuts = new HashSet<>();
+    Pair<Set<MockId>, Set<MockId>> expiredDeletes = new Pair<>(new HashSet<>(), new HashSet<>());
     for (Offset indSegStartOffset : state.referenceIndex.keySet()) {
       List<IndexEntry> validEntries =
           state.getValidIndexEntriesForIndexSegment(indSegStartOffset, deleteReferenceTimeInMs, expiryReferenceTimeInMs,
-              null, seenPuts, deleteTombstoneStats);
+              null, seenPuts, deleteTombstoneStats, expiredDeletes, false);
       for (IndexEntry indexEntry : validEntries) {
         IndexValue indexValue = indexEntry.getValue();
         if (indexValue.isPut()) {

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreStatsTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreStatsTest.java
@@ -1214,7 +1214,7 @@ public class BlobStoreStatsTest {
 
       long expectedLogSegmentValidSize =
           state.getValidDataSizeForLogSegment(logSegment, timeRange.getEndTimeInMs(), expiryReferenceTime, null,
-              deleteTombstoneStats, expiredDeletes);
+              deleteTombstoneStats, expiredDeletes, true);
       long actualLogSegmentValidSize = actualLogSegmentValidSizeMap.getSecond().get(logSegmentName);
       assertEquals("Valid data size mismatch for log segment: " + logSegmentName + " in TimeRange " + timeRange,
           expectedLogSegmentValidSize, actualLogSegmentValidSize);
@@ -1252,7 +1252,7 @@ public class BlobStoreStatsTest {
     for (Offset indSegStartOffset : state.referenceIndex.keySet()) {
       List<IndexEntry> validEntries =
           state.getValidIndexEntriesForIndexSegment(indSegStartOffset, deleteReferenceTimeInMs, expiryReferenceTimeInMs,
-              null, deleteTombstoneStats, expiredDeletes);
+              null, deleteTombstoneStats, expiredDeletes, true);
       for (IndexEntry indexEntry : validEntries) {
         IndexValue indexValue = indexEntry.getValue();
         if (indexValue.isPut()) {

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreStatsTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreStatsTest.java
@@ -1205,7 +1205,6 @@ public class BlobStoreStatsTest {
     int expectedNumberOfLogSegments = 0;
     long expectedTotalLogSegmentValidSize = 0L;
     LogSegment logSegment = state.log.getFirstSegment();
-    Set<MockId> seenPuts = new HashSet<>();
     Pair<Set<MockId>, Set<MockId>> expiredDeletes = new Pair<>(new HashSet<>(), new HashSet<>());
     Map<String, Pair<AtomicLong, AtomicLong>> deleteTombstoneStats = generateDeleteTombstoneStats();
     while (logSegment != null) {
@@ -1215,7 +1214,7 @@ public class BlobStoreStatsTest {
 
       long expectedLogSegmentValidSize =
           state.getValidDataSizeForLogSegment(logSegment, timeRange.getEndTimeInMs(), expiryReferenceTime, null,
-              seenPuts, deleteTombstoneStats, expiredDeletes);
+              deleteTombstoneStats, expiredDeletes);
       long actualLogSegmentValidSize = actualLogSegmentValidSizeMap.getSecond().get(logSegmentName);
       assertEquals("Valid data size mismatch for log segment: " + logSegmentName + " in TimeRange " + timeRange,
           expectedLogSegmentValidSize, actualLogSegmentValidSize);
@@ -1249,12 +1248,11 @@ public class BlobStoreStatsTest {
   private Map<String, Map<String, Long>> getValidSizeByContainer(long deleteReferenceTimeInMs,
       long expiryReferenceTimeInMs, Map<String, Pair<AtomicLong, AtomicLong>> deleteTombstoneStats) {
     Map<String, Map<String, Long>> containerValidSizeMap = new HashMap<>();
-    Set<MockId> seenPuts = new HashSet<>();
     Pair<Set<MockId>, Set<MockId>> expiredDeletes = new Pair<>(new HashSet<>(), new HashSet<>());
     for (Offset indSegStartOffset : state.referenceIndex.keySet()) {
       List<IndexEntry> validEntries =
           state.getValidIndexEntriesForIndexSegment(indSegStartOffset, deleteReferenceTimeInMs, expiryReferenceTimeInMs,
-              null, seenPuts, deleteTombstoneStats, expiredDeletes, false);
+              null, deleteTombstoneStats, expiredDeletes);
       for (IndexEntry indexEntry : validEntries) {
         IndexValue indexValue = indexEntry.getValue();
         if (indexValue.isPut()) {

--- a/ambry-store/src/test/java/com/github/ambry/store/CuratedLogIndexState.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CuratedLogIndexState.java
@@ -849,14 +849,15 @@ class CuratedLogIndexState {
    * @param deleteTombstoneStats a hashmap that tracks stats related delete tombstones in log segments.
    * @param expiredDeletes a pair of two sets of deletes. The first one contains expired delete tombstones (with no
    *                       associated PUT); the second one includes expired deletes currently with PUTs ahead of them.
+   * @param invalidateExpiredDelete whether to invalidate the expired delete.
    * @return the expected size of the valid data at {@code deleteReferenceTimeMs} in {@code segment}.
    */
   long getValidDataSizeForLogSegment(LogSegment segment, long deleteReferenceTimeMs, long expiryReferenceTimeMs,
       FileSpan fileSpanUnderCompaction, Map<String, Pair<AtomicLong, AtomicLong>> deleteTombstoneStats,
-      Pair<Set<MockId>, Set<MockId>> expiredDeletes) {
+      Pair<Set<MockId>, Set<MockId>> expiredDeletes, boolean invalidateExpiredDelete) {
     List<IndexEntry> validEntries =
         getValidIndexEntriesForLogSegment(segment, deleteReferenceTimeMs, expiryReferenceTimeMs,
-            fileSpanUnderCompaction, deleteTombstoneStats, expiredDeletes);
+            fileSpanUnderCompaction, deleteTombstoneStats, expiredDeletes, invalidateExpiredDelete);
     long size = 0;
     for (IndexEntry indexEntry : validEntries) {
       size += indexEntry.getValue().getSize();
@@ -874,17 +875,19 @@ class CuratedLogIndexState {
    * @param deleteTombstoneStats a hashmap that tracks stats related delete tombstones in log segments.
    * @param expiredDeletes a pair of two sets of deletes. The first one contains expired delete tombstones (with no
    *                       associated PUT); the second one includes expired deletes currently with PUTs ahead of them.
+   * @param invalidateExpiredDelete whether to invalidate expired delete.
    * @return all the valid index entries in the {@code segment}.
    */
   List<IndexEntry> getValidIndexEntriesForLogSegment(LogSegment segment, long deleteReferenceTimeMs,
       long expiryReferenceTimeMs, FileSpan fileSpanUnderCompaction,
-      Map<String, Pair<AtomicLong, AtomicLong>> deleteTombstoneStats, Pair<Set<MockId>, Set<MockId>> expiredDeletes) {
+      Map<String, Pair<AtomicLong, AtomicLong>> deleteTombstoneStats, Pair<Set<MockId>, Set<MockId>> expiredDeletes,
+      boolean invalidateExpiredDelete) {
     List<IndexEntry> validEntries = new ArrayList<>();
     Offset indexSegmentStartOffset = new Offset(segment.getName(), segment.getStartOffset());
     while (indexSegmentStartOffset != null && indexSegmentStartOffset.getName().equals(segment.getName())) {
       validEntries.addAll(
           getValidIndexEntriesForIndexSegment(indexSegmentStartOffset, deleteReferenceTimeMs, expiryReferenceTimeMs,
-              fileSpanUnderCompaction, deleteTombstoneStats, expiredDeletes));
+              fileSpanUnderCompaction, deleteTombstoneStats, expiredDeletes, invalidateExpiredDelete));
       indexSegmentStartOffset = referenceIndex.higherKey(indexSegmentStartOffset);
     }
     return validEntries;
@@ -1570,11 +1573,13 @@ class CuratedLogIndexState {
    * @param deleteTombstoneStats a hashmap that tracks stats related delete tombstones in log segments.
    * @param expiredDeletes a pair of two sets of deletes. The first one contains expired delete tombstones (with no
    *                       associated PUT); the second one includes expired deletes currently with PUTs ahead of them.
+   * @param invalidateExpiredDelete whether to invalidate expired delete.
    * @return all the valid index entries valid in the index segment with start offset {@code indexSegmentStartOffset}.
    */
   List<IndexEntry> getValidIndexEntriesForIndexSegment(Offset indexSegmentStartOffset, long deleteReferenceTimeMs,
       long expiryReferenceTimeMs, FileSpan fileSpanUnderCompaction,
-      Map<String, Pair<AtomicLong, AtomicLong>> deleteTombstoneStats, Pair<Set<MockId>, Set<MockId>> expiredDeletes) {
+      Map<String, Pair<AtomicLong, AtomicLong>> deleteTombstoneStats, Pair<Set<MockId>, Set<MockId>> expiredDeletes,
+      boolean invalidateExpiredDelete) {
     List<IndexEntry> validEntries = new ArrayList<>();
     if (referenceIndex.containsKey(indexSegmentStartOffset)) {
       for (Map.Entry<MockId, TreeSet<IndexValue>> indexSegmentEntry : referenceIndex.get(indexSegmentStartOffset)
@@ -1603,14 +1608,14 @@ class CuratedLogIndexState {
                   } else {
                     deleteTombstoneStats.get(EXPIRED_DELETE_TOMBSTONE).getFirst().getAndAdd(1);
                     deleteTombstoneStats.get(EXPIRED_DELETE_TOMBSTONE).getSecond().getAndAdd(currentValue.getSize());
-                    if (currentValue.getExpiresAtMs() < time.milliseconds()) {
+                    if (invalidateExpiredDelete && currentValue.getExpiresAtMs() < time.milliseconds()) {
                       isValid = false;
                       expiredDeletes.getFirst().add(key);
                     }
                   }
                 } else {
                   // if this is a delete with PUT, we check if it has expired and track it in a separate set
-                  if (currentValue.getExpiresAtMs() != Utils.Infinite_Time
+                  if (invalidateExpiredDelete && currentValue.getExpiresAtMs() != Utils.Infinite_Time
                       && currentValue.getExpiresAtMs() < time.milliseconds()) {
                     expiredDeletes.getSecond().add(key);
                   }


### PR DESCRIPTION
The delete tombstones left by compaction still occupy disk space and slow down the index search.
This PR targets to clean up the expired delete tombstones. Expired tombstone refers to the delete
with finite expiration time and has expired already.