### PR TITLE
Support async get valid data size

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -241,13 +241,6 @@ public class StoreConfig {
   public final long storeStatsRecentEntryProcessingIntervalInMinutes;
 
   /**
-   * Enable asynchronously get valid data size for metric emitting.
-   */
-  @Config("store.async.get.valid.size.enable")
-  @Default("false")
-  public final boolean storeAsyncGetValidSizeEnable;
-
-  /**
    * Period in minutes to specify how frequent the validDataSizeCollector executed.
    */
   @Config("store.get.valid.size.interval.in.minutes")
@@ -526,7 +519,6 @@ public class StoreConfig {
         verifiableProperties.getLongInRange("store.stats.bucket.span.in.minutes", 60, 1, 10000);
     storeStatsRecentEntryProcessingIntervalInMinutes =
         verifiableProperties.getLongInRange("store.stats.recent.entry.processing.interval.in.minutes", 2, 1, 60);
-    storeAsyncGetValidSizeEnable = verifiableProperties.getBoolean("store.async.get.valid.size.enable", false);
     storeGetValidSizeIntervalInMinutes =
         verifiableProperties.getLongInRange("store.get.valid.size.interval.in.minutes", 2, 1, 60);
     storeStatsWaitTimeoutInSecs =

--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -241,6 +241,20 @@ public class StoreConfig {
   public final long storeStatsRecentEntryProcessingIntervalInMinutes;
 
   /**
+   * Enable asynchronously get valid data size for metric emitting.
+   */
+  @Config("store.async.get.valid.size.enable")
+  @Default("false")
+  public final boolean storeAsyncGetValidSizeEnable;
+
+  /**
+   * Period in minutes to specify how frequent the validDataSizeCollector executed.
+   */
+  @Config("store.get.valid.size.interval.in.minutes")
+  @Default("2")
+  public final long storeGetValidSizeIntervalInMinutes;
+
+  /**
    * The upper limit in seconds for requests to wait for a ongoing construction of buckets (that contains the answer)
    * to complete.
    */
@@ -512,6 +526,9 @@ public class StoreConfig {
         verifiableProperties.getLongInRange("store.stats.bucket.span.in.minutes", 60, 1, 10000);
     storeStatsRecentEntryProcessingIntervalInMinutes =
         verifiableProperties.getLongInRange("store.stats.recent.entry.processing.interval.in.minutes", 2, 1, 60);
+    storeAsyncGetValidSizeEnable = verifiableProperties.getBoolean("store.async.get.valid.size.enable", false);
+    storeGetValidSizeIntervalInMinutes =
+        verifiableProperties.getLongInRange("store.get.valid.size.interval.in.minutes", 2, 1, 60);
     storeStatsWaitTimeoutInSecs =
         verifiableProperties.getLongInRange("store.stats.wait.timeout.in.secs", 2 * 60, 0, 30 * 60);
     storeStatsIndexEntriesPerSecond =

--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -241,11 +241,11 @@ public class StoreConfig {
   public final long storeStatsRecentEntryProcessingIntervalInMinutes;
 
   /**
-   * Period in minutes to specify how frequent the validDataSizeCollector executed.
+   * Period in seconds to specify how frequent the validDataSizeCollector executed.
    */
-  @Config("store.get.valid.size.interval.in.minutes")
-  @Default("2")
-  public final long storeGetValidSizeIntervalInMinutes;
+  @Config("store.get.valid.size.interval.in.secs")
+  @Default("2*60")
+  public final long storeGetValidSizeIntervalInSecs;
 
   /**
    * The upper limit in seconds for requests to wait for a ongoing construction of buckets (that contains the answer)
@@ -519,8 +519,8 @@ public class StoreConfig {
         verifiableProperties.getLongInRange("store.stats.bucket.span.in.minutes", 60, 1, 10000);
     storeStatsRecentEntryProcessingIntervalInMinutes =
         verifiableProperties.getLongInRange("store.stats.recent.entry.processing.interval.in.minutes", 2, 1, 60);
-    storeGetValidSizeIntervalInMinutes =
-        verifiableProperties.getLongInRange("store.get.valid.size.interval.in.minutes", 2, 1, 60);
+    storeGetValidSizeIntervalInSecs =
+        verifiableProperties.getLongInRange("store.get.valid.size.interval.in.secs", 2 * 60, 1, 60 * 60);
     storeStatsWaitTimeoutInSecs =
         verifiableProperties.getLongInRange("store.stats.wait.timeout.in.secs", 2 * 60, 0, 30 * 60);
     storeStatsIndexEntriesPerSecond =

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -258,7 +258,7 @@ public class BlobStore implements Store {
                   metrics);
         }
         metrics.initializeIndexGauges(storeId, index, capacityInBytes, blobStoreStats,
-            config.storeEnableCurrentInvalidSizeMetric, config.storeAsyncGetValidSizeEnable);
+            config.storeEnableCurrentInvalidSizeMetric);
         checkCapacityAndUpdateReplicaStatusDelegate();
         logger.trace("The store {} is successfully started", storeId);
         onSuccess();

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -258,7 +258,7 @@ public class BlobStore implements Store {
                   metrics);
         }
         metrics.initializeIndexGauges(storeId, index, capacityInBytes, blobStoreStats,
-            config.storeEnableCurrentInvalidSizeMetric);
+            config.storeEnableCurrentInvalidSizeMetric, config.storeAsyncGetValidSizeEnable);
         checkCapacityAndUpdateReplicaStatusDelegate();
         logger.trace("The store {} is successfully started", storeId);
         onSuccess();

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreStats.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreStats.java
@@ -150,14 +150,16 @@ class BlobStoreStats implements StoreStats, Closeable {
         TimeUnit.MINUTES.toMillis(config.storeStatsRecentEntryProcessingIntervalInMinutes),
         config.storeStatsWaitTimeoutInSecs, config.storeEnableBucketForLogSegmentReports,
         config.storeCompactionPurgeDeleteTombstone, time, longLiveTaskScheduler, shortLiveTaskScheduler,
-        diskIOScheduler, metrics, TimeUnit.SECONDS.toMillis(config.storeGetValidSizeIntervalInSecs));
+        diskIOScheduler, metrics, TimeUnit.SECONDS.toMillis(config.storeGetValidSizeIntervalInSecs),
+        config.storeEnableCurrentInvalidSizeMetric);
   }
 
   BlobStoreStats(String storeId, PersistentIndex index, int bucketCount, long bucketSpanTimeInMs,
       long logSegmentForecastOffsetMs, long queueProcessingPeriodInMs, long waitTimeoutInSecs,
       boolean enableBucketForLogSegmentReports, boolean enablePurgeDeleteTombstone, Time time,
       ScheduledExecutorService longLiveTaskScheduler, ScheduledExecutorService shortLiveTaskScheduler,
-      DiskIOScheduler diskIOScheduler, StoreMetrics metrics, long storeGetValidSizeIntervalInSecs) {
+      DiskIOScheduler diskIOScheduler, StoreMetrics metrics, long storeGetValidSizeIntervalInSecs,
+      boolean storeEnableCurrentInvalidSizeMetric) {
     this.storeId = storeId;
     this.index = index;
     this.time = time;
@@ -177,7 +179,7 @@ class BlobStoreStats implements StoreStats, Closeable {
       queueProcessor = new QueueProcessor();
       shortLiveTaskScheduler.scheduleAtFixedRate(queueProcessor, 0, queueProcessingPeriodInMs, TimeUnit.MILLISECONDS);
     }
-    if (shortLiveTaskScheduler != null) {
+    if (storeEnableCurrentInvalidSizeMetric && shortLiveTaskScheduler != null) {
       validDataSizeCollector = new ValidDataSizeCollector();
       shortLiveTaskScheduler.scheduleAtFixedRate(validDataSizeCollector, 0, storeGetValidSizeIntervalInSecs, TimeUnit.MILLISECONDS);
     }

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreStats.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreStats.java
@@ -150,13 +150,14 @@ class BlobStoreStats implements StoreStats, Closeable {
         TimeUnit.MINUTES.toMillis(config.storeStatsRecentEntryProcessingIntervalInMinutes),
         config.storeStatsWaitTimeoutInSecs, config.storeEnableBucketForLogSegmentReports,
         config.storeCompactionPurgeDeleteTombstone, time, longLiveTaskScheduler, shortLiveTaskScheduler,
-        diskIOScheduler, metrics, TimeUnit.MINUTES.toMillis(config.storeGetValidSizeIntervalInMinutes));
+        diskIOScheduler, metrics, TimeUnit.SECONDS.toMillis(config.storeGetValidSizeIntervalInSecs));
   }
 
   BlobStoreStats(String storeId, PersistentIndex index, int bucketCount, long bucketSpanTimeInMs,
       long logSegmentForecastOffsetMs, long queueProcessingPeriodInMs, long waitTimeoutInSecs,
-      boolean enableBucketForLogSegmentReports, boolean enablePurgeDeleteTombstone, Time time, ScheduledExecutorService longLiveTaskScheduler,
-      ScheduledExecutorService shortLiveTaskScheduler, DiskIOScheduler diskIOScheduler, StoreMetrics metrics, long storeGetValidSizeIntervalInMs) {
+      boolean enableBucketForLogSegmentReports, boolean enablePurgeDeleteTombstone, Time time,
+      ScheduledExecutorService longLiveTaskScheduler, ScheduledExecutorService shortLiveTaskScheduler,
+      DiskIOScheduler diskIOScheduler, StoreMetrics metrics, long storeGetValidSizeIntervalInSecs) {
     this.storeId = storeId;
     this.index = index;
     this.time = time;
@@ -176,8 +177,10 @@ class BlobStoreStats implements StoreStats, Closeable {
       queueProcessor = new QueueProcessor();
       shortLiveTaskScheduler.scheduleAtFixedRate(queueProcessor, 0, queueProcessingPeriodInMs, TimeUnit.MILLISECONDS);
     }
-    validDataSizeCollector = new ValidDataSizeCollector();
-    shortLiveTaskScheduler.scheduleAtFixedRate(validDataSizeCollector, 0, storeGetValidSizeIntervalInMs, TimeUnit.MILLISECONDS);
+    if (shortLiveTaskScheduler != null) {
+      validDataSizeCollector = new ValidDataSizeCollector();
+      shortLiveTaskScheduler.scheduleAtFixedRate(validDataSizeCollector, 0, storeGetValidSizeIntervalInSecs, TimeUnit.MILLISECONDS);
+    }
   }
 
   @Override

--- a/ambry-store/src/main/java/com/github/ambry/store/StoreMetrics.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StoreMetrics.java
@@ -272,7 +272,7 @@ public class StoreMetrics {
         long invalidDataSize = -1;
         try {
           if (storeAsyncGetValidSizeEnable) {
-            invalidDataSize = index.getLogUsedCapacity() - blobStoreStats.getValidSizeAsync().getSecond();
+            invalidDataSize = index.getLogUsedCapacity() - blobStoreStats.getCachedValidSize().getSecond();
           } else {
             invalidDataSize = index.getLogUsedCapacity() - blobStoreStats.getValidSize(
                 new TimeRange(System.currentTimeMillis(), blobStoreStats.getBucketSpanTimeInMs())).getSecond();

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
@@ -275,7 +275,7 @@ public class BlobStoreCompactorTest {
 
     BlobStoreStats stats =
         new BlobStoreStats("", state.index, 0, Time.MsPerSec, 0, 100, Time.SecsPerMin, false, purgeDeleteTombstone,
-            state.time, scheduler, scheduler, DISK_IO_SCHEDULER, new StoreMetrics(new MetricRegistry()), 0);
+            state.time, scheduler, scheduler, DISK_IO_SCHEDULER, new StoreMetrics(new MetricRegistry()), 1);
     BlobStoreStats spyStats = Mockito.spy(stats);
     Mockito.doReturn(PUT_RECORD_SIZE).when(spyStats).getMaxBlobSize();
     CompactionDetails details =
@@ -2945,7 +2945,7 @@ public class BlobStoreCompactorTest {
     ScheduledExecutorService scheduler = Utils.newScheduler(1, true);
     BlobStoreStats stats =
         new BlobStoreStats("", state.index, 0, Time.MsPerSec, 0, 100, Time.SecsPerMin, false, purgeDeleteTombstone,
-            state.time, scheduler, scheduler, DISK_IO_SCHEDULER, new StoreMetrics(new MetricRegistry()), 0);
+            state.time, scheduler, scheduler, DISK_IO_SCHEDULER, new StoreMetrics(new MetricRegistry()), 1);
     NavigableMap<LogSegmentName, Long> validDataSizeFromBlobStoreStats =
         stats.getValidDataSizeByLogSegment(new TimeRange(deleteReferenceTimeMs, 0L),
             getFileSpanForLogSegments(segmentsUnderCompaction)).getSecond();

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
@@ -275,7 +275,7 @@ public class BlobStoreCompactorTest {
 
     BlobStoreStats stats =
         new BlobStoreStats("", state.index, 0, Time.MsPerSec, 0, 100, Time.SecsPerMin, false, purgeDeleteTombstone,
-            state.time, scheduler, scheduler, DISK_IO_SCHEDULER, new StoreMetrics(new MetricRegistry()), false, 0);
+            state.time, scheduler, scheduler, DISK_IO_SCHEDULER, new StoreMetrics(new MetricRegistry()), 0);
     BlobStoreStats spyStats = Mockito.spy(stats);
     Mockito.doReturn(PUT_RECORD_SIZE).when(spyStats).getMaxBlobSize();
     CompactionDetails details =
@@ -2945,7 +2945,7 @@ public class BlobStoreCompactorTest {
     ScheduledExecutorService scheduler = Utils.newScheduler(1, true);
     BlobStoreStats stats =
         new BlobStoreStats("", state.index, 0, Time.MsPerSec, 0, 100, Time.SecsPerMin, false, purgeDeleteTombstone,
-            state.time, scheduler, scheduler, DISK_IO_SCHEDULER, new StoreMetrics(new MetricRegistry()), false, 0);
+            state.time, scheduler, scheduler, DISK_IO_SCHEDULER, new StoreMetrics(new MetricRegistry()), 0);
     NavigableMap<LogSegmentName, Long> validDataSizeFromBlobStoreStats =
         stats.getValidDataSizeByLogSegment(new TimeRange(deleteReferenceTimeMs, 0L),
             getFileSpanForLogSegments(segmentsUnderCompaction)).getSecond();

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
@@ -31,7 +31,6 @@ import com.github.ambry.network.PortType;
 import com.github.ambry.utils.ByteBufferOutputStream;
 import com.github.ambry.utils.MockTime;
 import com.github.ambry.utils.Pair;
-import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
@@ -275,7 +274,7 @@ public class BlobStoreCompactorTest {
 
     BlobStoreStats stats =
         new BlobStoreStats("", state.index, 0, Time.MsPerSec, 0, 100, Time.SecsPerMin, false, purgeDeleteTombstone,
-            state.time, scheduler, scheduler, DISK_IO_SCHEDULER, new StoreMetrics(new MetricRegistry()), 1);
+            state.time, scheduler, scheduler, DISK_IO_SCHEDULER, new StoreMetrics(new MetricRegistry()), 1, false);
     BlobStoreStats spyStats = Mockito.spy(stats);
     Mockito.doReturn(PUT_RECORD_SIZE).when(spyStats).getMaxBlobSize();
     CompactionDetails details =
@@ -2945,7 +2944,7 @@ public class BlobStoreCompactorTest {
     ScheduledExecutorService scheduler = Utils.newScheduler(1, true);
     BlobStoreStats stats =
         new BlobStoreStats("", state.index, 0, Time.MsPerSec, 0, 100, Time.SecsPerMin, false, purgeDeleteTombstone,
-            state.time, scheduler, scheduler, DISK_IO_SCHEDULER, new StoreMetrics(new MetricRegistry()), 1);
+            state.time, scheduler, scheduler, DISK_IO_SCHEDULER, new StoreMetrics(new MetricRegistry()), 1, false);
     NavigableMap<LogSegmentName, Long> validDataSizeFromBlobStoreStats =
         stats.getValidDataSizeByLogSegment(new TimeRange(deleteReferenceTimeMs, 0L),
             getFileSpanForLogSegments(segmentsUnderCompaction)).getSecond();

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
@@ -275,7 +275,7 @@ public class BlobStoreCompactorTest {
 
     BlobStoreStats stats =
         new BlobStoreStats("", state.index, 0, Time.MsPerSec, 0, 100, Time.SecsPerMin, false, purgeDeleteTombstone,
-            state.time, scheduler, scheduler, DISK_IO_SCHEDULER, new StoreMetrics(new MetricRegistry()));
+            state.time, scheduler, scheduler, DISK_IO_SCHEDULER, new StoreMetrics(new MetricRegistry()), false, 0);
     BlobStoreStats spyStats = Mockito.spy(stats);
     Mockito.doReturn(PUT_RECORD_SIZE).when(spyStats).getMaxBlobSize();
     CompactionDetails details =
@@ -2945,7 +2945,7 @@ public class BlobStoreCompactorTest {
     ScheduledExecutorService scheduler = Utils.newScheduler(1, true);
     BlobStoreStats stats =
         new BlobStoreStats("", state.index, 0, Time.MsPerSec, 0, 100, Time.SecsPerMin, false, purgeDeleteTombstone,
-            state.time, scheduler, scheduler, DISK_IO_SCHEDULER, new StoreMetrics(new MetricRegistry()));
+            state.time, scheduler, scheduler, DISK_IO_SCHEDULER, new StoreMetrics(new MetricRegistry()), false, 0);
     NavigableMap<LogSegmentName, Long> validDataSizeFromBlobStoreStats =
         stats.getValidDataSizeByLogSegment(new TimeRange(deleteReferenceTimeMs, 0L),
             getFileSpanForLogSegments(segmentsUnderCompaction)).getSecond();

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreStatsTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreStatsTest.java
@@ -90,7 +90,7 @@ public class BlobStoreStatsTest {
   private BlobStoreStats setupBlobStoreStats(int bucketCount, long logSegmentForecastOffsetMs) {
     return new BlobStoreStats("", state.index, bucketCount, BUCKET_SPAN_IN_MS, logSegmentForecastOffsetMs,
         QUEUE_PROCESSOR_PERIOD_IN_Ms, DEFAULT_WAIT_TIMEOUT_SECS, true, true, state.time, indexScannerScheduler,
-        queueProcessorScheduler, diskIOScheduler, METRICS, 1);
+        queueProcessorScheduler, diskIOScheduler, METRICS, 1, false);
   }
 
   /**
@@ -824,7 +824,7 @@ public class BlobStoreStatsTest {
     int expectedMinimumThrottleCount = 2 * state.referenceIndex.size();
     BlobStoreStats blobStoreStats =
         new BlobStoreStats("", state.index, 10, BUCKET_SPAN_IN_MS, 0, QUEUE_PROCESSOR_PERIOD_IN_Ms, 1, true, true,
-            state.time, indexScannerScheduler, queueProcessorScheduler, diskIOScheduler, METRICS, 1);
+            state.time, indexScannerScheduler, queueProcessorScheduler, diskIOScheduler, METRICS, 1, false);
     // proceed only when the scan is started
     assertTrue("IndexScanner took too long to start", scanStartedLatch.await(5, TimeUnit.SECONDS));
     advanceTimeToNextSecond();

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreStatsTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreStatsTest.java
@@ -90,7 +90,7 @@ public class BlobStoreStatsTest {
   private BlobStoreStats setupBlobStoreStats(int bucketCount, long logSegmentForecastOffsetMs) {
     return new BlobStoreStats("", state.index, bucketCount, BUCKET_SPAN_IN_MS, logSegmentForecastOffsetMs,
         QUEUE_PROCESSOR_PERIOD_IN_Ms, DEFAULT_WAIT_TIMEOUT_SECS, true, true, state.time, indexScannerScheduler,
-        queueProcessorScheduler, diskIOScheduler, METRICS, false, 0);
+        queueProcessorScheduler, diskIOScheduler, METRICS, 0);
   }
 
   /**
@@ -824,7 +824,7 @@ public class BlobStoreStatsTest {
     int expectedMinimumThrottleCount = 2 * state.referenceIndex.size();
     BlobStoreStats blobStoreStats =
         new BlobStoreStats("", state.index, 10, BUCKET_SPAN_IN_MS, 0, QUEUE_PROCESSOR_PERIOD_IN_Ms, 1, true, true,
-            state.time, indexScannerScheduler, queueProcessorScheduler, diskIOScheduler, METRICS, false, 0);
+            state.time, indexScannerScheduler, queueProcessorScheduler, diskIOScheduler, METRICS, 0);
     // proceed only when the scan is started
     assertTrue("IndexScanner took too long to start", scanStartedLatch.await(5, TimeUnit.SECONDS));
     advanceTimeToNextSecond();

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreStatsTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreStatsTest.java
@@ -90,7 +90,7 @@ public class BlobStoreStatsTest {
   private BlobStoreStats setupBlobStoreStats(int bucketCount, long logSegmentForecastOffsetMs) {
     return new BlobStoreStats("", state.index, bucketCount, BUCKET_SPAN_IN_MS, logSegmentForecastOffsetMs,
         QUEUE_PROCESSOR_PERIOD_IN_Ms, DEFAULT_WAIT_TIMEOUT_SECS, true, true, state.time, indexScannerScheduler,
-        queueProcessorScheduler, diskIOScheduler, METRICS);
+        queueProcessorScheduler, diskIOScheduler, METRICS, false, 0);
   }
 
   /**
@@ -824,7 +824,7 @@ public class BlobStoreStatsTest {
     int expectedMinimumThrottleCount = 2 * state.referenceIndex.size();
     BlobStoreStats blobStoreStats =
         new BlobStoreStats("", state.index, 10, BUCKET_SPAN_IN_MS, 0, QUEUE_PROCESSOR_PERIOD_IN_Ms, 1, true, true,
-            state.time, indexScannerScheduler, queueProcessorScheduler, diskIOScheduler, METRICS);
+            state.time, indexScannerScheduler, queueProcessorScheduler, diskIOScheduler, METRICS, false, 0);
     // proceed only when the scan is started
     assertTrue("IndexScanner took too long to start", scanStartedLatch.await(5, TimeUnit.SECONDS));
     advanceTimeToNextSecond();

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreStatsTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreStatsTest.java
@@ -87,6 +87,7 @@ public class BlobStoreStatsTest {
     bucketingEnabled = isBucketingEnabled;
   }
 
+  //TODO: currently the valid data size background job is not tested and needs changes to the logic to check the number of throttling events
   private BlobStoreStats setupBlobStoreStats(int bucketCount, long logSegmentForecastOffsetMs) {
     return new BlobStoreStats("", state.index, bucketCount, BUCKET_SPAN_IN_MS, logSegmentForecastOffsetMs,
         QUEUE_PROCESSOR_PERIOD_IN_Ms, DEFAULT_WAIT_TIMEOUT_SECS, true, true, state.time, indexScannerScheduler,

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreStatsTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreStatsTest.java
@@ -90,7 +90,7 @@ public class BlobStoreStatsTest {
   private BlobStoreStats setupBlobStoreStats(int bucketCount, long logSegmentForecastOffsetMs) {
     return new BlobStoreStats("", state.index, bucketCount, BUCKET_SPAN_IN_MS, logSegmentForecastOffsetMs,
         QUEUE_PROCESSOR_PERIOD_IN_Ms, DEFAULT_WAIT_TIMEOUT_SECS, true, true, state.time, indexScannerScheduler,
-        queueProcessorScheduler, diskIOScheduler, METRICS, 0);
+        queueProcessorScheduler, diskIOScheduler, METRICS, 1);
   }
 
   /**
@@ -824,7 +824,7 @@ public class BlobStoreStatsTest {
     int expectedMinimumThrottleCount = 2 * state.referenceIndex.size();
     BlobStoreStats blobStoreStats =
         new BlobStoreStats("", state.index, 10, BUCKET_SPAN_IN_MS, 0, QUEUE_PROCESSOR_PERIOD_IN_Ms, 1, true, true,
-            state.time, indexScannerScheduler, queueProcessorScheduler, diskIOScheduler, METRICS, 0);
+            state.time, indexScannerScheduler, queueProcessorScheduler, diskIOScheduler, METRICS, 1);
     // proceed only when the scan is started
     assertTrue("IndexScanner took too long to start", scanStartedLatch.await(5, TimeUnit.SECONDS));
     advanceTimeToNextSecond();

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
@@ -3476,7 +3476,7 @@ public class BlobStoreTest {
     volatile IndexValue previousValue;
 
     MockBlobStoreStats(Time time) {
-      super("", null, 0, 0, 0, 0, 0, false, true, time, null, null, null, null, 1);
+      super("", null, 0, 0, 0, 0, 0, false, true, time, null, null, null, null, 1, false);
     }
 
     @Override

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
@@ -3476,7 +3476,7 @@ public class BlobStoreTest {
     volatile IndexValue previousValue;
 
     MockBlobStoreStats(Time time) {
-      super("", null, 0, 0, 0, 0, 0, false, true, time, null, null, null, null, 0);
+      super("", null, 0, 0, 0, 0, 0, false, true, time, null, null, null, null, 1);
     }
 
     @Override

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
@@ -3476,7 +3476,7 @@ public class BlobStoreTest {
     volatile IndexValue previousValue;
 
     MockBlobStoreStats(Time time) {
-      super("", null, 0, 0, 0, 0, 0, false, true, time, null, null, null, null, false, 0);
+      super("", null, 0, 0, 0, 0, 0, false, true, time, null, null, null, null, 0);
     }
 
     @Override

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
@@ -3476,7 +3476,7 @@ public class BlobStoreTest {
     volatile IndexValue previousValue;
 
     MockBlobStoreStats(Time time) {
-      super("", null, 0, 0, 0, 0, 0, false, true, time, null, null, null, null);
+      super("", null, 0, 0, 0, 0, 0, false, true, time, null, null, null, null, false, 0);
     }
 
     @Override

--- a/ambry-store/src/test/java/com/github/ambry/store/CompactionPolicyTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CompactionPolicyTest.java
@@ -491,12 +491,12 @@ class MockBlobStoreStats extends BlobStoreStats {
   private String storeId = "";
 
   MockBlobStoreStats(long maxBlobSize) {
-    super("", null, 0, 0, 0, 0, 0, true, true, null, null, null, null, null);
+    super("", null, 0, 0, 0, 0, 0, true, true, null, null, null, null, null, false, 0);
     this.maxBlobSize = maxBlobSize;
   }
 
   MockBlobStoreStats(long maxBlobSize, int i) {
-    super("storeId" + i, null, 0, 0, 0, 0, 0, true, true, null, null, null, null, null);
+    super("storeId" + i, null, 0, 0, 0, 0, 0, true, true, null, null, null, null, null, false, 0);
     this.storeId = "storeId" + i;
     this.maxBlobSize = maxBlobSize;
   }

--- a/ambry-store/src/test/java/com/github/ambry/store/CompactionPolicyTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CompactionPolicyTest.java
@@ -491,12 +491,12 @@ class MockBlobStoreStats extends BlobStoreStats {
   private String storeId = "";
 
   MockBlobStoreStats(long maxBlobSize) {
-    super("", null, 0, 0, 0, 0, 0, true, true, null, null, null, null, null, 1);
+    super("", null, 0, 0, 0, 0, 0, true, true, null, null, null, null, null, 1, false);
     this.maxBlobSize = maxBlobSize;
   }
 
   MockBlobStoreStats(long maxBlobSize, int i) {
-    super("storeId" + i, null, 0, 0, 0, 0, 0, true, true, null, null, null, null, null, 1);
+    super("storeId" + i, null, 0, 0, 0, 0, 0, true, true, null, null, null, null, null, 1, false);
     this.storeId = "storeId" + i;
     this.maxBlobSize = maxBlobSize;
   }

--- a/ambry-store/src/test/java/com/github/ambry/store/CompactionPolicyTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CompactionPolicyTest.java
@@ -491,12 +491,12 @@ class MockBlobStoreStats extends BlobStoreStats {
   private String storeId = "";
 
   MockBlobStoreStats(long maxBlobSize) {
-    super("", null, 0, 0, 0, 0, 0, true, true, null, null, null, null, null, false, 0);
+    super("", null, 0, 0, 0, 0, 0, true, true, null, null, null, null, null, 0);
     this.maxBlobSize = maxBlobSize;
   }
 
   MockBlobStoreStats(long maxBlobSize, int i) {
-    super("storeId" + i, null, 0, 0, 0, 0, 0, true, true, null, null, null, null, null, false, 0);
+    super("storeId" + i, null, 0, 0, 0, 0, 0, true, true, null, null, null, null, null, 0);
     this.storeId = "storeId" + i;
     this.maxBlobSize = maxBlobSize;
   }

--- a/ambry-store/src/test/java/com/github/ambry/store/CompactionPolicyTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CompactionPolicyTest.java
@@ -491,12 +491,12 @@ class MockBlobStoreStats extends BlobStoreStats {
   private String storeId = "";
 
   MockBlobStoreStats(long maxBlobSize) {
-    super("", null, 0, 0, 0, 0, 0, true, true, null, null, null, null, null, 0);
+    super("", null, 0, 0, 0, 0, 0, true, true, null, null, null, null, null, 1);
     this.maxBlobSize = maxBlobSize;
   }
 
   MockBlobStoreStats(long maxBlobSize, int i) {
-    super("storeId" + i, null, 0, 0, 0, 0, 0, true, true, null, null, null, null, null, 0);
+    super("storeId" + i, null, 0, 0, 0, 0, 0, true, true, null, null, null, null, null, 1);
     this.storeId = "storeId" + i;
     this.maxBlobSize = maxBlobSize;
   }


### PR DESCRIPTION
While debugging the dotted metric issue, we found that one piece of code using gauge takes a really long time(5 to 10 s) to get the size of valid data at a particular point in time for all log segments. And the reason this issue only happens in the main cluster is we have many small blobs and many partitions in the main cluster are almost full. This pr support to calculate the valid data size in a background thread that won't block metrics collection.