### PR TITLE
Support updating disk capacity dynamically

### DIFF
--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryDisk.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryDisk.java
@@ -27,9 +27,9 @@ import static com.github.ambry.clustermap.ClusterMapSnapshotConstants.*;
 class AmbryDisk implements DiskId, Resource {
   private final AmbryDataNode datanode;
   private final String mountPath;
-  private final long rawCapacityBytes;
   private final ResourceStatePolicy resourceStatePolicy;
   private final long maxCapacityInBytes;
+  private volatile long rawCapacityBytes;
 
   /**
    * Instantiate an AmbryDisk object.
@@ -130,6 +130,15 @@ class AmbryDisk implements DiskId, Resource {
     } else {
       resourceStatePolicy.onHardDown();
     }
+  }
+
+  /**
+   * Set the new disk capacity in bytes.
+   * @param capacityInBytes the new capacity in bytes.
+   */
+  void setDiskCapacityInBytes(long capacityInBytes) {
+    rawCapacityBytes = capacityInBytes;
+    ClusterMapUtils.validateDiskCapacity(rawCapacityBytes, maxCapacityInBytes);
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
@@ -86,6 +86,7 @@ public class ClusterMapUtils {
   static final String DATACENTER_ID_STR = "id";
   static final String SCHEMA_VERSION_STR = "schemaVersion";
   static final String XID_STR = "xid";
+  static final String DISK_CAPACITY_DELIM_STR = ",";
   static final long DEFAULT_XID = Long.MIN_VALUE;
   static final int MIN_PORT = 1025;
   static final int MAX_PORT = 65535;

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DynamicClusterChangeHandler.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DynamicClusterChangeHandler.java
@@ -341,6 +341,14 @@ public class DynamicClusterChangeHandler implements HelixClusterChangeHandler {
         // TODO support dynamically adding disk in the future
         continue;
       }
+      // update disk capacity if needed
+      if (disk.getRawCapacityInBytes() != diskConfig.getDiskCapacityInBytes()) {
+        long prevDiskCapacity = disk.getRawCapacityInBytes();
+        logger.info("Capacity of disk at {} on {} has changed. Previous was: {} bytes, new capacity is {} bytes",
+            mountPath, instanceName, prevDiskCapacity, diskConfig.getDiskCapacityInBytes());
+        disk.setDiskCapacityInBytes(diskConfig.getDiskCapacityInBytes());
+        clusterChangeHandlerCallback.addClusterWideRawCapacity(diskConfig.getDiskCapacityInBytes() - prevDiskCapacity);
+      }
       for (Map.Entry<String, DataNodeConfig.ReplicaConfig> replicaEntry : diskConfig.getReplicaConfigs().entrySet()) {
         // partition name and replica name are the same.
         String partitionName = replicaEntry.getKey();

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeUtil.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeUtil.java
@@ -63,7 +63,6 @@ import org.slf4j.LoggerFactory;
 
 import static com.github.ambry.clustermap.ClusterMapUtils.*;
 import static com.github.ambry.clustermap.DataNodeConfigSourceType.*;
-import static com.github.ambry.clustermap.PropertyStoreToDataNodeConfigAdapter.Converter.*;
 import static com.github.ambry.utils.Utils.*;
 
 
@@ -628,17 +627,18 @@ public class HelixBootstrapUpgradeUtil {
    *     "1": {
    *         "replicaCapacityInBytes": 107374182400,
    *         "partitionClass": "max-replicas-all-datacenters",
-   *         "localhost1_17088": "/tmp/c/1",
-   *         "localhost2_17088": "/tmp/d/1"
+   *         "localhost1_17088": "/tmp/c/1,536870912000",
+   *         "localhost2_17088": "/tmp/d/1,536870912000"
    *     },
    *     "2": {
    *         "replicaCapacityInBytes": 107374182400,
    *         "partitionClass": "max-replicas-all-datacenters",
-   *         "localhost3_17088": "/tmp/e/1"
+   *         "localhost3_17088": "/tmp/e/1,536870912000"
    *     }
    * }
    * In above example, two new replicas of partition[1] will be added to localhost1 and localhost2 respectively.
-   * The host name is followed by mount path on which the new replica should be placed.
+   * The host name is followed by mount path and disk capacity (separated by comma) on which the new replica should be
+   * placed.
    * @return a map that contains detailed replica info.
    */
   private Map<String, Map<String, Map<String, String>>> generateReplicaAdditionMap() {
@@ -689,7 +689,9 @@ public class HelixBootstrapUpgradeUtil {
                 partitionMap.put(PARTITION_CLASS_STR, replica.getPartitionId().getPartitionClass());
                 partitionMap.put(REPLICAS_CAPACITY_STR, String.valueOf(replica.getCapacityInBytes()));
                 return partitionMap;
-              }).put(instance, replica.getMountPath());
+              })
+                  .put(instance,
+                      replica.getMountPath() + DISK_CAPACITY_DELIM_STR + replica.getDiskId().getRawCapacityInBytes());
             }
           }
         }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeUtil.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeUtil.java
@@ -496,7 +496,7 @@ public class HelixBootstrapUpgradeUtil {
     this.portNum = portNum;
     this.partitionName = partitionName;
     this.helixAdminOperation = helixAdminOperation;
-    this.dataNodeConfigSourceType = dataNodeConfigSourceType == null ? INSTANCE_CONFIG : dataNodeConfigSourceType;
+    this.dataNodeConfigSourceType = dataNodeConfigSourceType == null ? PROPERTY_STORE : dataNodeConfigSourceType;
     this.overrideReplicaStatus = overrideReplicaStatus;
     dataCenterToZkAddress = parseAndUpdateDcInfoFromArg(dcs, zkLayoutPath);
     // The following properties are immaterial for the tool, but the ClusterMapConfig mandates their presence.

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/Replica.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/Replica.java
@@ -56,7 +56,7 @@ class Replica implements ReplicaId {
               clusterMapConfig);
       resourceStatePolicy = resourceStatePolicyFactory.getResourceStatePolicy();
     } catch (Exception e) {
-      logger.error("Error creating resource state policy when instantiating a replica {}", e);
+      logger.error("Error creating resource state policy when instantiating a replica", e);
       throw new IllegalStateException("Error creating resource state policy when instantiating a replica " + partition,
           e);
     }

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/ClusterChangeHandlerTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/ClusterChangeHandlerTest.java
@@ -687,6 +687,10 @@ public class ClusterChangeHandlerTest {
     helixClusterManager.close();
   }
 
+  /**
+   * Test the case where the disk capacity is updated dynamically.
+   * @throws Exception
+   */
   @Test
   public void diskCapacityUpdateTest() throws Exception {
     // create a HelixClusterManager with DynamicClusterChangeHandler
@@ -701,7 +705,6 @@ public class ClusterChangeHandlerTest {
     assertEquals("Mismatch in disk capacity", 100L * 1024 * 1024 * 1024, partitionId.getReplicaIds().get(0).getDiskId().getRawCapacityInBytes());
     // update disk capacity
     testHardwareLayout.updateDiskCapacity(500L * 1024 * 1024 * 1024);
-    //JSONObject jsonObject = testHardwareLayout.getHardwareLayout().toJSONObject();
     Utils.writeJsonObjectToFile(testHardwareLayout.getHardwareLayout().toJSONObject(), hardwareLayoutPath);
     helixCluster.upgradeWithNewHardwareLayout(hardwareLayoutPath);
     partitionId = helixClusterManager.getAllPartitionIds(null).get(0);

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/TestUtils.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/TestUtils.java
@@ -25,16 +25,13 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 import java.util.Random;
 import java.util.Set;
-import org.apache.helix.model.InstanceConfig;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import static com.github.ambry.clustermap.ClusterMapUtils.*;
 import static org.junit.Assert.*;
 
 
@@ -192,6 +189,12 @@ public class TestUtils {
       int basePort, int sslPort, int http2Port, HardwareState hardwareState, JSONArray disks) throws JSONException {
     for (int i = dataNodeJsonArray.length(); i < dataNodeCount; ++i) {
       dataNodeJsonArray.put(getJsonDataNode(hostname, basePort + i, sslPort + i, http2Port + i, hardwareState, disks));
+    }
+  }
+
+  private static void updateDataNodeJsonArrayWithNewDiskCapacity(JSONArray dataNodeJsonArray, JSONArray disks) {
+    for (int i = 0; i < dataNodeJsonArray.length(); ++i) {
+      ((JSONObject) dataNodeJsonArray.get(i)).put("disks", disks);
     }
   }
 
@@ -638,10 +641,10 @@ public class TestUtils {
       }
     }
 
-    protected JSONArray getDatacenters(boolean createNew) throws JSONException {
-      List<String> names = new ArrayList<String>(datacenterCount);
+    protected JSONArray getDatacenters(boolean createNew, boolean updateDisks) throws JSONException {
+      List<String> names = new ArrayList<>(datacenterCount);
       if (createNew) {
-        datanodeJSONArrays = new ArrayList<JSONArray>(datacenterCount);
+        datanodeJSONArrays = new ArrayList<>(datacenterCount);
       }
 
       int curBasePort = basePort;
@@ -649,10 +652,14 @@ public class TestUtils {
       int http2Port = sslPort + 10000;
       for (int i = 0; i < datacenterCount; i++) {
         names.add(i, "DC" + i);
+        JSONArray disksArray = getDisks();
         if (createNew) {
-          datanodeJSONArrays.add(i, getDataNodes(curBasePort, sslPort, http2Port, getDisks()));
+          datanodeJSONArrays.add(i, getDataNodes(curBasePort, sslPort, http2Port, disksArray));
         } else {
-          updateDataNodeJsonArray(datanodeJSONArrays.get(i), curBasePort, sslPort, http2Port, getDisks());
+          updateDataNodeJsonArray(datanodeJSONArrays.get(i), curBasePort, sslPort, http2Port, disksArray);
+        }
+        if (updateDisks) {
+          updateDataNodeJsonArrayWithNewDiskCapacity(datanodeJSONArrays.get(i), disksArray);
         }
         curBasePort += dataNodeCount;
       }
@@ -677,12 +684,18 @@ public class TestUtils {
       properties.setProperty("clustermap.host.name", "localhost");
       clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(properties));
       this.hardwareLayout =
-          new HardwareLayout(getJsonHardwareLayout(clusterName, getDatacenters(true)), clusterMapConfig);
+          new HardwareLayout(getJsonHardwareLayout(clusterName, getDatacenters(true, false)), clusterMapConfig);
     }
 
     void addNewDataNodes(int i) throws JSONException {
       this.dataNodeCount += i;
-      this.hardwareLayout = new HardwareLayout(getJsonHardwareLayout(clusterName, getDatacenters(false)),
+      this.hardwareLayout = new HardwareLayout(getJsonHardwareLayout(clusterName, getDatacenters(false, false)),
+          new ClusterMapConfig(new VerifiableProperties(properties)));
+    }
+
+    void updateDiskCapacity(long newCapacityInBytes) {
+      diskCapacityInBytes = newCapacityInBytes;
+      this.hardwareLayout = new HardwareLayout(getJsonHardwareLayout(clusterName, getDatacenters(false, true)),
           new ClusterMapConfig(new VerifiableProperties(properties)));
     }
 
@@ -813,7 +826,7 @@ public class TestUtils {
     // Finds diskCount disks, each on distinct random datanodes.
     public List<Disk> getIndependentDisks(int diskCount) {
       List<DataNode> dataNodes = getIndependentDataNodes(diskCount);
-      List<Disk> disks = new ArrayList<Disk>(diskCount);
+      List<Disk> disks = new ArrayList<>(diskCount);
       for (DataNode dataNode : dataNodes) {
         disks.add(dataNode.getDisks().get(new Random().nextInt(dataNode.getDisks().size())));
       }

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/TestUtils.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/TestUtils.java
@@ -192,6 +192,11 @@ public class TestUtils {
     }
   }
 
+  /**
+   * Update the given array of JSON data node objects by replacing original disks with given ones.
+   * @param dataNodeJsonArray the datanode JSONArray to update
+   * @param disks a new {@link JSONArray} of disks to replace original ones for each node
+   */
   private static void updateDataNodeJsonArrayWithNewDiskCapacity(JSONArray dataNodeJsonArray, JSONArray disks) {
     for (int i = 0; i < dataNodeJsonArray.length(); ++i) {
       ((JSONObject) dataNodeJsonArray.get(i)).put("disks", disks);

--- a/ambry-tools/src/integration-test/java/com/github/ambry/clustermap/HelixBootstrapUpgradeToolTest.java
+++ b/ambry-tools/src/integration-test/java/com/github/ambry/clustermap/HelixBootstrapUpgradeToolTest.java
@@ -513,7 +513,12 @@ public class HelixBootstrapUpgradeToolTest {
         String instanceName =
             diskForNewReplica.getDataNode().getHostname() + "_" + diskForNewReplica.getDataNode().getPort();
         assertTrue("Instance name doesn't exist", newReplicaMap.containsKey(instanceName));
-        assertEquals("Mount path is not expected", diskForNewReplica.getMountPath(), newReplicaMap.get(instanceName));
+        String[] mountPathAndDiskCapacity = newReplicaMap.get(instanceName).split(DISK_CAPACITY_DELIM_STR);
+        String mountPath = mountPathAndDiskCapacity[0];
+        String diskCapacity = mountPathAndDiskCapacity[1];
+        assertEquals("Mount path is not expected", diskForNewReplica.getMountPath(), mountPath);
+        assertEquals("Disk capacity is not expected", diskForNewReplica.getRawCapacityInBytes(),
+            Long.parseLong(diskCapacity));
       }
     }
     // test deleting replica addition config (failure case)

--- a/ambry-tools/src/integration-test/java/com/github/ambry/clustermap/HelixBootstrapUpgradeToolTest.java
+++ b/ambry-tools/src/integration-test/java/com/github/ambry/clustermap/HelixBootstrapUpgradeToolTest.java
@@ -1111,8 +1111,8 @@ public class HelixBootstrapUpgradeToolTest {
       HelixPropertyStore<ZNRecord> propertyStore =
           CommonUtils.createHelixPropertyStore("localhost:" + zkInfo.getPort(), propertyStoreConfig,
               Collections.singletonList(propertyStoreConfig.rootPath));
-      String getPath = ClusterMapUtils.PARTITION_OVERRIDE_ZNODE_PATH;
-      ZNRecord zNRecord = propertyStore.get(getPath, null, AccessOption.PERSISTENT);
+      ZNRecord zNRecord =
+          propertyStore.get(ClusterMapUtils.PARTITION_OVERRIDE_ZNODE_PATH, null, AccessOption.PERSISTENT);
       assertNull("Partition override config should no longer exist", zNRecord);
     }
   }

--- a/ambry-tools/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeTool.java
+++ b/ambry-tools/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeTool.java
@@ -211,8 +211,8 @@ public class HelixBootstrapUpgradeTool {
     OptionSpecBuilder dryRun =
         parser.accepts("dryRun", "(Optional argument) Dry run, do not modify the cluster map in Helix.");
 
-    OptionSpecBuilder disableValidatingClusterManager = parser.accepts("disableVCM",
-        "(Optional argument) whether to disable validating cluster manager(VCM) in Helix bootstrap tool.");
+    OptionSpecBuilder enableValidatingClusterManager = parser.accepts("enableVCM",
+        "(Optional argument) whether to enable validating cluster manager(VCM) in Helix bootstrap tool.");
 
     ArgumentAcceptingOptionSpec<String> adminConfigFilePathOpt = parser.accepts("adminConfigFilePath",
         "The path to a static admin config file. For example, it can be a file that holds a list of partitions"
@@ -222,7 +222,8 @@ public class HelixBootstrapUpgradeTool {
         .ofType(String.class);
 
     ArgumentAcceptingOptionSpec<String> dataNodeConfigSourceOpt = parser.accepts("dataNodeConfigSource",
-        "(Optional argument) The type of data node config source. See DataNodeConfigSourceType enum for more details.")
+        "(Optional argument) The type of data node config source (default is PROPERTY_STORE). "
+            + "See DataNodeConfigSourceType enum for more details.")
         .withRequiredArg()
         .describedAs("data_node_config_source")
         .ofType(String.class);
@@ -309,7 +310,7 @@ public class HelixBootstrapUpgradeTool {
         default:
           HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
               clusterNamePrefix, dcs, maxPartitionsInOneResource, options.has(dryRun), options.has(forceRemove), null,
-              !options.has(disableValidatingClusterManager), stateModelDef, operation, dataNodeConfigSourceType,
+              options.has(enableValidatingClusterManager), stateModelDef, operation, dataNodeConfigSourceType,
               options.has(overrideReplicaStatus));
       }
     }


### PR DESCRIPTION
Ambry currently doesn't support updating disk capacity dynamically through Helix. This PR enables DynamicClusterChangeHandler to compare current capcity with capacity from DataNodeConfig and update the capacity if there is a difference.
Also, Helix tool now inlucdes disk capacity in new replica info, thus target server is able to set new disk capacity based on new replica info. With this change, we should be able to (1) upgrade Helix clustermap and update disk capacities, (2) add replicas to target node and update corresponding disk capacity all at once.