### PR TITLE
[named blobs] set correct ttl in metadata DB for permanent blobs

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/messageformat/BlobProperties.java
+++ b/ambry-api/src/main/java/com/github/ambry/messageformat/BlobProperties.java
@@ -118,6 +118,16 @@ public class BlobProperties {
     this.filename = filename;
   }
 
+  /**
+   * Constructor to copy all fields from another {@link BlobProperties}.
+   * @param other the {@link BlobProperties} to copy.
+   */
+  public BlobProperties(BlobProperties other) {
+    this(other.blobSize, other.serviceId, other.ownerId, other.contentType, other.isPrivate, other.timeToLiveInSeconds,
+        other.creationTimeInMs, other.accountId, other.containerId, other.isEncrypted, other.externalAssetTag,
+        other.contentEncoding, other.filename);
+  }
+
   public long getTimeToLiveInSeconds() {
     return timeToLiveInSeconds;
   }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
@@ -183,11 +183,7 @@ public class NamedBlobPutHandler {
           restRequest.readInto(channel, fetchStitchRequestBodyCallback(channel, blobInfo));
         } else {
           PutBlobOptions options = getPutBlobOptionsFromRequest();
-          if (blobInfo.getBlobProperties().getTimeToLiveInSeconds() == Utils.Infinite_Time) {
-            // For blob with infinite time, the procedure is putBlob, record insert to database, and ttlUpdate.
-            blobInfo.getBlobProperties().setTimeToLiveInSeconds(frontendConfig.permanentNamedBlobInitialPutTtl);
-          }
-          router.putBlob(blobInfo.getBlobProperties(), blobInfo.getUserMetadata(), restRequest, options,
+          router.putBlob(getPropertiesForRouterUpload(blobInfo), blobInfo.getUserMetadata(), restRequest, options,
               routerPutBlobCallback(blobInfo));
         }
       }, uri, LOGGER, finalCallback);
@@ -215,7 +211,7 @@ public class NamedBlobPutHandler {
      */
     private Callback<Long> fetchStitchRequestBodyCallback(RetainingAsyncWritableChannel channel, BlobInfo blobInfo) {
       return buildCallback(frontendMetrics.putReadStitchRequestMetrics,
-          bytesRead -> router.stitchBlob(blobInfo.getBlobProperties(), blobInfo.getUserMetadata(),
+          bytesRead -> router.stitchBlob(getPropertiesForRouterUpload(blobInfo), blobInfo.getUserMetadata(),
               getChunksToStitch(blobInfo.getBlobProperties(), readJsonFromChannel(channel)),
               routerStitchBlobCallback(blobInfo)), uri, LOGGER, finalCallback);
     }
@@ -242,10 +238,10 @@ public class NamedBlobPutHandler {
     private Callback<String> idConverterCallback(BlobInfo blobInfo, String blobId) {
       return buildCallback(frontendMetrics.putIdConversionMetrics, convertedBlobId -> {
         restResponseChannel.setHeader(RestUtils.Headers.LOCATION, convertedBlobId);
-        if (RestUtils.getTtlFromRequestHeader(restRequest.getArgs()) == Utils.Infinite_Time) {
+        if (blobInfo.getBlobProperties().getTimeToLiveInSeconds() == Utils.Infinite_Time) {
           // Do ttl update with retryExecutor. Use the blob ID returned from the router instead of the converted ID
           // since the converted ID may be changed by the ID converter.
-          String serviceId = RestUtils.getHeader(restRequest.getArgs(), RestUtils.Headers.SERVICE_ID, true);
+          String serviceId = blobInfo.getBlobProperties().getServiceId();
           retryExecutor.runWithRetries(retryPolicy,
               callback -> router.updateBlobTtl(blobId, serviceId, Utils.Infinite_Time, callback), this::isRetriable,
               routerTtlUpdateCallback(blobInfo));
@@ -410,6 +406,25 @@ public class NamedBlobPutHandler {
             + stitchedBlobProperties.getAccountId() + ", " + stitchedBlobProperties.getContainerId() + ")",
             RestServiceErrorCode.BadRequest);
       }
+    }
+
+    /**
+     * Create a {@link BlobProperties} for the router upload (putBlob or stitchBlob) with a finite TTL such that
+     * orphaned blobs will not be created if the write to the named blob metadata DB fails.
+     * @param blobInfoFromRequest the {@link BlobInfo} parsed from the request.
+     * @return a {@link BlobProperties} for a TTL-ed initial router call.
+     */
+    BlobProperties getPropertiesForRouterUpload(BlobInfo blobInfoFromRequest) {
+      BlobProperties properties;
+      if (blobInfoFromRequest.getBlobProperties().getTimeToLiveInSeconds() == Utils.Infinite_Time) {
+        properties = new BlobProperties(blobInfoFromRequest.getBlobProperties());
+        // For blob with infinite time, the procedure is putBlob with a TTL, record insert to database with
+        // infinite TTL, and ttlUpdate.
+        properties.setTimeToLiveInSeconds(frontendConfig.permanentNamedBlobInitialPutTtl);
+      } else {
+        properties = blobInfoFromRequest.getBlobProperties();
+      }
+      return properties;
     }
   }
 }

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
@@ -2970,6 +2970,7 @@ class FrontendTestIdConverterFactory implements IdConverterFactory {
   String translation = null;
   boolean returnInputIfTranslationNull = false;
   volatile String lastInput = null;
+  volatile BlobInfo lastBlobInfo = null;
   volatile String lastConvertedId = null;
 
   @Override
@@ -2982,10 +2983,15 @@ class FrontendTestIdConverterFactory implements IdConverterFactory {
 
     @Override
     public Future<String> convert(RestRequest restRequest, String input, Callback<String> callback) {
+      return convert(restRequest, input, null, callback);
+    }
+
+    @Override
+    public Future<String> convert(RestRequest restRequest, String input, BlobInfo blobInfo, Callback<String> callback) {
       if (!isOpen) {
         throw new IllegalStateException("IdConverter closed");
       }
-      return completeOperation(input, callback);
+      return completeOperation(input, blobInfo, callback);
     }
 
     @Override
@@ -2996,11 +3002,13 @@ class FrontendTestIdConverterFactory implements IdConverterFactory {
     /**
      * Completes the operation by creating and invoking a {@link Future} and invoking the {@code callback} if non-null.
      * @param input the original input ID received
+     * @param blobInfo the blob info received.
      * @param callback the {@link Callback} to invoke. Can be null.
      * @return the created {@link Future}.
      */
-    private Future<String> completeOperation(String input, Callback<String> callback) {
+    private Future<String> completeOperation(String input, BlobInfo blobInfo, Callback<String> callback) {
       lastInput = input;
+      lastBlobInfo = blobInfo;
       if (exceptionToThrow != null) {
         throw exceptionToThrow;
       }


### PR DESCRIPTION
Previously, in the permanent blob upload flow for named blobs, the DB
would be populated with the TTL used for the initial router upload.
Later, the ambry blob TTL would be updated to make the blob permanent.
However, the metadata would still have the original expiry time.

This ensures that the metadata record is marked as permanent by not
sharing the same instance of BlobProperties with the router call. This
commit also supplies the correct initial TTL for stitchBlob calls.