### PR TITLE
Add Helix notifier to MySqlAccountService

### DIFF
--- a/ambry-account/src/main/java/com/github/ambry/account/HelixAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/HelixAccountService.java
@@ -91,16 +91,12 @@ import static com.github.ambry.utils.Utils.*;
  * </p>
  */
 public class HelixAccountService extends AbstractAccountService implements AccountService {
-  static final String ACCOUNT_METADATA_CHANGE_TOPIC = "account_metadata_change_topic";
-  static final String FULL_ACCOUNT_METADATA_CHANGE_MESSAGE = "full_account_metadata_change";
 
   private final AtomicBoolean open = new AtomicBoolean(true);
   private final BackupFileManager backupFileManager;
   private final HelixPropertyStore<ZNRecord> helixStore;
-  private final Notifier<String> notifier;
   private final ScheduledExecutorService scheduler;
   private final HelixAccountServiceConfig config;
-  private final TopicListener<String> changeTopicListener = this::onAccountChangeMessage;
   private final AccountMetadataStore accountMetadataStore;
   private static final Logger logger = LoggerFactory.getLogger(HelixAccountService.class);
   private final AtomicReference<Router> router = new AtomicReference<>();
@@ -127,9 +123,8 @@ public class HelixAccountService extends AbstractAccountService implements Accou
   HelixAccountService(HelixPropertyStore<ZNRecord> helixStore, AccountServiceMetrics accountServiceMetrics,
       Notifier<String> notifier, ScheduledExecutorService scheduler, HelixAccountServiceConfig config)
       throws IOException {
-    super(config, Objects.requireNonNull(accountServiceMetrics, "accountServiceMetrics cannot be null"));
+    super(config, Objects.requireNonNull(accountServiceMetrics, "accountServiceMetrics cannot be null"), notifier);
     this.helixStore = Objects.requireNonNull(helixStore, "helixStore cannot be null");
-    this.notifier = notifier;
     this.scheduler = scheduler;
     this.config = config;
     this.backupFileManager =
@@ -156,14 +151,6 @@ public class HelixAccountService extends AbstractAccountService implements Accou
     } else if (config.useNewZNodePath) {
       initialFetchAndSchedule();
     }
-  }
-
-  /**
-   * Return the {@link Notifier}.
-   * @return The {@link Notifier}
-   */
-  Notifier<String> getNotifier() {
-    return notifier;
   }
 
   /**
@@ -236,13 +223,7 @@ public class HelixAccountService extends AbstractAccountService implements Accou
           initialDelay, config.updaterPollingIntervalMs);
     }
 
-    if (notifier != null) {
-      notifier.subscribe(ACCOUNT_METADATA_CHANGE_TOPIC, changeTopicListener);
-    } else {
-      logger.warn("Notifier is null. Account updates cannot be notified to other entities. Local account cache may not "
-          + "be in sync with remote account data.");
-      accountServiceMetrics.nullNotifierCount.inc();
-    }
+    maybeSubscribeChangeTopic(true);
   }
 
   /**
@@ -321,9 +302,7 @@ public class HelixAccountService extends AbstractAccountService implements Accou
   @Override
   public void close() {
     if (open.compareAndSet(true, false)) {
-      if (notifier != null) {
-        notifier.unsubscribe(ACCOUNT_METADATA_CHANGE_TOPIC, changeTopicListener);
-      }
+      maybeUnsubscribeChangeTopic();
       if (scheduler != null) {
         shutDownExecutorService(scheduler, config.updaterShutDownTimeoutMs, TimeUnit.MILLISECONDS);
       }
@@ -337,7 +316,8 @@ public class HelixAccountService extends AbstractAccountService implements Accou
    * @param topic The topic.
    * @param message The message for the topic.
    */
-  private void onAccountChangeMessage(String topic, String message) {
+  @Override
+  protected void onAccountChangeMessage(String topic, String message) {
     if (!open.get()) {
       // take no action instead of throwing an exception to silence noisy log messages when a message is received while
       // closing the AccountService.

--- a/ambry-account/src/main/java/com/github/ambry/account/JsonAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/JsonAccountService.java
@@ -67,7 +67,7 @@ final class JsonAccountService extends AbstractAccountService {
    */
   JsonAccountService(Path accountFile, AccountServiceMetrics accountServiceMetrics, ScheduledExecutorService scheduler,
       JsonAccountConfig accountConfig) {
-    super(accountConfig, accountServiceMetrics);
+    super(accountConfig, accountServiceMetrics, null);
 
     this.accountFile = Objects.requireNonNull(accountFile, "helixStore cannot be null");
     this.accountServiceMetrics = Objects.requireNonNull(accountServiceMetrics, "accountServiceMetrics cannot be null");
@@ -113,6 +113,11 @@ final class JsonAccountService extends AbstractAccountService {
     if (!initialized.get()) {
       throw new IllegalStateException("AccountService is closed.");
     }
+  }
+
+  @Override
+  protected void onAccountChangeMessage(String topic, String message) {
+    // We're good.
   }
 
   /**

--- a/ambry-account/src/main/java/com/github/ambry/account/MySqlAccountServiceFactory.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/MySqlAccountServiceFactory.java
@@ -15,6 +15,9 @@ package com.github.ambry.account;
 
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.account.mysql.MySqlAccountStoreFactory;
+import com.github.ambry.commons.HelixNotifier;
+import com.github.ambry.commons.Notifier;
+import com.github.ambry.config.HelixPropertyStoreConfig;
 import com.github.ambry.config.MySqlAccountServiceConfig;
 import com.github.ambry.config.VerifiableProperties;
 import org.slf4j.Logger;
@@ -31,6 +34,7 @@ public class MySqlAccountServiceFactory implements AccountServiceFactory {
   protected final MySqlAccountServiceConfig accountServiceConfig;
   protected final AccountServiceMetrics accountServiceMetrics;
   protected final MySqlAccountStoreFactory mySqlAccountStoreFactory;
+  protected final Notifier<String> notifier;
 
   /**
    * Constructor.
@@ -41,6 +45,8 @@ public class MySqlAccountServiceFactory implements AccountServiceFactory {
     this.accountServiceConfig = new MySqlAccountServiceConfig(verifiableProperties);
     this.accountServiceMetrics = new AccountServiceMetrics(metricRegistry);
     this.mySqlAccountStoreFactory = new MySqlAccountStoreFactory(verifiableProperties, metricRegistry);
+    this.notifier = accountServiceConfig.zkClientConnectString != null ? new HelixNotifier(
+        accountServiceConfig.zkClientConnectString, new HelixPropertyStoreConfig(verifiableProperties)) : null;
   }
 
   @Override
@@ -49,7 +55,7 @@ public class MySqlAccountServiceFactory implements AccountServiceFactory {
       long startTimeMs = System.currentTimeMillis();
       logger.info("Starting a MySqlAccountService");
       MySqlAccountService mySqlAccountService =
-          new MySqlAccountService(accountServiceMetrics, accountServiceConfig, mySqlAccountStoreFactory);
+          new MySqlAccountService(accountServiceMetrics, accountServiceConfig, mySqlAccountStoreFactory, notifier);
       long spentTimeMs = System.currentTimeMillis() - startTimeMs;
       logger.info("MySqlAccountService started, took {} ms", spentTimeMs);
       accountServiceMetrics.startupTimeInMs.update(spentTimeMs);

--- a/ambry-account/src/test/java/com/github/ambry/account/MockNotifier.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/MockNotifier.java
@@ -18,6 +18,7 @@ import com.github.ambry.commons.TopicListener;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 
@@ -67,5 +68,13 @@ public class MockNotifier<T> implements Notifier<T> {
     if (listeners != null) {
       listeners.remove(listener);
     }
+  }
+
+  /**
+   * Remove all listeners.
+   */
+  void unsubscribeAll() {
+    topicToListenersMap.clear();
+    //Optional.ofNullable(topicToListenersMap.get(topic)).ifPresent(Set::clear);
   }
 }

--- a/ambry-account/src/test/java/com/github/ambry/account/MockNotifier.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/MockNotifier.java
@@ -75,6 +75,5 @@ public class MockNotifier<T> implements Notifier<T> {
    */
   void unsubscribeAll() {
     topicToListenersMap.clear();
-    //Optional.ofNullable(topicToListenersMap.get(topic)).ifPresent(Set::clear);
   }
 }

--- a/ambry-account/src/test/java/com/github/ambry/account/MySqlAccountServiceTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/MySqlAccountServiceTest.java
@@ -16,6 +16,7 @@ package com.github.ambry.account;
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.account.mysql.MySqlAccountStore;
 import com.github.ambry.account.mysql.MySqlAccountStoreFactory;
+import com.github.ambry.commons.Notifier;
 import com.github.ambry.config.MySqlAccountServiceConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.utils.SystemTime;
@@ -52,6 +53,7 @@ public class MySqlAccountServiceTest {
   MySqlAccountService mySqlAccountService;
   MySqlAccountStoreFactory mockMySqlAccountStoreFactory;
   MySqlAccountStore mockMySqlAccountStore;
+  Notifier<String> mockNotifier = new MockNotifier<>();
   Properties mySqlConfigProps = new Properties();
 
   public MySqlAccountServiceTest() throws Exception {
@@ -68,7 +70,8 @@ public class MySqlAccountServiceTest {
   private MySqlAccountService getAccountService() throws IOException, SQLException {
     AccountServiceMetrics accountServiceMetrics = new AccountServiceMetrics(new MetricRegistry());
     return new MySqlAccountService(accountServiceMetrics,
-        new MySqlAccountServiceConfig(new VerifiableProperties(mySqlConfigProps)), mockMySqlAccountStoreFactory);
+        new MySqlAccountServiceConfig(new VerifiableProperties(mySqlConfigProps)), mockMySqlAccountStoreFactory,
+        mockNotifier);
   }
 
   /**
@@ -163,8 +166,8 @@ public class MySqlAccountServiceTest {
     verify(mockMySqlAccountStore, atLeastOnce()).updateAccounts(argThat(accountsInfo -> {
       AccountUtils.AccountUpdateInfo accountUpdateInfo = accountsInfo.get(0);
       return accountUpdateInfo.getAccount().equals(finalTestAccount0) && !accountUpdateInfo.isAdded()
-          && accountUpdateInfo.isUpdated() && accountUpdateInfo.getAddedContainers()
-          .isEmpty() && accountUpdateInfo.getUpdatedContainers().isEmpty();
+          && accountUpdateInfo.isUpdated() && accountUpdateInfo.getAddedContainers().isEmpty()
+          && accountUpdateInfo.getUpdatedContainers().isEmpty();
     }));
     assertEquals("Mismatch in account retrieved by ID", testAccount,
         mySqlAccountService.getAccountById(testAccount.getId()));

--- a/ambry-api/src/main/java/com/github/ambry/config/MySqlAccountServiceConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/MySqlAccountServiceConfig.java
@@ -27,6 +27,7 @@ public class MySqlAccountServiceConfig extends AccountServiceConfig {
   public static final String UPDATE_DISABLED = MYSQL_ACCOUNT_SERVICE_PREFIX + "update.disabled";
   private static final String MAX_BACKUP_FILE_COUNT = MYSQL_ACCOUNT_SERVICE_PREFIX + "max.backup.file.count";
   public static final String DB_EXECUTE_BATCH_SIZE = MYSQL_ACCOUNT_SERVICE_PREFIX + "db.execute.batch.size";
+  public static final String ZK_CLIENT_CONNECT_STRING_KEY = MYSQL_ACCOUNT_SERVICE_PREFIX + "zk.client.connect.string";
 
   /**
    * Serialized json array containing the information about all mysql end points.
@@ -106,6 +107,13 @@ public class MySqlAccountServiceConfig extends AccountServiceConfig {
   @Default("50")
   public final int dbExecuteBatchSize;
 
+  /**
+   * The ZooKeeper server address for change notifications.  May be null.  If supplied, account service
+   * will subscribe to the change topic.
+   */
+  @Config(ZK_CLIENT_CONNECT_STRING_KEY)
+  public final String zkClientConnectString;
+
   public MySqlAccountServiceConfig(VerifiableProperties verifiableProperties) {
     super(verifiableProperties);
     dbInfo = verifiableProperties.getString(DB_INFO);
@@ -117,5 +125,6 @@ public class MySqlAccountServiceConfig extends AccountServiceConfig {
     updateDisabled = verifiableProperties.getBoolean(UPDATE_DISABLED, false);
     maxBackupFileCount = verifiableProperties.getIntInRange(MAX_BACKUP_FILE_COUNT, 10, 1, Integer.MAX_VALUE);
     dbExecuteBatchSize = verifiableProperties.getIntInRange(DB_EXECUTE_BATCH_SIZE, 50, 1, Integer.MAX_VALUE);
+    zkClientConnectString = verifiableProperties.getString(ZK_CLIENT_CONNECT_STRING_KEY, null);
   }
 }


### PR DESCRIPTION
Mainly refactoring that moves notification logic from HelixAccountService to parent class so MySqlAccountService could use it.