### PR TITLE
Use concurrent hash map for inner value-Map to avoid concurrent modification exception.

### DIFF
--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -612,11 +612,6 @@ public class ReplicaThread implements Runnable {
                   }
                 }
 
-                // add exchangeMetadataResponse to list after replicaSyncUpManager(if not null) has completed update. The
-                // reason is replicaSyncUpManager may also throw exception and add one more exchangeMetadataResponse
-                // associated with same RemoteReplicaInfo.
-                exchangeMetadataResponseList.add(exchangeMetadataResponse);
-
                 // If remote token has not moved forward, wait for back off time before resending next metadata request
                 if (remoteReplicaInfo.getToken().equals(exchangeMetadataResponse.remoteToken)) {
                   remoteReplicaInfo.setReEnableReplicationTime(
@@ -646,6 +641,11 @@ public class ReplicaThread implements Runnable {
                           .get(replicaMetadataResponseInfo.getMessageInfoList().size() - 1)
                           .getOperationTimeMs());
                 }
+
+                // Add exchangeMetadataResponse to list at the end after operations such as replicaSyncUpManager(if not null)
+                // has completed update, etc. The reason is we may get exceptions in between (for ex: replicaSyncUpManager may
+                // throw exception) and end up adding one more exchangeMetadataResponse associated with same RemoteReplicaInfo.
+                exchangeMetadataResponseList.add(exchangeMetadataResponse);
               } catch (Exception e) {
                 if (e instanceof StoreException
                     && ((StoreException) e).getErrorCode() == StoreErrorCodes.Store_Not_Started) {

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationMetrics.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationMetrics.java
@@ -453,7 +453,8 @@ public class ReplicationMetrics {
    */
   public void addLagMetricForPartition(PartitionId partitionId, boolean enableEmmitMetricForReplicaLag) {
     if (!partitionLags.containsKey(partitionId)) {
-      partitionLags.put(partitionId, new HashMap<>());
+      // Use concurrent hash map for the inner value map as well to avoid concurrent modification exception.
+      partitionLags.put(partitionId, new ConcurrentHashMap<>());
       // Set up metrics if and only if no mapping for this partition before.
       if (enableEmmitMetricForReplicaLag) {
         Gauge<Long> replicaLag = () -> getMaxLagForPartition(partitionId);


### PR DESCRIPTION
This PR fixes the exception due to concurrent modification on a collection used as a value inside concurrent hash map.