### PR TITLE
Fix NPE in findkey method when index is updated due to compaction

### DIFF
--- a/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
@@ -763,10 +763,17 @@ class PersistentIndex {
         logger.trace("Searching all indexes for {} in the entire index", key);
         segmentsMapToSearch = indexSegments.descendingMap();
       } else {
-        logger.trace("Searching all indexes for {} in index with filespan ranging from {} to {}", key,
+        logger.trace("Searching all indexes for {} in index with fileSpan ranging from {} to {}", key,
             fileSpan.getStartOffset(), fileSpan.getEndOffset());
-        segmentsMapToSearch = indexSegments.subMap(indexSegments.floorKey(fileSpan.getStartOffset()), true,
-            indexSegments.lowerKey(fileSpan.getEndOffset()), true).descendingMap();
+        Offset fromIndexOffset = indexSegments.floorKey(fileSpan.getStartOffset());
+        Offset toIndexOffset = indexSegments.lowerKey(fileSpan.getEndOffset());
+        if (toIndexOffset == null) {
+          segmentsMapToSearch = new ConcurrentSkipListMap<>();
+        } else {
+          segmentsMapToSearch =
+              indexSegments.subMap(fromIndexOffset == null ? indexSegments.firstKey() : fromIndexOffset, true,
+                  indexSegments.lowerKey(fileSpan.getEndOffset()), true).descendingMap();
+        }
         metrics.segmentSizeForExists.update(segmentsMapToSearch.size());
       }
       int segmentsSearched = 0;

--- a/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
@@ -649,10 +649,17 @@ class PersistentIndex {
         logger.trace("Searching for {} in the entire index", key);
         segmentsMapToSearch = indexSegments.descendingMap();
       } else {
-        logger.trace("Searching for {} in index with filespan ranging from {} to {}", key, fileSpan.getStartOffset(),
+        logger.trace("Searching for {} in index with filSpan ranging from {} to {}", key, fileSpan.getStartOffset(),
             fileSpan.getEndOffset());
-        segmentsMapToSearch = indexSegments.subMap(indexSegments.floorKey(fileSpan.getStartOffset()), true,
-            indexSegments.lowerKey(fileSpan.getEndOffset()), true).descendingMap();
+        Offset fromIndexOffset = indexSegments.floorKey(fileSpan.getStartOffset());
+        Offset toIndexOffset = indexSegments.lowerKey(fileSpan.getEndOffset());
+        if (toIndexOffset == null) {
+          segmentsMapToSearch = new ConcurrentSkipListMap<>();
+        } else {
+          segmentsMapToSearch =
+              indexSegments.subMap(fromIndexOffset == null ? indexSegments.firstKey() : fromIndexOffset, true,
+                  toIndexOffset, true).descendingMap();
+        }
         metrics.segmentSizeForExists.update(segmentsMapToSearch.size());
       }
       int segmentsSearched = 0;

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
@@ -419,7 +419,7 @@ public class BlobStoreCompactorTest {
     } finally {
       compactor.close(0);
     }
-    // find the key by using old file span (the 1_0 log segment has been compacted to 1_1). The index should use current
+    // find the key by using old file span (the 0_0 log segment has been compacted to 0_1). The index should use current
     // first segment if there is no log segment found less than or equal to start offset in old file span.
     IndexValue indexValue = state.index.findKey(tombstone1, oldFileSpan);
     assertNotNull("The key should exist", indexValue);

--- a/ambry-store/src/test/java/com/github/ambry/store/IndexTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/IndexTest.java
@@ -1595,11 +1595,10 @@ public class IndexTest {
 
   /**
    * Test that verifies that everything is ok even if {@link MessageStoreHardDelete} instance provided is null.
-   * @throws IOException
    * @throws StoreException
    */
   @Test
-  public void hardDeleteNullTest() throws IOException, StoreException {
+  public void hardDeleteNullTest() throws StoreException {
     state.hardDelete = null;
     state.reloadIndex(true, false);
     state.addPutEntries(1, CuratedLogIndexState.PUT_RECORD_SIZE, Utils.Infinite_Time);
@@ -1728,7 +1727,7 @@ public class IndexTest {
    * Tests the behavior of {@link Journal} bootstrap.
    */
   @Test
-  public void journalBootstrapTest() throws StoreException, IOException {
+  public void journalBootstrapTest() throws StoreException {
     if (state.getMaxInMemElements() <= 1) {
       fail("This test can work only if the max in mem elements config > 1");
     }
@@ -1804,7 +1803,7 @@ public class IndexTest {
   private void undeleteKeyAndVerify(StoreKey targetKey, short expectedLifeVersion, boolean expectTtlUpdateSet)
       throws StoreException {
     assertTrue("targetKey is not deleted", state.index.findKey(targetKey).isDelete());
-    assertTrue("targetKey is undeleted early", !state.index.findKey(targetKey).isUndelete());
+    assertFalse("targetKey is undeleted early", state.index.findKey(targetKey).isUndelete());
     IndexValue prevValue = state.index.findKey(targetKey);
     assertEquals("Life version isn't " + (expectedLifeVersion - 1) + " but " + prevValue.getLifeVersion(),
         expectedLifeVersion - 1, prevValue.getLifeVersion());
@@ -1841,14 +1840,14 @@ public class IndexTest {
    * @throws StoreException
    */
   private void deleteKeyAndVerify(StoreKey key, short expectedLifeVersion) throws StoreException {
-    assertTrue("targetKey is already deleted", !state.index.findKey(key).isDelete());
+    assertFalse("targetKey is already deleted", state.index.findKey(key).isDelete());
     short actualLifeVersion = state.index.findKey(key).getLifeVersion();
     assertEquals("Life version isn't " + expectedLifeVersion + " but " + actualLifeVersion, expectedLifeVersion,
         actualLifeVersion);
     state.appendToLog(DELETE_RECORD_SIZE);
     FileSpan fileSpan = state.log.getFileSpanForMessage(state.index.getCurrentEndOffset(), DELETE_RECORD_SIZE);
     state.index.markAsDeleted(key, fileSpan, System.currentTimeMillis());
-    assertTrue("targetKey is undeleted", !state.index.findKey(key).isUndelete());
+    assertFalse("targetKey is undeleted", state.index.findKey(key).isUndelete());
     assertTrue("targetKey is not deleted", state.index.findKey(key).isDelete());
     actualLifeVersion = state.index.findKey(key).getLifeVersion();
     assertEquals("Life version isn't " + expectedLifeVersion + " but " + actualLifeVersion, expectedLifeVersion,
@@ -1862,7 +1861,7 @@ public class IndexTest {
    * @throws StoreException
    */
   private void ttlUpdateKeyAndVerify(StoreKey key, short expectedLifeVersion) throws StoreException {
-    assertTrue("targetKey is already ttlUpdated", !state.index.findKey(key).isTtlUpdate());
+    assertFalse("targetKey is already ttlUpdated", state.index.findKey(key).isTtlUpdate());
     short actualLifeVersion = state.index.findKey(key).getLifeVersion();
     assertEquals("Life version isn't " + expectedLifeVersion + " but " + actualLifeVersion, expectedLifeVersion,
         actualLifeVersion);
@@ -2087,10 +2086,9 @@ public class IndexTest {
    * @param maxLogSegmentsToBeIgnored number of log segments not to be returned via {@link PersistentIndex#getLogSegmentsNotInJournal()}
    * @param maxEntriesInJournal max number of entries in {@link Journal}
    * @throws StoreException
-   * @throws IOException
    */
   private void testGetLogSegmentsNotInJournal(int maxLogSegmentsToBeIgnored, int maxEntriesInJournal)
-      throws StoreException, IOException {
+      throws StoreException {
     // fill current log segment to its capacity
     fillLastLogSegmentToCapacity(1, false);
 
@@ -2140,10 +2138,9 @@ public class IndexTest {
    * @param numberOfEntries number of entries to be added to fill the log segment to its capacity
    * @param newLogSegment {@code true} if this is a new log segment. {@code false} otherwise
    * @throws StoreException
-   * @throws IOException
    */
   private void fillLastLogSegmentToCapacity(int numberOfEntries, boolean newLogSegment)
-      throws StoreException, IOException {
+      throws StoreException {
     if (newLogSegment) {
       // to ensure a new log segment is created. If not, find the remaining size below will fail
       state.addPutEntries(1, PUT_RECORD_SIZE, Utils.Infinite_Time);


### PR DESCRIPTION
Assume that fileSpan's start offset is (0_0, 18) and there is a compaction happening parallel to this function. Also assume that compaction is compacting log segment [0_0, 1_0] to [0_1]. Then before compaction, the indexSegments.floorKey( (0_0, 18)) would return (0_0, 18) itself, since this is the smallest offset in the index segments map. However, if compaction finishes before this method call, then the fileSpan's start offset is still (0_0, 18) but the smallest index segment offset would become (0_1, 18). In this case, indexSegments.floorKey(fileSpan.getStartOffset()) would return null, thus we would see NullPointerException.

This PR makes index use current first log segment if we cannot find any segment less than or equal to start offset in old fileSpan.