### PR TITLE
Return a task result object from container deletion sync task.

### DIFF
--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/DeprecatedContainerCloudSyncTask.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/DeprecatedContainerCloudSyncTask.java
@@ -52,6 +52,7 @@ public class DeprecatedContainerCloudSyncTask implements Task {
 
   @Override
   public TaskResult run() {
+    TaskResult taskResult = null;
     Timer.Context deprecationTaskRunTimer = vcrMetrics.deprecationTaskRunTime.time();
     try {
       logger.info("DeprecatedContainerCloudSyncTask run started.");
@@ -61,13 +62,17 @@ public class DeprecatedContainerCloudSyncTask implements Task {
       accountServiceFetchTimer.stop();
       logger.info("Attempting deprecation of {} containers.", deprecatedContainers.size());
       cloudDestination.deprecateContainers(deprecatedContainers);
+      taskResult =
+          new TaskResult(TaskResult.Status.COMPLETED, "DeprecatedContainerCloudSyncTask completed successfully.");
     } catch (CloudStorageException cloudStorageException) {
       logger.error("Error in updating deprecated containers from account service to cloud: ", cloudStorageException);
+      taskResult = new TaskResult(TaskResult.Status.FAILED,
+          "DeprecatedContainerCloudSyncTask failed due to ." + cloudStorageException.getMessage());
     } finally {
       logger.info("DeprecatedContainerCloudSyncTask done.");
       deprecationTaskRunTimer.stop();
     }
-    return null;
+    return taskResult;
   }
 
   @Override


### PR DESCRIPTION
We were returning null as `TaskResult` in `DeprecatedContainerCloudSyncTask`. While this doesn't affect the correctness for cloud container deletion, the `TaskRunner` of helix errors out on seeing null `TaskResult`. Hence the helix task is marked as failed, even though the task actually passed.
This PR fixes the issue by returning an appropriate object of `TaskResult` based on whether the task failed or passed. 