### PR TITLE
Send multiple frames if content size greater than http2 max frame size

### DIFF
--- a/ambry-network/src/main/java/com/github/ambry/network/http2/AmbrySendToHttp2Adaptor.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/AmbrySendToHttp2Adaptor.java
@@ -37,14 +37,16 @@ import org.slf4j.LoggerFactory;
 public class AmbrySendToHttp2Adaptor extends ChannelOutboundHandlerAdapter {
   private static final Logger logger = LoggerFactory.getLogger(AmbrySendToHttp2Adaptor.class);
   private final boolean forServer;
-  private final int maxFrameSize = 5000;
+  private final int maxFrameSize;
 
   /**
    * @param forServer if true, the handler is used as server side outbound handler. Otherwise, it's use as client side
    *                  outbound handler.
+   * @param maxFrameSize
    */
-  public AmbrySendToHttp2Adaptor(boolean forServer) {
+  public AmbrySendToHttp2Adaptor(boolean forServer, int maxFrameSize) {
     this.forServer = forServer;
+    this.maxFrameSize = maxFrameSize;
   }
 
   /**
@@ -73,8 +75,6 @@ public class AmbrySendToHttp2Adaptor extends ChannelOutboundHandlerAdapter {
     DefaultHttp2HeadersFrame headersFrame = new DefaultHttp2HeadersFrame(http2Headers, false);
     ctx.write(headersFrame);
 
-    int frameNumber =
-        send.content().readableBytes() / maxFrameSize + (send.content().readableBytes() % maxFrameSize == 0 ? 0 : 1);
     // Referencing counting for derived {@link ByteBuf}: https://netty.io/wiki/reference-counted-objects.html#derived-buffers
     try {
       while (send.content().readableBytes() > maxFrameSize) {

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/AmbrySendToHttp2Adaptor.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/AmbrySendToHttp2Adaptor.java
@@ -77,11 +77,11 @@ public class AmbrySendToHttp2Adaptor extends ChannelOutboundHandlerAdapter {
 
     // Referencing counting for derived {@link ByteBuf}: https://netty.io/wiki/reference-counted-objects.html#derived-buffers
     try {
-      while (send.content().readableBytes() > maxFrameSize) {
+      while (send.content().isReadable(maxFrameSize)) {
         ByteBuf slice = send.content().readSlice(maxFrameSize);
         slice.retain();
         DefaultHttp2DataFrame dataFrame = new DefaultHttp2DataFrame(slice, false);
-        ctx.write(dataFrame, promise);
+        ctx.write(dataFrame);
       }
       // The last slice
       ByteBuf slice = send.content().readSlice(send.content().readableBytes());

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/AmbrySendToHttp2Adaptor.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/AmbrySendToHttp2Adaptor.java
@@ -42,7 +42,7 @@ public class AmbrySendToHttp2Adaptor extends ChannelOutboundHandlerAdapter {
   /**
    * @param forServer if true, the handler is used as server side outbound handler. Otherwise, it's use as client side
    *                  outbound handler.
-   * @param maxFrameSize
+   * @param maxFrameSize the max size of a http2 frame.
    */
   public AmbrySendToHttp2Adaptor(boolean forServer, int maxFrameSize) {
     this.forServer = forServer;
@@ -87,7 +87,7 @@ public class AmbrySendToHttp2Adaptor extends ChannelOutboundHandlerAdapter {
       ByteBuf slice = send.content().readSlice(send.content().readableBytes());
       slice.retain();
       DefaultHttp2DataFrame dataFrame = new DefaultHttp2DataFrame(slice, true);
-      ctx.writeAndFlush(dataFrame, promise);
+      ctx.write(dataFrame, promise);
     } catch (Exception e) {
       logger.error("Error while processing frames. Channel: {}", ctx.channel(), e);
     } finally {

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2BlockingChannel.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2BlockingChannel.java
@@ -69,7 +69,7 @@ public class Http2BlockingChannel implements ConnectedChannel {
         new Http2MultiplexedChannelPool(new InetSocketAddress(hostName, port), nettySslHttp2Factory,
             Epoll.isAvailable() ? new EpollEventLoopGroup() : new NioEventLoopGroup(), http2ClientConfig,
             http2ClientMetrics,
-            new Http2BlockingChannelStreamChannelInitializer(http2ClientConfig.http2MaxContentLength));
+            new Http2BlockingChannelStreamChannelInitializer(http2ClientConfig));
   }
 
   @Override

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2BlockingChannelPool.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2BlockingChannelPool.java
@@ -49,7 +49,7 @@ public class Http2BlockingChannelPool implements ConnectionPool {
       this.eventLoopGroup = new NioEventLoopGroup(http2ClientConfig.http2NettyEventLoopGroupThreads);
     }
     http2ChannelPoolMap = new Http2ChannelPoolMap(sslFactory, eventLoopGroup, http2ClientConfig, http2ClientMetrics,
-        new Http2BlockingChannelStreamChannelInitializer(http2ClientConfig.http2MaxContentLength));
+        new Http2BlockingChannelStreamChannelInitializer(http2ClientConfig));
     this.http2ClientConfig = http2ClientConfig;
   }
 

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2BlockingChannelStreamChannelInitializer.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2BlockingChannelStreamChannelInitializer.java
@@ -14,6 +14,7 @@
  */
 package com.github.ambry.network.http2;
 
+import com.github.ambry.config.Http2ClientConfig;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
@@ -25,22 +26,25 @@ import io.netty.handler.codec.http2.Http2StreamFrameToHttpObjectCodec;
  * A ChannelInitializer used to setup stream channel pipeline once stream is created in {@link MultiplexedChannelRecord}.
  */
 public class Http2BlockingChannelStreamChannelInitializer extends ChannelInitializer {
-  private final int http2MaxContentLength;
+  private final Http2ClientConfig http2ClientConfig;
   private static final Http2StreamFrameToHttpObjectCodec http2StreamFrameToHttpObjectCodec =
       new Http2StreamFrameToHttpObjectCodec(false);
   private static final Http2BlockingChannelResponseHandler http2BlockingChannelResponseHandler =
       new Http2BlockingChannelResponseHandler();
-  private static final AmbrySendToHttp2Adaptor ambrySendToHttp2Adaptor = new AmbrySendToHttp2Adaptor(false);
+  private static AmbrySendToHttp2Adaptor ambrySendToHttp2Adaptor = null;
 
-  Http2BlockingChannelStreamChannelInitializer(int http2MaxContentLength) {
-    this.http2MaxContentLength = http2MaxContentLength;
+  Http2BlockingChannelStreamChannelInitializer(Http2ClientConfig http2ClientConfig) {
+    this.http2ClientConfig = http2ClientConfig;
+    if (ambrySendToHttp2Adaptor == null) {
+      ambrySendToHttp2Adaptor = new AmbrySendToHttp2Adaptor(false, http2ClientConfig.http2FrameMaxSize);
+    }
   }
 
   @Override
   protected void initChannel(Channel ch) throws Exception {
     ChannelPipeline p = ch.pipeline();
     p.addLast(http2StreamFrameToHttpObjectCodec);
-    p.addLast(new HttpObjectAggregator(http2MaxContentLength));
+    p.addLast(new HttpObjectAggregator(http2ClientConfig.http2MaxContentLength));
     p.addLast(http2BlockingChannelResponseHandler);
     p.addLast(ambrySendToHttp2Adaptor);
   }

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2BlockingChannelStreamChannelInitializer.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2BlockingChannelStreamChannelInitializer.java
@@ -27,17 +27,15 @@ import io.netty.handler.codec.http2.Http2StreamFrameToHttpObjectCodec;
  */
 public class Http2BlockingChannelStreamChannelInitializer extends ChannelInitializer {
   private final Http2ClientConfig http2ClientConfig;
+  private final AmbrySendToHttp2Adaptor ambrySendToHttp2Adaptor;
   private static final Http2StreamFrameToHttpObjectCodec http2StreamFrameToHttpObjectCodec =
       new Http2StreamFrameToHttpObjectCodec(false);
   private static final Http2BlockingChannelResponseHandler http2BlockingChannelResponseHandler =
       new Http2BlockingChannelResponseHandler();
-  private static AmbrySendToHttp2Adaptor ambrySendToHttp2Adaptor = null;
 
   Http2BlockingChannelStreamChannelInitializer(Http2ClientConfig http2ClientConfig) {
     this.http2ClientConfig = http2ClientConfig;
-    if (ambrySendToHttp2Adaptor == null) {
-      ambrySendToHttp2Adaptor = new AmbrySendToHttp2Adaptor(false, http2ClientConfig.http2FrameMaxSize);
-    }
+    this.ambrySendToHttp2Adaptor = new AmbrySendToHttp2Adaptor(false, http2ClientConfig.http2FrameMaxSize);
   }
 
   @Override

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2NetworkClient.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2NetworkClient.java
@@ -35,7 +35,6 @@ import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 import java.net.InetSocketAddress;
-import java.nio.channels.ClosedChannelException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -70,7 +69,7 @@ public class Http2NetworkClient implements NetworkClient {
     this.http2ClientResponseHandler = new Http2ClientResponseHandler(http2ClientMetrics);
     this.http2ClientStreamStatsHandler = new Http2ClientStreamStatsHandler(http2ClientMetrics);
     this.http2StreamFrameToHttpObjectCodec = new Http2StreamFrameToHttpObjectCodec(false);
-    this.ambrySendToHttp2Adaptor = new AmbrySendToHttp2Adaptor(false);
+    this.ambrySendToHttp2Adaptor = new AmbrySendToHttp2Adaptor(false, http2ClientConfig.http2FrameMaxSize);
     this.pools = new Http2ChannelPoolMap(sslFactory, eventLoopGroup, http2ClientConfig, http2ClientMetrics,
         new StreamChannelInitializer());
     this.http2ClientMetrics = http2ClientMetrics;

--- a/ambry-network/src/test/java/com/github/ambry/network/http2/AmbrySendToHttp2AdaptorTest.java
+++ b/ambry-network/src/test/java/com/github/ambry/network/http2/AmbrySendToHttp2AdaptorTest.java
@@ -82,6 +82,7 @@ public class AmbrySendToHttp2AdaptorTest {
     data.content().readBytes(resultArray, i * maxFrameSize, data.content().readableBytes());
     data.content().release();
     Assert.assertArrayEquals(byteArray, resultArray);
+    content.release();
   }
 
   /**

--- a/ambry-network/src/test/java/com/github/ambry/network/http2/AmbrySendToHttp2AdaptorTest.java
+++ b/ambry-network/src/test/java/com/github/ambry/network/http2/AmbrySendToHttp2AdaptorTest.java
@@ -17,7 +17,7 @@ import com.github.ambry.network.Send;
 import com.github.ambry.utils.AbstractByteBufHolder;
 import com.github.ambry.utils.NettyByteBufLeakHelper;
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http2.DefaultHttp2DataFrame;
 import io.netty.handler.codec.http2.DefaultHttp2HeadersFrame;
@@ -60,7 +60,7 @@ public class AmbrySendToHttp2AdaptorTest {
     int contentSize = 7000;
     byte[] byteArray = new byte[contentSize];
     new Random().nextBytes(byteArray);
-    ByteBuf content = UnpooledByteBufAllocator.DEFAULT.heapBuffer(contentSize).writeBytes(byteArray);
+    ByteBuf content = PooledByteBufAllocator.DEFAULT.heapBuffer(contentSize).writeBytes(byteArray);
     // Retain the ByteBuf for data comparison
     content.retain();
     Send send = new MockSend(content);

--- a/ambry-server/src/main/java/com/github/ambry/server/StorageServerNettyFactory.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/StorageServerNettyFactory.java
@@ -83,7 +83,8 @@ public class StorageServerNettyFactory implements NioServerFactory {
     ServerSecurityHandler serverSecurityHandler = new ServerSecurityHandler(serverSecurityService, serverMetrics);
     Http2ServerStreamHandler http2ServerStreamHandler =
         new Http2ServerStreamHandler(new AmbryNetworkRequestHandler(requestResponseChannel, http2ServerMetrics),
-            new Http2StreamFrameToHttpObjectCodec(true), new AmbrySendToHttp2Adaptor(true), http2ClientConfig);
+            new Http2StreamFrameToHttpObjectCodec(true),
+            new AmbrySendToHttp2Adaptor(true, http2ClientConfig.http2FrameMaxSize), http2ClientConfig);
     ConnectionStatsHandler connectionStatsHandler = new ConnectionStatsHandler(nettyMetrics);
     Map<Integer, ChannelInitializer<SocketChannel>> initializers = Collections.singletonMap(http2Port,
         new StorageServerNettyChannelInitializer(http2ClientConfig, http2ServerMetrics, sslFactory,


### PR DESCRIPTION
It was assumed we can send out all content in one frame(5MB), but replication data size maybe 100MB.
This change is to allow multiple frames if content size greater than http2 max frame size.