### PR TITLE
Add a gauge metric to record the number of log segment compacted in compaction

### DIFF
--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
@@ -43,6 +43,7 @@ import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -103,8 +104,8 @@ class BlobStoreCompactor {
   private volatile CountDownLatch runningLatch = new CountDownLatch(0);
   private byte[] bundleReadBuffer;
   private final AtomicReference<CompactionDetails> currentCompactionDetails = new AtomicReference();
-  private final AtomicLong compactedLogCount = new AtomicLong(0L);
-  private final AtomicLong logSegmentCount = new AtomicLong(0L);
+  private final AtomicInteger compactedLogCount = new AtomicInteger(0);
+  private final AtomicInteger logSegmentCount = new AtomicInteger(0);
 
   /**
    * Constructs the compactor component.
@@ -1160,7 +1161,7 @@ class BlobStoreCompactor {
           // eg: log segment under compaction [0_23, 130_16, 144_3]
           //     log segment after compaction [0_24, 130_24, 155_0, 166_0]
           // log segment 144_3's position doesn't exist in the compaction log, so we have one log segment compacted.
-          compactedLogCount.set(logSegmentPositionsUnderCompaction.stream()
+          compactedLogCount.set((int)logSegmentPositionsUnderCompaction.stream()
               .filter(p -> !logSegmentPositionsAfterCompaction.contains(p))
               .count());
         }

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
@@ -104,6 +104,7 @@ class BlobStoreCompactor {
   private byte[] bundleReadBuffer;
   private final AtomicReference<CompactionDetails> currentCompactionDetails = new AtomicReference();
   private final AtomicLong compactedLogCount = new AtomicLong(0L);
+  private final AtomicLong logSegmentCount = new AtomicLong(0L);
 
   /**
    * Constructs the compactor component.
@@ -169,7 +170,8 @@ class BlobStoreCompactor {
     isActive = true;
     logger.info("Direct IO config: {}, OS: {}, availability: {}", config.storeCompactionEnableDirectIO,
         System.getProperty("os.name"), useDirectIO);
-    srcMetrics.initializeCompactorGauges(storeId, compactionInProgress, currentCompactionDetails, compactedLogCount);
+    srcMetrics.initializeCompactorGauges(storeId, compactionInProgress, currentCompactionDetails, compactedLogCount,
+        logSegmentCount);
     logger.trace("Initialized BlobStoreCompactor for {}", storeId);
   }
 
@@ -1140,15 +1142,16 @@ class BlobStoreCompactor {
         logger.info("Compaction of {} finished", storeId);
         if (srcIndex != null && !srcIndex.isEmpty() && !compactionLog.cycleLogs.isEmpty()) {
           // The log segment positions after compaction
-          Set<Long> compactedLogSegments = srcIndex.getLogSegments()
+          Set<Long> logSegmentPositionsAfterCompaction = srcIndex.getLogSegments()
               .stream()
               .map(LogSegment::getName)
               .map(LogSegmentName::getPosition)
               .collect(Collectors.toSet());
+          logSegmentCount.set(logSegmentPositionsAfterCompaction.size());
           // The log segment positions under compaction
-          Set<Long> logSegmentsUnderCompaction = new HashSet<>();
+          Set<Long> logSegmentPositionsUnderCompaction = new HashSet<>();
           for (CompactionLog.CycleLog clog : compactionLog.cycleLogs) {
-            logSegmentsUnderCompaction.addAll(clog.compactionDetails.getLogSegmentsUnderCompaction()
+            logSegmentPositionsUnderCompaction.addAll(clog.compactionDetails.getLogSegmentsUnderCompaction()
                 .stream()
                 .map(LogSegmentName::getPosition)
                 .collect(Collectors.toSet()));
@@ -1157,8 +1160,9 @@ class BlobStoreCompactor {
           // eg: log segment under compaction [0_23, 130_16, 144_3]
           //     log segment after compaction [0_24, 130_24, 155_0, 166_0]
           // log segment 144_3's position doesn't exist in the compaction log, so we have one log segment compacted.
-          compactedLogCount.set(
-              logSegmentsUnderCompaction.stream().filter(p -> !compactedLogSegments.contains(p)).count());
+          compactedLogCount.set(logSegmentPositionsUnderCompaction.stream()
+              .filter(p -> !logSegmentPositionsAfterCompaction.contains(p))
+              .count());
         }
 
         if (srcIndex != null && srcIndex.hardDeleter != null) {

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
@@ -103,6 +103,7 @@ class BlobStoreCompactor {
   private volatile CountDownLatch runningLatch = new CountDownLatch(0);
   private byte[] bundleReadBuffer;
   private final AtomicReference<CompactionDetails> currentCompactionDetails = new AtomicReference();
+  private final AtomicLong compactedLogCount = new AtomicLong(0L);
 
   /**
    * Constructs the compactor component.
@@ -168,7 +169,7 @@ class BlobStoreCompactor {
     isActive = true;
     logger.info("Direct IO config: {}, OS: {}, availability: {}", config.storeCompactionEnableDirectIO,
         System.getProperty("os.name"), useDirectIO);
-    srcMetrics.initializeCompactorGauges(storeId, compactionInProgress, currentCompactionDetails);
+    srcMetrics.initializeCompactorGauges(storeId, compactionInProgress, currentCompactionDetails, compactedLogCount);
     logger.trace("Initialized BlobStoreCompactor for {}", storeId);
   }
 
@@ -1137,6 +1138,29 @@ class BlobStoreCompactor {
     if (compactionLog != null) {
       if (compactionLog.getCompactionPhase().equals(CompactionLog.Phase.DONE)) {
         logger.info("Compaction of {} finished", storeId);
+        if (srcIndex != null && !srcIndex.isEmpty() && !compactionLog.cycleLogs.isEmpty()) {
+          // The log segment positions after compaction
+          Set<Long> compactedLogSegments = srcIndex.getLogSegments()
+              .stream()
+              .map(LogSegment::getName)
+              .map(LogSegmentName::getPosition)
+              .collect(Collectors.toSet());
+          // The log segment positions under compaction
+          Set<Long> logSegmentsUnderCompaction = new HashSet<>();
+          for (CompactionLog.CycleLog clog : compactionLog.cycleLogs) {
+            logSegmentsUnderCompaction.addAll(clog.compactionDetails.getLogSegmentsUnderCompaction()
+                .stream()
+                .map(LogSegmentName::getPosition)
+                .collect(Collectors.toSet()));
+          }
+          // If the position under compaction doesn't exist in the set after compaction, then this log segment is compacted
+          // eg: log segment under compaction [0_23, 130_16, 144_3]
+          //     log segment after compaction [0_24, 130_24, 155_0, 166_0]
+          // log segment 144_3's position doesn't exist in the compaction log, so we have one log segment compacted.
+          compactedLogCount.set(
+              logSegmentsUnderCompaction.stream().filter(p -> !compactedLogSegments.contains(p)).count());
+        }
+
         if (srcIndex != null && srcIndex.hardDeleter != null) {
           srcIndex.hardDeleter.resume();
         }

--- a/ambry-store/src/main/java/com/github/ambry/store/StoreMetrics.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StoreMetrics.java
@@ -21,7 +21,7 @@ import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -307,8 +307,8 @@ public class StoreMetrics {
   }
 
   void initializeCompactorGauges(String storeId, final AtomicBoolean compactionInProgress,
-      AtomicReference<CompactionDetails> compactionDetailsAtomicReference, AtomicLong compactedLogCount,
-      AtomicLong logSegmentCount) {
+      AtomicReference<CompactionDetails> compactionDetailsAtomicReference, AtomicInteger compactedLogCount,
+      AtomicInteger logSegmentCount) {
     String prefix = storeId + SEPARATOR;
     Gauge<Long> compactionInProgressGauge = () -> compactionInProgress.get() ? 1L : 0L;
     registry.register(MetricRegistry.name(BlobStoreCompactor.class, prefix + "CompactionInProgress"),
@@ -331,10 +331,10 @@ public class StoreMetrics {
       }
     };
     registry.register(MetricRegistry.name(BlobStoreCompactor.class, prefix + "CompactionBenefit"), compactionBenefit);
-    Gauge<Long> compactedLogCountGauge = compactedLogCount::get;
+    Gauge<Integer> compactedLogCountGauge = compactedLogCount::get;
     registry.gauge(MetricRegistry.name(BlobStoreCompactor.class, prefix + "CompactedLogCount"),
         () -> compactedLogCountGauge);
-    Gauge<Long> logSegmentCountGauge = logSegmentCount::get;
+    Gauge<Integer> logSegmentCountGauge = logSegmentCount::get;
     registry.gauge(MetricRegistry.name(BlobStoreCompactor.class, prefix + "LogSegmentCount"),
         () -> logSegmentCountGauge);
   }

--- a/ambry-store/src/main/java/com/github/ambry/store/StoreMetrics.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StoreMetrics.java
@@ -21,6 +21,7 @@ import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -306,7 +307,7 @@ public class StoreMetrics {
   }
 
   void initializeCompactorGauges(String storeId, final AtomicBoolean compactionInProgress,
-      AtomicReference<CompactionDetails> compactionDetailsAtomicReference) {
+      AtomicReference<CompactionDetails> compactionDetailsAtomicReference, AtomicLong compactedLogCount) {
     String prefix = storeId + SEPARATOR;
     Gauge<Long> compactionInProgressGauge = () -> compactionInProgress.get() ? 1L : 0L;
     registry.register(MetricRegistry.name(BlobStoreCompactor.class, prefix + "CompactionInProgress"),
@@ -329,6 +330,9 @@ public class StoreMetrics {
       }
     };
     registry.register(MetricRegistry.name(BlobStoreCompactor.class, prefix + "CompactionBenefit"), compactionBenefit);
+    Gauge<Long> compactedLogCountGauge = compactedLogCount::get;
+    registry.gauge(MetricRegistry.name(BlobStoreCompactor.class, prefix + "CompactedLogCount"),
+        () -> compactedLogCountGauge);
   }
 
   /**

--- a/ambry-store/src/main/java/com/github/ambry/store/StoreMetrics.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StoreMetrics.java
@@ -307,7 +307,8 @@ public class StoreMetrics {
   }
 
   void initializeCompactorGauges(String storeId, final AtomicBoolean compactionInProgress,
-      AtomicReference<CompactionDetails> compactionDetailsAtomicReference, AtomicLong compactedLogCount) {
+      AtomicReference<CompactionDetails> compactionDetailsAtomicReference, AtomicLong compactedLogCount,
+      AtomicLong logSegmentCount) {
     String prefix = storeId + SEPARATOR;
     Gauge<Long> compactionInProgressGauge = () -> compactionInProgress.get() ? 1L : 0L;
     registry.register(MetricRegistry.name(BlobStoreCompactor.class, prefix + "CompactionInProgress"),
@@ -333,6 +334,9 @@ public class StoreMetrics {
     Gauge<Long> compactedLogCountGauge = compactedLogCount::get;
     registry.gauge(MetricRegistry.name(BlobStoreCompactor.class, prefix + "CompactedLogCount"),
         () -> compactedLogCountGauge);
+    Gauge<Long> logSegmentCountGauge = logSegmentCount::get;
+    registry.gauge(MetricRegistry.name(BlobStoreCompactor.class, prefix + "LogSegmentCount"),
+        () -> logSegmentCountGauge);
   }
 
   /**


### PR DESCRIPTION
Adding a metric to record how many log segments we can save from each round of compaction. 
We are expecting at least 1 log segment saved in StatsBasedCompactionStrategy.

This PR introduced a complex way to count how many segments are compacted because this PR also handles the case where process failed in the middle of compaction. The easy way is to have a variable to store the number of log segment before compaction and then after compaction we just subtract this number. But this won't work when the process fails in the middle of the compaction. That's why we need this complex method.