### PR TITLE
Use full fetch-depth for publish task

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -19,6 +19,9 @@ jobs:
     steps:
       - name: Checkout Ambry
         uses: actions/checkout@v2
+        # Full fetch depth is used to fetch all existing tags in the repo to assign a version for this build
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK 11
         uses: actions/setup-java@v2
@@ -54,6 +57,9 @@ jobs:
     steps:
       - name: Checkout Ambry
         uses: actions/checkout@v2
+        # Full fetch depth is used to fetch all existing tags in the repo to assign a version for this build
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK 11
         uses: actions/setup-java@v2
@@ -89,6 +95,9 @@ jobs:
     steps:
       - name: Checkout Ambry
         uses: actions/checkout@v2
+        # Full fetch depth is used to fetch all existing tags in the repo to assign a version for this build
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK 11
         uses: actions/setup-java@v2
@@ -147,6 +156,9 @@ jobs:
     steps:
       - name: Checkout Ambry
         uses: actions/checkout@v2
+        # Full fetch depth is used to fetch all existing tags in the repo to assign a version for this build
+        with:
+          fetch-depth: 0
         # environment variables are only supported in step conditionals
         # TODO once the PUBLISH variable is no longer needed move the if statement up to the job level
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && env.PUBLISH == 'true'}}


### PR DESCRIPTION
By default, only the latest commit is fetched. We need more commits to
so the build logic can see what the most recent tag version is.