### PR TITLE
Introduce PersistentIndex version 4 to incorporate reset key version in index segment

### DIFF
--- a/ambry-store/src/main/java/com/github/ambry/store/IndexSegment.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/IndexSegment.java
@@ -111,8 +111,7 @@ class IndexSegment implements Iterable<IndexEntry> {
   private short version;
   private Offset prevSafeEndPoint = null;
   // reset key refers to the first StoreKey that is added to the index segment
-  private Pair<StoreKey, PersistentIndex.IndexEntryType> resetKey = null;
-  private short resetKeyLifeVersion = UNINITIALIZED_RESET_KEY_VERSION;
+  private ResetKeyInfo resetKeyInfo = null;
   private NavigableMap<StoreKey, ConcurrentSkipListSet<IndexValue>> index = null;
 
   /**
@@ -327,21 +326,30 @@ class IndexSegment implements Iterable<IndexEntry> {
   }
 
   /**
-   * @return the reset key for the index segment which is a {@link Pair} of StoreKey and
-   * {@link PersistentIndex.IndexEntryType}
+   * @return the reset key for the index segment.
    */
-  Pair<StoreKey, PersistentIndex.IndexEntryType> getResetKey() {
-    return resetKey;
+  StoreKey getResetKey() {
+    return resetKeyInfo.getResetKey();
+  }
+
+  /**
+   * @return the {@link com.github.ambry.store.PersistentIndex.IndexEntryType} of reset key.
+   */
+  PersistentIndex.IndexEntryType getResetKeyType() {
+    return resetKeyInfo.getResetKeyType();
   }
 
   /**
    * @return life version of reset key.
    */
   short getResetKeyLifeVersion() throws StoreException {
-    if (resetKey == null || resetKeyLifeVersion != UNINITIALIZED_RESET_KEY_VERSION) {
-      return resetKeyLifeVersion;
+    if (resetKeyInfo == null) {
+      return UNINITIALIZED_RESET_KEY_VERSION;
     }
-    NavigableSet<IndexValue> indexValues = find(resetKey.getFirst());
+    if (resetKeyInfo.getResetKeyLifeVersion() != UNINITIALIZED_RESET_KEY_VERSION) {
+      return resetKeyInfo.getResetKeyLifeVersion();
+    }
+    NavigableSet<IndexValue> indexValues = find(resetKeyInfo.getResetKey());
     // reset key should be present in current index segment, hence indexValues is guaranteed to be non-empty
     return indexValues.first().getLifeVersion();
   }
@@ -570,9 +578,9 @@ class IndexSegment implements Iterable<IndexEntry> {
       if (!isPresent) {
         bloomFilter.add(getStoreKeyBytes(entry.getKey()));
       }
-      if (resetKey == null) {
-        resetKey = new Pair<>(entry.getKey(), entry.getValue().getIndexValueType());
-        resetKeyLifeVersion = entry.getValue().getLifeVersion();
+      if (resetKeyInfo == null) {
+        resetKeyInfo =
+            new ResetKeyInfo(entry.getKey(), entry.getValue().getIndexValueType(), entry.getValue().getLifeVersion());
       }
       numberOfItems.incrementAndGet();
       sizeWritten.addAndGet(entry.getKey().sizeInBytes() + entry.getValue().getBytes().capacity());
@@ -753,12 +761,12 @@ class IndexSegment implements Iterable<IndexEntry> {
         if (getVersion() != PersistentIndex.VERSION_0) {
           // write last modified time and reset key in case of version != 0
           writer.writeLong(lastModifiedTimeSec.get());
-          writer.write(resetKey.getFirst().toBytes());
-          writer.writeShort(resetKey.getSecond().ordinal());
+          writer.write(resetKeyInfo.getResetKey().toBytes());
+          writer.writeShort(resetKeyInfo.getResetKeyType().ordinal());
         }
         if (getVersion() >= PersistentIndex.VERSION_4) {
           // write reset key life version
-          writer.writeShort(resetKeyLifeVersion);
+          writer.writeShort(resetKeyInfo.getResetKeyLifeVersion());
         }
 
         byte[] maxPaddingBytes = null;
@@ -880,7 +888,8 @@ class IndexSegment implements Iterable<IndexEntry> {
       setVersion(serEntries.getShort());
       StoreKey storeKey;
       int keySize;
-      short resetKeyType;
+      PersistentIndex.IndexEntryType resetKeyType;
+      short resetKeyLifeVersion = UNINITIALIZED_RESET_KEY_VERSION;
       switch (getVersion()) {
         case PersistentIndex.VERSION_0:
           indexSizeExcludingEntries = VERSION_FIELD_LENGTH + KEY_OR_ENTRY_SIZE_FIELD_LENGTH + VALUE_SIZE_FIELD_LENGTH
@@ -899,11 +908,11 @@ class IndexSegment implements Iterable<IndexEntry> {
           endOffset.set(new Offset(startOffset.getName(), serEntries.getLong()));
           lastModifiedTimeSec.set(serEntries.getLong());
           storeKey = factory.getStoreKey(new DataInputStream(new ByteBufferInputStream(serEntries)));
-          resetKeyType = serEntries.getShort();
-          resetKey = new Pair<>(storeKey, PersistentIndex.IndexEntryType.values()[resetKeyType]);
+          resetKeyType = PersistentIndex.IndexEntryType.values()[serEntries.getShort()];
+          resetKeyInfo = new ResetKeyInfo(storeKey, resetKeyType, resetKeyLifeVersion);
           indexSizeExcludingEntries = VERSION_FIELD_LENGTH + KEY_OR_ENTRY_SIZE_FIELD_LENGTH + VALUE_SIZE_FIELD_LENGTH
-              + LOG_END_OFFSET_FIELD_LENGTH + CRC_FIELD_LENGTH + LAST_MODIFIED_TIME_FIELD_LENGTH + resetKey.getFirst()
-              .sizeInBytes() + RESET_KEY_TYPE_FIELD_LENGTH;
+              + LOG_END_OFFSET_FIELD_LENGTH + CRC_FIELD_LENGTH + LAST_MODIFIED_TIME_FIELD_LENGTH
+              + storeKey.sizeInBytes() + RESET_KEY_TYPE_FIELD_LENGTH;
           firstKeyRelativeOffset = indexSizeExcludingEntries - CRC_FIELD_LENGTH;
           break;
         case PersistentIndex.VERSION_2:
@@ -913,11 +922,11 @@ class IndexSegment implements Iterable<IndexEntry> {
           endOffset.set(new Offset(startOffset.getName(), serEntries.getLong()));
           lastModifiedTimeSec.set(serEntries.getLong());
           storeKey = factory.getStoreKey(new DataInputStream(new ByteBufferInputStream(serEntries)));
-          resetKeyType = serEntries.getShort();
-          resetKey = new Pair<>(storeKey, PersistentIndex.IndexEntryType.values()[resetKeyType]);
+          resetKeyType = PersistentIndex.IndexEntryType.values()[serEntries.getShort()];
+          resetKeyInfo = new ResetKeyInfo(storeKey, resetKeyType, resetKeyLifeVersion);
           indexSizeExcludingEntries = VERSION_FIELD_LENGTH + KEY_OR_ENTRY_SIZE_FIELD_LENGTH + VALUE_SIZE_FIELD_LENGTH
-              + LOG_END_OFFSET_FIELD_LENGTH + CRC_FIELD_LENGTH + LAST_MODIFIED_TIME_FIELD_LENGTH + resetKey.getFirst()
-              .sizeInBytes() + RESET_KEY_TYPE_FIELD_LENGTH;
+              + LOG_END_OFFSET_FIELD_LENGTH + CRC_FIELD_LENGTH + LAST_MODIFIED_TIME_FIELD_LENGTH
+              + storeKey.sizeInBytes() + RESET_KEY_TYPE_FIELD_LENGTH;
           firstKeyRelativeOffset = indexSizeExcludingEntries - CRC_FIELD_LENGTH;
           break;
         case PersistentIndex.VERSION_4:
@@ -926,12 +935,12 @@ class IndexSegment implements Iterable<IndexEntry> {
           endOffset.set(new Offset(startOffset.getName(), serEntries.getLong()));
           lastModifiedTimeSec.set(serEntries.getLong());
           storeKey = factory.getStoreKey(new DataInputStream(new ByteBufferInputStream(serEntries)));
-          resetKeyType = serEntries.getShort();
+          resetKeyType = PersistentIndex.IndexEntryType.values()[serEntries.getShort()];
           resetKeyLifeVersion = serEntries.getShort();
-          resetKey = new Pair<>(storeKey, PersistentIndex.IndexEntryType.values()[resetKeyType]);
+          resetKeyInfo = new ResetKeyInfo(storeKey, resetKeyType, resetKeyLifeVersion);
           indexSizeExcludingEntries = VERSION_FIELD_LENGTH + KEY_OR_ENTRY_SIZE_FIELD_LENGTH + VALUE_SIZE_FIELD_LENGTH
-              + LOG_END_OFFSET_FIELD_LENGTH + CRC_FIELD_LENGTH + LAST_MODIFIED_TIME_FIELD_LENGTH + resetKey.getFirst()
-              .sizeInBytes() + RESET_KEY_TYPE_FIELD_LENGTH + RESET_KEY_VERSION_FIELD_LENGTH;
+              + LOG_END_OFFSET_FIELD_LENGTH + CRC_FIELD_LENGTH + LAST_MODIFIED_TIME_FIELD_LENGTH
+              + storeKey.sizeInBytes() + RESET_KEY_TYPE_FIELD_LENGTH + RESET_KEY_VERSION_FIELD_LENGTH;
           firstKeyRelativeOffset = indexSizeExcludingEntries - CRC_FIELD_LENGTH;
           break;
         default:
@@ -989,14 +998,15 @@ class IndexSegment implements Iterable<IndexEntry> {
       } else {
         lastModifiedTimeSec.set(stream.readLong());
         StoreKey storeKey = factory.getStoreKey(stream);
-        short resetKeyType = stream.readShort();
-        resetKey = new Pair<>(storeKey, PersistentIndex.IndexEntryType.values()[resetKeyType]);
+        PersistentIndex.IndexEntryType resetKeyType = PersistentIndex.IndexEntryType.values()[stream.readShort()];
+        short resetKeyLifeVersion = UNINITIALIZED_RESET_KEY_VERSION;
         indexSizeExcludingEntries +=
-            LAST_MODIFIED_TIME_FIELD_LENGTH + resetKey.getFirst().sizeInBytes() + RESET_KEY_TYPE_FIELD_LENGTH;
-        if(getVersion() >= PersistentIndex.VERSION_4){
+            LAST_MODIFIED_TIME_FIELD_LENGTH + storeKey.sizeInBytes() + RESET_KEY_TYPE_FIELD_LENGTH;
+        if (getVersion() >= PersistentIndex.VERSION_4) {
           resetKeyLifeVersion = stream.readShort();
           indexSizeExcludingEntries += RESET_KEY_VERSION_FIELD_LENGTH;
         }
+        resetKeyInfo = new ResetKeyInfo(storeKey, resetKeyType, resetKeyLifeVersion);
       }
       firstKeyRelativeOffset = indexSizeExcludingEntries - CRC_FIELD_LENGTH;
       logger.trace("IndexSegment : {} reading log end offset {} from file", indexFile.getAbsolutePath(), logEndOffset);
@@ -1305,6 +1315,33 @@ class IndexSegment implements Iterable<IndexEntry> {
       startOffsetValue = filename.substring(lastButOneSepIdx + 1, lastSepIdx);
     }
     return new Offset(LogSegmentName.fromString(logSegmentName), Long.parseLong(startOffsetValue));
+  }
+
+  /**
+   * A data structure to hold info associated with reset key of index segment.
+   */
+  private static class ResetKeyInfo {
+    private final StoreKey key;
+    private final PersistentIndex.IndexEntryType keyType;
+    private final short lifeVersion;
+
+    public ResetKeyInfo(StoreKey key, PersistentIndex.IndexEntryType keyType, short lifeVersion) {
+      this.key = key;
+      this.keyType = keyType;
+      this.lifeVersion = lifeVersion;
+    }
+
+    StoreKey getResetKey() {
+      return key;
+    }
+
+    PersistentIndex.IndexEntryType getResetKeyType() {
+      return keyType;
+    }
+
+    short getResetKeyLifeVersion() {
+      return lifeVersion;
+    }
   }
 
   /**

--- a/ambry-store/src/main/java/com/github/ambry/store/IndexSegment.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/IndexSegment.java
@@ -329,14 +329,14 @@ class IndexSegment implements Iterable<IndexEntry> {
    * @return the reset key for the index segment.
    */
   StoreKey getResetKey() {
-    return resetKeyInfo.getResetKey();
+    return resetKeyInfo == null ? null : resetKeyInfo.getResetKey();
   }
 
   /**
    * @return the {@link com.github.ambry.store.PersistentIndex.IndexEntryType} of reset key.
    */
   PersistentIndex.IndexEntryType getResetKeyType() {
-    return resetKeyInfo.getResetKeyType();
+    return resetKeyInfo == null ? null : resetKeyInfo.getResetKeyType();
   }
 
   /**

--- a/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
@@ -69,7 +69,8 @@ class PersistentIndex {
   static final short VERSION_1 = 1;
   static final short VERSION_2 = 2;
   static final short VERSION_3 = 3;
-  static short CURRENT_VERSION = VERSION_3;
+  static final short VERSION_4 = 4;
+  static short CURRENT_VERSION = VERSION_4;
   static final String CLEAN_SHUTDOWN_FILENAME = "cleanshutdown";
 
   static final FilenameFilter INDEX_SEGMENT_FILE_FILTER = new FilenameFilter() {

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
@@ -3082,15 +3082,7 @@ public class BlobStoreCompactorTest {
     Collections.sort(indexEntries, PersistentIndex.INDEX_ENTRIES_OFFSET_COMPARATOR);
     for (IndexEntry entry : indexEntries) {
       MockId id = (MockId) entry.getKey();
-      PersistentIndex.IndexEntryType entryType = PersistentIndex.IndexEntryType.PUT;
-      if (entry.getValue().isDelete()) {
-        entryType = PersistentIndex.IndexEntryType.DELETE;
-      } else if (entry.getValue().isUndelete()) {
-        entryType = PersistentIndex.IndexEntryType.UNDELETE;
-      } else if (entry.getValue().isTtlUpdate()) {
-        entryType = PersistentIndex.IndexEntryType.TTL_UPDATE;
-      }
-      logEntriesInOrder.add(new LogEntry(id, entryType, entry.getValue().getSize()));
+      logEntriesInOrder.add(new LogEntry(id, entry.getValue().getIndexValueType(), entry.getValue().getSize()));
     }
   }
 

--- a/ambry-store/src/test/java/com/github/ambry/store/CuratedLogIndexState.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CuratedLogIndexState.java
@@ -984,7 +984,7 @@ class CuratedLogIndexState {
         } else if (value.isUndelete()) {
           Short prevLifeVersion = keyToLifeVersionMap.put(id, value.getLifeVersion());
           short currentLifeVersion = value.getLifeVersion();
-          if (PersistentIndex.CURRENT_VERSION == PersistentIndex.VERSION_3 && prevLifeVersion != null) {
+          if (PersistentIndex.CURRENT_VERSION >= PersistentIndex.VERSION_3 && prevLifeVersion != null) {
             assertTrue("Undelete's lifeVersion should be greater than previous one, Undelete: " + currentLifeVersion
                 + " Previous: " + prevLifeVersion, prevLifeVersion < currentLifeVersion);
           }

--- a/ambry-store/src/test/java/com/github/ambry/store/IndexSegmentTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/IndexSegmentTest.java
@@ -943,22 +943,30 @@ public class IndexSegmentTest {
    */
   private IndexSegment generateIndexSegment(Offset startOffset, StoreKeyFactory storeKeyFactory) {
     IndexSegment indexSegment;
-    if (formatVersion == PersistentIndex.VERSION_0) {
-      indexSegment = new MockIndexSegment(tempDir.getAbsolutePath(), startOffset, storeKeyFactory,
-          KEY_SIZE + IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V0, IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V0, config, metrics,
-          time, PersistentIndex.VERSION_0);
-    } else if (formatVersion == PersistentIndex.VERSION_1) {
-      indexSegment = new MockIndexSegment(tempDir.getAbsolutePath(), startOffset, storeKeyFactory,
-          KEY_SIZE + IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V1_V2, IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V1_V2, config,
-          metrics, time, formatVersion);
-    } else if (formatVersion == PersistentIndex.VERSION_2) {
-      indexSegment = new IndexSegment(tempDir.getAbsolutePath(), startOffset, storeKeyFactory,
-          KEY_SIZE + IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V1_V2, IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V1_V2, config,
-          metrics, time);
-    } else {
-      indexSegment = new MockIndexSegment(tempDir.getAbsolutePath(), startOffset, storeKeyFactory,
-          KEY_SIZE + IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V3_V4, IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V3_V4, config, metrics,
-          time, formatVersion);
+    switch (formatVersion) {
+      case PersistentIndex.VERSION_0:
+        indexSegment = new MockIndexSegment(tempDir.getAbsolutePath(), startOffset, storeKeyFactory,
+            KEY_SIZE + IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V0, IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V0, config,
+            metrics, time, formatVersion);
+        break;
+      case PersistentIndex.VERSION_1:
+      case PersistentIndex.VERSION_2:
+        indexSegment = new MockIndexSegment(tempDir.getAbsolutePath(), startOffset, storeKeyFactory,
+            KEY_SIZE + IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V1_V2, IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V1_V2, config,
+            metrics, time, formatVersion);
+        break;
+      case PersistentIndex.VERSION_3:
+        indexSegment = new MockIndexSegment(tempDir.getAbsolutePath(), startOffset, storeKeyFactory,
+            KEY_SIZE + IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V3_V4, IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V3_V4, config,
+            metrics, time, formatVersion);
+        break;
+      case PersistentIndex.VERSION_4:
+        indexSegment = new IndexSegment(tempDir.getAbsolutePath(), startOffset, storeKeyFactory,
+            KEY_SIZE + IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V3_V4, IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V3_V4, config,
+            metrics, time);
+        break;
+      default:
+        throw new IllegalArgumentException("Unsupported index version: " + formatVersion);
     }
     return indexSegment;
   }

--- a/ambry-store/src/test/java/com/github/ambry/store/IndexSegmentTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/IndexSegmentTest.java
@@ -125,7 +125,6 @@ public class IndexSegmentTest {
    */
   @Test
   public void comprehensiveTest() throws IOException, StoreException {
-    assumeTrue(formatVersion == PersistentIndex.VERSION_0);
     if (formatVersion >= PersistentIndex.VERSION_2) {
       for (boolean includeSmall : new boolean[]{false, true}) {
         for (boolean includeLarge : new boolean[]{false, true}) {

--- a/ambry-store/src/test/java/com/github/ambry/store/IndexSegmentTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/IndexSegmentTest.java
@@ -235,8 +235,9 @@ public class IndexSegmentTest {
       verifyValues(fromDisk, id, valueCount, flags);
     }
     // verify reset key
-    if(formatVersion >= PersistentIndex.VERSION_1){
-      verifyResetKeyInfo(id3, value1, fromDisk.getResetKey(), fromDisk.getResetKeyLifeVersion());
+    if (formatVersion >= PersistentIndex.VERSION_1) {
+      verifyResetKeyInfo(id3, value1, fromDisk.getResetKey(), fromDisk.getResetKeyType(),
+          fromDisk.getResetKeyLifeVersion());
     }
   }
 
@@ -355,8 +356,9 @@ public class IndexSegmentTest {
         assertEquals("Value in entry is incorrect", delValue2.getBytes(), entries.get(2).getValue().getBytes());
         entries.clear();
       }
-      if(formatVersion >= PersistentIndex.VERSION_1) {
-        verifyResetKeyInfo(id3, value1, fromDisk.getResetKey(), fromDisk.getResetKeyLifeVersion());
+      if (formatVersion >= PersistentIndex.VERSION_1) {
+        verifyResetKeyInfo(id3, value1, fromDisk.getResetKey(), fromDisk.getResetKeyType(),
+            fromDisk.getResetKeyLifeVersion());
       }
     }
   }
@@ -696,7 +698,8 @@ public class IndexSegmentTest {
       assertIndexEntryEquals(expected, obtained);
     }
     if (formatVersion >= PersistentIndex.VERSION_1) {
-      verifyResetKeyInfo(id3, value1, indexSegment.getResetKey(), indexSegment.getResetKeyLifeVersion());
+      verifyResetKeyInfo(id3, value1, indexSegment.getResetKey(), indexSegment.getResetKeyType(),
+          indexSegment.getResetKeyLifeVersion());
     }
   }
 
@@ -771,14 +774,15 @@ public class IndexSegmentTest {
    * Verify reset key info in the index segment.
    * @param expectedId the expected store key of reset key.
    * @param indexValue the initial {@link IndexValue} associated with reset key.
-   * @param actualResetKeyPair actual reset key pair got from index segment.
-   * @param actualResetKeyLifeVersion actual reset key version got from index segment.
+   * @param actualResetKey actual reset key.
+   * @param actualResetKeyType actual reset key type.
+   * @param actualResetKeyLifeVersion actual reset key life version got from index segment.
    */
-  private void verifyResetKeyInfo(MockId expectedId, IndexValue indexValue,
-      Pair<StoreKey, PersistentIndex.IndexEntryType> actualResetKeyPair, short actualResetKeyLifeVersion) {
-    assertEquals("Mismatch in reset key", expectedId, actualResetKeyPair.getFirst());
-    assertEquals("Mismatch in reset key type", indexValue.getIndexValueType(), actualResetKeyPair.getSecond());
-    assertEquals("Mismatch in version", indexValue.getLifeVersion(), actualResetKeyLifeVersion);
+  private void verifyResetKeyInfo(MockId expectedId, IndexValue indexValue, StoreKey actualResetKey,
+      PersistentIndex.IndexEntryType actualResetKeyType, short actualResetKeyLifeVersion) {
+    assertEquals("Mismatch in reset key", expectedId, actualResetKey);
+    assertEquals("Mismatch in reset key type", indexValue.getIndexValueType(), actualResetKeyType);
+    assertEquals("Mismatch in life version", indexValue.getLifeVersion(), actualResetKeyLifeVersion);
   }
 
   /**
@@ -1585,7 +1589,7 @@ class MockIndexSegment extends IndexSegment {
   }
 
   @Override
-  Pair<StoreKey, PersistentIndex.IndexEntryType> getResetKey() {
+  StoreKey getResetKey() {
     if (getVersion() == PersistentIndex.VERSION_0) {
       return null;
     } else {

--- a/ambry-store/src/test/java/com/github/ambry/store/IndexSegmentTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/IndexSegmentTest.java
@@ -17,7 +17,6 @@ import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.config.StoreConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.utils.MockTime;
-import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
@@ -827,10 +826,11 @@ public class IndexSegmentTest {
       time.sleep(10 * Time.MsPerSec);
       PersistentIndex.cleanupIndexSegmentFilesForLogSegment(tempDir.getAbsolutePath(), logSegmentName);
       IndexSegment indexSegment = generateIndexSegment(startOffset, STORE_KEY_FACTORY);
-      Pair<StoreKey, PersistentIndex.IndexEntryType> resetKey = null;
+      StoreKey resetKey = null;
+      PersistentIndex.IndexEntryType resetKeyType = null;
       short resetKeyLifeVersion = StoreFindToken.UNINITIALIZED_RESET_KEY_VERSION;
       verifyIndexSegmentDetails(indexSegment, startOffset, 0, 0, false, startOffset.getOffset(), time.milliseconds(),
-          null, resetKeyLifeVersion);
+          null, null, resetKeyLifeVersion);
       int numItems = 10;
       int numSmallKeys = 0;
       int numLargeKeys = 0;
@@ -853,14 +853,15 @@ public class IndexSegmentTest {
       List<IndexEntry> newEntries =
           addPutEntries(offsets, lastEntrySize, indexSegment, referenceIndex, includeSmallKeys, includeLargeKeys);
       if (version != PersistentIndex.VERSION_0) {
-        resetKey = new Pair<>(newEntries.get(0).getKey(), PersistentIndex.IndexEntryType.PUT);
+        resetKey = newEntries.get(0).getKey();
+        resetKeyType = PersistentIndex.IndexEntryType.PUT;
         resetKeyLifeVersion = newEntries.get(0).getValue().getLifeVersion();
       }
       int expectedSizeWritten =
           SMALLER_KEY_SIZE * numSmallKeys + LARGER_KEY_SIZE * numLargeKeys + KEY_SIZE * (numItems - numSmallKeys
               - numLargeKeys) + numItems * valueSize;
       verifyAllForIndexSegmentFromFile(referenceIndex, indexSegment, startOffset, numItems, expectedSizeWritten, false,
-          endOffset, time.milliseconds(), resetKey, resetKeyLifeVersion);
+          endOffset, time.milliseconds(), resetKey, resetKeyType, resetKeyLifeVersion);
 
       int extraIdsToTtlUpdate = 5;
       Set<MockId> idsToTtlUpdate = getIdsToTtlUpdate(referenceIndex, extraIdsToTtlUpdate);
@@ -871,10 +872,10 @@ public class IndexSegmentTest {
         expectedSizeWritten += valueSize + id.sizeInBytes();
       }
       verifyAllForIndexSegmentFromFile(referenceIndex, indexSegment, startOffset, numItems, expectedSizeWritten, false,
-          endOffset, time.milliseconds(), resetKey, resetKeyLifeVersion);
+          endOffset, time.milliseconds(), resetKey, resetKeyType, resetKeyLifeVersion);
       indexSegment.writeIndexSegmentToFile(indexSegment.getEndOffset());
       verifyReadFromFile(referenceIndex, indexSegment.getFile(), startOffset, numItems, expectedSizeWritten, endOffset,
-          time.milliseconds(), resetKey, resetKeyLifeVersion);
+          time.milliseconds(), resetKey, resetKeyType, resetKeyLifeVersion);
 
       int extraIdsToDelete = 5;
       Set<MockId> idsToDelete = getIdsToDelete(referenceIndex, extraIdsToDelete);
@@ -885,10 +886,10 @@ public class IndexSegmentTest {
         expectedSizeWritten += valueSize + id.sizeInBytes();
       }
       verifyAllForIndexSegmentFromFile(referenceIndex, indexSegment, startOffset, numItems, expectedSizeWritten, false,
-          endOffset, time.milliseconds(), resetKey, resetKeyLifeVersion);
+          endOffset, time.milliseconds(), resetKey, resetKeyType, resetKeyLifeVersion);
       indexSegment.writeIndexSegmentToFile(indexSegment.getEndOffset());
       verifyReadFromFile(referenceIndex, indexSegment.getFile(), startOffset, numItems, expectedSizeWritten, endOffset,
-          time.milliseconds(), resetKey, resetKeyLifeVersion);
+          time.milliseconds(), resetKey, resetKeyType, resetKeyLifeVersion);
 
       // all combinations
       offsets = new ArrayList<>();
@@ -918,10 +919,10 @@ public class IndexSegmentTest {
       numItems += 7;
       expectedSizeWritten += 7 * (KEY_SIZE + valueSize);
       verifyAllForIndexSegmentFromFile(referenceIndex, indexSegment, startOffset, numItems, expectedSizeWritten, false,
-          endOffset, time.milliseconds(), resetKey, resetKeyLifeVersion);
+          endOffset, time.milliseconds(), resetKey, resetKeyType, resetKeyLifeVersion);
       indexSegment.writeIndexSegmentToFile(indexSegment.getEndOffset());
       verifyReadFromFile(referenceIndex, indexSegment.getFile(), startOffset, numItems, expectedSizeWritten, endOffset,
-          time.milliseconds(), resetKey, resetKeyLifeVersion);
+          time.milliseconds(), resetKey, resetKeyType, resetKeyLifeVersion);
 
       // verify that flipping StoreConfig.storeIndexMemStateName does not break anything
       IndexMemState saved = config.storeIndexMemState;
@@ -929,7 +930,7 @@ public class IndexSegmentTest {
         if (!state.equals(saved)) {
           setIndexMemState(state);
           verifyReadFromFile(referenceIndex, indexSegment.getFile(), startOffset, numItems, expectedSizeWritten,
-              endOffset, time.milliseconds(), resetKey, resetKeyLifeVersion);
+              endOffset, time.milliseconds(), resetKey, resetKeyType, resetKeyLifeVersion);
         }
       }
       setIndexMemState(saved);
@@ -1038,11 +1039,12 @@ public class IndexSegmentTest {
    * @param endOffset the expected end offset of the {@code indexSegment}
    * @param lastModifiedTimeInMs the last modified time in ms
    * @param resetKey the reset key for the index segment
+   * @param resetKeyType the reset key type
    * @param resetKeyLifeVersion the life version of reset key
    */
   private void verifyIndexSegmentDetails(IndexSegment indexSegment, Offset startOffset, int numItems, int sizeWritten,
-      boolean sealed, long endOffset, long lastModifiedTimeInMs,
-      Pair<StoreKey, PersistentIndex.IndexEntryType> resetKey, short resetKeyLifeVersion) throws StoreException {
+      boolean sealed, long endOffset, long lastModifiedTimeInMs, StoreKey resetKey,
+      PersistentIndex.IndexEntryType resetKeyType, short resetKeyLifeVersion) throws StoreException {
     LogSegmentName logSegmentName = startOffset.getName();
     int valueSize;
     switch (formatVersion) {
@@ -1070,6 +1072,7 @@ public class IndexSegmentTest {
         indexSegment.getPersistedEntrySize());
     assertEquals("Value size is incorrect", valueSize, indexSegment.getValueSize());
     assertEquals("Reset key mismatch ", resetKey, indexSegment.getResetKey());
+    assertEquals("Reset key type mismatch ", resetKeyType, indexSegment.getResetKeyType());
     assertEquals("Reset key life version mismatch", resetKeyLifeVersion, indexSegment.getResetKeyLifeVersion());
     if (formatVersion != PersistentIndex.VERSION_0) {
       assertEquals("Last modified time is incorrect", lastModifiedTimeInMs, indexSegment.getLastModifiedTimeMs());
@@ -1411,17 +1414,18 @@ public class IndexSegmentTest {
    * @param endOffset the expected end offset of the {@code indexSegment}
    * @param lastModifiedTimeInMs the last modified time of the index segment in ms
    * @param resetKey the resetKey of the index segment
+   * @param resetKeyType the reset key type
    * @param resetKeyLifeVersion the life version of reset key
    * @throws StoreException
    */
   private void verifyReadFromFile(NavigableMap<MockId, NavigableSet<IndexValue>> referenceIndex, File file,
       Offset startOffset, int numItems, int expectedSizeWritten, long endOffset, long lastModifiedTimeInMs,
-      Pair<StoreKey, PersistentIndex.IndexEntryType> resetKey, short resetKeyLifeVersion) throws StoreException {
+      StoreKey resetKey, PersistentIndex.IndexEntryType resetKeyType, short resetKeyLifeVersion) throws StoreException {
     // read from file (not sealed) and verify that everything is ok
     Journal journal = new Journal(tempDir.getAbsolutePath(), Integer.MAX_VALUE, Integer.MAX_VALUE);
     IndexSegment fromDisk = createIndexSegmentFromFile(file, false, journal);
     verifyAllForIndexSegmentFromFile(referenceIndex, fromDisk, startOffset, numItems, expectedSizeWritten, false,
-        endOffset, lastModifiedTimeInMs, resetKey, resetKeyLifeVersion);
+        endOffset, lastModifiedTimeInMs, resetKey, resetKeyType, resetKeyLifeVersion);
     // journal should contain all the entries
     verifyJournal(referenceIndex, journal);
     File bloomFile = new File(file.getParent(),
@@ -1429,13 +1433,13 @@ public class IndexSegmentTest {
     fromDisk.seal();
     assertTrue("Bloom file does not exist", bloomFile.exists());
     verifyAllForIndexSegmentFromFile(referenceIndex, fromDisk, startOffset, numItems, expectedSizeWritten, true,
-        endOffset, lastModifiedTimeInMs, resetKey, resetKeyLifeVersion);
+        endOffset, lastModifiedTimeInMs, resetKey, resetKeyType, resetKeyLifeVersion);
 
     // read from file (sealed) and verify that everything is ok
     journal = new Journal(tempDir.getAbsolutePath(), Integer.MAX_VALUE, Integer.MAX_VALUE);
     fromDisk = createIndexSegmentFromFile(file, true, journal);
     verifyAllForIndexSegmentFromFile(referenceIndex, fromDisk, startOffset, numItems, expectedSizeWritten, true,
-        endOffset, lastModifiedTimeInMs, resetKey, resetKeyLifeVersion);
+        endOffset, lastModifiedTimeInMs, resetKey, resetKeyType, resetKeyLifeVersion);
     // journal should not contain any entries
     assertNull("Journal should not have any entries", journal.getFirstOffset());
 
@@ -1448,7 +1452,7 @@ public class IndexSegmentTest {
     fromDisk = createIndexSegmentFromFile(file, true, journal);
     assertTrue("Bloom file does not exist", bloomFile.exists());
     verifyAllForIndexSegmentFromFile(referenceIndex, fromDisk, startOffset, numItems, expectedSizeWritten, true,
-        endOffset, lastModifiedTimeInMs, resetKey, resetKeyLifeVersion);
+        endOffset, lastModifiedTimeInMs, resetKey, resetKeyType, resetKeyLifeVersion);
     // journal should not contain any entries
     assertNull("Journal should not have any entries", journal.getFirstOffset());
   }
@@ -1478,16 +1482,17 @@ public class IndexSegmentTest {
    * @param sealed the expected sealed state of the {@code indexSegment}
    * @param endOffset the expected end offset of the {@code indexSegment}
    * @param lastModifiedTimeInMs the last modified time of the index segment in ms
-   * @param resetKey the resetKey of the index segment
+   * @param resetKey the reset key of the index segment
+   * @param resetKeyType the reset key type
    * @param resetKeyLifeVersion the life version of reset key
    * @throws StoreException
    */
   private void verifyAllForIndexSegmentFromFile(NavigableMap<MockId, NavigableSet<IndexValue>> referenceIndex,
       IndexSegment fromDisk, Offset startOffset, int numItems, int expectedSizeWritten, boolean sealed, long endOffset,
-      long lastModifiedTimeInMs, Pair<StoreKey, PersistentIndex.IndexEntryType> resetKey, short resetKeyLifeVersion)
+      long lastModifiedTimeInMs, StoreKey resetKey, PersistentIndex.IndexEntryType resetKeyType, short resetKeyLifeVersion)
       throws StoreException {
     verifyIndexSegmentDetails(fromDisk, startOffset, numItems, expectedSizeWritten, sealed, endOffset,
-        lastModifiedTimeInMs, resetKey, resetKeyLifeVersion);
+        lastModifiedTimeInMs, resetKey, resetKeyType, resetKeyLifeVersion);
     verifyFind(referenceIndex, fromDisk);
     verifyGetEntriesSince(referenceIndex, fromDisk);
   }
@@ -1594,6 +1599,15 @@ class MockIndexSegment extends IndexSegment {
       return null;
     } else {
       return super.getResetKey();
+    }
+  }
+
+  @Override
+  PersistentIndex.IndexEntryType getResetKeyType() {
+    if (getVersion() == PersistentIndex.VERSION_0) {
+      return null;
+    } else {
+      return super.getResetKeyType();
     }
   }
 

--- a/ambry-store/src/test/java/com/github/ambry/store/IndexValueTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/IndexValueTest.java
@@ -50,7 +50,7 @@ public class IndexValueTest {
   public static List<Object[]> data() {
     return Arrays.asList(
         new Object[][]{{PersistentIndex.VERSION_0}, {PersistentIndex.VERSION_1}, {PersistentIndex.VERSION_2},
-            {PersistentIndex.VERSION_3}});
+            {PersistentIndex.VERSION_3}, {PersistentIndex.VERSION_4}});
   }
 
   /**
@@ -225,6 +225,7 @@ public class IndexValueTest {
       case PersistentIndex.VERSION_1:
       case PersistentIndex.VERSION_2:
       case PersistentIndex.VERSION_3:
+      case PersistentIndex.VERSION_4:
         expiresAtMs = expiresAtMs >= 0 ? Utils.getTimeInMsToTheNearestSec(expiresAtMs) : Utils.Infinite_Time;
         expiresAtMs =
             TimeUnit.MILLISECONDS.toSeconds(expiresAtMs) > Integer.MAX_VALUE ? Utils.Infinite_Time : expiresAtMs;
@@ -362,7 +363,8 @@ public class IndexValueTest {
         indexValue = new IndexValue(offset.getName(), value, persistentIndexVersion);
         break;
       case PersistentIndex.VERSION_3:
-        value = ByteBuffer.allocate(IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V3);
+      case PersistentIndex.VERSION_4:
+        value = ByteBuffer.allocate(IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V3_V4);
         value.putLong(size);
         value.putLong(offset.getOffset());
         value.put(flags);
@@ -374,7 +376,7 @@ public class IndexValueTest {
         value.putShort(containerId);
         value.putShort(lifeVersion);
         value.position(0);
-        indexValue = new IndexValue(offset.getName(), value, PersistentIndex.VERSION_3);
+        indexValue = new IndexValue(offset.getName(), value, persistentIndexVersion);
         break;
       default:
         throw new IllegalArgumentException("Unrecognized version: " + persistentIndexVersion);

--- a/ambry-tools/src/main/java/com/github/ambry/store/HardDeleteVerifier.java
+++ b/ambry-tools/src/main/java/com/github/ambry/store/HardDeleteVerifier.java
@@ -325,7 +325,8 @@ public class HardDeleteVerifier {
               valueByteSize = IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V1_V2;
               break;
             case PersistentIndex.VERSION_3:
-              valueByteSize = IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V3;
+            case PersistentIndex.VERSION_4:
+              valueByteSize = IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V3_V4;
               break;
             default:
               throw new IllegalArgumentException("Unknown PersistentIndex Version.");


### PR DESCRIPTION
Previous index segment only contains reset key and its type without version info. This PR ensures index segment also tracks reset key life version to help generate new store find token. To achieve that, Persistent Index version 4 is introduced to support serializing/deserializing new index segment format.