### PR TITLE
[Compaction] Fix blob store stats to return 0 value for the invalid log segment

### DIFF
--- a/ambry-server/src/main/java/com/github/ambry/server/StatsManager.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/StatsManager.java
@@ -509,7 +509,7 @@ class StatsManager {
           Iterator<PartitionId> iterator = partitionToReplicaMap.keySet().iterator();
           while (!cancelled && iterator.hasNext()) {
             PartitionId partitionId = iterator.next();
-            logger.trace("Aggregating account stats for local report started for store {}", partitionId);
+            logger.debug("Aggregating account stats for local report started for store {}", partitionId);
             collectAndAggregateAccountStats(aggregatedSnapshot, partitionId, unreachablePartitions);
           }
           aggregatedSnapshot.updateValue();
@@ -579,7 +579,7 @@ class StatsManager {
           Iterator<PartitionId> iterator = partitionToReplicaMap.keySet().iterator();
           while (!cancelled && iterator.hasNext()) {
             PartitionId partitionId = iterator.next();
-            logger.info("Aggregating partition class stats for local report started for store {}", partitionId);
+            logger.debug("Aggregating partition class stats for local report started for store {}", partitionId);
             collectAndAggregatePartitionClassStats(aggregatedSnapshot, partitionId, unreachablePartitions);
           }
           aggregatedSnapshot.updateValue();

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreStats.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreStats.java
@@ -257,7 +257,7 @@ class BlobStoreStats implements StoreStats, Closeable {
    * Returns the max blob size that is encountered while generating stats
    * @return the max blob size that is encountered while generating stats
    */
-  static long getMaxBlobSize() {
+  long getMaxBlobSize() {
     return MAX_BLOB_SIZE;
   }
 

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreStats.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreStats.java
@@ -257,7 +257,7 @@ class BlobStoreStats implements StoreStats, Closeable {
    * Returns the max blob size that is encountered while generating stats
    * @return the max blob size that is encountered while generating stats
    */
-  long getMaxBlobSize() {
+  static long getMaxBlobSize() {
     return MAX_BLOB_SIZE;
   }
 

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreStats.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreStats.java
@@ -76,6 +76,7 @@ class BlobStoreStats implements StoreStats, Closeable {
   private final long logSegmentForecastOffsetMs;
   private final long waitTimeoutInSecs;
   private final boolean enableBucketForLogSegmentReports;
+  private final boolean fillupLogSegmentNames;
   private final StoreMetrics metrics;
   private final ReentrantLock scanLock = new ReentrantLock();
   private final Condition waitCondition = scanLock.newCondition();
@@ -142,6 +143,16 @@ class BlobStoreStats implements StoreStats, Closeable {
       long logSegmentForecastOffsetMs, long queueProcessingPeriodInMs, long waitTimeoutInSecs,
       boolean enableBucketForLogSegmentReports, Time time, ScheduledExecutorService longLiveTaskScheduler,
       ScheduledExecutorService shortLiveTaskScheduler, DiskIOScheduler diskIOScheduler, StoreMetrics metrics) {
+    this(storeId, index, bucketCount, bucketSpanTimeInMs, logSegmentForecastOffsetMs, queueProcessingPeriodInMs,
+        waitTimeoutInSecs, enableBucketForLogSegmentReports, true, time, longLiveTaskScheduler, shortLiveTaskScheduler,
+        diskIOScheduler, metrics);
+  }
+
+  BlobStoreStats(String storeId, PersistentIndex index, int bucketCount, long bucketSpanTimeInMs,
+      long logSegmentForecastOffsetMs, long queueProcessingPeriodInMs, long waitTimeoutInSecs,
+      boolean enableBucketForLogSegmentReports, boolean fillupLogSegmentNames, Time time,
+      ScheduledExecutorService longLiveTaskScheduler, ScheduledExecutorService shortLiveTaskScheduler,
+      DiskIOScheduler diskIOScheduler, StoreMetrics metrics) {
     this.storeId = storeId;
     this.index = index;
     this.time = time;
@@ -152,6 +163,7 @@ class BlobStoreStats implements StoreStats, Closeable {
     this.waitTimeoutInSecs = waitTimeoutInSecs;
     this.metrics = metrics;
     this.enableBucketForLogSegmentReports = enableBucketForLogSegmentReports;
+    this.fillupLogSegmentNames = fillupLogSegmentNames;
 
     if (bucketCount > 0) {
       indexScanner = new IndexScanner();
@@ -338,6 +350,13 @@ class BlobStoreStats implements StoreStats, Closeable {
       referenceTimeInMs = timeRange.getEndTimeInMs();
       retValue =
           new Pair<>(referenceTimeInMs, collectValidDataSizeByLogSegment(referenceTimeInMs, expiryReferenceTime));
+    }
+    if (fillupLogSegmentNames) {
+      // Before return the value, make sure all the log segments are in the final map
+      for (IndexSegment indexSegment : index.getIndexSegments().descendingMap().values()) {
+        LogSegmentName logSegmentName = indexSegment.getLogSegmentName();
+        retValue.getSecond().putIfAbsent(logSegmentName, 0L);
+      }
     }
     return retValue;
   }
@@ -549,7 +568,7 @@ class BlobStoreStats implements StoreStats, Closeable {
           TimeUnit.MILLISECONDS);
       indexSegmentCount++;
       if (indexSegmentCount == 1 || indexSegmentCount % 10 == 0) {
-        logger.info("Compaction Stats: Index segment {} processing complete (on-demand scanning) for store {}",
+        logger.debug("Compaction Stats: Index segment {} processing complete (on-demand scanning) for store {}",
             indexSegment.getFile().getName(), storeId);
       }
     }

--- a/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
@@ -408,6 +408,19 @@ class PersistentIndex {
   }
 
   /**
+   * @return All the {@link LogSegment}s.
+   */
+  List<LogSegment> getLogSegments() {
+    List<LogSegment> result = new ArrayList<>();
+    LogSegment segment = log.getFirstSegment();
+    while (segment != null) {
+      result.add(segment);
+      segment = log.getNextSegment(segment);
+    }
+    return result;
+  }
+
+  /**
    * Atomically adds {@code segmentFilesToAdd} to and removes {@code segmentsToRemove} from the map of {@link Offset} to
    * {@link IndexSegment} instances.
    * @param segmentFilesToAdd the backing files of the {@link IndexSegment} instances to add.

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
@@ -258,10 +258,10 @@ public class BlobStoreCompactorTest {
     StatsBasedCompactionPolicy policy = new StatsBasedCompactionPolicy(storeConfig, state.time);
     ScheduledExecutorService scheduler = Utils.newScheduler(1, true);
 
-    // Create stats, so the fillupLogSegment is false
+    // Create stats, so the fillupLogSegment is true
     BlobStoreStats stats =
-        new BlobStoreStats("", state.index, 0, Time.MsPerSec, 0, 100, Time.SecsPerMin, false, false, state.time,
-            scheduler, scheduler, DISK_IO_SCHEDULER, new StoreMetrics(new MetricRegistry()));
+        new BlobStoreStats("", state.index, 0, Time.MsPerSec, 0, 100, Time.SecsPerMin, false, state.time, scheduler,
+            scheduler, DISK_IO_SCHEDULER, new StoreMetrics(new MetricRegistry()));
     BlobStoreStats spyStats = Mockito.spy(stats);
     Mockito.doReturn(PUT_RECORD_SIZE).when(spyStats).getMaxBlobSize();
     CompactionDetails details =
@@ -269,20 +269,6 @@ public class BlobStoreCompactorTest {
             state.log.getSegmentCapacity(), LogSegment.HEADER_SIZE, state.index.getLogSegmentsNotInJournal(), spyStats,
             "/tmp");
     List<LogSegmentName> logSegmentNames = details.getLogSegmentsUnderCompaction();
-    assertEquals(3, logSegmentNames.size());
-    assertEquals("1" + BlobStore.SEPARATOR + "0", logSegmentNames.get(0).toString());
-    assertEquals("2" + BlobStore.SEPARATOR + "0", logSegmentNames.get(1).toString());
-    assertEquals("4" + BlobStore.SEPARATOR + "0", logSegmentNames.get(2).toString());
-
-    // Create stats, so the fillupLogSegment is true
-    stats = new BlobStoreStats("", state.index, 0, Time.MsPerSec, 0, 100, Time.SecsPerMin, false, true, state.time,
-        scheduler, scheduler, DISK_IO_SCHEDULER, new StoreMetrics(new MetricRegistry()));
-    spyStats = Mockito.spy(stats);
-    Mockito.doReturn(PUT_RECORD_SIZE).when(spyStats).getMaxBlobSize();
-    details = policy.getCompactionDetails(state.log.getCapacityInBytes(), state.index.getLogUsedCapacity(),
-        state.log.getSegmentCapacity(), LogSegment.HEADER_SIZE, state.index.getLogSegmentsNotInJournal(), spyStats,
-        "/tmp");
-    logSegmentNames = details.getLogSegmentsUnderCompaction();
     assertEquals(1, logSegmentNames.size());
     assertEquals("3" + BlobStore.SEPARATOR + "0", logSegmentNames.get(0).toString());
   }

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
@@ -277,6 +277,8 @@ public class BlobStoreCompactorTest {
     // Create stats, so the fillupLogSegment is true
     stats = new BlobStoreStats("", state.index, 0, Time.MsPerSec, 0, 100, Time.SecsPerMin, false, true, state.time,
         scheduler, scheduler, DISK_IO_SCHEDULER, new StoreMetrics(new MetricRegistry()));
+    spyStats = Mockito.spy(stats);
+    Mockito.doReturn(PUT_RECORD_SIZE).when(spyStats).getMaxBlobSize();
     details = policy.getCompactionDetails(state.log.getCapacityInBytes(), state.index.getLogUsedCapacity(),
         state.log.getSegmentCapacity(), LogSegment.HEADER_SIZE, state.index.getLogSegmentsNotInJournal(), spyStats,
         "/tmp");

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreStatsTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreStatsTest.java
@@ -174,6 +174,22 @@ public class BlobStoreStatsTest {
     blobStoreStats.close();
   }
 
+  @Test
+  public void testLogSegementValidDataSizeWithZeroValidByteSegment() throws StoreException {
+    assumeTrue(!bucketingEnabled);
+    BlobStoreStats blobStoreStats = setupBlobStoreStats(0, 0);
+    long requiredCount = state.index.getLogSegmentCount() + 1;
+    long requiredBytes = requiredCount * state.log.getSegmentCapacity();
+    // Fill up these segments with expired PUTs
+    long numPuts = (requiredBytes - state.index.getLogUsedCapacity()) / PUT_RECORD_SIZE;
+    state.addPutEntries((int) numPuts, PUT_RECORD_SIZE, 0);
+
+    long currentTimeInMs = state.time.milliseconds();
+    TimeRange timeRange = new TimeRange(currentTimeInMs, 0L);
+    verifyAndGetLogSegmentValidSize(blobStoreStats, timeRange);
+    blobStoreStats.close();
+  }
+
   /**
    * Tests to verify the correctness of reported stats after new puts via the following steps:
    * 1. Verify reported stats and record the total valid size prior to adding the new puts.

--- a/ambry-store/src/test/java/com/github/ambry/store/CompactionPolicyTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CompactionPolicyTest.java
@@ -222,9 +222,9 @@ public class CompactionPolicyTest {
           * blobStore.capacityInBytes)) {
         verifyCompactionDetails(null, blobStore, compactionPolicy);
       } else {
-        verifyCompactionDetails(new CompactionDetails(time.milliseconds() - messageRetentionTimeInMs, bestCandidates,
-                null),
-            blobStore, compactionPolicy);
+        verifyCompactionDetails(
+            new CompactionDetails(time.milliseconds() - messageRetentionTimeInMs, bestCandidates, null), blobStore,
+            compactionPolicy);
       }
     }
   }
@@ -252,9 +252,9 @@ public class CompactionPolicyTest {
           * blobStore.capacityInBytes)) {
         verifyCompactionDetails(null, blobStore, compactionPolicy);
       } else {
-        verifyCompactionDetails(new CompactionDetails(time.milliseconds() - messageRetentionTimeInMs, bestCandidates,
-                null),
-            blobStore, compactionPolicy);
+        verifyCompactionDetails(
+            new CompactionDetails(time.milliseconds() - messageRetentionTimeInMs, bestCandidates, null), blobStore,
+            compactionPolicy);
       }
     }
   }
@@ -281,8 +281,7 @@ public class CompactionPolicyTest {
       }
       verifyCompactionDetails(
           new CompactionDetails(time.milliseconds() - TimeUnit.HOURS.toMillis(messageRetentionHours), bestCandidates,
-              null),
-          blobStore, compactionPolicy);
+              null), blobStore, compactionPolicy);
     }
   }
 
@@ -402,9 +401,8 @@ public class CompactionPolicyTest {
    * @param validDataSizeForBest valid data size to be set for best candidate
    * @return a {@link NavigableMap} of log segment name to valid data size
    */
-  static NavigableMap<LogSegmentName, Long> generateValidDataSize(
-      List<LogSegmentName> logSegmentNames, List<LogSegmentName> bestCandidates,
-      long validDataSizeForBest, long maxLogSegmentCapacity) {
+  static NavigableMap<LogSegmentName, Long> generateValidDataSize(List<LogSegmentName> logSegmentNames,
+      List<LogSegmentName> bestCandidates, long validDataSizeForBest, long maxLogSegmentCapacity) {
     NavigableMap<LogSegmentName, Long> validDataSize = new TreeMap<>();
     for (LogSegmentName logSegmentName : logSegmentNames) {
       if (bestCandidates.contains(logSegmentName)) {
@@ -487,9 +485,9 @@ class MockBlobStore extends BlobStore {
  * Mock {@link BlobStoreStats} for test purposes
  */
 class MockBlobStoreStats extends BlobStoreStats {
+  private final long maxBlobSize;
 
   NavigableMap<LogSegmentName, Long> validDataSizeByLogSegments;
-  private long maxBlobSize;
   private String storeId = "";
 
   MockBlobStoreStats(long maxBlobSize) {
@@ -499,8 +497,13 @@ class MockBlobStoreStats extends BlobStoreStats {
 
   MockBlobStoreStats(long maxBlobSize, int i) {
     super("storeId" + i, null, 0, 0, 0, 0, 0, true, null, null, null, null, null);
-    this.maxBlobSize = maxBlobSize;
     this.storeId = "storeId" + i;
+    this.maxBlobSize = maxBlobSize;
+  }
+
+  @Override
+  public long getMaxBlobSize() {
+    return maxBlobSize;
   }
 
   @Override

--- a/ambry-store/src/test/java/com/github/ambry/store/CompactionPolicyTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CompactionPolicyTest.java
@@ -513,11 +513,6 @@ class MockBlobStoreStats extends BlobStoreStats {
     }
   }
 
-  @Override
-  long getMaxBlobSize() {
-    return maxBlobSize;
-  }
-
   String getStoreId() {
     return this.storeId;
   }

--- a/ambry-store/src/test/java/com/github/ambry/store/StatsBasedCompactionPolicyTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/StatsBasedCompactionPolicyTest.java
@@ -127,7 +127,7 @@ public class StatsBasedCompactionPolicyTest {
     long logSegmentCount = blobStore.capacityInBytes / blobStore.segmentCapacity;
     blobStore.logSegmentsNotInJournal = CompactionPolicyTest.generateRandomLogSegmentName((int) logSegmentCount);
     for (int i = 0; i < logSegmentCount; i++) {
-      for (int j = i + 1; j < logSegmentCount; j++) {
+      for (int j = i; j < logSegmentCount; j++) {
         List<LogSegmentName> bestCandidates = blobStore.logSegmentsNotInJournal.subList(i, j + 1);
         NavigableMap<LogSegmentName, Long> validDataSize =
             CompactionPolicyTest.generateValidDataSize(blobStore.logSegmentsNotInJournal, bestCandidates, 0,

--- a/ambry-store/src/test/java/com/github/ambry/store/StatsBasedCompactionPolicyTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/StatsBasedCompactionPolicyTest.java
@@ -127,7 +127,7 @@ public class StatsBasedCompactionPolicyTest {
     long logSegmentCount = blobStore.capacityInBytes / blobStore.segmentCapacity;
     blobStore.logSegmentsNotInJournal = CompactionPolicyTest.generateRandomLogSegmentName((int) logSegmentCount);
     for (int i = 0; i < logSegmentCount; i++) {
-      for (int j = i; j < logSegmentCount; j++) {
+      for (int j = i + 1; j < logSegmentCount; j++) {
         List<LogSegmentName> bestCandidates = blobStore.logSegmentsNotInJournal.subList(i, j + 1);
         NavigableMap<LogSegmentName, Long> validDataSize =
             CompactionPolicyTest.generateValidDataSize(blobStore.logSegmentsNotInJournal, bestCandidates, 0,


### PR DESCRIPTION
This PR fixes one crucial bug for compaction.
When using StatsBasedCompactionStrategy, we would load all the log segments stats from BlobStoreStats, and figure out the cost benefit of compact various log segment. However, if a log segment doesn't have any valid index values, it would not be included in the map returned to StatsBasedCompactionStrategy, thus we might ignore this log segment, and decide to compact the log segments before and after it. This is a huge problem, since the log segments under compaction have to be consecutive.
