### PR TITLE
Read partition id directly from token info in cloud to store replication.

### DIFF
--- a/ambry-replication/src/main/java/com/github/ambry/replication/CloudToStoreReplicationManager.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/CloudToStoreReplicationManager.java
@@ -212,10 +212,7 @@ public class CloudToStoreReplicationManager extends ReplicationEngine {
     // Note that in case of cloudReplicaTokens, the actual remote vcr node might not match as the vcr node is chosen at
     // random during initialization. So it's enough to just match the partitionId in the token so that replication
     // can start from cloud from where it left off.
-    return tokenInfo.getReplicaInfo()
-        .getReplicaId()
-        .getPartitionId()
-        .equals(remoteReplicaInfo.getReplicaId().getPartitionId());
+    return tokenInfo.getPartitionId().equals(remoteReplicaInfo.getReplicaId().getPartitionId());
   }
 
   /**


### PR DESCRIPTION
Read partition id directly from token info in CloudToStoreReplicationManager as ReplicaInfo is not persisted.