### PR TITLE
[StorageQuota] Rename the supplier interface

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/FrontendConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/FrontendConfig.java
@@ -38,8 +38,6 @@ public class FrontendConfig {
       PREFIX + "max.acceptable.ttl.secs.if.ttl.required";
   public static final String MAX_JSON_REQUEST_SIZE_BYTES_KEY = PREFIX + "max.json.request.size.bytes";
   public static final String ENABLE_UNDELETE = PREFIX + "enable.undelete";
-  public static final String ENABLE_STORAGE_QUOTA_SERVICE = PREFIX + "enable.storage.quota.service";
-  public static final String STORAGE_QUOTA_SERVICE_FACTORY = PREFIX + "storage.quota.service.factory";
   public static final String NAMED_BLOB_DB_FACTORY = PREFIX + "named.blob.db.factory";
   public static final String CONTAINER_METRICS_EXCLUDED_ACCOUNTS = PREFIX + "container.metrics.excluded.accounts";
   public static final String ACCOUNT_STATS_STORE_FACTORY = PREFIX + "account.stats.store.factory";
@@ -222,14 +220,6 @@ public class FrontendConfig {
   public final String accountStatsStoreFactory;
 
   /**
-   * Set to true to enable storage quota in frontend.
-   */
-  @Config(ENABLE_STORAGE_QUOTA_SERVICE)
-  @Default("false")
-  public final boolean enableStorageQuotaService;
-
-
-  /**
    * Can be set to a classname that implements {@link com.github.ambry.named.NamedBlobDbFactory} to enable named blob
    * support.
    */
@@ -294,7 +284,6 @@ public class FrontendConfig {
     enableUndelete = verifiableProperties.getBoolean(ENABLE_UNDELETE, false);
     accountStatsStoreFactory =
         verifiableProperties.getString(ACCOUNT_STATS_STORE_FACTORY, DEFAULT_ACCOUNT_STATS_STORE_FACTORY);
-    enableStorageQuotaService = verifiableProperties.getBoolean(ENABLE_STORAGE_QUOTA_SERVICE, false);
     namedBlobDbFactory = verifiableProperties.getString(NAMED_BLOB_DB_FACTORY, null);
     containerMetricsExcludedAccounts =
         Utils.splitString(verifiableProperties.getString(CONTAINER_METRICS_EXCLUDED_ACCOUNTS, ""), ",");

--- a/ambry-api/src/main/java/com/github/ambry/quota/storage/StorageQuotaSource.java
+++ b/ambry-api/src/main/java/com/github/ambry/quota/storage/StorageQuotaSource.java
@@ -15,6 +15,7 @@ package com.github.ambry.quota.storage;
 
 import com.github.ambry.quota.QuotaSource;
 import java.util.Map;
+import java.util.function.Supplier;
 
 
 /**
@@ -48,22 +49,10 @@ public interface StorageQuotaSource extends QuotaSource {
   void registerListener(Listener listener);
 
   /**
-   * Callback to get the  current storage usage.
+   * Add the supplier method to get storage usage so that {@link StorageQuotaSource} would know the updated storage usage.
+   * @param supplier The method to return storage usages for all containers.
    */
-  interface StorageUsageCallback {
-    /**
-     *  Method to return container storage usage in a map. The format of this map follows the container storage quota
-     *  in this class.
-     * @return The storage usage for each container.
-     */
-    Map<String, Map<String, Long>> containerStorageUsage();
-  }
-
-  /**
-   * Add the callback to get storage usage so that {@link StorageQuotaSource} would know the updated storage usage.
-   * @param callback
-   */
-  void addStorageUsageCallback(StorageUsageCallback callback);
+  void addStorageUsageSupplier(Supplier<Map<String, Map<String, Long>>> supplier);
 
   /**
    * Shutdown the {@link StorageQuotaSource}.

--- a/ambry-quota/src/main/java/com/github/ambry/quota/storage/JSONStringStorageQuotaSource.java
+++ b/ambry-quota/src/main/java/com/github/ambry/quota/storage/JSONStringStorageQuotaSource.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,7 +66,7 @@ public class JSONStringStorageQuotaSource implements StorageQuotaSource {
   }
 
   @Override
-  public void addStorageUsageCallback(StorageUsageCallback callback) {
+  public void addStorageUsageSupplier(Supplier<Map<String, Map<String, Long>>> supplier) {
     // no-op
   }
 

--- a/ambry-quota/src/main/java/com/github/ambry/quota/storage/StorageQuotaEnforcer.java
+++ b/ambry-quota/src/main/java/com/github/ambry/quota/storage/StorageQuotaEnforcer.java
@@ -206,8 +206,8 @@ public class StorageQuotaEnforcer implements QuotaEnforcer {
     logger.info("Register quota source and usage refresher listeners");
     storageQuotaSource.registerListener(getQuotaSourceListener());
     storageUsageRefresher.registerListener(getUsageRefresherListener());
-    // Register the storage usage callback to source.
-    storageQuotaSource.addStorageUsageCallback(this::getStorageUsage);
+    // Register the storage usage supplier to source.
+    storageQuotaSource.addStorageUsageSupplier(this::getStorageUsage);
   }
 
   /**


### PR DESCRIPTION
This PR removes two configuration values that are not used anymore
This PR also uses Supplier to replace StorageUsageCallback interface.