### PR TITLE
Fix test failure on delete tombstone cleanup

### DIFF
--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeUtil.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeUtil.java
@@ -991,7 +991,7 @@ public class HelixBootstrapUpgradeUtil {
         } else {
           if (!dryRun) {
             info("[{}] Instance {} already present in Helix {}, with same Data, skipping. Remaining instances: {}",
-                dcName.toUpperCase(), instanceName, --totalInstances);
+                dcName.toUpperCase(), instanceName, dataNodeConfigSourceType.name(), --totalInstances);
           }
         }
       }

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
@@ -297,18 +297,14 @@ public class BlobStoreCompactorTest {
     IndexSegment indexSegment1 = state.index.getIndexSegments().floorEntry(deleteIndexValue1.getOffset()).getValue();
     IndexSegment indexSegment2 = state.index.getIndexSegments().floorEntry(deleteIndexValue2.getOffset()).getValue();
     // find a key that is behind tombstone1 and the other key that falls between tombstone1 and tombstone2
-    Iterator<IndexEntry> iterator = indexSegment1.iterator();
-    while(iterator.hasNext()){
-      MockId key = (MockId) iterator.next().getKey();
-      if(key.compareTo(tombstone1) == 0){
-        break;
-      }
-    }
-    MockId keyInToken1 = (MockId) iterator.next().getKey();
+    IndexSegment segmentBehindSegment1 =
+        state.index.getIndexSegments().higherEntry(indexSegment1.getStartOffset()).getValue();
+    MockId keyInToken1 = (MockId) segmentBehindSegment1.iterator().next().getKey();
     MockId keyInToken2 = (MockId) indexSegment2.iterator().next().getKey();
     StoreFindToken peerToken1 =
-        new StoreFindToken(keyInToken1, indexSegment1.getStartOffset(), state.sessionId, state.incarnationId,
-            indexSegment1.getResetKey(), indexSegment1.getResetKeyType(), indexSegment1.getResetKeyLifeVersion());
+        new StoreFindToken(keyInToken1, segmentBehindSegment1.getStartOffset(), state.sessionId, state.incarnationId,
+            segmentBehindSegment1.getResetKey(), segmentBehindSegment1.getResetKeyType(),
+            segmentBehindSegment1.getResetKeyLifeVersion());
     StoreFindToken peerToken2 =
         new StoreFindToken(keyInToken2, indexSegment2.getStartOffset(), state.sessionId, state.incarnationId,
             indexSegment2.getResetKey(), indexSegment2.getResetKeyType(), indexSegment2.getResetKeyLifeVersion());

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
@@ -280,7 +280,6 @@ public class BlobStoreCompactorTest {
    * @throws Exception
    */
   @Test
-  @Ignore // TODO: need to fix https://github.com/linkedin/ambry/issues/1811
   public void deleteTombstoneCleanupTest() throws Exception {
     assumeTrue(purgeDeleteTombstone);
     refreshState(false, true);


### PR DESCRIPTION
Previous test attempted to find an entry behind delete tombstone within same index segment. However, this is not always possible because we randomly generated blob ids and sort them in lexicographical way. So the delete tombstone may sit at the end of index segment and caused NoSuchElementException exception.
This PR picks the index segment behind the segment that holds delete tombstone. Thus, we can guarantee the index entry exists in next index segment.

#1811 should be fixed when this PR is merged.