### PR TITLE
Publish to linkedin.frog.io/artifactory

### DIFF
--- a/gradle/buildscript.gradle
+++ b/gradle/buildscript.gradle
@@ -9,7 +9,7 @@
 // CONDITIONS OF ANY KIND, either express or implied.
 repositories {
     repositories {
-        // For license plugin.
+        // For various gradle plugins.
         maven {
             url "https://plugins.gradle.org/m2/"
         }
@@ -17,7 +17,10 @@ repositories {
 }
 
 dependencies {
-    classpath "gradle.plugin.com.hierynomus.gradle.plugins:license-gradle-plugin:0.15.0"    
+    classpath "gradle.plugin.com.hierynomus.gradle.plugins:license-gradle-plugin:0.15.0"
     classpath "org.shipkit:shipkit-auto-version:0.0.30"
+    // TODO remove bintray after artifactory fully tested
     classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4"
+    // this is actually the artifactory plugin
+    classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.21.0"
 }

--- a/gradle/ci-release.gradle
+++ b/gradle/ci-release.gradle
@@ -1,3 +1,15 @@
+task artifactoryPublishAll {
+    description = "Runs 'artifactoryPublish' tasks from all projects"
+    mustRunAfter "gitPush" //git push is easier to rollback so we run it first
+}
+
+allprojects {
+    tasks.matching { it.name == "artifactoryPublish" }.all {
+        artifactoryPublishAll.dependsOn it
+    }
+}
+
+// TODO remove bintray after artifactory fully tested
 task bintrayUploadAll {
     description = "Runs 'bintrayUpload' tasks from all projects"
     mustRunAfter "gitPush" //git push is easier to rollback so we run it first
@@ -11,7 +23,7 @@ allprojects {
 
 task ciPerformRelease {
     description = "Performs the release, intended to be ran on CI"
-    dependsOn "gitTag", "gitPush", "bintrayUploadAll"    
+    dependsOn "gitTag", "gitPush", "artifactoryPublishAll", "bintrayUploadAll"
 }
 
 task gitTag {
@@ -30,7 +42,7 @@ task gitTag {
 task gitPush(type: Exec) {
     description = "Pushes tags by running 'git push --tags'. Hides secret key from git push output."
     mustRunAfter "gitTag" //tag first, push later
-    
+
     doFirst { println "Pushing tag v$version" }
     commandLine "./gradle/git-push.sh", "v$version"
     doLast { println "Pushed tag v$version" }

--- a/gradle/java-publishing.gradle
+++ b/gradle/java-publishing.gradle
@@ -1,6 +1,7 @@
 assert plugins.hasPlugin("java")
 
 apply plugin: 'maven-publish'
+apply plugin: 'com.jfrog.artifactory'
 apply plugin: 'com.jfrog.bintray'
 
 tasks.withType(Jar) {
@@ -54,7 +55,33 @@ publishing {
         }
     }
 }
+// Artifactory publishing
+artifactory {
+    //docs: https://www.jfrog.com/confluence/display/rtf/gradle+artifactory+plugin
+    contextUrl = 'https://linkedin.jfrog.io/artifactory'
+    publish {
+        repository {
+            repoKey = 'ambry'
+            username = System.getenv('ARTIFACTORY_USER')
+            password = System.getenv('ARTIFACTORY_API_KEY')
+            maven = true
+        }
 
+        defaults {
+            publications('maven')
+        }
+    }
+}
+
+artifactoryPublish {
+    skip = project.hasProperty('artifactory.dryRun')
+
+    doFirst {
+        println "Publishing $jar.baseName to Artifactory (dryRun: $dryRun, repo: $repoName, publish: $publish)"
+    }
+}
+
+// TODO remove bintray after artifactory fully tested
 bintray { //docs: https://github.com/bintray/gradle-bintray-plugin
     user = System.getenv("BINTRAY_USER")
     key = System.getenv("BINTRAY_API_KEY")

--- a/travis-int-test.sh
+++ b/travis-int-test.sh
@@ -4,7 +4,7 @@
 set -e
 
 echo "Running integration tests"
-./gradlew -s --scan intTest codeCoverageReport
+./gradlew --scan intTest codeCoverageReport
 
 echo "Uploading integration test coverage to codecov"
 bash <(curl -s https://codecov.io/bash)

--- a/travis-publish.sh
+++ b/travis-publish.sh
@@ -4,15 +4,16 @@
 set -e
 
 echo "Building artifacts, and creating pom files"
-./gradlew -s --scan assemble publishToMavenLocal
+./gradlew --scan assemble publishToMavenLocal
 
-echo "Testing Bintray publication by uploading in dry run mode"
-./gradlew -s -i --scan bintrayUploadAll -Pbintray.dryRun
+echo "Testing publication by uploading in dry run mode"
+# TODO remove bintray here
+./gradlew -i --scan bintrayUploadAll artifactoryPublishAll -Pbintray.dryRun -Partifactory.dryRun
 
 echo "Pull request: [$TRAVIS_PULL_REQUEST], Travis branch: [$TRAVIS_BRANCH]"
 # release only from master when no pull request build
 if [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]
 then
     echo "Releasing (tagging, uploading to Bintray)"
-    ./gradlew -s -i --scan ciPerformRelease
+    ./gradlew -i --scan ciPerformRelease
 fi

--- a/travis-store-test.sh
+++ b/travis-store-test.sh
@@ -4,7 +4,7 @@
 set -e
 
 echo "Building and running unit tests for ambry-store"
-./gradlew -s --scan :ambry-store:test codeCoverageReport
+./gradlew --scan :ambry-store:test codeCoverageReport
 
 echo "Uploading unit test coverage for ambry-store to codecov"
 bash <(curl -s https://codecov.io/bash)

--- a/travis-unit-test.sh
+++ b/travis-unit-test.sh
@@ -4,7 +4,7 @@
 set -e
 
 echo "Building and running unit tests excluding ambry-store"
-./gradlew -s --scan -x :ambry-store:test build codeCoverageReport
+./gradlew --scan -x :ambry-store:test build codeCoverageReport
 
 echo "Uploading unit test coverage excluding ambry-store to codecov"
 bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Bintray is being deprecated soon. This enables publishing to LinkedIn's
jfrog artifactory instance instead. After this has been verified, we will
remove all bintray related code from the build.