### PR TITLE
Rebuild bloom filter if the bloom file has corrupted

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -357,6 +357,15 @@ public class StoreConfig {
   public final boolean storeIndexRebuildBloomFilterEnabled;
 
   /**
+   * Maximum page count to invalidate some corrupted bloom files that may compute super large value for number of pages
+   * and cause OutOfMemory issue. If computed page count is larger this value, an exception will be thrown to terminate
+   * store startup.
+   */
+  @Config("store.bloom.filter.maximum.page.count")
+  @Default("128")
+  public final int storeBloomFilterMaximumPageCount;
+
+  /**
    * True to enable container deletion in store.
    */
   @Config("store.container.deletion.enabled")
@@ -462,6 +471,8 @@ public class StoreConfig {
     storeUuidBasedBloomFilterEnabled = verifiableProperties.getBoolean("store.uuid.based.bloom.filter.enabled", false);
     storeIndexRebuildBloomFilterEnabled =
         verifiableProperties.getBoolean("store.index.rebuild.bloom.filter.enabled", false);
+    storeBloomFilterMaximumPageCount =
+        verifiableProperties.getIntInRange("store.bloom.filter.maximum.page.count", 128, 1, Integer.MAX_VALUE);
     storeContainerDeletionEnabled = verifiableProperties.getBoolean("store.container.deletion.enabled", false);
     storeSetLocalPartitionStateEnabled =
         verifiableProperties.getBoolean("store.set.local.partition.state.enabled", false);

--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -358,8 +358,8 @@ public class StoreConfig {
 
   /**
    * Maximum page count to invalidate some corrupted bloom files that may compute super large value for number of pages
-   * and cause OutOfMemory issue. If computed page count is larger this value, an exception will be thrown to terminate
-   * store startup.
+   * and cause OutOfMemory issue. If computed page count is larger this value, an exception will be thrown to either
+   * rebuild bloom file or terminate store startup.
    */
   @Config("store.bloom.filter.maximum.page.count")
   @Default("128")

--- a/ambry-store/src/main/java/com/github/ambry/store/IndexSegment.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/IndexSegment.java
@@ -196,16 +196,15 @@ class IndexSegment implements Iterable<IndexEntry> {
                   "IndexSegment : " + indexFile.getAbsolutePath() + " error validating crc for bloom filter");
             }
           } catch (Exception e) {
-            logger.warn("Encountered exception when loading bloom filter {} : {}", bloomFile.getAbsolutePath(),
-                e.getMessage());
+            logger.error("Encountered exception when loading bloom filter {}", bloomFile.getAbsolutePath(), e);
             rebuildBloomFilter = true;
           }
           if (rebuildBloomFilter) {
+            metrics.bloomRebuildOnLoadFailureCount.inc();
             logger.info("Rebuilding bloom filter for index segment: {}", indexFile.getAbsolutePath());
             Utils.deleteFileOrDirectory(bloomFile);
             generateBloomFilterAndPersist();
             logger.info("Bloom filter for index segment: {} is generated", indexFile.getAbsolutePath());
-            metrics.bloomRebuildOnLoadFailureCount.inc();
           }
         }
         if (config.storeSetFilePermissionEnabled) {

--- a/ambry-store/src/main/java/com/github/ambry/store/StoreMetrics.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StoreMetrics.java
@@ -62,6 +62,8 @@ public class StoreMetrics {
   public final Counter bloomAccessedCount;
   public final Counter bloomPositiveCount;
   public final Counter bloomFalsePositiveCount;
+  public final Counter bloomRebuildOnLoadFailureCount;
+  public final Counter bloomPersistFailureCount;
   public final Counter mappedSegmentIsLoadedDuringFindCount;
   public final Counter mappedSegmentIsNotLoadedDuringFindCount;
   public final Counter keySizeMismatchCount;
@@ -157,6 +159,10 @@ public class StoreMetrics {
     bloomPositiveCount = registry.counter(MetricRegistry.name(IndexSegment.class, name + "BloomPositiveCount"));
     bloomFalsePositiveCount =
         registry.counter(MetricRegistry.name(IndexSegment.class, name + "BloomFalsePositiveCount"));
+    bloomRebuildOnLoadFailureCount =
+        registry.counter(MetricRegistry.name(IndexSegment.class, name + "BloomRebuildOnLoadFailureCount"));
+    bloomPersistFailureCount =
+        registry.counter(MetricRegistry.name(IndexSegment.class, name + "BloomPersistFailureCount"));
     mappedSegmentIsLoadedDuringFindCount =
         registry.counter(MetricRegistry.name(IndexSegment.class, name + "MappedSegmentIsLoadedDuringFindCount"));
     mappedSegmentIsNotLoadedDuringFindCount =

--- a/ambry-utils/src/main/java/com/github/ambry/utils/BloomFilterSerializer.java
+++ b/ambry-utils/src/main/java/com/github/ambry/utils/BloomFilterSerializer.java
@@ -24,9 +24,9 @@ abstract class BloomFilterSerializer {
     bf.bitset.serialize(out);
   }
 
-  public BloomFilter deserialize(DataInput in) throws IOException {
+  public BloomFilter deserialize(DataInput in, int maxPageCount) throws IOException {
     int hashes = in.readInt();
-    IBitSet bs = OpenBitSet.deserialize(in);
+    IBitSet bs = OpenBitSet.deserialize(in, maxPageCount);
     return createFilter(hashes, bs);
   }
 

--- a/ambry-utils/src/main/java/com/github/ambry/utils/OpenBitSet.java
+++ b/ambry-utils/src/main/java/com/github/ambry/utils/OpenBitSet.java
@@ -22,7 +22,7 @@ import java.util.Arrays;
 /**
  * An "open" BitSet implementation that allows direct access to the arrays of words
  * storing the bits.  Derived from Lucene's OpenBitSet, but with a paged backing array
- * (see bits delaration, below).
+ * (see bits declaration, below).
  * <p/>
  * Unlike java.util.bitset, the fact that bits are packed into an array of longs
  * is part of the interface.  This allows efficient implementation of other algorithms
@@ -56,13 +56,20 @@ public class OpenBitSet implements IBitSet {
   /**
    * Constructs an OpenBitSet large enough to hold numBits.
    * @param numBits
+   * @param maxPageCount
    */
-  public OpenBitSet(long numBits) {
+  public OpenBitSet(long numBits, int maxPageCount) {
+    if (numBits <= 0) {
+      throw new IllegalArgumentException("Number of bits should be positive but got : " + numBits);
+    }
     wlen = (int) bits2words(numBits);
     int lastPageSize = wlen % PAGE_SIZE;
     int fullPageCount = wlen / PAGE_SIZE;
     pageCount = fullPageCount + (lastPageSize == 0 ? 0 : 1);
-
+    if (pageCount > maxPageCount) {
+      throw new IllegalArgumentException(
+          "Page count " + pageCount + " is larger than specified limit: " + maxPageCount);
+    }
     bits = new long[pageCount][];
 
     for (int i = 0; i < fullPageCount; ++i) {
@@ -72,10 +79,6 @@ public class OpenBitSet implements IBitSet {
     if (lastPageSize != 0) {
       bits[bits.length - 1] = new long[lastPageSize];
     }
-  }
-
-  public OpenBitSet() {
-    this(64);
   }
 
   /**
@@ -420,10 +423,9 @@ public class OpenBitSet implements IBitSet {
     clear(0, capacity());
   }
 
-  public static OpenBitSet deserialize(DataInput in) throws IOException {
+  public static OpenBitSet deserialize(DataInput in, int maxPageCount) throws IOException {
     long bitLength = in.readInt();
-
-    OpenBitSet bs = new OpenBitSet(bitLength << 6);
+    OpenBitSet bs = new OpenBitSet(bitLength << 6, maxPageCount);
     int pageSize = bs.getPageSize();
     int pageCount = bs.getPageCount();
 

--- a/ambry-utils/src/test/java/com/github/ambry/utils/FilterTestHelper.java
+++ b/ambry-utils/src/test/java/com/github/ambry/utils/FilterTestHelper.java
@@ -23,6 +23,7 @@ public class FilterTestHelper {
   public static final BloomCalculations.BloomSpecification spec =
       BloomCalculations.computeBloomSpec(15, MAX_FAILURE_RATE);
   static final int ELEMENTS = 10000;
+  static final int BLOOM_FILTER_MAX_PAGE_COUNT = 128;
 
   static final ResetableIterator<ByteBuffer> intKeys() {
     return new KeyGenerator.IntGenerator(ELEMENTS);

--- a/ambry-utils/src/test/java/com/github/ambry/utils/OpenBitSetTest.java
+++ b/ambry-utils/src/test/java/com/github/ambry/utils/OpenBitSetTest.java
@@ -16,6 +16,9 @@ package com.github.ambry.utils;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static com.github.ambry.utils.FilterTestHelper.*;
+import static org.junit.Assert.*;
+
 
 /**
  * OpenBitSet Test
@@ -23,7 +26,7 @@ import org.junit.Test;
 public class OpenBitSetTest {
   @Test
   public void testOpenBitSetTest() {
-    OpenBitSet bitSet = new OpenBitSet(1000);
+    OpenBitSet bitSet = new OpenBitSet(1000, BLOOM_FILTER_MAX_PAGE_COUNT);
     bitSet.set(0);
     bitSet.set(100);
     Assert.assertTrue(bitSet.get(0));
@@ -34,9 +37,9 @@ public class OpenBitSetTest {
     Assert.assertEquals(bitSet.capacity(), 1024);
     Assert.assertEquals(bitSet.size(), 1024);
     Assert.assertEquals(bitSet.length(), 1024);
-    Assert.assertEquals(bitSet.isEmpty(), false);
+    Assert.assertFalse(bitSet.isEmpty());
     Assert.assertEquals(bitSet.cardinality(), 1);
-    OpenBitSet bitSet2 = new OpenBitSet(1000);
+    OpenBitSet bitSet2 = new OpenBitSet(1000, BLOOM_FILTER_MAX_PAGE_COUNT);
     bitSet2.set(100);
     bitSet2.set(1);
     bitSet2.and(bitSet);
@@ -44,9 +47,9 @@ public class OpenBitSetTest {
     Assert.assertFalse(bitSet2.get(1));
     bitSet2.intersect(bitSet);
     Assert.assertTrue(bitSet2.get(100));
-    OpenBitSet bitSet3 = new OpenBitSet(1000);
+    OpenBitSet bitSet3 = new OpenBitSet(1000, BLOOM_FILTER_MAX_PAGE_COUNT);
     bitSet3.set(100);
-    Assert.assertTrue(bitSet2.equals(bitSet3));
+    Assert.assertEquals(bitSet2, bitSet3);
     bitSet3.set(101);
     bitSet3.set(102);
     bitSet3.set(103);
@@ -55,5 +58,21 @@ public class OpenBitSetTest {
     Assert.assertFalse(bitSet3.get(101));
     Assert.assertFalse(bitSet3.get(102));
     Assert.assertFalse(bitSet3.get(103));
+  }
+
+  @Test
+  public void testInvalidOpenBitSet() {
+    try {
+      new OpenBitSet(-1, BLOOM_FILTER_MAX_PAGE_COUNT);
+      fail("Negative numBits should fail");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+    try {
+      new OpenBitSet(Integer.MAX_VALUE, BLOOM_FILTER_MAX_PAGE_COUNT);
+      fail("Too large page count should fail");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
   }
 }


### PR DESCRIPTION
1. Introduced a config to specify max page count for bloom filter aiming to invalidate corrupted bloom file to avoid OutOfMemory issue
2. Rebuild bloom filter on failure of loading bloom file
3. Added metric to track persisting bloom file failure