### PR TITLE
Fix copy paste error with artifactory publishing

### DIFF
--- a/gradle/java-publishing.gradle
+++ b/gradle/java-publishing.gradle
@@ -77,7 +77,7 @@ artifactoryPublish {
     skip = project.hasProperty('artifactory.dryRun')
 
     doFirst {
-        println "Publishing $jar.baseName to Artifactory (dryRun: $dryRun, repo: $repoName, publish: $publish)"
+        println "Publishing $jar.baseName to Artifactory (dryRun: $skip)"
     }
 }
 


### PR DESCRIPTION
Copied variables from bintray into a println statement that did not
actually exist for the artifactoryPublish task.

This time, I tested it with the following procedure:
1. Changed `version.properties` to use a dummy version, 0.0
2. Published the change from my personal machine with the following commands (adapted from travis-publish.sh):
    ```
     ./gradlew --scan assemble publishToMavenLocal
     ./gradlew -i --scan bintrayUploadAll artifactoryPublishAll -Pbintray.dryRun -Partifactory.dryRun
     ARTIFACTORY_USER=cgetz ARTIFACTORY_API_KEY=<redacted>  ./gradlew -i --scan artifactoryPublishAll
     ```
3. Checked that the artifacts showed up in the artifactory: https://linkedin.jfrog.io/ui/repos/tree/General/ambry%2Fcom%2Fgithub%2Fambry%2Fambry-account%2F0.0.1%2Fambry-account-0.0.1-javadoc.jar