### PR TITLE
[build] Enable gradle caching and use ubuntu 20.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: java
-dist: xenial
-sudo: required
+dist: focal
 jdk:
   - openjdk11
 before_cache:
@@ -10,22 +9,9 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
-addons:
-  apt:
-    packages:
-      #- oracle-java8-installer
-      #- oracle-java8-unlimited-jce-policy
 services:
   - mysql
 before_install:
-  - mysql --version
-  - wget https://repo.mysql.com//mysql-apt-config_0.8.10-1_all.deb
-  - sudo dpkg -i mysql-apt-config_0.8.10-1_all.deb
-  - sudo apt-get update -q
-  - sudo apt-get install -q -y --allow-unauthenticated -o Dpkg::Options::=--force-confnew mysql-server
-  - sudo systemctl restart mysql
-  - sudo mysql_upgrade
-  - mysql --version
   - mysql -e 'CREATE DATABASE AccountMetadata;'
   - mysql -e 'USE AccountMetadata; SOURCE ./ambry-account/src/main/resources/AccountSchema.ddl;'
   - mysql -e 'CREATE DATABASE ambry_container_storage_stats;'

--- a/build.gradle
+++ b/build.gradle
@@ -539,6 +539,9 @@ task codeCoverageReport(type: JacocoReport) {
         sourceSets it.sourceSets.main
     }
 
+    // always rerun task when requested to get new execution data
+    outputs.upToDateWhen { false }
+
     reports {
         xml.enabled true
         xml.destination file("${buildDir}/reports/jacoco/report.xml")

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,4 +11,4 @@
 #
 org.gradle.daemon=true
 org.gradle.configureondemand=true
-org.gradle.caching=false
+org.gradle.caching=true


### PR DESCRIPTION
This commit will enable gradle caching. Enabling caching means that
tests only run for a module if there are changes in that module or a
dependency. This can speed up builds for many small changes and makes
reruns because of a single test failure much faster, but does not give
us as much insight into flaky tests or potentially hidden dependencies.

Also, change the codeCoverageReport to always run since this task does
not explicitly declare its dependencies (it creates a report for
whatever test cases were run in the build but not necessarily all test
cases).

Finally, this migrates to using ubuntu 20.04 LTS (Focal) as the default repos
have mysql 8 and we do not have to install it from an external repo.