### PR TITLE
[StatsMigration] Remove invalid aggregated stats in mysql aggregation task

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/accountstats/AccountStatsStore.java
+++ b/ambry-api/src/main/java/com/github/ambry/accountstats/AccountStatsStore.java
@@ -21,7 +21,6 @@ import java.util.Set;
 
 /**
  * The interface that stores and fetches account stats, aggregated account stats.
- * TODO: add method to deal with replica reassignment.
  */
 public interface AccountStatsStore {
   /**
@@ -38,6 +37,14 @@ public interface AccountStatsStore {
    * @throws Exception
    */
   void storeAggregatedAccountStats(StatsSnapshot snapshot) throws Exception;
+
+  /**
+   * Delete aggregated account stats for the given {@code accountId} and {@code containerId}.
+   * @param accountId The account id
+   * @param containerId The container id
+   * @throws Exception
+   */
+  void deleteAggregatedAccountStatsForContainer(short accountId, short containerId) throws Exception;
 
   /**
    * Return individual ambry server's stats for the given {@code hostname}. This is the stats stored by method {@link #storeAccountStats}.
@@ -103,6 +110,12 @@ public interface AccountStatsStore {
    * @throws Exception
    */
   void takeSnapshotOfAggregatedAccountStatsAndUpdateMonth(String monthValue) throws Exception;
+
+  /**
+   * Delete the snapshot of latest aggregated account stats. This is usually used to prepare for the new snapshot.
+   * @throws Exception
+   */
+  void deleteSnapshotOfAggregatedAccountStats() throws Exception;
 
   /**
    * Return all the partition class names and their corresponding partition ids in a set.
@@ -180,6 +193,17 @@ public interface AccountStatsStore {
    * @throws Exception
    */
   void storeAggregatedPartitionClassStats(StatsSnapshot statsSnapshot) throws Exception;
+
+  /**
+   * Delete aggregated partition class stats for the given {@code partitionClassName} and the {@code accountContainerKey}.
+   * The {@code accountContainerKey} is the key in the PartitionClass StatsSnapshot. It includes account id and container id.
+   * The account id and container id can be extracted from this key.
+   * @param partitionClassName The partition class name.
+   * @param accountContainerKey The key that contains account id and container id.
+   * @throws Exception
+   */
+  void deleteAggregatedPartitionClassStatsForAccountContainer(String partitionClassName, String accountContainerKey)
+      throws Exception;
 
   /**
    * Return the aggregated partition class stats for given. The returned StatsSnapshot is constructed in the same way

--- a/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
@@ -34,6 +34,8 @@ public class ClusterMapConfig {
   public static final String ENABLE_HELIX_HEALTH_REPORT = "clustermap.enable.helix.health.report";
   public static final String ENABLE_HELIX_AGGREGATION_TASK = "clustermap.enable.helix.aggregation.task";
   public static final String ENABLE_MYSQL_AGGREGATION_TASK = "clustermap.enable.mysql.aggregation.task";
+  public static final String ENABLE_DELETE_INVALID_DATA_IN_MYSQL_AGGREGATION_TASK =
+      "clustermap.enable.delete.invalid.data.in.mysql.aggregation.task";
   public static final String ENABLE_AGGREGATED_MONTHLY_ACCOUNT_REPORT =
       "clustermap.enable.aggregated.monthly.account.report";
   private static final String MAX_REPLICAS_ALL_DATACENTERS = "max-replicas-all-datacenters";
@@ -324,6 +326,13 @@ public class ClusterMapConfig {
   public final boolean clustermapEnableMySqlAggregationTask;
 
   /**
+   * True to enable deleting invalid aggregated data in mysql aggregation task.
+   */
+  @Config(ENABLE_DELETE_INVALID_DATA_IN_MYSQL_AGGREGATION_TASK)
+  @Default("false")
+  public final boolean clustermapEnableDeleteInvalidDataInMysqlAggregationTask;
+
+  /**
    * True to enable aggregation task of stats data in helix. Set default to true to be backward compatible.
    */
   @Config(ENABLE_HELIX_AGGREGATION_TASK)
@@ -407,6 +416,8 @@ public class ClusterMapConfig {
     clustermapEnableMySqlAggregationTask = verifiableProperties.getBoolean(ENABLE_MYSQL_AGGREGATION_TASK, false);
     clustermapEnableAggregatedMonthlyAccountReport =
         verifiableProperties.getBoolean(ENABLE_AGGREGATED_MONTHLY_ACCOUNT_REPORT, false);
+    clustermapEnableDeleteInvalidDataInMysqlAggregationTask =
+        verifiableProperties.getBoolean(ENABLE_DELETE_INVALID_DATA_IN_MYSQL_AGGREGATION_TASK, false);
     clustermapEnableHelixAggregationTask = verifiableProperties.getBoolean(ENABLE_HELIX_AGGREGATION_TASK, true);
     clustermapEnableHelixHealthReport = verifiableProperties.getBoolean(ENABLE_HELIX_AGGREGATION_TASK, true);
   }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/MySqlReportAggregatorTask.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/MySqlReportAggregatorTask.java
@@ -172,7 +172,7 @@ public class MySqlReportAggregatorTask extends UserContentStore implements Task 
     }
   }
 
-  private boolean removeInvalidAggregatedAccountAndContainerStats(StatsSnapshot currentStats) throws Exception {
+  private void removeInvalidAggregatedAccountAndContainerStats(StatsSnapshot currentStats) throws Exception {
     Map<String, Map<String, Long>> existingStats = accountStatsStore.queryAggregatedAccountStats();
     List<Pair<Short, Short>> toBeDeletedAccountAndContainers = new ArrayList<>();
     for (Map.Entry<String, Map<String, Long>> accountEntry : existingStats.entrySet()) {
@@ -189,10 +189,9 @@ public class MySqlReportAggregatorTask extends UserContentStore implements Task 
       accountStatsStore.deleteAggregatedAccountStatsForContainer(accountContainer.getFirst(),
           accountContainer.getSecond());
     }
-    return !toBeDeletedAccountAndContainers.isEmpty();
   }
 
-  private boolean removeInvalidAggregatedPartitionClassStats(StatsSnapshot currentStats) throws Exception {
+  private void removeInvalidAggregatedPartitionClassStats(StatsSnapshot currentStats) throws Exception {
     List<Pair<String, String>> toBeDeletedPartitionClassNameAndAccountContainer = new ArrayList<>();
     StatsSnapshot existingStats = accountStatsStore.queryAggregatedPartitionClassStats();
     for (Map.Entry<String, StatsSnapshot> partitionClassEntry : existingStats.getSubMap().entrySet()) {
@@ -207,7 +206,6 @@ public class MySqlReportAggregatorTask extends UserContentStore implements Task 
     for (Pair<String, String> pair : toBeDeletedPartitionClassNameAndAccountContainer) {
       accountStatsStore.deleteAggregatedPartitionClassStatsForAccountContainer(pair.getFirst(), pair.getSecond());
     }
-    return !toBeDeletedPartitionClassNameAndAccountContainer.isEmpty();
   }
 
   private boolean accountAndContainerExistsInStatsSnapshot(StatsSnapshot snapshot, short accountId, short containerId) {

--- a/ambry-mysql/src/main/java/com/github/ambry/accountstats/InmemoryAccountStatsStore.java
+++ b/ambry-mysql/src/main/java/com/github/ambry/accountstats/InmemoryAccountStatsStore.java
@@ -56,6 +56,10 @@ public class InmemoryAccountStatsStore implements AccountStatsStore {
   }
 
   @Override
+  public void deleteAggregatedAccountStatsForContainer(short accountId, short containerId) throws Exception {
+  }
+
+  @Override
   public StatsWrapper queryAccountStatsByHost(String hostname, int port) throws Exception {
     if (hostname.equals(this.hostname)) {
       return currentHostStatsWrapper;
@@ -112,6 +116,11 @@ public class InmemoryAccountStatsStore implements AccountStatsStore {
   }
 
   @Override
+  public void deleteSnapshotOfAggregatedAccountStats() throws Exception {
+
+  }
+
+  @Override
   public Map<String, Set<Integer>> queryPartitionNameAndIds() throws Exception {
     return null;
   }
@@ -130,6 +139,12 @@ public class InmemoryAccountStatsStore implements AccountStatsStore {
   @Override
   public void storeAggregatedPartitionClassStats(StatsSnapshot statsSnapshot) throws Exception {
     aggregatedPartitionClassStats = statsSnapshot;
+  }
+
+  @Override
+  public void deleteAggregatedPartitionClassStatsForAccountContainer(String partitionClassName,
+      String accountContainerKey) throws Exception {
+
   }
 
   @Override

--- a/ambry-server/src/main/java/com/github/ambry/server/StatsManager.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/StatsManager.java
@@ -509,7 +509,7 @@ class StatsManager {
           Iterator<PartitionId> iterator = partitionToReplicaMap.keySet().iterator();
           while (!cancelled && iterator.hasNext()) {
             PartitionId partitionId = iterator.next();
-            logger.info("Aggregating account stats for local report started for store {}", partitionId);
+            logger.trace("Aggregating account stats for local report started for store {}", partitionId);
             collectAndAggregateAccountStats(aggregatedSnapshot, partitionId, unreachablePartitions);
           }
           aggregatedSnapshot.updateValue();


### PR DESCRIPTION
When an account/container is deleted, the host account stats and partition class stats would not generate any data for it so that the aggregated account and partition class stats in aggregation task don't include any data for this account/container. At this time, the aggregated account and partition class stats for this account/container is useless and can be removed.

This PR adds some logic to remove those data and a configuration to turn it on and off. 