### PR TITLE
Introduce new properties in Account/Container to prepare for account-level ACL

### DIFF
--- a/ambry-account/src/main/java/com/github/ambry/account/InMemoryUnknownAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/InMemoryUnknownAccountService.java
@@ -28,7 +28,7 @@ import java.util.function.Consumer;
 class InMemoryUnknownAccountService implements AccountService {
   static final Account UNKNOWN_ACCOUNT =
       new Account(Account.UNKNOWN_ACCOUNT_ID, Account.UNKNOWN_ACCOUNT_NAME, Account.AccountStatus.ACTIVE,
-          Account.SNAPSHOT_VERSION_DEFAULT_VALUE,
+          Account.ACL_INHERITED_BY_CONTAINER_DEFAULT_VALUE, Account.SNAPSHOT_VERSION_DEFAULT_VALUE,
           Arrays.asList(Container.UNKNOWN_CONTAINER, Container.DEFAULT_PUBLIC_CONTAINER,
               Container.DEFAULT_PRIVATE_CONTAINER));
   private static final Collection<Account> accounts =

--- a/ambry-api/src/main/java/com/github/ambry/account/AccountBlobsResource.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/AccountBlobsResource.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.account;
+
+public class AccountBlobsResource implements AclService.Resource {
+  public static final String RESOURCE_TYPE = "AccountBlobs";
+  private final String resourceId;
+
+  /**
+   * Construct the resource from an account.
+   * @param account the {@link Account} associated with this ACL resource.
+   */
+  public AccountBlobsResource(Account account) {
+    resourceId = String.valueOf(account.getId());
+  }
+
+  /**
+   * {@inheritDoc}
+   * @return A type name for this resource: {@code AccountBlobs}
+   */
+  @Override
+  public String getResourceType() {
+    return RESOURCE_TYPE;
+  }
+
+  /**
+   * {@inheritDoc}
+   * @return a unique identifier for this account: {@code {account-id}}
+   */
+  @Override
+  public String getResourceId() {
+    return resourceId;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    AccountBlobsResource that = (AccountBlobsResource) o;
+
+    return resourceId.equals(that.resourceId);
+  }
+
+  @Override
+  public int hashCode() {
+    return resourceId.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return RESOURCE_TYPE + ":" + resourceId;
+  }
+}

--- a/ambry-api/src/main/java/com/github/ambry/account/AccountBuilder.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/AccountBuilder.java
@@ -30,8 +30,9 @@ public class AccountBuilder {
   private short id;
   private String name;
   private AccountStatus status;
-  private int snapshotVersion = Account.SNAPSHOT_VERSION_DEFAULT_VALUE;
+  private int snapshotVersion = SNAPSHOT_VERSION_DEFAULT_VALUE;
   private long lastModifiedTime = LAST_MODIFIED_TIME_DEFAULT_VALUE;
+  private boolean aclInheritedByContainer = ACL_INHERITED_BY_CONTAINER_DEFAULT_VALUE;
   private Map<Short, Container> idToContainerMetadataMap = new HashMap<>();
 
   /**
@@ -46,6 +47,7 @@ public class AccountBuilder {
     id = origin.getId();
     name = origin.getName();
     status = origin.getStatus();
+    aclInheritedByContainer = origin.isAclInheritedByContainer();
     snapshotVersion = origin.getSnapshotVersion();
     lastModifiedTime = origin.getLastModifiedTime();
     for (Container container : origin.getAllContainers()) {
@@ -119,6 +121,16 @@ public class AccountBuilder {
   }
 
   /**
+   * Specifies whether acl of {@link Account} is inherited by {@link Container}.
+   * @param aclInheritedByContainer whether account's ACL is inherited by container.
+   * @return This builder.
+   */
+  public AccountBuilder aclInheritedByContainer(boolean aclInheritedByContainer) {
+    this.aclInheritedByContainer = aclInheritedByContainer;
+    return this;
+  }
+
+  /**
    * Clear the set of containers for the {@link Account} to build and add the provided ones.
    * @param containers A collection of {@link Container}s to use. Can be {@code null} to just remove all containers.
    * @return This builder.
@@ -170,6 +182,6 @@ public class AccountBuilder {
    * @throws IllegalStateException If any required fields is not set or there is inconsistency in containers.
    */
   public Account build() {
-    return new Account(id, name, status, snapshotVersion, idToContainerMetadataMap.values(), lastModifiedTime);
+    return new Account(id, name, status, aclInheritedByContainer, snapshotVersion, idToContainerMetadataMap.values(), lastModifiedTime);
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/account/Container.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/Container.java
@@ -72,6 +72,7 @@ public class Container {
   static final String REPLICATION_POLICY_KEY = "replicationPolicy";
   static final String TTL_REQUIRED_KEY = "ttlRequired";
   static final String SECURE_PATH_REQUIRED_KEY = "securePathRequired";
+  static final String OVERRIDE_ACCOUNT_ACL_KEY = "overrideAccountAcl";
   static final String CONTENT_TYPE_WHITELIST_FOR_FILENAMES_ON_DOWNLOAD = "contentTypeWhitelistForFilenamesOnDownload";
   static final String PARENT_ACCOUNT_ID_KEY = "parentAccountId";
   static final String LAST_MODIFIED_TIME_KEY = "lastModifiedTime";
@@ -83,6 +84,7 @@ public class Container {
   static final boolean TTL_REQUIRED_DEFAULT_VALUE = true;
   static final long CONTAINER_DELETE_TRIGGER_TIME_DEFAULT_VALUE = 0;
   static final boolean SECURE_PATH_REQUIRED_DEFAULT_VALUE = false;
+  static final boolean OVERRIDE_ACCOUNT_ACL_DEFAULT_VALUE = false;
   static final boolean CACHEABLE_DEFAULT_VALUE = true;
   static final Set<String> CONTENT_TYPE_WHITELIST_FOR_FILENAMES_ON_DOWNLOAD_DEFAULT_VALUE = Collections.emptySet();
   static final long LAST_MODIFIED_TIME_DEFAULT_VALUE = 0;
@@ -295,7 +297,8 @@ public class Container {
           UNKNOWN_CONTAINER_PREVIOUSLY_ENCRYPTED_SETTING, UNKNOWN_CONTAINER_CACHEABLE_SETTING,
           UNKNOWN_CONTAINER_MEDIA_SCAN_DISABLED_SETTING, null, UNKNOWN_CONTAINER_TTL_REQUIRED_SETTING,
           SECURE_PATH_REQUIRED_DEFAULT_VALUE, CONTENT_TYPE_WHITELIST_FOR_FILENAMES_ON_DOWNLOAD_DEFAULT_VALUE,
-          BACKUP_ENABLED_DEFAULT_VALUE, UNKNOWN_CONTAINER_PARENT_ACCOUNT_ID, UNKNOWN_CONTAINER_DELETE_TRIGGER_TIME);
+          BACKUP_ENABLED_DEFAULT_VALUE, OVERRIDE_ACCOUNT_ACL_DEFAULT_VALUE, UNKNOWN_CONTAINER_PARENT_ACCOUNT_ID,
+          UNKNOWN_CONTAINER_DELETE_TRIGGER_TIME);
 
   /**
    * A container defined specifically for the blobs put without specifying target container but isPrivate flag is
@@ -310,7 +313,7 @@ public class Container {
           DEFAULT_PUBLIC_CONTAINER_PREVIOUSLY_ENCRYPTED_SETTING, DEFAULT_PUBLIC_CONTAINER_CACHEABLE_SETTING,
           DEFAULT_PUBLIC_CONTAINER_MEDIA_SCAN_DISABLED_SETTING, null, DEFAULT_PUBLIC_CONTAINER_TTL_REQUIRED_SETTING,
           SECURE_PATH_REQUIRED_DEFAULT_VALUE, CONTENT_TYPE_WHITELIST_FOR_FILENAMES_ON_DOWNLOAD_DEFAULT_VALUE,
-          BACKUP_ENABLED_DEFAULT_VALUE, DEFAULT_PUBLIC_CONTAINER_PARENT_ACCOUNT_ID,
+          BACKUP_ENABLED_DEFAULT_VALUE, OVERRIDE_ACCOUNT_ACL_DEFAULT_VALUE, DEFAULT_PUBLIC_CONTAINER_PARENT_ACCOUNT_ID,
           DEFAULT_PRIVATE_CONTAINER_DELETE_TRIGGER_TIME);
 
   /**
@@ -326,7 +329,7 @@ public class Container {
           DEFAULT_PRIVATE_CONTAINER_PREVIOUSLY_ENCRYPTED_SETTING, DEFAULT_PRIVATE_CONTAINER_CACHEABLE_SETTING,
           DEFAULT_PRIVATE_CONTAINER_MEDIA_SCAN_DISABLED_SETTING, null, DEFAULT_PRIVATE_CONTAINER_TTL_REQUIRED_SETTING,
           SECURE_PATH_REQUIRED_DEFAULT_VALUE, CONTENT_TYPE_WHITELIST_FOR_FILENAMES_ON_DOWNLOAD_DEFAULT_VALUE,
-          BACKUP_ENABLED_DEFAULT_VALUE, DEFAULT_PRIVATE_CONTAINER_PARENT_ACCOUNT_ID,
+          BACKUP_ENABLED_DEFAULT_VALUE, OVERRIDE_ACCOUNT_ACL_DEFAULT_VALUE, DEFAULT_PRIVATE_CONTAINER_PARENT_ACCOUNT_ID,
           DEFAULT_PUBLIC_CONTAINER_DELETE_TRIGGER_TIME);
 
   // container field variables
@@ -343,6 +346,7 @@ public class Container {
   private final String replicationPolicy;
   private final boolean ttlRequired;
   private final boolean securePathRequired;
+  private final boolean overrideAccountAcl;
   private final Set<String> contentTypeWhitelistForFilenamesOnDownload;
   private final short parentAccountId;
   private final long lastModifiedTime;
@@ -377,6 +381,7 @@ public class Container {
         contentTypeWhitelistForFilenamesOnDownload = CONTENT_TYPE_WHITELIST_FOR_FILENAMES_ON_DOWNLOAD_DEFAULT_VALUE;
         lastModifiedTime = metadata.optLong(LAST_MODIFIED_TIME_KEY, LAST_MODIFIED_TIME_DEFAULT_VALUE);
         snapshotVersion = metadata.optInt(SNAPSHOT_VERSION_KEY, SNAPSHOT_VERSION_DEFAULT_VALUE);
+        overrideAccountAcl = metadata.optBoolean(OVERRIDE_ACCOUNT_ACL_KEY, OVERRIDE_ACCOUNT_ACL_DEFAULT_VALUE);
         break;
       case JSON_VERSION_2:
         id = (short) metadata.getInt(CONTAINER_ID_KEY);
@@ -404,6 +409,7 @@ public class Container {
         }
         lastModifiedTime = metadata.optLong(LAST_MODIFIED_TIME_KEY, LAST_MODIFIED_TIME_DEFAULT_VALUE);
         snapshotVersion = metadata.optInt(SNAPSHOT_VERSION_KEY, SNAPSHOT_VERSION_DEFAULT_VALUE);
+        overrideAccountAcl = metadata.optBoolean(OVERRIDE_ACCOUNT_ACL_KEY, OVERRIDE_ACCOUNT_ACL_DEFAULT_VALUE);
         break;
       default:
         throw new IllegalStateException("Unsupported container json version=" + metadataVersion);
@@ -427,17 +433,18 @@ public class Container {
    * @param ttlRequired {@code true} if ttl is required on content created in this container.
    * @param securePathRequired {@code true} if secure path validation is required in this container.
    * @param contentTypeWhitelistForFilenamesOnDownload the set of content types for which the filename can be sent on
-   *                                                   download
-   * @param backupEnabled Whether backup is enabled for this container or not
+   *                                                   download.
+   * @param backupEnabled Whether backup is enabled for this container or not.
+   * @param overrideAccountAcl Whether to override account's ACL.
    * @param parentAccountId The id of the parent {@link Account} of this container.
    */
   Container(short id, String name, ContainerStatus status, String description, boolean encrypted,
       boolean previouslyEncrypted, boolean cacheable, boolean mediaScanDisabled, String replicationPolicy,
       boolean ttlRequired, boolean securePathRequired, Set<String> contentTypeWhitelistForFilenamesOnDownload,
-      boolean backupEnabled, short parentAccountId, long deleteTriggerTime) {
+      boolean backupEnabled, boolean overrideAccountAcl, short parentAccountId, long deleteTriggerTime) {
     this(id, name, status, description, encrypted, previouslyEncrypted, cacheable, mediaScanDisabled, replicationPolicy,
-        ttlRequired, securePathRequired, contentTypeWhitelistForFilenamesOnDownload, backupEnabled, parentAccountId,
-        deleteTriggerTime, LAST_MODIFIED_TIME_DEFAULT_VALUE, SNAPSHOT_VERSION_DEFAULT_VALUE);
+        ttlRequired, securePathRequired, contentTypeWhitelistForFilenamesOnDownload, backupEnabled, overrideAccountAcl,
+        parentAccountId, deleteTriggerTime, LAST_MODIFIED_TIME_DEFAULT_VALUE, SNAPSHOT_VERSION_DEFAULT_VALUE);
   }
 
   /**
@@ -456,15 +463,16 @@ public class Container {
    * @param ttlRequired {@code true} if ttl is required on content created in this container.
    * @param securePathRequired {@code true} if secure path validation is required in this container.
    * @param contentTypeWhitelistForFilenamesOnDownload the set of content types for which the filename can be sent on
-   *                                                   download
-   * @param backupEnabled Whether backup is enabled for this container or not
+   *                                                   download.
+   * @param backupEnabled Whether backup is enabled for this container or not.
+   * @param overrideAccountAcl Whether to override account-level ACLs.
    * @param parentAccountId The id of the parent {@link Account} of this container.
    * @param lastModifiedTime created/modified time of this container.
    */
   Container(short id, String name, ContainerStatus status, String description, boolean encrypted,
       boolean previouslyEncrypted, boolean cacheable, boolean mediaScanDisabled, String replicationPolicy,
       boolean ttlRequired, boolean securePathRequired, Set<String> contentTypeWhitelistForFilenamesOnDownload,
-      boolean backupEnabled, short parentAccountId, long deleteTriggerTime, long lastModifiedTime,
+      boolean backupEnabled, boolean overrideAccountAcl, short parentAccountId, long deleteTriggerTime, long lastModifiedTime,
       int snapshotVersion) {
     checkPreconditions(name, status, encrypted, previouslyEncrypted);
     this.id = id;
@@ -487,6 +495,7 @@ public class Container {
         this.securePathRequired = SECURE_PATH_REQUIRED_DEFAULT_VALUE;
         this.contentTypeWhitelistForFilenamesOnDownload =
             CONTENT_TYPE_WHITELIST_FOR_FILENAMES_ON_DOWNLOAD_DEFAULT_VALUE;
+        this.overrideAccountAcl = OVERRIDE_ACCOUNT_ACL_DEFAULT_VALUE;
         break;
       case JSON_VERSION_2:
         this.backupEnabled = backupEnabled;
@@ -500,6 +509,7 @@ public class Container {
         this.contentTypeWhitelistForFilenamesOnDownload =
             contentTypeWhitelistForFilenamesOnDownload == null ? Collections.emptySet()
                 : contentTypeWhitelistForFilenamesOnDownload;
+        this.overrideAccountAcl = overrideAccountAcl;
         break;
       default:
         throw new IllegalStateException("Unsupported container json version=" + currentJsonVersion);
@@ -537,7 +547,8 @@ public class Container {
         && Objects.equals(this.isSecurePathRequired(), containerToCompare.isSecurePathRequired())
         && Objects.equals(this.isBackupEnabled(), containerToCompare.isBackupEnabled())
         && Objects.equals(this.getContentTypeWhitelistForFilenamesOnDownload(),
-                          containerToCompare.getContentTypeWhitelistForFilenamesOnDownload());
+                          containerToCompare.getContentTypeWhitelistForFilenamesOnDownload())
+        && Objects.equals(this.isAccountAclOverridden(), containerToCompare.isAccountAclOverridden());
     //@formatter:on
   }
 
@@ -596,6 +607,7 @@ public class Container {
         }
         metadata.put(LAST_MODIFIED_TIME_KEY, lastModifiedTime);
         metadata.put(SNAPSHOT_VERSION_KEY, snapshotVersion);
+        metadata.put(OVERRIDE_ACCOUNT_ACL_KEY, overrideAccountAcl);
         break;
       default:
         throw new IllegalStateException("Unsupported container json version=" + currentJsonVersion);
@@ -709,6 +721,12 @@ public class Container {
   }
 
   /**
+   * @return {@code true} if current container overrides parent account's ACL.
+   */
+  public boolean isAccountAclOverridden() {
+    return overrideAccountAcl;
+  }
+  /**
    * Gets the if of the {@link Account} that owns this container.
    * @return The id of the parent {@link Account} of this container.
    */
@@ -759,8 +777,9 @@ public class Container {
         && Objects.equals(name, container.name) && status == container.status
         && deleteTriggerTime == container.deleteTriggerTime && Objects.equals(description, container.description)
         && Objects.equals(replicationPolicy, container.replicationPolicy) && ttlRequired == container.ttlRequired
-        && securePathRequired == container.securePathRequired && Objects.equals(
-        contentTypeWhitelistForFilenamesOnDownload, container.contentTypeWhitelistForFilenamesOnDownload);
+        && securePathRequired == container.securePathRequired && overrideAccountAcl == container.overrideAccountAcl
+        && Objects.equals(contentTypeWhitelistForFilenamesOnDownload,
+        container.contentTypeWhitelistForFilenamesOnDownload);
   }
 
   @Override

--- a/ambry-api/src/main/java/com/github/ambry/account/ContainerBuilder.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/ContainerBuilder.java
@@ -41,6 +41,7 @@ public class ContainerBuilder {
   private String replicationPolicy = null;
   private boolean ttlRequired = TTL_REQUIRED_DEFAULT_VALUE;
   private boolean securePathRequired = SECURE_PATH_REQUIRED_DEFAULT_VALUE;
+  private boolean overrideAccountAcl = OVERRIDE_ACCOUNT_ACL_DEFAULT_VALUE;
   private Set<String> contentTypeWhitelistForFilenamesOnDownload =
       CONTENT_TYPE_WHITELIST_FOR_FILENAMES_ON_DOWNLOAD_DEFAULT_VALUE;
   private boolean backupEnabled = BACKUP_ENABLED_DEFAULT_VALUE;
@@ -70,6 +71,7 @@ public class ContainerBuilder {
     ttlRequired = origin.isTtlRequired();
     parentAccountId = origin.getParentAccountId();
     securePathRequired = origin.isSecurePathRequired();
+    overrideAccountAcl = origin.isAccountAclOverridden();
     contentTypeWhitelistForFilenamesOnDownload = origin.getContentTypeWhitelistForFilenamesOnDownload();
     backupEnabled = origin.isBackupEnabled();
     lastModifiedTime = origin.getLastModifiedTime();
@@ -243,6 +245,16 @@ public class ContainerBuilder {
   }
 
   /**
+   * Sets whether to override account-level ACL in this container.
+   * @param overrideAccountAcl the boolean value indicating whether this container overrides account's ACL.
+   * @return This builder.
+   */
+  public ContainerBuilder setOverrideAccountAcl(boolean overrideAccountAcl) {
+    this.overrideAccountAcl = overrideAccountAcl;
+    return this;
+  }
+
+  /**
    * Sets the created/modified time of the {@link Container}
    * @param lastModifiedTime epoch time in milliseconds.
    * @return This builder.
@@ -271,7 +283,7 @@ public class ContainerBuilder {
   public Container build() {
     return new Container(id, name, status, description, encrypted, previouslyEncrypted || encrypted, cacheable,
         mediaScanDisabled, replicationPolicy, ttlRequired, securePathRequired,
-        contentTypeWhitelistForFilenamesOnDownload, backupEnabled, parentAccountId, deleteTriggerTime, lastModifiedTime,
+        contentTypeWhitelistForFilenamesOnDownload, backupEnabled, overrideAccountAcl, parentAccountId, deleteTriggerTime, lastModifiedTime,
         snapshotVersion);
   }
 }

--- a/ambry-test-utils/src/main/java/com/github/ambry/account/InMemAccountService.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/account/InMemAccountService.java
@@ -41,7 +41,7 @@ public class InMemAccountService implements AccountService {
    */
   public static final Account UNKNOWN_ACCOUNT =
       new Account(Account.UNKNOWN_ACCOUNT_ID, Account.UNKNOWN_ACCOUNT_NAME, Account.AccountStatus.ACTIVE,
-          Account.SNAPSHOT_VERSION_DEFAULT_VALUE,
+          Account.ACL_INHERITED_BY_CONTAINER_DEFAULT_VALUE, Account.SNAPSHOT_VERSION_DEFAULT_VALUE,
           Arrays.asList(Container.UNKNOWN_CONTAINER, Container.DEFAULT_PUBLIC_CONTAINER,
               Container.DEFAULT_PRIVATE_CONTAINER));
   private final boolean shouldReturnOnlyUnknown;


### PR DESCRIPTION
1. Introduced AccountBlobsResource as new type of ACL resource dedicated for account-level ACL.
2. Added "aclInheritedByContainer" property to Account class. If it's true, containers within account will inherit account's ACL.
3. Added "overrideAccountAcl" property to Container class. If it's true, container can override account's ACL even though account-level ACL inheritance is enabled. 