### PR TITLE
[StatsMigration] Remove database rows for missing partition/account/container in AccountReports 

### DIFF
--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbryIdConverterFactory.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbryIdConverterFactory.java
@@ -32,6 +32,7 @@ import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.Utils;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Future;
@@ -163,6 +164,7 @@ public class AmbryIdConverterFactory implements IdConverterFactory {
         }
       } else if (restRequest.getRestMethod() == RestMethod.PUT && RestUtils.getRequestPath(restRequest)
           .matchesOperation(Operations.NAMED_BLOB)) {
+        Objects.requireNonNull(blobInfo, "blobInfo cannot be null.");
         NamedBlobPath namedBlobPath = NamedBlobPath.parse(RestUtils.getRequestPath(restRequest), restRequest.getArgs());
         String blobId = RestUtils.stripSlashAndExtensionFromId(input);
         BlobProperties properties = blobInfo.getBlobProperties();

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
@@ -228,8 +228,8 @@ public class NamedBlobPutHandler {
      */
     private Callback<String> routerStitchBlobCallback(BlobInfo blobInfo) {
       return buildCallback(frontendMetrics.putRouterStitchBlobMetrics,
-          blobId -> idConverter.convert(restRequest, blobId, idConverterCallback(blobInfo, blobId)), uri, LOGGER,
-          finalCallback);
+          blobId -> idConverter.convert(restRequest, blobId, blobInfo, idConverterCallback(blobInfo, blobId)), uri,
+          LOGGER, finalCallback);
     }
 
     /**

--- a/ambry-mysql/src/main/java/com/github/ambry/accountstats/AccountReportsDao.java
+++ b/ambry-mysql/src/main/java/com/github/ambry/accountstats/AccountReportsDao.java
@@ -132,6 +132,13 @@ public class AccountReportsDao {
     }
   }
 
+  /**
+   * Delete container storage usage rows for given {@code clusterName}, {@code hostname} and {@code partitionId}.
+   * @param clusterName The clusterName
+   * @param hostname The hostname
+   * @param partitionId The partitionId
+   * @throws SQLException
+   */
   void deleteStorageUsageForPartition(String clusterName, String hostname, int partitionId) throws SQLException {
     try {
       long startTimeMs = System.currentTimeMillis();
@@ -148,6 +155,14 @@ public class AccountReportsDao {
     }
   }
 
+  /**
+   * Delete container storage usage rows for given {@code clusterName}, {@code hostname}, {@code partitionId} and {@code accountId}.
+   * @param clusterName The clusterName
+   * @param hostname The hostname
+   * @param partitionId The partitionId
+   * @param accountId The accountId
+   * @throws SQLException
+   */
   void deleteStorageUsageForAccount(String clusterName, String hostname, int partitionId, int accountId)
       throws SQLException {
     try {
@@ -167,6 +182,16 @@ public class AccountReportsDao {
     }
   }
 
+  /**
+   * Delete container storage usage rows for given {@code clusterName}, {@code hostname}, {@code partitionId},
+   * {@code accountId} and {@code containerId}.
+   * @param clusterName The clusterName
+   * @param hostname The hostname
+   * @param partitionId The partitionId
+   * @param accountId The accountId
+   * @param containerId The containerId
+   * @throws SQLException
+   */
   void deleteStorageUsageForContainer(String clusterName, String hostname, int partitionId, int accountId,
       int containerId) throws SQLException {
     try {

--- a/ambry-mysql/src/main/java/com/github/ambry/accountstats/AccountStatsMySqlStore.java
+++ b/ambry-mysql/src/main/java/com/github/ambry/accountstats/AccountStatsMySqlStore.java
@@ -250,7 +250,7 @@ public class AccountStatsMySqlStore implements AccountStatsStore {
   }
 
   /**
-   * Delete container account stats data if the partition, or account, or container exists in previous partition map but
+   * Delete container's accountstats data if partition, or account, or container exists in previous partition map but
    * missing in current partition map.
    * @param prevPartitionMap the previous partition stats map.
    * @param currPartitionMap the current partition stats map.

--- a/ambry-mysql/src/main/java/com/github/ambry/accountstats/AccountStatsMySqlStore.java
+++ b/ambry-mysql/src/main/java/com/github/ambry/accountstats/AccountStatsMySqlStore.java
@@ -190,8 +190,8 @@ public class AccountStatsMySqlStore implements AccountStatsStore {
     // Find the differences between two {@link StatsSnapshot} and apply them to the given {@link ContainerUsageFunction}.
     // The difference is defined as
     // 1. If a container storage usage exists in both StatsSnapshot, and the values are different.
-    // 2. If a container storage usage only exists in first StatsSnapshot.
-    // If a container storage usage only exists in the second StatsSnapshot, then it will not be applied to the given function.
+    // 2. If a container storage usage only exists in current StatsSnapshot.
+    // If a container storage usage only exists in the previous StatsSnapshot, then it will not be applied to the given function.
     // TODO: should delete rows in database when the previous statsSnapshot has more data than current one.
     Map<String, StatsSnapshot> currPartitionMap =
         Optional.ofNullable(statsWrapper.getSnapshot().getSubMap()).orElseGet(HashMap<String, StatsSnapshot>::new);
@@ -233,8 +233,8 @@ public class AccountStatsMySqlStore implements AccountStatsStore {
       }
     }
     batch.flush();
-    storeMetrics.publishTimeMs.update(System.currentTimeMillis() - startTimeMs);
     storeMetrics.batchSize.update(batchSize);
+    storeMetrics.publishTimeMs.update(System.currentTimeMillis() - startTimeMs);
     previousStats = statsWrapper;
   }
 

--- a/ambry-mysql/src/main/java/com/github/ambry/accountstats/AccountStatsMySqlStore.java
+++ b/ambry-mysql/src/main/java/com/github/ambry/accountstats/AccountStatsMySqlStore.java
@@ -244,6 +244,20 @@ public class AccountStatsMySqlStore implements AccountStatsStore {
     storeMetrics.batchSize.update(batchSize);
     storeMetrics.insertAccountStatsTimeMs.update(System.currentTimeMillis() - startTimeMs);
 
+    deleteContainerAccountStats(prevPartitionMap, currPartitionMap);
+    storeMetrics.publishTimeMs.update(System.currentTimeMillis() - startTimeMs);
+    previousStats = statsWrapper;
+  }
+
+  /**
+   * Delete container account stats data if the partition, or account, or container exists in previous partition map but
+   * missing in current partition map.
+   * @param prevPartitionMap the previous partition stats map.
+   * @param currPartitionMap the current partition stats map.
+   * @throws SQLException
+   */
+  private void deleteContainerAccountStats(Map<String, StatsSnapshot> prevPartitionMap,
+      Map<String, StatsSnapshot> currPartitionMap) throws SQLException {
     long deleteStartTimeMs = System.currentTimeMillis();
     int deleteStatementCounter = 0;
     // Now delete the rows that appear in previousStats but not in the currentStats
@@ -291,8 +305,6 @@ public class AccountStatsMySqlStore implements AccountStatsStore {
     }
     storeMetrics.deleteStatementSize.update(deleteStatementCounter);
     storeMetrics.deleteAccountStatsTimeMs.update(System.currentTimeMillis() - deleteStartTimeMs);
-    storeMetrics.publishTimeMs.update(System.currentTimeMillis() - startTimeMs);
-    previousStats = statsWrapper;
   }
 
   /**

--- a/ambry-mysql/src/test/java/com/github/ambry/accountstats/AccountStatsMySqlStoreTest.java
+++ b/ambry-mysql/src/test/java/com/github/ambry/accountstats/AccountStatsMySqlStoreTest.java
@@ -23,6 +23,7 @@ import com.github.ambry.mysql.MySqlUtils;
 import com.github.ambry.server.StatsHeader;
 import com.github.ambry.server.StatsSnapshot;
 import com.github.ambry.server.StatsWrapper;
+import com.github.ambry.utils.Utils;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -125,15 +126,15 @@ public class AccountStatsMySqlStoreTest {
           long containerUsage = defaultValue ? DEFAULT_CONTAINER_USAGE
               : Math.abs(random.nextLong()) % (MAX_CONTAINER_USAGE - MIN_CONTAINER_USAGE) + MIN_CONTAINER_USAGE;
           StatsSnapshot containerStatsSnapshot = new StatsSnapshot(containerUsage, null);
-          containerSubMap.put("C[" + (BASE_CONTAINER_ID + ic) + "]", containerStatsSnapshot);
+          containerSubMap.put(Utils.statsContainerKey((short) (BASE_CONTAINER_ID + ic)), containerStatsSnapshot);
           allContainerValue += containerUsage;
         }
         StatsSnapshot accountStatsSnapshot = new StatsSnapshot(allContainerValue, containerSubMap);
-        accountSubMap.put("A[" + (BASE_ACCOUNT_ID + ia) + "]", accountStatsSnapshot);
+        accountSubMap.put(Utils.statsAccountKey((short) (BASE_ACCOUNT_ID + ia)), accountStatsSnapshot);
         allAccountValue += allContainerValue;
       }
       StatsSnapshot partitionStatsSnapshot = new StatsSnapshot(allAccountValue, accountSubMap);
-      partitionSubMap.put("Partition[" + (BASE_PARTITION_ID + ip) + "]", partitionStatsSnapshot);
+      partitionSubMap.put(Utils.statsPartitionKey((short) (BASE_PARTITION_ID + ip)), partitionStatsSnapshot);
       allPartitionValue += allAccountValue;
     }
     return new StatsSnapshot(allPartitionValue, partitionSubMap);

--- a/ambry-network/src/main/java/com/github/ambry/network/NettyServerRequestResponseChannel.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/NettyServerRequestResponseChannel.java
@@ -57,10 +57,13 @@ public class NettyServerRequestResponseChannel implements RequestResponseChannel
     ChannelHandlerContext ctx = ((NettyServerRequest) originalRequest).getCtx();
     http2ServerMetrics.requestTotalProcessingTime.update(
         System.currentTimeMillis() - originalRequest.getStartTimeInMs());
+    long sendStartTime = System.currentTimeMillis();
     ChannelFutureListener channelFutureListener = new ChannelFutureListener() {
       @Override
       public void operationComplete(ChannelFuture future) throws Exception {
-        http2ServerMetrics.responseFlushTime.update(System.currentTimeMillis() - originalRequest.getStartTimeInMs());
+        long responseFlushTime = System.currentTimeMillis() - sendStartTime;
+        http2ServerMetrics.responseFlushTime.update(responseFlushTime);
+        metrics.updateSendTime(responseFlushTime);
         if (!future.isSuccess()) {
           ReferenceCountUtil.safeRelease(payloadToSend);
         }

--- a/ambry-rest/src/main/java/com/github/ambry/rest/RestServer.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/RestServer.java
@@ -84,6 +84,7 @@ public class RestServer {
   private final PublicAccessLogger publicAccessLogger;
   private final RestServerState restServerState;
   private final NettyInternalMetrics nettyInternalMetrics;
+  private final NotificationSystem notificationSystem;
 
   /**
    * {@link RestServer} specific metrics tracking.
@@ -107,6 +108,7 @@ public class RestServer {
     public final Histogram restServerStartTimeInMs;
     public final Histogram routerCloseTimeInMs;
     public final Histogram accountServiceCloseTimeInMs;
+    public final Histogram notificationSystemCloseTimeInMs;
 
     /**
      * Creates an instance of RestServerMetrics using the given {@code metricRegistry}.
@@ -145,7 +147,8 @@ public class RestServer {
       routerCloseTimeInMs = metricRegistry.histogram(MetricRegistry.name(RestServer.class, "RouterCloseTimeInMs"));
       accountServiceCloseTimeInMs =
           metricRegistry.histogram(MetricRegistry.name(RestServer.class, "AccountServiceCloseTimeInMs"));
-
+      notificationSystemCloseTimeInMs =
+          metricRegistry.histogram(MetricRegistry.name(RestServer.class, "NotificationSystemCloseTimeInMs"));
       Gauge<Integer> restServerStatus = () -> restServerState.isServiceUp() ? 1 : 0;
       metricRegistry.register(MetricRegistry.name(RestServer.class, "RestServerState"), restServerStatus);
     }
@@ -189,6 +192,7 @@ public class RestServer {
     RestRequestMetricsTracker.setDefaults(metricRegistry);
     restServerState = new RestServerState(restServerConfig.restServerHealthCheckUri);
     restServerMetrics = new RestServerMetrics(metricRegistry, restServerState);
+    this.notificationSystem = notificationSystem;
 
     AccountServiceFactory accountServiceFactory =
         Utils.getObj(restServerConfig.restServerAccountServiceFactory, verifiableProperties,
@@ -340,8 +344,20 @@ public class RestServer {
       logger.info("Account service close took {} ms", elapsedTime);
       restServerMetrics.accountServiceCloseTimeInMs.update(elapsedTime);
 
+      long notificationSystemCloseTime;
+      try {
+        notificationSystem.close();
+      } catch (IOException e) {
+        logger.error("Error while closing notification system.", e);
+      } finally {
+        notificationSystemCloseTime = System.currentTimeMillis();
+        elapsedTime = notificationSystemCloseTime - accountServiceCloseTime;
+        logger.info("Notification system close took {} ms", elapsedTime);
+        restServerMetrics.notificationSystemCloseTimeInMs.update(elapsedTime);
+      }
+
       reporter.stop();
-      elapsedTime = System.currentTimeMillis() - accountServiceCloseTime;
+      elapsedTime = System.currentTimeMillis() - notificationSystemCloseTime;
       logger.info("JMX reporter shutdown took {} ms", elapsedTime);
       restServerMetrics.jmxReporterShutdownTimeInMs.update(elapsedTime);
     } catch (IOException e) {

--- a/gradle/buildscript.gradle
+++ b/gradle/buildscript.gradle
@@ -9,7 +9,7 @@
 // CONDITIONS OF ANY KIND, either express or implied.
 repositories {
     repositories {
-        // For license plugin.
+        // For various gradle plugins.
         maven {
             url "https://plugins.gradle.org/m2/"
         }
@@ -17,7 +17,10 @@ repositories {
 }
 
 dependencies {
-    classpath "gradle.plugin.com.hierynomus.gradle.plugins:license-gradle-plugin:0.15.0"    
+    classpath "gradle.plugin.com.hierynomus.gradle.plugins:license-gradle-plugin:0.15.0"
     classpath "org.shipkit:shipkit-auto-version:0.0.30"
+    // TODO remove bintray after artifactory fully tested
     classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4"
+    // this is actually the artifactory plugin
+    classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.21.0"
 }

--- a/gradle/ci-release.gradle
+++ b/gradle/ci-release.gradle
@@ -1,3 +1,15 @@
+task artifactoryPublishAll {
+    description = "Runs 'artifactoryPublish' tasks from all projects"
+    mustRunAfter "gitPush" //git push is easier to rollback so we run it first
+}
+
+allprojects {
+    tasks.matching { it.name == "artifactoryPublish" }.all {
+        artifactoryPublishAll.dependsOn it
+    }
+}
+
+// TODO remove bintray after artifactory fully tested
 task bintrayUploadAll {
     description = "Runs 'bintrayUpload' tasks from all projects"
     mustRunAfter "gitPush" //git push is easier to rollback so we run it first
@@ -11,7 +23,7 @@ allprojects {
 
 task ciPerformRelease {
     description = "Performs the release, intended to be ran on CI"
-    dependsOn "gitTag", "gitPush", "bintrayUploadAll"    
+    dependsOn "gitTag", "gitPush", "artifactoryPublishAll", "bintrayUploadAll"
 }
 
 task gitTag {
@@ -30,7 +42,7 @@ task gitTag {
 task gitPush(type: Exec) {
     description = "Pushes tags by running 'git push --tags'. Hides secret key from git push output."
     mustRunAfter "gitTag" //tag first, push later
-    
+
     doFirst { println "Pushing tag v$version" }
     commandLine "./gradle/git-push.sh", "v$version"
     doLast { println "Pushed tag v$version" }

--- a/gradle/java-publishing.gradle
+++ b/gradle/java-publishing.gradle
@@ -77,7 +77,7 @@ artifactoryPublish {
     skip = project.hasProperty('artifactory.dryRun')
 
     doFirst {
-        println "Publishing $jar.baseName to Artifactory (dryRun: $dryRun, repo: $repoName, publish: $publish)"
+        println "Publishing $jar.baseName to Artifactory (dryRun: $skip)"
     }
 }
 

--- a/gradle/java-publishing.gradle
+++ b/gradle/java-publishing.gradle
@@ -1,6 +1,7 @@
 assert plugins.hasPlugin("java")
 
 apply plugin: 'maven-publish'
+apply plugin: 'com.jfrog.artifactory'
 apply plugin: 'com.jfrog.bintray'
 
 tasks.withType(Jar) {
@@ -54,7 +55,33 @@ publishing {
         }
     }
 }
+// Artifactory publishing
+artifactory {
+    //docs: https://www.jfrog.com/confluence/display/rtf/gradle+artifactory+plugin
+    contextUrl = 'https://linkedin.jfrog.io/artifactory'
+    publish {
+        repository {
+            repoKey = 'ambry'
+            username = System.getenv('ARTIFACTORY_USER')
+            password = System.getenv('ARTIFACTORY_API_KEY')
+            maven = true
+        }
 
+        defaults {
+            publications('maven')
+        }
+    }
+}
+
+artifactoryPublish {
+    skip = project.hasProperty('artifactory.dryRun')
+
+    doFirst {
+        println "Publishing $jar.baseName to Artifactory (dryRun: $dryRun, repo: $repoName, publish: $publish)"
+    }
+}
+
+// TODO remove bintray after artifactory fully tested
 bintray { //docs: https://github.com/bintray/gradle-bintray-plugin
     user = System.getenv("BINTRAY_USER")
     key = System.getenv("BINTRAY_API_KEY")

--- a/travis-int-test.sh
+++ b/travis-int-test.sh
@@ -4,7 +4,7 @@
 set -e
 
 echo "Running integration tests"
-./gradlew -s --scan intTest codeCoverageReport
+./gradlew --scan intTest codeCoverageReport
 
 echo "Uploading integration test coverage to codecov"
 bash <(curl -s https://codecov.io/bash)

--- a/travis-publish.sh
+++ b/travis-publish.sh
@@ -4,15 +4,16 @@
 set -e
 
 echo "Building artifacts, and creating pom files"
-./gradlew -s --scan assemble publishToMavenLocal
+./gradlew --scan assemble publishToMavenLocal
 
-echo "Testing Bintray publication by uploading in dry run mode"
-./gradlew -s -i --scan bintrayUploadAll -Pbintray.dryRun
+echo "Testing publication by uploading in dry run mode"
+# TODO remove bintray here
+./gradlew -i --scan bintrayUploadAll artifactoryPublishAll -Pbintray.dryRun -Partifactory.dryRun
 
 echo "Pull request: [$TRAVIS_PULL_REQUEST], Travis branch: [$TRAVIS_BRANCH]"
 # release only from master when no pull request build
 if [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]
 then
     echo "Releasing (tagging, uploading to Bintray)"
-    ./gradlew -s -i --scan ciPerformRelease
+    ./gradlew -i --scan ciPerformRelease
 fi

--- a/travis-store-test.sh
+++ b/travis-store-test.sh
@@ -4,7 +4,7 @@
 set -e
 
 echo "Building and running unit tests for ambry-store"
-./gradlew -s --scan :ambry-store:test codeCoverageReport
+./gradlew --scan :ambry-store:test codeCoverageReport
 
 echo "Uploading unit test coverage for ambry-store to codecov"
 bash <(curl -s https://codecov.io/bash)

--- a/travis-unit-test.sh
+++ b/travis-unit-test.sh
@@ -4,7 +4,7 @@
 set -e
 
 echo "Building and running unit tests excluding ambry-store"
-./gradlew -s --scan -x :ambry-store:test build codeCoverageReport
+./gradlew --scan -x :ambry-store:test build codeCoverageReport
 
 echo "Uploading unit test coverage excluding ambry-store to codecov"
 bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
When a new StatsWrapper is generated and persisted to database, we only override the database rows where the storage value is different. Since we have a copy of previous StatsWrapper, we can easily know which database rows to update.
However, we don't remove those database rows when any partition or account or container no longer exists in the host, we just silently ignore it.

This PR would take the absence of partition/account/container into consideration and remove corresponding database rows.
We are not using batch operations for these DELETEs, since we know the delete should be a rare operation.