### PR TITLE
[StatsMigration] Add methods in AccountStatsMysqlStore for partition class reports

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/AccountStatsMySqlConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/AccountStatsMySqlConfig.java
@@ -65,7 +65,7 @@ public class AccountStatsMySqlConfig {
    * Negative numbers means disable batch. 0 means unlimited batch size. Any positive number means the size of each batch.
    */
   @Config(UPDATE_BATCH_SIZE)
-  @Default("-1")
+  @Default("0")
   public final int updateBatchSize;
 
   /**
@@ -79,7 +79,7 @@ public class AccountStatsMySqlConfig {
   public AccountStatsMySqlConfig(VerifiableProperties verifiableProperties) {
     dbInfo = verifiableProperties.getString(DB_INFO, "");
     domainNamesToRemove = verifiableProperties.getString(DOMAIN_NAMES_TO_REMOVE, "");
-    updateBatchSize = verifiableProperties.getInt(UPDATE_BATCH_SIZE, -1);
+    updateBatchSize = verifiableProperties.getInt(UPDATE_BATCH_SIZE, 0);
     enableRewriteBatchedStatement = verifiableProperties.getBoolean(ENABLE_REWRITE_BATCHED_STATEMENT, false);
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/server/AccountStatsStore.java
+++ b/ambry-api/src/main/java/com/github/ambry/server/AccountStatsStore.java
@@ -43,7 +43,7 @@ public interface AccountStatsStore {
    * @return {@link StatsWrapper} of given {@code hostname}.
    * @throws Exception
    */
-  StatsWrapper queryAccountStatsOf(String hostname) throws Exception;
+  StatsWrapper queryAccountStatsByHost(String hostname) throws Exception;
 
   /**
    * Return the aggregated stats. This is the stats stored by method {@link #storeAggregatedAccountStats}.

--- a/ambry-api/src/main/java/com/github/ambry/server/AccountStatsStore.java
+++ b/ambry-api/src/main/java/com/github/ambry/server/AccountStatsStore.java
@@ -174,4 +174,10 @@ public interface AccountStatsStore {
    * @throws Exception
    */
   StatsSnapshot queryAggregatedPartitionClassStatsOf() throws Exception;
+
+  /**
+   * Helper method to close the active connection, if there is one. Connection should be closed when there is no
+   * action to be performed for a while.
+   */
+  void closeConnection();
 }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/MySqlReportAggregatorTask.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/MySqlReportAggregatorTask.java
@@ -109,6 +109,7 @@ public class MySqlReportAggregatorTask extends UserContentStore implements Task 
       exception = e;
       return new TaskResult(TaskResult.Status.FAILED, "Exception thrown");
     } finally {
+      accountStatsStore.closeConnection();
       if (clusterMapConfig.clustermapEnableContainerDeletionAggregation && callback != null && results != null
           && statsReportType.equals(StatsReportType.ACCOUNT_REPORT)) {
         callback.onCompletion(results.getFirst(), exception);

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/MySqlReportAggregatorTask.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/MySqlReportAggregatorTask.java
@@ -84,12 +84,11 @@ public class MySqlReportAggregatorTask extends UserContentStore implements Task 
       for (String instanceName : instanceNames) {
         // Helix instance name would suffix port number, here let's take port number out.
         instanceName = stripPortNumber(instanceName);
-        statsWrappers.put(instanceName,
-            accountStatsStore.queryStatsOf(clusterMapConfig.clusterMapClusterName, instanceName));
+        statsWrappers.put(instanceName, accountStatsStore.queryAccountStatsOf(instanceName));
       }
       logger.info("Aggregating stats from " + statsWrappers.size() + " hosts");
       results = clusterAggregator.doWorkOnStatsWrapperMap(statsWrappers, statsReportType);
-      accountStatsStore.storeAggregatedStats(results.getSecond());
+      accountStatsStore.storeAggregatedAccountStats(results.getSecond());
       // Create a base report at the beginning of each month.
       // Check if there is a base report for this month or not.
       if (clusterMapConfig.clustermapEnableAggregatedMonthlyAccountReport
@@ -97,12 +96,11 @@ public class MySqlReportAggregatorTask extends UserContentStore implements Task 
         // Get the month, if not the same month, then copy the aggregated stats and update the month
         String currentMonthValue =
             LocalDateTime.ofEpochSecond(time.seconds(), 0, ZONE_OFFSET).format(TIMESTAMP_FORMATTER);
-        String recordedMonthValue = accountStatsStore.queryRecordedMonth(clusterMapConfig.clusterMapClusterName);
+        String recordedMonthValue = accountStatsStore.queryRecordedMonth();
         if (recordedMonthValue == null || recordedMonthValue.isEmpty() || !currentMonthValue.equals(
             recordedMonthValue)) {
           logger.info("Taking snapshot of aggregated stats for month " + currentMonthValue);
-          accountStatsStore.takeSnapshotOfAggregatedStatsAndUpdateMonth(clusterMapConfig.clusterMapClusterName,
-              currentMonthValue);
+          accountStatsStore.takeSnapshotOfAggregatedAccountStatsAndUpdateMonth(currentMonthValue);
         }
       }
       return new TaskResult(TaskResult.Status.COMPLETED, "Aggregation success");

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/MySqlReportAggregatorTask.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/MySqlReportAggregatorTask.java
@@ -84,7 +84,7 @@ public class MySqlReportAggregatorTask extends UserContentStore implements Task 
       for (String instanceName : instanceNames) {
         // Helix instance name would suffix port number, here let's take port number out.
         instanceName = stripPortNumber(instanceName);
-        statsWrappers.put(instanceName, accountStatsStore.queryAccountStatsOf(instanceName));
+        statsWrappers.put(instanceName, accountStatsStore.queryAccountStatsByHost(instanceName));
       }
       logger.info("Aggregating stats from " + statsWrappers.size() + " hosts");
       results = clusterAggregator.doWorkOnStatsWrapperMap(statsWrappers, statsReportType);

--- a/ambry-mysql/src/integration-test/java/com/github/ambry/accountstats/AccountStatsMySqlStoreIntegrationTest.java
+++ b/ambry-mysql/src/integration-test/java/com/github/ambry/accountstats/AccountStatsMySqlStoreIntegrationTest.java
@@ -372,7 +372,7 @@ public class AccountStatsMySqlStoreIntegrationTest {
       finalStats.getSubMap().put(className, classNameStats);
       for (int ia = 0; ia < numAccount; ia++) {
         for (int ic = 0; ic < numContainer; ic++) {
-          String key = "A[" + ia + "]" + Utils.ACCOUNT_CONTAINER_SEPARATOR + "C[" + ic + "]";
+          String key = Utils.partitionClassStatsAccountContainerKey((short)ia, (short)ic);
           classNameStats.getSubMap().put(key, new StatsSnapshot(random.nextLong() % maxValue, null));
         }
       }

--- a/ambry-mysql/src/integration-test/java/com/github/ambry/accountstats/AccountStatsMySqlStoreIntegrationTest.java
+++ b/ambry-mysql/src/integration-test/java/com/github/ambry/accountstats/AccountStatsMySqlStoreIntegrationTest.java
@@ -24,6 +24,7 @@ import com.github.ambry.server.StatsHeader;
 import com.github.ambry.server.StatsReportType;
 import com.github.ambry.server.StatsSnapshot;
 import com.github.ambry.server.StatsWrapper;
+import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
 import java.io.IOException;
@@ -35,10 +36,14 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Random;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -64,7 +69,7 @@ public class AccountStatsMySqlStoreIntegrationTest {
 
   @Parameterized.Parameters
   public static List<Object[]> data() {
-    return Arrays.asList(new Object[][]{{-1}, {0}, {17}});
+    return Arrays.asList(new Object[][]{{0}, {17}});
   }
 
   public AccountStatsMySqlStoreIntegrationTest(int batchSize) throws Exception {
@@ -87,18 +92,18 @@ public class AccountStatsMySqlStoreIntegrationTest {
     AccountStatsMySqlStore mySqlStore2 = createAccountStatsMySqlStore(clusterName1, hostname2, false);
     AccountStatsMySqlStore mySqlStore3 = createAccountStatsMySqlStore(clusterName2, hostname3, false);
 
-    StatsWrapper stats1 = generateStatsWrapper(10, 10, 1);
-    StatsWrapper stats2 = generateStatsWrapper(10, 10, 1);
-    StatsWrapper stats3 = generateStatsWrapper(10, 10, 1);
-    mySqlStore1.storeStats(stats1);
-    mySqlStore2.storeStats(stats2);
-    mySqlStore3.storeStats(stats3);
+    StatsWrapper stats1 = generateStatsWrapper(10, 10, 1, StatsReportType.ACCOUNT_REPORT);
+    StatsWrapper stats2 = generateStatsWrapper(10, 10, 1, StatsReportType.ACCOUNT_REPORT);
+    StatsWrapper stats3 = generateStatsWrapper(10, 10, 1, StatsReportType.ACCOUNT_REPORT);
+    mySqlStore1.storeAccountStats(stats1);
+    mySqlStore2.storeAccountStats(stats2);
+    mySqlStore3.storeAccountStats(stats3);
 
     assertTableSize(mySqlStore1.getMySqlDataAccessor(), 3 * 10 * 10);
 
-    StatsWrapper obtainedStats1 = mySqlStore1.queryStatsOf(clusterName1, hostname1);
-    StatsWrapper obtainedStats2 = mySqlStore2.queryStatsOf(clusterName1, hostname2);
-    StatsWrapper obtainedStats3 = mySqlStore3.queryStatsOf(clusterName2, hostname3);
+    StatsWrapper obtainedStats1 = mySqlStore1.queryAccountStatsOf(hostname1);
+    StatsWrapper obtainedStats2 = mySqlStore2.queryAccountStatsOf(hostname2);
+    StatsWrapper obtainedStats3 = mySqlStore3.queryAccountStatsOf(hostname3);
     assertTwoStatsSnapshots(obtainedStats1.getSnapshot(), stats1.getSnapshot());
     assertTwoStatsSnapshots(obtainedStats2.getSnapshot(), stats2.getSnapshot());
     assertTwoStatsSnapshots(obtainedStats3.getSnapshot(), stats3.getSnapshot());
@@ -111,15 +116,15 @@ public class AccountStatsMySqlStoreIntegrationTest {
   @Test
   public void testStoreMulitpleWrites() throws Exception {
     AccountStatsMySqlStore mySqlStore = createAccountStatsMySqlStore(clusterName1, hostname1, false);
-    StatsWrapper stats1 = generateStatsWrapper(10, 10, 1);
-    mySqlStore.storeStats(stats1);
+    StatsWrapper stats1 = generateStatsWrapper(10, 10, 1, StatsReportType.ACCOUNT_REPORT);
+    mySqlStore.storeAccountStats(stats1);
     StatsWrapper stats2 =
         new StatsWrapper(new StatsHeader(stats1.getHeader()), new StatsSnapshot(stats1.getSnapshot()));
     // change one value, and store it to mysql database again
     stats2.getSnapshot().getSubMap().get("Partition[0]").getSubMap().get("A[0]").getSubMap().get("C[0]").setValue(1);
     stats2.getSnapshot().updateValue();
-    mySqlStore.storeStats(stats2);
-    StatsWrapper obtainedStats = mySqlStore.queryStatsOf(clusterName1, hostname1);
+    mySqlStore.storeAccountStats(stats2);
+    StatsWrapper obtainedStats = mySqlStore.queryAccountStatsOf(hostname1);
     assertTwoStatsSnapshots(obtainedStats.getSnapshot(), stats2.getSnapshot());
   }
 
@@ -127,8 +132,8 @@ public class AccountStatsMySqlStoreIntegrationTest {
   public void testAggregatedStats() throws Exception {
     Map<String, Map<String, Long>> containerStorageUsages = TestUtils.makeStorageMap(10, 10, 100000, 1000);
     StatsSnapshot snapshot = TestUtils.makeStatsSnapshotFromContainerStorageMap(containerStorageUsages);
-    mySqlStore.storeAggregatedStats(snapshot);
-    Map<String, Map<String, Long>> obtainedContainerStorageUsages = mySqlStore.queryAggregatedStats(clusterName1);
+    mySqlStore.storeAggregatedAccountStats(snapshot);
+    Map<String, Map<String, Long>> obtainedContainerStorageUsages = mySqlStore.queryAggregatedAccountStats();
     TestUtils.assertContainerMap(containerStorageUsages, obtainedContainerStorageUsages);
 
     // Change one value and store it to mysql database again
@@ -136,39 +141,122 @@ public class AccountStatsMySqlStoreIntegrationTest {
     newSnapshot.getSubMap().get("A[1]").getSubMap().get("C[1]").setValue(1);
     newSnapshot.updateValue();
     containerStorageUsages.get("1").put("1", 1L);
-    mySqlStore.storeAggregatedStats(newSnapshot);
-    obtainedContainerStorageUsages = mySqlStore.queryAggregatedStats(clusterName1);
+    mySqlStore.storeAggregatedAccountStats(newSnapshot);
+    obtainedContainerStorageUsages = mySqlStore.queryAggregatedAccountStats();
     TestUtils.assertContainerMap(containerStorageUsages, obtainedContainerStorageUsages);
   }
 
   @Test
   public void testMonthlyAggregatedStats() throws Exception {
     String monthValue = "2020-01";
-    Map<String, Map<String, Long>> currentContainerStorageUsages = mySqlStore.queryAggregatedStats(clusterName1);
+    Map<String, Map<String, Long>> currentContainerStorageUsages = mySqlStore.queryAggregatedAccountStats();
     if (currentContainerStorageUsages.size() == 0) {
       Map<String, Map<String, Long>> containerStorageUsages = TestUtils.makeStorageMap(10, 10, 100000, 1000);
       StatsSnapshot snapshot = TestUtils.makeStatsSnapshotFromContainerStorageMap(containerStorageUsages);
-      mySqlStore.storeAggregatedStats(snapshot);
-      currentContainerStorageUsages = mySqlStore.queryAggregatedStats(clusterName1);
+      mySqlStore.storeAggregatedAccountStats(snapshot);
+      currentContainerStorageUsages = mySqlStore.queryAggregatedAccountStats();
     }
     // fetch the month and it should return emtpy string
-    Assert.assertEquals("", mySqlStore.queryRecordedMonth(clusterName1));
-    mySqlStore.takeSnapshotOfAggregatedStatsAndUpdateMonth(clusterName1, monthValue);
-    Map<String, Map<String, Long>> monthlyContainerStorageUsages = mySqlStore.queryMonthlyAggregatedStats(clusterName1);
+    Assert.assertEquals("", mySqlStore.queryRecordedMonth());
+    mySqlStore.takeSnapshotOfAggregatedAccountStatsAndUpdateMonth(monthValue);
+    Map<String, Map<String, Long>> monthlyContainerStorageUsages = mySqlStore.queryMonthlyAggregatedAccountStats();
     TestUtils.assertContainerMap(currentContainerStorageUsages, monthlyContainerStorageUsages);
-    String obtainedMonthValue = mySqlStore.queryRecordedMonth(clusterName1);
+    String obtainedMonthValue = mySqlStore.queryRecordedMonth();
     assertTrue(obtainedMonthValue.equals(monthValue));
 
     // Change the value and store it back to mysql database
     monthValue = "2020-02";
     currentContainerStorageUsages = TestUtils.makeStorageMap(10, 10, 100000, 1000);
     StatsSnapshot snapshot = TestUtils.makeStatsSnapshotFromContainerStorageMap(currentContainerStorageUsages);
-    mySqlStore.storeAggregatedStats(snapshot);
-    mySqlStore.takeSnapshotOfAggregatedStatsAndUpdateMonth(clusterName1, monthValue);
-    monthlyContainerStorageUsages = mySqlStore.queryMonthlyAggregatedStats(clusterName1);
+    mySqlStore.storeAggregatedAccountStats(snapshot);
+    mySqlStore.takeSnapshotOfAggregatedAccountStatsAndUpdateMonth(monthValue);
+    monthlyContainerStorageUsages = mySqlStore.queryMonthlyAggregatedAccountStats();
     TestUtils.assertContainerMap(currentContainerStorageUsages, monthlyContainerStorageUsages);
-    obtainedMonthValue = mySqlStore.queryRecordedMonth(clusterName1);
+    obtainedMonthValue = mySqlStore.queryRecordedMonth();
     assertTrue(obtainedMonthValue.equals(monthValue));
+  }
+
+  @Test
+  public void testHostPartitionClassStats() throws Exception {
+    // First write some stats to account reports
+    testMultiStoreStats();
+    StatsWrapper accountStats1 = mySqlStore.queryAccountStatsOf(hostname1);
+    StatsWrapper accountStats2 = mySqlStore.queryAccountStatsOf(hostname2);
+    AccountStatsMySqlStore mySqlStore3 = createAccountStatsMySqlStore(clusterName2, hostname3, false);
+    StatsWrapper accountStats3 = mySqlStore3.queryAccountStatsOf(hostname3);
+
+    // From this account stats, create partition class stats;
+    Set<String> allPartitionKeys = new HashSet<String>() {
+      {
+        addAll(accountStats1.getSnapshot().getSubMap().keySet());
+        addAll(accountStats2.getSnapshot().getSubMap().keySet());
+        addAll(accountStats3.getSnapshot().getSubMap().keySet());
+      }
+    };
+    List<String> partitionClassNames = Arrays.asList("default", "new");
+    Map<String, String> partitionKeyToClassName = new HashMap<>();
+    int ind = 0;
+    for (String partitionKey : allPartitionKeys) {
+      partitionKeyToClassName.put(partitionKey, partitionClassNames.get(ind % partitionClassNames.size()));
+      ind++;
+    }
+    StatsWrapper partitionClassStats1 =
+        convertAccountStatsToPartitionClassStats(accountStats1, partitionKeyToClassName);
+    StatsWrapper partitionClassStats2 =
+        convertAccountStatsToPartitionClassStats(accountStats2, partitionKeyToClassName);
+    StatsWrapper partitionClassStats3 =
+        convertAccountStatsToPartitionClassStats(accountStats3, partitionKeyToClassName);
+    mySqlStore.storePartitionClassStats(partitionClassStats1);
+    mySqlStore.storePartitionClassStats(partitionClassStats2);
+    mySqlStore3.storePartitionClassStats(partitionClassStats3);
+
+    Map<String, Set<Short>> partitionNameAndIds = mySqlStore.queryPartitionNameAndIds();
+    assertEquals(new HashSet<>(partitionClassNames), partitionNameAndIds.keySet());
+    Map<String, String> dbPartitionKeyToClassName = partitionNameAndIds.entrySet()
+        .stream()
+        .flatMap(
+            ent -> ent.getValue().stream().map(pid -> new Pair<String, String>(ent.getKey(), "Partition[" + pid + "]")))
+        .collect(Collectors.toMap(Pair::getSecond, Pair::getFirst));
+    assertEquals(partitionKeyToClassName, dbPartitionKeyToClassName);
+
+    StatsWrapper obtainedStats1 = mySqlStore.queryPartitionClassStatsOf(hostname1, partitionNameAndIds);
+    assertEquals(partitionClassStats1.getSnapshot(), obtainedStats1.getSnapshot());
+    StatsWrapper obtainedStats2 = mySqlStore.queryPartitionClassStatsOf(hostname2, partitionNameAndIds);
+    assertEquals(partitionClassStats2.getSnapshot(), obtainedStats2.getSnapshot());
+    StatsWrapper obtainedStats3 = mySqlStore3.queryPartitionClassStatsOf(hostname3, partitionNameAndIds);
+    assertEquals(partitionClassStats3.getSnapshot(), obtainedStats3.getSnapshot());
+  }
+
+  @Test
+  public void testAggregatedPartitionClassStats() throws Exception {
+    testHostPartitionClassStats();
+    Map<String, Set<Short>> partitionNameAndIds = mySqlStore.queryPartitionNameAndIds();
+    AccountStatsMySqlStore mySqlStore3 = createAccountStatsMySqlStore(clusterName2, hostname3, false);
+
+    // Now we should have partition class names and partition ids in database
+    // Construct an aggregated partition class report
+    StatsSnapshot aggregated =
+        generateAggregatedPartitionClassStats(partitionNameAndIds.keySet().toArray(new String[0]), 10, 10);
+    mySqlStore.storeAggregatedPartitionClassStats(aggregated);
+
+    partitionNameAndIds = mySqlStore3.queryPartitionNameAndIds();
+    StatsSnapshot aggregated3 =
+        generateAggregatedPartitionClassStats(partitionNameAndIds.keySet().toArray(new String[0]), 10, 10);
+    mySqlStore3.storeAggregatedPartitionClassStats(aggregated3);
+
+    StatsSnapshot obtained = mySqlStore.queryAggregatedPartitionClassStatsOf();
+    assertEquals(aggregated, obtained);
+
+    StatsSnapshot obtained3 = mySqlStore3.queryAggregatedPartitionClassStatsOf();
+    assertEquals(aggregated3, obtained3);
+
+    // Change one value and store it to mysql database again
+    StatsSnapshot newSnapshot = new StatsSnapshot(aggregated);
+    newSnapshot.getSubMap().get("default").getSubMap().get("A[1]___C[1]").setValue(1);
+    newSnapshot.updateValue();
+    mySqlStore.storeAggregatedPartitionClassStats(aggregated);
+    obtained = mySqlStore.queryAggregatedPartitionClassStatsOf();
+    assertEquals(aggregated, obtained);
   }
 
   private AccountStatsMySqlStore createAccountStatsMySqlStore(String clusterName, String hostname,
@@ -191,7 +279,7 @@ public class AccountStatsMySqlStoreIntegrationTest {
     Path localBackupFilePath = createTemporaryFile();
     ObjectMapper objectMapper = new ObjectMapper();
     objectMapper.writeValue(localBackupFilePath.toFile(),
-        generateStatsWrapper(numPartitions, numAccounts, numContainers));
+        generateStatsWrapper(numPartitions, numAccounts, numContainers, StatsReportType.ACCOUNT_REPORT));
     return localBackupFilePath;
   }
 
@@ -200,23 +288,22 @@ public class AccountStatsMySqlStoreIntegrationTest {
     return tempDir.resolve("localbackup");
   }
 
-  private static StatsWrapper generateStatsWrapper(int numPartitions, int numAccounts, int numContainers) {
+  private static StatsWrapper generateStatsWrapper(int numPartitions, int numAccounts, int numContainers,
+      StatsReportType reportType) {
     Random random = new Random();
     List<StatsSnapshot> storeSnapshots = new ArrayList<>();
     for (int i = 0; i < numPartitions; i++) {
-      storeSnapshots.add(
-          TestUtils.generateStoreStats(numAccounts, numContainers, random, StatsReportType.ACCOUNT_REPORT));
+      storeSnapshots.add(TestUtils.generateStoreStats(numAccounts, numContainers, random, reportType));
     }
-    return TestUtils.generateNodeStats(storeSnapshots, 1000, StatsReportType.ACCOUNT_REPORT);
+    return TestUtils.generateNodeStats(storeSnapshots, 1000, reportType);
   }
 
   private void cleanup(MySqlDataAccessor dataAccessor) throws SQLException {
     Connection dbConnection = dataAccessor.getDatabaseConnection(true);
     Statement statement = dbConnection.createStatement();
-    statement.executeUpdate("DELETE FROM " + AccountReportsDao.ACCOUNT_REPORTS_TABLE);
-    statement.executeUpdate("DELETE FROM " + AggregatedAccountReportsDao.AGGREGATED_ACCOUNT_REPORTS_TABLE);
-    statement.executeUpdate("DELETE FROM " + AggregatedAccountReportsDao.MONTHLY_AGGREGATED_ACCOUNT_REPORTS_TABLE);
-    statement.executeUpdate("DELETE FROM " + AggregatedAccountReportsDao.AGGREGATED_ACCOUNT_REPORTS_MONTH_TABLE);
+    for (String table : AccountStatsMySqlStore.TABLES) {
+      statement.executeUpdate("DELETE FROM " + table);
+    }
   }
 
   private void assertTableSize(MySqlDataAccessor dataAccessor, int expectedNumRows) throws SQLException {
@@ -244,5 +331,55 @@ public class AccountStatsMySqlStoreIntegrationTest {
         assertTwoStatsSnapshots(snapshot1.getSubMap().get(key), snapshot2.getSubMap().get(key));
       }
     }
+  }
+
+  private StatsWrapper convertAccountStatsToPartitionClassStats(StatsWrapper accountStats,
+      Map<String, String> partitionKeyToClassName) {
+    Map<String, StatsSnapshot> partitionClassSubMap = new HashMap<>();
+    StatsSnapshot originHostStats = accountStats.getSnapshot();
+    for (String partitionKey : originHostStats.getSubMap().keySet()) {
+      StatsSnapshot originPartitionStats = originHostStats.getSubMap().get(partitionKey);
+      String currentClassName = partitionKeyToClassName.get(partitionKey);
+      StatsSnapshot partitionClassStats =
+          partitionClassSubMap.computeIfAbsent(currentClassName, k -> new StatsSnapshot(0L, new HashMap<>()));
+      Map<String, StatsSnapshot> accountContainerSubMap = new HashMap<>();
+      for (String accountKey : originPartitionStats.getSubMap().keySet()) {
+        for (Map.Entry<String, StatsSnapshot> containerEntry : originPartitionStats.getSubMap()
+            .get(accountKey)
+            .getSubMap()
+            .entrySet()) {
+          String containerKey = containerEntry.getKey();
+          StatsSnapshot containerStats = new StatsSnapshot(containerEntry.getValue());
+          accountContainerSubMap.put(accountKey + Utils.ACCOUNT_CONTAINER_SEPARATOR + containerKey, containerStats);
+        }
+      }
+      long accountContainerValue = accountContainerSubMap.values().stream().mapToLong(StatsSnapshot::getValue).sum();
+      StatsSnapshot partitionStats = new StatsSnapshot(accountContainerValue, accountContainerSubMap);
+      partitionClassStats.getSubMap().put(partitionKey, partitionStats);
+      partitionClassStats.setValue(partitionClassStats.getValue() + accountContainerValue);
+    }
+    return new StatsWrapper(new StatsHeader(accountStats.getHeader()),
+        new StatsSnapshot(originHostStats.getValue(), partitionClassSubMap));
+  }
+
+  private StatsSnapshot generateAggregatedPartitionClassStats(String[] partitionClassNames, int numAccount,
+      int numContainer) {
+    Random random = new Random();
+    long maxValue = 10000;
+    StatsSnapshot finalStats = new StatsSnapshot(0L, new HashMap<>());
+    for (String className : partitionClassNames) {
+      StatsSnapshot classNameStats = new StatsSnapshot(0L, new HashMap<>());
+      finalStats.getSubMap().put(className, classNameStats);
+      for (int ia = 0; ia < numAccount; ia++) {
+        for (int ic = 0; ic < numContainer; ic++) {
+          String key = "A[" + ia + "]" + Utils.ACCOUNT_CONTAINER_SEPARATOR + "C[" + ic + "]";
+          classNameStats.getSubMap().put(key, new StatsSnapshot(random.nextLong() % maxValue, null));
+        }
+      }
+      long classNameValue = classNameStats.getSubMap().values().stream().mapToLong(StatsSnapshot::getValue).sum();
+      classNameStats.setValue(classNameValue);
+    }
+    finalStats.setValue(finalStats.getSubMap().values().stream().mapToLong(StatsSnapshot::getValue).sum());
+    return finalStats;
   }
 }

--- a/ambry-mysql/src/integration-test/java/com/github/ambry/accountstats/AccountStatsMySqlStoreIntegrationTest.java
+++ b/ambry-mysql/src/integration-test/java/com/github/ambry/accountstats/AccountStatsMySqlStoreIntegrationTest.java
@@ -101,9 +101,9 @@ public class AccountStatsMySqlStoreIntegrationTest {
 
     assertTableSize(mySqlStore1.getMySqlDataAccessor(), 3 * 10 * 10);
 
-    StatsWrapper obtainedStats1 = mySqlStore1.queryAccountStatsOf(hostname1);
-    StatsWrapper obtainedStats2 = mySqlStore2.queryAccountStatsOf(hostname2);
-    StatsWrapper obtainedStats3 = mySqlStore3.queryAccountStatsOf(hostname3);
+    StatsWrapper obtainedStats1 = mySqlStore1.queryAccountStatsByHost(hostname1);
+    StatsWrapper obtainedStats2 = mySqlStore2.queryAccountStatsByHost(hostname2);
+    StatsWrapper obtainedStats3 = mySqlStore3.queryAccountStatsByHost(hostname3);
     assertTwoStatsSnapshots(obtainedStats1.getSnapshot(), stats1.getSnapshot());
     assertTwoStatsSnapshots(obtainedStats2.getSnapshot(), stats2.getSnapshot());
     assertTwoStatsSnapshots(obtainedStats3.getSnapshot(), stats3.getSnapshot());
@@ -124,7 +124,7 @@ public class AccountStatsMySqlStoreIntegrationTest {
     stats2.getSnapshot().getSubMap().get("Partition[0]").getSubMap().get("A[0]").getSubMap().get("C[0]").setValue(1);
     stats2.getSnapshot().updateValue();
     mySqlStore.storeAccountStats(stats2);
-    StatsWrapper obtainedStats = mySqlStore.queryAccountStatsOf(hostname1);
+    StatsWrapper obtainedStats = mySqlStore.queryAccountStatsByHost(hostname1);
     assertTwoStatsSnapshots(obtainedStats.getSnapshot(), stats2.getSnapshot());
   }
 
@@ -180,10 +180,10 @@ public class AccountStatsMySqlStoreIntegrationTest {
   public void testHostPartitionClassStats() throws Exception {
     // First write some stats to account reports
     testMultiStoreStats();
-    StatsWrapper accountStats1 = mySqlStore.queryAccountStatsOf(hostname1);
-    StatsWrapper accountStats2 = mySqlStore.queryAccountStatsOf(hostname2);
+    StatsWrapper accountStats1 = mySqlStore.queryAccountStatsByHost(hostname1);
+    StatsWrapper accountStats2 = mySqlStore.queryAccountStatsByHost(hostname2);
     AccountStatsMySqlStore mySqlStore3 = createAccountStatsMySqlStore(clusterName2, hostname3, false);
-    StatsWrapper accountStats3 = mySqlStore3.queryAccountStatsOf(hostname3);
+    StatsWrapper accountStats3 = mySqlStore3.queryAccountStatsByHost(hostname3);
 
     // From this account stats, create partition class stats;
     Set<String> allPartitionKeys = new HashSet<String>() {

--- a/ambry-mysql/src/integration-test/java/com/github/ambry/accountstats/PartitionClassReportsDaoTest.java
+++ b/ambry-mysql/src/integration-test/java/com/github/ambry/accountstats/PartitionClassReportsDaoTest.java
@@ -1,0 +1,222 @@
+/**
+ * Copyright 2021 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.accountstats;
+
+import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.config.AccountStatsMySqlConfig;
+import com.github.ambry.config.ClusterMapConfig;
+import com.github.ambry.config.StatsManagerConfig;
+import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.mysql.MySqlDataAccessor;
+import com.github.ambry.utils.Utils;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.Statement;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Random;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+/**
+ * Unit test for {@link PartitionClassReportsDao}.
+ */
+public class PartitionClassReportsDaoTest {
+  private final MySqlDataAccessor dataAccessor;
+  private final PartitionClassReportsDao dao;
+
+  public PartitionClassReportsDaoTest() throws Exception {
+    dataAccessor = createAccountStatsMySqlStore("clusterName", "hostName", 12345, 100).getMySqlDataAccessor();
+    dao = new PartitionClassReportsDao(dataAccessor);
+  }
+
+  @Before
+  public void before() throws Exception {
+    Connection dbConnection = dataAccessor.getDatabaseConnection(true);
+    Statement statement = dbConnection.createStatement();
+    for (String table : AccountStatsMySqlStore.TABLES) {
+      statement.executeUpdate("DELETE FROM " + table);
+    }
+  }
+
+  @Test
+  public void testPartitionClassName() throws Exception {
+    // There is no partition class name rows in the table now, query should return empty result
+    String clusterName = "ambry-test";
+    Map<String, Short> partitionClassNames = dao.queryPartitionClassNames(clusterName);
+    assertTrue(partitionClassNames.isEmpty());
+
+    String partitionClassName1 = "default";
+    String partitionClassName2 = "new-partition";
+
+    dao.insertPartitionClassName(clusterName, partitionClassName1);
+    dao.insertPartitionClassName(clusterName, partitionClassName2);
+    // Add partition class 2 again, it shouldn't fail
+    dao.insertPartitionClassName(clusterName, partitionClassName2);
+
+    // Now query partition class names, it should return two result;
+    partitionClassNames = dao.queryPartitionClassNames(clusterName);
+    assertEquals(2, partitionClassNames.size());
+    assertTrue(partitionClassNames.containsKey(partitionClassName1));
+    assertTrue(partitionClassNames.containsKey(partitionClassName2));
+    assertEquals(2, partitionClassNames.values().stream().distinct().collect(Collectors.toList()).size());
+
+    // Add same partition class name with different clustername
+    String clusterName2 = "ambry-git";
+    dao.insertPartitionClassName(clusterName2, partitionClassName1);
+    dao.insertPartitionClassName(clusterName2, partitionClassName1);
+
+    // It should equal to the first result
+    Map<String, Short> partitionClassNamesAgain = dao.queryPartitionClassNames(clusterName);
+    assertEquals(partitionClassNames, partitionClassNamesAgain);
+
+    // get partition class names for clusterName2
+    Map<String, Short> partitionClassNames2 = dao.queryPartitionClassNames(clusterName2);
+    assertEquals(1, partitionClassNames2.size());
+    assertTrue(partitionClassNames2.containsKey(partitionClassName1));
+    assertFalse(partitionClassNames.values().contains(partitionClassNames2.get(partitionClassName1)));
+  }
+
+  @Test
+  public void testPartitionId() throws Exception {
+    String clusterName = "ambry-test";
+    // Before adding any partition ids, query should return empty result
+    Set<Short> partitionIds = dao.queryPartitionIds(clusterName);
+    assertTrue(partitionIds.isEmpty());
+    Map<String, Set<Short>> partitionNameAndIds = dao.queryPartitionNameAndIds(clusterName);
+    assertTrue(partitionNameAndIds.isEmpty());
+
+    String partitionClassName1 = "default";
+    String partitionClassName2 = "new-partition";
+    dao.insertPartitionClassName(clusterName, partitionClassName1);
+    dao.insertPartitionClassName(clusterName, partitionClassName2);
+    Map<String, Short> partitionClassNames = dao.queryPartitionClassNames(clusterName);
+    short partitionClassId1 = partitionClassNames.get(partitionClassName1);
+    short partitionClassId2 = partitionClassNames.get(partitionClassName2);
+
+    // insert some partition ids and query them later
+    Map<String, Set<Short>> expectedPartitionIds = new HashMap<>();
+    for (int i = 0; i < 100; i++) {
+      short classId = i % 2 == 0 ? partitionClassId1 : partitionClassId2;
+      String className = i % 2 == 0 ? partitionClassName1 : partitionClassName2;
+      dao.insertPartitionId(clusterName, (short) i, classId);
+      // reinsert the same partition id should result in conflict, but conflict is handled by method
+      dao.insertPartitionId(clusterName, (short) i, classId);
+      expectedPartitionIds.computeIfAbsent(className, k -> new HashSet<Short>()).add((short) i);
+    }
+
+    // Add partition ids for other clusters
+    dao.insertPartitionClassName("other-cluster", partitionClassName1);
+    partitionClassNames = dao.queryPartitionClassNames("other-cluster");
+    short partitionClassIdForOtherCluster = partitionClassNames.get(partitionClassName1);
+    for (int i = 0; i < 100; i++) {
+      dao.insertPartitionId(clusterName, (short) i, partitionClassIdForOtherCluster);
+    }
+
+    // Get all partition ids for cluster
+    partitionIds = dao.queryPartitionIds(clusterName);
+    assertEquals(100, partitionIds.size());
+    for (int i = 0; i < 100; i++) {
+      assertTrue(partitionIds.contains((short) i));
+    }
+
+    // Get all partition ids under corresponding class name
+    partitionNameAndIds = dao.queryPartitionNameAndIds(clusterName);
+    assertEquals(expectedPartitionIds, partitionNameAndIds);
+  }
+
+  @Test
+  public void testAggregatedPartitionClassReports() throws Exception {
+    // Prepare the partition class name and partition id
+    String clusterName = "ambry-test";
+    String clusterName1 = "ambry-another-cluster";
+    String className1 = "default";
+    String className2 = "new-class";
+
+    dao.insertPartitionClassName(clusterName, className1);
+    dao.insertPartitionClassName(clusterName, className2);
+    dao.insertPartitionClassName(clusterName1, className1);
+
+    final Map<String, Map<Short, Map<Short, Long>>> usagesInDB = new HashMap<>();
+    dao.queryAggregatedPartitionClassReport(clusterName,
+        (partitionClassName, accountId, containerId, storageUsage, updatedAt) -> {
+          usagesInDB.computeIfAbsent(partitionClassName, k -> new HashMap<>())
+              .computeIfAbsent(accountId, k -> new HashMap<>())
+              .put(containerId, storageUsage);
+        });
+    assertTrue(usagesInDB.isEmpty());
+
+    final int numAccount = 100;
+    final int numContainer = 10;
+    Map<String, Map<Short, Map<Short, Long>>> classNameAccountContainerUsages = new HashMap<>();
+    Random random = new Random();
+    final long maxUsage = 10000;
+
+    for (int i = 0; i < 3; i++) {
+      classNameAccountContainerUsages.clear();
+      usagesInDB.clear();
+      for (String className : new String[]{className1, className2}) {
+        classNameAccountContainerUsages.put(className, IntStream.range(0, numAccount)
+            .boxed()
+            .collect(Collectors.toMap(Integer::shortValue, a -> IntStream.range(0, numContainer)
+                .boxed()
+                .collect(Collectors.toMap(Integer::shortValue, c -> random.nextLong() % maxUsage)))));
+      }
+
+      PartitionClassReportsDao.StorageBatchUpdater batch = dao.new StorageBatchUpdater(17);
+      for (String className : classNameAccountContainerUsages.keySet()) {
+        for (short accountId : classNameAccountContainerUsages.get(className).keySet()) {
+          for (short containerId : classNameAccountContainerUsages.get(className).get(accountId).keySet()) {
+            long usage = classNameAccountContainerUsages.get(className).get(accountId).get(containerId);
+            batch.addUpdateToBatch(clusterName, className, accountId, containerId, usage);
+          }
+        }
+      }
+      batch.flush();
+      dao.queryAggregatedPartitionClassReport(clusterName,
+          (partitionClassName, accountId, containerId, storageUsage, updatedAt) -> {
+            usagesInDB.computeIfAbsent(partitionClassName, k -> new HashMap<>())
+                .computeIfAbsent(accountId, k -> new HashMap<>())
+                .put(containerId, storageUsage);
+          });
+
+      assertEquals(classNameAccountContainerUsages, usagesInDB);
+    }
+  }
+
+  private static AccountStatsMySqlStore createAccountStatsMySqlStore(String clusterName, String hostname, int port,
+      int batchSize) throws Exception {
+    Path tempDir = Files.createTempDirectory("PartitionClassReportsDaoTest");
+    Properties configProps = Utils.loadPropsFromResource("accountstats_mysql.properties");
+    configProps.setProperty(ClusterMapConfig.CLUSTERMAP_CLUSTER_NAME, clusterName);
+    configProps.setProperty(ClusterMapConfig.CLUSTERMAP_HOST_NAME, hostname);
+    configProps.setProperty(ClusterMapConfig.CLUSTERMAP_DATACENTER_NAME, "dc1");
+    configProps.setProperty(ClusterMapConfig.CLUSTERMAP_PORT, String.valueOf(port));
+    configProps.setProperty(AccountStatsMySqlConfig.DOMAIN_NAMES_TO_REMOVE, ".github.com");
+    configProps.setProperty(AccountStatsMySqlConfig.UPDATE_BATCH_SIZE, String.valueOf(batchSize));
+    configProps.setProperty(StatsManagerConfig.STATS_OUTPUT_FILE_PATH, tempDir.toString());
+    VerifiableProperties verifiableProperties = new VerifiableProperties(configProps);
+    return new AccountStatsMySqlStoreFactory(verifiableProperties, new ClusterMapConfig(verifiableProperties),
+        new StatsManagerConfig(verifiableProperties), new MetricRegistry()).getAccountStatsMySqlStore();
+  }
+}

--- a/ambry-mysql/src/main/java/com/github/ambry/accountstats/AccountReportsDao.java
+++ b/ambry-mysql/src/main/java/com/github/ambry/accountstats/AccountReportsDao.java
@@ -48,30 +48,26 @@ public class AccountReportsDao {
           CONTAINER_ID_COLUMN, STORAGE_USAGE_COLUMN, UPDATED_AT_COLUMN, ACCOUNT_REPORTS_TABLE, CLUSTER_NAME_COLUMN,
           HOSTNAME_COLUMN);
   private final MySqlDataAccessor dataAccessor;
-  private final String clusterName;
-  private final String hostname;
 
   /**
    * Constructor to create a {@link AccountReportsDao}.
    * @param dataAccessor The underlying {@link MySqlDataAccessor}.
-   * @param clusterName The name of the cluster this host is belonging to, like Ambry-test.
-   * @param hostname The name of the host. It should include the hostname and the port.
    */
-  AccountReportsDao(MySqlDataAccessor dataAccessor, String clusterName, String hostname) {
+  AccountReportsDao(MySqlDataAccessor dataAccessor) {
     this.dataAccessor = Objects.requireNonNull(dataAccessor, "MySqlDataAccessor is empty");
-    this.clusterName = Objects.requireNonNull(clusterName, "clusterName is empty");
-    this.hostname = Objects.requireNonNull(hostname, "hostname is empty");
   }
 
   /**
    * Update the storage usage for the given account/container.
+   * @param clusterName the name of target cluster
+   * @param hostname the name of target host
    * @param partitionId The partition id of this account/container usage.
    * @param accountId The account id.
    * @param containerId The container id.
    * @param storageUsage The storage usage in bytes.
    */
-  void updateStorageUsage(short partitionId, short accountId, short containerId, long storageUsage)
-      throws SQLException {
+  void updateStorageUsage(String clusterName, String hostname, short partitionId, short accountId, short containerId,
+      long storageUsage) throws SQLException {
     try {
       long startTimeMs = System.currentTimeMillis();
       PreparedStatement insertStatement = dataAccessor.getPreparedStatement(insertSql, true);
@@ -143,14 +139,16 @@ public class AccountReportsDao {
 
     /**
      * Supply values to the prepared statement and add it to the batch updater.
+     * @param clusterName the cluster name
+     * @param hostname the hostname
      * @param partitionId The partition id of this account/container usage.
      * @param accountId The account id.
      * @param containerId The container id.
      * @param storageUsage The storage usage in bytes.
      * @throws SQLException
      */
-    public void addUpdateToBatch(short partitionId, short accountId, short containerId, long storageUsage)
-        throws SQLException {
+    public void addUpdateToBatch(String clusterName, String hostname, short partitionId, short accountId,
+        short containerId, long storageUsage) throws SQLException {
       addUpdateToBatch(statement -> {
         statement.setString(1, clusterName);
         statement.setString(2, hostname);

--- a/ambry-mysql/src/main/java/com/github/ambry/accountstats/AccountStatsMySqlStore.java
+++ b/ambry-mysql/src/main/java/com/github/ambry/accountstats/AccountStatsMySqlStore.java
@@ -510,4 +510,14 @@ public class AccountStatsMySqlStore implements AccountStatsStore {
   public MySqlDataAccessor getMySqlDataAccessor() {
     return mySqlDataAccessor;
   }
+
+  /**
+   * Helper method to close the active connection, if there is one.
+   */
+  @Override
+  public void closeConnection() {
+    if (mySqlDataAccessor != null) {
+      mySqlDataAccessor.closeActiveConnection();
+    }
+  }
 }

--- a/ambry-mysql/src/main/java/com/github/ambry/accountstats/AggregatedAccountReportsDao.java
+++ b/ambry-mysql/src/main/java/com/github/ambry/accountstats/AggregatedAccountReportsDao.java
@@ -75,16 +75,13 @@ public class AggregatedAccountReportsDao {
           AGGREGATED_ACCOUNT_REPORTS_MONTH_TABLE, CLUSTER_NAME_COLUMN, MONTH_COLUMN, MONTH_COLUMN);
 
   private final MySqlDataAccessor dataAccessor;
-  private final String clusterName;
 
   /**
    * Constructor to create {@link AggregatedAccountReportsDao}.
    * @param dataAccessor The {@link MySqlDataAccessor}.
-   * @param clusterName The clusterName.
    */
-  AggregatedAccountReportsDao(MySqlDataAccessor dataAccessor, String clusterName) {
+  AggregatedAccountReportsDao(MySqlDataAccessor dataAccessor) {
     this.dataAccessor = Objects.requireNonNull(dataAccessor, "MySqlDataAccessor is empty");
-    this.clusterName = Objects.requireNonNull(clusterName, "clusterName is empty");
   }
 
   /**
@@ -94,7 +91,8 @@ public class AggregatedAccountReportsDao {
    * @param storageUsage The storage usage in bytes.
    * @throws SQLException
    */
-  void updateStorageUsage(short accountId, short containerId, long storageUsage) throws SQLException {
+  void updateStorageUsage(String clusterName, short accountId, short containerId, long storageUsage)
+      throws SQLException {
     try {
       long startTimeMs = System.currentTimeMillis();
       PreparedStatement insertStatement = dataAccessor.getPreparedStatement(insertSql, true);
@@ -258,7 +256,8 @@ public class AggregatedAccountReportsDao {
      * @param storageUsage The storage usage in bytes.
      * @throws SQLException
      */
-    public void addUpdateToBatch(short accountId, short containerId, long storageUsage) throws SQLException {
+    public void addUpdateToBatch(String clusterName, short accountId, short containerId, long storageUsage)
+        throws SQLException {
       addUpdateToBatch(statement -> {
         statement.setString(1, clusterName);
         statement.setInt(2, accountId);

--- a/ambry-mysql/src/main/java/com/github/ambry/accountstats/ContainerUsageFunction.java
+++ b/ambry-mysql/src/main/java/com/github/ambry/accountstats/ContainerUsageFunction.java
@@ -25,6 +25,7 @@ public interface ContainerUsageFunction {
    * @param accountId
    * @param containerId
    * @param storageUsage
+   * @param updatedAtMs
    */
   void apply(short partitionId, short accountId, short containerId, long storageUsage, long updatedAtMs);
 }

--- a/ambry-mysql/src/main/java/com/github/ambry/accountstats/ContainerUsageFunction.java
+++ b/ambry-mysql/src/main/java/com/github/ambry/accountstats/ContainerUsageFunction.java
@@ -21,11 +21,11 @@ public interface ContainerUsageFunction {
 
   /**
    * Process container storage usage.
-   * @param partitionId
-   * @param accountId
-   * @param containerId
-   * @param storageUsage
-   * @param updatedAtMs
+   * @param partitionId The partition id.
+   * @param accountId The account id.
+   * @param containerId The container id.
+   * @param storageUsage The storage usage in bytes for this container.
+   * @param updatedAtMs The timestamp in milliseconds when this data is updated.
    */
   void apply(short partitionId, short accountId, short containerId, long storageUsage, long updatedAtMs);
 }

--- a/ambry-mysql/src/main/java/com/github/ambry/accountstats/PartitionClassContainerUsageFunction.java
+++ b/ambry-mysql/src/main/java/com/github/ambry/accountstats/PartitionClassContainerUsageFunction.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.accountstats;
+
+/**
+ * A callback function to call when processing aggregated partition class container usage.
+ */
+@FunctionalInterface
+public interface PartitionClassContainerUsageFunction {
+
+  /**
+   * Process aggregated partition class container usage.
+   * @param partitionClassName The partition class name
+   * @param accountId the account id
+   * @param containerId the container id
+   * @param storageUsage the storage usage
+   * @param updatedAt the updated at time in milliseconds
+   */
+  void apply(String partitionClassName, short accountId, short containerId, long storageUsage, long updatedAt);
+}

--- a/ambry-mysql/src/main/java/com/github/ambry/accountstats/PartitionClassReportsDao.java
+++ b/ambry-mysql/src/main/java/com/github/ambry/accountstats/PartitionClassReportsDao.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright 2021 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.accountstats;
+
+import com.github.ambry.mysql.BatchUpdater;
+import com.github.ambry.mysql.MySqlDataAccessor;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.SQLIntegrityConstraintViolationException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.github.ambry.mysql.MySqlDataAccessor.OperationType.*;
+
+
+/**
+ * PartitionClassNames, Partitions, AggregatedPartitionClassReports Data Access Object.
+ */
+public class PartitionClassReportsDao {
+  public static final String PARTITION_CLASS_NAMES_TABLE = "PartitionClassNames";
+  public static final String PARTITIONS_TABLE = "Partitions";
+  public static final String AGGREGATED_PARTITION_CLASS_REPORTS_TABLE = "AggregatedPartitionClassReports";
+  private static final String ID_COLUMN = "id";
+  private static final String NAME_COLUMN = "name";
+  private static final String PARTITION_CLASS_ID_COLUMN = "partitionClassId";
+  private static final String CLUSTER_NAME_COLUMN = "clusterName";
+  private static final String ACCOUNT_ID_COLUMN = "accountId";
+  private static final String CONTAINER_ID_COLUMN = "containerId";
+  private static final String STORAGE_USAGE_COLUMN = "storageUsage";
+  private static final String UPDATED_AT_COLUMN = "updatedAt";
+
+  private static final String insertPartitionClassNamesSql =
+      String.format("INSERT INTO %s (%s, %s) VALUES (?, ?)", PARTITION_CLASS_NAMES_TABLE, CLUSTER_NAME_COLUMN,
+          NAME_COLUMN);
+
+  private static final String queryPartitionClassNamesSql =
+      String.format("SELECT %s, %s FROM %S WHERE %s = ?", ID_COLUMN, NAME_COLUMN, PARTITION_CLASS_NAMES_TABLE,
+          CLUSTER_NAME_COLUMN);
+
+  private static final String insertPartitionIdSql = String.format("INSERT INTO %s VALUES (?, ?, ?)", PARTITIONS_TABLE);
+
+  private static final String queryPartitionIdsSql =
+      String.format("SELECT %s FROM %s WHERE %s = ?", ID_COLUMN, PARTITIONS_TABLE, CLUSTER_NAME_COLUMN);
+
+  private static final String queryPartitionIdAndNamesSql = String.format(
+      "SELECT %1$s.%2$s, %3$s.%4$s FROM %1$s INNER JOIN %3$s ON %1$s.%5$s = %3$s.%2$s AND %1$s.%6$s = %3$s.%6$s "
+          + "WHERE %1$s.%6$s = ?", PARTITIONS_TABLE, ID_COLUMN, PARTITION_CLASS_NAMES_TABLE, NAME_COLUMN,
+      PARTITION_CLASS_ID_COLUMN, CLUSTER_NAME_COLUMN);
+
+  private static final String insertAggregatedSql = String.format(
+      "INSERT INTO %s SELECT %s, ?, ?, ?, NOW() FROM %s WHERE %s=? AND %s=? ON DUPLICATE KEY UPDATE %s=?, %s=NOW()",
+      AGGREGATED_PARTITION_CLASS_REPORTS_TABLE, ID_COLUMN, PARTITION_CLASS_NAMES_TABLE, CLUSTER_NAME_COLUMN,
+      NAME_COLUMN, STORAGE_USAGE_COLUMN, UPDATED_AT_COLUMN);
+
+  private static final String queryAggregatedSql = String.format(
+      "SELECT TableA.%s, %s, %s, %s, %s FROM %s " + "INNER JOIN (SELECT * FROM %s WHERE %s = ?) TableA"
+          + " WHERE TableA.%s = %s.%s;", NAME_COLUMN, ACCOUNT_ID_COLUMN, CONTAINER_ID_COLUMN, STORAGE_USAGE_COLUMN,
+      UPDATED_AT_COLUMN, AGGREGATED_PARTITION_CLASS_REPORTS_TABLE, PARTITION_CLASS_NAMES_TABLE, CLUSTER_NAME_COLUMN,
+      ID_COLUMN, AGGREGATED_PARTITION_CLASS_REPORTS_TABLE, PARTITION_CLASS_ID_COLUMN);
+
+  private static final Logger logger = LoggerFactory.getLogger(PartitionClassReportsDao.class);
+  private final MySqlDataAccessor dataAccessor;
+
+  /**
+   * Constructor to instantiate a {@link PartitionClassReportsDao}.
+   * @param dataAccessor
+   */
+  PartitionClassReportsDao(MySqlDataAccessor dataAccessor) {
+    this.dataAccessor = Objects.requireNonNull(dataAccessor, "MySqlDataAccessor is empty");
+  }
+
+  /**
+   * Query partition class names and their corresponding id for given {@code clusterName}. An empty map will be returned
+   * if there is not rows for the given {@code clusterName}.
+   * @param clusterName The clusterName to query partition class names for
+   * @return A map whose key is the partition class name and the value is the corresponding id.
+   * @throws SQLException
+   */
+  Map<String, Short> queryPartitionClassNames(String clusterName) throws SQLException {
+    Map<String, Short> result = new HashMap<>();
+    try {
+      long startTimeMs = System.currentTimeMillis();
+      PreparedStatement queryStatement = dataAccessor.getPreparedStatement(queryPartitionClassNamesSql, false);
+      queryStatement.setString(1, clusterName);
+      try (ResultSet rs = queryStatement.executeQuery()) {
+        while (rs.next()) {
+          short partitionClassId = rs.getShort(1);
+          String className = rs.getString(2);
+          result.put(className, partitionClassId);
+        }
+      }
+      dataAccessor.onSuccess(Read, System.currentTimeMillis() - startTimeMs);
+      return result;
+    } catch (SQLException e) {
+      dataAccessor.onException(e, Read);
+      logger.error("Failed to execute query of {}, with parameter {}", queryPartitionClassNamesSql, clusterName, e);
+      throw e;
+    }
+  }
+
+  /**
+   * Insert the partition class name under given {@code clusterName}. Same partition class name can be inserted to different
+   * clusterNames. If partition class name is already inserted under clusterName, this method would treat it as a no-op.
+   * @param clusterName The clusterName.
+   * @param partitionClassName The partition class name.
+   * @throws SQLException
+   */
+  void insertPartitionClassName(String clusterName, String partitionClassName) throws SQLException {
+    try {
+      long startTimeMs = System.currentTimeMillis();
+      PreparedStatement insertStatement = dataAccessor.getPreparedStatement(insertPartitionClassNamesSql, true);
+      insertStatement.setString(1, clusterName);
+      insertStatement.setString(2, partitionClassName);
+      insertStatement.executeUpdate();
+      dataAccessor.onSuccess(Write, System.currentTimeMillis() - startTimeMs);
+    } catch (SQLIntegrityConstraintViolationException e) {
+      // If somehow the unique pair(clusterName, partitionClassName) is inserted, consider this as a success
+      // ignore it
+    } catch (SQLException e) {
+      dataAccessor.onException(e, Write);
+      logger.error("Failed to execute of {}, with parameter {} {}", insertPartitionClassNamesSql, clusterName,
+          partitionClassName, e);
+      throw e;
+    }
+  }
+
+  /**
+   * Query partition class names and partitions that belong to certain partition class name for the given {@code clusterName}.
+   * An empty map will be returned if there is no partition names and ids for the given {@code clusterName}.
+   * @param clusterName the clusterName
+   * @return A map whose key is the partition class name and the value is a set of partition ids.
+   * @throws SQLException
+   */
+  Map<String, Set<Short>> queryPartitionNameAndIds(String clusterName) throws SQLException {
+    Map<String, Set<Short>> nameAndIds = new HashMap<>();
+    try {
+      long startTimeMs = System.currentTimeMillis();
+      PreparedStatement queryStatement = dataAccessor.getPreparedStatement(queryPartitionIdAndNamesSql, false);
+      queryStatement.setString(1, clusterName);
+      try (ResultSet resultSet = queryStatement.executeQuery()) {
+        while (resultSet.next()) {
+          int partitionId = resultSet.getInt(1);
+          String partitionClassName = resultSet.getString(2);
+          nameAndIds.computeIfAbsent(partitionClassName, k -> new HashSet<>()).add((short) partitionId);
+        }
+      }
+      dataAccessor.onSuccess(Read, System.currentTimeMillis() - startTimeMs);
+      return nameAndIds;
+    } catch (SQLException e) {
+      dataAccessor.onException(e, Read);
+      logger.error("Failed to execute query {}, with parameter {}", queryPartitionIdAndNamesSql, clusterName, e);
+      throw e;
+    }
+  }
+
+  /**
+   * Query the partition ids belonging to the given {@code clusterName}. An empty set will be returned if there is no
+   * partitions for the given {@code clusterName}.
+   * @param clusterName The clusterName.
+   * @return
+   * @throws SQLException
+   */
+  Set<Short> queryPartitionIds(String clusterName) throws SQLException {
+    Set<Short> partitionIds = new HashSet<>();
+    try {
+      long startTimeMs = System.currentTimeMillis();
+      PreparedStatement queryStatement = dataAccessor.getPreparedStatement(queryPartitionIdsSql, false);
+      queryStatement.setString(1, clusterName);
+      try (ResultSet rs = queryStatement.executeQuery()) {
+        while (rs.next()) {
+          partitionIds.add((short) rs.getInt(1));
+        }
+      }
+      dataAccessor.onSuccess(Read, System.currentTimeMillis() - startTimeMs);
+      return partitionIds;
+    } catch (SQLException e) {
+      dataAccessor.onException(e, Read);
+      logger.error("Failed to execute query {}, with parameter {}", queryPartitionIdsSql, clusterName, e);
+      throw e;
+    }
+  }
+
+  /**
+   * Insert partition id with it's partition class id of given {@code clusterName}. If the partition id already
+   * exist for given {@code clusterName}, then this will be a no-op.
+   * @param clusterName The clusterName
+   * @param partitionId The id of the partition
+   * @param partitionClassId The id of the partition class name
+   * @throws SQLException
+   */
+  void insertPartitionId(String clusterName, short partitionId, short partitionClassId) throws SQLException {
+    try {
+      long startTimeMs = System.currentTimeMillis();
+      PreparedStatement insertStatement = dataAccessor.getPreparedStatement(insertPartitionIdSql, true);
+      insertStatement.setString(1, clusterName);
+      insertStatement.setInt(2, partitionId);
+      insertStatement.setShort(3, partitionClassId);
+      insertStatement.executeUpdate();
+      dataAccessor.onSuccess(Write, System.currentTimeMillis() - startTimeMs);
+    } catch (SQLIntegrityConstraintViolationException e) {
+      // If somehow the unique pair(clusterName, partitionId) is inserted, consider this as a success
+      // ignore it
+    } catch (SQLException e) {
+      dataAccessor.onException(e, Write);
+      logger.error("Failed to execute of {}, with parameter {} {} {}", insertPartitionIdSql, clusterName, partitionId,
+          partitionClassId, e);
+      throw e;
+    }
+  }
+
+  /**
+   * Query container storage usage for given {@code clusterName}. This usage is aggregated under each partition class name.
+   * The results will be applied to the given {@link PartitionClassContainerUsageFunction}.
+   * @param clusterName The clusterName.
+   * @param func The callback to apply query results
+   * @throws SQLException
+   */
+  void queryAggregatedPartitionClassReport(String clusterName, PartitionClassContainerUsageFunction func)
+      throws SQLException {
+    try {
+      long startTimeMs = System.currentTimeMillis();
+      PreparedStatement queryStatement = dataAccessor.getPreparedStatement(queryAggregatedSql, false);
+      queryStatement.setString(1, clusterName);
+      try (ResultSet rs = queryStatement.executeQuery()) {
+        while (rs.next()) {
+          String className = rs.getString(1);
+          int accountId = rs.getInt(2);
+          int containerId = rs.getInt(3);
+          long usage = rs.getLong(4);
+          long updatedAt = rs.getTimestamp(5).getTime();
+          func.apply(className, (short) accountId, (short) containerId, usage, updatedAt);
+        }
+      }
+      dataAccessor.onSuccess(Read, System.currentTimeMillis() - startTimeMs);
+    } catch (SQLException e) {
+      dataAccessor.onException(e, Read);
+      logger.error("Failed to execute query {}, with parameter {}", queryAggregatedSql, clusterName, e);
+      throw e;
+    }
+  }
+
+  /**
+   * A batch updater to update aggregated partition class container storage usage.
+   */
+  class StorageBatchUpdater extends BatchUpdater {
+
+    /**
+     * Constructor to instantiate a {@link BatchUpdater}.
+     * @param maxBatchSize The max batch size.
+     * @throws SQLException
+     */
+    public StorageBatchUpdater(int maxBatchSize) throws SQLException {
+      super(dataAccessor, insertAggregatedSql, "AggregatedPartitionClassReports", maxBatchSize);
+    }
+
+    /**
+     * Supply values to the prepared statement and add it to batch updater.
+     * @param clusterName the clusterName.
+     * @param partitionClassName the partition class name
+     * @param accountId the account id
+     * @param containerId the container id
+     * @param usage the storage usage
+     * @throws SQLException
+     */
+    public void addUpdateToBatch(String clusterName, String partitionClassName, short accountId, short containerId,
+        long usage) throws SQLException {
+      addUpdateToBatch(statement -> {
+        statement.setInt(1, accountId);
+        statement.setInt(2, containerId);
+        statement.setLong(3, usage);
+        statement.setString(4, clusterName);
+        statement.setString(5, partitionClassName);
+        statement.setLong(6, usage);
+      });
+    }
+  }
+}

--- a/ambry-mysql/src/main/java/com/github/ambry/accountstats/PartitionClassReportsDao.java
+++ b/ambry-mysql/src/main/java/com/github/ambry/accountstats/PartitionClassReportsDao.java
@@ -51,7 +51,7 @@ public class PartitionClassReportsDao {
           NAME_COLUMN);
 
   private static final String queryPartitionClassNamesSql =
-      String.format("SELECT %s, %s FROM %S WHERE %s = ?", ID_COLUMN, NAME_COLUMN, PARTITION_CLASS_NAMES_TABLE,
+      String.format("SELECT %s, %s FROM %s WHERE %s = ?", ID_COLUMN, NAME_COLUMN, PARTITION_CLASS_NAMES_TABLE,
           CLUSTER_NAME_COLUMN);
 
   private static final String insertPartitionIdSql = String.format("INSERT INTO %s VALUES (?, ?, ?)", PARTITIONS_TABLE);

--- a/ambry-mysql/src/main/java/com/github/ambry/mysql/BatchUpdater.java
+++ b/ambry-mysql/src/main/java/com/github/ambry/mysql/BatchUpdater.java
@@ -79,10 +79,11 @@ public class BatchUpdater {
     }
     this.maxBatchSize = maxBatchSize;
     try {
-      autoCommit = dataAccessor.getAutoCommmit();
-      dataAccessor.setAutoCommit(false);
+      // Calling getPreparedStatement first, since it will setup connection if there is none
       statement = dataAccessor.getPreparedStatement(sql, true);
       statement.clearBatch();
+      autoCommit = dataAccessor.getAutoCommmit();
+      dataAccessor.setAutoCommit(false);
     } catch (SQLException e) {
       dataAccessor.onException(e, BatchUpdate);
       logger.error("Failed to prepare for batch insert on {}", tableName, e);

--- a/ambry-mysql/src/test/java/com/github/ambry/accountstats/AccountReportsDaoTest.java
+++ b/ambry-mysql/src/test/java/com/github/ambry/accountstats/AccountReportsDaoTest.java
@@ -80,7 +80,7 @@ public class AccountReportsDaoTest {
 
     metrics = new MySqlMetrics(AccountReportsDao.class, new MetricRegistry());
     dataAccessor = getDataAccessor(mockConnection, metrics);
-    accountReportsDao = new AccountReportsDao(dataAccessor, clusterName, hostname);
+    accountReportsDao = new AccountReportsDao(dataAccessor);
   }
 
   /**
@@ -104,11 +104,11 @@ public class AccountReportsDaoTest {
     short accountId = 100;
     short containerId = 8;
     long storageUsage = 100000;
-    accountReportsDao.updateStorageUsage(partitionId, accountId, containerId, storageUsage);
+    accountReportsDao.updateStorageUsage(clusterName, hostname, partitionId, accountId, containerId, storageUsage);
     verify(mockConnection).prepareStatement(anyString());
     assertEquals("Write success count should be 1", 1, metrics.writeSuccessCount.getCount());
     // Run second time to reuse statement
-    accountReportsDao.updateStorageUsage(partitionId, accountId, containerId, storageUsage);
+    accountReportsDao.updateStorageUsage(clusterName, hostname, partitionId, accountId, containerId, storageUsage);
     verify(mockConnection).prepareStatement(anyString());
     assertEquals("Write success count should be 2", 2, metrics.writeSuccessCount.getCount());
   }
@@ -117,7 +117,8 @@ public class AccountReportsDaoTest {
   public void testUpdateStorageUsageWithException() throws Exception {
     when(mockInsertStatement.executeUpdate()).thenThrow(new SQLTransientConnectionException());
     TestUtils.assertException(SQLTransientConnectionException.class,
-        () -> accountReportsDao.updateStorageUsage((short) 1, (short) 1000, (short) 8, 100000), null);
+        () -> accountReportsDao.updateStorageUsage(clusterName, hostname, (short) 1, (short) 1000, (short) 8, 100000),
+        null);
     assertEquals("Write failure count should be 1", 1, metrics.writeFailureCount.getCount());
   }
 

--- a/ambry-mysql/src/test/java/com/github/ambry/accountstats/AccountStatsMySqlStoreTest.java
+++ b/ambry-mysql/src/test/java/com/github/ambry/accountstats/AccountStatsMySqlStoreTest.java
@@ -120,7 +120,7 @@ public class AccountStatsMySqlStoreTest {
     StatsHeader header =
         new StatsHeader(StatsHeader.StatsDescription.STORED_DATA_SIZE, System.currentTimeMillis(), 10, 10, null);
     StatsWrapper statsWrapper = new StatsWrapper(header, snapshot);
-    store.storeStats(statsWrapper);
+    store.storeAccountStats(statsWrapper);
     assertEquals("Write success count should be " + (10 * 10), 10 * 10, metrics.writeSuccessCount.getCount());
 
     ObjectMapper objectMapper = new ObjectMapper();
@@ -131,7 +131,7 @@ public class AccountStatsMySqlStoreTest {
 
     // We have a local backup to start with.
     // Write the statsWrapper from local backup
-    store.storeStats(statsWrapper);
+    store.storeAccountStats(statsWrapper);
     assertEquals("Write success count should be " + (10 * 10), (10 * 10), metrics.writeSuccessCount.getCount());
   }
 
@@ -151,13 +151,13 @@ public class AccountStatsMySqlStoreTest {
     AccountStatsMySqlStore store =
         new AccountStatsMySqlStore(config, dataAccessor, clusterName, hostname, localBackupFilePath.toString(), null,
             new MetricRegistry());
-    store.storeStats(statsWrapper);
+    store.storeAccountStats(statsWrapper);
     assertEquals("Write success count should be 0", 0, metrics.writeSuccessCount.getCount());
 
     // Since all container storage usages are default values, second Snapshot should be the same as the first snapshot
     StatsSnapshot secondSnapshot = createStatsSnapshot(10, 10, 1, true);
     StatsWrapper secondStatsWrapper = new StatsWrapper(header, secondSnapshot);
-    store.storeStats(secondStatsWrapper);
+    store.storeAccountStats(secondStatsWrapper);
     assertEquals("Write success count should be 0", 0, metrics.writeSuccessCount.getCount());
     // Now the previous stats wrapper should be the second statsWrapper
     assertTrue(secondStatsWrapper == store.getPreviousStats());
@@ -172,7 +172,7 @@ public class AccountStatsMySqlStoreTest {
         .get("A[" + accountId + "]")
         .getSubMap()
         .put("C[" + BASE_CONTAINER_ID + "]", new StatsSnapshot((long) (DEFAULT_CONTAINER_USAGE + 1), null));
-    store.storeStats(statsWrapper);
+    store.storeAccountStats(statsWrapper);
     assertEquals("Write success count should be 1", 1, metrics.writeSuccessCount.getCount());
     assertTrue(statsWrapper == store.getPreviousStats());
 
@@ -183,7 +183,7 @@ public class AccountStatsMySqlStoreTest {
         .put("Partition[" + (BASE_PARTITION_ID + 10) + "]",
             additionalSnapshot.getSubMap().get("Partition[" + BASE_PARTITION_ID + "]"));
     // With the change from the previous one, we should see 10 + 1 writes
-    store.storeStats(secondStatsWrapper);
+    store.storeAccountStats(secondStatsWrapper);
     assertEquals("Write success count should be 12", 12, metrics.writeSuccessCount.getCount());
     assertTrue(secondStatsWrapper == store.getPreviousStats());
   }

--- a/ambry-mysql/src/test/java/com/github/ambry/accountstats/AggregatedAccountReportsDaoTest.java
+++ b/ambry-mysql/src/test/java/com/github/ambry/accountstats/AggregatedAccountReportsDaoTest.java
@@ -102,7 +102,7 @@ public class AggregatedAccountReportsDaoTest {
 
     metrics = new MySqlMetrics(AggregatedAccountReportsDao.class, new MetricRegistry());
     dataAccessor = getDataAccessor(mockConnection, metrics);
-    aggregatedAccountReportsDao = new AggregatedAccountReportsDao(dataAccessor, clusterName);
+    aggregatedAccountReportsDao = new AggregatedAccountReportsDao(dataAccessor);
   }
 
   /**
@@ -125,11 +125,11 @@ public class AggregatedAccountReportsDaoTest {
     short accountId = 10;
     short containerId = 1;
     long storageUsage = 1000;
-    aggregatedAccountReportsDao.updateStorageUsage(accountId, containerId, storageUsage);
+    aggregatedAccountReportsDao.updateStorageUsage(clusterName, accountId, containerId, storageUsage);
     verify(mockConnection).prepareStatement(anyString());
     assertEquals("Write success count should be 1", 1, metrics.writeSuccessCount.getCount());
     // Run second time to reuse statement
-    aggregatedAccountReportsDao.updateStorageUsage(accountId, containerId, storageUsage);
+    aggregatedAccountReportsDao.updateStorageUsage(clusterName, accountId, containerId, storageUsage);
     verify(mockConnection).prepareStatement(anyString());
     assertEquals("Write success count should be 2", 2, metrics.writeSuccessCount.getCount());
   }
@@ -138,7 +138,7 @@ public class AggregatedAccountReportsDaoTest {
   public void testInsertAggregatedStatsWithException() throws Exception {
     when(mockInsertAggregatedStatement.executeUpdate()).thenThrow(new SQLTransientConnectionException());
     TestUtils.assertException(SQLTransientConnectionException.class,
-        () -> aggregatedAccountReportsDao.updateStorageUsage((short) 1, (short) 1000, 100000), null);
+        () -> aggregatedAccountReportsDao.updateStorageUsage(clusterName, (short) 1, (short) 1000, 100000), null);
     assertEquals("Write failure count should be 1", 1, metrics.writeFailureCount.getCount());
   }
 

--- a/ambry-quota/src/main/java/com/github/ambry/quota/storage/AmbryStorageQuotaService.java
+++ b/ambry-quota/src/main/java/com/github/ambry/quota/storage/AmbryStorageQuotaService.java
@@ -14,7 +14,6 @@
 package com.github.ambry.quota.storage;
 
 import com.codahale.metrics.MetricRegistry;
-import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.StorageQuotaConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.quota.QuotaMode;
@@ -43,8 +42,8 @@ public class AmbryStorageQuotaService implements StorageQuotaService {
     this.metrics = new StorageQuotaServiceMetrics(metricRegistry);
     this.scheduler = Utils.newScheduler(1, STORAGE_QUOTA_SERVICE_PREFIX, false);
     this.config = new StorageQuotaConfig(verifiableProperties);
-    this.storageUsageRefresher = new MySqlStorageUsageRefresher(accountStatsStore, this.scheduler, this.config,
-        new ClusterMapConfig(verifiableProperties), metrics);
+    this.storageUsageRefresher =
+        new MySqlStorageUsageRefresher(accountStatsStore, this.scheduler, this.config, metrics);
     this.storageQuotaSource =
         Utils.<StorageQuotaSourceFactory>getObj(config.sourceFactory, scheduler, config).getStorageQuotaSource();
     this.storageQuotaEnforcer = new AmbryStorageQuotaEnforcer(null, this.metrics);

--- a/ambry-quota/src/main/java/com/github/ambry/quota/storage/MySqlStorageUsageRefresher.java
+++ b/ambry-quota/src/main/java/com/github/ambry/quota/storage/MySqlStorageUsageRefresher.java
@@ -149,6 +149,8 @@ public class MySqlStorageUsageRefresher implements StorageUsageRefresher {
         }
       } catch (Exception e) {
         throw new IllegalStateException("Unable to fetch monthly storage usage from mysql", e);
+      } finally {
+        accountStatsStore.closeConnection();
       }
     }
     metrics.mysqlRefresherInitTimeMs.update(System.currentTimeMillis() - startTimeMs);
@@ -187,6 +189,8 @@ public class MySqlStorageUsageRefresher implements StorageUsageRefresher {
     } catch (Exception e) {
       logger.error("Failed to refresh monthly storage usage", e);
       shouldRetry = true;
+    } finally {
+      accountStatsStore.closeConnection();
     }
 
     if (shouldRetry) {
@@ -263,6 +267,8 @@ public class MySqlStorageUsageRefresher implements StorageUsageRefresher {
         logger.error("Failed to retrieve the container usage from mysql", e);
         // If we already have a container usage map in memory, then don't replace it with empty map.
         containerStorageUsageForCurrentMonthRef.compareAndSet(null, Collections.EMPTY_MAP);
+      } finally {
+        accountStatsStore.closeConnection();
       }
     };
     updater.run();

--- a/ambry-server/src/main/java/com/github/ambry/server/StatsManager.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/StatsManager.java
@@ -480,6 +480,10 @@ class StatsManager {
         metrics.statsAggregationFailureCount.inc();
         logger.error("Exception while aggregating stats for local report. Stats output file path - {}",
             statsOutputFile.getAbsolutePath(), e);
+      } finally {
+        if (accountStatsMySqlStore != null) {
+          accountStatsMySqlStore.closeConnection();
+        }
       }
     }
 

--- a/ambry-server/src/main/java/com/github/ambry/server/StatsManager.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/StatsManager.java
@@ -471,7 +471,7 @@ class StatsManager {
           // First write to account stats
           StatsWrapper statsWrapper = new StatsWrapper(statsHeader, aggregatedSnapshot);
           if (accountStatsMySqlStore != null) {
-            accountStatsMySqlStore.storeStats(statsWrapper);
+            accountStatsMySqlStore.storeAccountStats(statsWrapper);
           }
           publish(statsWrapper);
           logger.info("Local stats snapshot published to {}", statsOutputFile.getAbsolutePath());

--- a/ambry-utils/src/main/java/com/github/ambry/utils/Utils.java
+++ b/ambry-utils/src/main/java/com/github/ambry/utils/Utils.java
@@ -133,6 +133,85 @@ public class Utils {
   }
 
   /**
+   * Return PartitionClassReport stats account container entry key of given {@code accountId} and {@code containerId}.
+   * For now, it's A[accountId]___C[containerId].
+   * @param accountId the account id.
+   * @param containerId the container id.
+   * @return the account container entry key in PartitionClassReport stats.
+   */
+  public static String partitionClassStatsAccountContainerKey(short accountId, short containerId) {
+    return "A[" + accountId + "]" + ACCOUNT_CONTAINER_SEPARATOR + "C[" + containerId + "]";
+  }
+
+  /**
+   * Return account id and container id from PartitionClassReport stats account container entry key. It's the opposite
+   * of {@link #partitionClassStatsAccountContainerKey}. It returns an array of short with exactly two elements. The first
+   * is the account id and the second is the container id.
+   * @param accountContainerKey The account container entry key in PartitionClassReport stats.
+   * @return An array of shorts with account id being the first element and container id being the second element.
+   */
+  public static short[] accountContainerIdFromPartitionClassStatsKey(String accountContainerKey) {
+    String[] parts = accountContainerKey.split(Utils.ACCOUNT_CONTAINER_SEPARATOR);
+    short accountId = Short.valueOf(parts[0].substring(2, parts[0].length() - 1));
+    short containerId = Short.valueOf(parts[1].substring(2, parts[1].length() - 1));
+    return new short[]{accountId, containerId};
+  }
+
+  /**
+   * Return partition key for stats report. For now, it's Partition[partitionId].
+   * @param partitionId the partition id.
+   * @return The partition key for stats report.
+   */
+  public static String statsPartitionKey(short partitionId) {
+    return "Partition[" + partitionId + "]";
+  }
+
+  /**
+   * Return account key for stats report. For now, it's A[accountId].
+   * @param accountId the account id.
+   * @return The account key for stats report.
+   */
+  public static String statsAccountKey(short accountId) {
+    return "A[" + accountId + "]";
+  }
+
+  /**
+   * Return container key for stats report. For now, it's C[containerId].
+   * @param containerId the container id.
+   * @return The container key for stats report.
+   */
+  public static String statsContainerKey(short containerId) {
+    return "C[" + containerId + "]";
+  }
+
+  /**
+   * Return partition id from partition key of stats report. It's the opposite of {@link #statsPartitionKey}.
+   * @param partitionKey the partition key of stats report.
+   * @return The partition id.
+   */
+  public static short partitionIdFromStatsPartitionKey(String partitionKey) {
+    return Short.valueOf(partitionKey.substring("Partition[".length(), partitionKey.length() - 1));
+  }
+
+  /**
+   * Return account id from account key of stats report. It's the opposite of {@link #statsAccountKey}.
+   * @param accountKey the account key of stats report.
+   * @return The account id.
+   */
+  public static short accountIdFromStatsAccountKey(String accountKey) {
+    return Short.valueOf(accountKey.substring(2, accountKey.length() - 1));
+  }
+
+  /**
+   * Return container is from container key of stats report. It's the opposite of {@link #statsContainerKey}.
+   * @param containerKey the container key of stats report.
+   * @return The container id.
+   */
+  public static short containerIdFromStatsContainerKey(String containerKey) {
+    return Short.valueOf(containerKey.substring(2, containerKey.length() - 1));
+  }
+
+  /**
    * Gets the size of the string in serialized form
    * @param value the string of interest to be serialized
    * @return the size of the string in serialized form


### PR DESCRIPTION
1. Adding method to update and fetch data from/to partition class tables.
2. Remove batch configuration and enable it by default.
3. Add synchronized qualifier to all AccountStatsMysqlStore method.
4. Close connection after interaction with mysql database finishes.