### PR TITLE
Update token generation when last log segment gets closed

### DIFF
--- a/ambry-store/src/main/java/com/github/ambry/store/LogSegment.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/LogSegment.java
@@ -290,6 +290,13 @@ class LogSegment implements Read, Write {
   }
 
   /**
+   * @return {@code true} if the startOffset and endOffset of this log segment is the same. Otherwise return {@code false}.
+   */
+  boolean isEmpty() {
+    return startOffset == endOffset.get();
+  }
+
+  /**
    * Make sure the size for append is legal.
    * @param size The amount of data in bytes to append.
    */


### PR DESCRIPTION
This pr support the following bug fix:
1. If the input is journal based token, but journal has been cleaned up by auto close last log segment feature, it should return the indexed based token with the last IndexSegment startOffset and first key.
2. If the input is index based token,  but journal has been cleaned up by auto close last log segment feature, it should moving forward until it reaches to the end of the last index segment.
3. Bypass throw exception since some of the previous check assume that if the token segmentStartOffset equals to indexSegments.lastKey(), it must be the journal based token and entry should be in journal. But since auto close last log segment will clean up journal, so we should bypass the exception reporting for this situation. 
4. If the segmentStartOffset of the index based token equals to last index segment, there's no need to check the journal since journal should be empty.
