### PR TITLE
Remove traces of bintray.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Build Status](https://travis-ci.com/linkedin/ambry.svg?branch=master)](https://travis-ci.com/linkedin/ambry)
 [![codecov.io](https://codecov.io/github/linkedin/ambry/branch/master/graph/badge.svg)](https://codecov.io/github/linkedin/ambry)
-[ ![Download](https://api.bintray.com/packages/linkedin/maven/ambry/images/download.svg) ](https://bintray.com/linkedin/maven/ambry/_latestVersion)
 [![license](https://img.shields.io/github/license/linkedin/ambry.svg)](LICENSE)
 
 Ambry is a distributed object store that supports storage of trillion of small immutable objects (50K -100K) as well as billions of large objects. It was specifically designed to store and serve media objects in web companies. However, it can be used as a general purpose storage system to store DB backups, search indexes or business reports. The system has the following characterisitics: 

--- a/gradle/buildscript.gradle
+++ b/gradle/buildscript.gradle
@@ -19,8 +19,6 @@ repositories {
 dependencies {
     classpath "gradle.plugin.com.hierynomus.gradle.plugins:license-gradle-plugin:0.15.0"
     classpath "org.shipkit:shipkit-auto-version:0.0.30"
-    // TODO remove bintray after artifactory fully tested
-    classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4"
     // this is actually the artifactory plugin
     classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.21.0"
 }

--- a/gradle/ci-release.gradle
+++ b/gradle/ci-release.gradle
@@ -9,21 +9,9 @@ allprojects {
     }
 }
 
-// TODO remove bintray after artifactory fully tested
-task bintrayUploadAll {
-    description = "Runs 'bintrayUpload' tasks from all projects"
-    mustRunAfter "gitPush" //git push is easier to rollback so we run it first
-}
-
-allprojects {
-    tasks.matching { it.name == "bintrayUpload" }.all {
-        bintrayUploadAll.dependsOn it
-    }
-}
-
 task ciPerformRelease {
     description = "Performs the release, intended to be ran on CI"
-    dependsOn "gitTag", "gitPush", "artifactoryPublishAll", "bintrayUploadAll"
+    dependsOn "gitTag", "gitPush", "artifactoryPublishAll"
 }
 
 task gitTag {

--- a/gradle/java-publishing.gradle
+++ b/gradle/java-publishing.gradle
@@ -2,7 +2,6 @@ assert plugins.hasPlugin("java")
 
 apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.artifactory'
-apply plugin: 'com.jfrog.bintray'
 
 tasks.withType(Jar) {
     from "$rootDir/LICENSE"
@@ -78,41 +77,5 @@ artifactoryPublish {
 
     doFirst {
         println "Publishing $jar.baseName to Artifactory (dryRun: $skip)"
-    }
-}
-
-// TODO remove bintray after artifactory fully tested
-bintray { //docs: https://github.com/bintray/gradle-bintray-plugin
-    user = System.getenv("BINTRAY_USER")
-    key = System.getenv("BINTRAY_API_KEY")
-
-    publish = true
-    dryRun = project.hasProperty("bintray.dryRun") //useful for testing
-
-    publications = ['maven']
-
-    pkg {
-        repo = 'maven'
-        userOrg = 'linkedin'
-        name = 'ambry'
-
-        licenses = ['Apache-2.0']
-        labels = ['blob storage']
-        version {
-            // disable gpg signing to speed up publishing
-            gpg {
-                sign = false
-            }
-            // disable upload to maven central
-            mavenCentralSync {
-                sync = false
-            }
-        }
-    }
-}
-
-bintrayUpload {
-    doFirst {
-        println "Publishing $jar.baseName to Bintray (dryRun: $dryRun, repo: $repoName, publish: $publish)"
     }
 }

--- a/travis-publish.sh
+++ b/travis-publish.sh
@@ -7,8 +7,7 @@ echo "Building artifacts, and creating pom files"
 ./gradlew --scan assemble publishToMavenLocal
 
 echo "Testing publication by uploading in dry run mode"
-# TODO remove bintray here
-./gradlew -i --scan bintrayUploadAll artifactoryPublishAll -Pbintray.dryRun -Partifactory.dryRun
+./gradlew -i --scan artifactoryPublishAll -Partifactory.dryRun
 
 echo "Pull request: [$TRAVIS_PULL_REQUEST], Travis branch: [$TRAVIS_BRANCH]"
 # release only from master when no pull request build


### PR DESCRIPTION
Since builds are successfully being published to the artifactory
instance, we can remove all code to publish to bintray before the end of
the month.