### PR TITLE
[StatsMigration] Add mysql tables for partition class reports

### DIFF
--- a/ambry-mysql/src/main/resources/AmbryContainerStorageStats.ddl
+++ b/ambry-mysql/src/main/resources/AmbryContainerStorageStats.ddl
@@ -19,18 +19,19 @@
  */
 CREATE TABLE IF NOT EXISTS AccountReports
 (
-    clusterName VARCHAR(25) NOT NULL,
-    hostname VARCHAR(30) NOT NULL,
-    partitionId INT NOT NULL,
-    accountId INT NOT NULL,
-    containerId INT NOT NULL,
-    storageUsage BIGINT NOT NULL,
-    updatedAt TIMESTAMP NOT NULL,
+    clusterName  VARCHAR(25) NOT NULL,
+    hostname     VARCHAR(30) NOT NULL,
+    partitionId  INT         NOT NULL,
+    accountId    INT         NOT NULL,
+    containerId  INT         NOT NULL,
+    storageUsage BIGINT      NOT NULL,
+    updatedAt    TIMESTAMP   NOT NULL,
 
-    PRIMARY KEY(clusterName, hostname, partitionId, accountId, containerId),
+    PRIMARY KEY (clusterName, hostname, partitionId, accountId, containerId),
     INDEX updatedAtIndex (updatedAt)
 )
-CHARACTER SET utf8 COLLATE utf8_bin;
+    CHARACTER SET utf8
+    COLLATE utf8_bin;
 
 /**
  * This table is created to store aggregated account storage usage. An aggregation task will be activated to read all
@@ -38,15 +39,16 @@ CHARACTER SET utf8 COLLATE utf8_bin;
  */
 CREATE TABLE IF NOT EXISTS AggregatedAccountReports
 (
-    clusterName VARCHAR(25) NOT NULL,
-    accountId INT NOT NULL,
-    containerId INT NOT NULL,
-    storageUsage BIGINT NOT NULL,
-    updatedAt TIMESTAMP NOT NULL,
+    clusterName  VARCHAR(25) NOT NULL,
+    accountId    INT         NOT NULL,
+    containerId  INT         NOT NULL,
+    storageUsage BIGINT      NOT NULL,
+    updatedAt    TIMESTAMP   NOT NULL,
 
     PRIMARY KEY (clusterName, accountId, containerId)
 )
-CHARACTER SET utf8 COLLATE utf8_bin;
+    CHARACTER SET utf8
+    COLLATE utf8_bin;
 
 /**
  * This table is created to keep a copy of aggregated container storage usage from table AggregatedAccountReports at the
@@ -61,54 +63,59 @@ CREATE TABLE IF NOT EXISTS MonthlyAggregatedAccountReports LIKE AggregatedAccoun
 CREATE TABLE IF NOT EXISTS AggregatedAccountReportsMonth
 (
     clusterName VARCHAR(25) NOT NULL PRIMARY KEY,
-    month VARCHAR(25) NOT NULL
+    month       VARCHAR(25) NOT NULL
 )
-CHARACTER SET utf8 COLLATE utf8_bin;
+    CHARACTER SET utf8
+    COLLATE utf8_bin;
 
 /**
  * This table is created to keep a list of partition class names. In "prod" cluster, we have "default".
  * In "test" cluster, we have "default" and "new-replication". For these three classes, we would have rows below:
- * -------------------------------------
- * clusterName  |id  |name             |
- * -------------------------------------
- * prod         |1   |default          |
- * test         |1   |default          |
- * test         |2   |new-replication  |
- * -------------------------------------
+ * ------------------------------------
+ * clusterName  |name             |id |
+ * ------------------------------------
+ * prod         |default          |1  |
+ * test         |default          |2  |
+ * test         |new-replication  |3  |
+ * ------------------------------------
  */
 CREATE TABLE IF NOT EXISTS PartitionClassNames
 (
+    id          SMALLINT    NOT NULL PRIMARY KEY AUTO_INCREMENT,
     clusterName VARCHAR(25) NOT NULL,
-    id SMALLINT NOT NULL,
-    name VARCHAR(45) NOT NULL,
+    name        VARCHAR(45) NOT NULL,
 
-    PRIMARY KEY(clusterName, id)
+    UNIQUE KEY (clusterName, name)
 )
-CHARACTER SET utf8 COLLATE utf8_bin;
+    CHARACTER SET utf8
+    COLLATE utf8_bin;
 
 /**
  * This table is created to store all the partition ids and its corresponding partition class id.
  */
-CREATE TABLE IF NOT EXISTS Partitions (
-    clusterName VARCHAR(25) NOT NULL,
-    id INT NOT NULL,
-    partitionClassId SMALLINT NOT NULL,
+CREATE TABLE IF NOT EXISTS Partitions
+(
+    clusterName      VARCHAR(25) NOT NULL,
+    id               INT         NOT NULL,
+    partitionClassId SMALLINT    NOT NULL,
 
-    PRIMARY KEY(clusterName, id)
+    PRIMARY KEY (clusterName, id)
 )
-CHARACTER SET utf8 COLLATE utf8_bin;
+    CHARACTER SET utf8
+    COLLATE utf8_bin;
 
 /**
  * This table is created to store the aggregated partition class report.
  */
-CREATE TABLE IF NOT EXISTS AggregatedPartitionClassReports (
-    clusterName VARCHAR(25) NOT NULL,
-    partitionClassId SMALLINT NOT NULL,
-    accountId INT NOT NULL,
-    containerId INT NOT NULL,
-    storageUsage BIGINT NOT NULL,
-    updatedAt TIMESTAMP NOT NULL,
+CREATE TABLE IF NOT EXISTS AggregatedPartitionClassReports
+(
+    partitionClassId SMALLINT  NOT NULL,
+    accountId        INT       NOT NULL,
+    containerId      INT       NOT NULL,
+    storageUsage     BIGINT    NOT NULL,
+    updatedAt        TIMESTAMP NOT NULL,
 
-    PRIMARY KEY (clusterName, partitionClassId, accountId, containerId)
+    PRIMARY KEY (partitionClassId, accountId, containerId)
 )
-CHARACTER SET utf8 COLLATE utf8_bin;
+    CHARACTER SET utf8
+    COLLATE utf8_bin;

--- a/ambry-mysql/src/main/resources/AmbryContainerStorageStats.ddl
+++ b/ambry-mysql/src/main/resources/AmbryContainerStorageStats.ddl
@@ -66,14 +66,15 @@ CREATE TABLE IF NOT EXISTS AggregatedAccountReportsMonth
 CHARACTER SET utf8 COLLATE utf8_bin;
 
 /**
- * This table is created to keep a list of partition class names. In main cluster, we have max-replicas-all-datacenters.
- * In video cluster, we have video-311. For these two classes, we would have rows below:
- * -------------------------------------------------
- * clusterName  |id  |name                         |
- * -------------------------------------------------
- * Ambry-Prod   |1   |max-replicas-all-datacenters |
- * Ambry-Video  |1   |video-311                    |
- * -------------------------------------------------
+ * This table is created to keep a list of partition class names. In "prod" cluster, we have "default".
+ * In "test" cluster, we have "default" and "new-replication". For these three classes, we would have rows below:
+ * -------------------------------------
+ * clusterName  |id  |name             |
+ * -------------------------------------
+ * prod         |1   |default          |
+ * test         |1   |default          |
+ * test         |2   |new-replication  |
+ * -------------------------------------
  */
 CREATE TABLE IF NOT EXISTS PartitionClassNames
 (
@@ -93,8 +94,7 @@ CREATE TABLE IF NOT EXISTS Partitions (
     id INT NOT NULL,
     partitionClassId SMALLINT NOT NULL,
 
-    PRIMARY KEY(clusterName, id),
-    FOREIGN KEY (clusterName, partitionClassId) REFERENCES PartitionClassNames(clusterName, id)
+    PRIMARY KEY(clusterName, id)
 )
 CHARACTER SET utf8 COLLATE utf8_bin;
 
@@ -109,7 +109,6 @@ CREATE TABLE IF NOT EXISTS AggregatedPartitionClassReports (
     storageUsage BIGINT NOT NULL,
     updatedAt TIMESTAMP NOT NULL,
 
-    PRIMARY KEY (clusterName, partitionClassId, accountId, containerId),
-    FOREIGN KEY (clusterName, partitionClassId) REFERENCES PartitionClassNames(clusterName, id)
+    PRIMARY KEY (clusterName, partitionClassId, accountId, containerId)
 )
 CHARACTER SET utf8 COLLATE utf8_bin;

--- a/ambry-mysql/src/main/resources/AmbryContainerStorageStats.ddl
+++ b/ambry-mysql/src/main/resources/AmbryContainerStorageStats.ddl
@@ -64,3 +64,52 @@ CREATE TABLE IF NOT EXISTS AggregatedAccountReportsMonth
     month VARCHAR(25) NOT NULL
 )
 CHARACTER SET utf8 COLLATE utf8_bin;
+
+/**
+ * This table is created to keep a list of partition class names. In main cluster, we have max-replicas-all-datacenters.
+ * In video cluster, we have video-311. For these two classes, we would have rows below:
+ * -------------------------------------------------
+ * clusterName  |id  |name                         |
+ * -------------------------------------------------
+ * Ambry-Prod   |1   |max-replicas-all-datacenters |
+ * Ambry-Video  |1   |video-311                    |
+ * -------------------------------------------------
+ */
+CREATE TABLE IF NOT EXISTS PartitionClassNames
+(
+    clusterName VARCHAR(25) NOT NULL,
+    id SMALLINT NOT NULL,
+    name VARCHAR(45) NOT NULL,
+
+    PRIMARY KEY(clusterName, id)
+)
+CHARACTER SET utf8 COLLATE utf8_bin;
+
+/**
+ * This table is created to store all the partition ids and its corresponding partition class id.
+ */
+CREATE TABLE IF NOT EXISTS Partitions (
+    clusterName VARCHAR(25) NOT NULL,
+    id INT NOT NULL,
+    partitionClassId SMALLINT NOT NULL,
+
+    PRIMARY KEY(clusterName, id),
+    FOREIGN KEY (partitionClassId) REFERENCES PartitionClassNames(id)
+)
+CHARACTER SET utf8 COLLATE utf8_bin;
+
+/**
+ * This table is created to store the aggregated partition class report.
+ */
+CREATE TABLE IF NOT EXISTS AggregatedPartitionClassReport (
+    clusterName VARCHAR(25) NOT NULL,
+    partitionClassId SMALLINT NOT NULL,
+    accountId INT NOT NULL,
+    containerId INT NOT NULL,
+    storageUsage BIGINT NOT NULL,
+    updatedAt TIMESTAMP NOT NULL,
+
+    PRIMARY KEY (clusterName, partitionClassId, accountId, containerId),
+    FOREIGN KEY (partitionClassId) REFERENCES PartitionClassNames(id)
+)
+CHARACTER SET utf8 COLLATE utf8_bin;

--- a/ambry-mysql/src/main/resources/AmbryContainerStorageStats.ddl
+++ b/ambry-mysql/src/main/resources/AmbryContainerStorageStats.ddl
@@ -94,14 +94,14 @@ CREATE TABLE IF NOT EXISTS Partitions (
     partitionClassId SMALLINT NOT NULL,
 
     PRIMARY KEY(clusterName, id),
-    FOREIGN KEY (partitionClassId) REFERENCES PartitionClassNames(id)
+    FOREIGN KEY (clusterName, partitionClassId) REFERENCES PartitionClassNames(clusterName, id)
 )
 CHARACTER SET utf8 COLLATE utf8_bin;
 
 /**
  * This table is created to store the aggregated partition class report.
  */
-CREATE TABLE IF NOT EXISTS AggregatedPartitionClassReport (
+CREATE TABLE IF NOT EXISTS AggregatedPartitionClassReports (
     clusterName VARCHAR(25) NOT NULL,
     partitionClassId SMALLINT NOT NULL,
     accountId INT NOT NULL,
@@ -110,6 +110,6 @@ CREATE TABLE IF NOT EXISTS AggregatedPartitionClassReport (
     updatedAt TIMESTAMP NOT NULL,
 
     PRIMARY KEY (clusterName, partitionClassId, accountId, containerId),
-    FOREIGN KEY (partitionClassId) REFERENCES PartitionClassNames(id)
+    FOREIGN KEY (clusterName, partitionClassId) REFERENCES PartitionClassNames(clusterName, id)
 )
 CHARACTER SET utf8 COLLATE utf8_bin;


### PR DESCRIPTION
We already migrated account stats report from helix to mysql, this PR would start the first step to migrate partition class report from helix to mysql by adding mysql tables.
This is the design doc for partition class report migration https://docs.google.com/document/d/1obzRunMrcA0BuBMLw42tw87gjzlGeZW4gpSw-4l47wI/edit#heading=h.1olkullkqvdq

A partition class report include account/container storage usage and keep them under different partition class names. A typical partition class report looks like this
```
{
    “max-replicas-all-datacenter”:{
        "Partition[11548]":{
            "A[1085]___C[8]":{"v":531308584},
            "A[1174]___C[8]":{"v":1443934},
            "A[1174]___C[9]":{"v":638918}
       }
    },
    “Video-31”:{
        "Partition[11657]":{
            "A[1085]___C[8]":{"v":524193383},
            "A[1174]___C[9]":{"v":1781907},
            "A[1186]___C[9]":{"v":153613},
            "A[154]___C[3]":{"v":12735027},
            "A[320]___C[8]":{"v":18379013},
            "A[320]___C[9]":{"v":1599623}
        }
    }
}
```
As you can see, the account/container usage data is exactly the same data as the AccountReoprt, so we can keep those storage usage data in AccountReports table. After that, we need to save partition and partition class metadata in other tables.

Partition class names like "max-replicas-all-datacenter", "video-31" would be saved in PartitionClassNames table. Partition ids would be saved in Partitions table. So to fetch the partition report for a given host:
```
1. select * from AccountReports where clusterName = clusterName and hostname = host; -> return all containers's usages
2. select Partitions.id, PartitionClassNames.name from Partitions INNER JOIN PartitionClassNames where Partition.partitionClassId = PartitionClassNames.id and Partitions.clusterName = PartitionClassNames.clusterName -> get all the partitions and their partition class names;
3. Separate partition ids based partition class names, and separate containers' usages based on what partition id container belongs to.
```