### PR TITLE
[StorageMigration] Fix empty submap in stats error

### DIFF
--- a/ambry-mysql/src/integration-test/java/com/github/ambry/accountstats/AccountStatsMySqlStoreIntegrationTest.java
+++ b/ambry-mysql/src/integration-test/java/com/github/ambry/accountstats/AccountStatsMySqlStoreIntegrationTest.java
@@ -139,6 +139,29 @@ public class AccountStatsMySqlStoreIntegrationTest {
 
     StatsWrapper obtainedStats3 = mySqlStore.queryAccountStatsByHost(hostname1, port1);
     assertTrue(obtainedStats3.getSnapshot().getSubMap().containsKey(Utils.statsPartitionKey((short) 10)));
+
+    // Write a new stats with empty submap
+    StatsWrapper stats4 = generateStatsWrapper(1, 1, 1, StatsReportType.ACCOUNT_REPORT);
+    stats4.getSnapshot().setSubMap(null);
+    mySqlStore.storeAccountStats(stats4);
+
+    // empty stats should not override any mysql database rows
+    StatsWrapper obtainedStats4 = mySqlStore.queryAccountStatsByHost(hostname1, port1);
+    assertEquals(obtainedStats3.getSnapshot(), obtainedStats4.getSnapshot());
+
+    // Write a new stats with empty submap again
+    StatsWrapper stats5 = generateStatsWrapper(1, 1, 1, StatsReportType.ACCOUNT_REPORT);
+    stats5.getSnapshot().setSubMap(null);
+    mySqlStore.storeAccountStats(stats5);
+
+    // empty stats should not override any mysql database rows
+    StatsWrapper obtainedStats5 = mySqlStore.queryAccountStatsByHost(hostname1, port1);
+    assertEquals(obtainedStats3.getSnapshot(), obtainedStats5.getSnapshot());
+
+    StatsWrapper stats6 = generateStatsWrapper(20, 20, 20, StatsReportType.ACCOUNT_REPORT);
+    mySqlStore.storeAccountStats(stats6);
+    StatsWrapper obtainedStats6 = mySqlStore.queryAccountStatsByHost(hostname1, port1);
+    assertEquals(obtainedStats6.getSnapshot(), stats6.getSnapshot());
   }
 
   /**

--- a/ambry-mysql/src/main/java/com/github/ambry/accountstats/AccountStatsMySqlStore.java
+++ b/ambry-mysql/src/main/java/com/github/ambry/accountstats/AccountStatsMySqlStore.java
@@ -193,8 +193,10 @@ public class AccountStatsMySqlStore implements AccountStatsStore {
     // 2. If a container storage usage only exists in first StatsSnapshot.
     // If a container storage usage only exists in the second StatsSnapshot, then it will not be applied to the given function.
     // TODO: should delete rows in database when the previous statsSnapshot has more data than current one.
-    Map<String, StatsSnapshot> currPartitionMap = statsWrapper.getSnapshot().getSubMap();
-    Map<String, StatsSnapshot> prevPartitionMap = prevSnapshot.getSubMap();
+    Map<String, StatsSnapshot> currPartitionMap =
+        Optional.ofNullable(statsWrapper.getSnapshot().getSubMap()).orElseGet(HashMap<String, StatsSnapshot>::new);
+    Map<String, StatsSnapshot> prevPartitionMap =
+        Optional.ofNullable(prevSnapshot.getSubMap()).orElseGet(HashMap<String, StatsSnapshot>::new);
     for (Map.Entry<String, StatsSnapshot> currPartitionMapEntry : currPartitionMap.entrySet()) {
       String partitionIdKey = currPartitionMapEntry.getKey();
       StatsSnapshot currAccountStatsSnapshot = currPartitionMapEntry.getValue();


### PR DESCRIPTION
This pr would fix the cases where all the partitions errors out when collecting account stats. It now doesn't assume the previous or the current stats submap have data.