### PR TITLE
Introduce RemoteTokenTracker in BlobStore to clean up permanent delete tombstone

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/clustermap/VirtualReplicatorCluster.java
+++ b/ambry-api/src/main/java/com/github/ambry/clustermap/VirtualReplicatorCluster.java
@@ -22,6 +22,7 @@ import java.util.List;
  * In Virtual Replicator Cluster, {@link PartitionId}s are resources and they are assigned to participant node.
  */
 public interface VirtualReplicatorCluster extends AutoCloseable {
+  String Cloud_Replica_Keyword = "vcr";
 
   /**
    * Gets all nodes in the cluster.

--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -134,9 +134,9 @@ public class StoreConfig {
   /**
    * Whether to purge expired delete tombstone in compaction.
    */
-  @Config("store.compaction.purge.expired.delete.tombstone")
+  @Config("store.compaction.purge.delete.tombstone")
   @Default("false")
-  public final boolean storeCompactionPurgeExpiredDeleteTombstone;
+  public final boolean storeCompactionPurgeDeleteTombstone;
 
   /**
    * The minimum buffer size for compaction copy phase.
@@ -411,8 +411,8 @@ public class StoreConfig {
     storeCompactionThrottlerCheckIntervalMs =
         verifiableProperties.getIntInRange("store.compaction.throttler.check.interval.ms", -1, -1, Integer.MAX_VALUE);
     storeCompactionEnableDirectIO = verifiableProperties.getBoolean("store.compaction.enable.direct.io", false);
-    storeCompactionPurgeExpiredDeleteTombstone =
-        verifiableProperties.getBoolean("store.compaction.purge.expired.delete.tombstone", false);
+    storeCompactionPurgeDeleteTombstone =
+        verifiableProperties.getBoolean("store.compaction.purge.delete.tombstone", false);
     storeCompactionMinBufferSize =
         verifiableProperties.getIntInRange("store.compaction.min.buffer.size", 10 * 1024 * 1024, 0, Integer.MAX_VALUE);
     storeCompactionFilter =

--- a/ambry-api/src/main/java/com/github/ambry/store/Store.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/Store.java
@@ -81,10 +81,13 @@ public interface Store {
    * @param token The token that acts as a bookmark to make subsequent searches
    * @param maxTotalSizeOfEntries The maximum total size of entries that needs to be returned. The api will try to
    *                              return a list of entries whose total size is close to this value.
+   * @param hostname HostName of the datanode where the token belongs to.
+   * @param remoteReplicaPath The path of remote replica.
    * @return The FindInfo instance that contains the entries found and the new token for future searches
    * @throws StoreException
    */
-  FindInfo findEntriesSince(FindToken token, long maxTotalSizeOfEntries) throws StoreException;
+  FindInfo findEntriesSince(FindToken token, long maxTotalSizeOfEntries, String hostname, String remoteReplicaPath)
+      throws StoreException;
 
   /**
    * Finds all the keys that are not present in the store from the input keys

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobStore.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobStore.java
@@ -758,7 +758,8 @@ class CloudBlobStore implements Store {
   }
 
   @Override
-  public FindInfo findEntriesSince(FindToken token, long maxTotalSizeOfEntries) throws StoreException {
+  public FindInfo findEntriesSince(FindToken token, long maxTotalSizeOfEntries, String hostname,
+      String remoteReplicaPath) throws StoreException {
     try {
       FindResult findResult = requestAgent.doWithRetries(
           () -> cloudDestination.findEntriesSince(partitionId.toPathString(), token, maxTotalSizeOfEntries),

--- a/ambry-cloud/src/test/java/com/github/ambry/cloud/CloudBlobStoreTest.java
+++ b/ambry-cloud/src/test/java/com/github/ambry/cloud/CloudBlobStoreTest.java
@@ -536,7 +536,8 @@ public class CloudBlobStoreTest {
     when(dest.findEntriesSince(anyString(), any(CosmosChangeFeedFindToken.class), anyLong())).thenReturn(
         new FindResult(Collections.emptyList(), cosmosChangeFeedFindToken));
     CosmosChangeFeedFindToken startToken = new CosmosChangeFeedFindToken();
-    FindInfo findInfo = store.findEntriesSince(startToken, maxTotalSize);
+    // remote node host name and replica path are not really used by cloud store, it's fine to keep them null
+    FindInfo findInfo = store.findEntriesSince(startToken, maxTotalSize, null, null);
     CosmosChangeFeedFindToken outputToken = (CosmosChangeFeedFindToken) findInfo.getFindToken();
     assertEquals(blobSize * numBlobsFound, outputToken.getBytesRead());
     assertEquals(numBlobsFound, outputToken.getTotalItems());
@@ -548,7 +549,7 @@ public class CloudBlobStoreTest {
             UUID.randomUUID().toString());
     when(dest.findEntriesSince(anyString(), any(CosmosChangeFeedFindToken.class), anyLong())).thenReturn(
         new FindResult(Collections.emptyList(), cosmosChangeFeedFindToken));
-    findInfo = store.findEntriesSince(outputToken, maxTotalSize);
+    findInfo = store.findEntriesSince(outputToken, maxTotalSize, null, null);
     outputToken = (CosmosChangeFeedFindToken) findInfo.getFindToken();
     assertEquals(blobSize * 2 * numBlobsFound, outputToken.getBytesRead());
     assertEquals(numBlobsFound, outputToken.getTotalItems());
@@ -557,7 +558,7 @@ public class CloudBlobStoreTest {
     // 3) call find with new token, no more data, verify token unchanged
     when(dest.findEntriesSince(anyString(), any(CosmosChangeFeedFindToken.class), anyLong())).thenReturn(
         new FindResult(Collections.emptyList(), outputToken));
-    findInfo = store.findEntriesSince(outputToken, maxTotalSize);
+    findInfo = store.findEntriesSince(outputToken, maxTotalSize, null, null);
     assertTrue(findInfo.getMessageEntries().isEmpty());
     FindToken finalToken = findInfo.getFindToken();
     assertEquals(outputToken, finalToken);

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/CloudReplica.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/CloudReplica.java
@@ -19,6 +19,7 @@ import java.util.stream.Collectors;
 import org.json.JSONObject;
 
 import static com.github.ambry.clustermap.ClusterMapSnapshotConstants.*;
+import static com.github.ambry.clustermap.VirtualReplicatorCluster.*;
 
 
 /**
@@ -27,7 +28,6 @@ import static com.github.ambry.clustermap.ClusterMapSnapshotConstants.*;
 public class CloudReplica implements ReplicaId {
   private final PartitionId partitionId;
   private final DataNodeId dataNodeId;
-  public static final String Cloud_Replica_Keyword = "vcr";
 
   /**
    * Instantiate an CloudReplica instance.

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/CloudReplicaTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/CloudReplicaTest.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.util.Properties;
 import org.junit.Test;
 
+import static com.github.ambry.clustermap.VirtualReplicatorCluster.*;
 import static org.junit.Assert.*;
 
 
@@ -55,7 +56,7 @@ public class CloudReplicaTest {
     CloudReplica cloudReplica = new CloudReplica(new MockPartitionId(), cloudDataNode);
     assertEquals("Wrong mount path", mockPartitionId.toPathString(), cloudReplica.getMountPath());
     assertEquals("Wrong replica path",
-        CloudReplica.Cloud_Replica_Keyword + File.separator + mockPartitionId.toPathString() + File.separator
+        Cloud_Replica_Keyword + File.separator + mockPartitionId.toPathString() + File.separator
             + mockPartitionId.toPathString(), cloudReplica.getReplicaPath());
     assertEquals("Wrong dataNodeId", cloudDataNode, cloudReplica.getDataNodeId());
     assertEquals("Wrong partitionId", mockPartitionId, cloudReplica.getPartitionId());

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/AmbryRequests.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/AmbryRequests.java
@@ -576,7 +576,8 @@ public class AmbryRequests implements RequestAPI {
 
             partitionStartTimeInMs = SystemTime.getInstance().milliseconds();
             FindInfo findInfo =
-                store.findEntriesSince(findToken, replicaMetadataRequest.getMaxTotalSizeOfEntriesInBytes());
+                store.findEntriesSince(findToken, replicaMetadataRequest.getMaxTotalSizeOfEntriesInBytes(), hostName,
+                    replicaPath);
             logger.trace("{} Time used to find entry since: {}", partitionId,
                 (SystemTime.getInstance().milliseconds() - partitionStartTimeInMs));
 

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/ReplicaMetadataRequestInfo.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/ReplicaMetadataRequestInfo.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
 
 
 /**
- * Contains the token, hostname, replicapath for a local partition. This is used
+ * Contains the token, hostname, replica path for a local partition. This is used
  * by replica metadata request to specify token in a partition
  */
 public class ReplicaMetadataRequestInfo {

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
@@ -56,6 +56,8 @@ import java.util.function.Predicate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.github.ambry.clustermap.VirtualReplicatorCluster.*;
+
 
 /**
  * Abstract class to handle replication for given partitions. Responsible for the following
@@ -231,7 +233,7 @@ public abstract class ReplicationEngine implements ReplicationAPI {
         break;
       }
     }
-    if (foundRemoteReplicaInfo == null && !replicaPath.startsWith(CloudReplica.Cloud_Replica_Keyword)) {
+    if (foundRemoteReplicaInfo == null && !replicaPath.startsWith(Cloud_Replica_Keyword)) {
       replicationMetrics.unknownRemoteReplicaRequestCount.inc();
       logger.error("ReplicaMetaDataRequest from unknown Replica {}, with path {}", hostName, replicaPath);
     }

--- a/ambry-replication/src/test/java/com/github/ambry/replication/CloudToStoreReplicationManagerTest.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/CloudToStoreReplicationManagerTest.java
@@ -55,9 +55,9 @@ import org.json.JSONObject;
 import org.junit.Test;
 import org.mockito.internal.util.reflection.FieldSetter;
 
-import static com.github.ambry.clustermap.CloudReplica.*;
 import static com.github.ambry.clustermap.ClusterMapSnapshotConstants.*;
 import static com.github.ambry.clustermap.TestUtils.*;
+import static com.github.ambry.clustermap.VirtualReplicatorCluster.*;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 

--- a/ambry-replication/src/test/java/com/github/ambry/replication/InMemoryStore.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/InMemoryStore.java
@@ -15,13 +15,13 @@ package com.github.ambry.replication;
 
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.clustermap.ReplicaState;
+import com.github.ambry.commons.Callback;
 import com.github.ambry.messageformat.DeleteMessageFormatInputStream;
 import com.github.ambry.messageformat.MessageFormatInputStream;
 import com.github.ambry.messageformat.MessageFormatWriteSet;
 import com.github.ambry.messageformat.TtlUpdateMessageFormatInputStream;
 import com.github.ambry.messageformat.UndeleteMessageFormatInputStream;
 import com.github.ambry.router.AsyncWritableChannel;
-import com.github.ambry.commons.Callback;
 import com.github.ambry.store.FindInfo;
 import com.github.ambry.store.MessageInfo;
 import com.github.ambry.store.MessageReadSet;
@@ -360,7 +360,8 @@ class InMemoryStore implements Store {
   }
 
   @Override
-  public FindInfo findEntriesSince(FindToken token, long maxSizeOfEntries) throws StoreException {
+  public FindInfo findEntriesSince(FindToken token, long maxSizeOfEntries, String hostname, String remoteReplicaPath)
+      throws StoreException {
     // unused function
     MockFindToken mockToken = (MockFindToken) token;
     List<MessageInfo> entriesToReturn = new ArrayList<>();

--- a/ambry-server/src/test/java/com/github/ambry/server/MockStorageManager.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/MockStorageManager.java
@@ -219,7 +219,7 @@ class MockStorageManager extends StorageManager {
       try {
         MessageFormatInputStream stream =
             new UndeleteMessageFormatInputStream(info.getStoreKey(), info.getAccountId(), info.getContainerId(),
-                info.getOperationTimeMs(), (short) returnValueOfUndelete);
+                info.getOperationTimeMs(), returnValueOfUndelete);
         // Update info to add stream size;
         info = new MessageInfo(info.getStoreKey(), stream.getSize(), false, false, true, Utils.Infinite_Time, null,
             info.getAccountId(), info.getContainerId(), info.getOperationTimeMs(), returnValueOfUndelete);
@@ -239,7 +239,8 @@ class MockStorageManager extends StorageManager {
     }
 
     @Override
-    public FindInfo findEntriesSince(FindToken token, long maxTotalSizeOfEntries) throws StoreException {
+    public FindInfo findEntriesSince(FindToken token, long maxTotalSizeOfEntries, String hostname,
+        String remoteReplicaPath) throws StoreException {
       operationReceived = RequestOrResponseType.ReplicaMetadataRequest;
       tokenReceived = token;
       maxTotalSizeOfEntriesReceived = maxTotalSizeOfEntries;
@@ -250,7 +251,7 @@ class MockStorageManager extends StorageManager {
 
     @Override
     public MessageInfo findKey(StoreKey key) throws StoreException {
-      return new MessageInfo(key, 1, Utils.Infinite_Time, (short) 0, (short) 0, (long) 0);
+      return new MessageInfo(key, 1, Utils.Infinite_Time, (short) 0, (short) 0, 0);
     }
 
     @Override

--- a/ambry-server/src/test/java/com/github/ambry/server/StatsManagerTest.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/StatsManagerTest.java
@@ -760,7 +760,8 @@ public class StatsManagerTest {
     }
 
     @Override
-    public FindInfo findEntriesSince(FindToken token, long maxTotalSizeOfEntries) throws StoreException {
+    public FindInfo findEntriesSince(FindToken token, long maxTotalSizeOfEntries, String hostname,
+        String remoteReplicaPath) throws StoreException {
       throw new IllegalStateException("Not implemented");
     }
 

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -50,6 +50,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.github.ambry.clustermap.VirtualReplicatorCluster.*;
+
 
 /**
  * The blob store that controls the log and index
@@ -82,6 +84,7 @@ public class BlobStore implements Store {
   private final long thresholdBytesHigh;
   private final long thresholdBytesLow;
   private final long ttlUpdateBufferTimeMs;
+  private final RemoteTokenTracker remoteTokenTracker;
   private final AtomicInteger errorCount;
   private final AccountService accountService;
 
@@ -200,6 +203,7 @@ public class BlobStore implements Store {
     ttlUpdateBufferTimeMs = TimeUnit.SECONDS.toMillis(config.storeTtlUpdateBufferTimeSeconds);
     errorCount = new AtomicInteger(0);
     currentState = ReplicaState.OFFLINE;
+    remoteTokenTracker = new RemoteTokenTracker(replicaId);
     logger.debug(
         "The enable state of replicaStatusDelegate is {} on store {}. The high threshold is {} bytes and the low threshold is {} bytes",
         config.storeReplicaStatusDelegateEnable, storeId, this.thresholdBytesHigh, this.thresholdBytesLow);
@@ -242,7 +246,7 @@ public class BlobStore implements Store {
         log = new Log(dataDir, capacityInBytes, diskSpaceAllocator, config, metrics);
         compactor = new BlobStoreCompactor(dataDir, storeId, factory, config, metrics, storeUnderCompactionMetrics,
             diskIOScheduler, diskSpaceAllocator, log, time, sessionId, storeDescriptor.getIncarnationId(),
-            accountService);
+            accountService, remoteTokenTracker);
         index = new PersistentIndex(dataDir, storeId, taskScheduler, log, config, factory, recovery, hardDelete,
             diskIOScheduler, metrics, time, sessionId, storeDescriptor.getIncarnationId());
         compactor.initialize(index);
@@ -892,10 +896,15 @@ public class BlobStore implements Store {
   }
 
   @Override
-  public FindInfo findEntriesSince(FindToken token, long maxTotalSizeOfEntries) throws StoreException {
+  public FindInfo findEntriesSince(FindToken token, long maxTotalSizeOfEntries, String hostname,
+      String remoteReplicaPath) throws StoreException {
     checkStarted();
     final Timer.Context context = metrics.findEntriesSinceResponse.time();
     try {
+      if (hostname != null && !hostname.startsWith(Cloud_Replica_Keyword)) {
+        // only tokens from disk-backed replicas are tracked
+        remoteTokenTracker.updateTokenFromPeerReplica(token, hostname, remoteReplicaPath);
+      }
       FindInfo findInfo = index.findEntriesSince(token, maxTotalSizeOfEntries);
       onSuccess();
       return findInfo;
@@ -1210,6 +1219,7 @@ public class BlobStore implements Store {
    */
   void compact(CompactionDetails details, byte[] bundleReadBuffer) throws IOException, StoreException {
     checkStarted();
+    remoteTokenTracker.refreshPeerReplicaTokens();
     compactor.compact(details, bundleReadBuffer);
     checkCapacityAndUpdateReplicaStatusDelegate();
     logger.info("One cycle of compaction is completed on the store {}", storeId);
@@ -1224,6 +1234,7 @@ public class BlobStore implements Store {
     checkStarted();
     if (CompactionLog.isCompactionInProgress(dataDir, storeId)) {
       logger.info("Resuming compaction of {}", this);
+      remoteTokenTracker.refreshPeerReplicaTokens();
       compactor.resumeCompaction(bundleReadBuffer);
       checkCapacityAndUpdateReplicaStatusDelegate();
     }

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
@@ -88,6 +88,7 @@ class BlobStoreCompactor {
   private final IndexSegmentValidEntryFilter validEntryFilter;
   private final AccountService accountService;
   private final Set<Pair<Short, Short>> deprecatedContainers;
+  private final RemoteTokenTracker remoteTokenTracker;
   private final boolean useDirectIO;
   private volatile boolean isActive = false;
   private PersistentIndex srcIndex;
@@ -113,13 +114,14 @@ class BlobStoreCompactor {
    * @param sessionId the sessionID of the store.
    * @param incarnationId the incarnation ID of the store.
    * @param accountService the {@link AccountService} instance to use.
+   * @param remoteTokenTracker the {@link RemoteTokenTracker} that tracks tokens from all peer replicas.
    * @throws IOException if the {@link CompactionLog} could not be created or if commit/cleanup failed during recovery.
    * @throws StoreException if the commit failed during recovery.
    */
   BlobStoreCompactor(String dataDir, String storeId, StoreKeyFactory storeKeyFactory, StoreConfig config,
       StoreMetrics srcMetrics, StoreMetrics tgtMetrics, DiskIOScheduler diskIOScheduler,
       DiskSpaceAllocator diskSpaceAllocator, Log srcLog, Time time, UUID sessionId, UUID incarnationId,
-      AccountService accountService) throws IOException, StoreException {
+      AccountService accountService, RemoteTokenTracker remoteTokenTracker) throws IOException, StoreException {
     this.dataDir = new File(dataDir);
     this.storeId = storeId;
     this.storeKeyFactory = storeKeyFactory;
@@ -135,6 +137,7 @@ class BlobStoreCompactor {
     this.incarnationId = incarnationId;
     this.useDirectIO = Utils.isLinux() && config.storeCompactionEnableDirectIO;
     this.deprecatedContainers = new HashSet<>();
+    this.remoteTokenTracker = remoteTokenTracker;
     if (config.storeCompactionFilter.equals(IndexSegmentValidEntryFilterWithoutUndelete.class.getSimpleName())) {
       validEntryFilter = new IndexSegmentValidEntryFilterWithoutUndelete();
     } else {

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
@@ -1146,6 +1146,9 @@ class BlobStoreCompactor {
     if (srcIndex.isExpired(deleteIndexValue)) {
       return true;
     }
+    if (remoteTokenTracker == null) {
+      return false;
+    }
     long deletePosition = srcIndex.getAbsolutePositionInLogForOffset(deleteIndexValue.getOffset());
     for (Map.Entry<String, FindToken> entry : remoteTokenTracker.getPeerReplicaAndToken().entrySet()) {
       FindToken token = srcIndex.resetTokenIfRequired((StoreFindToken) entry.getValue());

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
@@ -1283,7 +1283,7 @@ class BlobStoreCompactor {
           } else {
             // DELETE entry without corresponding PUT (may be left by previous compaction). Check if this delete
             // tombstone is removable.
-            if (config.storeCompactionPurgeExpiredDeleteTombstone && isDeleteTombstoneRemovable(indexEntry,
+            if (config.storeCompactionPurgeDeleteTombstone && isDeleteTombstoneRemovable(indexEntry,
                 indexSegment)) {
               logger.debug(
                   "Delete tombstone of {} (with expiration time {} ms) is removable and won't be copied to target log segment",
@@ -1554,7 +1554,7 @@ class BlobStoreCompactor {
           }
           if (currentLatestState.isDelete() && currentLatestState.getLifeVersion() == currentValue.getLifeVersion()) {
             // check if this is a removable delete tombstone.
-            if (config.storeCompactionPurgeExpiredDeleteTombstone && isDeleteTombstoneRemovable(entry, indexSegment)
+            if (config.storeCompactionPurgeDeleteTombstone && isDeleteTombstoneRemovable(entry, indexSegment)
                 && getPutValueFromSrc(currentKey, currentValue, indexSegment) == null) {
               logger.debug(
                   "Delete tombstone of {} (with expiration time {} ms) is removable and won't be copied to target log segment",

--- a/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
@@ -1310,7 +1310,7 @@ class PersistentIndex {
    * @param storeToken the {@link StoreFindToken} that needs to be validated
    * @return the new {@link StoreFindToken} after validating
    */
-  private StoreFindToken resetTokenIfRequired(StoreFindToken storeToken) throws StoreException {
+  StoreFindToken resetTokenIfRequired(StoreFindToken storeToken) throws StoreException {
     UUID remoteIncarnationId = storeToken.getIncarnationId();
     // if incarnationId is null, for backwards compatibility purposes, the token is considered as good.
     /// if not null, we check for a match

--- a/ambry-store/src/main/java/com/github/ambry/store/RemoteTokenTracker.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/RemoteTokenTracker.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2021 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.store;
+
+import com.github.ambry.clustermap.ReplicaId;
+import com.github.ambry.replication.FindToken;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+
+/**
+ * {@link RemoteTokenTracker} tracks tokens from all peer replicas and updates them when handling metadata request from
+ * peer node.
+ */
+public class RemoteTokenTracker {
+  private static final String DELIMITER = ":";
+  // The key of peerReplicaAndToken is a string containing hostname and path of peer replica.
+  // For example: localhost:/mnt/u001/p1
+  private ConcurrentMap<String, FindToken> peerReplicaAndToken = new ConcurrentHashMap<>();
+  private ReplicaId localReplica;
+
+  public RemoteTokenTracker(ReplicaId localReplica) {
+    this.localReplica = localReplica;
+    localReplica.getPeerReplicaIds().forEach(r -> {
+      String hostnameAndPath = r.getDataNodeId().getHostname() + DELIMITER + r.getReplicaPath();
+      peerReplicaAndToken.put(hostnameAndPath, null);
+    });
+  }
+
+  void updateTokenFromPeerReplica(FindToken token, String remoteHostName, String remoteReplicaPath) {
+    // this already handles newly added peer replica (i.e. move replica)
+    peerReplicaAndToken.put(remoteHostName + DELIMITER + remoteReplicaPath, token);
+  }
+
+  /**
+   * Refresh the peerReplicaAndToken map in case peer replica has changed (i.e. new replica is added and old replica is removed)
+   */
+  void refreshPeerReplicaTokens() {
+    ConcurrentMap<String, FindToken> newPeerReplicaAndToken = new ConcurrentHashMap<>();
+    // this should remove peer replica that no longer exists (i.e original replica is moved to other node)
+    localReplica.getPeerReplicaIds().forEach(r -> {
+      String hostnameAndPath = r.getDataNodeId().getHostname() + DELIMITER + r.getReplicaPath();
+      newPeerReplicaAndToken.put(hostnameAndPath, peerReplicaAndToken.getOrDefault(hostnameAndPath, null));
+    });
+    // atomic switch
+    peerReplicaAndToken = newPeerReplicaAndToken;
+  }
+}

--- a/ambry-store/src/main/java/com/github/ambry/store/RemoteTokenTracker.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/RemoteTokenTracker.java
@@ -15,6 +15,9 @@ package com.github.ambry.store;
 
 import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.replication.FindToken;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -32,6 +35,7 @@ public class RemoteTokenTracker {
 
   public RemoteTokenTracker(ReplicaId localReplica) {
     this.localReplica = localReplica;
+    List<? extends ReplicaId> list = localReplica.getPeerReplicaIds();
     localReplica.getPeerReplicaIds().forEach(r -> {
       String hostnameAndPath = r.getDataNodeId().getHostname() + DELIMITER + r.getReplicaPath();
       peerReplicaAndToken.put(hostnameAndPath, new StoreFindToken());
@@ -56,5 +60,12 @@ public class RemoteTokenTracker {
     });
     // atomic switch
     peerReplicaAndToken = newPeerReplicaAndToken;
+  }
+
+  /**
+   * @return a snapshot of peer replica to token map.
+   */
+  Map<String, FindToken> getPeerReplicaAndToken() {
+    return new HashMap<>(peerReplicaAndToken);
   }
 }

--- a/ambry-store/src/main/java/com/github/ambry/store/RemoteTokenTracker.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/RemoteTokenTracker.java
@@ -34,7 +34,7 @@ public class RemoteTokenTracker {
     this.localReplica = localReplica;
     localReplica.getPeerReplicaIds().forEach(r -> {
       String hostnameAndPath = r.getDataNodeId().getHostname() + DELIMITER + r.getReplicaPath();
-      peerReplicaAndToken.put(hostnameAndPath, null);
+      peerReplicaAndToken.put(hostnameAndPath, new StoreFindToken());
     });
   }
 
@@ -51,7 +51,8 @@ public class RemoteTokenTracker {
     // this should remove peer replica that no longer exists (i.e original replica is moved to other node)
     localReplica.getPeerReplicaIds().forEach(r -> {
       String hostnameAndPath = r.getDataNodeId().getHostname() + DELIMITER + r.getReplicaPath();
-      newPeerReplicaAndToken.put(hostnameAndPath, peerReplicaAndToken.getOrDefault(hostnameAndPath, null));
+      newPeerReplicaAndToken.put(hostnameAndPath,
+          peerReplicaAndToken.getOrDefault(hostnameAndPath, new StoreFindToken()));
     });
     // atomic switch
     peerReplicaAndToken = newPeerReplicaAndToken;

--- a/ambry-store/src/main/java/com/github/ambry/store/RemoteTokenTracker.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/RemoteTokenTracker.java
@@ -35,7 +35,6 @@ public class RemoteTokenTracker {
 
   public RemoteTokenTracker(ReplicaId localReplica) {
     this.localReplica = localReplica;
-    List<? extends ReplicaId> list = localReplica.getPeerReplicaIds();
     localReplica.getPeerReplicaIds().forEach(r -> {
       String hostnameAndPath = r.getDataNodeId().getHostname() + DELIMITER + r.getReplicaPath();
       peerReplicaAndToken.put(hostnameAndPath, new StoreFindToken());

--- a/ambry-store/src/main/java/com/github/ambry/store/RemoteTokenTracker.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/RemoteTokenTracker.java
@@ -16,7 +16,6 @@ package com.github.ambry.store;
 import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.replication.FindToken;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -28,10 +27,10 @@ import java.util.concurrent.ConcurrentMap;
  */
 public class RemoteTokenTracker {
   private static final String DELIMITER = ":";
+  private final ReplicaId localReplica;
   // The key of peerReplicaAndToken is a string containing hostname and path of peer replica.
   // For example: localhost:/mnt/u001/p1
   private ConcurrentMap<String, FindToken> peerReplicaAndToken = new ConcurrentHashMap<>();
-  private ReplicaId localReplica;
 
   public RemoteTokenTracker(ReplicaId localReplica) {
     this.localReplica = localReplica;
@@ -41,6 +40,12 @@ public class RemoteTokenTracker {
     });
   }
 
+  /**
+   * Update peer replica token within this tracker.
+   * @param token the most recent token from peer replica.
+   * @param remoteHostName the hostname of peer node (where the peer replica resides).
+   * @param remoteReplicaPath the path of peer replica on remote peer node.
+   */
   void updateTokenFromPeerReplica(FindToken token, String remoteHostName, String remoteReplicaPath) {
     // this already handles newly added peer replica (i.e. move replica)
     peerReplicaAndToken.put(remoteHostName + DELIMITER + remoteReplicaPath, token);

--- a/ambry-store/src/main/java/com/github/ambry/store/StoreMetrics.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StoreMetrics.java
@@ -89,6 +89,7 @@ public class StoreMetrics {
   public final Counter compactionBundleReadBufferUsed;
   public final Counter compactionBundleReadBufferIoCount;
   public final Counter compactionTargetIndexDuplicateOnNonRecoveryCount;
+  public final Counter permanentDeleteTombstonePurgeCount;
   public final Timer compactionCopyRecordTimeInMs;
   public final Timer compactionCopyDataByIndexSegmentTimeInMs;
   public final Timer compactionCopyDataByLogSegmentTimeInMs;
@@ -197,6 +198,8 @@ public class StoreMetrics {
         registry.counter(MetricRegistry.name(BlobStoreCompactor.class, name + "CompactionBundleReadBufferIoCount"));
     compactionTargetIndexDuplicateOnNonRecoveryCount = registry.counter(
         MetricRegistry.name(BlobStoreCompactor.class, name + "CompactionTargetIndexDuplicateOnNonRecoveryCount"));
+    permanentDeleteTombstonePurgeCount = registry.counter(
+        MetricRegistry.name(BlobStoreCompactor.class, name + "PermanentDeleteTombstonePurgeCount"));
     compactionCopyRecordTimeInMs =
         registry.timer(MetricRegistry.name(BlobStoreCompactor.class, name + "CompactionCopyRecordTimeInMs"));
     compactionCopyDataByIndexSegmentTimeInMs = registry.timer(

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
@@ -2459,7 +2459,7 @@ public class BlobStoreCompactorTest {
     StoreMetrics metrics = new StoreMetrics(metricRegistry);
     return new BlobStoreCompactor(tempDirStr, STORE_ID, STORE_KEY_FACTORY, config, metrics, metrics, ioScheduler,
         StoreTestUtils.DEFAULT_DISK_SPACE_ALLOCATOR, log, state.time, state.sessionId, state.incarnationId,
-        accountService);
+        accountService, null);
   }
 
   /**

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
@@ -2609,7 +2609,7 @@ public class BlobStoreCompactorTest {
     if (withUndelete) {
       state.properties.put("store.compaction.filter", "IndexSegmentValidEntryWithUndelete");
     }
-    state.properties.put("store.compaction.purge.expired.delete.tombstone", Boolean.toString(purgeDeleteTombstone));
+    state.properties.put("store.compaction.purge.delete.tombstone", Boolean.toString(purgeDeleteTombstone));
     state.properties.put(StoreConfig.storeAlwaysEnableTargetIndexDuplicateCheckingName,
         Boolean.toString(alwaysEnableTargetIndexDuplicateChecking));
     StoreConfig config = new StoreConfig(new VerifiableProperties(state.properties));

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
@@ -1687,7 +1687,7 @@ public class BlobStoreTest {
   }
 
   /**
-   * Tests {@link BlobStore#findEntriesSince(FindToken, long)}.
+   * Tests {@link Store#findEntriesSince(FindToken, long, String, String)}.
    * <p/>
    * This test is minimal for two reasons
    * 1. The BlobStore simply calls into the index for this function and the index has extensive tests for this.
@@ -1697,7 +1697,7 @@ public class BlobStoreTest {
    */
   @Test
   public void findEntriesSinceTest() throws StoreException {
-    FindInfo findInfo = store.findEntriesSince(new StoreFindToken(), Long.MAX_VALUE);
+    FindInfo findInfo = store.findEntriesSince(new StoreFindToken(), Long.MAX_VALUE, null, null);
     Set<StoreKey> keysPresent = new HashSet<>();
     for (MessageInfo info : findInfo.getMessageEntries()) {
       keysPresent.add(info.getStoreKey());
@@ -1707,7 +1707,7 @@ public class BlobStoreTest {
     // Extra Test: findEntriesSince method can correctly capture disk related IO error and shutdown store if needed.
     store.shutdown();
     catchStoreExceptionAndVerifyErrorCode(
-        (blobStore) -> blobStore.findEntriesSince(new StoreFindToken(), Long.MAX_VALUE));
+        (blobStore) -> blobStore.findEntriesSince(new StoreFindToken(), Long.MAX_VALUE, null, null));
     reloadStore();
   }
 
@@ -3232,7 +3232,7 @@ public class BlobStoreTest {
       assertEquals("Unexpected StoreErrorCode", StoreErrorCodes.Store_Not_Started, e.getErrorCode());
     }
     try {
-      blobStore.findEntriesSince(new StoreFindToken(), Long.MAX_VALUE);
+      blobStore.findEntriesSince(new StoreFindToken(), Long.MAX_VALUE, null, null);
       fail("Operation should have failed because store is inactive");
     } catch (StoreException e) {
       assertEquals("Unexpected StoreErrorCode", StoreErrorCodes.Store_Not_Started, e.getErrorCode());

--- a/ambry-store/src/test/java/com/github/ambry/store/CuratedLogIndexState.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CuratedLogIndexState.java
@@ -136,6 +136,7 @@ class CuratedLogIndexState {
   MetricRegistry metricRegistry = new MetricRegistry();
   // The deleted key with associated PUT record in the same log segment
   MockId deletedKeyWithPutInSameSegment = null;
+  List<MockId> permanentDeleteTombstones = new ArrayList<>();
 
   // Variables that represent the folder where the data resides
   private final File tempDir;
@@ -1419,6 +1420,7 @@ class CuratedLogIndexState {
       }
       // 1 DELETE that has the TTL update flag set but has no corresponding TTL update or PUT entries
       uniqueId = getUniqueId();
+      permanentDeleteTombstones.add(uniqueId);
       addDeleteEntry(uniqueId,
           new MessageInfo(uniqueId, Integer.MAX_VALUE, true, true, Utils.Infinite_Time, uniqueId.getAccountId(),
               uniqueId.getContainerId(), time.milliseconds()));

--- a/ambry-store/src/test/java/com/github/ambry/store/StoreTestUtils.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/StoreTestUtils.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import org.json.JSONObject;
@@ -110,7 +111,7 @@ class StoreTestUtils {
 
     @Override
     public List<? extends ReplicaId> getPeerReplicaIds() {
-      return null;
+      return Collections.emptyList();
     }
 
     @Override

--- a/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockReplicaId.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockReplicaId.java
@@ -27,7 +27,7 @@ public class MockReplicaId implements ReplicaId {
   private static final String REPLICA_FILE_PREFIX = "replica";
   private String mountPath;
   private String replicaPath;
-  private List<ReplicaId> peerReplicas;
+  private List<ReplicaId> peerReplicas = new ArrayList<>();
   private MockPartitionId partitionId;
   private MockDataNodeId dataNodeId;
   private MockDiskId diskId;
@@ -90,7 +90,7 @@ public class MockReplicaId implements ReplicaId {
   }
 
   public void setPeerReplicas(List<ReplicaId> peerReplicas) {
-    this.peerReplicas = new ArrayList<>();
+    this.peerReplicas.clear();
     for (ReplicaId replicaId : peerReplicas) {
       if (!Objects.equals(mountPath, replicaId.getMountPath())) {
         this.peerReplicas.add(replicaId);

--- a/ambry-tools/src/main/java/com/github/ambry/store/StoreCopier.java
+++ b/ambry-tools/src/main/java/com/github/ambry/store/StoreCopier.java
@@ -53,8 +53,8 @@ import static com.github.ambry.utils.Utils.*;
  * made before copying
  * <p/>
  * This tool requires the source store to *not* return blobs that have already been deleted when
- * {@link Store#findEntriesSince(FindToken, long)} is called. It is also expected to be run when both locations (src and
- * tgt) are offline.
+ * {@link Store#findEntriesSince(FindToken, long, String, String)} is called. It is also expected to be run when both
+ * locations (src and tgt) are offline.
  */
 public class StoreCopier implements Closeable {
 
@@ -204,7 +204,7 @@ public class StoreCopier implements Closeable {
     FindToken token = startToken;
     do {
       lastToken = token;
-      FindInfo findInfo = src.findEntriesSince(lastToken, fetchSizeInBytes);
+      FindInfo findInfo = src.findEntriesSince(lastToken, fetchSizeInBytes, null, null);
       List<MessageInfo> messageInfos = findInfo.getMessageEntries();
       for (Transformer transformer : transformers) {
         transformer.warmup(messageInfos);


### PR DESCRIPTION
Introduce RemoteTokenTracker to help keep track of replication tokens from all peer replicas. The tokens maintained within this tracker will be consumed by compaction.