### PR TITLE
Support deserialization of V3 StoreFindToken to incorporate reset key

### DIFF
--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
@@ -1144,7 +1144,8 @@ class BlobStoreCompactor {
           new AtomicLong(0), true);
       // save a token for restart (the key gets ignored but is required to be non null for construction)
       StoreFindToken safeToken =
-          new StoreFindToken(allIndexEntries.get(0).getKey(), indexSegment.getStartOffset(), sessionId, incarnationId);
+          new StoreFindToken(allIndexEntries.get(0).getKey(), indexSegment.getStartOffset(), sessionId, incarnationId,
+              null);
       compactionLog.setSafeToken(safeToken);
       logger.debug("Set safe token for compaction in {} to {}", storeId, safeToken);
 
@@ -1457,7 +1458,7 @@ class BlobStoreCompactor {
         if (previousKey == null) {
           // save a token for restart (the key gets ignored but is required to be non null for construction)
           StoreFindToken safeToken =
-              new StoreFindToken(currentKey, indexSegment.getStartOffset(), sessionId, incarnationId);
+              new StoreFindToken(currentKey, indexSegment.getStartOffset(), sessionId, incarnationId, null);
           compactionLog.setSafeToken(safeToken);
           logger.debug("Set safe token for compaction in {} to {}", storeId, safeToken);
         }

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
@@ -1145,7 +1145,7 @@ class BlobStoreCompactor {
       // save a token for restart (the key gets ignored but is required to be non null for construction)
       StoreFindToken safeToken =
           new StoreFindToken(allIndexEntries.get(0).getKey(), indexSegment.getStartOffset(), sessionId, incarnationId,
-              null);
+              null, null);
       compactionLog.setSafeToken(safeToken);
       logger.debug("Set safe token for compaction in {} to {}", storeId, safeToken);
 
@@ -1458,7 +1458,7 @@ class BlobStoreCompactor {
         if (previousKey == null) {
           // save a token for restart (the key gets ignored but is required to be non null for construction)
           StoreFindToken safeToken =
-              new StoreFindToken(currentKey, indexSegment.getStartOffset(), sessionId, incarnationId, null);
+              new StoreFindToken(currentKey, indexSegment.getStartOffset(), sessionId, incarnationId, null, null);
           compactionLog.setSafeToken(safeToken);
           logger.debug("Set safe token for compaction in {} to {}", storeId, safeToken);
         }

--- a/ambry-store/src/main/java/com/github/ambry/store/IndexSegment.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/IndexSegment.java
@@ -1105,7 +1105,7 @@ class IndexSegment implements Iterable<IndexEntry> {
    * Gets all the index entries upto maxEntries from the start of a given key (exclusive) or all entries if key is null,
    * till maxTotalSizeOfEntriesInBytes
    * @param key The key from where to start retrieving entries.
-   *            If the key is null, all entries are retrieved upto maxentries
+   *            If the key is null, all entries are retrieved up to max entries
    * @param findEntriesCondition The condition that determines when to stop fetching entries.
    * @param entries The input entries list that needs to be filled. The entries list can have existing entries
    * @param currentTotalSizeOfEntriesInBytes The current total size in bytes of the entries

--- a/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
@@ -1232,7 +1232,7 @@ class PersistentIndex {
           logger.trace("Journal based token, Time used to eliminate duplicates: {}",
               (time.milliseconds() - startTimeInMs));
 
-          StoreFindToken storeFindToken = new StoreFindToken(offsetEnd, sessionId, incarnationId, false);
+          StoreFindToken storeFindToken = new StoreFindToken(offsetEnd, sessionId, incarnationId, false, null);
           // use the latest ref of indexSegments
           long bytesRead = getTotalBytesRead(storeFindToken, messageEntries, logEndOffsetBeforeFind, indexSegments);
           storeFindToken.setBytesRead(bytesRead);
@@ -1325,7 +1325,7 @@ class PersistentIndex {
             && storeToken.getOffset().compareTo(logEndOffsetOnStartup) > 0) {
           logger.info("Index : {} resetting offset after not clean shutdown {} before offset {}", dataDir,
               logEndOffsetOnStartup, storeToken.getOffset());
-          storeToken = new StoreFindToken(logEndOffsetOnStartup, sessionId, incarnationId, true);
+          storeToken = new StoreFindToken(logEndOffsetOnStartup, sessionId, incarnationId, true, null);
         }
       } else if (!storeToken.getType().equals(FindTokenType.Uninitialized)
           && storeToken.getOffset().compareTo(logEndOffsetOnStartup) > 0) {
@@ -1524,7 +1524,7 @@ class PersistentIndex {
       logger.trace("Index : {} findEntriesFromOffset segment start offset {} with key {} total entries received {}",
           dataDir, segmentStartOffset, key, messageEntries.size());
       // Notice that we might not finish scanning the segmentToProcess, it's possible that current index segment contains
-      // enough index values so that the findEngtriesCondition returns false. But we are still moving to the next index segment
+      // enough index values so that the findEntriesCondition returns false. But we are still moving to the next index segment
       // because when findEntriesCondition returns false, we will skip the while loop below and return the new find token
       // right away. And if findEntriesCondition returns true, that means we finish scanning of the current index segment so
       // we can move to the next one.
@@ -1603,9 +1603,9 @@ class PersistentIndex {
       }
     }
     if (newTokenOffsetInJournal != null) {
-      return new StoreFindToken(newTokenOffsetInJournal, sessionId, incarnationId, false);
+      return new StoreFindToken(newTokenOffsetInJournal, sessionId, incarnationId, false, null);
     } else if (messageEntries.size() == 0 && !findEntriesCondition.hasEndTime()) {
-      // If the condition does not have an endtime, then since we have entered a segment, we should return at least one
+      // If the condition does not have an end time, then since we have entered a segment, we should return at least one
       // message
       throw new IllegalStateException(
           "Message entries cannot be null. At least one entry should have been returned, start offset: "
@@ -1615,7 +1615,7 @@ class PersistentIndex {
       // uninitialized token
       return newTokenSegmentStartOffset == null ? new StoreFindToken()
           : new StoreFindToken(messageEntries.get(messageEntries.size() - 1).getStoreKey(), newTokenSegmentStartOffset,
-              sessionId, incarnationId);
+              sessionId, incarnationId, null);
     }
   }
 
@@ -1899,7 +1899,7 @@ class PersistentIndex {
             break;
           }
         }
-        newToken = new StoreFindToken(offsetEnd, sessionId, incarnationId, false);
+        newToken = new StoreFindToken(offsetEnd, sessionId, incarnationId, false, null);
       } else {
         // Case 3: offset based, but offset out of journal
         Map.Entry<Offset, IndexSegment> entry = indexSegments.floorEntry(offsetToStart);

--- a/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
@@ -1232,7 +1232,7 @@ class PersistentIndex {
           logger.trace("Journal based token, Time used to eliminate duplicates: {}",
               (time.milliseconds() - startTimeInMs));
 
-          StoreFindToken storeFindToken = new StoreFindToken(offsetEnd, sessionId, incarnationId, false, null);
+          StoreFindToken storeFindToken = new StoreFindToken(offsetEnd, sessionId, incarnationId, false, null, null);
           // use the latest ref of indexSegments
           long bytesRead = getTotalBytesRead(storeFindToken, messageEntries, logEndOffsetBeforeFind, indexSegments);
           storeFindToken.setBytesRead(bytesRead);
@@ -1325,7 +1325,7 @@ class PersistentIndex {
             && storeToken.getOffset().compareTo(logEndOffsetOnStartup) > 0) {
           logger.info("Index : {} resetting offset after not clean shutdown {} before offset {}", dataDir,
               logEndOffsetOnStartup, storeToken.getOffset());
-          storeToken = new StoreFindToken(logEndOffsetOnStartup, sessionId, incarnationId, true, null);
+          storeToken = new StoreFindToken(logEndOffsetOnStartup, sessionId, incarnationId, true, null, null);
         }
       } else if (!storeToken.getType().equals(FindTokenType.Uninitialized)
           && storeToken.getOffset().compareTo(logEndOffsetOnStartup) > 0) {
@@ -1603,7 +1603,7 @@ class PersistentIndex {
       }
     }
     if (newTokenOffsetInJournal != null) {
-      return new StoreFindToken(newTokenOffsetInJournal, sessionId, incarnationId, false, null);
+      return new StoreFindToken(newTokenOffsetInJournal, sessionId, incarnationId, false, null, null);
     } else if (messageEntries.size() == 0 && !findEntriesCondition.hasEndTime()) {
       // If the condition does not have an end time, then since we have entered a segment, we should return at least one
       // message
@@ -1615,7 +1615,7 @@ class PersistentIndex {
       // uninitialized token
       return newTokenSegmentStartOffset == null ? new StoreFindToken()
           : new StoreFindToken(messageEntries.get(messageEntries.size() - 1).getStoreKey(), newTokenSegmentStartOffset,
-              sessionId, incarnationId, null);
+              sessionId, incarnationId, null, null);
     }
   }
 
@@ -1899,7 +1899,7 @@ class PersistentIndex {
             break;
           }
         }
-        newToken = new StoreFindToken(offsetEnd, sessionId, incarnationId, false, null);
+        newToken = new StoreFindToken(offsetEnd, sessionId, incarnationId, false, null, null);
       } else {
         // Case 3: offset based, but offset out of journal
         Map.Entry<Offset, IndexSegment> entry = indexSegments.floorEntry(offsetToStart);

--- a/ambry-store/src/main/java/com/github/ambry/store/StoreFindToken.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StoreFindToken.java
@@ -19,6 +19,7 @@ import com.github.ambry.utils.Utils;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Objects;
 import java.util.UUID;
 
 
@@ -37,16 +38,18 @@ public class StoreFindToken implements FindToken {
   static final short VERSION_0 = 0;
   static final short VERSION_1 = 1;
   static final short VERSION_2 = 2;
+  static final short VERSION_3 = 3;
   static final short CURRENT_VERSION = VERSION_2;
 
-  private static final int VERSION_SIZE = 2;
-  private static final int TYPE_SIZE = 2;
-  private static final int SESSION_ID_LENGTH_SIZE = 4;
-  private static final int INCARNATION_ID_LENGTH_SIZE = 4;
-  private static final int INCLUSIVE_BYTE_SIZE = 1;
+  static final int VERSION_SIZE = 2;
+  static final int TYPE_SIZE = 2;
+  static final int SESSION_ID_LENGTH_SIZE = 4;
+  static final int INCARNATION_ID_LENGTH_SIZE = 4;
+  static final int INCLUSIVE_BYTE_SIZE = 1;
 
   private static final byte[] ZERO_LENGTH_ARRAY = new byte[0];
   private static final int UNINITIALIZED_OFFSET = -1;
+
   // refers to the type of the token
   private final FindTokenType type;
   // refers to the offset in the log. Could be either of Journal or Index based token
@@ -54,6 +57,9 @@ public class StoreFindToken implements FindToken {
   // refers to the store key in case of Index based token
   // in case of journal based token, represents if the blob at the offset(of the token)
   private final StoreKey storeKey;
+  // refers to the store key lies at index segment start offset in the log (used to find valid start point if previous
+  // index segment has been compacted)
+  private final StoreKey resetKey;
   // is inclusive or not
   private final byte inclusive;
   // refers to the sessionId of the store. On every restart a new sessionId is created
@@ -69,7 +75,7 @@ public class StoreFindToken implements FindToken {
    * Uninitialized token. Refers to the starting of the log.
    */
   StoreFindToken() {
-    this(FindTokenType.Uninitialized, null, null, null, null, true, CURRENT_VERSION);
+    this(FindTokenType.Uninitialized, null, null, null, null, true, CURRENT_VERSION, null);
   }
 
   /**
@@ -78,9 +84,12 @@ public class StoreFindToken implements FindToken {
    * @param indexSegmentStartOffset the start offset of the index segment which the token refers to
    * @param sessionId the sessionId of the store
    * @param incarnationId the incarnationId of the store
+   * @param resetKey The {@link StoreKey} used to find closest valid starting point in case the index segment the token
+   *                 refers to has been compacted.
    */
-  StoreFindToken(StoreKey key, Offset indexSegmentStartOffset, UUID sessionId, UUID incarnationId) {
-    this(FindTokenType.IndexBased, indexSegmentStartOffset, key, sessionId, incarnationId, false, CURRENT_VERSION);
+  StoreFindToken(StoreKey key, Offset indexSegmentStartOffset, UUID sessionId, UUID incarnationId, StoreKey resetKey) {
+    this(FindTokenType.IndexBased, indexSegmentStartOffset, key, sessionId, incarnationId, false, CURRENT_VERSION,
+        resetKey);
   }
 
   /**
@@ -90,9 +99,11 @@ public class StoreFindToken implements FindToken {
    * @param incarnationId the incarnationId of the store
    * @param inclusive {@code true} if the offset is inclusive or in other words the blob at the given offset is inclusive.
    *                  {@code false} otherwise
+   * @param resetKey The {@link StoreKey} used to find closest valid starting point in case the index segment the token
+   *                 refers to has been compacted.
    */
-  StoreFindToken(Offset offset, UUID sessionId, UUID incarnationId, boolean inclusive) {
-    this(FindTokenType.JournalBased, offset, null, sessionId, incarnationId, inclusive, CURRENT_VERSION);
+  StoreFindToken(Offset offset, UUID sessionId, UUID incarnationId, boolean inclusive, StoreKey resetKey) {
+    this(FindTokenType.JournalBased, offset, null, sessionId, incarnationId, inclusive, CURRENT_VERSION, resetKey);
   }
 
   /**
@@ -105,17 +116,22 @@ public class StoreFindToken implements FindToken {
    * @param inclusive {@code true} if the offset is inclusive or in other words the blob at the given offset is inclusive.
    *                  {@code false} otherwise
    * @param version refers to the version of the token
+   * @param resetKey The {@link StoreKey} used to find closest valid starting point in case the index segment the token
+   *                 refers to has been compacted.
    */
-  private StoreFindToken(FindTokenType type, Offset offset, StoreKey key, UUID sessionId, UUID incarnationId,
-      boolean inclusive, short version) {
+   StoreFindToken(FindTokenType type, Offset offset, StoreKey key, UUID sessionId, UUID incarnationId,
+      boolean inclusive, short version, StoreKey resetKey) {
     if (!type.equals(FindTokenType.Uninitialized)) {
       if (offset == null || sessionId == null) {
         throw new IllegalArgumentException("Offset [" + offset + "] or SessionId [" + sessionId + "] cannot be null");
       } else if (type.equals(FindTokenType.IndexBased) && key == null) {
         throw new IllegalArgumentException("StoreKey cannot be null for an index based token");
       }
-      if (version == VERSION_2 && incarnationId == null) {
+      if (version >= VERSION_2 && incarnationId == null) {
         throw new IllegalArgumentException("IncarnationId cannot be null for StoreFindToken of version 2");
+      }
+      if (version == VERSION_3 && resetKey == null) {
+        throw new IllegalArgumentException("Reset key cannot be null for StoreFindToken of version 3.");
       }
     }
     this.type = type;
@@ -126,6 +142,7 @@ public class StoreFindToken implements FindToken {
     this.incarnationId = incarnationId;
     this.bytesRead = -1;
     this.version = version;
+    this.resetKey = resetKey;
   }
 
   void setBytesRead(long bytesRead) {
@@ -153,13 +170,14 @@ public class StoreFindToken implements FindToken {
         if (indexStartOffset != UNINITIALIZED_OFFSET) {
           // read store key if needed
           storeFindToken = new StoreFindToken(FindTokenType.IndexBased, new Offset(logSegmentName, indexStartOffset),
-              factory.getStoreKey(stream), sessionIdUUID, null, false, VERSION_0);
+              factory.getStoreKey(stream), sessionIdUUID, null, false, VERSION_0, null);
         } else if (offset != UNINITIALIZED_OFFSET) {
           storeFindToken =
               new StoreFindToken(FindTokenType.JournalBased, new Offset(logSegmentName, offset), null, sessionIdUUID,
-                  null, false, VERSION_0);
+                  null, false, VERSION_0, null);
         } else {
-          storeFindToken = new StoreFindToken(FindTokenType.Uninitialized, null, null, null, null, true, VERSION_0);
+          storeFindToken =
+              new StoreFindToken(FindTokenType.Uninitialized, null, null, null, null, true, VERSION_0, null);
         }
         break;
       case VERSION_1:
@@ -173,18 +191,20 @@ public class StoreFindToken implements FindToken {
         FindTokenType type = FindTokenType.values()[stream.readShort()];
         switch (type) {
           case Uninitialized:
-            storeFindToken = new StoreFindToken(FindTokenType.Uninitialized, null, null, null, null, true, VERSION_1);
+            storeFindToken =
+                new StoreFindToken(FindTokenType.Uninitialized, null, null, null, null, true, VERSION_1, null);
             break;
           case JournalBased:
             Offset logOffset = Offset.fromBytes(stream);
             storeFindToken =
-                new StoreFindToken(FindTokenType.JournalBased, logOffset, null, sessionIdUUID, null, false, VERSION_1);
+                new StoreFindToken(FindTokenType.JournalBased, logOffset, null, sessionIdUUID, null, false, VERSION_1,
+                    null);
             break;
           case IndexBased:
             Offset indexSegmentStartOffset = Offset.fromBytes(stream);
             storeFindToken =
                 new StoreFindToken(FindTokenType.IndexBased, indexSegmentStartOffset, factory.getStoreKey(stream),
-                    sessionIdUUID, null, false, VERSION_1);
+                    sessionIdUUID, null, false, VERSION_1, null);
             break;
           default:
             throw new IllegalStateException("Unknown store find token type: " + type);
@@ -206,7 +226,8 @@ public class StoreFindToken implements FindToken {
             sessionIdUUID = UUID.fromString(sessionId);
             Offset logOffset = Offset.fromBytes(stream);
             byte inclusive = stream.readByte();
-            storeFindToken = new StoreFindToken(logOffset, sessionIdUUID, incarnationIdUUID, inclusive == (byte) 1);
+            storeFindToken =
+                new StoreFindToken(logOffset, sessionIdUUID, incarnationIdUUID, inclusive == (byte) 1, null);
             break;
           case IndexBased:
             // read incarnationId
@@ -217,7 +238,51 @@ public class StoreFindToken implements FindToken {
             sessionIdUUID = UUID.fromString(sessionId);
             Offset indexSegmentStartOffset = Offset.fromBytes(stream);
             StoreKey storeKey = factory.getStoreKey(stream);
-            storeFindToken = new StoreFindToken(storeKey, indexSegmentStartOffset, sessionIdUUID, incarnationIdUUID);
+            storeFindToken =
+                new StoreFindToken(storeKey, indexSegmentStartOffset, sessionIdUUID, incarnationIdUUID, null);
+            break;
+          default:
+            throw new IllegalStateException("Unknown store find token type: " + type);
+        }
+        break;
+      case VERSION_3:
+        // read type
+        type = FindTokenType.values()[stream.readShort()];
+        switch (type) {
+          // TODO update StoreFindToken method once CURRENT VERSION = VERSION 3.
+          case Uninitialized:
+            storeFindToken =
+                new StoreFindToken(FindTokenType.Uninitialized, null, null, null, null, true, VERSION_3, null);
+            break;
+          case JournalBased:
+            // read incarnationId
+            String incarnationId = Utils.readIntString(stream);
+            UUID incarnationIdUUID = UUID.fromString(incarnationId);
+            // read sessionId
+            sessionId = Utils.readIntString(stream);
+            sessionIdUUID = UUID.fromString(sessionId);
+            Offset logOffset = Offset.fromBytes(stream);
+            byte inclusive = stream.readByte();
+            // read reset key
+            StoreKey journalTokenResetKey = factory.getStoreKey(stream);
+            storeFindToken =
+                new StoreFindToken(FindTokenType.JournalBased, logOffset, null, sessionIdUUID, incarnationIdUUID,
+                    inclusive == (byte) 1, VERSION_3, journalTokenResetKey);
+            break;
+          case IndexBased:
+            // read incarnationId
+            incarnationId = Utils.readIntString(stream);
+            incarnationIdUUID = UUID.fromString(incarnationId);
+            // read sessionId
+            sessionId = Utils.readIntString(stream);
+            sessionIdUUID = UUID.fromString(sessionId);
+            Offset indexSegmentStartOffset = Offset.fromBytes(stream);
+            StoreKey storeKey = factory.getStoreKey(stream);
+            // read reset key
+            StoreKey indexTokenResetKey = factory.getStoreKey(stream);
+            storeFindToken =
+                new StoreFindToken(FindTokenType.IndexBased, indexSegmentStartOffset, storeKey, sessionIdUUID,
+                    incarnationIdUUID, false, VERSION_3, indexTokenResetKey);
             break;
           default:
             throw new IllegalStateException("Unknown store find token type: " + type);
@@ -235,6 +300,10 @@ public class StoreFindToken implements FindToken {
 
   public StoreKey getStoreKey() {
     return storeKey;
+  }
+
+  public StoreKey getResetKey() {
+    return resetKey;
   }
 
   public Offset getOffset() {
@@ -273,8 +342,8 @@ public class StoreFindToken implements FindToken {
       case VERSION_0:
         int offsetSize = 8;
         int startOffsetSize = 8;
-        byte[] sessionIdBytes = sessionId != null ? sessionId.toString().getBytes() : ZERO_LENGTH_ARRAY;
-        byte[] storeKeyBytes = storeKey != null ? storeKey.toBytes() : ZERO_LENGTH_ARRAY;
+        byte[] sessionIdBytes = getSessionIdInBytes();
+        byte[] storeKeyBytes = getStoreKeyInBytes();
         int size = VERSION_SIZE + SESSION_ID_LENGTH_SIZE + sessionIdBytes.length + offsetSize + startOffsetSize
             + storeKeyBytes.length;
         buf = new byte[size];
@@ -288,13 +357,13 @@ public class StoreFindToken implements FindToken {
         bufWrap.putLong((type == FindTokenType.JournalBased) ? offset.getOffset() : UNINITIALIZED_OFFSET);
         // add index start offset for Index based token
         bufWrap.putLong((type == FindTokenType.IndexBased) ? offset.getOffset() : UNINITIALIZED_OFFSET);
-        // add storekey
+        // add store key
         bufWrap.put(storeKeyBytes);
         break;
       case VERSION_1:
-        byte[] offsetBytes = offset != null ? offset.toBytes() : ZERO_LENGTH_ARRAY;
-        sessionIdBytes = sessionId != null ? sessionId.toString().getBytes() : ZERO_LENGTH_ARRAY;
-        storeKeyBytes = storeKey != null ? storeKey.toBytes() : ZERO_LENGTH_ARRAY;
+        byte[] offsetBytes = getOffsetInBytes();
+        sessionIdBytes = getSessionIdInBytes();
+        storeKeyBytes = getStoreKeyInBytes();
         size = VERSION_SIZE + SESSION_ID_LENGTH_SIZE + sessionIdBytes.length + TYPE_SIZE + offsetBytes.length
             + storeKeyBytes.length;
         buf = new byte[size];
@@ -312,10 +381,10 @@ public class StoreFindToken implements FindToken {
         bufWrap.put(storeKeyBytes);
         break;
       case VERSION_2:
-        offsetBytes = offset != null ? offset.toBytes() : ZERO_LENGTH_ARRAY;
-        sessionIdBytes = sessionId != null ? sessionId.toString().getBytes() : ZERO_LENGTH_ARRAY;
-        byte[] incarnationIdBytes = incarnationId != null ? incarnationId.toString().getBytes() : ZERO_LENGTH_ARRAY;
-        storeKeyBytes = storeKey != null ? storeKey.toBytes() : ZERO_LENGTH_ARRAY;
+        offsetBytes = getOffsetInBytes();
+        sessionIdBytes = getSessionIdInBytes();
+        byte[] incarnationIdBytes = getIncarnationIdInBytes();
+        storeKeyBytes = getStoreKeyInBytes();
         size = VERSION_SIZE + TYPE_SIZE;
         if (type != FindTokenType.Uninitialized) {
           size +=
@@ -353,6 +422,22 @@ public class StoreFindToken implements FindToken {
     return buf;
   }
 
+  byte[] getOffsetInBytes() {
+    return offset != null ? offset.toBytes() : ZERO_LENGTH_ARRAY;
+  }
+
+  byte[] getStoreKeyInBytes() {
+    return storeKey != null ? storeKey.toBytes() : ZERO_LENGTH_ARRAY;
+  }
+
+  byte[] getSessionIdInBytes() {
+    return sessionId != null ? sessionId.toString().getBytes() : ZERO_LENGTH_ARRAY;
+  }
+
+  byte [] getIncarnationIdInBytes() {
+    return incarnationId != null ? incarnationId.toString().getBytes() : ZERO_LENGTH_ARRAY;
+  }
+
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
@@ -368,6 +453,9 @@ public class StoreFindToken implements FindToken {
       }
       if (storeKey != null) {
         sb.append(" storeKey ").append(storeKey);
+      }
+      if (resetKey != null) {
+        sb.append(" resetKey ").append(resetKey);
       }
       sb.append(" offset ").append(offset);
       sb.append(" bytesRead ").append(bytesRead);
@@ -389,13 +477,16 @@ public class StoreFindToken implements FindToken {
     if (type != that.type) {
       return false;
     }
-    if (offset != null ? !offset.equals(that.offset) : that.offset != null) {
+    if (!Objects.equals(offset, that.offset)) {
       return false;
     }
     if (inclusive != that.inclusive) {
       return false;
     }
-    return storeKey != null ? storeKey.equals(that.storeKey) : that.storeKey == null;
+    if (!Objects.equals(storeKey, that.storeKey)) {
+      return false;
+    }
+    return Objects.equals(resetKey, that.resetKey);
   }
 
   @Override
@@ -404,6 +495,7 @@ public class StoreFindToken implements FindToken {
     result = 31 * result + (offset != null ? offset.hashCode() : 0);
     result = 31 * result + inclusive;
     result = 31 * result + (storeKey != null ? storeKey.hashCode() : 0);
+    result = 31 * result + (resetKey != null ? resetKey.hashCode() : 0);
     return result;
   }
 }

--- a/ambry-store/src/main/java/com/github/ambry/store/StoreFindToken.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StoreFindToken.java
@@ -160,8 +160,8 @@ public class StoreFindToken implements FindToken {
    * @param resetKey The {@link StoreKey} used to find closest valid starting point in case the index segment the token
    * @param resetKeyType The {@link PersistentIndex.IndexEntryType} associated with this reset key.
    */
-   StoreFindToken(FindTokenType type, Offset offset, StoreKey key, UUID sessionId, UUID incarnationId, boolean inclusive, short version, StoreKey resetKey,
-       PersistentIndex.IndexEntryType resetKeyType) {
+  StoreFindToken(FindTokenType type, Offset offset, StoreKey key, UUID sessionId, UUID incarnationId, boolean inclusive,
+      short version, StoreKey resetKey, PersistentIndex.IndexEntryType resetKeyType) {
     if (!type.equals(FindTokenType.Uninitialized)) {
       if (offset == null || sessionId == null) {
         throw new IllegalArgumentException("Offset [" + offset + "] or SessionId [" + sessionId + "] cannot be null");
@@ -486,7 +486,7 @@ public class StoreFindToken implements FindToken {
     return sessionId != null ? sessionId.toString().getBytes() : ZERO_LENGTH_ARRAY;
   }
 
-  byte [] getIncarnationIdInBytes() {
+  byte[] getIncarnationIdInBytes() {
     return incarnationId != null ? incarnationId.toString().getBytes() : ZERO_LENGTH_ARRAY;
   }
 
@@ -526,22 +526,11 @@ public class StoreFindToken implements FindToken {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-
     StoreFindToken that = (StoreFindToken) o;
 
-    if (type != that.type) {
-      return false;
-    }
-    if (!Objects.equals(offset, that.offset)) {
-      return false;
-    }
-    if (inclusive != that.inclusive) {
-      return false;
-    }
-    if (!Objects.equals(storeKey, that.storeKey)) {
-      return false;
-    }
-    return Objects.equals(resetKey, that.resetKey) && Objects.equals(resetKeyType, that.resetKeyType);
+    return type == that.type && Objects.equals(offset, that.offset) && inclusive == that.inclusive && Objects.equals(
+        storeKey, that.storeKey) && Objects.equals(resetKey, that.resetKey) && Objects.equals(resetKeyType,
+        that.resetKeyType);
   }
 
   @Override

--- a/ambry-store/src/main/java/com/github/ambry/store/StoreFindToken.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StoreFindToken.java
@@ -105,7 +105,9 @@ public class StoreFindToken implements FindToken {
    * @param indexSegmentStartOffset the start offset of the index segment which the token refers to
    * @param sessionId the sessionId of the store
    * @param incarnationId the incarnationId of the store
-   * @param resetKey The {@link StoreKey} used to find closest valid starting point in case the index segment the token
+   * @param resetKey The {@link StoreKey} at start offset of current index segment. When log segment on source node is
+   *                 compacted (and token becomes invalid), this key is used to find current valid log segment where
+   *                 {@link PersistentIndex#findEntriesSince(FindToken, long)} can start from.
    * @param resetKeyType The {@link PersistentIndex.IndexEntryType} associated with this reset key.
    */
   StoreFindToken(StoreKey key, Offset indexSegmentStartOffset, UUID sessionId, UUID incarnationId, StoreKey resetKey,
@@ -138,7 +140,9 @@ public class StoreFindToken implements FindToken {
    * @param incarnationId the incarnationId of the store
    * @param inclusive {@code true} if the offset is inclusive or in other words the blob at the given offset is inclusive.
    *                  {@code false} otherwise
-   * @param resetKey The {@link StoreKey} used to find closest valid starting point in case the index segment the token
+   * @param resetKey The {@link StoreKey} at start offset of current index segment. When log segment on source node is
+   *                 compacted (and token becomes invalid), this key is used to find current valid log segment where
+   *                 {@link PersistentIndex#findEntriesSince(FindToken, long)} can start from.
    * @param resetKeyType The {@link PersistentIndex.IndexEntryType} associated with this reset key.
    */
   StoreFindToken(Offset offset, UUID sessionId, UUID incarnationId, boolean inclusive, StoreKey resetKey,
@@ -157,7 +161,9 @@ public class StoreFindToken implements FindToken {
    * @param inclusive {@code true} if the offset is inclusive or in other words the blob at the given offset is inclusive.
    *                  {@code false} otherwise
    * @param version refers to the version of the token
-   * @param resetKey The {@link StoreKey} used to find closest valid starting point in case the index segment the token
+   * @param resetKey The {@link StoreKey} at start offset of current index segment. When log segment on source node is
+   *                 compacted (and token becomes invalid), this key is used to find current valid log segment where
+   *                 {@link PersistentIndex#findEntriesSince(FindToken, long)} can start from.
    * @param resetKeyType The {@link PersistentIndex.IndexEntryType} associated with this reset key.
    */
   StoreFindToken(FindTokenType type, Offset offset, StoreKey key, UUID sessionId, UUID incarnationId, boolean inclusive,

--- a/ambry-store/src/test/java/com/github/ambry/store/CompactionLogTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CompactionLogTest.java
@@ -107,7 +107,7 @@ public class CompactionLogTest {
           cLog.getStartOffsetOfLastIndexSegmentForDeleteCheck());
       StoreFindToken safeToken =
           new StoreFindToken(new MockId("dummy"), new Offset(LogSegmentName.generateFirstSegmentName(true), 0),
-              new UUID(1, 1), new UUID(1, 1), null);
+              new UUID(1, 1), new UUID(1, 1), null, null);
       cLog.setSafeToken(safeToken);
       assertEquals("Returned token not the same as the one that was set", safeToken, cLog.getSafeToken());
       CompactionDetails nextDetails = detailsIterator.hasNext() ? detailsIterator.next() : null;
@@ -170,7 +170,7 @@ public class CompactionLogTest {
           cLog.getStartOffsetOfLastIndexSegmentForDeleteCheck());
       StoreFindToken safeToken =
           new StoreFindToken(new MockId("dummy"), new Offset(LogSegmentName.generateFirstSegmentName(true), 0),
-              new UUID(1, 1), new UUID(1, 1), null);
+              new UUID(1, 1), new UUID(1, 1), null, null);
       cLog.setSafeToken(safeToken);
 
       cLog.close();
@@ -412,7 +412,7 @@ public class CompactionLogTest {
     if (!cLog.getCompactionPhase().equals(CompactionLog.Phase.COPY)) {
       StoreFindToken safeToken =
           new StoreFindToken(new MockId("dummy"), new Offset(LogSegmentName.generateFirstSegmentName(true), 0),
-              new UUID(1, 1), new UUID(1, 1), null);
+              new UUID(1, 1), new UUID(1, 1), null, null);
       try {
         cLog.setSafeToken(safeToken);
         fail("Setting safe token should have failed");

--- a/ambry-store/src/test/java/com/github/ambry/store/CompactionLogTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CompactionLogTest.java
@@ -107,7 +107,7 @@ public class CompactionLogTest {
           cLog.getStartOffsetOfLastIndexSegmentForDeleteCheck());
       StoreFindToken safeToken =
           new StoreFindToken(new MockId("dummy"), new Offset(LogSegmentName.generateFirstSegmentName(true), 0),
-              new UUID(1, 1), new UUID(1, 1));
+              new UUID(1, 1), new UUID(1, 1), null);
       cLog.setSafeToken(safeToken);
       assertEquals("Returned token not the same as the one that was set", safeToken, cLog.getSafeToken());
       CompactionDetails nextDetails = detailsIterator.hasNext() ? detailsIterator.next() : null;
@@ -170,7 +170,7 @@ public class CompactionLogTest {
           cLog.getStartOffsetOfLastIndexSegmentForDeleteCheck());
       StoreFindToken safeToken =
           new StoreFindToken(new MockId("dummy"), new Offset(LogSegmentName.generateFirstSegmentName(true), 0),
-              new UUID(1, 1), new UUID(1, 1));
+              new UUID(1, 1), new UUID(1, 1), null);
       cLog.setSafeToken(safeToken);
 
       cLog.close();
@@ -412,7 +412,7 @@ public class CompactionLogTest {
     if (!cLog.getCompactionPhase().equals(CompactionLog.Phase.COPY)) {
       StoreFindToken safeToken =
           new StoreFindToken(new MockId("dummy"), new Offset(LogSegmentName.generateFirstSegmentName(true), 0),
-              new UUID(1, 1), new UUID(1, 1));
+              new UUID(1, 1), new UUID(1, 1), null);
       try {
         cLog.setSafeToken(safeToken);
         fail("Setting safe token should have failed");

--- a/ambry-store/src/test/java/com/github/ambry/store/IndexTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/IndexTest.java
@@ -979,7 +979,7 @@ public class IndexTest {
 
     // token with log end offset should not return anything
     StoreFindToken token =
-        new StoreFindToken(state.log.getEndOffset(), state.sessionId, state.incarnationId, false, null);
+        new StoreFindToken(state.log.getEndOffset(), state.sessionId, state.incarnationId, false, null, null);
     token.setBytesRead(state.index.getLogUsedCapacity());
     doFindEntriesSinceTest(token, Long.MAX_VALUE, Collections.emptySet(), token);
 
@@ -990,7 +990,7 @@ public class IndexTest {
 
     // error case - can never have provided an index based token that is contains the offset of the last segment
     token = new StoreFindToken(state.referenceIndex.lastEntry().getValue().firstKey(), state.referenceIndex.lastKey(),
-        state.sessionId, state.incarnationId, null);
+        state.sessionId, state.incarnationId, null, null);
     doFindEntriesSinceFailureTest(token, StoreErrorCodes.Unknown_Error);
 
     findEntriesSinceInEmptyIndexTest(false);
@@ -1017,7 +1017,8 @@ public class IndexTest {
 
     // if there is no bad shutdown but the store token is past the index end offset, it is an error state
     StoreFindToken startToken =
-        new StoreFindToken(secondRecordFileSpan.getStartOffset(), new UUID(1, 1), state.incarnationId, false, null);
+        new StoreFindToken(secondRecordFileSpan.getStartOffset(), new UUID(1, 1), state.incarnationId, false, null,
+            null);
     doFindEntriesSinceFailureTest(startToken, StoreErrorCodes.Unknown_Error);
 
     UUID oldSessionId = state.sessionId;
@@ -1042,29 +1043,32 @@ public class IndexTest {
       // create a token that will be past the index end offset on startup after recovery.
       if (incarnationIdToTest == null) {
         startToken = getTokenWithNullIncarnationId(
-            new StoreFindToken(secondRecordFileSpan.getEndOffset(), oldSessionId, state.incarnationId, false, null));
+            new StoreFindToken(secondRecordFileSpan.getEndOffset(), oldSessionId, state.incarnationId, false, null,
+                null));
         assertNull("IncarnationId is expected to be null ", startToken.getIncarnationId());
       } else {
         startToken =
-            new StoreFindToken(secondRecordFileSpan.getEndOffset(), oldSessionId, incarnationIdToTest, false, null);
+            new StoreFindToken(secondRecordFileSpan.getEndOffset(), oldSessionId, incarnationIdToTest, false, null,
+                null);
       }
       // token should get reset internally, no keys should be returned and the returned token should be correct (offset
       // in it will be the current log end offset = firstRecordFileSpan.getEndOffset()).
       StoreFindToken expectedEndToken =
-          new StoreFindToken(firstRecordFileSpan.getEndOffset(), state.sessionId, state.incarnationId, true, null);
+          new StoreFindToken(firstRecordFileSpan.getEndOffset(), state.sessionId, state.incarnationId, true, null, null);
       expectedEndToken.setBytesRead(bytesRead);
       doFindEntriesSinceTest(startToken, Long.MAX_VALUE, Collections.emptySet(), expectedEndToken);
 
       // create a token that is not past the index end offset on startup after recovery. Should work as expected
       if (incarnationIdToTest == null) {
         startToken = getTokenWithNullIncarnationId(
-            new StoreFindToken(lastRecordOffset, oldSessionId, state.incarnationId, false, null));
+            new StoreFindToken(lastRecordOffset, oldSessionId, state.incarnationId, false, null, null));
         assertNull("IncarnationId is expected to be null ", startToken.getIncarnationId());
       } else {
-        startToken = new StoreFindToken(lastRecordOffset, oldSessionId, incarnationIdToTest, false, null);
+        startToken = new StoreFindToken(lastRecordOffset, oldSessionId, incarnationIdToTest, false, null, null);
       }
       expectedEndToken =
-          new StoreFindToken(firstRecordFileSpan.getStartOffset(), state.sessionId, state.incarnationId, false, null);
+          new StoreFindToken(firstRecordFileSpan.getStartOffset(), state.sessionId, state.incarnationId, false, null,
+              null);
       expectedEndToken.setBytesRead(bytesRead);
       doFindEntriesSinceTest(startToken, Long.MAX_VALUE, Collections.singleton(newId), expectedEndToken);
     }
@@ -1099,7 +1103,7 @@ public class IndexTest {
     // this test is valid only when the log has > 1 log segments i.e. when it can undergo compaction.
     if (isLogSegmented) {
       StoreFindToken absoluteEndToken =
-          new StoreFindToken(state.logOrder.lastKey(), state.sessionId, state.incarnationId, false, null);
+          new StoreFindToken(state.logOrder.lastKey(), state.sessionId, state.incarnationId, false, null, null);
       absoluteEndToken.setBytesRead(state.index.getLogUsedCapacity());
 
       Offset firstIndexSegmentStartOffset = state.referenceIndex.firstKey();
@@ -1119,11 +1123,12 @@ public class IndexTest {
       for (Offset invalidOffset : invalidOffsets) {
         // Generate an index based token from invalidOffset
         StoreFindToken startToken =
-            new StoreFindToken(firstIdInFirstIndexSegment, invalidOffset, state.sessionId, state.incarnationId, null);
+            new StoreFindToken(firstIdInFirstIndexSegment, invalidOffset, state.sessionId, state.incarnationId, null,
+                null);
         doFindEntriesSinceTest(startToken, Long.MAX_VALUE, state.allKeys.keySet(), absoluteEndToken);
 
         // Generate a journal based token from invalidOffset (not in journal and is invalid)
-        startToken = new StoreFindToken(invalidOffset, state.sessionId, state.incarnationId, false, null);
+        startToken = new StoreFindToken(invalidOffset, state.sessionId, state.incarnationId, false, null, null);
         doFindEntriesSinceTest(startToken, Long.MAX_VALUE, state.allKeys.keySet(), absoluteEndToken);
       }
     }
@@ -1158,11 +1163,11 @@ public class IndexTest {
     // create a token that will be past the log end offset on start up after restart.
     StoreFindToken startToken = new StoreFindToken(new Offset(state.log.getEndOffset().getName(),
         (state.log.getEndOffset().getOffset() + (2 * CuratedLogIndexState.PUT_RECORD_SIZE))), oldSessionId,
-        state.incarnationId, false, null);
+        state.incarnationId, false, null, null);
     // end token should point to log end offset on startup
     long bytesRead = state.index.getAbsolutePositionInLogForOffset(state.log.getEndOffset());
     StoreFindToken expectedEndToken =
-        new StoreFindToken(state.log.getEndOffset(), state.sessionId, state.incarnationId, true, null);
+        new StoreFindToken(state.log.getEndOffset(), state.sessionId, state.incarnationId, true, null, null);
     expectedEndToken.setBytesRead(bytesRead);
     // Fetch the FindToken returned from findEntriesSince
     FindInfo findInfo = state.index.findEntriesSince(startToken, Long.MAX_VALUE);
@@ -1177,7 +1182,7 @@ public class IndexTest {
     expectedEntries.add(state.logOrder.lastEntry().getValue().getFirst());
     bytesRead = state.index.getAbsolutePositionInLogForOffset(state.index.getCurrentEndOffset());
     expectedEndToken =
-        new StoreFindToken(state.index.journal.getLastOffset(), state.sessionId, state.incarnationId, false, null);
+        new StoreFindToken(state.index.journal.getLastOffset(), state.sessionId, state.incarnationId, false, null, null);
     expectedEndToken.setBytesRead(bytesRead);
     doFindEntriesSinceTest((StoreFindToken) findInfo.getFindToken(), Long.MAX_VALUE, expectedEntries, expectedEndToken);
   }
@@ -1218,20 +1223,22 @@ public class IndexTest {
     long bytesRead = state.index.getAbsolutePositionInLogForOffset(firstRecordFileSpan.getEndOffset());
     // create a token that will be past the index end offset on startup after recovery with old incarnationId
     StoreFindToken startToken =
-        new StoreFindToken(secondRecordFileSpan.getEndOffset(), oldSessionId, oldIncarnationId, false, null);
+        new StoreFindToken(secondRecordFileSpan.getEndOffset(), oldSessionId, oldIncarnationId, false, null, null);
     // token should get reset internally, all keys should be returned and the returned token should be pointing to
     // start offset of firstRecordFileSpan.
     StoreFindToken expectedEndToken =
-        new StoreFindToken(firstRecordFileSpan.getStartOffset(), state.sessionId, state.incarnationId, false, null);
+        new StoreFindToken(firstRecordFileSpan.getStartOffset(), state.sessionId, state.incarnationId, false, null,
+            null);
     expectedEndToken.setBytesRead(bytesRead);
     doFindEntriesSinceTest(startToken, Long.MAX_VALUE, state.allKeys.keySet(), expectedEndToken);
 
     // create a token that is not past the index end offset on startup after recovery with old incarnationId.
     // token should get reset internally, all keys should be returned and the returned token should be be pointing to
     // start offset of firstRecordFileSpan.
-    startToken = new StoreFindToken(lastRecordOffset, oldSessionId, oldIncarnationId, false, null);
+    startToken = new StoreFindToken(lastRecordOffset, oldSessionId, oldIncarnationId, false, null, null);
     expectedEndToken =
-        new StoreFindToken(firstRecordFileSpan.getStartOffset(), state.sessionId, state.incarnationId, false, null);
+        new StoreFindToken(firstRecordFileSpan.getStartOffset(), state.sessionId, state.incarnationId, false, null,
+            null);
     expectedEndToken.setBytesRead(bytesRead);
     doFindEntriesSinceTest(startToken, Long.MAX_VALUE, state.allKeys.keySet(), expectedEndToken);
   }
@@ -1256,7 +1263,7 @@ public class IndexTest {
 
     // token with log end offset should not return anything
     StoreFindToken token =
-        new StoreFindToken(state.log.getEndOffset(), state.sessionId, state.incarnationId, false, null);
+        new StoreFindToken(state.log.getEndOffset(), state.sessionId, state.incarnationId, false, null, null);
     doFindDeletedEntriesSinceTest(token, Long.MAX_VALUE, Collections.emptySet(), token);
 
     findDeletedEntriesSinceToIndexBasedTest();
@@ -2438,10 +2445,10 @@ public class IndexTest {
     maxTotalSizeOfEntries += getSizeOfAllValues(secondIndexSegmentEntry.getValue());
 
     StoreFindToken startToken =
-        new StoreFindToken(firstId, firstIndexSegmentStartOffset, state.sessionId, state.incarnationId, null);
+        new StoreFindToken(firstId, firstIndexSegmentStartOffset, state.sessionId, state.incarnationId, null, null);
     StoreFindToken expectedEndToken =
         new StoreFindToken(secondIndexSegmentEntry.getKey(), secondIndexSegmentStartOffset, state.sessionId,
-            state.incarnationId, null);
+            state.incarnationId, null, null);
     expectedEndToken.setBytesRead(state.index.getAbsolutePositionInLogForOffset(secondIndexSegmentStartOffset));
     doFindEntriesSinceTest(startToken, maxTotalSizeOfEntries, expectedKeys, expectedEndToken);
 
@@ -2456,7 +2463,7 @@ public class IndexTest {
     // ------------------
     // 3. Journal -> Index
     // create a journal based token for an offset that isn't in the journal
-    startToken = new StoreFindToken(state.logOrder.firstKey(), state.sessionId, state.incarnationId, false, null);
+    startToken = new StoreFindToken(state.logOrder.firstKey(), state.sessionId, state.incarnationId, false, null, null);
     doFindEntriesSinceTest(startToken, maxTotalSizeOfEntries, expectedKeys, expectedEndToken);
   }
 
@@ -2471,7 +2478,7 @@ public class IndexTest {
    */
   private void findEntriesSinceToJournalBasedTest() throws StoreException {
     StoreFindToken absoluteEndToken =
-        new StoreFindToken(state.logOrder.lastKey(), state.sessionId, state.incarnationId, false, null);
+        new StoreFindToken(state.logOrder.lastKey(), state.sessionId, state.incarnationId, false, null, null);
     absoluteEndToken.setBytesRead(state.index.getLogUsedCapacity());
 
     // ------------------
@@ -2483,7 +2490,8 @@ public class IndexTest {
     Offset firstIndexSegmentStartOffset = state.referenceIndex.firstKey();
     StoreKey firstStoreKey = state.referenceIndex.get(firstIndexSegmentStartOffset).firstKey();
     StoreFindToken startToken =
-        new StoreFindToken(firstStoreKey, firstIndexSegmentStartOffset, state.sessionId, state.incarnationId, null);
+        new StoreFindToken(firstStoreKey, firstIndexSegmentStartOffset, state.sessionId, state.incarnationId, null,
+            null);
     Set<MockId> expectedKeys = new HashSet<>(state.allKeys.keySet());
     if (!state.deletedKeys.contains(firstStoreKey)) {
       // if firstStoreKey has not been deleted, it will not show up in findEntries since its PUT record is ignored
@@ -2494,12 +2502,13 @@ public class IndexTest {
     // ------------------
     // 3. Journal -> Journal
     // a. Token no longer in journal
-    startToken = new StoreFindToken(state.logOrder.firstKey(), state.sessionId, state.incarnationId, false, null);
+    startToken = new StoreFindToken(state.logOrder.firstKey(), state.sessionId, state.incarnationId, false, null, null);
     doFindEntriesSinceTest(startToken, Long.MAX_VALUE, state.allKeys.keySet(), absoluteEndToken);
 
     // b. Token still in journal
     startToken =
-        new StoreFindToken(state.index.journal.getFirstOffset(), state.sessionId, state.incarnationId, false, null);
+        new StoreFindToken(state.index.journal.getFirstOffset(), state.sessionId, state.incarnationId, false, null,
+            null);
     expectedKeys = new HashSet<>();
     for (Map.Entry<Offset, Pair<MockId, CuratedLogIndexState.LogEntry>> entry : state.logOrder.tailMap(
         startToken.getOffset(), false).entrySet()) {
@@ -2509,7 +2518,7 @@ public class IndexTest {
 
     // c. Token still in journal with inclusiveness set to true
     startToken =
-        new StoreFindToken(state.index.journal.getFirstOffset(), state.sessionId, state.incarnationId, true, null);
+        new StoreFindToken(state.index.journal.getFirstOffset(), state.sessionId, state.incarnationId, true, null, null);
     expectedKeys.add(state.logOrder.tailMap(startToken.getOffset(), true).firstEntry().getValue().getFirst());
     doFindEntriesSinceTest(startToken, Long.MAX_VALUE, expectedKeys, absoluteEndToken);
 
@@ -2538,7 +2547,7 @@ public class IndexTest {
       for (Map.Entry<MockId, TreeSet<IndexValue>> indexSegmentEntry : indexEntry.getValue().entrySet()) {
         MockId id = indexSegmentEntry.getKey();
         StoreFindToken expectedEndToken =
-            new StoreFindToken(id, indexSegmentStartOffset, state.sessionId, state.incarnationId, null);
+            new StoreFindToken(id, indexSegmentStartOffset, state.sessionId, state.incarnationId, null, null);
         expectedEndToken.setBytesRead(state.index.getAbsolutePositionInLogForOffset(indexSegmentStartOffset));
         doFindEntriesSinceTest(startToken, getSizeOfAllValues(indexSegmentEntry.getValue()), Collections.singleton(id),
             expectedEndToken);
@@ -2553,7 +2562,7 @@ public class IndexTest {
       // size returned is the size of the most recent record
       long size = state.getExpectedValue(id, EnumSet.allOf(PersistentIndex.IndexEntryType.class), null).getSize();
       StoreFindToken expectedEndToken =
-          new StoreFindToken(startOffset, state.sessionId, state.incarnationId, false, null);
+          new StoreFindToken(startOffset, state.sessionId, state.incarnationId, false, null, null);
       Offset endOffset = state.log.getFileSpanForMessage(startOffset, size).getEndOffset();
       expectedEndToken.setBytesRead(state.index.getAbsolutePositionInLogForOffset(endOffset));
       doFindEntriesSinceTest(startToken, size, Collections.singleton(id), expectedEndToken);
@@ -2573,7 +2582,7 @@ public class IndexTest {
     Offset nextIndexSegmentStartOffset = state.referenceIndex.higherKey(indexEntry.getKey());
     MockId firstIdInSegment = indexEntry.getValue().firstKey();
     StoreFindToken startToken =
-        new StoreFindToken(firstIdInSegment, indexEntry.getKey(), state.sessionId, state.incarnationId, null);
+        new StoreFindToken(firstIdInSegment, indexEntry.getKey(), state.sessionId, state.incarnationId, null, null);
     long maxSize = 0;
     Set<MockId> expectedKeys = new HashSet<>();
     for (Map.Entry<MockId, TreeSet<IndexValue>> indexSegmentEntry : indexEntry.getValue().entrySet()) {
@@ -2590,7 +2599,7 @@ public class IndexTest {
 
     Offset endOffset = state.log.getFileSpanForMessage(nextIndexSegmentStartOffset, size).getEndOffset();
     StoreFindToken expectedEndToken =
-        new StoreFindToken(nextIndexSegmentStartOffset, state.sessionId, state.incarnationId, false, null);
+        new StoreFindToken(nextIndexSegmentStartOffset, state.sessionId, state.incarnationId, false, null, null);
     expectedEndToken.setBytesRead(state.index.getAbsolutePositionInLogForOffset(endOffset));
     doFindEntriesSinceTest(startToken, maxSize, expectedKeys, expectedEndToken);
   }
@@ -2706,7 +2715,7 @@ public class IndexTest {
     MockId id = (MockId) state.addPutEntries(1, PUT_RECORD_SIZE, expiresAtMs).get(0).getKey();
     state.makePermanent(id, false);
     StoreFindToken expectedEndToken =
-        new StoreFindToken(state.logOrder.lastKey(), state.sessionId, state.incarnationId, false, null);
+        new StoreFindToken(state.logOrder.lastKey(), state.sessionId, state.incarnationId, false, null, null);
     expectedEndToken.setBytesRead(state.index.getLogUsedCapacity());
     doFindEntriesSinceTest(new StoreFindToken(), Long.MAX_VALUE, Collections.singleton(id), expectedEndToken);
     findEntriesSinceOneByOneTest();
@@ -2759,7 +2768,7 @@ public class IndexTest {
    */
   private StoreFindToken getExpectedJournalEndToken(Offset tokenOffset, StoreKey lastKey) {
     StoreFindToken expectedEndToken =
-        new StoreFindToken(tokenOffset, state.sessionId, state.incarnationId, false, null);
+        new StoreFindToken(tokenOffset, state.sessionId, state.incarnationId, false, null, null);
     // the last message's size will be the size of the most recent log entry for its key, not necessarily the entry at
     // tokenOffset. This size is used to calculate bytes read. even if it is not strictly the entry at the log offset
     // of the last journal entry processed.
@@ -2804,9 +2813,9 @@ public class IndexTest {
     }
     StoreFindToken startToken =
         new StoreFindToken(firstSegmentEntry.getKey(), secondIndexSegmentStartOffset, state.sessionId,
-            state.incarnationId, null);
+            state.incarnationId, null, null);
     StoreFindToken expectedEndToken =
-        new StoreFindToken(lastKey, secondIndexSegmentStartOffset, state.sessionId, state.incarnationId, null);
+        new StoreFindToken(lastKey, secondIndexSegmentStartOffset, state.sessionId, state.incarnationId, null, null);
     doFindDeletedEntriesSinceTest(startToken, maxTotalSizeOfEntries, expectedKeys, expectedEndToken);
 
     // ------------------
@@ -2834,7 +2843,7 @@ public class IndexTest {
     // ------------------
     // 3. Journal -> Index
     // create a journal based token for an offset that isn't in the journal
-    startToken = new StoreFindToken(state.logOrder.firstKey(), state.sessionId, state.incarnationId, false, null);
+    startToken = new StoreFindToken(state.logOrder.firstKey(), state.sessionId, state.incarnationId, false, null, null);
     doFindDeletedEntriesSinceTest(startToken, maxTotalSizeOfEntries, expectedKeys, expectedEndToken);
   }
 
@@ -2849,7 +2858,7 @@ public class IndexTest {
    */
   private void findDeletedEntriesSinceToJournalBasedTest() throws StoreException {
     StoreFindToken absoluteEndToken =
-        new StoreFindToken(state.logOrder.lastKey(), state.sessionId, state.incarnationId, false, null);
+        new StoreFindToken(state.logOrder.lastKey(), state.sessionId, state.incarnationId, false, null, null);
 
     // ------------------
     // 1. Uninitialized -> Journal
@@ -2861,7 +2870,8 @@ public class IndexTest {
     // second index segment contains the first delete entry
     StoreKey firstDeletedKey = getDeletedKeyFromIndexSegment(secondIndexSegmentStartOffset);
     StoreFindToken startToken =
-        new StoreFindToken(firstDeletedKey, secondIndexSegmentStartOffset, state.sessionId, state.incarnationId, null);
+        new StoreFindToken(firstDeletedKey, secondIndexSegmentStartOffset, state.sessionId, state.incarnationId, null,
+            null);
     Set<MockId> expectedKeys = new HashSet<>(state.deletedKeys);
     expectedKeys.remove(firstDeletedKey);
     doFindDeletedEntriesSinceTest(startToken, Long.MAX_VALUE, expectedKeys, absoluteEndToken);
@@ -2871,12 +2881,13 @@ public class IndexTest {
     // a. Token no longer in journal
     startToken =
         new StoreFindToken(state.getExpectedValue((MockId) firstDeletedKey, false).getOffset(), state.sessionId,
-            state.incarnationId, false, null);
+            state.incarnationId, false, null, null);
     doFindDeletedEntriesSinceTest(startToken, Long.MAX_VALUE, state.deletedKeys, absoluteEndToken);
 
     // b. Token still in journal
     startToken =
-        new StoreFindToken(state.index.journal.getFirstOffset(), state.sessionId, state.incarnationId, false, null);
+        new StoreFindToken(state.index.journal.getFirstOffset(), state.sessionId, state.incarnationId, false, null,
+            null);
     expectedKeys.clear();
     for (Map.Entry<Offset, Pair<MockId, CuratedLogIndexState.LogEntry>> entry : state.logOrder.tailMap(
         startToken.getOffset(), false).entrySet()) {
@@ -2916,7 +2927,7 @@ public class IndexTest {
             state.getExpectedValue(indexSegmentEntry.getKey(), EnumSet.of(PersistentIndex.IndexEntryType.UNDELETE),
                 null) == null;
         StoreFindToken expectedEndToken =
-            new StoreFindToken(id, indexSegmentStartOffset, state.sessionId, state.incarnationId, null);
+            new StoreFindToken(id, indexSegmentStartOffset, state.sessionId, state.incarnationId, null, null);
         long size = getSizeOfAllValues(indexSegmentEntry.getValue());
         doFindDeletedEntriesSinceTest(startToken, size, isDeleted ? Collections.singleton(id) : Collections.emptySet(),
             expectedEndToken);
@@ -2935,7 +2946,7 @@ public class IndexTest {
       // size returned is the size of the delete if the key has been deleted.
       long size = value.getSize();
       StoreFindToken expectedEndToken =
-          new StoreFindToken(startOffset, state.sessionId, state.incarnationId, false, null);
+          new StoreFindToken(startOffset, state.sessionId, state.incarnationId, false, null, null);
       doFindDeletedEntriesSinceTest(startToken, size, isDeleted ? Collections.singleton(id) : Collections.emptySet(),
           expectedEndToken);
       startToken = expectedEndToken;
@@ -2954,7 +2965,7 @@ public class IndexTest {
     Offset nextIndexSegmentStartOffset = state.referenceIndex.higherKey(indexEntry.getKey());
     MockId firstIdInSegment = indexEntry.getValue().firstKey();
     StoreFindToken startToken =
-        new StoreFindToken(firstIdInSegment, indexEntry.getKey(), state.sessionId, state.incarnationId, null);
+        new StoreFindToken(firstIdInSegment, indexEntry.getKey(), state.sessionId, state.incarnationId, null, null);
     long maxSize = 0;
     Set<MockId> expectedKeys = new HashSet<>();
     for (Map.Entry<MockId, TreeSet<IndexValue>> indexSegmentEntry : indexEntry.getValue().entrySet()) {
@@ -2974,7 +2985,7 @@ public class IndexTest {
     maxSize += size;
 
     StoreFindToken expectedEndToken =
-        new StoreFindToken(nextIndexSegmentStartOffset, state.sessionId, state.incarnationId, false, null);
+        new StoreFindToken(nextIndexSegmentStartOffset, state.sessionId, state.incarnationId, false, null, null);
     doFindDeletedEntriesSinceTest(startToken, maxSize, expectedKeys, expectedEndToken);
   }
 

--- a/ambry-store/src/test/java/com/github/ambry/store/IndexTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/IndexTest.java
@@ -690,7 +690,7 @@ public class IndexTest {
     partitionIndexSegments(toRemoveOne, toRetainOne);
 
     // remove the first batch without adding anything
-    state.index.changeIndexSegments(Collections.EMPTY_LIST, toRemoveOne.keySet());
+    state.index.changeIndexSegments(Collections.emptyList(), toRemoveOne.keySet());
     assertEquals("Offsets in index do not match expected", toRetainOne, state.index.getIndexSegments().keySet());
     // make sure persist does not throw errors
     state.index.persistIndex();
@@ -716,7 +716,7 @@ public class IndexTest {
     for (IndexSegment indexSegment : toRemoveTwo.values()) {
       filesToAdd.add(indexSegment.getFile());
     }
-    state.index.changeIndexSegments(filesToAdd, Collections.EMPTY_SET);
+    state.index.changeIndexSegments(filesToAdd, Collections.emptySet());
     assertEquals("Offsets in index do not match expected", saved, state.index.getIndexSegments().keySet());
     // make sure persist does not throw errors
     state.index.persistIndex();
@@ -724,7 +724,7 @@ public class IndexTest {
     // error case
     // try to remove the last segment (its offset is in the journal)
     try {
-      state.index.changeIndexSegments(Collections.EMPTY_LIST, Collections.singleton(state.referenceIndex.lastKey()));
+      state.index.changeIndexSegments(Collections.emptyList(), Collections.singleton(state.referenceIndex.lastKey()));
       fail("Should have failed to remove index segment because start offset is past the first offset in the journal");
     } catch (IllegalArgumentException e) {
       // expected. Nothing to do.
@@ -736,7 +736,7 @@ public class IndexTest {
     IndexSegment firstSegment = state.index.getIndexSegments().remove(state.index.getIndexSegments().firstKey());
     // try to add it back and it should result in an error
     try {
-      state.index.changeIndexSegments(Collections.singletonList(firstSegment.getFile()), Collections.EMPTY_SET);
+      state.index.changeIndexSegments(Collections.singletonList(firstSegment.getFile()), Collections.emptySet());
       fail("Should have failed to add index segment because its end offset is past the first offset in the journal");
     } catch (IllegalArgumentException e) {
       // expected. Nothing to do.
@@ -852,14 +852,14 @@ public class IndexTest {
           int idx = TestUtils.RANDOM.nextInt(candidateIndexSegments.size());
           IndexSegment segmentToUse = candidateIndexSegments.get(idx);
           // remove the index segment
-          state.index.changeIndexSegments(Collections.EMPTY_LIST, Collections.singleton(segmentToUse.getStartOffset()));
+          state.index.changeIndexSegments(Collections.emptyList(), Collections.singleton(segmentToUse.getStartOffset()));
           // ensure that the relevant index segment is gone.
           if (state.index.getIndexSegments().containsKey(segmentToUse.getStartOffset())) {
             throw new IllegalStateException(
                 "Segment with offset " + segmentToUse.getStartOffset() + " should have been" + " removed.");
           }
           // add it back
-          state.index.changeIndexSegments(Collections.singletonList(segmentToUse.getFile()), Collections.EMPTY_SET);
+          state.index.changeIndexSegments(Collections.singletonList(segmentToUse.getFile()), Collections.emptySet());
           // ensure that the relevant index segment is back.
           if (!state.index.getIndexSegments().containsKey(segmentToUse.getStartOffset())) {
             throw new IllegalStateException(
@@ -968,20 +968,20 @@ public class IndexTest {
    * 5. Error case - trying to findEntriesSince() using an index based token that contains the last index segment
    * 6. Using findEntriesSince() in an empty index
    * 7. Token that has the log end offset
-   * @throws IOException
    * @throws StoreException
    */
   @Test
-  public void findEntriesSinceTest() throws IOException, StoreException {
+  public void findEntriesSinceTest() throws StoreException {
     // add some more entries so that the journal gets entries across segments and doesn't start at the beginning
     // of an index segment.
     state.addPutEntries(7, CuratedLogIndexState.PUT_RECORD_SIZE, Utils.Infinite_Time);
     state.addDeleteEntry(state.getIdToDeleteFromIndexSegment(state.referenceIndex.lastKey(), false));
 
     // token with log end offset should not return anything
-    StoreFindToken token = new StoreFindToken(state.log.getEndOffset(), state.sessionId, state.incarnationId, false);
+    StoreFindToken token =
+        new StoreFindToken(state.log.getEndOffset(), state.sessionId, state.incarnationId, false, null);
     token.setBytesRead(state.index.getLogUsedCapacity());
-    doFindEntriesSinceTest(token, Long.MAX_VALUE, Collections.EMPTY_SET, token);
+    doFindEntriesSinceTest(token, Long.MAX_VALUE, Collections.emptySet(), token);
 
     findEntriesSinceToIndexBasedTest();
     findEntriesSinceToJournalBasedTest();
@@ -990,7 +990,7 @@ public class IndexTest {
 
     // error case - can never have provided an index based token that is contains the offset of the last segment
     token = new StoreFindToken(state.referenceIndex.lastEntry().getValue().firstKey(), state.referenceIndex.lastKey(),
-        state.sessionId, state.incarnationId);
+        state.sessionId, state.incarnationId, null);
     doFindEntriesSinceFailureTest(token, StoreErrorCodes.Unknown_Error);
 
     findEntriesSinceInEmptyIndexTest(false);
@@ -1017,7 +1017,7 @@ public class IndexTest {
 
     // if there is no bad shutdown but the store token is past the index end offset, it is an error state
     StoreFindToken startToken =
-        new StoreFindToken(secondRecordFileSpan.getStartOffset(), new UUID(1, 1), state.incarnationId, false);
+        new StoreFindToken(secondRecordFileSpan.getStartOffset(), new UUID(1, 1), state.incarnationId, false, null);
     doFindEntriesSinceFailureTest(startToken, StoreErrorCodes.Unknown_Error);
 
     UUID oldSessionId = state.sessionId;
@@ -1030,14 +1030,8 @@ public class IndexTest {
         new IndexValue(CuratedLogIndexState.PUT_RECORD_SIZE, firstRecordFileSpan.getStartOffset(), Utils.Infinite_Time,
             operationTimeMs, accountId, containerId);
     state.allKeys.computeIfAbsent(newId, k -> new TreeSet<>()).add(putValue);
-    state.recovery = new MessageStoreRecovery() {
-      @Override
-      public List<MessageInfo> recover(Read read, long startOffset, long endOffset, StoreKeyFactory factory)
-          throws IOException {
-        return Collections.singletonList(
-            new MessageInfo(newId, CuratedLogIndexState.PUT_RECORD_SIZE, accountId, containerId, operationTimeMs));
-      }
-    };
+    state.recovery = (read, startOffset, endOffset, factory) -> Collections.singletonList(
+        new MessageInfo(newId, CuratedLogIndexState.PUT_RECORD_SIZE, accountId, containerId, operationTimeMs));
     state.reloadIndex(true, true);
 
     // If there is no incarnationId in the incoming token, for backwards compatibility purposes we consider it as valid
@@ -1048,28 +1042,29 @@ public class IndexTest {
       // create a token that will be past the index end offset on startup after recovery.
       if (incarnationIdToTest == null) {
         startToken = getTokenWithNullIncarnationId(
-            new StoreFindToken(secondRecordFileSpan.getEndOffset(), oldSessionId, state.incarnationId, false));
+            new StoreFindToken(secondRecordFileSpan.getEndOffset(), oldSessionId, state.incarnationId, false, null));
         assertNull("IncarnationId is expected to be null ", startToken.getIncarnationId());
       } else {
-        startToken = new StoreFindToken(secondRecordFileSpan.getEndOffset(), oldSessionId, incarnationIdToTest, false);
+        startToken =
+            new StoreFindToken(secondRecordFileSpan.getEndOffset(), oldSessionId, incarnationIdToTest, false, null);
       }
       // token should get reset internally, no keys should be returned and the returned token should be correct (offset
       // in it will be the current log end offset = firstRecordFileSpan.getEndOffset()).
       StoreFindToken expectedEndToken =
-          new StoreFindToken(firstRecordFileSpan.getEndOffset(), state.sessionId, state.incarnationId, true);
+          new StoreFindToken(firstRecordFileSpan.getEndOffset(), state.sessionId, state.incarnationId, true, null);
       expectedEndToken.setBytesRead(bytesRead);
-      doFindEntriesSinceTest(startToken, Long.MAX_VALUE, Collections.EMPTY_SET, expectedEndToken);
+      doFindEntriesSinceTest(startToken, Long.MAX_VALUE, Collections.emptySet(), expectedEndToken);
 
       // create a token that is not past the index end offset on startup after recovery. Should work as expected
       if (incarnationIdToTest == null) {
         startToken = getTokenWithNullIncarnationId(
-            new StoreFindToken(lastRecordOffset, oldSessionId, state.incarnationId, false));
+            new StoreFindToken(lastRecordOffset, oldSessionId, state.incarnationId, false, null));
         assertNull("IncarnationId is expected to be null ", startToken.getIncarnationId());
       } else {
-        startToken = new StoreFindToken(lastRecordOffset, oldSessionId, incarnationIdToTest, false);
+        startToken = new StoreFindToken(lastRecordOffset, oldSessionId, incarnationIdToTest, false, null);
       }
       expectedEndToken =
-          new StoreFindToken(firstRecordFileSpan.getStartOffset(), state.sessionId, state.incarnationId, false);
+          new StoreFindToken(firstRecordFileSpan.getStartOffset(), state.sessionId, state.incarnationId, false, null);
       expectedEndToken.setBytesRead(bytesRead);
       doFindEntriesSinceTest(startToken, Long.MAX_VALUE, Collections.singleton(newId), expectedEndToken);
     }
@@ -1104,7 +1099,7 @@ public class IndexTest {
     // this test is valid only when the log has > 1 log segments i.e. when it can undergo compaction.
     if (isLogSegmented) {
       StoreFindToken absoluteEndToken =
-          new StoreFindToken(state.logOrder.lastKey(), state.sessionId, state.incarnationId, false);
+          new StoreFindToken(state.logOrder.lastKey(), state.sessionId, state.incarnationId, false, null);
       absoluteEndToken.setBytesRead(state.index.getLogUsedCapacity());
 
       Offset firstIndexSegmentStartOffset = state.referenceIndex.firstKey();
@@ -1124,11 +1119,11 @@ public class IndexTest {
       for (Offset invalidOffset : invalidOffsets) {
         // Generate an index based token from invalidOffset
         StoreFindToken startToken =
-            new StoreFindToken(firstIdInFirstIndexSegment, invalidOffset, state.sessionId, state.incarnationId);
+            new StoreFindToken(firstIdInFirstIndexSegment, invalidOffset, state.sessionId, state.incarnationId, null);
         doFindEntriesSinceTest(startToken, Long.MAX_VALUE, state.allKeys.keySet(), absoluteEndToken);
 
         // Generate a journal based token from invalidOffset (not in journal and is invalid)
-        startToken = new StoreFindToken(invalidOffset, state.sessionId, state.incarnationId, false);
+        startToken = new StoreFindToken(invalidOffset, state.sessionId, state.incarnationId, false, null);
         doFindEntriesSinceTest(startToken, Long.MAX_VALUE, state.allKeys.keySet(), absoluteEndToken);
       }
     }
@@ -1153,22 +1148,21 @@ public class IndexTest {
    * token to logEndOffsetOnStartup and returns the same.
    * On the subsequent findEntriesSince() call, the index should start returning entries
    * starting from that offset and should not consider that token as non-inclusive
-   * @throws IOException
    * @throws StoreException
    */
   @Test
-  public void findEntriesSinceOnCrashRestartTest() throws IOException, StoreException {
+  public void findEntriesSinceOnCrashRestartTest() throws StoreException {
     UUID oldSessionId = state.sessionId;
     state.addPutEntries(3, CuratedLogIndexState.PUT_RECORD_SIZE, Utils.Infinite_Time);
     state.reloadIndex(true, true);
     // create a token that will be past the log end offset on start up after restart.
     StoreFindToken startToken = new StoreFindToken(new Offset(state.log.getEndOffset().getName(),
         (state.log.getEndOffset().getOffset() + (2 * CuratedLogIndexState.PUT_RECORD_SIZE))), oldSessionId,
-        state.incarnationId, false);
+        state.incarnationId, false, null);
     // end token should point to log end offset on startup
     long bytesRead = state.index.getAbsolutePositionInLogForOffset(state.log.getEndOffset());
     StoreFindToken expectedEndToken =
-        new StoreFindToken(state.log.getEndOffset(), state.sessionId, state.incarnationId, true);
+        new StoreFindToken(state.log.getEndOffset(), state.sessionId, state.incarnationId, true, null);
     expectedEndToken.setBytesRead(bytesRead);
     // Fetch the FindToken returned from findEntriesSince
     FindInfo findInfo = state.index.findEntriesSince(startToken, Long.MAX_VALUE);
@@ -1183,7 +1177,7 @@ public class IndexTest {
     expectedEntries.add(state.logOrder.lastEntry().getValue().getFirst());
     bytesRead = state.index.getAbsolutePositionInLogForOffset(state.index.getCurrentEndOffset());
     expectedEndToken =
-        new StoreFindToken(state.index.journal.getLastOffset(), state.sessionId, state.incarnationId, false);
+        new StoreFindToken(state.index.journal.getLastOffset(), state.sessionId, state.incarnationId, false, null);
     expectedEndToken.setBytesRead(bytesRead);
     doFindEntriesSinceTest((StoreFindToken) findInfo.getFindToken(), Long.MAX_VALUE, expectedEntries, expectedEndToken);
   }
@@ -1215,14 +1209,8 @@ public class IndexTest {
         new IndexValue(CuratedLogIndexState.PUT_RECORD_SIZE, firstRecordFileSpan.getStartOffset(), Utils.Infinite_Time,
             operationTimeMs, accountId, containerId);
     state.allKeys.computeIfAbsent(newId, k -> new TreeSet<>()).add(putValue);
-    state.recovery = new MessageStoreRecovery() {
-      @Override
-      public List<MessageInfo> recover(Read read, long startOffset, long endOffset, StoreKeyFactory factory)
-          throws IOException {
-        return Collections.singletonList(
-            new MessageInfo(newId, CuratedLogIndexState.PUT_RECORD_SIZE, accountId, containerId, operationTimeMs));
-      }
-    };
+    state.recovery = (read, startOffset, endOffset, factory) -> Collections.singletonList(
+        new MessageInfo(newId, CuratedLogIndexState.PUT_RECORD_SIZE, accountId, containerId, operationTimeMs));
     // change in incarnationId
     state.incarnationId = UUID.randomUUID();
     state.reloadIndex(true, true);
@@ -1230,20 +1218,20 @@ public class IndexTest {
     long bytesRead = state.index.getAbsolutePositionInLogForOffset(firstRecordFileSpan.getEndOffset());
     // create a token that will be past the index end offset on startup after recovery with old incarnationId
     StoreFindToken startToken =
-        new StoreFindToken(secondRecordFileSpan.getEndOffset(), oldSessionId, oldIncarnationId, false);
+        new StoreFindToken(secondRecordFileSpan.getEndOffset(), oldSessionId, oldIncarnationId, false, null);
     // token should get reset internally, all keys should be returned and the returned token should be pointing to
     // start offset of firstRecordFileSpan.
     StoreFindToken expectedEndToken =
-        new StoreFindToken(firstRecordFileSpan.getStartOffset(), state.sessionId, state.incarnationId, false);
+        new StoreFindToken(firstRecordFileSpan.getStartOffset(), state.sessionId, state.incarnationId, false, null);
     expectedEndToken.setBytesRead(bytesRead);
     doFindEntriesSinceTest(startToken, Long.MAX_VALUE, state.allKeys.keySet(), expectedEndToken);
 
     // create a token that is not past the index end offset on startup after recovery with old incarnationId.
     // token should get reset internally, all keys should be returned and the returned token should be be pointing to
     // start offset of firstRecordFileSpan.
-    startToken = new StoreFindToken(lastRecordOffset, oldSessionId, oldIncarnationId, false);
+    startToken = new StoreFindToken(lastRecordOffset, oldSessionId, oldIncarnationId, false, null);
     expectedEndToken =
-        new StoreFindToken(firstRecordFileSpan.getStartOffset(), state.sessionId, state.incarnationId, false);
+        new StoreFindToken(firstRecordFileSpan.getStartOffset(), state.sessionId, state.incarnationId, false, null);
     expectedEndToken.setBytesRead(bytesRead);
     doFindEntriesSinceTest(startToken, Long.MAX_VALUE, state.allKeys.keySet(), expectedEndToken);
   }
@@ -1256,11 +1244,10 @@ public class IndexTest {
    * 4. Getting entries using an index based token for an offset in the journal
    * 5. Using findDeletedEntriesSince() in an empty index
    * 6. Token that has the log end offset
-   * @throws IOException
    * @throws StoreException
    */
   @Test
-  public void findDeletedEntriesSinceTest() throws IOException, StoreException {
+  public void findDeletedEntriesSinceTest() throws StoreException {
     // add some more entries so that the journal gets entries across segments and doesn't start at the beginning
     // of an index segment.
     state.addPutEntries(7, CuratedLogIndexState.PUT_RECORD_SIZE, Utils.Infinite_Time);
@@ -1268,8 +1255,9 @@ public class IndexTest {
     state.addDeleteEntry(idToDelete);
 
     // token with log end offset should not return anything
-    StoreFindToken token = new StoreFindToken(state.log.getEndOffset(), state.sessionId, state.incarnationId, false);
-    doFindDeletedEntriesSinceTest(token, Long.MAX_VALUE, Collections.EMPTY_SET, token);
+    StoreFindToken token =
+        new StoreFindToken(state.log.getEndOffset(), state.sessionId, state.incarnationId, false, null);
+    doFindDeletedEntriesSinceTest(token, Long.MAX_VALUE, Collections.emptySet(), token);
 
     findDeletedEntriesSinceToIndexBasedTest();
     findDeletedEntriesSinceToJournalBasedTest();
@@ -2450,10 +2438,10 @@ public class IndexTest {
     maxTotalSizeOfEntries += getSizeOfAllValues(secondIndexSegmentEntry.getValue());
 
     StoreFindToken startToken =
-        new StoreFindToken(firstId, firstIndexSegmentStartOffset, state.sessionId, state.incarnationId);
+        new StoreFindToken(firstId, firstIndexSegmentStartOffset, state.sessionId, state.incarnationId, null);
     StoreFindToken expectedEndToken =
         new StoreFindToken(secondIndexSegmentEntry.getKey(), secondIndexSegmentStartOffset, state.sessionId,
-            state.incarnationId);
+            state.incarnationId, null);
     expectedEndToken.setBytesRead(state.index.getAbsolutePositionInLogForOffset(secondIndexSegmentStartOffset));
     doFindEntriesSinceTest(startToken, maxTotalSizeOfEntries, expectedKeys, expectedEndToken);
 
@@ -2468,7 +2456,7 @@ public class IndexTest {
     // ------------------
     // 3. Journal -> Index
     // create a journal based token for an offset that isn't in the journal
-    startToken = new StoreFindToken(state.logOrder.firstKey(), state.sessionId, state.incarnationId, false);
+    startToken = new StoreFindToken(state.logOrder.firstKey(), state.sessionId, state.incarnationId, false, null);
     doFindEntriesSinceTest(startToken, maxTotalSizeOfEntries, expectedKeys, expectedEndToken);
   }
 
@@ -2483,7 +2471,7 @@ public class IndexTest {
    */
   private void findEntriesSinceToJournalBasedTest() throws StoreException {
     StoreFindToken absoluteEndToken =
-        new StoreFindToken(state.logOrder.lastKey(), state.sessionId, state.incarnationId, false);
+        new StoreFindToken(state.logOrder.lastKey(), state.sessionId, state.incarnationId, false, null);
     absoluteEndToken.setBytesRead(state.index.getLogUsedCapacity());
 
     // ------------------
@@ -2495,7 +2483,7 @@ public class IndexTest {
     Offset firstIndexSegmentStartOffset = state.referenceIndex.firstKey();
     StoreKey firstStoreKey = state.referenceIndex.get(firstIndexSegmentStartOffset).firstKey();
     StoreFindToken startToken =
-        new StoreFindToken(firstStoreKey, firstIndexSegmentStartOffset, state.sessionId, state.incarnationId);
+        new StoreFindToken(firstStoreKey, firstIndexSegmentStartOffset, state.sessionId, state.incarnationId, null);
     Set<MockId> expectedKeys = new HashSet<>(state.allKeys.keySet());
     if (!state.deletedKeys.contains(firstStoreKey)) {
       // if firstStoreKey has not been deleted, it will not show up in findEntries since its PUT record is ignored
@@ -2506,11 +2494,12 @@ public class IndexTest {
     // ------------------
     // 3. Journal -> Journal
     // a. Token no longer in journal
-    startToken = new StoreFindToken(state.logOrder.firstKey(), state.sessionId, state.incarnationId, false);
+    startToken = new StoreFindToken(state.logOrder.firstKey(), state.sessionId, state.incarnationId, false, null);
     doFindEntriesSinceTest(startToken, Long.MAX_VALUE, state.allKeys.keySet(), absoluteEndToken);
 
     // b. Token still in journal
-    startToken = new StoreFindToken(state.index.journal.getFirstOffset(), state.sessionId, state.incarnationId, false);
+    startToken =
+        new StoreFindToken(state.index.journal.getFirstOffset(), state.sessionId, state.incarnationId, false, null);
     expectedKeys = new HashSet<>();
     for (Map.Entry<Offset, Pair<MockId, CuratedLogIndexState.LogEntry>> entry : state.logOrder.tailMap(
         startToken.getOffset(), false).entrySet()) {
@@ -2519,13 +2508,14 @@ public class IndexTest {
     doFindEntriesSinceTest(startToken, Long.MAX_VALUE, expectedKeys, absoluteEndToken);
 
     // c. Token still in journal with inclusiveness set to true
-    startToken = new StoreFindToken(state.index.journal.getFirstOffset(), state.sessionId, state.incarnationId, true);
+    startToken =
+        new StoreFindToken(state.index.journal.getFirstOffset(), state.sessionId, state.incarnationId, true, null);
     expectedKeys.add(state.logOrder.tailMap(startToken.getOffset(), true).firstEntry().getValue().getFirst());
     doFindEntriesSinceTest(startToken, Long.MAX_VALUE, expectedKeys, absoluteEndToken);
 
     // ------------------
     // 4. Journal no change
-    doFindEntriesSinceTest(absoluteEndToken, Long.MAX_VALUE, Collections.EMPTY_SET, absoluteEndToken);
+    doFindEntriesSinceTest(absoluteEndToken, Long.MAX_VALUE, Collections.emptySet(), absoluteEndToken);
   }
 
   /**
@@ -2548,7 +2538,7 @@ public class IndexTest {
       for (Map.Entry<MockId, TreeSet<IndexValue>> indexSegmentEntry : indexEntry.getValue().entrySet()) {
         MockId id = indexSegmentEntry.getKey();
         StoreFindToken expectedEndToken =
-            new StoreFindToken(id, indexSegmentStartOffset, state.sessionId, state.incarnationId);
+            new StoreFindToken(id, indexSegmentStartOffset, state.sessionId, state.incarnationId, null);
         expectedEndToken.setBytesRead(state.index.getAbsolutePositionInLogForOffset(indexSegmentStartOffset));
         doFindEntriesSinceTest(startToken, getSizeOfAllValues(indexSegmentEntry.getValue()), Collections.singleton(id),
             expectedEndToken);
@@ -2562,7 +2552,8 @@ public class IndexTest {
       MockId id = logEntry.getValue().getFirst();
       // size returned is the size of the most recent record
       long size = state.getExpectedValue(id, EnumSet.allOf(PersistentIndex.IndexEntryType.class), null).getSize();
-      StoreFindToken expectedEndToken = new StoreFindToken(startOffset, state.sessionId, state.incarnationId, false);
+      StoreFindToken expectedEndToken =
+          new StoreFindToken(startOffset, state.sessionId, state.incarnationId, false, null);
       Offset endOffset = state.log.getFileSpanForMessage(startOffset, size).getEndOffset();
       expectedEndToken.setBytesRead(state.index.getAbsolutePositionInLogForOffset(endOffset));
       doFindEntriesSinceTest(startToken, size, Collections.singleton(id), expectedEndToken);
@@ -2582,7 +2573,7 @@ public class IndexTest {
     Offset nextIndexSegmentStartOffset = state.referenceIndex.higherKey(indexEntry.getKey());
     MockId firstIdInSegment = indexEntry.getValue().firstKey();
     StoreFindToken startToken =
-        new StoreFindToken(firstIdInSegment, indexEntry.getKey(), state.sessionId, state.incarnationId);
+        new StoreFindToken(firstIdInSegment, indexEntry.getKey(), state.sessionId, state.incarnationId, null);
     long maxSize = 0;
     Set<MockId> expectedKeys = new HashSet<>();
     for (Map.Entry<MockId, TreeSet<IndexValue>> indexSegmentEntry : indexEntry.getValue().entrySet()) {
@@ -2599,7 +2590,7 @@ public class IndexTest {
 
     Offset endOffset = state.log.getFileSpanForMessage(nextIndexSegmentStartOffset, size).getEndOffset();
     StoreFindToken expectedEndToken =
-        new StoreFindToken(nextIndexSegmentStartOffset, state.sessionId, state.incarnationId, false);
+        new StoreFindToken(nextIndexSegmentStartOffset, state.sessionId, state.incarnationId, false, null);
     expectedEndToken.setBytesRead(state.index.getAbsolutePositionInLogForOffset(endOffset));
     doFindEntriesSinceTest(startToken, maxSize, expectedKeys, expectedEndToken);
   }
@@ -2696,9 +2687,9 @@ public class IndexTest {
     StoreFindToken token = new StoreFindToken();
     token.setBytesRead(0);
     if (deletedEntries) {
-      doFindDeletedEntriesSinceTest(token, Long.MAX_VALUE, Collections.EMPTY_SET, token);
+      doFindDeletedEntriesSinceTest(token, Long.MAX_VALUE, Collections.emptySet(), token);
     } else {
-      doFindEntriesSinceTest(token, Long.MAX_VALUE, Collections.EMPTY_SET, token);
+      doFindEntriesSinceTest(token, Long.MAX_VALUE, Collections.emptySet(), token);
     }
   }
 
@@ -2715,7 +2706,7 @@ public class IndexTest {
     MockId id = (MockId) state.addPutEntries(1, PUT_RECORD_SIZE, expiresAtMs).get(0).getKey();
     state.makePermanent(id, false);
     StoreFindToken expectedEndToken =
-        new StoreFindToken(state.logOrder.lastKey(), state.sessionId, state.incarnationId, false);
+        new StoreFindToken(state.logOrder.lastKey(), state.sessionId, state.incarnationId, false, null);
     expectedEndToken.setBytesRead(state.index.getLogUsedCapacity());
     doFindEntriesSinceTest(new StoreFindToken(), Long.MAX_VALUE, Collections.singleton(id), expectedEndToken);
     findEntriesSinceOneByOneTest();
@@ -2767,7 +2758,8 @@ public class IndexTest {
    * @return a {@link StoreFindToken} with bytes read set.
    */
   private StoreFindToken getExpectedJournalEndToken(Offset tokenOffset, StoreKey lastKey) {
-    StoreFindToken expectedEndToken = new StoreFindToken(tokenOffset, state.sessionId, state.incarnationId, false);
+    StoreFindToken expectedEndToken =
+        new StoreFindToken(tokenOffset, state.sessionId, state.incarnationId, false, null);
     // the last message's size will be the size of the most recent log entry for its key, not necessarily the entry at
     // tokenOffset. This size is used to calculate bytes read. even if it is not strictly the entry at the log offset
     // of the last journal entry processed.
@@ -2812,9 +2804,9 @@ public class IndexTest {
     }
     StoreFindToken startToken =
         new StoreFindToken(firstSegmentEntry.getKey(), secondIndexSegmentStartOffset, state.sessionId,
-            state.incarnationId);
+            state.incarnationId, null);
     StoreFindToken expectedEndToken =
-        new StoreFindToken(lastKey, secondIndexSegmentStartOffset, state.sessionId, state.incarnationId);
+        new StoreFindToken(lastKey, secondIndexSegmentStartOffset, state.sessionId, state.incarnationId, null);
     doFindDeletedEntriesSinceTest(startToken, maxTotalSizeOfEntries, expectedKeys, expectedEndToken);
 
     // ------------------
@@ -2842,7 +2834,7 @@ public class IndexTest {
     // ------------------
     // 3. Journal -> Index
     // create a journal based token for an offset that isn't in the journal
-    startToken = new StoreFindToken(state.logOrder.firstKey(), state.sessionId, state.incarnationId, false);
+    startToken = new StoreFindToken(state.logOrder.firstKey(), state.sessionId, state.incarnationId, false, null);
     doFindDeletedEntriesSinceTest(startToken, maxTotalSizeOfEntries, expectedKeys, expectedEndToken);
   }
 
@@ -2857,7 +2849,7 @@ public class IndexTest {
    */
   private void findDeletedEntriesSinceToJournalBasedTest() throws StoreException {
     StoreFindToken absoluteEndToken =
-        new StoreFindToken(state.logOrder.lastKey(), state.sessionId, state.incarnationId, false);
+        new StoreFindToken(state.logOrder.lastKey(), state.sessionId, state.incarnationId, false, null);
 
     // ------------------
     // 1. Uninitialized -> Journal
@@ -2869,7 +2861,7 @@ public class IndexTest {
     // second index segment contains the first delete entry
     StoreKey firstDeletedKey = getDeletedKeyFromIndexSegment(secondIndexSegmentStartOffset);
     StoreFindToken startToken =
-        new StoreFindToken(firstDeletedKey, secondIndexSegmentStartOffset, state.sessionId, state.incarnationId);
+        new StoreFindToken(firstDeletedKey, secondIndexSegmentStartOffset, state.sessionId, state.incarnationId, null);
     Set<MockId> expectedKeys = new HashSet<>(state.deletedKeys);
     expectedKeys.remove(firstDeletedKey);
     doFindDeletedEntriesSinceTest(startToken, Long.MAX_VALUE, expectedKeys, absoluteEndToken);
@@ -2879,11 +2871,12 @@ public class IndexTest {
     // a. Token no longer in journal
     startToken =
         new StoreFindToken(state.getExpectedValue((MockId) firstDeletedKey, false).getOffset(), state.sessionId,
-            state.incarnationId, false);
+            state.incarnationId, false, null);
     doFindDeletedEntriesSinceTest(startToken, Long.MAX_VALUE, state.deletedKeys, absoluteEndToken);
 
     // b. Token still in journal
-    startToken = new StoreFindToken(state.index.journal.getFirstOffset(), state.sessionId, state.incarnationId, false);
+    startToken =
+        new StoreFindToken(state.index.journal.getFirstOffset(), state.sessionId, state.incarnationId, false, null);
     expectedKeys.clear();
     for (Map.Entry<Offset, Pair<MockId, CuratedLogIndexState.LogEntry>> entry : state.logOrder.tailMap(
         startToken.getOffset(), false).entrySet()) {
@@ -2897,7 +2890,7 @@ public class IndexTest {
 
     // ------------------
     // 4. Journal no change
-    doFindDeletedEntriesSinceTest(absoluteEndToken, Long.MAX_VALUE, Collections.EMPTY_SET, absoluteEndToken);
+    doFindDeletedEntriesSinceTest(absoluteEndToken, Long.MAX_VALUE, Collections.emptySet(), absoluteEndToken);
   }
 
   /**
@@ -2923,9 +2916,9 @@ public class IndexTest {
             state.getExpectedValue(indexSegmentEntry.getKey(), EnumSet.of(PersistentIndex.IndexEntryType.UNDELETE),
                 null) == null;
         StoreFindToken expectedEndToken =
-            new StoreFindToken(id, indexSegmentStartOffset, state.sessionId, state.incarnationId);
+            new StoreFindToken(id, indexSegmentStartOffset, state.sessionId, state.incarnationId, null);
         long size = getSizeOfAllValues(indexSegmentEntry.getValue());
-        doFindDeletedEntriesSinceTest(startToken, size, isDeleted ? Collections.singleton(id) : Collections.EMPTY_SET,
+        doFindDeletedEntriesSinceTest(startToken, size, isDeleted ? Collections.singleton(id) : Collections.emptySet(),
             expectedEndToken);
         startToken = expectedEndToken;
       }
@@ -2941,8 +2934,9 @@ public class IndexTest {
       ;
       // size returned is the size of the delete if the key has been deleted.
       long size = value.getSize();
-      StoreFindToken expectedEndToken = new StoreFindToken(startOffset, state.sessionId, state.incarnationId, false);
-      doFindDeletedEntriesSinceTest(startToken, size, isDeleted ? Collections.singleton(id) : Collections.EMPTY_SET,
+      StoreFindToken expectedEndToken =
+          new StoreFindToken(startOffset, state.sessionId, state.incarnationId, false, null);
+      doFindDeletedEntriesSinceTest(startToken, size, isDeleted ? Collections.singleton(id) : Collections.emptySet(),
           expectedEndToken);
       startToken = expectedEndToken;
       logEntry = state.logOrder.higherEntry(logEntry.getKey());
@@ -2960,7 +2954,7 @@ public class IndexTest {
     Offset nextIndexSegmentStartOffset = state.referenceIndex.higherKey(indexEntry.getKey());
     MockId firstIdInSegment = indexEntry.getValue().firstKey();
     StoreFindToken startToken =
-        new StoreFindToken(firstIdInSegment, indexEntry.getKey(), state.sessionId, state.incarnationId);
+        new StoreFindToken(firstIdInSegment, indexEntry.getKey(), state.sessionId, state.incarnationId, null);
     long maxSize = 0;
     Set<MockId> expectedKeys = new HashSet<>();
     for (Map.Entry<MockId, TreeSet<IndexValue>> indexSegmentEntry : indexEntry.getValue().entrySet()) {
@@ -2980,7 +2974,7 @@ public class IndexTest {
     maxSize += size;
 
     StoreFindToken expectedEndToken =
-        new StoreFindToken(nextIndexSegmentStartOffset, state.sessionId, state.incarnationId, false);
+        new StoreFindToken(nextIndexSegmentStartOffset, state.sessionId, state.incarnationId, false, null);
     doFindDeletedEntriesSinceTest(startToken, maxSize, expectedKeys, expectedEndToken);
   }
 

--- a/ambry-store/src/test/java/com/github/ambry/store/StoreFindTokenTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/StoreFindTokenTest.java
@@ -23,12 +23,14 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.UUID;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import static com.github.ambry.store.StoreFindToken.*;
 import static org.junit.Assert.*;
 
 
@@ -74,15 +76,24 @@ public class StoreFindTokenTest {
     Offset otherOffset = new Offset(logSegmentName, 1);
     MockId key = new MockId(TestUtils.getRandomString(10));
     MockId otherKey = new MockId(TestUtils.getRandomString(10));
+    MockId resetKey = new MockId(TestUtils.getRandomString(10));
 
     StoreFindToken initToken = new StoreFindToken();
     StoreFindToken otherInitToken = new StoreFindToken();
-    StoreFindToken indexToken = new StoreFindToken(key, offset, sessionId, incarnationId);
-    StoreFindToken otherIndexToken = new StoreFindToken(key, offset, sessionId, incarnationId);
-    StoreFindToken journalToken = new StoreFindToken(offset, sessionId, incarnationId, false);
-    StoreFindToken otherJournalToken = new StoreFindToken(offset, sessionId, incarnationId, false);
-    StoreFindToken inclusiveJournalToken = new StoreFindToken(offset, sessionId, incarnationId, true);
-    StoreFindToken otherInclusiveJournalToken = new StoreFindToken(offset, sessionId, incarnationId, true);
+    StoreFindToken indexToken = new StoreFindToken(key, offset, sessionId, incarnationId, null);
+    StoreFindToken otherIndexToken = new StoreFindToken(key, offset, sessionId, incarnationId, null);
+    StoreFindToken journalToken = new StoreFindToken(offset, sessionId, incarnationId, false, null);
+    StoreFindToken otherJournalToken = new StoreFindToken(offset, sessionId, incarnationId, false, null);
+    StoreFindToken inclusiveJournalToken = new StoreFindToken(offset, sessionId, incarnationId, true, null);
+    StoreFindToken otherInclusiveJournalToken = new StoreFindToken(offset, sessionId, incarnationId, true, null);
+    StoreFindToken v3JournalToken = new StoreFindToken(FindTokenType.JournalBased, offset, key, sessionId, incarnationId,
+    true, VERSION_3, resetKey);
+    StoreFindToken otherV3JournalToken = new StoreFindToken(FindTokenType.JournalBased, offset, key, sessionId, incarnationId,
+        true, VERSION_3, resetKey);
+    StoreFindToken v3IndexToken =
+        new StoreFindToken(FindTokenType.IndexBased, offset, key, sessionId, incarnationId, true, VERSION_3, resetKey);
+    StoreFindToken otherV3IndexToken =
+        new StoreFindToken(FindTokenType.IndexBased, offset, key, sessionId, incarnationId, true, VERSION_3, resetKey);
 
     // equality
     compareTokens(initToken, initToken);
@@ -92,17 +103,31 @@ public class StoreFindTokenTest {
     compareTokens(journalToken, journalToken);
     compareTokens(journalToken, otherJournalToken);
     compareTokens(inclusiveJournalToken, otherInclusiveJournalToken);
+    compareTokens(v3JournalToken, v3JournalToken);
+    compareTokens(v3JournalToken, otherV3JournalToken);
+    compareTokens(v3IndexToken, v3IndexToken);
+    compareTokens(v3IndexToken, otherV3IndexToken);
 
     UUID newSessionId = getRandomUUID(sessionId);
     UUID newIncarnationId = getRandomUUID(incarnationId);
 
     // equality even if session IDs are different
-    compareTokens(indexToken, new StoreFindToken(key, offset, newSessionId, incarnationId));
-    compareTokens(journalToken, new StoreFindToken(offset, newSessionId, incarnationId, false));
+    compareTokens(indexToken, new StoreFindToken(key, offset, newSessionId, incarnationId, null));
+    compareTokens(journalToken, new StoreFindToken(offset, newSessionId, incarnationId, false, null));
+    compareTokens(v3JournalToken, new StoreFindToken(FindTokenType.JournalBased, offset, key, newSessionId, incarnationId,
+        true, VERSION_3, resetKey));
+    compareTokens(v3IndexToken, new StoreFindToken(FindTokenType.IndexBased, offset, key, newSessionId, incarnationId,
+        true, VERSION_3, resetKey));
 
     // equality even if incarnation IDs are different
-    compareTokens(indexToken, new StoreFindToken(key, offset, sessionId, newIncarnationId));
-    compareTokens(journalToken, new StoreFindToken(offset, sessionId, newIncarnationId, false));
+    compareTokens(indexToken, new StoreFindToken(key, offset, sessionId, newIncarnationId, null));
+    compareTokens(journalToken, new StoreFindToken(offset, sessionId, newIncarnationId, false, null));
+    compareTokens(v3JournalToken,
+        new StoreFindToken(FindTokenType.JournalBased, offset, key, sessionId, newIncarnationId, true, VERSION_3,
+            resetKey));
+    compareTokens(v3IndexToken,
+        new StoreFindToken(FindTokenType.IndexBased, offset, key, sessionId, newIncarnationId, true, VERSION_3,
+            resetKey));
 
     // inequality if some fields differ
     List<Pair<StoreFindToken, StoreFindToken>> unequalPairs = new ArrayList<>();
@@ -111,10 +136,11 @@ public class StoreFindTokenTest {
     unequalPairs.add(new Pair<>(initToken, inclusiveJournalToken));
     unequalPairs.add(new Pair<>(indexToken, journalToken));
     unequalPairs.add(new Pair<>(indexToken, inclusiveJournalToken));
-    unequalPairs.add(new Pair<>(indexToken, new StoreFindToken(key, otherOffset, sessionId, incarnationId)));
-    unequalPairs.add(new Pair<>(indexToken, new StoreFindToken(otherKey, offset, sessionId, incarnationId)));
-    unequalPairs.add(new Pair<>(journalToken, new StoreFindToken(otherOffset, sessionId, incarnationId, false)));
+    unequalPairs.add(new Pair<>(indexToken, new StoreFindToken(key, otherOffset, sessionId, incarnationId, null)));
+    unequalPairs.add(new Pair<>(indexToken, new StoreFindToken(otherKey, offset, sessionId, incarnationId, null)));
+    unequalPairs.add(new Pair<>(journalToken, new StoreFindToken(otherOffset, sessionId, incarnationId, false, null)));
     unequalPairs.add(new Pair<>(inclusiveJournalToken, journalToken));
+    unequalPairs.add(new Pair<>(indexToken, new StoreFindToken(key, offset, sessionId, incarnationId, resetKey)));
 
     for (Pair<StoreFindToken, StoreFindToken> unequalPair : unequalPairs) {
       StoreFindToken first = unequalPair.getFirst();
@@ -135,33 +161,38 @@ public class StoreFindTokenTest {
     LogSegmentName logSegmentName = LogSegmentName.generateFirstSegmentName(isLogSegmented);
     Offset offset = new Offset(logSegmentName, 0);
     MockId key = new MockId(TestUtils.getRandomString(10));
-
+    MockId resetKey = new MockId(TestUtils.getRandomString(10));
     if (!isLogSegmented) {
       // UnInitialized
-      doSerDeTest(new StoreFindToken(), StoreFindToken.VERSION_0, StoreFindToken.VERSION_1, StoreFindToken.VERSION_2);
+      doSerDeTest(new StoreFindToken(), VERSION_0, VERSION_1, VERSION_2, VERSION_3);
 
       // Journal based token
-      doSerDeTest(new StoreFindToken(offset, sessionId, incarnationId, false), StoreFindToken.VERSION_0,
-          StoreFindToken.VERSION_1, StoreFindToken.VERSION_2);
-      // inclusiveness is present only in VERSION_2
-      doSerDeTest(new StoreFindToken(offset, sessionId, incarnationId, true), StoreFindToken.VERSION_2);
+      doSerDeTest(new StoreFindToken(offset, sessionId, incarnationId, false, null), VERSION_0, VERSION_1, VERSION_2);
+      // Journal based token (VERSION_3)
+      doSerDeTest(new StoreFindToken(offset, sessionId, incarnationId, false, resetKey), VERSION_3);
+
+      // inclusiveness is present only in {VERSION_2, VERSION_3}
+      doSerDeTest(new StoreFindToken(offset, sessionId, incarnationId, true, null), VERSION_2);
+      doSerDeTest(new StoreFindToken(offset, sessionId, incarnationId, true, resetKey), VERSION_3);
 
       // Index based
-      doSerDeTest(new StoreFindToken(key, offset, sessionId, incarnationId), StoreFindToken.VERSION_0,
-          StoreFindToken.VERSION_1, StoreFindToken.VERSION_2);
+      doSerDeTest(new StoreFindToken(key, offset, sessionId, incarnationId, null), VERSION_0, VERSION_1, VERSION_2);
+      doSerDeTest(new StoreFindToken(key, offset, sessionId, incarnationId, resetKey), VERSION_3);
     } else {
       // UnInitialized
-      doSerDeTest(new StoreFindToken(), StoreFindToken.VERSION_1, StoreFindToken.VERSION_2);
+      doSerDeTest(new StoreFindToken(), VERSION_1, VERSION_2);
 
       // Journal based token
-      doSerDeTest(new StoreFindToken(offset, sessionId, incarnationId, false), StoreFindToken.VERSION_1,
-          StoreFindToken.VERSION_2);
+      doSerDeTest(new StoreFindToken(offset, sessionId, incarnationId, false, null), VERSION_1, VERSION_2);
+      doSerDeTest(new StoreFindToken(offset, sessionId, incarnationId, false, resetKey), VERSION_3);
+
       // inclusiveness is present only in VERSION_2
-      doSerDeTest(new StoreFindToken(offset, sessionId, incarnationId, true), StoreFindToken.VERSION_2);
+      doSerDeTest(new StoreFindToken(offset, sessionId, incarnationId, true, null), VERSION_2);
+      doSerDeTest(new StoreFindToken(offset, sessionId, incarnationId, true, resetKey), VERSION_3);
 
       // Index based
-      doSerDeTest(new StoreFindToken(key, offset, sessionId, incarnationId), StoreFindToken.VERSION_1,
-          StoreFindToken.VERSION_2);
+      doSerDeTest(new StoreFindToken(key, offset, sessionId, incarnationId, null), VERSION_1, VERSION_2);
+      doSerDeTest(new StoreFindToken(key, offset, sessionId, incarnationId, resetKey), VERSION_3);
     }
   }
 
@@ -185,10 +216,21 @@ public class StoreFindTokenTest {
 
     // no key in IndexBased
     try {
-      new StoreFindToken(null, offset, sessionId, null);
+      new StoreFindToken(null, offset, sessionId, null, null);
       fail("Construction of StoreFindToken should have failed");
     } catch (IllegalArgumentException e) {
       // expected. Nothing to do.
+    }
+
+    // version 3 token without reset key
+    for (FindTokenType type : EnumSet.of(FindTokenType.JournalBased, FindTokenType.IndexBased)) {
+      try {
+        new StoreFindToken(type, offset, key, sessionId, incarnationId, type == FindTokenType.JournalBased, VERSION_3,
+            null);
+        fail("Construction of StoreFindToken should have failed because rest key is null.");
+      } catch (IllegalArgumentException e) {
+        // expected
+      }
     }
   }
 
@@ -222,19 +264,25 @@ public class StoreFindTokenTest {
       assertEquals("Version mismatch for token ", version.shortValue(), deSerToken.getVersion());
       compareTokens(token, deSerToken);
       assertEquals("SessionId does not match", token.getSessionId(), deSerToken.getSessionId());
-      if (version == StoreFindToken.VERSION_2) {
+      if (version >= VERSION_2) {
         assertEquals("IncarnationId mismatch ", token.getIncarnationId(), deSerToken.getIncarnationId());
       }
-      // use StoreFindToken's actual serialize method to verify that token is serialized in the expected
-      // version
-      stream = new DataInputStream(new ByteBufferInputStream(ByteBuffer.wrap(deSerToken.toBytes())));
-      deSerToken = StoreFindToken.fromBytes(stream, STORE_KEY_FACTORY);
-      assertEquals("Stream should have ended ", 0, stream.available());
-      assertEquals("Version mismatch for token ", version.shortValue(), deSerToken.getVersion());
-      compareTokens(token, deSerToken);
-      assertEquals("SessionId does not match", token.getSessionId(), deSerToken.getSessionId());
-      if (version == StoreFindToken.VERSION_2) {
-        assertEquals("IncarnationId mismatch ", token.getIncarnationId(), deSerToken.getIncarnationId());
+      if (version == VERSION_3) {
+        assertEquals("Reset key mismatch ", token.getResetKey(), deSerToken.getResetKey());
+      }
+      // TODO remove this "if" condition when StoreFindToken's serialize method supports VERSION 3.
+      if (version < VERSION_3) {
+        // use StoreFindToken's actual serialize method to verify that token is serialized in the expected
+        // version
+        stream = new DataInputStream(new ByteBufferInputStream(ByteBuffer.wrap(deSerToken.toBytes())));
+        deSerToken = StoreFindToken.fromBytes(stream, STORE_KEY_FACTORY);
+        assertEquals("Stream should have ended ", 0, stream.available());
+        assertEquals("Version mismatch for token ", version.shortValue(), deSerToken.getVersion());
+        compareTokens(token, deSerToken);
+        assertEquals("SessionId does not match", token.getSessionId(), deSerToken.getSessionId());
+        if (version >= VERSION_2) {
+          assertEquals("IncarnationId mismatch ", token.getIncarnationId(), deSerToken.getIncarnationId());
+        }
       }
     }
   }
@@ -247,23 +295,23 @@ public class StoreFindTokenTest {
    */
   static DataInputStream getSerializedStream(StoreFindToken token, short version) {
     byte[] bytes;
+    FindTokenType type = token.getType();
+    byte[] sessionIdBytes = token.getSessionIdInBytes();
+    byte[] storeKeyInBytes = token.getStoreKeyInBytes();
     switch (version) {
       case StoreFindToken.VERSION_0:
-        UUID sessionId = token.getSessionId();
-        StoreKey key = token.getStoreKey();
         // version size + sessionId length size + session id size + log offset size + index segment start offset size
         // + store key size
-        int size = 2 + 4 + (sessionId == null ? 0 : sessionId.toString().getBytes().length) + 8 + 8 + (key == null ? 0
-            : key.sizeInBytes());
+        int size = 2 + 4 + sessionIdBytes.length + 8 + 8 + storeKeyInBytes.length;
         bytes = new byte[size];
         ByteBuffer bufWrap = ByteBuffer.wrap(bytes);
         // add version
         bufWrap.putShort(StoreFindToken.VERSION_0);
         // add sessionId
-        Utils.serializeNullableString(bufWrap, sessionId == null ? null : sessionId.toString());
+        bufWrap.putInt(sessionIdBytes.length);
+        bufWrap.put(sessionIdBytes);
         long logOffset = -1;
         long indexStartOffset = -1;
-        FindTokenType type = token.getType();
         if (type.equals(FindTokenType.JournalBased)) {
           logOffset = token.getOffset().getOffset();
         } else if (type.equals(FindTokenType.IndexBased)) {
@@ -273,35 +321,106 @@ public class StoreFindTokenTest {
         bufWrap.putLong(logOffset);
         // add index start offset
         bufWrap.putLong(indexStartOffset);
-        // add storekey
-        if (key != null) {
-          bufWrap.put(key.toBytes());
+        // add storeKey
+        if (storeKeyInBytes.length > 0) {
+          bufWrap.put(storeKeyInBytes);
         }
         break;
       case StoreFindToken.VERSION_1:
-        sessionId = token.getSessionId();
-        key = token.getStoreKey();
-        byte[] offsetBytes = token.getOffset() != null ? token.getOffset().toBytes() : new byte[0];
+        byte[] offsetBytes = token.getOffsetInBytes();
         // version size + sessionId length size + session id size + type + log offset / index segment start offset size
         // + store key size
-        size = 2 + 4 + (sessionId == null ? 0 : sessionId.toString().getBytes().length) + 2 + offsetBytes.length + (
-            key == null ? 0 : key.sizeInBytes());
+        size = 2 + 4 + sessionIdBytes.length + 2 + offsetBytes.length + storeKeyInBytes.length;
         bytes = new byte[size];
         bufWrap = ByteBuffer.wrap(bytes);
         // add version
         bufWrap.putShort(StoreFindToken.VERSION_1);
         // add sessionId
-        Utils.serializeNullableString(bufWrap, sessionId == null ? null : sessionId.toString());
+        bufWrap.putInt(sessionIdBytes.length);
+        bufWrap.put(sessionIdBytes);
         // add type
-        type = token.getType();
         bufWrap.putShort((byte) type.ordinal());
         bufWrap.put(offsetBytes);
-        if (key != null) {
-          bufWrap.put(key.toBytes());
+        if (storeKeyInBytes.length > 0) {
+          bufWrap.put(storeKeyInBytes);
         }
         break;
-      case StoreFindToken.CURRENT_VERSION:
-        bytes = token.toBytes();
+      case VERSION_2:
+        offsetBytes = token.getOffsetInBytes();
+        byte[] incarnationIdBytes = token.getIncarnationIdInBytes();
+        size = VERSION_SIZE + TYPE_SIZE;
+        if (type != FindTokenType.Uninitialized) {
+          size +=
+              INCARNATION_ID_LENGTH_SIZE + incarnationIdBytes.length + SESSION_ID_LENGTH_SIZE + sessionIdBytes.length
+                  + offsetBytes.length;
+          if (type == FindTokenType.JournalBased) {
+            size += INCLUSIVE_BYTE_SIZE;
+          } else if (type == FindTokenType.IndexBased) {
+            size += storeKeyInBytes.length;
+          }
+        }
+        bytes = new byte[size];
+        bufWrap = ByteBuffer.wrap(bytes);
+        // add version
+        bufWrap.putShort(VERSION_2);
+        // add type
+        bufWrap.putShort((short) type.ordinal());
+        if (type != FindTokenType.Uninitialized) {
+          // add incarnationId
+          bufWrap.putInt(incarnationIdBytes.length);
+          bufWrap.put(incarnationIdBytes);
+          // add sessionId
+          bufWrap.putInt(sessionIdBytes.length);
+          bufWrap.put(sessionIdBytes);
+          // add offset
+          bufWrap.put(offsetBytes);
+          if (type == FindTokenType.JournalBased) {
+            bufWrap.put(token.getInclusive() ? (byte) 1 : (byte) 0);
+          } else if (type == FindTokenType.IndexBased) {
+            bufWrap.put(storeKeyInBytes);
+          }
+        }
+        break;
+      case StoreFindToken.VERSION_3:
+        offsetBytes = token.getOffsetInBytes();
+        StoreKey resetKey = token.getResetKey();
+        incarnationIdBytes = token.getIncarnationIdInBytes();
+        byte[] resetKeyInBytes = resetKey != null ? resetKey.toBytes() : new byte[0];
+        size = VERSION_SIZE + TYPE_SIZE;
+        if (type != FindTokenType.Uninitialized) {
+          size +=
+              INCARNATION_ID_LENGTH_SIZE + incarnationIdBytes.length + SESSION_ID_LENGTH_SIZE + sessionIdBytes.length
+                  + offsetBytes.length;
+          if (type == FindTokenType.JournalBased) {
+            size += INCLUSIVE_BYTE_SIZE;
+          } else if (type == FindTokenType.IndexBased) {
+            size += storeKeyInBytes.length;
+          }
+          size += resetKeyInBytes.length;
+        }
+        bytes = new byte[size];
+        bufWrap = ByteBuffer.wrap(bytes);
+        // add version
+        bufWrap.putShort(VERSION_3);
+        // add type
+        bufWrap.putShort((short) type.ordinal());
+        if (type != FindTokenType.Uninitialized) {
+          // add incarnationId
+          bufWrap.putInt(incarnationIdBytes.length);
+          bufWrap.put(incarnationIdBytes);
+          // add sessionId
+          bufWrap.putInt(sessionIdBytes.length);
+          bufWrap.put(sessionIdBytes);
+          // add offset
+          bufWrap.put(offsetBytes);
+          if (type == FindTokenType.JournalBased) {
+            bufWrap.put(token.getInclusive() ? (byte) 1 : (byte) 0);
+          } else if (type == FindTokenType.IndexBased) {
+            bufWrap.put(storeKeyInBytes);
+          }
+          // both journal and index based tokens have reset key
+          bufWrap.put(resetKeyInBytes);
+        }
         break;
       default:
         throw new IllegalArgumentException("Version " + version + " of StoreFindToken does not exist");
@@ -321,7 +440,7 @@ public class StoreFindTokenTest {
   private void testConstructionFailure(StoreKey key, UUID sessionId, UUID incarnationId, Offset offset) {
     // journal based
     try {
-      new StoreFindToken(offset, sessionId, incarnationId, true);
+      new StoreFindToken(offset, sessionId, incarnationId, true, null);
       fail("Construction of StoreFindToken should have failed");
     } catch (IllegalArgumentException e) {
       // expected. Nothing to do.
@@ -329,7 +448,7 @@ public class StoreFindTokenTest {
 
     // index based
     try {
-      new StoreFindToken(key, offset, sessionId, incarnationId);
+      new StoreFindToken(key, offset, sessionId, incarnationId, null);
       fail("Construction of StoreFindToken should have failed");
     } catch (IllegalArgumentException e) {
       // expected. Nothing to do.


### PR DESCRIPTION
Introduced reset key into StoreFindToken with aim to help find closest valid index segment for replication token. This is useful when replication token is invalidated by source node. Instead of resetting it to very beginning, reset key may help find valid starting point without losing too much ground.