### PR TITLE
Add life version to reset key in store find token

### DIFF
--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
@@ -46,6 +46,8 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.github.ambry.store.StoreFindToken.*;
+
 
 /**
  * Component that removes the "dead" data from the set of provided log segments and reclaims space.
@@ -1145,7 +1147,7 @@ class BlobStoreCompactor {
       // save a token for restart (the key gets ignored but is required to be non null for construction)
       StoreFindToken safeToken =
           new StoreFindToken(allIndexEntries.get(0).getKey(), indexSegment.getStartOffset(), sessionId, incarnationId,
-              null, null);
+              null, null, UNINITIALIZED_RESET_KEY_VERSION);
       compactionLog.setSafeToken(safeToken);
       logger.debug("Set safe token for compaction in {} to {}", storeId, safeToken);
 
@@ -1458,7 +1460,8 @@ class BlobStoreCompactor {
         if (previousKey == null) {
           // save a token for restart (the key gets ignored but is required to be non null for construction)
           StoreFindToken safeToken =
-              new StoreFindToken(currentKey, indexSegment.getStartOffset(), sessionId, incarnationId, null, null);
+              new StoreFindToken(currentKey, indexSegment.getStartOffset(), sessionId, incarnationId, null, null,
+                  UNINITIALIZED_RESET_KEY_VERSION);
           compactionLog.setSafeToken(safeToken);
           logger.debug("Set safe token for compaction in {} to {}", storeId, safeToken);
         }

--- a/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
@@ -49,6 +49,8 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.github.ambry.store.StoreFindToken.*;
+
 
 /**
  * A persistent index implementation that is responsible for adding and modifying index entries,
@@ -1232,7 +1234,8 @@ class PersistentIndex {
           logger.trace("Journal based token, Time used to eliminate duplicates: {}",
               (time.milliseconds() - startTimeInMs));
 
-          StoreFindToken storeFindToken = new StoreFindToken(offsetEnd, sessionId, incarnationId, false, null, null);
+          StoreFindToken storeFindToken = new StoreFindToken(offsetEnd, sessionId, incarnationId, false, null, null,
+              UNINITIALIZED_RESET_KEY_VERSION);
           // use the latest ref of indexSegments
           long bytesRead = getTotalBytesRead(storeFindToken, messageEntries, logEndOffsetBeforeFind, indexSegments);
           storeFindToken.setBytesRead(bytesRead);
@@ -1325,7 +1328,8 @@ class PersistentIndex {
             && storeToken.getOffset().compareTo(logEndOffsetOnStartup) > 0) {
           logger.info("Index : {} resetting offset after not clean shutdown {} before offset {}", dataDir,
               logEndOffsetOnStartup, storeToken.getOffset());
-          storeToken = new StoreFindToken(logEndOffsetOnStartup, sessionId, incarnationId, true, null, null);
+          storeToken = new StoreFindToken(logEndOffsetOnStartup, sessionId, incarnationId, true, null, null,
+              UNINITIALIZED_RESET_KEY_VERSION);
         }
       } else if (!storeToken.getType().equals(FindTokenType.Uninitialized)
           && storeToken.getOffset().compareTo(logEndOffsetOnStartup) > 0) {
@@ -1603,7 +1607,8 @@ class PersistentIndex {
       }
     }
     if (newTokenOffsetInJournal != null) {
-      return new StoreFindToken(newTokenOffsetInJournal, sessionId, incarnationId, false, null, null);
+      return new StoreFindToken(newTokenOffsetInJournal, sessionId, incarnationId, false, null, null,
+          UNINITIALIZED_RESET_KEY_VERSION);
     } else if (messageEntries.size() == 0 && !findEntriesCondition.hasEndTime()) {
       // If the condition does not have an end time, then since we have entered a segment, we should return at least one
       // message
@@ -1615,7 +1620,7 @@ class PersistentIndex {
       // uninitialized token
       return newTokenSegmentStartOffset == null ? new StoreFindToken()
           : new StoreFindToken(messageEntries.get(messageEntries.size() - 1).getStoreKey(), newTokenSegmentStartOffset,
-              sessionId, incarnationId, null, null);
+              sessionId, incarnationId, null, null, UNINITIALIZED_RESET_KEY_VERSION);
     }
   }
 
@@ -1899,7 +1904,8 @@ class PersistentIndex {
             break;
           }
         }
-        newToken = new StoreFindToken(offsetEnd, sessionId, incarnationId, false, null, null);
+        newToken =
+            new StoreFindToken(offsetEnd, sessionId, incarnationId, false, null, null, UNINITIALIZED_RESET_KEY_VERSION);
       } else {
         // Case 3: offset based, but offset out of journal
         Map.Entry<Offset, IndexSegment> entry = indexSegments.floorEntry(offsetToStart);

--- a/ambry-store/src/test/java/com/github/ambry/store/CompactionLogTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CompactionLogTest.java
@@ -34,6 +34,7 @@ import java.util.UUID;
 import org.junit.After;
 import org.junit.Test;
 
+import static com.github.ambry.store.StoreFindToken.*;
 import static org.junit.Assert.*;
 
 
@@ -57,7 +58,7 @@ public class CompactionLogTest {
   private final StoreConfig config;
   // the time instance that will be used in the index
   private final Time time = new MockTime();
-  private final Set<LogSegmentName> generatedSegmentNames = new HashSet<LogSegmentName>();
+  private final Set<LogSegmentName> generatedSegmentNames = new HashSet<>();
 
   /**
    * Creates a temporary directory for the compaction log file.
@@ -107,7 +108,7 @@ public class CompactionLogTest {
           cLog.getStartOffsetOfLastIndexSegmentForDeleteCheck());
       StoreFindToken safeToken =
           new StoreFindToken(new MockId("dummy"), new Offset(LogSegmentName.generateFirstSegmentName(true), 0),
-              new UUID(1, 1), new UUID(1, 1), null, null);
+              new UUID(1, 1), new UUID(1, 1), null, null, UNINITIALIZED_RESET_KEY_VERSION);
       cLog.setSafeToken(safeToken);
       assertEquals("Returned token not the same as the one that was set", safeToken, cLog.getSafeToken());
       CompactionDetails nextDetails = detailsIterator.hasNext() ? detailsIterator.next() : null;
@@ -170,7 +171,7 @@ public class CompactionLogTest {
           cLog.getStartOffsetOfLastIndexSegmentForDeleteCheck());
       StoreFindToken safeToken =
           new StoreFindToken(new MockId("dummy"), new Offset(LogSegmentName.generateFirstSegmentName(true), 0),
-              new UUID(1, 1), new UUID(1, 1), null, null);
+              new UUID(1, 1), new UUID(1, 1), null, null, UNINITIALIZED_RESET_KEY_VERSION);
       cLog.setSafeToken(safeToken);
 
       cLog.close();
@@ -412,7 +413,7 @@ public class CompactionLogTest {
     if (!cLog.getCompactionPhase().equals(CompactionLog.Phase.COPY)) {
       StoreFindToken safeToken =
           new StoreFindToken(new MockId("dummy"), new Offset(LogSegmentName.generateFirstSegmentName(true), 0),
-              new UUID(1, 1), new UUID(1, 1), null, null);
+              new UUID(1, 1), new UUID(1, 1), null, null, UNINITIALIZED_RESET_KEY_VERSION);
       try {
         cLog.setSafeToken(safeToken);
         fail("Setting safe token should have failed");


### PR DESCRIPTION
Previously we introduced reset key and its type to help find key in current log (after compaction). As UNDELETE may change the version of record, we need life version to help uniquely identify the reset key in the log. This PR fixes this potential issue in find key logic and adds life version into token deserialization code. 

(Note: token serialization change will be in future PR.)