### PR TITLE
Set journal size to zero when config enabled

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -373,6 +373,13 @@ public class StoreConfig {
   public final boolean storeContainerDeletionEnabled;
 
   /**
+   * True to enable close last log segment automatically and journal size will be set to zero.
+   */
+  @Config("store.auto.close.last.log.segment.enabled")
+  @Default("false")
+  public final boolean storeAutoCloseLastLogSegmentEnabled;
+
+  /**
    * Whether to set local partition state through InstanceConfig in Helix. If true, store is allowed to enable/disable
    * partition on local node by calling InstanceConfig API.
    */
@@ -474,6 +481,7 @@ public class StoreConfig {
     storeBloomFilterMaximumPageCount =
         verifiableProperties.getIntInRange("store.bloom.filter.maximum.page.count", 128, 1, Integer.MAX_VALUE);
     storeContainerDeletionEnabled = verifiableProperties.getBoolean("store.container.deletion.enabled", false);
+    storeAutoCloseLastLogSegmentEnabled = verifiableProperties.getBoolean("store.auto.close.last.log.segment.enabled", false);
     storeSetLocalPartitionStateEnabled =
         verifiableProperties.getBoolean("store.set.local.partition.state.enabled", false);
     storeEnableBucketForLogSegmentReports =

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
@@ -377,7 +377,7 @@ class BlobStoreCompactor {
       }
       // should be outside the range of the journal
       Offset segmentEndOffset = new Offset(segment.getName(), segment.getEndOffset());
-      if (segmentEndOffset.compareTo(srcIndex.journal.getFirstOffset()) >= 0) {
+      if (srcIndex.journal.getFirstOffset() != null && segmentEndOffset.compareTo(srcIndex.journal.getFirstOffset()) >= 0) {
         throw new IllegalArgumentException("Some of the offsets provided for compaction are within the journal");
       }
       prevSegmentName = segment.getName();
@@ -519,7 +519,7 @@ class BlobStoreCompactor {
         targetLogTotalCapacity, storeId, existingTargetLogSegments, targetSegmentNamesAndFilenames);
     tgtLog = new Log(dataDir.getAbsolutePath(), targetLogTotalCapacity, diskSpaceAllocator, config, tgtMetrics, true,
         existingTargetLogSegments, targetSegmentNamesAndFilenames.iterator());
-    Journal journal = new Journal(dataDir.getAbsolutePath(), 2 * config.storeIndexMaxNumberOfInmemElements,
+    Journal journal = new Journal(dataDir.getAbsolutePath(), config.storeAutoCloseLastLogSegmentEnabled ? 0 : 2 * config.storeIndexMaxNumberOfInmemElements,
         config.storeMaxNumberOfEntriesToReturnFromJournal);
     tgtIndex =
         new PersistentIndex(dataDir.getAbsolutePath(), storeId, null, tgtLog, config, storeKeyFactory, null, null,

--- a/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
@@ -150,7 +150,7 @@ class PersistentIndex {
     to be created that doesn't squash entries.
      */
     this(datadir, storeId, scheduler, log, config, factory, recovery, hardDelete, diskIOScheduler, metrics,
-        new Journal(datadir, 2 * config.storeIndexMaxNumberOfInmemElements,
+        new Journal(datadir, config.storeAutoCloseLastLogSegmentEnabled ? 0 : 2 * config.storeIndexMaxNumberOfInmemElements,
             config.storeMaxNumberOfEntriesToReturnFromJournal), time, sessionId, incarnationId,
         CLEAN_SHUTDOWN_FILENAME);
   }
@@ -431,7 +431,7 @@ class PersistentIndex {
 
     for (Offset offset : segmentsToRemove) {
       IndexSegment segmentToRemove = validIndexSegments.get(offset);
-      if (segmentToRemove.getEndOffset().compareTo(journalFirstOffset) >= 0) {
+      if (journalFirstOffset != null && segmentToRemove.getEndOffset().compareTo(journalFirstOffset) >= 0) {
         throw new IllegalArgumentException(
             "End Offset of the one of the segments to remove [" + segmentToRemove.getFile() + "] is"
                 + " higher than the first offset in the journal");

--- a/ambry-store/src/test/java/com/github/ambry/store/CuratedLogIndexState.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CuratedLogIndexState.java
@@ -288,7 +288,9 @@ class CuratedLogIndexState {
       endOffsetOfPrevMsg = fileSpan.getEndOffset();
     }
     assertEquals("End Offset of index not as expected", endOffsetOfPrevMsg, index.getCurrentEndOffset());
-    assertEquals("Journal's last offset not as expected", expectedJournalLastOffset, index.journal.getLastOffset());
+    if (index.journal.getLastOffset() != null) {
+      assertEquals("Journal's last offset not as expected", expectedJournalLastOffset, index.journal.getLastOffset());
+    }
     return indexEntries;
   }
 


### PR DESCRIPTION
Set journal size to zero for impact test.
In order to compact the last log segment, the compaction candidate should not be included in the journal. So when we close the last log segment, in order to make sure it’s under compaction, we need to decrease the journal size and make sure it only contains the indexEntry mapping to the last log segment. This leads to a problem for replication, the replication token will be invalid after compaction, so the replication might start from the middle of log segments(token reset logic enabled).