### PR TITLE
[named blobs] fix equals for Container.namedBlobMode

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/account/Container.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/Container.java
@@ -768,7 +768,7 @@ public class Container {
         && deleteTriggerTime == container.deleteTriggerTime && Objects.equals(description, container.description)
         && Objects.equals(replicationPolicy, container.replicationPolicy) && ttlRequired == container.ttlRequired
         && securePathRequired == container.securePathRequired && overrideAccountAcl == container.overrideAccountAcl
-        && Objects.equals(contentTypeWhitelistForFilenamesOnDownload,
+        && namedBlobMode == container.namedBlobMode && Objects.equals(contentTypeWhitelistForFilenamesOnDownload,
         container.contentTypeWhitelistForFilenamesOnDownload);
   }
 


### PR DESCRIPTION
I forgot to add namedBlobMode to the equals method, which prevents the
container from being updated if no other fields are changed.