### PR TITLE
Fix dot metrics issue caused by long getValidDataSizeByLogSegment() call time

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -387,6 +387,10 @@ public class StoreConfig {
   @Default("false")
   public final boolean storeEnableBucketForLogSegmentReports;
 
+  @Config("store.enable.per.store.gauges")
+  @Default("false")
+  public final boolean storeEnablePerStoreGauges;
+
   @Config(storeAlwaysEnableTargetIndexDuplicateCheckingName)
   @Default("false")
   public final boolean storeAlwaysEnableTargetIndexDuplicateChecking;
@@ -484,6 +488,7 @@ public class StoreConfig {
         verifiableProperties.getBoolean("store.set.local.partition.state.enabled", false);
     storeEnableBucketForLogSegmentReports =
         verifiableProperties.getBoolean("store.enable.bucket.for.log.segment.reports", false);
+    storeEnablePerStoreGauges = verifiableProperties.getBoolean("store.enable.per.store.gauges", false);
     storeAlwaysEnableTargetIndexDuplicateChecking =
         verifiableProperties.getBoolean(storeAlwaysEnableTargetIndexDuplicateCheckingName, false);
     storeRebuildTokenBasedOnResetKey = verifiableProperties.getBoolean("store.rebuild.token.based.on.reset.key", false);

--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -387,9 +387,9 @@ public class StoreConfig {
   @Default("false")
   public final boolean storeEnableBucketForLogSegmentReports;
 
-  @Config("store.enable.per.store.gauges")
+  @Config("store.enable.current.invalid.size.metric")
   @Default("false")
-  public final boolean storeEnablePerStoreGauges;
+  public final boolean storeEnableCurrentInvalidSizeMetric;
 
   @Config(storeAlwaysEnableTargetIndexDuplicateCheckingName)
   @Default("false")
@@ -488,7 +488,8 @@ public class StoreConfig {
         verifiableProperties.getBoolean("store.set.local.partition.state.enabled", false);
     storeEnableBucketForLogSegmentReports =
         verifiableProperties.getBoolean("store.enable.bucket.for.log.segment.reports", false);
-    storeEnablePerStoreGauges = verifiableProperties.getBoolean("store.enable.per.store.gauges", false);
+    storeEnableCurrentInvalidSizeMetric =
+        verifiableProperties.getBoolean("store.enable.current.invalid.size.metric", false);
     storeAlwaysEnableTargetIndexDuplicateChecking =
         verifiableProperties.getBoolean(storeAlwaysEnableTargetIndexDuplicateCheckingName, false);
     storeRebuildTokenBasedOnResetKey = verifiableProperties.getBoolean("store.rebuild.token.based.on.reset.key", false);

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -260,9 +260,8 @@ public class BlobStore implements Store {
               config.storeEnableBucketForLogSegmentReports, time, longLivedTaskScheduler, taskScheduler,
               diskIOScheduler, metrics);
         }
-        if (config.storeEnablePerStoreGauges) {
-          metrics.initializeIndexGauges(storeId, index, capacityInBytes, blobStoreStats);
-        }
+        metrics.initializeIndexGauges(storeId, index, capacityInBytes, blobStoreStats,
+            config.storeEnableCurrentInvalidSizeMetric);
         checkCapacityAndUpdateReplicaStatusDelegate();
         logger.trace("The store {} is successfully started", storeId);
         onSuccess();

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -260,7 +260,9 @@ public class BlobStore implements Store {
               config.storeEnableBucketForLogSegmentReports, time, longLivedTaskScheduler, taskScheduler,
               diskIOScheduler, metrics);
         }
-        metrics.initializeIndexGauges(storeId, index, capacityInBytes, blobStoreStats);
+        if (config.storeEnablePerStoreGauges) {
+          metrics.initializeIndexGauges(storeId, index, capacityInBytes, blobStoreStats);
+        }
         checkCapacityAndUpdateReplicaStatusDelegate();
         logger.trace("The store {} is successfully started", storeId);
         onSuccess();
@@ -1150,8 +1152,7 @@ public class BlobStore implements Store {
       logger.error("Shutting down BlobStore {} because IO error count exceeds threshold", storeId);
       shutdown(true);
       // Explicitly disable replica to trigger Helix state transition: LEADER -> STANDBY -> INACTIVE -> OFFLINE
-      if (config.storeSetLocalPartitionStateEnabled && !isDisabled.getAndSet(true)
-          && replicaStatusDelegates != null) {
+      if (config.storeSetLocalPartitionStateEnabled && !isDisabled.getAndSet(true) && replicaStatusDelegates != null) {
         try {
           replicaStatusDelegates.forEach(delegate -> delegate.disableReplica(replicaId));
         } catch (Exception e) {
@@ -1236,7 +1237,7 @@ public class BlobStore implements Store {
     checkStarted();
     if (CompactionLog.isCompactionInProgress(dataDir, storeId)) {
       logger.info("Resuming compaction of {}", this);
-      if(remoteTokenTracker != null) {
+      if (remoteTokenTracker != null) {
         remoteTokenTracker.refreshPeerReplicaTokens();
       }
       compactor.resumeCompaction(bundleReadBuffer);

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreStats.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreStats.java
@@ -17,6 +17,7 @@ package com.github.ambry.store;
 import com.github.ambry.server.StatsReportType;
 import com.github.ambry.server.StatsSnapshot;
 import com.github.ambry.utils.Pair;
+import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
 import java.io.Closeable;
@@ -163,7 +164,9 @@ class BlobStoreStats implements StoreStats, Closeable {
 
   @Override
   public Pair<Long, Long> getValidSize(TimeRange timeRange) throws StoreException {
+    long start = SystemTime.getInstance().milliseconds();
     Pair<Long, NavigableMap<LogSegmentName, Long>> logSegmentValidSizeResult = getValidDataSizeByLogSegment(timeRange);
+    logger.debug("Time to getValidDataSizeByLogSegment: {} ms", SystemTime.getInstance().milliseconds() - start);
     Long totalValidSize = 0L;
     for (Long value : logSegmentValidSizeResult.getSecond().values()) {
       totalValidSize += value;

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreStats.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreStats.java
@@ -166,7 +166,8 @@ class BlobStoreStats implements StoreStats, Closeable {
   public Pair<Long, Long> getValidSize(TimeRange timeRange) throws StoreException {
     long start = SystemTime.getInstance().milliseconds();
     Pair<Long, NavigableMap<LogSegmentName, Long>> logSegmentValidSizeResult = getValidDataSizeByLogSegment(timeRange);
-    logger.debug("Time to getValidDataSizeByLogSegment: {} ms", SystemTime.getInstance().milliseconds() - start);
+    logger.debug("Time to getValidDataSizeByLogSegment on store {} : {} ms", storeId,
+        SystemTime.getInstance().milliseconds() - start);
     Long totalValidSize = 0L;
     for (Long value : logSegmentValidSizeResult.getSecond().values()) {
       totalValidSize += value;


### PR DESCRIPTION
Fix dot metrics issue caused by long getValidDataSizeByLogSegment() call time