### PR TITLE
Remove counter from Hybrid Compaction Policy

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -85,15 +85,8 @@ public class StoreConfig {
    * How often the HybridCompactionPolicy switch from StatsBasedCompactionPolicy to CompactAllPolicy based on timestamp.
    */
   @Config("store.compaction.policy.switch.timestamp.days")
-  @Default("7")
+  @Default("6")
   public final int storeCompactionPolicySwitchTimestampDays;
-
-  /**
-   * How often the HybridCompactionPolicy switch from StatsBasedCompactionPolicy to CompactAllPolicy based on counter value.
-   */
-  @Config("store.compaction.policy.switch.counter.days")
-  @Default("7")
-  public final int storeCompactionPolicySwitchCounterDays;
 
   /**
    * How long (in days) a container must be in DELETE_IN_PROGRESS state before it's been deleted during compaction.
@@ -471,9 +464,7 @@ public class StoreConfig {
     storeDeletedMessageRetentionHours =
         verifiableProperties.getIntInRange("store.deleted.message.retention.hours", 168, 1, Integer.MAX_VALUE);
     storeCompactionPolicySwitchTimestampDays =
-        verifiableProperties.getIntInRange("store.compaction.policy.switch.timestamp.days", 7, 1, 14);
-    storeCompactionPolicySwitchCounterDays =
-        verifiableProperties.getIntInRange("store.compaction.policy.switch.counter.days", 7, 1, 14);
+        verifiableProperties.getIntInRange("store.compaction.policy.switch.timestamp.days", 6, 1, 14);
     storeContainerDeletionRetentionDays = verifiableProperties.getInt("store.container.deletion.retention.days", 14);
     storeHardDeleteOperationsBytesPerSec =
         verifiableProperties.getIntInRange("store.hard.delete.operations.bytes.per.sec", 100 * 1024, 1,

--- a/ambry-store/src/main/java/com/github/ambry/store/CompactionPolicySwitchInfo.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/CompactionPolicySwitchInfo.java
@@ -20,34 +20,26 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 /**
  * The {@link CompactionPolicy} info to determine when to use which {@link CompactionPolicy}.
  */
-@JsonPropertyOrder({"compactionPolicyCounter", "lastCompactionTime"})
+@JsonPropertyOrder({"lastCompactionTime", "nextRoundIsCompactAllPolicy"})
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public class CompactionPolicySwitchInfo {
-  private CompactionPolicyCounter compactionPolicyCounter;
   private long lastCompactAllTime;
+  private boolean nextRoundIsCompactAllPolicy;
 
   /**
    * Constructor to create {@link CompactionPolicySwitchInfo} object.
-   * @param compactionPolicyCounter Counter used to switch {@link CompactAllPolicy}
    * @param lastCompactAllTime last time when {@link CompactAllPolicy} has been selected.
+   * @param nextRoundIsCompactAllPolicy {@code True} if the next round of compaction policy is compactAll. {@code False} Otherwise.
    */
-  CompactionPolicySwitchInfo(CompactionPolicyCounter compactionPolicyCounter, long lastCompactAllTime) {
-    this.compactionPolicyCounter = compactionPolicyCounter;
+  CompactionPolicySwitchInfo(long lastCompactAllTime, boolean nextRoundIsCompactAllPolicy) {
     this.lastCompactAllTime = lastCompactAllTime;
+    this.nextRoundIsCompactAllPolicy = nextRoundIsCompactAllPolicy;
   }
 
   /**
    * make sure objectMapper can work correctly
    */
   CompactionPolicySwitchInfo() {
-  }
-
-  /**
-   * Get current {@link CompactionPolicyCounter}
-   * @return {@link CompactionPolicyCounter}
-   */
-  CompactionPolicyCounter getCompactionPolicyCounter() {
-    return this.compactionPolicyCounter;
   }
 
   /**
@@ -64,5 +56,19 @@ public class CompactionPolicySwitchInfo {
    */
   void setLastCompactAllTime(long lastCompactAllTime) {
     this.lastCompactAllTime = lastCompactAllTime;
+  }
+
+  /**
+   * @return {@code True} if the next round of compaction policy is compactAll. {@code False} Otherwise.
+   */
+  boolean isNextRoundCompactAllPolicy() {
+    return this.nextRoundIsCompactAllPolicy;
+  }
+
+  /**
+   * Set the nextRoundIsCompactAllPolicy to {@code True} if the next round of compaction policy is compactAll.
+   */
+  void setNextRoundIsCompactAllPolicy(boolean isNextRoundCompactAllPolicy) {
+    this.nextRoundIsCompactAllPolicy = isNextRoundCompactAllPolicy;
   }
 }

--- a/ambry-store/src/main/java/com/github/ambry/store/HybridCompactionPolicy.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/HybridCompactionPolicy.java
@@ -18,7 +18,6 @@ import com.github.ambry.config.StoreConfig;
 import com.github.ambry.utils.Time;
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -38,8 +37,8 @@ public class HybridCompactionPolicy implements CompactionPolicy {
   private static final Logger logger = LoggerFactory.getLogger(HybridCompactionPolicy.class);
   private final Map<String, CompactionPolicySwitchInfo> blobToCompactionPolicySwitchInfoMap;
   private static final ObjectMapper objectMapper = new ObjectMapper();
-  private static final String COMPACT_POLICY_INFO_PATH = File.separator + "compactionPolicyInfo.json";
-  private static final String COMPACT_POLICY_INFO_PATH_V2 = File.separator + "compactionPolicyInfoV2.json";
+  private static final String COMPACT_POLICY_INFO_FILE_NAME = "compactionPolicyInfo.json";
+  private static final String COMPACT_POLICY_INFO_FILE_NAME_V2 = "compactionPolicyInfoV2.json";
   private static final long INIT_COMPACT_ALL_TIME = System.currentTimeMillis();
   private static final int DELTA_TIME_IN_DAYS = 3;
   private static final Random random = new Random();
@@ -87,8 +86,8 @@ public class HybridCompactionPolicy implements CompactionPolicy {
   private CompactionPolicySwitchInfo getCompactionPolicySwitchInfo(String storeId, String dataDir,
       BlobStoreStats blobStoreStats) {
     if (!blobToCompactionPolicySwitchInfoMap.containsKey(storeId)) {
-      File file = new File(dataDir, COMPACT_POLICY_INFO_PATH_V2);
-      File oldFile = new File(dataDir, COMPACT_POLICY_INFO_PATH);
+      File file = new File(dataDir, COMPACT_POLICY_INFO_FILE_NAME_V2);
+      File oldFile = new File(dataDir, COMPACT_POLICY_INFO_FILE_NAME);
       if (oldFile.exists()) {
         if (!oldFile.delete()) {
           logger.error("Old compact policy info file has not been successfully deleted in dataDir: {}", dataDir);
@@ -191,11 +190,11 @@ public class HybridCompactionPolicy implements CompactionPolicy {
    */
   private void backUpCompactionPolicyInfo(String dataDir, CompactionPolicySwitchInfo compactionPolicySwitchInfo) {
     if (dataDir != null && !dataDir.isEmpty()) {
-      File tempFile = new File(dataDir, COMPACT_POLICY_INFO_PATH_V2 + ".temp");
+      File tempFile = new File(dataDir, COMPACT_POLICY_INFO_FILE_NAME_V2 + ".temp");
       try {
         tempFile.createNewFile();
         objectMapper.writerWithDefaultPrettyPrinter().writeValue(tempFile, compactionPolicySwitchInfo);
-        tempFile.renameTo(new File(dataDir, COMPACT_POLICY_INFO_PATH_V2));
+        tempFile.renameTo(new File(dataDir, COMPACT_POLICY_INFO_FILE_NAME_V2));
       } catch (IOException e) {
         logger.error("Exception while store compaction policy info for local report. Output file path - {}",
             tempFile.getAbsolutePath(), e);

--- a/ambry-store/src/main/java/com/github/ambry/store/HybridCompactionPolicy.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/HybridCompactionPolicy.java
@@ -22,6 +22,7 @@ import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,8 +39,10 @@ public class HybridCompactionPolicy implements CompactionPolicy {
   private final Map<String, CompactionPolicySwitchInfo> blobToCompactionPolicySwitchInfoMap;
   private static final ObjectMapper objectMapper = new ObjectMapper();
   private static final String COMPACT_POLICY_INFO_PATH = File.separator + "compactionPolicyInfo.json";
-  private static final int INIT_COMPACT_ALL_TIME = 0;
-  private static final int INIT_COUNTER_VALUE = 0;
+  private static final String COMPACT_POLICY_INFO_PATH_V2 = File.separator + "compactionPolicyInfoV2.json";
+  private static final long INIT_COMPACT_ALL_TIME = System.currentTimeMillis();
+  private static final int DELTA_TIME_IN_DAYS = 3;
+  private static final Random random = new Random();
 
   HybridCompactionPolicy(StoreConfig storeConfig, Time time) {
     this.storeConfig = storeConfig;
@@ -61,14 +64,15 @@ public class HybridCompactionPolicy implements CompactionPolicy {
    */
   @Override
   public CompactionDetails getCompactionDetails(long totalCapacity, long usedCapacity, long segmentCapacity,
-      long segmentHeaderSize, List<LogSegmentName> logSegmentsNotInJournal, BlobStoreStats blobStoreStats, String dataDir)
-      throws StoreException {
+      long segmentHeaderSize, List<LogSegmentName> logSegmentsNotInJournal, BlobStoreStats blobStoreStats,
+      String dataDir) throws StoreException {
     String storeId = blobStoreStats.getStoreId();
-    CompactionPolicySwitchInfo compactionPolicySwitchInfo = getCompactionPolicySwitchInfo(storeId, dataDir, blobStoreStats);
+    CompactionPolicySwitchInfo compactionPolicySwitchInfo =
+        getCompactionPolicySwitchInfo(storeId, dataDir, blobStoreStats);
     CompactionPolicy selectCompactionPolicy =
         selectCompactionPolicyAndUpdateCompactionPolicySwitchInfo(compactionPolicySwitchInfo, storeId, dataDir);
-    logger.info("Current compaction policy  is : {} for store : {}, dataDir : {}", selectCompactionPolicy, storeId, dataDir);
-    compactionPolicySwitchInfo.getCompactionPolicyCounter().increment();
+    logger.info("Current compaction policy  is : {} for store : {}, dataDir : {}", selectCompactionPolicy, storeId,
+        dataDir);
     backUpCompactionPolicyInfo(dataDir, compactionPolicySwitchInfo);
     return selectCompactionPolicy.getCompactionDetails(totalCapacity, usedCapacity, segmentCapacity, segmentHeaderSize,
         logSegmentsNotInJournal, blobStoreStats, dataDir);
@@ -80,16 +84,23 @@ public class HybridCompactionPolicy implements CompactionPolicy {
    * @param storeId id of the BlobStore
    * @return {@link CompactionPolicySwitchInfo} gets from map or recover from file if needed.
    */
-  private CompactionPolicySwitchInfo getCompactionPolicySwitchInfo(String storeId, String dataDir, BlobStoreStats blobStoreStats) {
+  private CompactionPolicySwitchInfo getCompactionPolicySwitchInfo(String storeId, String dataDir,
+      BlobStoreStats blobStoreStats) {
     if (!blobToCompactionPolicySwitchInfoMap.containsKey(storeId)) {
-      File file = new File(Paths.get(dataDir, COMPACT_POLICY_INFO_PATH).toString());
+      File file = new File(dataDir, COMPACT_POLICY_INFO_PATH_V2);
+      File oldFile = new File(dataDir, COMPACT_POLICY_INFO_PATH);
+      if (oldFile.exists()) {
+        if (!oldFile.delete()) {
+          logger.error("Old compact policy info file has not been successfully deleted in dataDir: {}", dataDir);
+        }
+      }
       if (file.exists()) {
         CompactionPolicySwitchInfo compactionPolicySwitchInfo = recoverCompactionPolicySwitchInfo(file, blobStoreStats);
         blobToCompactionPolicySwitchInfoMap.put(storeId, compactionPolicySwitchInfo);
       } else {
-        blobToCompactionPolicySwitchInfoMap.put(storeId,
-            new CompactionPolicySwitchInfo(new CompactionPolicyCounter(storeConfig.storeCompactionPolicySwitchCounterDays),
-                INIT_COMPACT_ALL_TIME));
+        //Randomly start compactAllPolicy after deployment.
+        blobToCompactionPolicySwitchInfoMap.put(storeId, new CompactionPolicySwitchInfo(
+            INIT_COMPACT_ALL_TIME - TimeUnit.DAYS.toMillis(random.nextInt(DELTA_TIME_IN_DAYS)), false));
       }
     }
     return blobToCompactionPolicySwitchInfoMap.get(storeId);
@@ -98,10 +109,7 @@ public class HybridCompactionPolicy implements CompactionPolicy {
   /**
    * Recover the {@link CompactionPolicySwitchInfo} from backup file.
    * {
-   *   "compactionPolicyCounter" : {
-   *     "storeCompactionPolicySwitchCounterDays" : 3,
-   *     "counter" : 1
-   *   },
+   *   "nextRoundIsCompactAllPolicy" : false,
    *   "lastCompactAllTime" : 1593492962651
    * }
    * @param file the backup file stores {@link CompactionPolicySwitchInfo}
@@ -112,8 +120,7 @@ public class HybridCompactionPolicy implements CompactionPolicy {
     } catch (IOException e) {
       logger.error("Could not deserialize file : {} into {} Object", file, CompactionPolicySwitchInfo.class.getName());
       blobStoreStats.getMetrics().blobStoreRecoverCompactionPolicySwitchInfoErrorCount.inc();
-      return new CompactionPolicySwitchInfo(new CompactionPolicyCounter(storeConfig.storeCompactionPolicySwitchCounterDays),
-          INIT_COMPACT_ALL_TIME);
+      return new CompactionPolicySwitchInfo(INIT_COMPACT_ALL_TIME, false);
     }
   }
 
@@ -135,10 +142,16 @@ public class HybridCompactionPolicy implements CompactionPolicy {
       updateCompactionInfoWhenCompactAll(compactionPolicySwitchInfo);
       return new CompactAllPolicy(storeConfig, time);
     } else {
-      if (compactionPolicySwitchInfo.getCompactionPolicyCounter() == null) {
-        logger.trace("Counter is null for store : {}, dataDir : {}", storeId, dataDir);
+      if (compactionPolicySwitchInfo.getLastCompactAllTime() == 0) {
+        logger.error("Last compact all time is {} for store : {}, dataDir : {}",
+            compactionPolicySwitchInfo.getLastCompactAllTime(), storeId, dataDir);
       } else {
         logger.trace("Return StatsBasedCompactionPolicy this round for store : {}, dataDir : {}", storeId, dataDir);
+      }
+      if (compactionPolicySwitchInfo.getLastCompactAllTime() + TimeUnit.DAYS.toMillis(
+          storeConfig.storeCompactionPolicySwitchTimestampDays) <= System.currentTimeMillis()) {
+        logger.trace("Set next round is compactAllPolicy to true");
+        compactionPolicySwitchInfo.setNextRoundIsCompactAllPolicy(true);
       }
       return new StatsBasedCompactionPolicy(storeConfig, time);
     }
@@ -150,10 +163,7 @@ public class HybridCompactionPolicy implements CompactionPolicy {
    * @return {@code true} if the counter value equals to 0 or it's storeCompactionPolicySwitchPeriod days past the start time of CompactAllPolicy.
    */
   private boolean readyToTriggerCompactionAllPolicy(CompactionPolicySwitchInfo compactionPolicySwitchInfo) {
-    return compactionPolicySwitchInfo.getCompactionPolicyCounter() != null
-        && compactionPolicySwitchInfo.getCompactionPolicyCounter().getCounter() == 0 ||
-        compactionPolicySwitchInfo.getLastCompactAllTime() + TimeUnit.DAYS.toMillis(
-            storeConfig.storeCompactionPolicySwitchTimestampDays) <= System.currentTimeMillis();
+    return compactionPolicySwitchInfo.isNextRoundCompactAllPolicy();
   }
 
   /**
@@ -164,7 +174,7 @@ public class HybridCompactionPolicy implements CompactionPolicy {
    */
   private void updateCompactionInfoWhenCompactAll(CompactionPolicySwitchInfo compactionPolicySwitchInfo) {
     compactionPolicySwitchInfo.setLastCompactAllTime(System.currentTimeMillis());
-    compactionPolicySwitchInfo.getCompactionPolicyCounter().setCounter(INIT_COUNTER_VALUE);
+    compactionPolicySwitchInfo.setNextRoundIsCompactAllPolicy(false);
   }
 
   /**
@@ -181,11 +191,11 @@ public class HybridCompactionPolicy implements CompactionPolicy {
    */
   private void backUpCompactionPolicyInfo(String dataDir, CompactionPolicySwitchInfo compactionPolicySwitchInfo) {
     if (dataDir != null && !dataDir.isEmpty()) {
-      File tempFile = new File(Paths.get(dataDir, COMPACT_POLICY_INFO_PATH + ".temp").toString());
+      File tempFile = new File(dataDir, COMPACT_POLICY_INFO_PATH_V2 + ".temp");
       try {
         tempFile.createNewFile();
         objectMapper.writerWithDefaultPrettyPrinter().writeValue(tempFile, compactionPolicySwitchInfo);
-        tempFile.renameTo(new File(Paths.get(dataDir, COMPACT_POLICY_INFO_PATH).toString()));
+        tempFile.renameTo(new File(dataDir, COMPACT_POLICY_INFO_PATH_V2));
       } catch (IOException e) {
         logger.error("Exception while store compaction policy info for local report. Output file path - {}",
             tempFile.getAbsolutePath(), e);

--- a/ambry-store/src/main/java/com/github/ambry/store/Log.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/Log.java
@@ -49,7 +49,7 @@ class Log implements Write {
   private static final Logger logger = LoggerFactory.getLogger(Log.class);
   private final AtomicLong remainingUnallocatedSegments = new AtomicLong(0);
   private final String storeId;
-  private static final String COMPACT_POLICY_INFO_PATH = File.separator + "compactionPolicyInfo.json";
+  private static final String COMPACT_POLICY_INFO_PATH_V2 = File.separator + "compactionPolicyInfoV2.json";
   private static final ObjectMapper objectMapper = new ObjectMapper();
 
   private boolean isLogSegmented;
@@ -470,7 +470,8 @@ class Log implements Write {
         return true;
       } catch (IllegalStateException e) {
         //no-op
-        logger.info("There's no more capacity left in: {} to create new log segment, bypass clean up journal logic" , dataDir);
+        logger.info("There's no more capacity left in: {} to create new log segment, bypass clean up journal logic",
+            dataDir);
         return false;
       }
     }
@@ -504,7 +505,7 @@ class Log implements Write {
    * @return {@code True} if next round is compact all policy.
    */
   private boolean compactionPolicySwitchInfoCounterValueReached() {
-    File file = new File(Paths.get(dataDir, COMPACT_POLICY_INFO_PATH).toString());
+    File file = new File(dataDir, COMPACT_POLICY_INFO_PATH_V2);
     if (file.exists()) {
       CompactionPolicySwitchInfo compactionPolicySwitchInfo = null;
       try {
@@ -514,8 +515,7 @@ class Log implements Write {
             CompactionPolicySwitchInfo.class.getName());
         return false;
       }
-      if (config.storeCompactionPolicySwitchCounterDays - 1 == (compactionPolicySwitchInfo.getCompactionPolicyCounter()
-          .getCounter())) {
+      if (compactionPolicySwitchInfo.isNextRoundCompactAllPolicy()) {
         logger.trace("The compaction policy switch counter value is qualified for closing last log segment.");
         return true;
       } else {
@@ -523,7 +523,7 @@ class Log implements Write {
         return false;
       }
     } else {
-      logger.error("Compaction policy file: {} is not exist in dir: {}", COMPACT_POLICY_INFO_PATH, dataDir);
+      logger.error("Compaction policy file: {} is not exist in dir: {}", COMPACT_POLICY_INFO_PATH_V2, dataDir);
       return false;
     }
   }

--- a/ambry-store/src/main/java/com/github/ambry/store/Log.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/Log.java
@@ -20,7 +20,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -49,7 +48,7 @@ class Log implements Write {
   private static final Logger logger = LoggerFactory.getLogger(Log.class);
   private final AtomicLong remainingUnallocatedSegments = new AtomicLong(0);
   private final String storeId;
-  private static final String COMPACT_POLICY_INFO_PATH_V2 = File.separator + "compactionPolicyInfoV2.json";
+  private static final String COMPACT_POLICY_INFO_FILE_NAME_V2 = "compactionPolicyInfoV2.json";
   private static final ObjectMapper objectMapper = new ObjectMapper();
 
   private boolean isLogSegmented;
@@ -505,7 +504,7 @@ class Log implements Write {
    * @return {@code True} if next round is compact all policy.
    */
   private boolean compactionPolicySwitchInfoCounterValueReached() {
-    File file = new File(dataDir, COMPACT_POLICY_INFO_PATH_V2);
+    File file = new File(dataDir, COMPACT_POLICY_INFO_FILE_NAME_V2);
     if (file.exists()) {
       CompactionPolicySwitchInfo compactionPolicySwitchInfo = null;
       try {
@@ -523,7 +522,7 @@ class Log implements Write {
         return false;
       }
     } else {
-      logger.error("Compaction policy file: {} is not exist in dir: {}", COMPACT_POLICY_INFO_PATH_V2, dataDir);
+      logger.error("Compaction policy file: {} is not exist in dir: {}", COMPACT_POLICY_INFO_FILE_NAME_V2, dataDir);
       return false;
     }
   }

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
@@ -39,7 +39,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -95,7 +94,7 @@ public class BlobStoreCompactorTest {
   private final StoreConfig config;
   private boolean alwaysEnableTargetIndexDuplicateChecking = false;
   private final Time time = new MockTime();
-  private static final String COMPACT_POLICY_INFO_PATH_V2 = File.separator + "compactionPolicyInfoV2.json";
+  private static final String COMPACT_POLICY_INFO_FILE_NAME_V2 = "compactionPolicyInfoV2.json";
   private static final ObjectMapper objectMapper = new ObjectMapper();
 
   private CuratedLogIndexState state = null;
@@ -2918,11 +2917,11 @@ public class BlobStoreCompactorTest {
 
   private void backUpCompactionPolicyInfo(String tempDir, CompactionPolicySwitchInfo compactionPolicySwitchInfo) {
     if (tempDir != null) {
-      File tempFile = new File(tempDir, COMPACT_POLICY_INFO_PATH_V2 + ".temp");
+      File tempFile = new File(tempDir, COMPACT_POLICY_INFO_FILE_NAME_V2 + ".temp");
       try {
         tempFile.createNewFile();
         objectMapper.writerWithDefaultPrettyPrinter().writeValue(tempFile, compactionPolicySwitchInfo);
-        tempFile.renameTo(new File(tempDir, COMPACT_POLICY_INFO_PATH_V2));
+        tempFile.renameTo(new File(tempDir, COMPACT_POLICY_INFO_FILE_NAME_V2));
       } catch (IOException e) {
         logger.error("Exception while store compaction policy info for local report. Output file path - {}",
             tempFile.getAbsolutePath(), e);

--- a/ambry-store/src/test/java/com/github/ambry/store/CompactionPolicyTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CompactionPolicyTest.java
@@ -62,7 +62,7 @@ public class CompactionPolicyTest {
   private final Path dataDirPath;
   private static final Logger logger = LoggerFactory.getLogger(CompactionPolicyTest.class);
   private static final ObjectMapper objectMapper = new ObjectMapper();
-  private static final String COMPACT_POLICY_INFO_PATH_V2 = File.separator + "compactionPolicyInfoV2.json";
+  private static final String COMPACT_POLICY_INFO_FILE_NAME_V2 = "compactionPolicyInfoV2.json";
 
   // the properties that will used to generate a StoreConfig. Clear before use if required.
   private final Properties properties = new Properties();
@@ -126,7 +126,7 @@ public class CompactionPolicyTest {
       tmpDir.mkdir();
     }
     compactionManager.getCompactionDetails(blobStore);
-    File compactionPolicyInfoFile = new File(tmpDir.toString(), COMPACT_POLICY_INFO_PATH_V2);
+    File compactionPolicyInfoFile = new File(tmpDir.toString(), COMPACT_POLICY_INFO_FILE_NAME_V2);
     CompactionPolicySwitchInfo compactionPolicySwitchInfo =
         objectMapper.readValue(compactionPolicyInfoFile, CompactionPolicySwitchInfo.class);
     assertFalse("Next round of compaction is not compactAll", compactionPolicySwitchInfo.isNextRoundCompactAllPolicy());
@@ -282,7 +282,7 @@ public class CompactionPolicyTest {
     File[] files = backupDir.listFiles(tempFileFilter);
     if (files != null) {
       for (File file : files) {
-        File deleteFile = new File(MOUNT_PATH + file.getName() + File.separator + "compactionPolicyInfo.json");
+        File deleteFile = new File(MOUNT_PATH + file.getName(), "compactionPolicyInfo.json");
         logger.trace("Delete temp file {}", deleteFile.getName());
         deleteFile(deleteFile.toPath());
       }

--- a/ambry-store/src/test/java/com/github/ambry/store/CompactionPolicyTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CompactionPolicyTest.java
@@ -14,6 +14,7 @@
 package com.github.ambry.store;
 
 import com.codahale.metrics.MetricRegistry;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.ambry.account.InMemAccountService;
 import com.github.ambry.config.StoreConfig;
 import com.github.ambry.config.VerifiableProperties;
@@ -60,6 +61,8 @@ public class CompactionPolicyTest {
   private static final String MOUNT_PATH = "/tmp/";
   private final Path dataDirPath;
   private static final Logger logger = LoggerFactory.getLogger(CompactionPolicyTest.class);
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+  private static final String COMPACT_POLICY_INFO_PATH_V2 = File.separator + "compactionPolicyInfoV2.json";
 
   // the properties that will used to generate a StoreConfig. Clear before use if required.
   private final Properties properties = new Properties();
@@ -106,94 +109,43 @@ public class CompactionPolicyTest {
     cleanupBackupFiles();
     // with compaction enabled.
     properties.setProperty("store.compaction.triggers", "Periodic");
-    properties.setProperty("store.compaction.policy.switch.counter.days", "3");
-    properties.setProperty("store.compaction.policy.switch.timestamp.days", "7");
+    properties.setProperty("store.compaction.policy.switch.timestamp.days", "6");
     properties.setProperty("store.compaction.policy.factory", "com.github.ambry.store.HybridCompactionPolicyFactory");
     config = new StoreConfig(new VerifiableProperties(properties));
     MetricRegistry metricRegistry = new MetricRegistry();
     CompactionManager compactionManager = new CompactionManager(MOUNT_PATH, config, Collections.singleton(blobStore),
         new StorageManagerMetrics(metricRegistry), time);
     StoreMetrics metrics = new StoreMetrics(metricRegistry);
-    int numStores = 5;
-    for (int i = 1; i <= numStores; i++) {
-      MockBlobStoreStats mockBlobStoreStats = new MockBlobStoreStats(DEFAULT_MAX_BLOB_SIZE, i);
-      MockBlobStore blobStore =
-          new MockBlobStore(config, metrics, time, CAPACITY_IN_BYTES, SEGMENT_CAPACITY_IN_BYTES, SEGMENT_HEADER_SIZE,
-              DEFAULT_USED_CAPACITY_IN_BYTES,
-              mockBlobStoreStats);      //BlobStore store = Mockito.mock(BlobStore.class);
-      String blobId = mockBlobStoreStats.getStoreId();
-      File tmpFile = new File(MOUNT_PATH + blobId);
-      if (!tmpFile.exists()) {
-        tmpFile.mkdir();
-      }
-      compactionManager.getCompactionDetails(blobStore);
-      assertEquals("Counter value should match with expectation", 1 % config.storeCompactionPolicySwitchCounterDays,
-          ((HybridCompactionPolicy) compactionManager.getCompactionPolicy()).getBlobToCompactionPolicySwitchInfoMap()
-              .get(blobId)
-              .getCompactionPolicyCounter()
-              .getCounter());
-      compactionManager.getCompactionDetails(blobStore);
-      assertEquals("Counter value should match with expectation", 2 % config.storeCompactionPolicySwitchCounterDays,
-          ((HybridCompactionPolicy) compactionManager.getCompactionPolicy()).getBlobToCompactionPolicySwitchInfoMap()
-              .get(blobId)
-              .getCompactionPolicyCounter()
-              .getCounter());
-      compactionManager.getCompactionDetails(blobStore);
-      assertEquals("Counter value should match with expectation", 3 % config.storeCompactionPolicySwitchCounterDays,
-          ((HybridCompactionPolicy) compactionManager.getCompactionPolicy()).getBlobToCompactionPolicySwitchInfoMap()
-              .get(blobId)
-              .getCompactionPolicyCounter()
-              .getCounter());
-      //set last compactAll kick off time to current time to trigger compactAllPolicy
-      ((HybridCompactionPolicy) compactionManager.getCompactionPolicy()).getBlobToCompactionPolicySwitchInfoMap()
-          .get(blobId)
-          .setLastCompactAllTime(
-              System.currentTimeMillis() - TimeUnit.DAYS.toMillis(config.storeCompactionPolicySwitchTimestampDays));
-      compactionManager.getCompactionDetails(blobStore);
-      assertEquals("TimeStamp will be set to the compactAllPolicy kick off time",
-          1 % config.storeCompactionPolicySwitchCounterDays,
-          ((HybridCompactionPolicy) compactionManager.getCompactionPolicy()).getBlobToCompactionPolicySwitchInfoMap()
-              .get(blobId)
-              .getCompactionPolicyCounter()
-              .getCounter());
-      //set last compactAll kick off time to current time to trigger compactAllPolicy
-      ((HybridCompactionPolicy) compactionManager.getCompactionPolicy()).getBlobToCompactionPolicySwitchInfoMap()
-          .get(blobId)
-          .setLastCompactAllTime(
-              System.currentTimeMillis() - TimeUnit.DAYS.toMillis(config.storeCompactionPolicySwitchTimestampDays));
-      compactionManager.getCompactionDetails(blobStore);
-      assertEquals("TimeStamp will be set to the compactAllPolicy kick off time",
-          1 % config.storeCompactionPolicySwitchTimestampDays,
-          ((HybridCompactionPolicy) compactionManager.getCompactionPolicy()).getBlobToCompactionPolicySwitchInfoMap()
-              .get(blobId)
-              .getCompactionPolicyCounter()
-              .getCounter());
-      //add one more round to check if compaction will be recovered from backup file
-      compactionManager.getCompactionDetails(blobStore);
-      assertEquals("Counter value should match with expectation", 2 % config.storeCompactionPolicySwitchCounterDays,
-          ((HybridCompactionPolicy) compactionManager.getCompactionPolicy()).getBlobToCompactionPolicySwitchInfoMap()
-              .get(blobId)
-              .getCompactionPolicyCounter()
-              .getCounter());
-    }
-    //check BlobToCompactionPolicySwitchInfoMap match with expectation.
-    assertEquals("map size should equals to number of stores", numStores,
-        ((HybridCompactionPolicy) compactionManager.getCompactionPolicy()).getBlobToCompactionPolicySwitchInfoMap()
-            .size());
-
-    //add one more round to check if compaction will be recovered from backup file
     MockBlobStoreStats mockBlobStoreStats = new MockBlobStoreStats(DEFAULT_MAX_BLOB_SIZE, 1);
     MockBlobStore blobStore =
         new MockBlobStore(config, metrics, time, CAPACITY_IN_BYTES, SEGMENT_CAPACITY_IN_BYTES, SEGMENT_HEADER_SIZE,
-            DEFAULT_USED_CAPACITY_IN_BYTES, mockBlobStoreStats);      //BlobStore store = Mockito.mock(BlobStore.class);
+            DEFAULT_USED_CAPACITY_IN_BYTES, mockBlobStoreStats);
     String blobId = mockBlobStoreStats.getStoreId();
+    File tmpDir = new File(MOUNT_PATH + blobId);
+    if (!tmpDir.exists()) {
+      tmpDir.mkdir();
+    }
+    compactionManager.getCompactionDetails(blobStore);
+    File compactionPolicyInfoFile = new File(tmpDir.toString(), COMPACT_POLICY_INFO_PATH_V2);
+    CompactionPolicySwitchInfo compactionPolicySwitchInfo =
+        objectMapper.readValue(compactionPolicyInfoFile, CompactionPolicySwitchInfo.class);
+    assertFalse("Next round of compaction is not compactAll", compactionPolicySwitchInfo.isNextRoundCompactAllPolicy());
+    //set last compactAll kick off time to current time to trigger compactAllPolicy
+    compactionPolicySwitchInfo.setLastCompactAllTime(
+        compactionPolicySwitchInfo.getLastCompactAllTime() - TimeUnit.DAYS.toMillis(
+            config.storeCompactionPolicySwitchTimestampDays));
+    ((HybridCompactionPolicy) compactionManager.getCompactionPolicy()).getBlobToCompactionPolicySwitchInfoMap()
+        .put(mockBlobStoreStats.getStoreId(), compactionPolicySwitchInfo);
+    objectMapper.writerWithDefaultPrettyPrinter().writeValue(compactionPolicyInfoFile, compactionPolicySwitchInfo);
+    compactionManager.getCompactionDetails(blobStore);
+    compactionPolicySwitchInfo = objectMapper.readValue(compactionPolicyInfoFile, CompactionPolicySwitchInfo.class);
+    assertTrue("Next round of compaction is not compactAll", compactionPolicySwitchInfo.isNextRoundCompactAllPolicy());
+
+    //add one more round to check if compaction will be recovered from backup file
     ((HybridCompactionPolicy) compactionManager.getCompactionPolicy()).getBlobToCompactionPolicySwitchInfoMap().clear();
     compactionManager.getCompactionDetails(blobStore);
-    assertEquals("Counter value should match with expectation", 3 % config.storeCompactionPolicySwitchCounterDays,
-        ((HybridCompactionPolicy) compactionManager.getCompactionPolicy()).getBlobToCompactionPolicySwitchInfoMap()
-            .get(blobId)
-            .getCompactionPolicyCounter()
-            .getCounter());
+    compactionPolicySwitchInfo = objectMapper.readValue(compactionPolicyInfoFile, CompactionPolicySwitchInfo.class);
+    assertFalse("Next round of compaction is not compactAll", compactionPolicySwitchInfo.isNextRoundCompactAllPolicy());
   }
 
   /**


### PR DESCRIPTION
In the future, we may speed up the frequency for running compaction, if we still leverage the counter to determine the policy switch, the counter value need to be updated correspondingly. So this pr removed the counter in Hybrid Compaction Policy and only leverage timestamp.