### PR TITLE
Clean up disabled state of dropped replicas in InstanceConfig/DataNodeConfig

### DIFF
--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
@@ -14,12 +14,12 @@
 package com.github.ambry.clustermap;
 
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.accountstats.AccountStatsStore;
 import com.github.ambry.commons.Callback;
 import com.github.ambry.commons.CommonUtils;
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.HelixPropertyStoreConfig;
 import com.github.ambry.config.VerifiableProperties;
-import com.github.ambry.accountstats.AccountStatsStore;
 import com.github.ambry.server.AmbryHealthReport;
 import com.github.ambry.server.StatsSnapshot;
 import com.github.ambry.utils.Utils;
@@ -267,40 +267,7 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
       throw new IllegalArgumentException(
           "HelixParticipant only works with the AmbryReplica implementation of ReplicaId");
     }
-    synchronized (helixAdministrationLock) {
-      String partitionName = replicaId.getPartitionId().toPathString();
-
-      // 1. update disabled replica list in DataNodeConfig. This modifies ListFields only
-      boolean dataNodeConfigChanged = false;
-      DataNodeConfig dataNodeConfig = getDataNodeConfig();
-      if (!disable && dataNodeConfig.getDisabledReplicas().remove(partitionName)) {
-        logger.info("Removing the partition {} from disabledReplicas list", partitionName);
-        dataNodeConfigChanged = true;
-      } else if (disable && dataNodeConfig.getDisabledReplicas().add(partitionName)) {
-        logger.info("Adding the partition {} to disabledReplicas list", partitionName);
-        dataNodeConfigChanged = true;
-      }
-      if (dataNodeConfigChanged) {
-        logger.info("Setting config with list of disabled replicas: {}", dataNodeConfig.getDisabledReplicas());
-        if (!dataNodeConfigSource.set(dataNodeConfig)) {
-          participantMetrics.setReplicaDisabledStateErrorCount.inc();
-          logger.warn("setReplicaDisabledState() failed DataNodeConfig update");
-        }
-
-        // 2. If the DataNodeConfig was changed, invoke Helix native method to enable/disable partition on local node,
-        //    this will trigger subsequent state transition on given replica. This method modifies MapFields in
-        //    InstanceConfig.
-        InstanceConfig instanceConfig = getInstanceConfig();
-        String resourceNameForPartition = getResourceNameOfPartition(helixAdmin, clusterName, partitionName);
-        logger.info("{} replica {} on current node", disable ? "Disabling" : "Enabling", partitionName);
-        instanceConfig.setInstanceEnabledForPartition(resourceNameForPartition, partitionName, !disable);
-        if (!helixAdmin.setInstanceConfig(clusterName, instanceName, instanceConfig)) {
-          participantMetrics.setReplicaDisabledStateErrorCount.inc();
-          logger.warn("setReplicaDisabledState() failed InstanceConfig update");
-        }
-      }
-      logger.info("Disabled state of partition {} is updated", partitionName);
-    }
+    setPartitionDisabledState(replicaId.getPartitionId().toPathString(), disable);
   }
 
   @Override
@@ -334,6 +301,46 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
    */
   protected void markDisablePartitionComplete() {
     disablePartitionsComplete = true;
+  }
+
+  /**
+   * Disable/enable partition on local node. This method will update both InstanceConfig and DataNodeConfig in PropertyStore.
+   * @param partitionName name of partition on local node
+   * @param disable if {@code true}, disable given partition on current node. {@code false} otherwise.
+   */
+  private void setPartitionDisabledState(String partitionName, boolean disable) {
+    synchronized (helixAdministrationLock) {
+      // 1. update disabled replica list in DataNodeConfig. This modifies ListFields only
+      boolean dataNodeConfigChanged = false;
+      DataNodeConfig dataNodeConfig = getDataNodeConfig();
+      if (!disable && dataNodeConfig.getDisabledReplicas().remove(partitionName)) {
+        logger.info("Removing the partition {} from disabledReplicas list", partitionName);
+        dataNodeConfigChanged = true;
+      } else if (disable && dataNodeConfig.getDisabledReplicas().add(partitionName)) {
+        logger.info("Adding the partition {} to disabledReplicas list", partitionName);
+        dataNodeConfigChanged = true;
+      }
+      if (dataNodeConfigChanged) {
+        logger.info("Setting config with list of disabled replicas: {}", dataNodeConfig.getDisabledReplicas());
+        if (!dataNodeConfigSource.set(dataNodeConfig)) {
+          participantMetrics.setReplicaDisabledStateErrorCount.inc();
+          logger.warn("setReplicaDisabledState() failed DataNodeConfig update");
+        }
+
+        // 2. If the DataNodeConfig was changed, invoke Helix native method to enable/disable partition on local node,
+        //    this will trigger subsequent state transition on given replica. This method modifies MapFields in
+        //    InstanceConfig.
+        InstanceConfig instanceConfig = getInstanceConfig();
+        String resourceNameForPartition = getResourceNameOfPartition(helixAdmin, clusterName, partitionName);
+        logger.info("{} replica {} on current node", disable ? "Disabling" : "Enabling", partitionName);
+        instanceConfig.setInstanceEnabledForPartition(resourceNameForPartition, partitionName, !disable);
+        if (!helixAdmin.setInstanceConfig(clusterName, instanceName, instanceConfig)) {
+          participantMetrics.setReplicaDisabledStateErrorCount.inc();
+          logger.warn("setReplicaDisabledState() failed InstanceConfig update");
+        }
+      }
+      logger.info("Disabled state of partition {} is updated", partitionName);
+    }
   }
 
   /**
@@ -682,12 +689,18 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
       localPartitionAndState.put(partitionName, ReplicaState.ERROR);
       throw e;
     }
+    logger.info("Clean up disabled state of dropped replica {} in both InstanceConfig and DataNodeConfig",
+        partitionName);
+    setPartitionDisabledState(partitionName, false);
     localPartitionAndState.remove(partitionName);
     participantMetrics.partitionDroppedCount.inc();
   }
 
   @Override
   public void onPartitionBecomeDroppedFromError(String partitionName) {
+    logger.info("Clean up disabled state of dropped replica {} in both InstanceConfig and DataNodeConfig",
+        partitionName);
+    setPartitionDisabledState(partitionName, false);
     localPartitionAndState.remove(partitionName);
     participantMetrics.partitionDroppedCount.inc();
   }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
@@ -689,7 +689,7 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
       localPartitionAndState.put(partitionName, ReplicaState.ERROR);
       throw e;
     }
-    logger.info("Clean up disabled state of dropped replica {} in both InstanceConfig and DataNodeConfig",
+    logger.info("Purging disabled state of dropped replica {} in both InstanceConfig and DataNodeConfig",
         partitionName);
     setPartitionDisabledState(partitionName, false);
     localPartitionAndState.remove(partitionName);
@@ -698,7 +698,7 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
 
   @Override
   public void onPartitionBecomeDroppedFromError(String partitionName) {
-    logger.info("Clean up disabled state of dropped replica {} in both InstanceConfig and DataNodeConfig",
+    logger.info("Purging disabled state of dropped replica {} in both InstanceConfig and DataNodeConfig",
         partitionName);
     setPartitionDisabledState(partitionName, false);
     localPartitionAndState.remove(partitionName);

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
@@ -308,7 +308,7 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
    * @param partitionName name of partition on local node
    * @param disable if {@code true}, disable given partition on current node. {@code false} otherwise.
    */
-  private void setPartitionDisabledState(String partitionName, boolean disable) {
+  protected void setPartitionDisabledState(String partitionName, boolean disable) {
     synchronized (helixAdministrationLock) {
       // 1. update disabled replica list in DataNodeConfig. This modifies ListFields only
       boolean dataNodeConfigChanged = false;
@@ -689,7 +689,7 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
       localPartitionAndState.put(partitionName, ReplicaState.ERROR);
       throw e;
     }
-    logger.info("Purging disabled state of dropped replica {} in both InstanceConfig and DataNodeConfig",
+    logger.info("Purging disabled state of dropped replica {} from both InstanceConfig and DataNodeConfig",
         partitionName);
     setPartitionDisabledState(partitionName, false);
     localPartitionAndState.remove(partitionName);
@@ -698,7 +698,7 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
 
   @Override
   public void onPartitionBecomeDroppedFromError(String partitionName) {
-    logger.info("Purging disabled state of dropped replica {} in both InstanceConfig and DataNodeConfig",
+    logger.info("Purging disabled state of dropped replica {} from both InstanceConfig and DataNodeConfig",
         partitionName);
     setPartitionDisabledState(partitionName, false);
     localPartitionAndState.remove(partitionName);

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixAdmin.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixAdmin.java
@@ -42,7 +42,7 @@ import static com.github.ambry.clustermap.ClusterMapUtils.*;
  * Mock implementation of {@link HelixAdmin} which stores all information internally.
  */
 public class MockHelixAdmin implements HelixAdmin {
-  private final Map<String, InstanceConfig> instanceNameToinstanceConfigs = new HashMap<>();
+  private final Map<String, InstanceConfig> instanceNameToInstanceConfigs = new HashMap<>();
   private final Map<String, IdealState> resourcesToIdealStates = new HashMap<>();
   private final Set<String> upInstances = new HashSet<>();
   private final Set<String> downInstances = new HashSet<>();
@@ -88,7 +88,7 @@ public class MockHelixAdmin implements HelixAdmin {
 
   @Override
   public void addInstance(String clusterName, InstanceConfig instanceConfig) {
-    instanceNameToinstanceConfigs.put(instanceConfig.getInstanceName(), instanceConfig);
+    instanceNameToInstanceConfigs.put(instanceConfig.getInstanceName(), instanceConfig);
     upInstances.add(instanceConfig.getInstanceName());
     Map<String, Map<String, String>> diskInfos = instanceConfig.getRecord().getMapFields();
     totalDiskCount += diskInfos.size();
@@ -135,23 +135,23 @@ public class MockHelixAdmin implements HelixAdmin {
 
   @Override
   public List<String> getInstancesInCluster(String clusterName) {
-    return new ArrayList<>(instanceNameToinstanceConfigs.keySet());
+    return new ArrayList<>(instanceNameToInstanceConfigs.keySet());
   }
 
   List<InstanceConfig> getInstanceConfigs(String clusterName) {
-    return new ArrayList<>(instanceNameToinstanceConfigs.values());
+    return new ArrayList<>(instanceNameToInstanceConfigs.values());
   }
 
   @Override
   public InstanceConfig getInstanceConfig(String clusterName, String instanceName) {
-    return instanceNameToinstanceConfigs.get(instanceName);
+    return instanceNameToInstanceConfigs.get(instanceName);
   }
 
   @Override
   public boolean setInstanceConfig(String clusterName, String instanceName, InstanceConfig instanceConfig) {
     setInstanceConfigCallCount++;
     removeDisabledReplicasIfNeeded(instanceConfig);
-    instanceNameToinstanceConfigs.put(instanceName, instanceConfig);
+    instanceNameToInstanceConfigs.put(instanceName, instanceConfig);
     return true;
   }
 
@@ -428,7 +428,7 @@ public class MockHelixAdmin implements HelixAdmin {
    * @return the count of disks registered for the given node via this admin.
    */
   long getDiskCountOnNode(String instanceName) {
-    InstanceConfig instanceConfig = instanceNameToinstanceConfigs.get(instanceName);
+    InstanceConfig instanceConfig = instanceNameToInstanceConfigs.get(instanceName);
     return instanceConfig.getRecord().getMapFields().size();
   }
 

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixParticipant.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixParticipant.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.*;
 
 public class MockHelixParticipant extends HelixParticipant {
   public static MetricRegistry metricRegistry = new MetricRegistry();
+  static HelixFactory mockHelixFactory = new MockHelixManagerFactory();
   public Boolean updateNodeInfoReturnVal = null;
   public Boolean setStoppedStateReturnVal = null;
   public PartitionStateChangeListener mockStatsManagerListener = null;
@@ -48,7 +49,7 @@ public class MockHelixParticipant extends HelixParticipant {
   private PartitionStateChangeListener mockReplicationManagerListener;
 
   public MockHelixParticipant(ClusterMapConfig clusterMapConfig) {
-    this(clusterMapConfig, new MockHelixManagerFactory());
+    this(clusterMapConfig, mockHelixFactory);
     // create mock state change listener for ReplicationManager
     mockReplicationManagerListener = Mockito.mock(PartitionStateChangeListener.class);
     // mock Bootstrap-To-Standby change

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixParticipant.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixParticipant.java
@@ -14,9 +14,9 @@
 package com.github.ambry.clustermap;
 
 import com.codahale.metrics.MetricRegistry;
-import com.github.ambry.config.ClusterMapConfig;
-import com.github.ambry.commons.Callback;
 import com.github.ambry.accountstats.AccountStatsStore;
+import com.github.ambry.commons.Callback;
+import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.server.AmbryHealthReport;
 import com.github.ambry.server.StatsSnapshot;
 import java.io.IOException;
@@ -164,6 +164,11 @@ public class MockHelixParticipant extends HelixParticipant {
   @Override
   public void close() {
     // no op
+  }
+
+  @Override
+  public void setPartitionDisabledState(String partitionName, boolean disable) {
+    super.setPartitionDisabledState(partitionName, disable);
   }
 
   /**

--- a/ambry-replication/src/test/java/com/github/ambry/replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/ReplicationTest.java
@@ -729,7 +729,8 @@ public class ReplicationTest extends ReplicationTestHelper {
     MockClusterMap clusterMap = new MockClusterMap();
     ClusterMapConfig clusterMapConfig = new ClusterMapConfig(verifiableProperties);
     MockHelixParticipant.metricRegistry = new MetricRegistry();
-    MockHelixParticipant mockHelixParticipant = new MockHelixParticipant(clusterMapConfig);
+    MockHelixParticipant mockHelixParticipant = Mockito.spy(new MockHelixParticipant(clusterMapConfig));
+    doNothing().when(mockHelixParticipant).setPartitionDisabledState(anyString(), anyBoolean());
     // choose a replica on local node and put decommission file into its dir
     ReplicaId localReplica = clusterMap.getReplicaIds(clusterMap.getDataNodeIds().get(0)).get(0);
     String partitionName = localReplica.getPartitionId().toPathString();
@@ -800,6 +801,8 @@ public class ReplicationTest extends ReplicationTestHelper {
         participantLatch.await(1, TimeUnit.SECONDS));
     // verify stats manager listener is called
     verify(mockHelixParticipant.mockStatsManagerListener).onPartitionBecomeDroppedFromOffline(anyString());
+    // verify setPartitionDisabledState method is called
+    verify(mockHelixParticipant).setPartitionDisabledState(partitionName, false);
     File storeDir = new File(localReplica.getReplicaPath());
     assertFalse("Store dir should not exist", storeDir.exists());
     storageManager.shutdown();

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryServerRequests.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryServerRequests.java
@@ -508,7 +508,7 @@ public class AmbryServerRequests extends AmbryRequests {
         error = ServerErrorCode.Unknown_Error;
       }
       // After store is shut down and stopped state is updated, we also need to temporarily disable this replica if Helix
-      // is adopted. The intention here is to make Helix re-elect leader replica if necessary.
+      // is adopted. The intention here is to force Helix to re-elect a new leader replica if necessary.
       if (storeManager instanceof StorageManager && clusterParticipant != null) {
         // Previous operation has guaranteed the store is not null
         Store store = ((StorageManager) storeManager).getStore(partitionId, true);

--- a/ambry-store/src/test/java/com/github/ambry/store/StorageManagerTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/StorageManagerTest.java
@@ -17,6 +17,7 @@ package com.github.ambry.store;
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.account.InMemAccountService;
+import com.github.ambry.accountstats.AccountStatsStore;
 import com.github.ambry.clustermap.ClusterMapUtils;
 import com.github.ambry.clustermap.ClusterParticipant;
 import com.github.ambry.clustermap.DataNodeId;
@@ -33,12 +34,11 @@ import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.clustermap.ReplicaState;
 import com.github.ambry.clustermap.StateModelListenerType;
 import com.github.ambry.clustermap.StateTransitionException;
+import com.github.ambry.commons.Callback;
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.DiskManagerConfig;
 import com.github.ambry.config.StoreConfig;
 import com.github.ambry.config.VerifiableProperties;
-import com.github.ambry.commons.Callback;
-import com.github.ambry.accountstats.AccountStatsStore;
 import com.github.ambry.server.AmbryHealthReport;
 import com.github.ambry.server.StatsSnapshot;
 import com.github.ambry.utils.Pair;
@@ -1142,7 +1142,8 @@ public class StorageManagerTest {
   public void residualDirDeletionTest() throws Exception {
     MockDataNodeId localNode = clusterMap.getDataNodes().get(0);
     List<ReplicaId> replicas = clusterMap.getReplicaIds(localNode);
-    MockClusterParticipant mockHelixParticipant = new MockClusterParticipant();
+    MockClusterParticipant mockHelixParticipant = Mockito.spy(new MockClusterParticipant());
+    doNothing().when(mockHelixParticipant).setPartitionDisabledState(anyString(), anyBoolean());
     // create an extra store dir at one of the mount paths
     String mountPath = replicas.get(0).getMountPath();
     String extraPartitionName = "1000";
@@ -1165,6 +1166,7 @@ public class StorageManagerTest {
     assertTrue("Could not make readable", invalidDir.setReadable(true));
     // trigger OFFLINE -> DROPPED transition on extra partition. Storage manager should delete residual store dir.
     mockHelixParticipant.onPartitionBecomeDroppedFromOffline(extraPartitionName);
+    verify(mockHelixParticipant).setPartitionDisabledState(extraPartitionName, false);
     assertFalse("Extra store dir should not exist", extraStoreDir.exists());
     shutdownAndAssertStoresInaccessible(storageManager, replicas);
   }
@@ -1414,6 +1416,11 @@ public class StorageManagerTest {
     @Override
     public void close() {
       // no op
+    }
+
+    @Override
+    public void setPartitionDisabledState(String partitionName, boolean disable) {
+      super.setPartitionDisabledState(partitionName, disable);
     }
   }
 


### PR DESCRIPTION
Decommissioning replica includes two steps: (1) disable replica, (2) drop replica.
After (1) is complete, Helix automatically creates a DISABLED partition field in InstanceConfig, which should be deleted after replica is successfully dropped. This is to handle an edge case where same replica is first removed and then added to the same host. The DISABLED partition field will prevent replica from bootstrapping.