### PR TITLE
[Compaction] Fix the delete reference timestamp differences between blob store compactor and stats

### DIFF
--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -250,15 +250,10 @@ public class BlobStore implements Store {
         index = new PersistentIndex(dataDir, storeId, taskScheduler, log, config, factory, recovery, hardDelete,
             diskIOScheduler, metrics, time, sessionId, storeDescriptor.getIncarnationId());
         compactor.initialize(index);
-        long logSegmentForecastOffsetMs = TimeUnit.HOURS.toMillis(config.storeDeletedMessageRetentionHours);
-        long bucketSpanInMs = TimeUnit.MINUTES.toMillis(config.storeStatsBucketSpanInMinutes);
-        long queueProcessingPeriodInMs =
-            TimeUnit.MINUTES.toMillis(config.storeStatsRecentEntryProcessingIntervalInMinutes);
         if (blobStoreStats == null) {
-          blobStoreStats = new BlobStoreStats(storeId, index, config.storeStatsBucketCount, bucketSpanInMs,
-              logSegmentForecastOffsetMs, queueProcessingPeriodInMs, config.storeStatsWaitTimeoutInSecs,
-              config.storeEnableBucketForLogSegmentReports, time, longLivedTaskScheduler, taskScheduler,
-              diskIOScheduler, metrics);
+          blobStoreStats =
+              new BlobStoreStats(storeId, index, config, time, longLivedTaskScheduler, taskScheduler, diskIOScheduler,
+                  metrics);
         }
         metrics.initializeIndexGauges(storeId, index, capacityInBytes, blobStoreStats,
             config.storeEnableCurrentInvalidSizeMetric);

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
@@ -1351,31 +1351,6 @@ class BlobStoreCompactor {
     }
 
     /**
-     * @return the start {@link Offset} of the index segment up until which delete records are considered applicable. Any
-     * delete records of blobs in subsequent index segments do not count and the blob is considered as not deleted.
-     * <p/>
-     * Returns {@code null} if none of the delete records are considered applicable.
-     */
-    private Offset getStartOffsetOfLastIndexSegmentForDeleteCheck() {
-      // TODO: move this to BlobStoreStats
-      Offset cutoffOffset = compactionLog.getStartOffsetOfLastIndexSegmentForDeleteCheck();
-      if (cutoffOffset == null || !srcIndex.getIndexSegments().containsKey(cutoffOffset)) {
-        long referenceTimeMs = compactionLog.getCompactionDetails().getReferenceTimeMs();
-        for (IndexSegment indexSegment : srcIndex.getIndexSegments().descendingMap().values()) {
-          if (indexSegment.getLastModifiedTimeMs() < referenceTimeMs) {
-            cutoffOffset = indexSegment.getEndOffset();
-            break;
-          }
-        }
-        if (cutoffOffset != null) {
-          compactionLog.setStartOffsetOfLastIndexSegmentForDeleteCheck(cutoffOffset);
-          logger.info("Start offset of last index segment for delete check is {} for {}", cutoffOffset, storeId);
-        }
-      }
-      return cutoffOffset;
-    }
-
-    /**
      * Determines whether a TTL update entry is valid. A TTL update entry is valid as long as the associated PUT record
      * is still present in the store (the validity of the PUT record does not matter - only its presence/absence does).
      * @param key the {@link StoreKey} being examined

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
@@ -1286,15 +1286,7 @@ class BlobStoreCompactor {
       // TTL update + DELETE -> DELETE
       // PUT + TTL update -> PUT (the one relevant to this comment)
       // PUT + TTL update + DELETE -> DELETE
-      // TODO: move this blob store stats
-      Offset startOffsetOfLastIndexSegmentForDeleteCheck = getStartOffsetOfLastIndexSegmentForDeleteCheck();
-      // deletes are in effect if this index segment does not have any deletes that are less than
-      // StoreConfig#storeDeletedMessageRetentionDays days old. If there are such deletes, then they are not counted as
-      // deletes and the PUT records are still valid as far as compaction is concerned
-      boolean deletesInEffect = startOffsetOfLastIndexSegmentForDeleteCheck != null
-          && indexSegment.getStartOffset().compareTo(startOffsetOfLastIndexSegmentForDeleteCheck) < 0;
-      logger.trace("Deletes in effect is {} for index segment with start offset {} in {}", deletesInEffect,
-          indexSegment.getStartOffset(), storeId);
+      long deleteReferenceTime = compactionLog.getCompactionDetails().getReferenceTimeMs();
       List<IndexEntry> validEntries = new ArrayList<>();
       for (IndexEntry indexEntry : allIndexEntries) {
         IndexValue value = indexEntry.getValue();
@@ -1303,7 +1295,7 @@ class BlobStoreCompactor {
           if (putValue != null) {
             // In PersistentIndex.markAsDeleted(), the expiry time of the put/ttl update value is copied into the
             // delete value. So it is safe to check for isExpired() on the delete value.
-            if (deletesInEffect || srcIndex.isExpired(value)) {
+            if (value.getOperationTimeInMs() < deleteReferenceTime || srcIndex.isExpired(value)) {
               // still have to evaluate whether the TTL update has to be copied
               NavigableSet<IndexValue> values = indexSegment.find(indexEntry.getKey());
               IndexValue secondVal = values.lower(values.last());
@@ -1340,20 +1332,14 @@ class BlobStoreCompactor {
           // Doesn't matter whether we get the PUT or DELETE entry for the expiry test
           if (!srcIndex.isExpired(valueFromIdx)) {
             // unexpired PUT entry.
-            if (deletesInEffect) {
-              if (!hasDeleteEntryInSpan(indexEntry.getKey(), indexSegment.getStartOffset(),
-                  startOffsetOfLastIndexSegmentForDeleteCheck)) {
-                // PUT entry that has not expired and is not considered deleted.
-                // Add all values in this index segment (to account for the presence of TTL updates)
-                addAllEntriesForKeyInSegment(validEntries, indexSegment, indexEntry);
-              } else {
-                logger.trace("{} in index segment with start offset {} in {} is not valid because it is a deleted PUT",
-                    indexEntry, indexSegment.getStartOffset(), storeId);
-              }
-            } else {
-              // valid PUT entry
+            if (!hasDeleteEntryOutOfRetention(indexEntry.getKey(), indexSegment.getStartOffset(),
+                deleteReferenceTime)) {
+              // PUT entry that has not expired and is not considered deleted.
               // Add all values in this index segment (to account for the presence of TTL updates)
               addAllEntriesForKeyInSegment(validEntries, indexSegment, indexEntry);
+            } else {
+              logger.trace("{} in index segment with start offset {} in {} is not valid because it is a deleted PUT",
+                  indexEntry, indexSegment.getStartOffset(), storeId);
             }
           } else {
             logger.trace("{} in index segment with start offset {} in {} is not valid because it is an expired PUT",
@@ -1460,14 +1446,16 @@ class BlobStoreCompactor {
     /**
      * @param key the {@link StoreKey} to check
      * @param searchStartOffset the start offset of the search for delete entry
-     * @param searchEndOffset the end offset of the search for delete entry
-     * @return {@code true} if the key has a delete entry in the given search span.
+     * @param deleteReferenceTime the timestamp to reference when deciding a delete is out of retention
+     * @return {@code true} if the key has a delete entry that is out of retention
      * @throws StoreException if there are any problems using the index
      */
-    private boolean hasDeleteEntryInSpan(StoreKey key, Offset searchStartOffset, Offset searchEndOffset)
+    private boolean hasDeleteEntryOutOfRetention(StoreKey key, Offset searchStartOffset, long deleteReferenceTime)
         throws StoreException {
-      FileSpan deleteSearchSpan = new FileSpan(searchStartOffset, searchEndOffset);
-      return srcIndex.findKey(key, deleteSearchSpan, EnumSet.of(PersistentIndex.IndexEntryType.DELETE)) != null;
+      FileSpan deleteSearchSpan = new FileSpan(searchStartOffset, srcIndex.getCurrentEndOffset());
+      IndexValue deleteValue =
+          srcIndex.findKey(key, deleteSearchSpan, EnumSet.of(PersistentIndex.IndexEntryType.DELETE));
+      return deleteValue != null && deleteValue.getOperationTimeInMs() < deleteReferenceTime;
     }
 
     @Override

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreStats.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreStats.java
@@ -287,14 +287,21 @@ class BlobStoreStats implements StoreStats, Closeable {
     return getValidDataSizeByLogSegment(timeRange, time.milliseconds(), null);
   }
 
+  /**
+   * Same as the {@link #getValidDataSizeByLogSegment(TimeRange)}, but provides a file span for under compaction log segments.
+   * This file span would impact TTL_UPDATE's validity.
+   * @param timeRange the delete reference {@link TimeRange} at which the data is requested. Defines both the reference time
+   *                  and the acceptable resolution.
+   * @param fileSpanUnderCompaction the {@link FileSpan} of the under compaction log segments. This file span would impact
+   *                                the validity of TTL_UPDATE. The rules can be found below. This file span could be null.
+   * @return a {@link Pair} whose first element is the time at which stats was collected (in ms) and whose second
+   * element is the valid data size for each segment in the form of a {@link NavigableMap} of segment names to
+   * valid data sizes.
+   * @throws StoreException
+   */
   Pair<Long, NavigableMap<LogSegmentName, Long>> getValidDataSizeByLogSegment(TimeRange timeRange,
       FileSpan fileSpanUnderCompaction) throws StoreException {
     return getValidDataSizeByLogSegment(timeRange, time.milliseconds(), fileSpanUnderCompaction);
-  }
-
-  Pair<Long, NavigableMap<LogSegmentName, Long>> getValidDataSizeByLogSegment(TimeRange timeRange,
-      long expiryReferenceTime) throws StoreException {
-    return getValidDataSizeByLogSegment(timeRange, expiryReferenceTime, null);
   }
 
   /**
@@ -304,6 +311,25 @@ class BlobStoreStats implements StoreStats, Closeable {
    *                  and the acceptable resolution.
    * @param expiryReferenceTime the reference time for expired blobs. Blobs with expiration time less than it would be
    *                            considered as expired. Usually it's now.
+   * @return a {@link Pair} whose first element is the time at which stats was collected (in ms) and whose second
+   * element is the valid data size for each segment in the form of a {@link NavigableMap} of segment names to
+   * valid data sizes.
+   * @throws StoreException
+   */
+  Pair<Long, NavigableMap<LogSegmentName, Long>> getValidDataSizeByLogSegment(TimeRange timeRange,
+      long expiryReferenceTime) throws StoreException {
+    return getValidDataSizeByLogSegment(timeRange, expiryReferenceTime, null);
+  }
+
+  /**
+   * Same as {@link #getValidDataSizeByLogSegment(TimeRange, long)}, but provides a file span for under compaction log segments.
+   * This file span would impact TTL_UPDATE's validity.
+   * @param timeRange the delete reference {@link TimeRange} at which the data is requested. Defines both the reference time
+   *                  and the acceptable resolution.
+   * @param expiryReferenceTime the reference time for expired blobs. Blobs with expiration time less than it would be
+   *                            considered as expired. Usually it's now.
+   * @param fileSpanUnderCompaction the {@link FileSpan} of the under compaction log segments. This file span would impact
+   *                                the validity of TTL_UPDATE. The rules can be found below. This file span could be null.
    * @return a {@link Pair} whose first element is the time at which stats was collected (in ms) and whose second
    * element is the valid data size for each segment in the form of a {@link NavigableMap} of segment names to
    * valid data sizes.

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreStatsTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreStatsTest.java
@@ -89,7 +89,7 @@ public class BlobStoreStatsTest {
 
   private BlobStoreStats setupBlobStoreStats(int bucketCount, long logSegmentForecastOffsetMs) {
     return new BlobStoreStats("", state.index, bucketCount, BUCKET_SPAN_IN_MS, logSegmentForecastOffsetMs,
-        QUEUE_PROCESSOR_PERIOD_IN_Ms, DEFAULT_WAIT_TIMEOUT_SECS, true, state.time, indexScannerScheduler,
+        QUEUE_PROCESSOR_PERIOD_IN_Ms, DEFAULT_WAIT_TIMEOUT_SECS, true, true, state.time, indexScannerScheduler,
         queueProcessorScheduler, diskIOScheduler, METRICS);
   }
 
@@ -823,8 +823,8 @@ public class BlobStoreStatsTest {
     throttlers.put(BlobStoreStats.IO_SCHEDULER_JOB_TYPE, mockThrottler);
     int expectedMinimumThrottleCount = 2 * state.referenceIndex.size();
     BlobStoreStats blobStoreStats =
-        new BlobStoreStats("", state.index, 10, BUCKET_SPAN_IN_MS, 0, QUEUE_PROCESSOR_PERIOD_IN_Ms, 1, true, state.time,
-            indexScannerScheduler, queueProcessorScheduler, diskIOScheduler, METRICS);
+        new BlobStoreStats("", state.index, 10, BUCKET_SPAN_IN_MS, 0, QUEUE_PROCESSOR_PERIOD_IN_Ms, 1, true, true,
+            state.time, indexScannerScheduler, queueProcessorScheduler, diskIOScheduler, METRICS);
     // proceed only when the scan is started
     assertTrue("IndexScanner took too long to start", scanStartedLatch.await(5, TimeUnit.SECONDS));
     advanceTimeToNextSecond();

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
@@ -3413,7 +3413,7 @@ public class BlobStoreTest {
     volatile IndexValue previousValue;
 
     MockBlobStoreStats(Time time) {
-      super("", null, 0, 0, 0, 0, 0, false, time, null, null, null, null);
+      super("", null, 0, 0, 0, 0, 0, false, true, time, null, null, null, null);
     }
 
     @Override

--- a/ambry-store/src/test/java/com/github/ambry/store/CompactionPolicyTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CompactionPolicyTest.java
@@ -491,12 +491,12 @@ class MockBlobStoreStats extends BlobStoreStats {
   private String storeId = "";
 
   MockBlobStoreStats(long maxBlobSize) {
-    super("", null, 0, 0, 0, 0, 0, true, null, null, null, null, null);
+    super("", null, 0, 0, 0, 0, 0, true, true, null, null, null, null, null);
     this.maxBlobSize = maxBlobSize;
   }
 
   MockBlobStoreStats(long maxBlobSize, int i) {
-    super("storeId" + i, null, 0, 0, 0, 0, 0, true, null, null, null, null, null);
+    super("storeId" + i, null, 0, 0, 0, 0, 0, true, true, null, null, null, null, null);
     this.storeId = "storeId" + i;
     this.maxBlobSize = maxBlobSize;
   }


### PR DESCRIPTION
Will add a test to make sure the stats and compactor returns the same data size