### PR TITLE
[StorageQuota] Fix NPE in storeAccountStats

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/server/AccountStatsStore.java
+++ b/ambry-api/src/main/java/com/github/ambry/server/AccountStatsStore.java
@@ -96,7 +96,7 @@ public interface AccountStatsStore {
    * @return A map whose key is the partition class name and the value is a set of a partition ids.
    * @throws Exception
    */
-  Map<String, Set<Short>> queryPartitionNameAndIds() throws Exception;
+  Map<String, Set<Integer>> queryPartitionNameAndIds() throws Exception;
 
   /**
    * Store partition class stats in {@link StatsWrapper}. This stats are per host stats. The stats is first grouped
@@ -142,7 +142,7 @@ public interface AccountStatsStore {
    * @return A {@link StatsWrapper} represents the per host partition class stats.
    * @throws Exception
    */
-  StatsWrapper queryPartitionClassStatsOf(String hostname, Map<String, Set<Short>> partitionNameAndIds)
+  StatsWrapper queryPartitionClassStatsOf(String hostname, Map<String, Set<Integer>> partitionNameAndIds)
       throws Exception;
 
   /**

--- a/ambry-mysql/src/integration-test/java/com/github/ambry/accountstats/AccountStatsMySqlStoreIntegrationTest.java
+++ b/ambry-mysql/src/integration-test/java/com/github/ambry/accountstats/AccountStatsMySqlStoreIntegrationTest.java
@@ -251,7 +251,7 @@ public class AccountStatsMySqlStoreIntegrationTest {
     mySqlStore.storePartitionClassStats(partitionClassStats2);
     mySqlStore3.storePartitionClassStats(partitionClassStats3);
 
-    Map<String, Set<Short>> partitionNameAndIds = mySqlStore.queryPartitionNameAndIds();
+    Map<String, Set<Integer>> partitionNameAndIds = mySqlStore.queryPartitionNameAndIds();
     assertEquals(new HashSet<>(partitionClassNames), partitionNameAndIds.keySet());
     Map<String, String> dbPartitionKeyToClassName = partitionNameAndIds.entrySet()
         .stream()
@@ -271,7 +271,7 @@ public class AccountStatsMySqlStoreIntegrationTest {
   @Test
   public void testAggregatedPartitionClassStats() throws Exception {
     testHostPartitionClassStats();
-    Map<String, Set<Short>> partitionNameAndIds = mySqlStore.queryPartitionNameAndIds();
+    Map<String, Set<Integer>> partitionNameAndIds = mySqlStore.queryPartitionNameAndIds();
     AccountStatsMySqlStore mySqlStore3 = createAccountStatsMySqlStore(clusterName2, hostname3, false);
 
     // Now we should have partition class names and partition ids in database

--- a/ambry-mysql/src/integration-test/java/com/github/ambry/accountstats/PartitionClassReportsDaoTest.java
+++ b/ambry-mysql/src/integration-test/java/com/github/ambry/accountstats/PartitionClassReportsDaoTest.java
@@ -101,9 +101,9 @@ public class PartitionClassReportsDaoTest {
   public void testPartitionId() throws Exception {
     String clusterName = "ambry-test";
     // Before adding any partition ids, query should return empty result
-    Set<Short> partitionIds = dao.queryPartitionIds(clusterName);
+    Set<Integer> partitionIds = dao.queryPartitionIds(clusterName);
     assertTrue(partitionIds.isEmpty());
-    Map<String, Set<Short>> partitionNameAndIds = dao.queryPartitionNameAndIds(clusterName);
+    Map<String, Set<Integer>> partitionNameAndIds = dao.queryPartitionNameAndIds(clusterName);
     assertTrue(partitionNameAndIds.isEmpty());
 
     String partitionClassName1 = "default";
@@ -115,14 +115,14 @@ public class PartitionClassReportsDaoTest {
     short partitionClassId2 = partitionClassNames.get(partitionClassName2);
 
     // insert some partition ids and query them later
-    Map<String, Set<Short>> expectedPartitionIds = new HashMap<>();
+    Map<String, Set<Integer>> expectedPartitionIds = new HashMap<>();
     for (int i = 0; i < 100; i++) {
       short classId = i % 2 == 0 ? partitionClassId1 : partitionClassId2;
       String className = i % 2 == 0 ? partitionClassName1 : partitionClassName2;
-      dao.insertPartitionId(clusterName, (short) i, classId);
+      dao.insertPartitionId(clusterName, i, classId);
       // reinsert the same partition id should result in conflict, but conflict is handled by method
-      dao.insertPartitionId(clusterName, (short) i, classId);
-      expectedPartitionIds.computeIfAbsent(className, k -> new HashSet<Short>()).add((short) i);
+      dao.insertPartitionId(clusterName, i, classId);
+      expectedPartitionIds.computeIfAbsent(className, k -> new HashSet<Integer>()).add(i);
     }
 
     // Add partition ids for other clusters
@@ -130,14 +130,14 @@ public class PartitionClassReportsDaoTest {
     partitionClassNames = dao.queryPartitionClassNames("other-cluster");
     short partitionClassIdForOtherCluster = partitionClassNames.get(partitionClassName1);
     for (int i = 0; i < 100; i++) {
-      dao.insertPartitionId(clusterName, (short) i, partitionClassIdForOtherCluster);
+      dao.insertPartitionId(clusterName, i, partitionClassIdForOtherCluster);
     }
 
     // Get all partition ids for cluster
     partitionIds = dao.queryPartitionIds(clusterName);
     assertEquals(100, partitionIds.size());
     for (int i = 0; i < 100; i++) {
-      assertTrue(partitionIds.contains((short) i));
+      assertTrue(partitionIds.contains(i));
     }
 
     // Get all partition ids under corresponding class name

--- a/ambry-mysql/src/main/java/com/github/ambry/accountstats/AccountReportsDao.java
+++ b/ambry-mysql/src/main/java/com/github/ambry/accountstats/AccountReportsDao.java
@@ -66,7 +66,7 @@ public class AccountReportsDao {
    * @param containerId The container id.
    * @param storageUsage The storage usage in bytes.
    */
-  void updateStorageUsage(String clusterName, String hostname, short partitionId, short accountId, short containerId,
+  void updateStorageUsage(String clusterName, String hostname, int partitionId, short accountId, short containerId,
       long storageUsage) throws SQLException {
     try {
       long startTimeMs = System.currentTimeMillis();
@@ -111,7 +111,7 @@ public class AccountReportsDao {
         int containerId = resultSet.getInt(CONTAINER_ID_COLUMN);
         long storageUsage = resultSet.getLong(STORAGE_USAGE_COLUMN);
         long updatedAtMs = resultSet.getTimestamp(UPDATED_AT_COLUMN).getTime();
-        func.apply((short) partitionId, (short) accountId, (short) containerId, storageUsage, updatedAtMs);
+        func.apply(partitionId, (short) accountId, (short) containerId, storageUsage, updatedAtMs);
       }
       dataAccessor.onSuccess(Read, System.currentTimeMillis() - startTimeMs);
     } catch (SQLException e) {
@@ -147,7 +147,7 @@ public class AccountReportsDao {
      * @param storageUsage The storage usage in bytes.
      * @throws SQLException
      */
-    public void addUpdateToBatch(String clusterName, String hostname, short partitionId, short accountId,
+    public void addUpdateToBatch(String clusterName, String hostname, int partitionId, short accountId,
         short containerId, long storageUsage) throws SQLException {
       addUpdateToBatch(statement -> {
         statement.setString(1, clusterName);

--- a/ambry-mysql/src/main/java/com/github/ambry/accountstats/AccountStatsMySqlStore.java
+++ b/ambry-mysql/src/main/java/com/github/ambry/accountstats/AccountStatsMySqlStore.java
@@ -33,6 +33,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import joptsimple.internal.Strings;
@@ -200,7 +201,8 @@ public class AccountStatsMySqlStore implements AccountStatsStore {
       StatsSnapshot prevAccountStatsSnapshot =
           prevPartitionMap.getOrDefault(partitionIdKey, new StatsSnapshot((long) 0, new HashMap<>()));
       short partitionId = Utils.partitionIdFromStatsPartitionKey(partitionIdKey);
-      Map<String, StatsSnapshot> currAccountMap = currAccountStatsSnapshot.getSubMap();
+      Map<String, StatsSnapshot> currAccountMap =
+          Optional.ofNullable(currAccountStatsSnapshot.getSubMap()).orElseGet(HashMap<String, StatsSnapshot>::new);
       Map<String, StatsSnapshot> prevAccountMap = prevAccountStatsSnapshot.getSubMap();
       for (Map.Entry<String, StatsSnapshot> currAccountMapEntry : currAccountMap.entrySet()) {
         String accountIdKey = currAccountMapEntry.getKey();
@@ -208,7 +210,8 @@ public class AccountStatsMySqlStore implements AccountStatsStore {
         StatsSnapshot prevContainerStatsSnapshot =
             prevAccountMap.getOrDefault(accountIdKey, new StatsSnapshot((long) 0, new HashMap<>()));
         short accountId = Utils.accountIdFromStatsAccountKey(accountIdKey);
-        Map<String, StatsSnapshot> currContainerMap = currContainerStatsSnapshot.getSubMap();
+        Map<String, StatsSnapshot> currContainerMap =
+            Optional.ofNullable(currContainerStatsSnapshot.getSubMap()).orElseGet(HashMap<String, StatsSnapshot>::new);
         Map<String, StatsSnapshot> prevContainerMap = prevContainerStatsSnapshot.getSubMap();
         for (Map.Entry<String, StatsSnapshot> currContainerMapEntry : currContainerMap.entrySet()) {
           String containerIdKey = currContainerMapEntry.getKey();

--- a/ambry-mysql/src/main/java/com/github/ambry/accountstats/ContainerUsageFunction.java
+++ b/ambry-mysql/src/main/java/com/github/ambry/accountstats/ContainerUsageFunction.java
@@ -27,5 +27,5 @@ public interface ContainerUsageFunction {
    * @param storageUsage The storage usage in bytes for this container.
    * @param updatedAtMs The timestamp in milliseconds when this data is updated.
    */
-  void apply(short partitionId, short accountId, short containerId, long storageUsage, long updatedAtMs);
+  void apply(int partitionId, short accountId, short containerId, long storageUsage, long updatedAtMs);
 }

--- a/ambry-mysql/src/main/java/com/github/ambry/accountstats/PartitionClassReportsDao.java
+++ b/ambry-mysql/src/main/java/com/github/ambry/accountstats/PartitionClassReportsDao.java
@@ -183,8 +183,8 @@ public class PartitionClassReportsDao {
    * @return A map whose key is the partition class name and the value is a set of partition ids.
    * @throws SQLException
    */
-  Map<String, Set<Short>> queryPartitionNameAndIds(String clusterName) throws SQLException {
-    Map<String, Set<Short>> nameAndIds = new HashMap<>();
+  Map<String, Set<Integer>> queryPartitionNameAndIds(String clusterName) throws SQLException {
+    Map<String, Set<Integer>> nameAndIds = new HashMap<>();
     try {
       long startTimeMs = System.currentTimeMillis();
       PreparedStatement queryStatement = dataAccessor.getPreparedStatement(queryPartitionIdAndNamesSql, false);
@@ -193,7 +193,7 @@ public class PartitionClassReportsDao {
         while (resultSet.next()) {
           int partitionId = resultSet.getInt(1);
           String partitionClassName = resultSet.getString(2);
-          nameAndIds.computeIfAbsent(partitionClassName, k -> new HashSet<>()).add((short) partitionId);
+          nameAndIds.computeIfAbsent(partitionClassName, k -> new HashSet<>()).add(partitionId);
         }
       }
       dataAccessor.onSuccess(Read, System.currentTimeMillis() - startTimeMs);
@@ -212,15 +212,15 @@ public class PartitionClassReportsDao {
    * @return A set of partition ids of the given {@code clusterName}.
    * @throws SQLException
    */
-  Set<Short> queryPartitionIds(String clusterName) throws SQLException {
-    Set<Short> partitionIds = new HashSet<>();
+  Set<Integer> queryPartitionIds(String clusterName) throws SQLException {
+    Set<Integer> partitionIds = new HashSet<>();
     try {
       long startTimeMs = System.currentTimeMillis();
       PreparedStatement queryStatement = dataAccessor.getPreparedStatement(queryPartitionIdsSql, false);
       queryStatement.setString(1, clusterName);
       try (ResultSet rs = queryStatement.executeQuery()) {
         while (rs.next()) {
-          partitionIds.add((short) rs.getInt(1));
+          partitionIds.add(rs.getInt(1));
         }
       }
       dataAccessor.onSuccess(Read, System.currentTimeMillis() - startTimeMs);
@@ -240,7 +240,7 @@ public class PartitionClassReportsDao {
    * @param partitionClassId The id of the partition class name
    * @throws SQLException
    */
-  void insertPartitionId(String clusterName, short partitionId, short partitionClassId) throws SQLException {
+  void insertPartitionId(String clusterName, int partitionId, short partitionClassId) throws SQLException {
     try {
       long startTimeMs = System.currentTimeMillis();
       PreparedStatement insertStatement = dataAccessor.getPreparedStatement(insertPartitionIdSql, true);

--- a/ambry-utils/src/main/java/com/github/ambry/utils/Utils.java
+++ b/ambry-utils/src/main/java/com/github/ambry/utils/Utils.java
@@ -162,7 +162,9 @@ public class Utils {
    * @param partitionId the partition id.
    * @return The partition key for stats report.
    */
-  public static String statsPartitionKey(short partitionId) {
+  public static String statsPartitionKey(int partitionId) {
+    // This is the same value as AmbryPartition.toString. However, in AmbryPartition, the partition id is long type.
+    // Here it's an integer.
     return "Partition[" + partitionId + "]";
   }
 
@@ -189,8 +191,8 @@ public class Utils {
    * @param partitionKey the partition key of stats report.
    * @return The partition id.
    */
-  public static short partitionIdFromStatsPartitionKey(String partitionKey) {
-    return Short.valueOf(partitionKey.substring("Partition[".length(), partitionKey.length() - 1));
+  public static int partitionIdFromStatsPartitionKey(String partitionKey) {
+    return Integer.valueOf(partitionKey.substring("Partition[".length(), partitionKey.length() - 1));
   }
 
   /**


### PR DESCRIPTION
There are cases that partition stats snapshot has empty subMap because all of the account and containers under this partition has 0 storage usage values. In such case, storeAccountStats method would throw a NPE. This PR fixes that.