### PR TITLE
Return failure reason back to client when data chunk is missing

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/rest/RestServiceException.java
+++ b/ambry-api/src/main/java/com/github/ambry/rest/RestServiceException.java
@@ -75,7 +75,11 @@ public class RestServiceException extends Exception {
     this.error = error;
     this.includeExceptionMessageInResponse = includeExceptionMessageInResponse;
     this.includeExceptionHeadersInResponse = includeExceptionHeadersInResponse;
-    this.exceptionHeadersMap = Collections.unmodifiableMap(exceptionHeadersMap);
+    if (includeExceptionHeadersInResponse) {
+      this.exceptionHeadersMap = Collections.unmodifiableMap(exceptionHeadersMap);
+    } else {
+      this.exceptionHeadersMap = Collections.emptyMap();
+    }
   }
 
   public RestServiceErrorCode getErrorCode() {

--- a/ambry-router/src/test/java/com/github/ambry/router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/GetBlobOperationTest.java
@@ -50,6 +50,8 @@ import com.github.ambry.protocol.GetRequest;
 import com.github.ambry.protocol.GetResponse;
 import com.github.ambry.protocol.PartitionRequestInfo;
 import com.github.ambry.protocol.PutRequest;
+import com.github.ambry.rest.RestServiceErrorCode;
+import com.github.ambry.rest.RestServiceException;
 import com.github.ambry.router.RouterTestHelpers.*;
 import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.store.StoreKey;
@@ -71,11 +73,13 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -458,6 +462,38 @@ public class GetBlobOperationTest {
     blobSize = 0;
     doPut();
     getAndAssertSuccess();
+  }
+
+  /**
+   * Test when data chunks are missing, the getBlob should return RestServiceException.
+   * @throws Exception
+   */
+  @Test
+  public void testMissingDataChunkException() throws Exception {
+    // Make sure we have two data chunks
+    blobSize = maxChunkSize + maxChunkSize / 2;
+    doPut();
+
+    // Now remove the all the data chunks, first collect data chunk ids and remove blob id
+    Set<String> dataChunkIds = new HashSet<>();
+    mockServerLayout.getMockServers().forEach(server -> dataChunkIds.addAll(server.getBlobs().keySet()));
+    dataChunkIds.remove(blobIdStr);
+    Assert.assertEquals(2, dataChunkIds.size());
+    // We can't just delete the data chunks by calling router.deleteBlob, we have to remove them from the mock servers.
+    mockServerLayout.getMockServers()
+        .forEach(server -> dataChunkIds.forEach(chunkId -> server.getBlobs().remove(chunkId)));
+
+    GetBlobResult result = router.getBlob(blobIdStr, new GetBlobOptionsBuilder().build()).get();
+    Future<Long> future = result.getBlobDataChannel().readInto(new ByteBufferAsyncWritableChannel(), null);
+    try {
+      future.get();
+      Assert.fail("Should fail with exception");
+    } catch (Exception e) {
+      Throwable cause = e.getCause();
+      Assert.assertTrue(cause instanceof RestServiceException);
+      Assert.assertEquals(RestServiceErrorCode.InternalServerError, ((RestServiceException) cause).getErrorCode());
+      Assert.assertTrue(((RestServiceException) cause).shouldIncludeExceptionMessageInResponse());
+    }
   }
 
   /**

--- a/build.gradle
+++ b/build.gradle
@@ -320,6 +320,7 @@ project(':ambry-replication') {
         compile "io.dropwizard.metrics:metrics-core:$metricsVersion"
         testCompile project(':ambry-store')
         testCompile project(':ambry-test-utils')
+        testCompile project(':ambry-clustermap')
         testCompile project(path: ':ambry-clustermap', configuration: 'testArchives')
         testCompile project(path: ':ambry-api', configuration: 'testArchives')
         testCompile project(path: ':ambry-messageformat', configuration: 'testArchives')

--- a/build.gradle
+++ b/build.gradle
@@ -320,7 +320,6 @@ project(':ambry-replication') {
         compile "io.dropwizard.metrics:metrics-core:$metricsVersion"
         testCompile project(':ambry-store')
         testCompile project(':ambry-test-utils')
-        testCompile project(':ambry-clustermap')
         testCompile project(path: ':ambry-clustermap', configuration: 'testArchives')
         testCompile project(path: ':ambry-api', configuration: 'testArchives')
         testCompile project(path: ':ambry-messageformat', configuration: 'testArchives')


### PR DESCRIPTION
When data chunk is missing, return RestServiceException from getBlob and include the failure reason in the response header.