### PR TITLE
Support returning a snapshot of replicas in different states in ClusterChangeHandler

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/clustermap/PartitionId.java
+++ b/ambry-api/src/main/java/com/github/ambry/clustermap/PartitionId.java
@@ -14,6 +14,8 @@
 package com.github.ambry.clustermap;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 
 /**
@@ -41,6 +43,14 @@ public interface PartitionId extends Resource, Comparable<PartitionId> {
    * @return list of Replicas that satisfy requirement.
    */
   List<? extends ReplicaId> getReplicaIdsByState(ReplicaState state, String dcName);
+
+  /**
+   * Get replicas (grouped by required state) from specified datacenter.
+   * @param states a set of {@link ReplicaState} that replicas should match.
+   * @param dcName the name of datacenter from which the replica should come.
+   * @return a map whose key is {@link ReplicaState} and value is a list of replicas in that state.
+   */
+  Map<ReplicaState, ? extends List<? extends ReplicaId>> getReplicaIdsByStates(Set<ReplicaState> states, String dcName);
 
   /**
    * Gets the state of this PartitionId.

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryPartition.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryPartition.java
@@ -18,6 +18,8 @@ import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import org.json.JSONArray;
@@ -71,6 +73,11 @@ public class AmbryPartition implements PartitionId {
   @Override
   public List<AmbryReplica> getReplicaIdsByState(ReplicaState state, String dcName) {
     return clusterManagerCallback.getReplicaIdsByState(this, state, dcName);
+  }
+
+  @Override
+  public Map<ReplicaState, List<AmbryReplica>> getReplicaIdsByStates(Set<ReplicaState> states, String dcName){
+    return clusterManagerCallback.getReplicaIdsByStates(this,  states, dcName);
   }
 
   @Override

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryPartition.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryPartition.java
@@ -17,6 +17,7 @@ import com.github.ambry.utils.Utils;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -76,8 +77,10 @@ public class AmbryPartition implements PartitionId {
   }
 
   @Override
-  public Map<ReplicaState, List<AmbryReplica>> getReplicaIdsByStates(Set<ReplicaState> states, String dcName){
-    return clusterManagerCallback.getReplicaIdsByStates(this,  states, dcName);
+  public Map<ReplicaState, List<AmbryReplica>> getReplicaIdsByStates(Set<ReplicaState> states, String dcName) {
+    Map<ReplicaState, List<AmbryReplica>> replicasByStates = new HashMap<>();
+    clusterManagerCallback.getReplicaIdsByStates(replicasByStates, this, states, dcName);
+    return replicasByStates;
   }
 
   @Override

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/CloudServiceClusterChangeHandler.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/CloudServiceClusterChangeHandler.java
@@ -95,7 +95,8 @@ class CloudServiceClusterChangeHandler implements ClusterMapChangeListener, Clus
   }
 
   @Override
-  public Map<ReplicaState, List<AmbryReplica>> getSnapshotOfReplicaStates(AmbryPartition partition){
+  public void getReplicaIdsByStates(Map<ReplicaState, List<AmbryReplica>> replicasByState,
+      Set<ReplicaState> states, AmbryPartition partition) {
     throw new UnsupportedOperationException("Get snapshot of replica state is temporarily not supported");
   }
 

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/CloudServiceClusterChangeHandler.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/CloudServiceClusterChangeHandler.java
@@ -95,6 +95,11 @@ class CloudServiceClusterChangeHandler implements ClusterMapChangeListener, Clus
   }
 
   @Override
+  public Map<ReplicaState, List<AmbryReplica>> getSnapshotOfReplicaStates(AmbryPartition partition){
+    throw new UnsupportedOperationException("Get snapshot of replica state is temporarily not supported");
+  }
+
+  @Override
   public Map<AmbryDataNode, Set<AmbryDisk>> getDataNodeToDisksMap() {
     return Collections.emptyMap();
   }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterChangeHandler.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterChangeHandler.java
@@ -23,8 +23,7 @@ import java.util.stream.Stream;
 
 /**
  * General handler that handles any resource or state changes in cluster. It exposes API(s) for cluster manager to
- * access up-to-date cluster info for a data center. Each data center has its own
- * {@link ClusterChangeHandler}.
+ * access up-to-date cluster info for a data center. Each data center has its own {@link ClusterChangeHandler}.
  */
 public interface ClusterChangeHandler {
   /**
@@ -40,6 +39,13 @@ public interface ClusterChangeHandler {
    * @return the {@link ReplicaId}s satisfying requirements.
    */
   Stream<AmbryReplica> getReplicaIdsByState(AmbryPartition partition, ReplicaState state);
+
+  /**
+   * Get a snapshot of replica states from given partition.
+   * @param partition the {@link AmbryPartition} that the replicas belong to.
+   * @return a map whose key is {@link ReplicaState} and value is a list of {@link AmbryReplica} in that state.
+   */
+  Map<ReplicaState, List<AmbryReplica>> getSnapshotOfReplicaStates(AmbryPartition partition);
 
   /**
    * @return a map from ambry data node to its disks.

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterChangeHandler.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterChangeHandler.java
@@ -41,11 +41,13 @@ public interface ClusterChangeHandler {
   Stream<AmbryReplica> getReplicaIdsByState(AmbryPartition partition, ReplicaState state);
 
   /**
-   * Get a snapshot of replica states from given partition.
+   * Get replicas grouped by given states from specific partition.
+   * @param replicasByState a map of replicas grouped by state to be populated.
+   * @param states the required states in which the replicas should stay.
    * @param partition the {@link AmbryPartition} that the replicas belong to.
-   * @return a map whose key is {@link ReplicaState} and value is a list of {@link AmbryReplica} in that state.
    */
-  Map<ReplicaState, List<AmbryReplica>> getSnapshotOfReplicaStates(AmbryPartition partition);
+  void getReplicaIdsByStates(Map<ReplicaState, List<AmbryReplica>> replicasByState, Set<ReplicaState> states,
+      AmbryPartition partition);
 
   /**
    * @return a map from ambry data node to its disks.

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterManagerCallback.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterManagerCallback.java
@@ -51,12 +51,13 @@ interface ClusterManagerCallback<R extends ReplicaId, D extends DiskId, P extend
 
   /**
    * Get replicas (grouped by required states) from given partition in specified datacenter.
+   * @param replicasByState a map of replicas by state to be populated.
    * @param partition the {@link PartitionId} that replicas belong to.
    * @param states a set of required states.
    * @param dcName name of datacenter from which the replicas should come
-   * @return a map whose key is required {@link ReplicaState} and value is a list of {@link ReplicaId} in that state.
    */
-  Map<ReplicaState, List<R>> getReplicaIdsByStates(P partition, Set<ReplicaState> states, String dcName);
+  void getReplicaIdsByStates(Map<ReplicaState, List<R>> replicasByState, P partition, Set<ReplicaState> states,
+      String dcName);
 
   /**
    * Get the counter for the sealed state change for partitions.

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterManagerCallback.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterManagerCallback.java
@@ -15,6 +15,8 @@ package com.github.ambry.clustermap;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 
 /**
@@ -46,6 +48,15 @@ interface ClusterManagerCallback<R extends ReplicaId, D extends DiskId, P extend
    * @return the list of {@link ReplicaId}s satisfying requirements.
    */
   List<R> getReplicaIdsByState(P partition, ReplicaState state, String dcName);
+
+  /**
+   * Get replicas (grouped by required states) from given partition in specified datacenter.
+   * @param partition the {@link PartitionId} that replicas belong to.
+   * @param states a set of required states.
+   * @param dcName name of datacenter from which the replicas should come
+   * @return a map whose key is required {@link ReplicaState} and value is a list of {@link ReplicaId} in that state.
+   */
+  Map<ReplicaState, List<R>> getReplicaIdsByStates(P partition, Set<ReplicaState> states, String dcName);
 
   /**
    * Get the counter for the sealed state change for partitions.

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterChangeHandler.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterChangeHandler.java
@@ -13,7 +13,12 @@
  */
 package com.github.ambry.clustermap;
 
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.helix.api.listeners.IdealStateChangeListener;
 import org.apache.helix.api.listeners.LiveInstanceChangeListener;
@@ -53,5 +58,23 @@ interface HelixClusterChangeHandler
         .stream()
         .map(instanceConfig -> getDataNode(instanceConfig.getInstanceName()))
         .map(dataNode -> getReplicaId(dataNode, partition.toPathString())).filter(Objects::nonNull);
+  }
+
+  @Override
+  default Map<ReplicaState, List<AmbryReplica>> getSnapshotOfReplicaStates(AmbryPartition partition) {
+    String resourceName = getPartitionToResourceMap().get(partition.toPathString());
+    RoutingTableSnapshot snapshot = getRoutingTableSnapshot();
+    Map<ReplicaState, List<AmbryReplica>> replicasByState = new HashMap<>();
+    for (ReplicaState state : EnumSet.of(ReplicaState.OFFLINE, ReplicaState.BOOTSTRAP, ReplicaState.STANDBY,
+        ReplicaState.LEADER, ReplicaState.INACTIVE)) {
+      List<AmbryReplica> list = snapshot.getInstancesForResource(resourceName, partition.toPathString(), state.name())
+          .stream()
+          .map(instanceConfig -> getDataNode(instanceConfig.getInstanceName()))
+          .map(dataNode -> getReplicaId(dataNode, partition.toPathString()))
+          .filter(Objects::nonNull)
+          .collect(Collectors.toList());
+      replicasByState.put(state, list);
+    }
+    return replicasByState;
   }
 }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
@@ -702,6 +702,26 @@ public class HelixClusterManager implements ClusterMap {
       return replicas;
     }
 
+    @Override
+    public Map<ReplicaState, List<AmbryReplica>> getReplicaIdsByStates(AmbryPartition partition,
+        Set<ReplicaState> states, String dcName) {
+      Map<ReplicaState, List<AmbryReplica>> replicasByState = new HashMap<>();
+      for (DcInfo dcInfo : dcToDcInfo.values()) {
+        String dc = dcInfo.dcName;
+        if (dcName == null || dcName.equals(dc)) {
+          Map<ReplicaState, List<AmbryReplica>> replicaStateMap =
+              dcInfo.clusterChangeHandler.getSnapshotOfReplicaStates(partition);
+          for (Map.Entry<ReplicaState, List<AmbryReplica>> entry : replicaStateMap.entrySet()) {
+            ReplicaState state = entry.getKey();
+            if (states.contains(state)) {
+              replicasByState.computeIfAbsent(state, k -> new ArrayList<>()).addAll(entry.getValue());
+            }
+          }
+        }
+      }
+      return replicasByState;
+    }
+
     /**
      * Get the value counter representing the sealed state change for partitions.
      * @return the value of the counter representing the sealed state change for partitions.

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
@@ -703,23 +703,14 @@ public class HelixClusterManager implements ClusterMap {
     }
 
     @Override
-    public Map<ReplicaState, List<AmbryReplica>> getReplicaIdsByStates(AmbryPartition partition,
+    public void getReplicaIdsByStates(Map<ReplicaState, List<AmbryReplica>> replicasByState, AmbryPartition partition,
         Set<ReplicaState> states, String dcName) {
-      Map<ReplicaState, List<AmbryReplica>> replicasByState = new HashMap<>();
       for (DcInfo dcInfo : dcToDcInfo.values()) {
         String dc = dcInfo.dcName;
         if (dcName == null || dcName.equals(dc)) {
-          Map<ReplicaState, List<AmbryReplica>> replicaStateMap =
-              dcInfo.clusterChangeHandler.getSnapshotOfReplicaStates(partition);
-          for (Map.Entry<ReplicaState, List<AmbryReplica>> entry : replicaStateMap.entrySet()) {
-            ReplicaState state = entry.getKey();
-            if (states.contains(state)) {
-              replicasByState.computeIfAbsent(state, k -> new ArrayList<>()).addAll(entry.getValue());
-            }
-          }
+          dcInfo.clusterChangeHandler.getReplicaIdsByStates(replicasByState, states, partition);
         }
       }
-      return replicasByState;
     }
 
     /**

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/Partition.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/Partition.java
@@ -18,8 +18,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.json.JSONArray;
@@ -108,6 +110,21 @@ public class Partition implements PartitionId {
           .collect(Collectors.toList());
     }
     return Collections.unmodifiableList(result);
+  }
+
+  @Override
+  public Map<ReplicaState, List<ReplicaId>> getReplicaIdsByStates(Set<ReplicaState> states, String dcName) {
+    Map<ReplicaState, List<ReplicaId>> replicaByState = new HashMap<>();
+    for (ReplicaState state : states) {
+      List<ReplicaId> replicaIds = new ArrayList<>();
+      if (state == ReplicaState.STANDBY) {
+        replicaIds.addAll(replicas.stream()
+            .filter(k -> dcName == null || k.getDataNodeId().getDatacenterName().equals(dcName))
+            .collect(Collectors.toList()));
+      }
+      replicaByState.put(state, replicaIds);
+    }
+    return replicaByState;
   }
 
   @Override

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/Partition.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/Partition.java
@@ -78,7 +78,7 @@ public class Partition implements PartitionId {
         : hardwareLayout.getClusterMapConfig().clusterMapDefaultPartitionClass;
     this.partitionState = PartitionState.valueOf(jsonObject.getString("partitionState"));
     this.replicaCapacityInBytes = jsonObject.getLong("replicaCapacityInBytes");
-    this.replicas = new ArrayList<ReplicaId>(jsonObject.getJSONArray("replicas").length());
+    this.replicas = new ArrayList<>(jsonObject.getJSONArray("replicas").length());
     for (int i = 0; i < jsonObject.getJSONArray("replicas").length(); ++i) {
       this.replicas.add(i, new Replica(hardwareLayout, this, jsonObject.getJSONArray("replicas").getJSONObject(i)));
     }
@@ -117,6 +117,7 @@ public class Partition implements PartitionId {
     Map<ReplicaState, List<ReplicaId>> replicaByState = new HashMap<>();
     for (ReplicaState state : states) {
       List<ReplicaId> replicaIds = new ArrayList<>();
+      // for static clustermap we assume all replicas are in StandBy state.
       if (state == ReplicaState.STANDBY) {
         replicaIds.addAll(replicas.stream()
             .filter(k -> dcName == null || k.getDataNodeId().getDatacenterName().equals(dcName))

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PartitionLayout.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PartitionLayout.java
@@ -328,7 +328,7 @@ class PartitionLayout {
     }
 
     @Override
-    public Map<ReplicaState, List<Replica>> getReplicaIdsByStates(Partition partition, Set<ReplicaState> states,
+    public void getReplicaIdsByStates(Map<ReplicaState, List<Replica>> replicasByState, Partition partition, Set<ReplicaState> states,
         String dcName) {
       throw new UnsupportedOperationException("Not supported in static cluster map");
     }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PartitionLayout.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PartitionLayout.java
@@ -328,6 +328,12 @@ class PartitionLayout {
     }
 
     @Override
+    public Map<ReplicaState, List<Replica>> getReplicaIdsByStates(Partition partition, Set<ReplicaState> states,
+        String dcName) {
+      throw new UnsupportedOperationException("Not supported in static cluster map");
+    }
+
+    @Override
     public long getSealedStateChangeCounter() {
       throw new UnsupportedOperationException("Not supported in static cluster map");
     }

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/DynamicClusterManagerComponentsTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/DynamicClusterManagerComponentsTest.java
@@ -307,6 +307,12 @@ public class DynamicClusterManagerComponentsTest {
     }
 
     @Override
+    public Map<ReplicaState, List<AmbryReplica>> getReplicaIdsByStates(AmbryPartition partition,
+        Set<ReplicaState> states, String dcName) {
+      throw new UnsupportedOperationException("Temporarily unsupported");
+    }
+
+    @Override
     public Collection<AmbryDisk> getDisks(AmbryDataNode dataNode) {
       if (dataNode != null) {
         return dataNodeToDisks.getOrDefault(dataNode, Collections.emptySet());

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/DynamicClusterManagerComponentsTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/DynamicClusterManagerComponentsTest.java
@@ -307,7 +307,7 @@ public class DynamicClusterManagerComponentsTest {
     }
 
     @Override
-    public Map<ReplicaState, List<AmbryReplica>> getReplicaIdsByStates(AmbryPartition partition,
+    public void getReplicaIdsByStates(Map<ReplicaState, List<AmbryReplica>> replicasByState, AmbryPartition partition,
         Set<ReplicaState> states, String dcName) {
       throw new UnsupportedOperationException("Temporarily unsupported");
     }

--- a/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockPartitionId.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockPartitionId.java
@@ -117,6 +117,17 @@ public class MockPartitionId implements PartitionId {
   }
 
   @Override
+  public Map<ReplicaState, List<ReplicaId>> getReplicaIdsByStates(Set<ReplicaState> states, String dcName) {
+    Map<ReplicaState, List<ReplicaId>> replicasByState = new HashMap<>();
+    for (Map.Entry<ReplicaId, ReplicaState> entry : replicaAndState.entrySet()) {
+      if (states.contains(entry.getValue())) {
+        replicasByState.computeIfAbsent(entry.getValue(), k -> new ArrayList<>()).add(entry.getKey());
+      }
+    }
+    return replicasByState;
+  }
+
+  @Override
   public PartitionState getPartitionState() {
     return partitionState;
   }

--- a/ambry-tools/src/main/java/com/github/ambry/cloud/azure/AzureCompactionTool.java
+++ b/ambry-tools/src/main/java/com/github/ambry/cloud/azure/AzureCompactionTool.java
@@ -30,6 +30,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -139,6 +140,12 @@ public class AzureCompactionTool {
 
     @Override
     public List<? extends ReplicaId> getReplicaIdsByState(ReplicaState state, String dcName) {
+      return null;
+    }
+
+    @Override
+    public Map<ReplicaState, ? extends List<? extends ReplicaId>> getReplicaIdsByStates(Set<ReplicaState> states,
+        String dcName) {
       return null;
     }
 


### PR DESCRIPTION
Previously, ClusterChangeHandler only allows getting replicas in one state at a time. To get replicas in multiple states, it has to call getReplicaByState() multiple times in sequential manner. The replica state may change during this process which causes race condition where a replica is counted twice or a replica is omitted. This PR introduces a new method to support get a snapshot of replicas in different states. It's populated based on same view of cluster which avoids aforementioned race condition induced by state transition.