### PR TITLE
Fix race condition regarding false alarm BlobNotFound in operation tracker

### DIFF
--- a/ambry-router/src/main/java/com/github/ambry/router/AdaptiveOperationTracker.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/AdaptiveOperationTracker.java
@@ -44,7 +44,6 @@ import static com.github.ambry.router.NonBlockingRouterMetrics.*;
  */
 class AdaptiveOperationTracker extends SimpleOperationTracker {
   private final RouterConfig routerConfig;
-  private final NonBlockingRouterMetrics routerMetrics;
   private final Time time;
   private final CachedHistogram localDcHistogram;
   private final CachedHistogram crossDcHistogram;
@@ -71,9 +70,8 @@ class AdaptiveOperationTracker extends SimpleOperationTracker {
    */
   AdaptiveOperationTracker(RouterConfig routerConfig, NonBlockingRouterMetrics routerMetrics,
       RouterOperation routerOperation, PartitionId partitionId, String originatingDcName, Time time) {
-    super(routerConfig, routerOperation, partitionId, originatingDcName, true);
+    super(routerConfig, routerOperation, partitionId, originatingDcName, true, routerMetrics);
     this.routerConfig = routerConfig;
-    this.routerMetrics = routerMetrics;
     this.time = time;
     this.localDcHistogram = getWholeDcTracker(routerOperation, true);
     this.crossDcHistogram = getWholeDcTracker(routerOperation, false);

--- a/ambry-router/src/main/java/com/github/ambry/router/DeleteOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/DeleteOperation.java
@@ -100,7 +100,7 @@ class DeleteOperation {
     String originatingDcName = clusterMap.getDatacenterName(blobDcId);
     this.operationTracker =
         new SimpleOperationTracker(routerConfig, RouterOperation.DeleteOperation, blobId.getPartition(),
-            originatingDcName, false);
+            originatingDcName, false, routerMetrics);
   }
 
   /**

--- a/ambry-router/src/main/java/com/github/ambry/router/GetOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/GetOperation.java
@@ -236,8 +236,8 @@ abstract class GetOperation {
     String trackerType = routerConfig.routerGetOperationTrackerType;
     String originatingDcName = clusterMap.getDatacenterName(datacenterId);
     if (trackerType.equals(SimpleOperationTracker.class.getSimpleName())) {
-      operationTracker =
-          new SimpleOperationTracker(routerConfig, routerOperation, partitionId, originatingDcName, true);
+      operationTracker = new SimpleOperationTracker(routerConfig, routerOperation, partitionId, originatingDcName, true,
+          routerMetrics);
     } else if (trackerType.equals(AdaptiveOperationTracker.class.getSimpleName())) {
       operationTracker =
           new AdaptiveOperationTracker(routerConfig, routerMetrics, routerOperation, partitionId, originatingDcName,

--- a/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterMetrics.java
@@ -194,7 +194,7 @@ public class NonBlockingRouterMetrics {
   public final Counter compositeBlobGetCount;
   public final Counter rawBlobGetCount;
 
-  // AdaptiveOperationTracker metrics
+  // SimpleOperationTracker and AdaptiveOperationTracker metrics
   public final CachedHistogram getBlobLocalDcLatencyMs;
   public final CachedHistogram getBlobCrossDcLatencyMs;
   public final Counter getBlobPastDueCount;
@@ -202,6 +202,8 @@ public class NonBlockingRouterMetrics {
   public final CachedHistogram getBlobInfoLocalDcLatencyMs;
   public final CachedHistogram getBlobInfoCrossDcLatencyMs;
   public final Counter getBlobInfoPastDueCount;
+  public final Counter failedOnOriginatingDcNotFoundCount;
+  public final Counter failedOnTotalNotFoundCount;
 
   // Workload characteristics
   public final AgeAtAccessMetrics ageAtGet;
@@ -475,6 +477,10 @@ public class NonBlockingRouterMetrics {
         (CachedHistogram) metricRegistry.histogram(MetricRegistry.name(GetBlobInfoOperation.class, "CrossDcLatencyMs"),
             () -> createHistogram(routerConfig, true));
     getBlobInfoPastDueCount = metricRegistry.counter(MetricRegistry.name(GetBlobInfoOperation.class, "PastDueCount"));
+    failedOnOriginatingDcNotFoundCount =
+        metricRegistry.counter(MetricRegistry.name(SimpleOperationTracker.class, "FailedOnOriginatingDcNotFoundCount"));
+    failedOnTotalNotFoundCount =
+        metricRegistry.counter(MetricRegistry.name(SimpleOperationTracker.class, "FailedOnTotalNotFoundCount"));
 
     // Workload
     ageAtGet = new AgeAtAccessMetrics(metricRegistry, "OnGet");

--- a/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
@@ -1127,7 +1127,7 @@ class PutOperation {
             passedInBlobProperties.getExternalAssetTag(), passedInBlobProperties.getContentEncoding(),
             passedInBlobProperties.getFilename());
         operationTracker =
-            new SimpleOperationTracker(routerConfig, RouterOperation.PutOperation, partitionId, null, true);
+            new SimpleOperationTracker(routerConfig, RouterOperation.PutOperation, partitionId, null, true, routerMetrics);
         correlationIdToChunkPutRequestInfo.clear();
         state = ChunkState.Ready;
       } catch (RouterException e) {

--- a/ambry-router/src/main/java/com/github/ambry/router/SimpleOperationTracker.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/SimpleOperationTracker.java
@@ -487,6 +487,14 @@ class SimpleOperationTracker implements OperationTracker {
   }
 
   /**
+   * Exposed for testing only.
+   * @return the number of replicas in current replica pool.
+   */
+  int getReplicaPoolSize() {
+    return replicaPool.size();
+  }
+
+  /**
    * Add a replica to the beginning of the replica pool linked list.
    * @param replicaId the replica to add.
    */

--- a/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateOperation.java
@@ -91,7 +91,7 @@ class TtlUpdateOperation {
     String originatingDcName = clusterMap.getDatacenterName(blobDcId);
     this.operationTracker =
         new SimpleOperationTracker(routerConfig, RouterOperation.TtlUpdateOperation, blobId.getPartition(),
-            originatingDcName, false);
+            originatingDcName, false, routerMetrics);
   }
 
   /**

--- a/ambry-router/src/main/java/com/github/ambry/router/UndeleteOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/UndeleteOperation.java
@@ -89,7 +89,7 @@ public class UndeleteOperation {
     this.time = time;
     this.operationTimeMs = operationTimeMs;
     this.operationTracker = new UndeleteOperationTracker(routerConfig, blobId.getPartition(),
-        clusterMap.getDatacenterName(blobId.getDatacenterId()));
+        clusterMap.getDatacenterName(blobId.getDatacenterId()), routerMetrics);
   }
 
   /**

--- a/ambry-router/src/main/java/com/github/ambry/router/UndeleteOperationTracker.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/UndeleteOperationTracker.java
@@ -40,9 +40,11 @@ public class UndeleteOperationTracker extends SimpleOperationTracker {
    * @param routerConfig The {@link RouterConfig} containing the configs for operation tracker.
    * @param partitionId The partition on which the operation is performed.
    * @param originatingDcName name of originating DC whose replicas should be tried first.
+   * @param routerMetrics
    */
-  UndeleteOperationTracker(RouterConfig routerConfig, PartitionId partitionId, String originatingDcName) {
-    super(routerConfig, RouterOperation.UndeleteOperation, partitionId, originatingDcName, false);
+  UndeleteOperationTracker(RouterConfig routerConfig, PartitionId partitionId, String originatingDcName,
+      NonBlockingRouterMetrics routerMetrics) {
+    super(routerConfig, RouterOperation.UndeleteOperation, partitionId, originatingDcName, false, routerMetrics);
     List<? extends ReplicaId> replicas = partitionId.getReplicaIds();
     for (ReplicaId replica : replicas) {
       String dcName = replica.getDataNodeId().getDatacenterName();

--- a/ambry-router/src/test/java/com/github/ambry/router/DeleteManagerTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/DeleteManagerTest.java
@@ -455,7 +455,7 @@ public class DeleteManagerTest {
   }
 
   /**
-   * Test the case  when getting NOT_FOUND error from origin DC while termination on NOT_FOUND is enabled.
+   * Test the case when getting NOT_FOUND error from origin DC while termination on NOT_FOUND is enabled.
    */
   @Test
   public void testOriginDcNotFoundError() throws Exception {
@@ -477,7 +477,7 @@ public class DeleteManagerTest {
     Arrays.fill(serverErrorCodes, ServerErrorCode.No_Error);
     serverErrorCodes[0] = ServerErrorCode.Blob_Not_Found;
     serverErrorCodes[1] = ServerErrorCode.Blob_Not_Found;
-    serverErrorCodes[2] = ServerErrorCode.Blob_Expired;
+    serverErrorCodes[2] = ServerErrorCode.Blob_Not_Found;
     // The first two responses are blob not found and they are from the local dc and originating dc.
     // So even if the rest of servers returns No_Error, router will not send any requests to them.
     testWithErrorCodes(serverErrorCodes, partition, serverLayout, RouterErrorCode.BlobDoesNotExist,

--- a/ambry-router/src/test/java/com/github/ambry/router/GetBlobInfoOperationTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/GetBlobInfoOperationTest.java
@@ -535,8 +535,9 @@ public class GetBlobInfoOperationTest {
         .forEach(server -> server.setServerErrorForAllRequests(ServerErrorCode.Blob_Not_Found));
     assertOperationFailure(RouterErrorCode.BlobDoesNotExist);
     // Blob is created by putBlob function so the local datacenter will be the origin datecenter.
-    // Thus only need two Blob_Not_Found to terminate the operation.
-    Assert.assertEquals("Must have attempted sending requests to all replicas", 2, correlationIdToGetOperation.size());
+    // It requires at least 3 Blob_Not_Found responses to terminate the operation.
+    Assert.assertTrue("Must have attempted sending at least 3 requests to all originating dc replicas",
+        correlationIdToGetOperation.size() >= 3);
   }
 
   /**

--- a/ambry-router/src/test/java/com/github/ambry/router/GetBlobInfoOperationTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/GetBlobInfoOperationTest.java
@@ -428,7 +428,7 @@ public class GetBlobInfoOperationTest {
     // error code should be OperationTimedOut because it precedes BlobDoesNotExist
     Assert.assertEquals(RouterErrorCode.BlobDoesNotExist, routerException.getErrorCode());
     // localReplica now becomes remote replica.
-    Assert.assertEquals("The number of data points in remote colo latency histogram is not expected", 2,
+    Assert.assertEquals("The number of data points in remote colo latency histogram is not expected", 3,
         tracker.getLatencyHistogram(localReplica).getCount());
 
     props = getNonBlockingRouterProperties(true);

--- a/ambry-router/src/test/java/com/github/ambry/router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/GetBlobOperationTest.java
@@ -702,9 +702,10 @@ public class GetBlobOperationTest {
           @Override
           public void testAndAssert(RouterErrorCode expectedError) throws Exception {
             GetBlobOperation op = createOperationAndComplete(null);
-            // Local dc is the origin DC, only two NOT_FOUND would terminate the operation.
-            Assert.assertEquals("Must have attempted sending requests to all replicas", 2,
-                correlationIdToGetOperation.size());
+            // Local dc is the origin DC, need at least three NOT_FOUND responses from origin DC to terminate the operation.
+            // Note that the default parallelism is 2 for GET. To terminate on not found, 4 requests may be sent out.
+            Assert.assertTrue("Must have attempted sending requests to all 3 originating dc replicas",
+                correlationIdToGetOperation.size() >= 3);
             assertFailureAndCheckErrorCode(op, expectedError);
           }
         });

--- a/ambry-router/src/test/java/com/github/ambry/router/OperationTrackerTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/OperationTrackerTest.java
@@ -838,12 +838,15 @@ public class OperationTrackerTest {
 
     sendRequests(ot, 3, false);
     assertEquals("Should have 3 replicas", 3, inflightReplicas.size());
-    // Only send two not found response, it will terminate the operation.
-    for (int i = 0; i < 2; i++) {
+    // Send three not found response from originating dc, it will terminate the operation.
+    for (int i = 0; i < 3; i++) {
       ReplicaId replica = inflightReplicas.poll();
       // fail first 3 requests to local replicas
       ot.onResponse(replica, TrackedRequestFinalState.NOT_FOUND);
       assertEquals("Should be originatingDcName DC", originatingDcName, replica.getDataNodeId().getDatacenterName());
+      if (i < 2) {
+        assertFalse("Operation should not have failed on NOT_FOUND", ot.hasFailedOnNotFound());
+      }
     }
     assertTrue("Operation should have failed on NOT_FOUND", ot.hasFailedOnNotFound());
     assertTrue("Operation should be done", ot.isDone());

--- a/ambry-router/src/test/java/com/github/ambry/router/OperationTrackerTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/OperationTrackerTest.java
@@ -973,7 +973,8 @@ public class OperationTrackerTest {
       switch (operationTrackerType) {
         case SIMPLE_OP_TRACKER:
           operationTracker =
-              new SimpleOperationTracker(routerConfig, entry.getKey(), mockPartition, originatingDcName, true);
+              new SimpleOperationTracker(routerConfig, entry.getKey(), mockPartition, originatingDcName, true,
+                  routerMetrics);
           break;
         case ADAPTIVE_OP_TRACKER:
           try {
@@ -1269,7 +1270,8 @@ public class OperationTrackerTest {
     OperationTracker tracker;
     switch (operationTrackerType) {
       case SIMPLE_OP_TRACKER:
-        tracker = new SimpleOperationTracker(routerConfig, routerOperation, mockPartition, originatingDcName, true);
+        tracker = new SimpleOperationTracker(routerConfig, routerOperation, mockPartition, originatingDcName, true,
+            routerMetrics);
         break;
       case ADAPTIVE_OP_TRACKER:
         // for now adaptive operation tracker only applies to GetOperation.

--- a/ambry-router/src/test/java/com/github/ambry/router/UndeleteOperationTrackerTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/UndeleteOperationTrackerTest.java
@@ -378,7 +378,8 @@ public class UndeleteOperationTrackerTest {
         Boolean.toString(replicasStateEnabled));
     props.setProperty(RouterConfig.ROUTER_UNDELETE_REQUEST_PARALLELISM, Integer.toString(parallelism));
     RouterConfig routerConfig = new RouterConfig(new VerifiableProperties(props));
-    return new UndeleteOperationTracker(routerConfig, mockPartition, originatingDcName);
+    NonBlockingRouterMetrics routerMetrics = new NonBlockingRouterMetrics(mockClusterMap, routerConfig);
+    return new UndeleteOperationTracker(routerConfig, mockPartition, originatingDcName, routerMetrics);
   }
 
   /**


### PR DESCRIPTION
This PR adds additional logs and metrics to capture failed-on-not-found event in simple operation tracker.
The logs and metrics will help us debug intermittent issues that frontend reports NotFound but blobs are actually present.
The root cause is identified as race condition induced by state transition on some replicas and one of originating replica is wiped out and rebuilt. This PR forces operation tracker to go through all originating dc replicas before terminating on NotFound.