### PR TITLE
Hide Stats Key prefix in Utils class

### DIFF
--- a/ambry-mysql/src/integration-test/java/com/github/ambry/accountstats/AccountStatsMySqlStoreIntegrationTest.java
+++ b/ambry-mysql/src/integration-test/java/com/github/ambry/accountstats/AccountStatsMySqlStoreIntegrationTest.java
@@ -395,7 +395,10 @@ public class AccountStatsMySqlStoreIntegrationTest {
             .entrySet()) {
           String containerKey = containerEntry.getKey();
           StatsSnapshot containerStats = new StatsSnapshot(containerEntry.getValue());
-          accountContainerSubMap.put(accountKey + Utils.ACCOUNT_CONTAINER_SEPARATOR + containerKey, containerStats);
+          String accountContainerKey =
+              Utils.partitionClassStatsAccountContainerKey(Utils.accountIdFromStatsAccountKey(accountKey),
+                  Utils.containerIdFromStatsContainerKey(containerKey));
+          accountContainerSubMap.put(accountContainerKey, containerStats);
         }
       }
       long accountContainerValue = accountContainerSubMap.values().stream().mapToLong(StatsSnapshot::getValue).sum();

--- a/ambry-server/src/test/java/com/github/ambry/server/StatsManagerTest.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/StatsManagerTest.java
@@ -659,7 +659,7 @@ public class StatsManagerTest {
       for (int j = 0; j < random.nextInt(MAX_CONTAINER_COUNT - MIN_CONTAINER_COUNT + 1) + MIN_CONTAINER_COUNT; j++) {
         long validSize = random.nextInt(2501) + 500;
         subTotalSize += validSize;
-        containerMap.put(Utils.statsContainerKey(j), new StatsSnapshot(validSize, null));
+        containerMap.put(Utils.statsContainerKey((short) j), new StatsSnapshot(validSize, null));
         accountContainerPairMap.put(Utils.partitionClassStatsAccountContainerKey((short) i, (short) j),
             new StatsSnapshot(validSize, null));
       }

--- a/ambry-server/src/test/java/com/github/ambry/server/StatsManagerTest.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/StatsManagerTest.java
@@ -654,19 +654,17 @@ public class StatsManagerTest {
     Map<String, StatsSnapshot> accountContainerPairMap = new HashMap<>();
     long totalSize = 0;
     for (int i = 0; i < random.nextInt(MAX_ACCOUNT_COUNT - MIN_ACCOUNT_COUNT + 1) + MIN_ACCOUNT_COUNT; i++) {
-      String accountIdStr = "A[".concat(String.valueOf(i)).concat("]");
       Map<String, StatsSnapshot> containerMap = new HashMap<>();
       long subTotalSize = 0;
       for (int j = 0; j < random.nextInt(MAX_CONTAINER_COUNT - MIN_CONTAINER_COUNT + 1) + MIN_CONTAINER_COUNT; j++) {
-        String containerIdStr = "C[".concat(String.valueOf(j)).concat("]");
         long validSize = random.nextInt(2501) + 500;
         subTotalSize += validSize;
-        containerMap.put(containerIdStr, new StatsSnapshot(validSize, null));
-        accountContainerPairMap.put(accountIdStr + Utils.ACCOUNT_CONTAINER_SEPARATOR + containerIdStr,
+        containerMap.put(Utils.statsContainerKey(j), new StatsSnapshot(validSize, null));
+        accountContainerPairMap.put(Utils.partitionClassStatsAccountContainerKey((short) i, (short) j),
             new StatsSnapshot(validSize, null));
       }
       totalSize += subTotalSize;
-      accountMap.put(accountIdStr, new StatsSnapshot(subTotalSize, containerMap));
+      accountMap.put(Utils.statsAccountKey((short) i), new StatsSnapshot(subTotalSize, containerMap));
     }
     Map<StatsReportType, StatsSnapshot> allSnapshots = new HashMap<>();
     allSnapshots.put(StatsReportType.PARTITION_CLASS_REPORT, new StatsSnapshot(totalSize, accountContainerPairMap));

--- a/ambry-store/src/main/java/com/github/ambry/store/ScanResults.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/ScanResults.java
@@ -81,8 +81,8 @@ class ScanResults {
   // whose key is the ContainerId and the value is the valid size of this container.
   // So {@code containerBaseBucket} is base value for all containers and the {@code containerBuckets} is the delta values
   // on each time bucket.
-  private final Map<String, Map<String, Long>> containerBaseBucket = new ConcurrentHashMap<>();
-  private final NavigableMap<Long, Map<String, Map<String, Long>>> containerDeltaBuckets = new TreeMap<>();
+  private final Map<Short, Map<Short, Long>> containerBaseBucket = new ConcurrentHashMap<>();
+  private final NavigableMap<Long, Map<Short, Map<Short, Long>>> containerDeltaBuckets = new TreeMap<>();
   final long containerForecastStartTimeMs;
   final long containerLastBucketTimeMs;
   final long containerForecastEndTimeMs;
@@ -187,12 +187,12 @@ class ScanResults {
 
   /**
    * Update the container base value bucket with the given value.
-   * @param serviceId the serviceId of the map entry to be updated
+   * @param accountId the accountId of the map entry to be updated
    * @param containerId the containerId of the map entry to be updated
    * @param value the value to be added
    */
-  void updateContainerBaseBucket(String serviceId, String containerId, long value) {
-    updateNestedMapHelper(containerBaseBucket, serviceId, containerId, value);
+  void updateContainerBaseBucket(short accountId, short containerId, long value) {
+    updateNestedMapHelper(containerBaseBucket, accountId, containerId, value);
   }
 
   /**
@@ -207,14 +207,14 @@ class ScanResults {
   /**
    * Helper function to update a container bucket with the given value.
    * @param bucketKey the bucket key to specify which bucket will be updated
-   * @param serviceId the serviceId of the map entry to be updated
+   * @param accountId the accountId of the map entry to be updated
    * @param containerId the containerId of the map entry to be updated
    * @param value the value to be added
    */
-  void updateContainerBucket(Long bucketKey, String serviceId, String containerId, long value) {
+  void updateContainerBucket(Long bucketKey, short accountId, short containerId, long value) {
     if (bucketKey != null && containerDeltaBuckets.containsKey(bucketKey)) {
-      Map<String, Map<String, Long>> existingBucketEntry = containerDeltaBuckets.get(bucketKey);
-      updateNestedMapHelper(existingBucketEntry, serviceId, containerId, value);
+      Map<Short, Map<Short, Long>> existingBucketEntry = containerDeltaBuckets.get(bucketKey);
+      updateNestedMapHelper(existingBucketEntry, accountId, containerId, value);
     }
   }
 
@@ -281,15 +281,15 @@ class ScanResults {
    * @return a {@link Pair} whose first element is the end time of the last bucket that was aggregated and whose second
    * element is the requested valid data size per container {@link Map}.
    */
-  Map<String, Map<String, Long>> getValidSizePerContainer(Long referenceTimeInMs) {
-    Map<String, Map<String, Long>> validSizePerContainer = new HashMap<>();
-    for (Map.Entry<String, Map<String, Long>> accountEntry : containerBaseBucket.entrySet()) {
+  Map<Short, Map<Short, Long>> getValidSizePerContainer(Long referenceTimeInMs) {
+    Map<Short, Map<Short, Long>> validSizePerContainer = new HashMap<>();
+    for (Map.Entry<Short, Map<Short, Long>> accountEntry : containerBaseBucket.entrySet()) {
       validSizePerContainer.put(accountEntry.getKey(), new HashMap<>(accountEntry.getValue()));
     }
-    NavigableMap<Long, Map<String, Map<String, Long>>> subMap = containerDeltaBuckets.headMap(referenceTimeInMs, true);
-    for (Map.Entry<Long, Map<String, Map<String, Long>>> bucket : subMap.entrySet()) {
-      for (Map.Entry<String, Map<String, Long>> accountEntry : bucket.getValue().entrySet()) {
-        for (Map.Entry<String, Long> containerEntry : accountEntry.getValue().entrySet()) {
+    NavigableMap<Long, Map<Short, Map<Short, Long>>> subMap = containerDeltaBuckets.headMap(referenceTimeInMs, true);
+    for (Map.Entry<Long, Map<Short, Map<Short, Long>>> bucket : subMap.entrySet()) {
+      for (Map.Entry<Short, Map<Short, Long>> accountEntry : bucket.getValue().entrySet()) {
+        for (Map.Entry<Short, Long> containerEntry : accountEntry.getValue().entrySet()) {
           updateNestedMapHelper(validSizePerContainer, accountEntry.getKey(), containerEntry.getKey(),
               containerEntry.getValue());
         }

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreStatsTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreStatsTest.java
@@ -916,13 +916,13 @@ public class BlobStoreStatsTest {
         long randValue = random.nextInt(10000);
         subTotal += randValue;
         innerUtilizationMap.put((short) j, randValue);
-        containerSubMap.put(String.valueOf(j), new StatsSnapshot(randValue, null));
+        containerSubMap.put(Utils.statsContainerKey((short) j), new StatsSnapshot(randValue, null));
         accountContainerPairSubMap.put(Utils.partitionClassStatsAccountContainerKey((short) i, (short) j),
             new StatsSnapshot(randValue, null));
       }
       total += subTotal;
       utilizationMap.put((short) i, innerUtilizationMap);
-      accountSubMap.put(String.valueOf(i), new StatsSnapshot(subTotal, containerSubMap));
+      accountSubMap.put(Utils.statsAccountKey((short) i), new StatsSnapshot(subTotal, containerSubMap));
     }
     StatsSnapshot expectAccountSnapshot = new StatsSnapshot(total, accountSubMap);
     StatsSnapshot convertedAccountStatsSnapshot =


### PR DESCRIPTION
In stats reports, we use string as the key for partition id, account id and container id, with some prefix. Eg. for account id 100, the account key is A[100]. The prefix is spread all over the codebase. This PR reuse the common methods in Utils class to replace those statements that directly implement the logic of converting ids to string keys and vice versa. 