### PR TITLE
DO NOT MERGE: Basic Sample for cross dc retries

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/MySqlNamedBlobDbConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/MySqlNamedBlobDbConfig.java
@@ -18,7 +18,8 @@ package com.github.ambry.config;
 public class MySqlNamedBlobDbConfig {
   private static final String PREFIX = "mysql.named.blob.";
   public static final String DB_INFO = PREFIX + "db.info";
-  public static final String POOL_SIZE = PREFIX + "pool.size";
+  public static final String LOCAL_POOL_SIZE = PREFIX + "local.pool.size";
+  public static final String REMOTE_POOL_SIZE = PREFIX + "remote.pool.size";
   public static final String  LIST_MAX_RESULTS = PREFIX + "list.max.results";
 
   /**
@@ -29,11 +30,18 @@ public class MySqlNamedBlobDbConfig {
   public final String dbInfo;
 
   /**
-   * Number of connections and threads to use for executing transactions.
+   * Number of connections and threads to use for executing transactions against databases in the local datacenter.
    */
-  @Config(POOL_SIZE)
-  @Default("10")
-  public final int poolSize;
+  @Config(LOCAL_POOL_SIZE)
+  @Default("5")
+  public final int localPoolSize;
+
+  /**
+   * Number of connections and threads to use for executing transactions against databases in a remote datacenter.
+   */
+  @Config(LOCAL_POOL_SIZE)
+  @Default("1")
+  public final int remotePoolSize;
 
   /**
    * The maximum number of entries to return per response page when listing blobs.
@@ -44,7 +52,8 @@ public class MySqlNamedBlobDbConfig {
 
   public MySqlNamedBlobDbConfig(VerifiableProperties verifiableProperties) {
     this.dbInfo = verifiableProperties.getString(DB_INFO);
-    this.poolSize = verifiableProperties.getIntInRange(POOL_SIZE, 10, 1, Integer.MAX_VALUE);
+    this.localPoolSize = verifiableProperties.getIntInRange(LOCAL_POOL_SIZE, 5, 1, Integer.MAX_VALUE);
+    this.remotePoolSize = verifiableProperties.getIntInRange(REMOTE_POOL_SIZE, 1, 1, Integer.MAX_VALUE);
     this.listMaxResults = verifiableProperties.getIntInRange(LIST_MAX_RESULTS, 100, 1, Integer.MAX_VALUE);
   }
 }

--- a/ambry-named-mysql/src/main/java/com/github/ambry/named/MySqlNamedBlobDbFactory.java
+++ b/ambry-named-mysql/src/main/java/com/github/ambry/named/MySqlNamedBlobDbFactory.java
@@ -17,10 +17,10 @@ package com.github.ambry.named;
 
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.account.AccountService;
-import com.github.ambry.mysql.MySqlUtils.DbEndpoint;
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.MySqlNamedBlobDbConfig;
 import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.mysql.MySqlUtils.DbEndpoint;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 
@@ -53,7 +53,8 @@ public class MySqlNamedBlobDbFactory implements NamedBlobDbFactory {
     hikariConfig.setJdbcUrl(dbEndpoint.getUrl());
     hikariConfig.setUsername(dbEndpoint.getUsername());
     hikariConfig.setPassword(dbEndpoint.getPassword());
-    hikariConfig.setMaximumPoolSize(config.poolSize);
+    hikariConfig.setMaximumPoolSize(
+        dbEndpoint.getDatacenter().equals(localDatacenter) ? config.localPoolSize : config.remotePoolSize);
     // Recommended properties for automatic prepared statement caching
     // https://github.com/brettwooldridge/HikariCP/wiki/MySQL-Configuration
     hikariConfig.addDataSourceProperty("cachePrepStmts", "true");

--- a/ambry-utils/src/main/java/com/github/ambry/utils/BatchBlockingQueue.java
+++ b/ambry-utils/src/main/java/com/github/ambry/utils/BatchBlockingQueue.java
@@ -18,7 +18,6 @@ package com.github.ambry.utils;
 import java.util.AbstractCollection;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
@@ -94,8 +93,7 @@ public class BatchBlockingQueue<E> {
       return;
     }
     // Filter out any wakeup markers that may be in the queue. These are only there to stop a timed poll early.
-    FilteredInserter<E> filteredInserter =
-        new BatchBlockingQueue.FilteredInserter<>(returnList, e -> e != wakeupMarker);
+    FilteredInserter<E> filteredInserter = new FilteredInserter<>(returnList, e -> e != wakeupMarker);
     filteredInserter.add(first);
     queue.drainTo(filteredInserter);
   }
@@ -122,7 +120,8 @@ public class BatchBlockingQueue<E> {
 
   /**
    * An implementation of {@link AbstractCollection} to be used to insert items that match a predicate into a
-   * collection. This can be useful when methods add items to a {@link Collections}, but
+   * collection. This can be useful to avoid extra iteration/copying when methods can only add items to a
+   * {@link Collection} instance.
    */
   private static class FilteredInserter<T> extends AbstractCollection<T> {
     private final Collection<T> data;

--- a/build.gradle
+++ b/build.gradle
@@ -158,7 +158,6 @@ project(':ambry-utils') {
         compile "commons-codec:commons-codec:$commonsVersion"
         compile "org.json:json:$jsonVersion"
         compile "net.sf.jopt-simple:jopt-simple:$joptSimpleVersion"
-        compile "io.netty:netty-buffer:$nettyVersion"
         compile "io.netty:netty-all:$nettyVersion"
         testCompile project(":ambry-test-utils")
     }
@@ -181,7 +180,6 @@ project(':ambry-api') {
         compile "io.dropwizard.metrics:metrics-core:$metricsVersion"
         compile "com.fasterxml.jackson.core:jackson-core:$jacksonVersion"
         compile "com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion"
-        compile "io.netty:netty-buffer:$nettyVersion"
         testCompile project(':ambry-clustermap')
         testCompile project(':ambry-test-utils')
     }
@@ -394,7 +392,6 @@ project(':ambry-router') {
                 project(':ambry-rest')
         compile "io.dropwizard.metrics:metrics-core:$metricsVersion"
         compile "org.bouncycastle:bcpkix-jdk15on:$bouncycastleVersion"
-        compile "io.netty:netty-buffer:$nettyVersion"
         testCompile project(':ambry-test-utils')
         testCompile project(path: ':ambry-network', configuration: 'testArchives')
         testCompile project(path: ':ambry-cloud', configuration: 'testArchives')


### PR DESCRIPTION
Skeleton of prod code modifications to enable retries on other DC so that it can be shared with @SophieGuo410 .

Description of changes:

Make a class `TransactionExecutor` for each datacenter, mysql connection pair. This is in charge of running a transaction asynchronously on a thread pool isolated for that datacenter, so that long latency cross colo requests do not block local datacenter requests.

Added a skeleton of a class `TransactionStateTracker` that can be supplied to the `executeTransaction` method. This is similar to the operation tracker in the router. It should determine if a request should be retried on another datacenter based on an exception received from the last datacenter tried (`processFailure`). If `processFailure` returned true, the next call to `getDatacenter` should return the datacenter to retry on. In the future we can potentially extend this to support parallel retries and ways to choose a result among multiple options based on some criteria (i.e. most recently updated in any datacenter)

Use RetryExecutor to retry from the callback instead of blocking the main thread. This may need more cleanup/extra functionality but it was easy to reuse the class in its current form here. We can consider pros/cons of having actual backoff vs just retrying immediately.