### PR TITLE
Fix paper link in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Requires at least JDK 1.8.
 Detailed documentation is available at https://github.com/linkedin/ambry/wiki
 
 ## Research
-Paper introducing Ambry at [SIGMOD 2016](http://sigmod2016.org/) -> http://dprg.cs.uiuc.edu/docs/SIGMOD2016-a/ambry.pdf
+Paper introducing Ambry at [SIGMOD 2016](http://sigmod2016.org/) -> http://dprg.cs.uiuc.edu/data/files/2016/ambry.pdf
 
 Reach out to us at ambrydev@googlegroups.com if you would like us to list a paper that is based off of research on Ambry.
 


### PR DESCRIPTION
Hello,
Seems link of paper in README file are not exists anymore, so updated.
It is related with #1708 .

Please check 🙏 