### PR TITLE
Fix account property didn't get updated in AccountInfoMap

### DIFF
--- a/ambry-account/src/main/java/com/github/ambry/account/AccountInfoMap.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/AccountInfoMap.java
@@ -249,7 +249,8 @@ class AccountInfoMap {
         AccountBuilder accountBuilder = new AccountBuilder(accountToUpdate).name(account.getName())
             .status(account.getStatus())
             .snapshotVersion(account.getSnapshotVersion())
-            .lastModifiedTime(account.getLastModifiedTime());
+            .lastModifiedTime(account.getLastModifiedTime())
+            .aclInheritedByContainer(account.isAclInheritedByContainer());
         account.getAllContainers().forEach(accountBuilder::addOrUpdateContainer);
         accountToUpdate = accountBuilder.build();
       }


### PR DESCRIPTION
We introduced new property "aclInheritedByContainer" to Account but didn't correctly update it within AccountInfoMap. This caused in-mem cache always has initial default value for this property and never gets a chance to update. This PR should fix issue in account update method.