### PR TITLE
[named blobs] add container option, fix small bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ build/
 logs/
 null/
 .DS_Store
+
+.remote*

--- a/ambry-api/src/main/java/com/github/ambry/account/Container.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/Container.java
@@ -73,6 +73,7 @@ public class Container {
   static final String TTL_REQUIRED_KEY = "ttlRequired";
   static final String SECURE_PATH_REQUIRED_KEY = "securePathRequired";
   static final String OVERRIDE_ACCOUNT_ACL_KEY = "overrideAccountAcl";
+  static final String NAMED_BLOB_MODE_KEY = "namedBlobMode";
   static final String CONTENT_TYPE_WHITELIST_FOR_FILENAMES_ON_DOWNLOAD = "contentTypeWhitelistForFilenamesOnDownload";
   static final String PARENT_ACCOUNT_ID_KEY = "parentAccountId";
   static final String LAST_MODIFIED_TIME_KEY = "lastModifiedTime";
@@ -85,6 +86,7 @@ public class Container {
   static final long CONTAINER_DELETE_TRIGGER_TIME_DEFAULT_VALUE = 0;
   static final boolean SECURE_PATH_REQUIRED_DEFAULT_VALUE = false;
   static final boolean OVERRIDE_ACCOUNT_ACL_DEFAULT_VALUE = false;
+  static final NamedBlobMode NAMED_BLOB_MODE_DEFAULT_VALUE = NamedBlobMode.DISABLED;
   static final boolean CACHEABLE_DEFAULT_VALUE = true;
   static final Set<String> CONTENT_TYPE_WHITELIST_FOR_FILENAMES_ON_DOWNLOAD_DEFAULT_VALUE = Collections.emptySet();
   static final long LAST_MODIFIED_TIME_DEFAULT_VALUE = 0;
@@ -297,8 +299,9 @@ public class Container {
           UNKNOWN_CONTAINER_PREVIOUSLY_ENCRYPTED_SETTING, UNKNOWN_CONTAINER_CACHEABLE_SETTING,
           UNKNOWN_CONTAINER_MEDIA_SCAN_DISABLED_SETTING, null, UNKNOWN_CONTAINER_TTL_REQUIRED_SETTING,
           SECURE_PATH_REQUIRED_DEFAULT_VALUE, CONTENT_TYPE_WHITELIST_FOR_FILENAMES_ON_DOWNLOAD_DEFAULT_VALUE,
-          BACKUP_ENABLED_DEFAULT_VALUE, OVERRIDE_ACCOUNT_ACL_DEFAULT_VALUE, UNKNOWN_CONTAINER_PARENT_ACCOUNT_ID,
-          UNKNOWN_CONTAINER_DELETE_TRIGGER_TIME);
+          BACKUP_ENABLED_DEFAULT_VALUE, OVERRIDE_ACCOUNT_ACL_DEFAULT_VALUE, NAMED_BLOB_MODE_DEFAULT_VALUE,
+          UNKNOWN_CONTAINER_PARENT_ACCOUNT_ID, UNKNOWN_CONTAINER_DELETE_TRIGGER_TIME, LAST_MODIFIED_TIME_DEFAULT_VALUE,
+          SNAPSHOT_VERSION_DEFAULT_VALUE);
 
   /**
    * A container defined specifically for the blobs put without specifying target container but isPrivate flag is
@@ -313,8 +316,9 @@ public class Container {
           DEFAULT_PUBLIC_CONTAINER_PREVIOUSLY_ENCRYPTED_SETTING, DEFAULT_PUBLIC_CONTAINER_CACHEABLE_SETTING,
           DEFAULT_PUBLIC_CONTAINER_MEDIA_SCAN_DISABLED_SETTING, null, DEFAULT_PUBLIC_CONTAINER_TTL_REQUIRED_SETTING,
           SECURE_PATH_REQUIRED_DEFAULT_VALUE, CONTENT_TYPE_WHITELIST_FOR_FILENAMES_ON_DOWNLOAD_DEFAULT_VALUE,
-          BACKUP_ENABLED_DEFAULT_VALUE, OVERRIDE_ACCOUNT_ACL_DEFAULT_VALUE, DEFAULT_PUBLIC_CONTAINER_PARENT_ACCOUNT_ID,
-          DEFAULT_PRIVATE_CONTAINER_DELETE_TRIGGER_TIME);
+          BACKUP_ENABLED_DEFAULT_VALUE, OVERRIDE_ACCOUNT_ACL_DEFAULT_VALUE, NAMED_BLOB_MODE_DEFAULT_VALUE,
+          DEFAULT_PUBLIC_CONTAINER_PARENT_ACCOUNT_ID, DEFAULT_PRIVATE_CONTAINER_DELETE_TRIGGER_TIME,
+          LAST_MODIFIED_TIME_DEFAULT_VALUE, SNAPSHOT_VERSION_DEFAULT_VALUE);
 
   /**
    * A container defined specifically for the blobs put without specifying target container but isPrivate flag is
@@ -329,8 +333,9 @@ public class Container {
           DEFAULT_PRIVATE_CONTAINER_PREVIOUSLY_ENCRYPTED_SETTING, DEFAULT_PRIVATE_CONTAINER_CACHEABLE_SETTING,
           DEFAULT_PRIVATE_CONTAINER_MEDIA_SCAN_DISABLED_SETTING, null, DEFAULT_PRIVATE_CONTAINER_TTL_REQUIRED_SETTING,
           SECURE_PATH_REQUIRED_DEFAULT_VALUE, CONTENT_TYPE_WHITELIST_FOR_FILENAMES_ON_DOWNLOAD_DEFAULT_VALUE,
-          BACKUP_ENABLED_DEFAULT_VALUE, OVERRIDE_ACCOUNT_ACL_DEFAULT_VALUE, DEFAULT_PRIVATE_CONTAINER_PARENT_ACCOUNT_ID,
-          DEFAULT_PUBLIC_CONTAINER_DELETE_TRIGGER_TIME);
+          BACKUP_ENABLED_DEFAULT_VALUE, OVERRIDE_ACCOUNT_ACL_DEFAULT_VALUE, NAMED_BLOB_MODE_DEFAULT_VALUE,
+          DEFAULT_PRIVATE_CONTAINER_PARENT_ACCOUNT_ID, DEFAULT_PUBLIC_CONTAINER_DELETE_TRIGGER_TIME,
+          LAST_MODIFIED_TIME_DEFAULT_VALUE, SNAPSHOT_VERSION_DEFAULT_VALUE);
 
   // container field variables
   private final short id;
@@ -347,6 +352,7 @@ public class Container {
   private final boolean ttlRequired;
   private final boolean securePathRequired;
   private final boolean overrideAccountAcl;
+  private final NamedBlobMode namedBlobMode;
   private final Set<String> contentTypeWhitelistForFilenamesOnDownload;
   private final short parentAccountId;
   private final long lastModifiedTime;
@@ -381,7 +387,8 @@ public class Container {
         contentTypeWhitelistForFilenamesOnDownload = CONTENT_TYPE_WHITELIST_FOR_FILENAMES_ON_DOWNLOAD_DEFAULT_VALUE;
         lastModifiedTime = metadata.optLong(LAST_MODIFIED_TIME_KEY, LAST_MODIFIED_TIME_DEFAULT_VALUE);
         snapshotVersion = metadata.optInt(SNAPSHOT_VERSION_KEY, SNAPSHOT_VERSION_DEFAULT_VALUE);
-        overrideAccountAcl = metadata.optBoolean(OVERRIDE_ACCOUNT_ACL_KEY, OVERRIDE_ACCOUNT_ACL_DEFAULT_VALUE);
+        overrideAccountAcl = OVERRIDE_ACCOUNT_ACL_DEFAULT_VALUE;
+        namedBlobMode = NAMED_BLOB_MODE_DEFAULT_VALUE;
         break;
       case JSON_VERSION_2:
         id = (short) metadata.getInt(CONTAINER_ID_KEY);
@@ -410,6 +417,7 @@ public class Container {
         lastModifiedTime = metadata.optLong(LAST_MODIFIED_TIME_KEY, LAST_MODIFIED_TIME_DEFAULT_VALUE);
         snapshotVersion = metadata.optInt(SNAPSHOT_VERSION_KEY, SNAPSHOT_VERSION_DEFAULT_VALUE);
         overrideAccountAcl = metadata.optBoolean(OVERRIDE_ACCOUNT_ACL_KEY, OVERRIDE_ACCOUNT_ACL_DEFAULT_VALUE);
+        namedBlobMode = metadata.optEnum(NamedBlobMode.class, NAMED_BLOB_MODE_KEY, NAMED_BLOB_MODE_DEFAULT_VALUE);
         break;
       default:
         throw new IllegalStateException("Unsupported container json version=" + metadataVersion);
@@ -435,45 +443,16 @@ public class Container {
    * @param contentTypeWhitelistForFilenamesOnDownload the set of content types for which the filename can be sent on
    *                                                   download.
    * @param backupEnabled Whether backup is enabled for this container or not.
-   * @param overrideAccountAcl Whether to override account's ACL.
-   * @param parentAccountId The id of the parent {@link Account} of this container.
-   */
-  Container(short id, String name, ContainerStatus status, String description, boolean encrypted,
-      boolean previouslyEncrypted, boolean cacheable, boolean mediaScanDisabled, String replicationPolicy,
-      boolean ttlRequired, boolean securePathRequired, Set<String> contentTypeWhitelistForFilenamesOnDownload,
-      boolean backupEnabled, boolean overrideAccountAcl, short parentAccountId, long deleteTriggerTime) {
-    this(id, name, status, description, encrypted, previouslyEncrypted, cacheable, mediaScanDisabled, replicationPolicy,
-        ttlRequired, securePathRequired, contentTypeWhitelistForFilenamesOnDownload, backupEnabled, overrideAccountAcl,
-        parentAccountId, deleteTriggerTime, LAST_MODIFIED_TIME_DEFAULT_VALUE, SNAPSHOT_VERSION_DEFAULT_VALUE);
-  }
-
-  /**
-   * Constructor that takes individual arguments. Cannot be null.
-   * @param id The id of the container.
-   * @param name The name of the container. Cannot be null.
-   * @param status The status of the container. Cannot be null.
-   * @param description The description of the container. Can be null.
-   * @param encrypted {@code true} if blobs in the {@link Container} should be encrypted, {@code false} otherwise.
-   * @param previouslyEncrypted {@code true} if this {@link Container} was encrypted in the past, or currently, and a
-   *                            subset of blobs in it could still be encrypted.
-   * @param cacheable {@code true} if cache control headers should be set to allow CDNs and browsers to cache blobs in
-   *                  this container.
-   * @param mediaScanDisabled {@code true} if media scanning for content in this container should be disabled.
-   * @param replicationPolicy the replication policy to use. If {@code null}, the cluster's default will be used.
-   * @param ttlRequired {@code true} if ttl is required on content created in this container.
-   * @param securePathRequired {@code true} if secure path validation is required in this container.
-   * @param contentTypeWhitelistForFilenamesOnDownload the set of content types for which the filename can be sent on
-   *                                                   download.
-   * @param backupEnabled Whether backup is enabled for this container or not.
    * @param overrideAccountAcl Whether to override account-level ACLs.
+   * @param namedBlobMode how named blob requests should be treated for this container.
    * @param parentAccountId The id of the parent {@link Account} of this container.
    * @param lastModifiedTime created/modified time of this container.
    */
   Container(short id, String name, ContainerStatus status, String description, boolean encrypted,
       boolean previouslyEncrypted, boolean cacheable, boolean mediaScanDisabled, String replicationPolicy,
       boolean ttlRequired, boolean securePathRequired, Set<String> contentTypeWhitelistForFilenamesOnDownload,
-      boolean backupEnabled, boolean overrideAccountAcl, short parentAccountId, long deleteTriggerTime, long lastModifiedTime,
-      int snapshotVersion) {
+      boolean backupEnabled, boolean overrideAccountAcl, NamedBlobMode namedBlobMode, short parentAccountId,
+      long deleteTriggerTime, long lastModifiedTime, int snapshotVersion) {
     checkPreconditions(name, status, encrypted, previouslyEncrypted);
     this.id = id;
     this.name = name;
@@ -496,6 +475,7 @@ public class Container {
         this.contentTypeWhitelistForFilenamesOnDownload =
             CONTENT_TYPE_WHITELIST_FOR_FILENAMES_ON_DOWNLOAD_DEFAULT_VALUE;
         this.overrideAccountAcl = OVERRIDE_ACCOUNT_ACL_DEFAULT_VALUE;
+        this.namedBlobMode = NAMED_BLOB_MODE_DEFAULT_VALUE;
         break;
       case JSON_VERSION_2:
         this.backupEnabled = backupEnabled;
@@ -510,6 +490,7 @@ public class Container {
             contentTypeWhitelistForFilenamesOnDownload == null ? Collections.emptySet()
                 : contentTypeWhitelistForFilenamesOnDownload;
         this.overrideAccountAcl = overrideAccountAcl;
+        this.namedBlobMode = namedBlobMode;
         break;
       default:
         throw new IllegalStateException("Unsupported container json version=" + currentJsonVersion);
@@ -608,6 +589,7 @@ public class Container {
         metadata.put(LAST_MODIFIED_TIME_KEY, lastModifiedTime);
         metadata.put(SNAPSHOT_VERSION_KEY, snapshotVersion);
         metadata.put(OVERRIDE_ACCOUNT_ACL_KEY, overrideAccountAcl);
+        metadata.put(NAMED_BLOB_MODE_KEY, namedBlobMode);
         break;
       default:
         throw new IllegalStateException("Unsupported container json version=" + currentJsonVersion);
@@ -726,6 +708,14 @@ public class Container {
   public boolean isAccountAclOverridden() {
     return overrideAccountAcl;
   }
+
+  /**
+   * @return how named blob requests should be treated for this container.
+   */
+  public NamedBlobMode getNamedBlobMode() {
+    return namedBlobMode;
+  }
+
   /**
    * Gets the if of the {@link Account} that owns this container.
    * @return The id of the parent {@link Account} of this container.
@@ -811,5 +801,20 @@ public class Container {
    */
   public enum ContainerStatus {
     ACTIVE, INACTIVE, DELETE_IN_PROGRESS
+  }
+
+  /**
+   * How named blob requests should be treated for this container.
+   */
+  public enum NamedBlobMode {
+    /**
+     * Named blob APIs are completely disabled for this container.
+     */
+    DISABLED,
+
+    /**
+     * Both named blob APIs and blob ID APIs may be used for this container.
+     */
+    OPTIONAL
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/account/ContainerBuilder.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/ContainerBuilder.java
@@ -42,6 +42,7 @@ public class ContainerBuilder {
   private boolean ttlRequired = TTL_REQUIRED_DEFAULT_VALUE;
   private boolean securePathRequired = SECURE_PATH_REQUIRED_DEFAULT_VALUE;
   private boolean overrideAccountAcl = OVERRIDE_ACCOUNT_ACL_DEFAULT_VALUE;
+  private NamedBlobMode namedBlobMode = NAMED_BLOB_MODE_DEFAULT_VALUE;
   private Set<String> contentTypeWhitelistForFilenamesOnDownload =
       CONTENT_TYPE_WHITELIST_FOR_FILENAMES_ON_DOWNLOAD_DEFAULT_VALUE;
   private boolean backupEnabled = BACKUP_ENABLED_DEFAULT_VALUE;
@@ -72,6 +73,7 @@ public class ContainerBuilder {
     parentAccountId = origin.getParentAccountId();
     securePathRequired = origin.isSecurePathRequired();
     overrideAccountAcl = origin.isAccountAclOverridden();
+    namedBlobMode = origin.getNamedBlobMode();
     contentTypeWhitelistForFilenamesOnDownload = origin.getContentTypeWhitelistForFilenamesOnDownload();
     backupEnabled = origin.isBackupEnabled();
     lastModifiedTime = origin.getLastModifiedTime();
@@ -255,6 +257,16 @@ public class ContainerBuilder {
   }
 
   /**
+   * Sets the named blob API mode for the container.
+   * @param namedBlobMode the {@link NamedBlobMode} to set.
+   * @return This builder.
+   */
+  public ContainerBuilder setNamedBlobMode(NamedBlobMode namedBlobMode) {
+    this.namedBlobMode = namedBlobMode;
+    return this;
+  }
+
+  /**
    * Sets the created/modified time of the {@link Container}
    * @param lastModifiedTime epoch time in milliseconds.
    * @return This builder.
@@ -283,7 +295,7 @@ public class ContainerBuilder {
   public Container build() {
     return new Container(id, name, status, description, encrypted, previouslyEncrypted || encrypted, cacheable,
         mediaScanDisabled, replicationPolicy, ttlRequired, securePathRequired,
-        contentTypeWhitelistForFilenamesOnDownload, backupEnabled, overrideAccountAcl, parentAccountId, deleteTriggerTime, lastModifiedTime,
-        snapshotVersion);
+        contentTypeWhitelistForFilenamesOnDownload, backupEnabled, overrideAccountAcl, namedBlobMode, parentAccountId,
+        deleteTriggerTime, lastModifiedTime, snapshotVersion);
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/frontend/Page.java
+++ b/ambry-api/src/main/java/com/github/ambry/frontend/Page.java
@@ -67,7 +67,7 @@ public class Page<T> {
   public JSONObject toJson(Function<T, JSONObject> entrySerializer) {
     JSONArray entriesArray = new JSONArray();
     entries.stream().map(entrySerializer).forEach(entriesArray::put);
-    return new JSONObject().put(ENTRIES_KEY, entries).putOpt(NEXT_PAGE_TOKEN_KEY, nextPageToken);
+    return new JSONObject().put(ENTRIES_KEY, entriesArray).putOpt(NEXT_PAGE_TOKEN_KEY, nextPageToken);
   }
 
   /**

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/AccountAndContainerInjector.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/AccountAndContainerInjector.java
@@ -121,6 +121,11 @@ public class AccountAndContainerInjector {
           "Container cannot be found for accountName=" + accountName + " and containerName=" + containerName
               + " in put request with account and container headers.", RestServiceErrorCode.InvalidContainer);
     }
+    if (targetContainer.getNamedBlobMode() == Container.NamedBlobMode.DISABLED) {
+      throw new RestServiceException(
+          "Named blob APIs disabled for this container. account=" + accountName + ", container=" + containerName,
+          RestServiceErrorCode.BadRequest);
+    }
     setTargetAccountAndContainerInRestRequest(restRequest, targetAccount, targetContainer, metricsGroup);
   }
 

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
@@ -38,9 +38,8 @@ import com.github.ambry.router.RouterException;
 import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.Utils;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -85,8 +84,8 @@ public class NamedBlobPutHandler {
   private final String clusterName;
   private final RetryPolicy retryPolicy = RetryPolicies.defaultPolicy();
   private final RetryExecutor retryExecutor = new RetryExecutor(Executors.newScheduledThreadPool(2));
-  private final Set<RouterErrorCode> retriableRouterError = new HashSet<RouterErrorCode>(
-      Arrays.asList(AmbryUnavailable, ChannelClosed, UnexpectedInternalError, OperationTimedOut));
+  private final Set<RouterErrorCode> retriableRouterError =
+      EnumSet.of(AmbryUnavailable, ChannelClosed, UnexpectedInternalError, OperationTimedOut);
 
   /**
    * Constructs a handler for handling requests for uploading or stitching blobs.
@@ -205,7 +204,7 @@ public class NamedBlobPutHandler {
     private Callback<String> routerPutBlobCallback(BlobInfo blobInfo) {
       return buildCallback(frontendMetrics.putRouterPutBlobMetrics, blobId -> {
         restResponseChannel.setHeader(RestUtils.Headers.BLOB_SIZE, restRequest.getBlobBytesReceived());
-        idConverter.convert(restRequest, blobId, blobInfo, idConverterCallback(blobInfo));
+        idConverter.convert(restRequest, blobId, blobInfo, idConverterCallback(blobInfo, blobId));
       }, uri, LOGGER, finalCallback);
     }
 
@@ -231,7 +230,7 @@ public class NamedBlobPutHandler {
      */
     private Callback<String> routerStitchBlobCallback(BlobInfo blobInfo) {
       return buildCallback(frontendMetrics.putRouterStitchBlobMetrics,
-          blobId -> idConverter.convert(restRequest, blobId, idConverterCallback(blobInfo)), uri, LOGGER,
+          blobId -> idConverter.convert(restRequest, blobId, idConverterCallback(blobInfo, blobId)), uri, LOGGER,
           finalCallback);
     }
 
@@ -239,16 +238,19 @@ public class NamedBlobPutHandler {
      * After {@link IdConverter#convert} finishes, call {@link SecurityService#postProcessRequest} to perform
      * request time security checks that rely on the request being fully parsed and any additional arguments set.
      * @param blobInfo the {@link BlobInfo} to use for security checks.
+     * @param blobId the blob ID returned by the router (without decoration or obfuscation by id converter).
      * @return a {@link Callback} to be used with {@link IdConverter#convert}.
      */
-    private Callback<String> idConverterCallback(BlobInfo blobInfo) {
-      return buildCallback(frontendMetrics.putIdConversionMetrics, blobId -> {
+    private Callback<String> idConverterCallback(BlobInfo blobInfo, String blobId) {
+      return buildCallback(frontendMetrics.putIdConversionMetrics, convertedBlobId -> {
+        restResponseChannel.setHeader(RestUtils.Headers.LOCATION, convertedBlobId);
         if (RestUtils.getTtlFromRequestHeader(restRequest.getArgs()) == Utils.Infinite_Time) {
-          // Do ttl update with retryExecutor
+          // Do ttl update with retryExecutor. Use the blob ID returned from the router instead of the converted ID
+          // since the converted ID may be changed by the ID converter.
           String serviceId = RestUtils.getHeader(restRequest.getArgs(), RestUtils.Headers.SERVICE_ID, true);
-          retryExecutor.runWithRetries(retryPolicy, callback -> updateBlobTtl(blobId, serviceId, callback),
-              throwable -> throwable instanceof RouterException && retriableRouterError.contains(
-                  ((RouterException) throwable).getErrorCode()), routerTtlUpdateCallback(blobInfo));
+          retryExecutor.runWithRetries(retryPolicy,
+              callback -> router.updateBlobTtl(blobId, serviceId, Utils.Infinite_Time, callback), this::isRetriable,
+              routerTtlUpdateCallback(blobInfo));
         } else {
           securityService.processResponse(restRequest, restResponseChannel, blobInfo,
               securityProcessResponseCallback());
@@ -256,11 +258,13 @@ public class NamedBlobPutHandler {
       }, uri, LOGGER, finalCallback);
     }
 
-    /*
-     * Wrapper method to call {@link Router#updateBlobTtl}.
+    /**
+     * @param throwable the error to check.
+     * @return true if the router error is retriable.
      */
-    private void updateBlobTtl(String blobId, String serviceId, Callback<Void> callback) {
-      router.updateBlobTtl(blobId, serviceId, Utils.Infinite_Time, callback);
+    private boolean isRetriable(Throwable throwable) {
+      return throwable instanceof RouterException && retriableRouterError.contains(
+          ((RouterException) throwable).getErrorCode());
     }
 
     /**

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
@@ -2969,6 +2969,7 @@ class FrontendTestIdConverterFactory implements IdConverterFactory {
   String translation = null;
   boolean returnInputIfTranslationNull = false;
   volatile String lastInput = null;
+  volatile String lastConvertedId = null;
 
   @Override
   public IdConverter getIdConverter() {
@@ -3007,6 +3008,7 @@ class FrontendTestIdConverterFactory implements IdConverterFactory {
       if (exceptionToReturn == null) {
         toReturn = translation == null ? returnInputIfTranslationNull ? input : null : translation;
       }
+      lastConvertedId = toReturn;
       futureResult.done(toReturn, exceptionToReturn);
       if (callback != null) {
         callback.onCompletion(toReturn, exceptionToReturn);

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/NamedBlobPutHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/NamedBlobPutHandlerTest.java
@@ -331,6 +331,8 @@ public class NamedBlobPutHandlerTest {
     namedBlobPutHandler.handle(request, restResponseChannel, future::done);
     if (errorChecker == null) {
       future.get(TIMEOUT_SECS, TimeUnit.SECONDS);
+      assertEquals("Unexpected location header", idConverterFactory.lastConvertedId,
+          restResponseChannel.getHeader(RestUtils.Headers.LOCATION));
       InMemoryRouter.InMemoryBlob blob = router.getActiveBlobs().get(idConverterFactory.lastInput);
       assertEquals("List of chunks stitched does not match expected", expectedStitchedChunks, blob.getStitchedChunks());
       ByteArrayOutputStream expectedContent = new ByteArrayOutputStream();
@@ -431,6 +433,8 @@ public class NamedBlobPutHandlerTest {
     namedBlobPutHandler.handle(request, restResponseChannel, future::done);
     if (errorChecker == null) {
       future.get(TIMEOUT_SECS, TimeUnit.SECONDS);
+      assertEquals("Unexpected location header", idConverterFactory.lastConvertedId,
+          restResponseChannel.getHeader(RestUtils.Headers.LOCATION));
       InMemoryRouter.InMemoryBlob blob = router.getActiveBlobs().get(idConverterFactory.lastInput);
       assertEquals("Unexpected blob content stored", ByteBuffer.wrap(content), blob.getBlob());
       assertEquals("Unexpected response status", restResponseChannel.getStatus(), ResponseStatus.Ok);

--- a/ambry-test-utils/src/main/java/com/github/ambry/account/InMemAccountService.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/account/InMemAccountService.java
@@ -186,9 +186,13 @@ public class InMemAccountService implements AccountService {
     Account.AccountStatus refAccountStatus = Account.AccountStatus.ACTIVE;
     Container randomContainer = getRandomContainer(refAccountId);
     Container publicContainer =
-        new ContainerBuilder(Container.DEFAULT_PUBLIC_CONTAINER).setParentAccountId(refAccountId).build();
+        new ContainerBuilder(Container.DEFAULT_PUBLIC_CONTAINER).setParentAccountId(refAccountId)
+            .setNamedBlobMode(Container.NamedBlobMode.OPTIONAL)
+            .build();
     Container privateContainer =
-        new ContainerBuilder(Container.DEFAULT_PRIVATE_CONTAINER).setParentAccountId(refAccountId).build();
+        new ContainerBuilder(Container.DEFAULT_PRIVATE_CONTAINER).setParentAccountId(refAccountId)
+            .setNamedBlobMode(Container.NamedBlobMode.OPTIONAL)
+            .build();
     return new AccountBuilder(refAccountId, refAccountName, refAccountStatus).addOrUpdateContainer(publicContainer)
         .addOrUpdateContainer(privateContainer)
         .addOrUpdateContainer(randomContainer)
@@ -243,6 +247,7 @@ public class InMemAccountService implements AccountService {
         .setTtlRequired(false)
         .setSecurePathRequired(false)
         .setBackupEnabled(refContainerBackupEnabled)
+        .setNamedBlobMode(Container.NamedBlobMode.OPTIONAL)
         .build();
   }
 }


### PR DESCRIPTION
- Add an option to designate whether the named blob API can be used for
      a container
- Fix how pages are serialized. Otherwise, all fields in the element
      type will be serialized instead of the limited serializer being used.
 - Feed the unconverted ID that the router understands to the TTL update
      call.
 - Send location header on put responses so that blob ID can be used as a
      fallback for clients that are migrating.
