### PR TITLE
Dont include get in StatsReport frontend operation

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/frontend/Operations.java
+++ b/ambry-api/src/main/java/com/github/ambry/frontend/Operations.java
@@ -22,7 +22,7 @@ public class Operations {
   public static final String UPDATE_TTL = "updateTtl";
   public static final String STITCH = "stitch";
   public static final String GET_CLUSTER_MAP_SNAPSHOT = "getClusterMapSnapshot";
-  public static final String GET_STATS_REPORT = "getStatsReport";
+  public static final String STATS_REPORT = "statsReport";
   public static final String ACCOUNTS = "accounts";
   public static final String ACCOUNTS_CONTAINERS = "accounts/containers";
   public static final String UNDELETE = "undelete";

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestService.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestService.java
@@ -242,7 +242,7 @@ class FrontendRestRequestService implements RestRequestService {
       } else if (requestPath.matchesOperation(Operations.ACCOUNTS)) {
         getAccountsHandler.handle(restRequest, restResponseChannel,
             (result, exception) -> submitResponse(restRequest, restResponseChannel, result, exception));
-      } else if (requestPath.matchesOperation(Operations.GET_STATS_REPORT)) {
+      } else if (requestPath.matchesOperation(Operations.STATS_REPORT)) {
         getStatsReportHandler.handle(restRequest, restResponseChannel,
             (result, exception) -> submitResponse(restRequest, restResponseChannel, result, exception));
       } else if (requestPath.matchesOperation(Operations.NAMED_BLOB)

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
@@ -1016,7 +1016,7 @@ public class FrontendRestRequestServiceTest {
   }
 
   /**
-   * Tests the handling of {@link Operations#GET_STATS_REPORT} get requests.
+   * Tests the handling of {@link Operations#STATS_REPORT} get requests.
    * @throws Exception
    */
   @Test
@@ -1047,7 +1047,7 @@ public class FrontendRestRequestServiceTest {
     JSONObject headers = new JSONObject();
     headers.put(RestUtils.Headers.CLUSTER_NAME, CLUSTER_NAME);
     headers.put(RestUtils.Headers.GET_STATS_REPORT_TYPE, StatsReportType.ACCOUNT_REPORT.name());
-    RestRequest request = createRestRequest(RestMethod.GET, Operations.GET_STATS_REPORT, headers, null);
+    RestRequest request = createRestRequest(RestMethod.GET, Operations.STATS_REPORT, headers, null);
     MockRestResponseChannel restResponseChannel = new MockRestResponseChannel();
     doOperation(request, restResponseChannel);
     StatsSnapshot accountStatsFromService =
@@ -1058,7 +1058,7 @@ public class FrontendRestRequestServiceTest {
     headers = new JSONObject();
     headers.put(RestUtils.Headers.CLUSTER_NAME, CLUSTER_NAME);
     headers.put(RestUtils.Headers.GET_STATS_REPORT_TYPE, StatsReportType.PARTITION_CLASS_REPORT.name());
-    request = createRestRequest(RestMethod.GET, Operations.GET_STATS_REPORT, headers, null);
+    request = createRestRequest(RestMethod.GET, Operations.STATS_REPORT, headers, null);
     restResponseChannel = new MockRestResponseChannel();
     doOperation(request, restResponseChannel);
     StatsSnapshot partitionClassStatsFromService =
@@ -1069,7 +1069,7 @@ public class FrontendRestRequestServiceTest {
     headers = new JSONObject();
     headers.put(RestUtils.Headers.CLUSTER_NAME, "WRONG_CLUSTER");
     headers.put(RestUtils.Headers.GET_STATS_REPORT_TYPE, StatsReportType.ACCOUNT_REPORT.name());
-    request = createRestRequest(RestMethod.GET, Operations.GET_STATS_REPORT, headers, null);
+    request = createRestRequest(RestMethod.GET, Operations.STATS_REPORT, headers, null);
     try {
       doOperation(request, new MockRestResponseChannel());
       fail("Operation should have failed");

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/GetStatsReportHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/GetStatsReportHandlerTest.java
@@ -119,7 +119,7 @@ public class GetStatsReportHandlerTest {
   private RestRequest createRestRequest(String clusterName, String reportType) throws Exception {
     JSONObject data = new JSONObject();
     data.put(MockRestRequest.REST_METHOD_KEY, RestMethod.GET.name());
-    data.put(MockRestRequest.URI_KEY, Operations.GET_STATS_REPORT);
+    data.put(MockRestRequest.URI_KEY, Operations.STATS_REPORT);
     JSONObject headers = new JSONObject();
     if (reportType != null) {
       headers.put(RestUtils.Headers.GET_STATS_REPORT_TYPE, reportType);


### PR DESCRIPTION
Remove "get" from stats report frontend operation literal. “GET" is already reflected in http method. 