### PR TITLE
Changes to fetch missing Containers from MySql db on demand during blob operations

### DIFF
--- a/ambry-account/src/integration-test/java/com/github/ambry/account/MySqlAccountServiceIntegrationTest.java
+++ b/ambry-account/src/integration-test/java/com/github/ambry/account/MySqlAccountServiceIntegrationTest.java
@@ -477,9 +477,9 @@ public class MySqlAccountServiceIntegrationTest {
         mySqlAccountService.getContainerByName(accountName, "c2"));
     // verify call to query container from mysql db
     verify(mySqlAccountStore).getContainerByName(eq((int) accountId), eq("c2"));
-    // verify container name "a1_c2" is added to LRU cache
-    assertTrue("container a1_c2 must be present in LRU cache",
-        mySqlAccountService.getRecentNotFoundContainersCache().contains("a1_c2"));
+    // verify container name "a1:c2" is added to LRU cache
+    assertTrue("container a1:c2 must be present in LRU cache",
+        mySqlAccountService.getRecentNotFoundContainersCache().contains("a1" + MySqlAccountService.SEPARATOR + "c2"));
 
     // Look up container "c2" again in account service
     assertNull("Container must not be present in account service",
@@ -492,8 +492,8 @@ public class MySqlAccountServiceIntegrationTest {
         new ContainerBuilder((short) -1, "c2", ContainerStatus.ACTIVE, DESCRIPTION, accountId).build()));
 
     // verify container "c2" is removed from not-found LRU cache
-    assertFalse("Added container a1_c2 must no longer be present in LRU cache",
-        mySqlAccountService.getRecentNotFoundContainersCache().contains("a1_c2"));
+    assertFalse("Added container a1:c2 must no longer be present in LRU cache",
+        mySqlAccountService.getRecentNotFoundContainersCache().contains("a1" + MySqlAccountService.SEPARATOR + "c2"));
   }
 
   /**

--- a/ambry-account/src/integration-test/java/com/github/ambry/account/MySqlAccountServiceIntegrationTest.java
+++ b/ambry-account/src/integration-test/java/com/github/ambry/account/MySqlAccountServiceIntegrationTest.java
@@ -406,7 +406,7 @@ public class MySqlAccountServiceIntegrationTest {
     MySqlAccountService consumerAccountService =
         new MySqlAccountService(accountServiceMetrics, accountServiceConfig, mockMySqlAccountStoreFactory);
 
-    // Add new account on producer account service
+    // Add new account "a1" on producer account service
     short accountId = 101;
     String accountName = "a1";
     int onDemandContainerFetchCount = 0;

--- a/ambry-account/src/main/java/com/github/ambry/account/AbstractAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/AbstractAccountService.java
@@ -41,7 +41,6 @@ import org.slf4j.LoggerFactory;
 abstract class AbstractAccountService implements AccountService {
 
   private static final Logger logger = LoggerFactory.getLogger(AbstractAccountService.class);
-
   protected final AtomicReference<AccountInfoMap> accountInfoMapRef;
   protected final ReentrantLock lock = new ReentrantLock();
   protected final CopyOnWriteArraySet<Consumer<Collection<Account>>> accountUpdateConsumers =
@@ -52,7 +51,6 @@ abstract class AbstractAccountService implements AccountService {
   public AbstractAccountService(AccountServiceConfig config, AccountServiceMetrics accountServiceMetrics) {
     this.config = config;
     this.accountServiceMetrics = accountServiceMetrics;
-
     this.accountInfoMapRef = new AtomicReference<>(new AccountInfoMap(accountServiceMetrics));
   }
 

--- a/ambry-account/src/main/java/com/github/ambry/account/AccountInfoMap.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/AccountInfoMap.java
@@ -207,9 +207,13 @@ class AccountInfoMap {
    * @return true if there is any container under given parent account with same name but different id.
    */
   boolean hasConflictingContainer(Collection<Container> containersToSet, short parentAccountId, boolean ignoreVersion) {
+    Account account = idToAccountMap.get(parentAccountId);
+    if (account == null) {
+      return false;
+    }
     for (Container container : containersToSet) {
       // if the container already exists, check that the snapshot version matches the expected value.
-      Container containerInMap = getContainerByNameForAccount(container.getParentAccountId(), container.getName());
+      Container containerInMap = account.getContainerByName(container.getName());
       if (!ignoreVersion && containerInMap != null
           && container.getSnapshotVersion() != containerInMap.getSnapshotVersion()) {
         logger.error(
@@ -271,38 +275,14 @@ class AccountInfoMap {
    * @throws IllegalArgumentException if {@link Account} with provided id doesn't exist.
    */
   void addOrUpdateContainer(short accountId, Container container) {
-    Account parentAccount = idToAccountMap.get(accountId);
-    if (parentAccount == null) {
+    Account account = idToAccountMap.get(accountId);
+    if (account == null) {
       throw new IllegalArgumentException("Account with ID " + accountId + "doesn't exist");
     }
-    AccountBuilder accountBuilder = new AccountBuilder(parentAccount).addOrUpdateContainer(container);
-    parentAccount = accountBuilder.build();
-    idToAccountMap.put(parentAccount.getId(), parentAccount);
-    nameToAccountMap.put(parentAccount.getName(), parentAccount);
-  }
-
-  /**
-   * Gets {@link Container} by its Parent Account id and id.
-   * @param accountId The id of the parent {@link Account} for this {@link Container}.
-   * @param id The id to get the {@link Container}.
-   * @return The {@link Container} with the given id within the parent Account Id, or {@code null} if
-   * such a parent {@link Account} or {@link Container} does not exist.
-   */
-  Container getContainerByIdForAccount(Short accountId, short id) {
-    Account parentAccount = idToAccountMap.get(accountId);
-    return parentAccount == null ? null : parentAccount.getContainerById(id);
-  }
-
-  /**
-   * Gets {@link Container} by its name and Parent Account id.
-   * @param accountId The id of the parent {@link Account} for this {@link Container}.
-   * @param name The name of the {@link Container} to get.
-   * @return The {@link Container} with the given name within the parent Account Id, or {@code null} if
-   * such a parent {@link Account} or {@link Container} does not exist.
-   */
-  Container getContainerByNameForAccount(Short accountId, String name) {
-    Account parentAccount = idToAccountMap.get(accountId);
-    return parentAccount == null ? null : parentAccount.getContainerByName(name);
+    AccountBuilder accountBuilder = new AccountBuilder(account).addOrUpdateContainer(container);
+    account = accountBuilder.build();
+    idToAccountMap.put(account.getId(), account);
+    nameToAccountMap.put(account.getName(), account);
   }
 
   /**

--- a/ambry-account/src/main/java/com/github/ambry/account/AccountServiceMetrics.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/AccountServiceMetrics.java
@@ -50,6 +50,7 @@ public class AccountServiceMetrics {
   public final Counter accountFetchFromAmbryServerErrorCount;
   public final Counter accountUpdatesToStoreErrorCount;
   public final Counter getAccountInconsistencyCount;
+  public final Counter onDemandContainerFetchCount;
 
   // Gauge
   Gauge<Integer> accountDataInconsistencyCount;
@@ -102,6 +103,8 @@ public class AccountServiceMetrics {
         metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "AccountFetchFromAmbryServerErrorCount"));
     getAccountInconsistencyCount =
         metricRegistry.counter(MetricRegistry.name(CompositeAccountService.class, "GetAccountInconsistencyCount"));
+    onDemandContainerFetchCount =
+        metricRegistry.counter(MetricRegistry.name(MySqlAccountService.class, "onDemandContainerFetchCount"));
   }
 
   /**
@@ -130,7 +133,6 @@ public class AccountServiceMetrics {
    */
   void trackContainerCount(Gauge<Integer> gauge) {
     containerCountGauge = gauge;
-    metricRegistry.register(MetricRegistry.name(MySqlAccountService.class, "ContainerCount"),
-        containerCountGauge);
+    metricRegistry.register(MetricRegistry.name(MySqlAccountService.class, "ContainerCount"), containerCountGauge);
   }
 }

--- a/ambry-account/src/main/java/com/github/ambry/account/AccountServiceMetrics.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/AccountServiceMetrics.java
@@ -25,6 +25,35 @@ import com.codahale.metrics.MetricRegistry;
  * Exports metrics that are triggered by the {@link AccountService} to the provided {@link MetricRegistry}.
  */
 public class AccountServiceMetrics {
+
+  public static final String STARTUP_TIME_MSEC = "StartupTimeInMs";
+  public static final String UPDATE_ACCOUNT_TIME_MSEC = "UpdateAccountTimeInMs";
+  public static final String FETCH_REMOTE_ACCOUNT_TIME_MSEC = "FetchRemoteAccountTimeInMs";
+  public static final String ACCOUNT_UPDATE_CONSUMER_TIME_MSEC = "AccountUpdateConsumerTimeInMs";
+  public static final String ACCOUNT_UPDATE_TO_AMBRY_TIME_MSEC = "AccountUpdateToAmbryTimeInMs";
+  public static final String ACCOUNT_FETCH_FROM_AMBRY_TIME_MSEC = "AccountFetchFromAmbryTimeInMs";
+  public static final String BACKUP_WRITE_TIME_MSEC = "BackupWriteTimeInMs";
+  public static final String BACKUP_READ_TIME_MSEC = "BackupReadTimeInMs";
+  public static final String UNRECOGNIZED_MESSAGE_ERROR_COUNT = "UnrecognizedMessageErrorCount";
+  public static final String NOTIFY_ACCOUNT_DATA_CHANGE_ERROR_COUNT = "NotifyAccountDataChangeErrorCount";
+  public static final String UPDATE_ACCOUNT_ERROR_COUNT = "UpdateAccountErrorCount";
+  public static final String CONFLICT_RETRY_COUNT = "ConflictRetryCount";
+  public static final String ACCOUNT_UPDATES_TO_STORE_ERROR_COUNT = "AccountUpdatesToStoreErrorCount";
+  public static final String FETCH_REMOTE_ACCOUNT_ERROR_COUNT = "FetchRemoteAccountErrorCount";
+  public static final String REMOTE_DATA_CORRUPTION_ERROR_COUNT = "RemoteDataCorruptionErrorCount";
+  public static final String BACKUP_ERROR_COUNT = "BackupErrorCount";
+  public static final String NULL_NOTIFIER_COUNT = "NullNotifierCount";
+  public static final String ACCOUNT_UPDATES_CAPTURED_BY_SCHEDULED_UPDATER_COUNT =
+      "AccountUpdatesCapturedByScheduledUpdaterCount";
+  public static final String ACCOUNT_UPDATES_TO_AMBRY_SERVER_ERROR_COUNT = "AccountUpdatesToAmbryServerErrorCount";
+  public static final String ACCOUNT_DELETES_TO_AMBRY_SERVER_ERROR_COUNT = "AccountDeletesToAmbryServerErrorCount";
+  public static final String ACCOUNT_FETCH_FROM_AMBRY_SERVER_ERROR_COUNT = "AccountFetchFromAmbryServerErrorCount";
+  public static final String GET_ACCOUNT_INCONSISTENCY_COUNT = "GetAccountInconsistencyCount";
+  public static final String ON_DEMAND_CONTAINER_FETCH_COUNT = "OnDemandContainerFetchCount";
+  public static final String ACCOUNT_DATA_INCONSISTENCY_COUNT = "AccountDataInconsistencyCount";
+  public static final String TIME_IN_SECONDS_SINCE_LAST_SYNC = "TimeInSecondsSinceLastSync";
+  public static final String CONTAINER_COUNT = "ContainerCount";
+
   // Histogram
   public final Histogram startupTimeInMs;
   public final Histogram updateAccountTimeInMs;
@@ -62,49 +91,50 @@ public class AccountServiceMetrics {
   public AccountServiceMetrics(MetricRegistry metricRegistry) {
     this.metricRegistry = metricRegistry;
     // Histogram
-    startupTimeInMs = metricRegistry.histogram(MetricRegistry.name(HelixAccountService.class, "StartupTimeInMs"));
+    startupTimeInMs = metricRegistry.histogram(MetricRegistry.name(HelixAccountService.class, STARTUP_TIME_MSEC));
     updateAccountTimeInMs =
-        metricRegistry.histogram(MetricRegistry.name(HelixAccountService.class, "UpdateAccountTimeInMs"));
+        metricRegistry.histogram(MetricRegistry.name(HelixAccountService.class, UPDATE_ACCOUNT_TIME_MSEC));
     fetchRemoteAccountTimeInMs =
-        metricRegistry.histogram(MetricRegistry.name(HelixAccountService.class, "FetchRemoteAccountTimeInMs"));
+        metricRegistry.histogram(MetricRegistry.name(HelixAccountService.class, FETCH_REMOTE_ACCOUNT_TIME_MSEC));
     accountUpdateConsumerTimeInMs =
-        metricRegistry.histogram(MetricRegistry.name(HelixAccountService.class, "AccountUpdateConsumerTimeInMs"));
+        metricRegistry.histogram(MetricRegistry.name(HelixAccountService.class, ACCOUNT_UPDATE_CONSUMER_TIME_MSEC));
     accountUpdateToAmbryTimeInMs =
-        metricRegistry.histogram(MetricRegistry.name(HelixAccountService.class, "AccountUpdateToAmbryTimeInMs"));
+        metricRegistry.histogram(MetricRegistry.name(HelixAccountService.class, ACCOUNT_UPDATE_TO_AMBRY_TIME_MSEC));
     accountFetchFromAmbryTimeInMs =
-        metricRegistry.histogram(MetricRegistry.name(HelixAccountService.class, "AccountFetchFromAmbryTimeInMs"));
+        metricRegistry.histogram(MetricRegistry.name(HelixAccountService.class, ACCOUNT_FETCH_FROM_AMBRY_TIME_MSEC));
     backupWriteTimeInMs =
-        metricRegistry.histogram(MetricRegistry.name(HelixAccountService.class, "BackupWriteTimeInMs"));
-    backupReadTimeInMs = metricRegistry.histogram(MetricRegistry.name(HelixAccountService.class, "BackupReadTimeInMs"));
+        metricRegistry.histogram(MetricRegistry.name(HelixAccountService.class, BACKUP_WRITE_TIME_MSEC));
+    backupReadTimeInMs =
+        metricRegistry.histogram(MetricRegistry.name(HelixAccountService.class, BACKUP_READ_TIME_MSEC));
 
     // Counter
     unrecognizedMessageErrorCount =
-        metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "UnrecognizedMessageErrorCount"));
+        metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, UNRECOGNIZED_MESSAGE_ERROR_COUNT));
     notifyAccountDataChangeErrorCount =
-        metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "NotifyAccountDataChangeErrorCount"));
+        metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, NOTIFY_ACCOUNT_DATA_CHANGE_ERROR_COUNT));
     updateAccountErrorCount =
-        metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "UpdateAccountErrorCount"));
-    conflictRetryCount = metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "ConflictRetryCount"));
+        metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, UPDATE_ACCOUNT_ERROR_COUNT));
+    conflictRetryCount = metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, CONFLICT_RETRY_COUNT));
     accountUpdatesToStoreErrorCount =
-        metricRegistry.counter(MetricRegistry.name(AbstractAccountService.class, "AccountUpdatesToStoreErrorCount"));
+        metricRegistry.counter(MetricRegistry.name(AbstractAccountService.class, ACCOUNT_UPDATES_TO_STORE_ERROR_COUNT));
     fetchRemoteAccountErrorCount =
-        metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "FetchRemoteAccountErrorCount"));
+        metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, FETCH_REMOTE_ACCOUNT_ERROR_COUNT));
     remoteDataCorruptionErrorCount =
-        metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "RemoteDataCorruptionErrorCount"));
-    backupErrorCount = metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "BackupErrorCount"));
-    nullNotifierCount = metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "NullNotifierCount"));
+        metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, REMOTE_DATA_CORRUPTION_ERROR_COUNT));
+    backupErrorCount = metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, BACKUP_ERROR_COUNT));
+    nullNotifierCount = metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, NULL_NOTIFIER_COUNT));
     accountUpdatesCapturedByScheduledUpdaterCount = metricRegistry.counter(
-        MetricRegistry.name(HelixAccountService.class, "AccountUpdatesCapturedByScheduledUpdaterCount"));
-    accountUpdatesToAmbryServerErrorCount =
-        metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "AccountUpdatesToAmbryServerErrorCount"));
-    accountDeletesToAmbryServerErrorCount =
-        metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "AccountDeletesToAmbryServerErrorCount"));
-    accountFetchFromAmbryServerErrorCount =
-        metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "AccountFetchFromAmbryServerErrorCount"));
+        MetricRegistry.name(HelixAccountService.class, ACCOUNT_UPDATES_CAPTURED_BY_SCHEDULED_UPDATER_COUNT));
+    accountUpdatesToAmbryServerErrorCount = metricRegistry.counter(
+        MetricRegistry.name(HelixAccountService.class, ACCOUNT_UPDATES_TO_AMBRY_SERVER_ERROR_COUNT));
+    accountDeletesToAmbryServerErrorCount = metricRegistry.counter(
+        MetricRegistry.name(HelixAccountService.class, ACCOUNT_DELETES_TO_AMBRY_SERVER_ERROR_COUNT));
+    accountFetchFromAmbryServerErrorCount = metricRegistry.counter(
+        MetricRegistry.name(HelixAccountService.class, ACCOUNT_FETCH_FROM_AMBRY_SERVER_ERROR_COUNT));
     getAccountInconsistencyCount =
-        metricRegistry.counter(MetricRegistry.name(CompositeAccountService.class, "GetAccountInconsistencyCount"));
+        metricRegistry.counter(MetricRegistry.name(CompositeAccountService.class, GET_ACCOUNT_INCONSISTENCY_COUNT));
     onDemandContainerFetchCount =
-        metricRegistry.counter(MetricRegistry.name(MySqlAccountService.class, "onDemandContainerFetchCount"));
+        metricRegistry.counter(MetricRegistry.name(MySqlAccountService.class, ON_DEMAND_CONTAINER_FETCH_COUNT));
   }
 
   /**
@@ -113,7 +143,7 @@ public class AccountServiceMetrics {
    */
   void trackAccountDataInconsistency(CompositeAccountService compositeAccountService) {
     accountDataInconsistencyCount = compositeAccountService::getAccountsMismatchCount;
-    metricRegistry.register(MetricRegistry.name(CompositeAccountService.class, "AccountDataInconsistencyCount"),
+    metricRegistry.register(MetricRegistry.name(CompositeAccountService.class, ACCOUNT_DATA_INCONSISTENCY_COUNT),
         accountDataInconsistencyCount);
   }
 
@@ -123,7 +153,7 @@ public class AccountServiceMetrics {
    */
   void trackTimeSinceLastSync(Gauge<Integer> gauge) {
     timeInSecondsSinceLastSyncGauge = gauge;
-    metricRegistry.register(MetricRegistry.name(MySqlAccountService.class, "TimeInSecondsSinceLastSync"),
+    metricRegistry.register(MetricRegistry.name(MySqlAccountService.class, TIME_IN_SECONDS_SINCE_LAST_SYNC),
         timeInSecondsSinceLastSyncGauge);
   }
 
@@ -133,6 +163,6 @@ public class AccountServiceMetrics {
    */
   void trackContainerCount(Gauge<Integer> gauge) {
     containerCountGauge = gauge;
-    metricRegistry.register(MetricRegistry.name(MySqlAccountService.class, "ContainerCount"), containerCountGauge);
+    metricRegistry.register(MetricRegistry.name(MySqlAccountService.class, CONTAINER_COUNT), containerCountGauge);
   }
 }

--- a/ambry-account/src/main/java/com/github/ambry/account/CompositeAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/CompositeAccountService.java
@@ -114,11 +114,11 @@ public class CompositeAccountService implements AccountService {
   }
 
   @Override
-  public Container getContainer(String accountName, String containerName) throws AccountServiceException {
-    Container primaryResult = primaryAccountService.getContainer(accountName, containerName);
+  public Container getContainerByName(String accountName, String containerName) throws AccountServiceException {
+    Container primaryResult = primaryAccountService.getContainerByName(accountName, containerName);
     if (shouldCompare()) {
       try {
-        Container secondaryResult = secondaryAccountService.getContainer(accountName, containerName);
+        Container secondaryResult = secondaryAccountService.getContainerByName(accountName, containerName);
         if (primaryResult != null && !primaryResult.equals(secondaryResult)) {
           logger.warn("Inconsistency detected between primary and secondary for accountName ={}, containerName = {}",
               accountName, containerName);

--- a/ambry-account/src/main/java/com/github/ambry/account/mysql/MySqlAccountStore.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/mysql/MySqlAccountStore.java
@@ -97,6 +97,28 @@ public class MySqlAccountStore {
   }
 
   /**
+   * Gets container by its name and parent account Id.
+   * @param accountId the id for the parent account.
+   * @param containerName name of the container.
+   * @return {@link Container} if found in mysql db or {@code null} if it doesn't exist.
+   * @throws SQLException
+   */
+  public Container getContainerByName(int accountId, String containerName) throws SQLException {
+    return accountDao.getContainerByName(accountId, containerName);
+  }
+
+  /**
+   * Gets container by its Id and parent account Id.
+   * @param accountId the id for the parent account.
+   * @param containerId the id of the container.
+   * @return {@link Container} if found in mysql db or {@code null} if it doesn't exist.
+   * @throws SQLException
+   */
+  public Container getContainerById(int accountId, int containerId) throws SQLException {
+    return accountDao.getContainerById(accountId, containerId);
+  }
+
+  /**
    * Helper method to close the active connection, if there is one.
    */
   public void closeConnection() {

--- a/ambry-account/src/test/java/com/github/ambry/account/CompositeAccountServiceTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/CompositeAccountServiceTest.java
@@ -116,12 +116,12 @@ public class CompositeAccountServiceTest {
   @Test
   public void testGetContainerByNameBothSuccess() throws AccountServiceException {
     Container testContainer = testAccount.getAllContainers().iterator().next();
-    when(primaryAccountService.getContainer(any(), any())).thenReturn(testContainer);
-    when(secondaryAccountService.getContainer(any(), any())).thenReturn(testContainer);
+    when(primaryAccountService.getContainerByName(any(), any())).thenReturn(testContainer);
+    when(secondaryAccountService.getContainerByName(any(), any())).thenReturn(testContainer);
     assertEquals("Unexpected response", testContainer,
-        compositeAccountService.getContainer(testAccount.getName(), testContainer.getName()));
-    verify(primaryAccountService).getContainer(testAccount.getName(), testContainer.getName());
-    verify(secondaryAccountService).getContainer(testAccount.getName(), testContainer.getName());
+        compositeAccountService.getContainerByName(testAccount.getName(), testContainer.getName()));
+    verify(primaryAccountService).getContainerByName(testAccount.getName(), testContainer.getName());
+    verify(secondaryAccountService).getContainerByName(testAccount.getName(), testContainer.getName());
     assertEquals("Expected zero inconsistency", 0, metrics.getAccountInconsistencyCount.getCount());
   }
 
@@ -131,12 +131,12 @@ public class CompositeAccountServiceTest {
   @Test
   public void testGetContainerByNameResultsDifferent() throws AccountServiceException {
     Container testContainer = testAccount.getAllContainers().iterator().next();
-    when(primaryAccountService.getContainer(any(), any())).thenReturn(testContainer);
-    when(secondaryAccountService.getContainer(any(), any())).thenReturn(null);
+    when(primaryAccountService.getContainerByName(any(), any())).thenReturn(testContainer);
+    when(secondaryAccountService.getContainerByName(any(), any())).thenReturn(null);
     assertEquals("Unexpected response", testContainer,
-        compositeAccountService.getContainer(testAccount.getName(), testContainer.getName()));
-    verify(primaryAccountService).getContainer(testAccount.getName(), testContainer.getName());
-    verify(secondaryAccountService).getContainer(testAccount.getName(), testContainer.getName());
+        compositeAccountService.getContainerByName(testAccount.getName(), testContainer.getName()));
+    verify(primaryAccountService).getContainerByName(testAccount.getName(), testContainer.getName());
+    verify(secondaryAccountService).getContainerByName(testAccount.getName(), testContainer.getName());
     assertEquals("Expected one inconsistency", 1, metrics.getAccountInconsistencyCount.getCount());
   }
 
@@ -268,8 +268,8 @@ public class CompositeAccountServiceTest {
     when(primaryAccountService.getAllAccounts()).thenReturn(accountsInPrimary);
     when(secondaryAccountService.getAllAccounts()).thenReturn(accountsInSecondary);
     when(secondaryAccountService.getAccountById((short) 1)).thenReturn(accountsInSecondary.iterator().next());
-    when(secondaryAccountService.getContainer("a1", "c1")).thenReturn(c1);
-    when(secondaryAccountService.getContainer("a1", "c2")).thenReturn(c2);
+    when(secondaryAccountService.getContainerByName("a1", "c1")).thenReturn(c1);
+    when(secondaryAccountService.getContainerByName("a1", "c2")).thenReturn(c2);
 
     ((CompositeAccountService) compositeAccountService).compareAccountMetadata();
     verify(primaryAccountService, atLeastOnce()).getAllAccounts();

--- a/ambry-account/src/test/java/com/github/ambry/account/MySqlAccountServiceTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/MySqlAccountServiceTest.java
@@ -508,7 +508,7 @@ public class MySqlAccountServiceTest {
         .build();
     mySqlAccountService.updateContainers(accountToUpdate.getName(), Collections.singletonList(containerToUpdate));
     assertEquals("Mismatch in container information", containerToUpdate,
-        mySqlAccountService.getContainer(accountToUpdate.getName(), containerToUpdate.getName()));
+        mySqlAccountService.getContainerByName(accountToUpdate.getName(), containerToUpdate.getName()));
   }
 
   /**

--- a/ambry-api/src/main/java/com/github/ambry/account/AccountService.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/AccountService.java
@@ -125,9 +125,21 @@ public interface AccountService extends Closeable {
    * @return the requested {@link Container} object or null if not present.
    * @throws AccountServiceException if exception occurs when getting container.
    */
-  default Container getContainer(String accountName, String containerName) throws AccountServiceException {
+  default Container getContainerByName(String accountName, String containerName) throws AccountServiceException {
     Account account = getAccountByName(accountName);
     return account != null ? account.getContainerByName(containerName) : null;
+  }
+
+  /**
+   * Get an existing container from a given account.
+   * @param accountId the name of account which container belongs to.
+   * @param containerId the id of container to get.
+   * @return the requested {@link Container} object or null if not present.
+   * @throws AccountServiceException if exception occurs when getting container.
+   */
+  default Container getContainerById(short accountId, Short containerId) throws AccountServiceException {
+    Account account = getAccountById(accountId);
+    return account != null ? account.getContainerById(containerId) : null;
   }
 
   /**

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/GetAccountsHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/GetAccountsHandler.java
@@ -174,7 +174,7 @@ class GetAccountsHandler {
       String containerName = RestUtils.getHeader(restRequest.getArgs(), RestUtils.Headers.TARGET_CONTAINER_NAME, true);
       Container container;
       try {
-        container = accountService.getContainer(accountName, containerName);
+        container = accountService.getContainerByName(accountName, containerName);
       } catch (AccountServiceException e) {
         throw new RestServiceException("Failed to get container " + containerName + " from account " + accountName,
             RestServiceErrorCode.getRestServiceErrorCode(e.getErrorCode()));

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendIntegrationTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendIntegrationTest.java
@@ -1518,7 +1518,7 @@ public class FrontendIntegrationTest {
 
     for (Container container : outputContainers) {
       assertEquals("Update not reflected in AccountService", container,
-          ACCOUNT_SERVICE.getContainer(accountName, container.getName()));
+          ACCOUNT_SERVICE.getContainerByName(accountName, container.getName()));
     }
   }
 

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/PostAccountContainersHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/PostAccountContainersHandlerTest.java
@@ -91,7 +91,7 @@ public class PostAccountContainersHandlerTest {
       assertEquals("Unexpected count returned", inputContainers.size(), outputContainers.size());
       for (Container container : outputContainers) {
         assertEquals("Container in account service not as expected", container,
-            accountService.getContainer(accountName, container.getName()));
+            accountService.getContainerByName(accountName, container.getName()));
       }
     };
 


### PR DESCRIPTION
Changes to:
1. Fetch container on-demand from mysql db during blob operations if it is not found in in-memory cache.
2. Add a local LRA cache for storing container names not found during getContainer() operations to avoid repeated queries to mysql db.