### PR TITLE
Ignore conflicts on unmodified containers

### DIFF
--- a/ambry-account/src/main/java/com/github/ambry/account/AbstractAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/AbstractAccountService.java
@@ -88,6 +88,7 @@ abstract class AbstractAccountService implements AccountService {
   protected void maybeSubscribeChangeTopic(boolean reportNull) {
     if (notifier != null) {
       notifier.subscribe(ACCOUNT_METADATA_CHANGE_TOPIC, changeTopicListener);
+      logger.info("Subscribed to {} for change notifications.", ACCOUNT_METADATA_CHANGE_TOPIC);
     } else if (reportNull) {
       logger.warn("Notifier is null. Account updates cannot be notified to other entities. Local account cache may not "
           + "be in sync with remote account data.");

--- a/ambry-account/src/main/java/com/github/ambry/account/AccountInfoMap.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/AccountInfoMap.java
@@ -176,9 +176,9 @@ class AccountInfoMap {
    */
   boolean hasConflictingAccount(Collection<Account> accountsToSet, boolean ignoreVersion) {
     for (Account account : accountsToSet) {
-      // if the account already exists, check that the snapshot version is not lower than the stored value.
+      // if the account already exists, check that the snapshot version matches the expected value.
       Account accountInMap = getAccountById(account.getId());
-      if (!ignoreVersion && accountInMap != null && account.getSnapshotVersion() < accountInMap.getSnapshotVersion()) {
+      if (!ignoreVersion && accountInMap != null && account.getSnapshotVersion() != accountInMap.getSnapshotVersion()) {
         logger.error(
             "Account to update (accountId={} accountName={}) has an unexpected snapshot version in store (expected={}, encountered={})",
             account.getId(), account.getName(), account.getSnapshotVersion(), accountInMap.getSnapshotVersion());
@@ -212,10 +212,10 @@ class AccountInfoMap {
       return false;
     }
     for (Container container : containersToSet) {
-      // if the container already exists, check that the snapshot version is not lower than the stored value.
+      // if the container already exists, check that the snapshot version matches the expected value.
       Container containerInMap = account.getContainerByName(container.getName());
       if (!ignoreVersion && containerInMap != null
-          && container.getSnapshotVersion() < containerInMap.getSnapshotVersion()) {
+          && container.getSnapshotVersion() != containerInMap.getSnapshotVersion()) {
         // Snapshot version only matters if other container properties are modified
         if (!container.isSameContainer(containerInMap)) {
           logger.error(

--- a/ambry-account/src/main/java/com/github/ambry/account/AccountInfoMap.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/AccountInfoMap.java
@@ -176,9 +176,9 @@ class AccountInfoMap {
    */
   boolean hasConflictingAccount(Collection<Account> accountsToSet, boolean ignoreVersion) {
     for (Account account : accountsToSet) {
-      // if the account already exists, check that the snapshot version matches the expected value.
+      // if the account already exists, check that the snapshot version is not lower than the stored value.
       Account accountInMap = getAccountById(account.getId());
-      if (!ignoreVersion && accountInMap != null && account.getSnapshotVersion() != accountInMap.getSnapshotVersion()) {
+      if (!ignoreVersion && accountInMap != null && account.getSnapshotVersion() < accountInMap.getSnapshotVersion()) {
         logger.error(
             "Account to update (accountId={} accountName={}) has an unexpected snapshot version in store (expected={}, encountered={})",
             account.getId(), account.getName(), account.getSnapshotVersion(), accountInMap.getSnapshotVersion());
@@ -212,15 +212,17 @@ class AccountInfoMap {
       return false;
     }
     for (Container container : containersToSet) {
-      // if the container already exists, check that the snapshot version matches the expected value.
+      // if the container already exists, check that the snapshot version is not lower than the stored value.
       Container containerInMap = account.getContainerByName(container.getName());
       if (!ignoreVersion && containerInMap != null
-          && container.getSnapshotVersion() != containerInMap.getSnapshotVersion()) {
-        logger.error(
-            "Container to update in AccountId {} (containerId={} containerName={}) has an unexpected snapshot version in store (expected={}, encountered={})",
-            parentAccountId, container.getId(), container.getName(), container.getSnapshotVersion(),
-            containerInMap.getSnapshotVersion());
-        return true;
+          && container.getSnapshotVersion() < containerInMap.getSnapshotVersion()) {
+        // Snapshot version only matters if other container properties are modified
+        if (!container.isSameContainer(containerInMap)) {
+          logger.error(
+              "Container to update in AccountId {} (containerId={} containerName={}) has an unexpected snapshot version in store (expected={}, encountered={})",
+              parentAccountId, container.getId(), container.getName(), container.getSnapshotVersion(), containerInMap.getSnapshotVersion());
+          return true;
+        }
       }
 
       // check that there are no other containers that conflict with the name of the container to update

--- a/ambry-account/src/main/java/com/github/ambry/account/MySqlAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/MySqlAccountService.java
@@ -325,8 +325,8 @@ public class MySqlAccountService extends AbstractAccountService {
     // Tell the world
     publishChangeNotice();
 
-    // write added/modified accounts to in-memory cache
-    updateAccountsInCache(accounts);
+    // Note: don't write accounts to in-memory cache since snapshot version will be incorrect.
+    // Cache will be updated on next DB sync.
   }
 
   @Override
@@ -424,8 +424,8 @@ public class MySqlAccountService extends AbstractAccountService {
     // Tell the world
     publishChangeNotice();
 
-    // write added/modified containers to in-memory cache
-    updateContainersInCache(resolvedContainers);
+    // Note: don't write containers to in-memory cache since snapshot version will be incorrect.
+    // Cache will be updated on next DB sync.
   }
 
   /**

--- a/ambry-api/src/main/java/com/github/ambry/account/Container.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/Container.java
@@ -524,6 +524,7 @@ public class Container {
         && Objects.equals(this.isEncrypted(), containerToCompare.isEncrypted())
         && Objects.equals(this.isMediaScanDisabled(), containerToCompare.isMediaScanDisabled())
         && Objects.equals(this.isTtlRequired(), containerToCompare.isTtlRequired())
+        && Objects.equals(this.getStatus(), containerToCompare.getStatus())
         && Objects.equals(this.getReplicationPolicy(), containerToCompare.getReplicationPolicy())
         && Objects.equals(this.isSecurePathRequired(), containerToCompare.isSecurePathRequired())
         && Objects.equals(this.isBackupEnabled(), containerToCompare.isBackupEnabled())
@@ -761,6 +762,7 @@ public class Container {
       return false;
     }
     Container container = (Container) o;
+    // Note: do not under any circumstances compare snapshotVersion!
     return id == container.id && encrypted == container.encrypted
         && previouslyEncrypted == container.previouslyEncrypted && cacheable == container.cacheable
         && mediaScanDisabled == container.mediaScanDisabled && parentAccountId == container.parentAccountId

--- a/ambry-api/src/main/java/com/github/ambry/config/MySqlAccountServiceConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/MySqlAccountServiceConfig.java
@@ -28,6 +28,7 @@ public class MySqlAccountServiceConfig extends AccountServiceConfig {
   private static final String MAX_BACKUP_FILE_COUNT = MYSQL_ACCOUNT_SERVICE_PREFIX + "max.backup.file.count";
   public static final String DB_EXECUTE_BATCH_SIZE = MYSQL_ACCOUNT_SERVICE_PREFIX + "db.execute.batch.size";
   public static final String ZK_CLIENT_CONNECT_STRING_KEY = MYSQL_ACCOUNT_SERVICE_PREFIX + "zk.client.connect.string";
+  public static final String WRITE_CACHE_AFTER_UPDATE = MYSQL_ACCOUNT_SERVICE_PREFIX + "write.cache.after.update";
 
   /**
    * Serialized json array containing the information about all mysql end points.
@@ -108,6 +109,14 @@ public class MySqlAccountServiceConfig extends AccountServiceConfig {
   public final int dbExecuteBatchSize;
 
   /**
+   * If true, account service will write changes to the cache immediately after updating the persistent store.
+   * If false, the cache will be updated on the subsequent sync call.
+   * If written immediately, updated accounts and containers will have out of date snapshot version.
+   */
+  @Config(WRITE_CACHE_AFTER_UPDATE)
+  @Default("true")
+  public final boolean writeCacheAfterUpdate;
+  /**
    * The ZooKeeper server address for change notifications.  May be null.  If supplied, account service
    * will subscribe to the change topic.
    */
@@ -126,5 +135,6 @@ public class MySqlAccountServiceConfig extends AccountServiceConfig {
     maxBackupFileCount = verifiableProperties.getIntInRange(MAX_BACKUP_FILE_COUNT, 10, 1, Integer.MAX_VALUE);
     dbExecuteBatchSize = verifiableProperties.getIntInRange(DB_EXECUTE_BATCH_SIZE, 50, 1, Integer.MAX_VALUE);
     zkClientConnectString = verifiableProperties.getString(ZK_CLIENT_CONNECT_STRING_KEY, null);
+    writeCacheAfterUpdate = verifiableProperties.getBoolean(WRITE_CACHE_AFTER_UPDATE, true);
   }
 }


### PR DESCRIPTION
Add config option to delay account cache update until next DB sync.