### PR TITLE
Use jackson annotations to serialize and deserialize Account and Container

### DIFF
--- a/ambry-account/src/integration-test/java/com/github/ambry/account/MySqlAccountServiceIntegrationTest.java
+++ b/ambry-account/src/integration-test/java/com/github/ambry/account/MySqlAccountServiceIntegrationTest.java
@@ -14,7 +14,6 @@
 package com.github.ambry.account;
 
 import com.codahale.metrics.MetricRegistry;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.ambry.account.AccountUtils.AccountUpdateInfo;
 import com.github.ambry.account.mysql.AccountDao;
 import com.github.ambry.account.mysql.MySqlAccountStore;
@@ -42,8 +41,6 @@ import java.util.Properties;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static com.github.ambry.account.Container.*;
 import static com.github.ambry.config.MySqlAccountServiceConfig.*;
@@ -59,7 +56,6 @@ import static org.mockito.Mockito.*;
  */
 public class MySqlAccountServiceIntegrationTest {
 
-  private static final Logger logger = LoggerFactory.getLogger(MySqlAccountServiceIntegrationTest.class);
   private static final String DESCRIPTION = "Indescribable";
   private final MySqlAccountStoreFactory mockMySqlAccountStoreFactory;
   private final Properties mySqlConfigProps;
@@ -122,7 +118,7 @@ public class MySqlAccountServiceIntegrationTest {
     accounts.add(testAccount);
     String filename = BackupFileManager.getBackupFilename(1, SystemTime.getInstance().seconds());
     Path filePath = accountBackupDir.resolve(filename);
-    BackupFileManager.writeAccountsToFile(filePath, new ObjectMapper(), accounts);
+    BackupFileManager.writeAccountsToFile(filePath, accounts);
 
     mySqlAccountService = getAccountService();
 

--- a/ambry-account/src/integration-test/java/com/github/ambry/account/MySqlAccountServiceIntegrationTest.java
+++ b/ambry-account/src/integration-test/java/com/github/ambry/account/MySqlAccountServiceIntegrationTest.java
@@ -14,6 +14,7 @@
 package com.github.ambry.account;
 
 import com.codahale.metrics.MetricRegistry;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.ambry.account.AccountUtils.AccountUpdateInfo;
 import com.github.ambry.account.mysql.AccountDao;
 import com.github.ambry.account.mysql.MySqlAccountStore;
@@ -36,9 +37,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -119,11 +118,11 @@ public class MySqlAccountServiceIntegrationTest {
     Account testAccount =
         new AccountBuilder((short) 1, "testAccount", Account.AccountStatus.ACTIVE).lastModifiedTime(lastModifiedTime)
             .build();
-    Map<String, String> accountMap = new HashMap<>();
-    accountMap.put(Short.toString(testAccount.getId()), testAccount.toJson(false).toString());
+    Collection<Account> accounts = new ArrayList<>();
+    accounts.add(testAccount);
     String filename = BackupFileManager.getBackupFilename(1, SystemTime.getInstance().seconds());
     Path filePath = accountBackupDir.resolve(filename);
-    BackupFileManager.writeAccountMapToFile(filePath, accountMap);
+    BackupFileManager.writeAccountsToFile(filePath, new ObjectMapper(), accounts);
 
     mySqlAccountService = getAccountService();
 

--- a/ambry-account/src/main/java/com/github/ambry/account/AccountInfoMap.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/AccountInfoMap.java
@@ -13,12 +13,14 @@
  */
 package com.github.ambry.account;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-import org.json.JSONArray;
-import org.json.JSONException;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,6 +43,7 @@ class AccountInfoMap {
   private final Map<Short, Account> idToAccountMap;
   // used to track last modified time of the accounts and containers in this cache
   private long lastModifiedTime = 0;
+  private final ObjectMapper objectMapper = new ObjectMapper();
 
   /**
    * Constructor for an empty {@code AccountInfoMap}.
@@ -61,27 +64,42 @@ class AccountInfoMap {
    *   {@code AccountInfoMap} will fail.
    * </p>
    * @param accountMap A map of {@link Account}s in the form of (accountIdString, accountJSONString).
-   * @throws JSONException If parsing account data in json fails.
    */
-  AccountInfoMap(AccountServiceMetrics accountServiceMetrics, Map<String, String> accountMap) throws JSONException {
+  AccountInfoMap(AccountServiceMetrics accountServiceMetrics, Map<String, String> accountMap) {
     nameToAccountMap = new HashMap<>();
     idToAccountMap = new HashMap<>();
     for (Map.Entry<String, String> entry : accountMap.entrySet()) {
       String idKey = entry.getKey();
       String valueString = entry.getValue();
-      Account account;
-      JSONObject accountJson = new JSONObject(valueString);
-      if (idKey == null) {
-        accountServiceMetrics.remoteDataCorruptionErrorCount.inc();
-        throw new IllegalStateException("Invalid account record when reading accountMap because idKey=null");
+      try {
+        Account account = objectMapper.readValue(valueString, Account.class);
+        if (idKey == null) {
+          accountServiceMetrics.remoteDataCorruptionErrorCount.inc();
+          throw new IllegalStateException("Invalid account record when reading accountMap because idKey=null");
+        }
+        if (account.getId() != Short.parseShort(idKey)) {
+          accountServiceMetrics.remoteDataCorruptionErrorCount.inc();
+          throw new IllegalStateException(
+              "Invalid account record when reading accountMap because idKey and accountId do not match. idKey=" + idKey
+                  + " accountId=" + account.getId());
+        }
+        if (idToAccountMap.containsKey(account.getId()) || nameToAccountMap.containsKey(account.getName())) {
+          throw new IllegalStateException(
+              "Duplicate account id or name exists. id=" + account.getId() + " name=" + account.getName());
+        }
+        idToAccountMap.put(account.getId(), account);
+        nameToAccountMap.put(account.getName(), account);
+      } catch (JsonProcessingException e) {
+        logger.error("Failed to deserialize {} to an Account object", valueString, e);
+        throw new RuntimeException(e);
       }
-      account = Account.fromJson(accountJson);
-      if (account.getId() != Short.parseShort(idKey)) {
-        accountServiceMetrics.remoteDataCorruptionErrorCount.inc();
-        throw new IllegalStateException(
-            "Invalid account record when reading accountMap because idKey and accountId do not match. idKey=" + idKey
-                + " accountId=" + account.getId());
-      }
+    }
+  }
+
+  AccountInfoMap(Collection<Account> accounts) {
+    nameToAccountMap = new HashMap<>();
+    idToAccountMap = new HashMap<>();
+    for (Account account : accounts) {
       if (idToAccountMap.containsKey(account.getId()) || nameToAccountMap.containsKey(account.getName())) {
         throw new IllegalStateException(
             "Duplicate account id or name exists. id=" + account.getId() + " name=" + account.getName());
@@ -101,25 +119,27 @@ class AccountInfoMap {
    * </p>
    *
    * @param accountsJsonString JSON data containing an array of all accounts.
-   * @throws JSONException If parsing account data in json fails.
    */
-  protected AccountInfoMap(String accountsJsonString) throws JSONException {
+  protected AccountInfoMap(String accountsJsonString) {
     nameToAccountMap = new HashMap<>();
     idToAccountMap = new HashMap<>();
 
-    JSONArray accountArray = new JSONArray(accountsJsonString);
+    try {
+      List<Account> accounts = objectMapper.readValue(accountsJsonString, new TypeReference<List<Account>>() {
+      });
 
-    for (int i = 0; i < accountArray.length(); i++) {
-      JSONObject accountJson = accountArray.getJSONObject(i);
-      Account account = Account.fromJson(accountJson);
+      for (Account account : accounts) {
+        if (idToAccountMap.containsKey(account.getId()) || nameToAccountMap.containsKey(account.getName())) {
+          throw new IllegalStateException(
+              "Duplicate account id or name exists. id=" + account.getId() + " name=" + account.getName());
+        }
 
-      if (idToAccountMap.containsKey(account.getId()) || nameToAccountMap.containsKey(account.getName())) {
-        throw new IllegalStateException(
-            "Duplicate account id or name exists. id=" + account.getId() + " name=" + account.getName());
+        idToAccountMap.put(account.getId(), account);
+        nameToAccountMap.put(account.getName(), account);
       }
-
-      idToAccountMap.put(account.getId(), account);
-      nameToAccountMap.put(account.getName(), account);
+    } catch (JsonProcessingException e) {
+      logger.error("Failed to deserialize {} to a list of Account object", accountsJsonString, e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -220,7 +240,8 @@ class AccountInfoMap {
         if (!container.isSameContainer(containerInMap)) {
           logger.error(
               "Container to update in AccountId {} (containerId={} containerName={}) has an unexpected snapshot version in store (expected={}, encountered={})",
-              parentAccountId, container.getId(), container.getName(), container.getSnapshotVersion(), containerInMap.getSnapshotVersion());
+              parentAccountId, container.getId(), container.getName(), container.getSnapshotVersion(),
+              containerInMap.getSnapshotVersion());
           return true;
         }
       }

--- a/ambry-account/src/main/java/com/github/ambry/account/AccountMetadataStore.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/AccountMetadataStore.java
@@ -13,7 +13,10 @@
  */
 package com.github.ambry.account;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 import org.apache.helix.AccessOption;
 import org.apache.helix.store.HelixPropertyStore;
@@ -29,6 +32,7 @@ import org.slf4j.LoggerFactory;
  */
 abstract class AccountMetadataStore {
   private static final Logger logger = LoggerFactory.getLogger(AccountMetadataStore.class);
+  protected final ObjectMapper objectMapper = new ObjectMapper();
 
   protected final AccountServiceMetrics accountServiceMetrics;
   protected final BackupFileManager backupFileManager;
@@ -82,7 +86,7 @@ abstract class AccountMetadataStore {
    * when there is no {@link Account} created.
    * @return {@link Account} metadata in a map.
    */
-  Map<String, String> fetchAccountMetadata() {
+  Collection<Account> fetchAccountMetadata() {
     long startTimeMs = System.currentTimeMillis();
     logger.trace("Start reading ZNRecord from path={}", znRecordPath);
     Stat stat = new Stat();
@@ -95,10 +99,38 @@ abstract class AccountMetadataStore {
       return null;
     }
     Map<String, String> newAccountMap = fetchAccountMetadataFromZNRecord(znRecord);
-    if (newAccountMap != null) {
-      backupFileManager.persistAccountMap(newAccountMap, stat.getVersion(), stat.getMtime() / 1000);
+    Map<Short, Account> idToAccountMap = new HashMap<>();
+    Map<String, Account> nameToAccountMap = new HashMap<>();
+    for (Map.Entry<String, String> entry : newAccountMap.entrySet()) {
+      String idKey = entry.getKey();
+      String valueString = entry.getValue();
+      try {
+        Account account = objectMapper.readValue(valueString, Account.class);
+        if (idKey == null) {
+          accountServiceMetrics.remoteDataCorruptionErrorCount.inc();
+          throw new IllegalStateException("Invalid account record when reading accountMap because idKey=null");
+        }
+        if (account.getId() != Short.parseShort(idKey)) {
+          accountServiceMetrics.remoteDataCorruptionErrorCount.inc();
+          throw new IllegalStateException(
+              "Invalid account record when reading accountMap because idKey and accountId do not match. idKey=" + idKey
+                  + " accountId=" + account.getId());
+        }
+        if (idToAccountMap.containsKey(account.getId()) || nameToAccountMap.containsKey(account.getName())) {
+          throw new IllegalStateException(
+              "Duplicate account id or name exists. id=" + account.getId() + " name=" + account.getName());
+        }
+        idToAccountMap.put(account.getId(), account);
+        nameToAccountMap.put(account.getName(), account);
+      } catch (JsonProcessingException e) {
+        logger.error("Failed to deserialize {} to an Account object", valueString, e);
+        throw new RuntimeException(e);
+      }
     }
-    return newAccountMap;
+    if (newAccountMap != null) {
+      backupFileManager.persistAccountMap(idToAccountMap.values(), stat.getVersion(), stat.getMtime() / 1000);
+    }
+    return idToAccountMap.values();
   }
 
   /**

--- a/ambry-account/src/main/java/com/github/ambry/account/BackupFileManager.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/BackupFileManager.java
@@ -13,13 +13,15 @@
  */
 package com.github.ambry.account;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.ambry.config.HelixAccountServiceConfig;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
@@ -30,16 +32,13 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -74,6 +73,7 @@ class BackupFileManager {
   static final Pattern newStateFilenamePattern = Pattern.compile("^(\\d{8}T\\d{6})\\." + NEW_STATE_SUFFIX + "$");
 
   private static final Logger logger = LoggerFactory.getLogger(BackupFileManager.class);
+  private final ObjectMapper objectMapper = new ObjectMapper();
   private final AccountServiceMetrics accountServiceMetrics;
   private final Path backupDirPath;
   private final int maxBackupFileCount;
@@ -88,6 +88,7 @@ class BackupFileManager {
    */
   public BackupFileManager(AccountServiceMetrics accountServiceMetrics, String backupDir, int maxBackupFileCount)
       throws IOException {
+    this.objectMapper.writer(new DefaultPrettyPrinter());
     this.accountServiceMetrics = accountServiceMetrics;
     backupDirPath = backupDir.isEmpty() ? null : Files.createDirectories(Paths.get(backupDir));
     this.maxBackupFileCount = maxBackupFileCount;
@@ -204,15 +205,15 @@ class BackupFileManager {
 
   /**
    * Persist account map to local storage, with associated version and modified time information.
-   * @param accountMap The account map
+   * @param accounts The account collection
    * @param version The version of the account
    * @param modifiedTimeInSec modified time in seconds
    */
-  void persistAccountMap(Map<String, String> accountMap, int version, long modifiedTimeInSec) {
+  void persistAccountMap(Collection<Account> accounts, int version, long modifiedTimeInSec) {
     if (backupDirPath == null) {
       return;
     }
-    Objects.requireNonNull(accountMap, "Invalid account map");
+    Objects.requireNonNull(accounts, "Invalid account collection");
     if (backupFileInfos.containsKey(version)) {
       logger.trace("Version {} already has a backup file {}, skip persisting the state", version,
           backupFileInfos.get(version).getFilename());
@@ -231,7 +232,7 @@ class BackupFileManager {
 
     long startTimeInMs = System.currentTimeMillis();
     try {
-      writeAccountMapToFile(tempFilePath, accountMap);
+      writeAccountsToFile(tempFilePath, objectMapper, accounts);
       Files.move(tempFilePath, filePath);
     } catch (IOException e) {
       logger.error("Failed to persist state to file: {}", fileName, e);
@@ -274,7 +275,7 @@ class BackupFileManager {
    * @param latestTimeAllowedInSecond The unix epoch time which the latest backup's modifiedTime must be greater than.
    * @return The account map from the latest backup file.
    */
-  Map<String, String> getLatestAccountMap(long latestTimeAllowedInSecond) {
+  Collection<Account> getLatestAccounts(long latestTimeAllowedInSecond) {
     if (backupDirPath == null) {
       return null;
     }
@@ -301,7 +302,7 @@ class BackupFileManager {
       long startTimeInMs = System.currentTimeMillis();
       byte[] bytes = Files.readAllBytes(filepath);
       accountServiceMetrics.backupReadTimeInMs.update(System.currentTimeMillis() - startTimeInMs);
-      return deserializeAccountMap(bytes);
+      return deserializeAccounts(objectMapper, bytes);
     } catch (IOException e) {
       accountServiceMetrics.backupErrorCount.inc();
       logger.error("Failed to read all bytes out from file {} {}", filepath, e.getMessage());
@@ -354,53 +355,47 @@ class BackupFileManager {
   }
 
   /**
-   * Persist the account map to the given file.
+   * Persist the account collection to the given file.
    * @param filepath The filepath to persist account map.
-   * @param accountMap Account map.
+   * @param accounts The {@link Collection} of {@link Account}s
    * @throws IOException Any I/O error.
    */
-  static void writeAccountMapToFile(Path filepath, Map<String, String> accountMap) throws IOException {
+  static void writeAccountsToFile(Path filepath, ObjectMapper objectMapper, Collection<Account> accounts)
+      throws IOException {
     try (FileChannel channel = FileChannel.open(filepath, StandardOpenOption.CREATE,
         StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE)) {
-      ByteBuffer buffer = serializeAccountMap(accountMap);
+      ByteBuffer buffer = serializeAccounts(objectMapper, accounts);
       channel.write(buffer);
     } catch (IOException e) {
       // Failed to persist file
-      logger.error("Failed to persist account map to file {}", filepath, e);
+      logger.error("Failed to persist accounts to file {}", filepath, e);
       throw e;
     }
   }
 
   /**
-   * Convert given account map to an array of {@link Account}s and serialize it in json format in a {@link ByteBuffer}.
-   * @param accountMap The account map.
+   * Serialize given account collection in json format in a {@link ByteBuffer}.
+   * @param accounts The {@link Collection} of {@link Account}s.
    * @return {@link ByteBuffer} that contains the serialized bytes.
    */
-  static ByteBuffer serializeAccountMap(Map<String, String> accountMap) {
-    JSONArray array = new JSONArray();
-    for (Map.Entry<String, String> entry : accountMap.entrySet()) {
-      array.put(new JSONObject(entry.getValue()));
-    }
-    return ByteBuffer.wrap(array.toString(2).getBytes(StandardCharsets.UTF_8));
+  static ByteBuffer serializeAccounts(ObjectMapper objectMapper, Collection<Account> accounts) throws IOException {
+    return ByteBuffer.wrap(objectMapper.writeValueAsBytes(accounts));
   }
 
   /**
-   * Deserialize the given byte array to an account map, which essentially just a map from string to string.
+   * Deserialize the given byte array to an account collection.
    * It returns null at any exception. This function assume the bytes are in json format.
+   * @param objectMapper {@link ObjectMapper}.
    * @param bytes The byte array to deserialize.
-   * @return An account map.
+   * @return The {@link Collection} of {@link Account}s.
    */
-  static Map<String, String> deserializeAccountMap(byte[] bytes) {
+  static Collection<Account> deserializeAccounts(ObjectMapper objectMapper, byte[] bytes) {
     try {
-      JSONArray array = new JSONArray(new String(bytes, StandardCharsets.UTF_8));
-      Map<String, String> result = new HashMap<>();
-      for (int i = 0; i < array.length(); i++) {
-        Account account = Account.fromJson(array.getJSONObject(i));
-        result.put(String.valueOf(account.getId()), array.getJSONObject(i).toString());
-      }
-      return result;
-    } catch (JSONException e) {
-      logger.error("Failed to deserialized bytes to account map: {}", e.getMessage());
+      Collection<Account> accounts = objectMapper.readValue(bytes, new TypeReference<Collection<Account>>() {
+      });
+      return accounts;
+    } catch (IOException e) {
+      logger.error("Failed to deserialized bytes to account collection: {}", e.getMessage());
       return null;
     }
   }

--- a/ambry-account/src/main/java/com/github/ambry/account/LegacyMetadataStore.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/LegacyMetadataStore.java
@@ -121,7 +121,9 @@ class LegacyMetadataStore extends AccountMetadataStore {
       } else {
         for (Account account : accountsToUpdate) {
           try {
-            accountMap.put(String.valueOf(account.getId()), account.toJson(true).toString());
+            String accountJsonStr = objectMapper.writeValueAsString(
+                new AccountBuilder(account).snapshotVersion(account.getSnapshotVersion() + 1).build());
+            accountMap.put(String.valueOf(account.getId()), accountJsonStr);
           } catch (Exception e) {
             errorMessage = "Updating accounts failed because unexpected exception occurred when updating accountId="
                 + account.getId() + " accountName=" + account.getName();

--- a/ambry-account/src/main/java/com/github/ambry/account/MySqlAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/MySqlAccountService.java
@@ -29,7 +29,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -124,11 +123,11 @@ public class MySqlAccountService extends AbstractAccountService {
    */
   private void initCacheFromBackupFile() {
     long aMonthAgo = SystemTime.getInstance().seconds() - TimeUnit.DAYS.toSeconds(30);
-    Map<String, String> accountMapFromFile = backupFileManager.getLatestAccountMap(aMonthAgo);
+    Collection<Account> accounts = backupFileManager.getLatestAccounts(aMonthAgo);
     AccountInfoMap accountInfoMap = null;
-    if (accountMapFromFile != null) {
+    if (accounts != null) {
       try {
-        accountInfoMap = new AccountInfoMap(accountServiceMetrics, accountMapFromFile);
+        accountInfoMap = new AccountInfoMap(accounts);
       } catch (Exception e) {
         logger.warn("Failure in parsing of Account Metadata from local backup file", e);
       }
@@ -233,10 +232,7 @@ public class MySqlAccountService extends AbstractAccountService {
         } finally {
           infoMapLock.readLock().unlock();
         }
-        Map<String, String> accountMap = new HashMap<>();
-        accountCollection.forEach(
-            account -> accountMap.put(Short.toString(account.getId()), account.toJson(false).toString()));
-        backupFileManager.persistAccountMap(accountMap, backupFileManager.getLatestVersion() + 1,
+        backupFileManager.persistAccountMap(accountCollection, backupFileManager.getLatestVersion() + 1,
             SystemTime.getInstance().seconds());
       } else {
         // Cache is up to date

--- a/ambry-account/src/main/java/com/github/ambry/account/RouterStore.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/RouterStore.java
@@ -341,7 +341,9 @@ class RouterStore extends AccountMetadataStore {
 
       for (Account account : this.accounts) {
         try {
-          accountMap.put(String.valueOf(account.getId()), account.toJson(true).toString());
+          String accountJsonStr = objectMapper.writeValueAsString(
+              new AccountBuilder(account).snapshotVersion(account.getSnapshotVersion() + 1).build());
+          accountMap.put(String.valueOf(account.getId()), accountJsonStr);
         } catch (Exception e) {
           logAndThrowIllegalStateException(
               "Updating accounts failed because unexpected exception occurred when updating accountId="

--- a/ambry-account/src/test/java/com/github/ambry/account/BackupFileManagerTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/BackupFileManagerTest.java
@@ -14,6 +14,7 @@
 package com.github.ambry.account;
 
 import com.codahale.metrics.MetricRegistry;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.ambry.config.HelixAccountServiceConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.utils.TestUtils;
@@ -25,10 +26,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Properties;
 import java.util.Random;
 import java.util.UUID;
@@ -44,6 +44,7 @@ import static org.junit.Assert.*;
  * Unit test for {@link BackupFileManager}
  */
 public class BackupFileManagerTest {
+  private static final ObjectMapper objectMapper = new ObjectMapper();
   private final AccountServiceMetrics accountServiceMetrics = new AccountServiceMetrics(new MetricRegistry());
   private final Properties helixConfigProps = new Properties();
   private static final int ZK_CLIENT_CONNECTION_TIMEOUT_MS = 20000;
@@ -93,20 +94,20 @@ public class BackupFileManagerTest {
     BackupFileManager backup =
         new BackupFileManager(accountServiceMetrics, config.backupDir, config.maxBackupFileCount);
 
-    // getLatestAccountMap should return null
-    assertNull("Disabled backup shouldn't have any state", backup.getLatestAccountMap(0));
+    // getLatestAccounts should return null
+    assertNull("Disabled backup shouldn't have any state", backup.getLatestAccounts(0));
 
     // persistAccountMap should not create any backup
     Stat stat = new Stat();
     stat.setVersion(1);
     stat.setMtime(System.currentTimeMillis());
 
-    backup.persistAccountMap(new HashMap<String, String>(), stat.getVersion(), stat.getMtime() / 1000);
+    backup.persistAccountMap(Collections.emptyList(), stat.getVersion(), stat.getMtime() / 1000);
     assertTrue("Disabled backup shouldn't add any backup", backup.isEmpty());
   }
 
   /**
-   * Test getLatestAccountMap function when all the backup files are files with version number.
+   * Test getLatestAccounts function when all the backup files are files with version number.
    * @throws IOException if I/O error occurs
    */
   @Test
@@ -119,22 +120,19 @@ public class BackupFileManagerTest {
         createBackupFilesWithVersion(accountBackupDir, startVersion, endVersion, baseModifiedTime, interval, false);
     saveAccountsToFile(Collections.singleton(refAccount), accountBackupDir.resolve(filenames[filenames.length - 1]));
 
-    Map<String, String> expected = new HashMap<>();
-    expected.put(String.valueOf(refAccount.getId()), refAccount.toJson(true).toString());
-
     BackupFileManager backup =
         new BackupFileManager(accountServiceMetrics, config.backupDir, config.maxBackupFileCount);
-    Map<String, String> obtained = backup.getLatestAccountMap(0);
-    assertTwoStringMapsEqual(expected, obtained);
+    Collection<Account> obtained = backup.getLatestAccounts(0);
+    assertEquals(Collections.singletonList(refAccount), obtained);
     assertFalse("There are backup files", backup.isEmpty());
 
-    obtained = backup.getLatestAccountMap(System.currentTimeMillis() / 1000);
+    obtained = backup.getLatestAccounts(System.currentTimeMillis() / 1000);
     assertNull("No backup file should have a modified time later than now", obtained);
     assertEquals(backup.size(), endVersion - startVersion + 1);
   }
 
   /**
-   * Test getLatestAccountMap function when all the backup files are files without version number.
+   * Test getLatestAccounts function when all the backup files are files without version number.
    * @throws IOException if I/O error occurs
    */
   @Test
@@ -147,14 +145,14 @@ public class BackupFileManagerTest {
 
     BackupFileManager backup =
         new BackupFileManager(accountServiceMetrics, config.backupDir, config.maxBackupFileCount);
-    Map<String, String> obtained = backup.getLatestAccountMap(0);
+    Collection<Account> obtained = backup.getLatestAccounts(0);
     assertNull("No state should be loaded from backup file from old format", obtained);
     assertFalse("Backup should not be empty since there are files from old format", backup.isEmpty());
     assertEquals(backup.size(), count);
   }
 
   /**
-   * Test getLatestAccountMap function when some of the files are with version number and some are not.
+   * Test getLatestAccounts function when some of the files are with version number and some are not.
    * @throws IOException if I/O error occurs
    */
   @Test
@@ -170,13 +168,10 @@ public class BackupFileManagerTest {
         baseModifiedTime + 2 * backupFileNoVersionCount * interval, interval, false);
     saveAccountsToFile(Collections.singleton(refAccount), accountBackupDir.resolve(filenames[filenames.length - 1]));
 
-    Map<String, String> expected = new HashMap<>();
-    expected.put(String.valueOf(refAccount.getId()), refAccount.toJson(true).toString());
-
     BackupFileManager backup =
         new BackupFileManager(accountServiceMetrics, config.backupDir, config.maxBackupFileCount);
-    Map<String, String> obtained = backup.getLatestAccountMap(0);
-    assertTwoStringMapsEqual(expected, obtained);
+    Collection<Account> obtained = backup.getLatestAccounts(0);
+    assertEquals(Collections.singletonList(refAccount), obtained);
     assertFalse("There are backup files", backup.isEmpty());
     assertEquals(backup.size(), endVersion - startVersion + 1 + backupFileNoVersionCount);
   }
@@ -261,7 +256,7 @@ public class BackupFileManagerTest {
   }
 
   /**
-   * Test {@link BackupFileManager#persistAccountMap(Map, int, long)} and then recover {@link BackupFileManager} from the same backup directory.
+   * Test {@link BackupFileManager#persistAccountMap(Collection, int, long)} and then recover {@link BackupFileManager} from the same backup directory.
    * @throws IOException if I/O error occurs
    */
   @Test
@@ -269,13 +264,13 @@ public class BackupFileManagerTest {
     BackupFileManager backup =
         new BackupFileManager(accountServiceMetrics, config.backupDir, config.maxBackupFileCount);
     final int numberAccounts = maxBackupFile * 2;
-    final Map<String, String> accounts = new HashMap<>(numberAccounts);
+    final Collection<Account> accounts = new ArrayList<>();
     final Stat stat = new Stat();
     final long interval = 1;
     long modifiedTime = System.currentTimeMillis() / 1000 - numberAccounts * 2;
     for (int i = 0; i < numberAccounts; i++) {
       Account account = createRandomAccount();
-      accounts.put(String.valueOf(account.getId()), account.toJson(true).toString());
+      accounts.add(account);
       stat.setVersion(i + 1);
       stat.setMtime(modifiedTime * 1000);
       backup.persistAccountMap(accounts, stat.getVersion(), stat.getMtime() / 1000);
@@ -284,8 +279,8 @@ public class BackupFileManagerTest {
 
     for (int i = 0; i < 2; i++) {
       assertEquals("Number of backup file mismatch", maxBackupFile, backup.size());
-      Map<String, String> obtained = backup.getLatestAccountMap(0);
-      assertTwoStringMapsEqual(accounts, obtained);
+      Collection<Account> obtained = backup.getLatestAccounts(0);
+      assertEquals(accounts, obtained);
       File[] remaingingFiles = accountBackupDir.toFile().listFiles();
       assertEquals("Remaining backup mismatch", maxBackupFile, remaingingFiles.length);
 
@@ -299,31 +294,18 @@ public class BackupFileManagerTest {
    * @throws JSONException if {@link Account} can't convert to json
    */
   @Test
-  public void testSerializationAndDeserialization() throws JSONException {
+  public void testSerializationAndDeserialization() throws IOException {
     // Since the account metadata is stored in an map from string to string, so here we only test map<string, string>
-    Map<String, String> state = new HashMap<>();
-    ByteBuffer buffer = BackupFileManager.serializeAccountMap(state);
-    Map<String, String> deserializedState = BackupFileManager.deserializeAccountMap(buffer.array());
-    assertTwoStringMapsEqual(state, deserializedState);
+    Collection<Account> state = new ArrayList<>();
+    ByteBuffer buffer = BackupFileManager.serializeAccounts(objectMapper, state);
+    Collection<Account> deserializedState = BackupFileManager.deserializeAccounts(objectMapper, buffer.array());
+    assertEquals(state, deserializedState);
 
     // Put a real account's json string
-    state.put(String.valueOf(refAccount.getId()), refAccount.toJson(true).toString());
-    buffer = BackupFileManager.serializeAccountMap(state);
-    deserializedState = BackupFileManager.deserializeAccountMap(buffer.array());
-    assertTwoStringMapsEqual(state, deserializedState);
-  }
-
-  /**
-   * Assert the given two maps equal to each other.
-   * @param m1 First map.
-   * @param m2 Second map.
-   */
-  private void assertTwoStringMapsEqual(Map<String, String> m1, Map<String, String> m2) {
-    assertEquals("Two maps don't have the same size", m1.size(), m2.size());
-    for (Map.Entry<String, String> entry : m1.entrySet()) {
-      assertTrue(entry.getKey() + " doesn't exist in second map", m2.containsKey(entry.getKey()));
-      assertEquals("Values of key " + entry.getKey() + " differ", entry.getValue(), m2.get(entry.getKey()));
-    }
+    state.add(refAccount);
+    buffer = BackupFileManager.serializeAccounts(objectMapper, state);
+    deserializedState = BackupFileManager.deserializeAccounts(objectMapper, buffer.array());
+    assertEquals(state, deserializedState);
   }
 
   /**
@@ -423,15 +405,8 @@ public class BackupFileManagerTest {
    * @param filePath The given file.
    */
   private static void saveAccountsToFile(Collection<Account> accounts, Path filePath) {
-    Map<String, String> accountMap = new HashMap<>();
     try {
-      accounts.stream()
-          .forEach((account) -> accountMap.put(String.valueOf(account.getId()), account.toJson(true).toString()));
-    } catch (JSONException e) {
-      fail("Fail to get a json format of accounts");
-    }
-    try {
-      BackupFileManager.writeAccountMapToFile(filePath, accountMap);
+      BackupFileManager.writeAccountsToFile(filePath, objectMapper, accounts);
     } catch (Exception e) {
       fail("Fail to write state to file: " + filePath.toString());
     }

--- a/ambry-account/src/test/java/com/github/ambry/account/BackupFileManagerTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/BackupFileManagerTest.java
@@ -14,7 +14,6 @@
 package com.github.ambry.account;
 
 import com.codahale.metrics.MetricRegistry;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.ambry.config.HelixAccountServiceConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.utils.TestUtils;
@@ -44,7 +43,6 @@ import static org.junit.Assert.*;
  * Unit test for {@link BackupFileManager}
  */
 public class BackupFileManagerTest {
-  private static final ObjectMapper objectMapper = new ObjectMapper();
   private final AccountServiceMetrics accountServiceMetrics = new AccountServiceMetrics(new MetricRegistry());
   private final Properties helixConfigProps = new Properties();
   private static final int ZK_CLIENT_CONNECTION_TIMEOUT_MS = 20000;
@@ -297,14 +295,14 @@ public class BackupFileManagerTest {
   public void testSerializationAndDeserialization() throws IOException {
     // Since the account metadata is stored in an map from string to string, so here we only test map<string, string>
     Collection<Account> state = new ArrayList<>();
-    ByteBuffer buffer = BackupFileManager.serializeAccounts(objectMapper, state);
-    Collection<Account> deserializedState = BackupFileManager.deserializeAccounts(objectMapper, buffer.array());
+    ByteBuffer buffer = BackupFileManager.serializeAccounts(state);
+    Collection<Account> deserializedState = BackupFileManager.deserializeAccounts(buffer.array());
     assertEquals(state, deserializedState);
 
     // Put a real account's json string
     state.add(refAccount);
-    buffer = BackupFileManager.serializeAccounts(objectMapper, state);
-    deserializedState = BackupFileManager.deserializeAccounts(objectMapper, buffer.array());
+    buffer = BackupFileManager.serializeAccounts(state);
+    deserializedState = BackupFileManager.deserializeAccounts(buffer.array());
     assertEquals(state, deserializedState);
   }
 
@@ -406,7 +404,7 @@ public class BackupFileManagerTest {
    */
   private static void saveAccountsToFile(Collection<Account> accounts, Path filePath) {
     try {
-      BackupFileManager.writeAccountsToFile(filePath, objectMapper, accounts);
+      BackupFileManager.writeAccountsToFile(filePath, accounts);
     } catch (Exception e) {
       fail("Fail to write state to file: " + filePath.toString());
     }

--- a/ambry-account/src/test/java/com/github/ambry/account/HelixAccountServiceTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/HelixAccountServiceTest.java
@@ -14,6 +14,7 @@
 package com.github.ambry.account;
 
 import com.codahale.metrics.MetricRegistry;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.ambry.clustermap.HelixStoreOperator;
 import com.github.ambry.clustermap.MockHelixPropertyStore;
 import com.github.ambry.config.HelixAccountServiceConfig;
@@ -53,10 +54,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.helix.store.HelixPropertyStore;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
-import org.json.JSONArray;
 import org.json.JSONException;
-import org.json.JSONObject;
-import org.json.JSONTokener;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -77,6 +75,7 @@ import static org.junit.Assume.*;
  */
 @RunWith(Parameterized.class)
 public class HelixAccountServiceTest {
+  private static final ObjectMapper objectMapper = new ObjectMapper();
   private static final int ZK_CLIENT_CONNECTION_TIMEOUT_MS = 20000;
   private static final int ZK_CLIENT_SESSION_TIMEOUT_MS = 20000;
   private static final String ZK_CONNECT_STRING = "dummyHost:dummyPort";
@@ -586,7 +585,8 @@ public class HelixAccountServiceTest {
   @Test
   public void testReadBadZNRecordCase3() throws Exception {
     Map<String, String> mapValue = new HashMap<>();
-    mapValue.put(String.valueOf(refAccount.getId()), refAccount.toJson(true).toString());
+    mapValue.put(String.valueOf(refAccount.getId()), objectMapper.writeValueAsString(
+        new AccountBuilder(refAccount).snapshotVersion(refAccount.getSnapshotVersion() + 1).build()));
     ZNRecord zNRecord = makeZNRecordWithMapField(null, "key", mapValue);
     updateAndWriteZNRecord(zNRecord, true);
   }
@@ -601,7 +601,8 @@ public class HelixAccountServiceTest {
   @Test
   public void testReadBadZNRecordCase4() throws Exception {
     Map<String, String> mapValue = new HashMap<>();
-    mapValue.put("-1", refAccount.toJson(true).toString());
+    mapValue.put("-1", objectMapper.writeValueAsString(
+        new AccountBuilder(refAccount).snapshotVersion(refAccount.getSnapshotVersion() + 1).build()));
     ZNRecord zNRecord = null;
     if (useNewZNodePath) {
       String blobID = RouterStore.writeAccountMapToRouter(mapValue, mockRouter);
@@ -644,7 +645,8 @@ public class HelixAccountServiceTest {
   public void testReadBadZNRecordCase6() throws Exception {
     ZNRecord zNRecord = new ZNRecord(String.valueOf(System.currentTimeMillis()));
     Map<String, String> accountMap = new HashMap<>();
-    accountMap.put(String.valueOf(refAccount.getId()), refAccount.toJson(true).toString());
+    accountMap.put(String.valueOf(refAccount.getId()), objectMapper.writeValueAsString(
+        new AccountBuilder(refAccount).snapshotVersion(refAccount.getSnapshotVersion() + 1).build()));
     accountMap.put(String.valueOf(refAccount.getId() + 1), BAD_ACCOUNT_METADATA_STRING);
     if (useNewZNodePath) {
       String blobID = RouterStore.writeAccountMapToRouter(accountMap, mockRouter);
@@ -669,7 +671,8 @@ public class HelixAccountServiceTest {
     }
     ZNRecord zNRecord = new ZNRecord(String.valueOf(System.currentTimeMillis()));
     Map<String, String> accountMap = new HashMap<>();
-    accountMap.put(String.valueOf(refAccount.getId()), refAccount.toJson(true).toString());
+    accountMap.put(String.valueOf(refAccount.getId()), objectMapper.writeValueAsString(
+        new AccountBuilder(refAccount).snapshotVersion(refAccount.getSnapshotVersion() + 1).build()));
     RouterStore.writeAccountMapToRouter(accountMap, mockRouter);
     List<String> list = Collections.singletonList("bad_list_string");
     zNRecord.setListField(RouterStore.ACCOUNT_METADATA_BLOB_IDS_LIST_KEY, list);
@@ -689,7 +692,8 @@ public class HelixAccountServiceTest {
     }
     ZNRecord zNRecord = new ZNRecord(String.valueOf(System.currentTimeMillis()));
     Map<String, String> accountMap = new HashMap<>();
-    accountMap.put(String.valueOf(refAccount.getId()), refAccount.toJson(true).toString());
+    accountMap.put(String.valueOf(refAccount.getId()), objectMapper.writeValueAsString(
+        new AccountBuilder(refAccount).snapshotVersion(refAccount.getSnapshotVersion() + 1).build()));
     String blobID = RouterStore.writeAccountMapToRouter(accountMap, mockRouter);
     List<String> list = new ArrayList<>();
     list.add("badliststring");
@@ -1267,32 +1271,13 @@ public class HelixAccountServiceTest {
   private void checkBackupFileWithVersion(Collection<Account> expectedAccounts, Path backupPath)
       throws JSONException, IOException {
     try (BufferedReader reader = Files.newBufferedReader(backupPath)) {
-      JSONArray accountArray = new JSONArray(new JSONTokener(reader));
-      int arrayLength = accountArray.length();
-      assertEquals("unexpected array size", expectedAccounts.size(), arrayLength);
+      Account[] accounts = objectMapper.readValue(reader, Account[].class);
+      assertEquals("unexpected array size", expectedAccounts.size(), accounts.length);
       Set<Account> expectedAccountSet = new HashSet<>(expectedAccounts);
-      for (int i = 0; i < arrayLength; i++) {
-        JSONObject accountJson = accountArray.getJSONObject(i);
-        Account account = Account.fromJson(accountJson);
-        assertTrue("unexpected account in array: " + accountJson.toString(), expectedAccountSet.contains(account));
+      for (int i = 0; i < accounts.length; i++) {
+        Account account = accounts[i];
+        assertTrue("unexpected account in array: " + account.toString(), expectedAccountSet.contains(account));
       }
-    }
-  }
-
-  /**
-   * Assert that the account map has the same accounts with the expected account set.
-   * @param expectedAccounts the expected {@link Account}s.
-   * @param accountMap the account map.
-   * @throws Exception
-   */
-  private void assertAccountMapEquals(Collection<Account> expectedAccounts, Map<String, String> accountMap)
-      throws Exception {
-    Set<Account> expectedAccountSet = new HashSet<>(expectedAccounts);
-    assertEquals("Number of accounts mismatch", expectedAccountSet.size(), accountMap.size());
-    for (String accountJsonString : accountMap.values()) {
-      JSONObject accountJson = new JSONObject(accountJsonString);
-      Account account = Account.fromJson(accountJson);
-      assertTrue("unexpected account in map: " + accountJson.toString(), expectedAccountSet.contains(account));
     }
   }
 
@@ -1308,7 +1293,8 @@ public class HelixAccountServiceTest {
     ZNRecord zNRecord = new ZNRecord(String.valueOf(System.currentTimeMillis()));
     Map<String, String> accountMap = new HashMap<>();
     for (Account account : accounts) {
-      accountMap.put(String.valueOf(account.getId()), account.toJson(true).toString());
+      accountMap.put(String.valueOf(account.getId()), objectMapper.writeValueAsString(
+          new AccountBuilder(account).snapshotVersion(refAccount.getSnapshotVersion() + 1).build()));
     }
     if (useNewZNodePath) {
       String blobID = RouterStore.writeAccountMapToRouter(accountMap, mockRouter);

--- a/ambry-account/src/test/java/com/github/ambry/account/JsonAccountServiceTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/JsonAccountServiceTest.java
@@ -14,12 +14,12 @@
 package com.github.ambry.account;
 
 import com.codahale.metrics.MetricRegistry;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.ambry.config.JsonAccountConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -29,7 +29,6 @@ import java.util.HashSet;
 import java.util.Properties;
 import java.util.Random;
 import java.util.Set;
-import org.json.JSONArray;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -101,7 +100,6 @@ public class JsonAccountServiceTest {
 
     Random pseudoRandom = new Random(randomSeed);
 
-    JSONArray accountsJsonRoot = new JSONArray();
     // Using a set since caller will probably use this to verify it's own results. So will be doing mostly random
     // lookups.
     Set<Account> generatedAccounts = new HashSet<>(noAccounts);
@@ -111,10 +109,9 @@ public class JsonAccountServiceTest {
           new AccountBuilder(x, randomString(pseudoRandom, 16), Account.AccountStatus.ACTIVE).build();
 
       generatedAccounts.add(generatedAccount);
-      accountsJsonRoot.put(generatedAccount.toJson(false));
     }
 
-    Files.write(accountJsonFilePath, Collections.singleton(accountsJsonRoot.toString(4)), StandardCharsets.UTF_8);
+    Files.write(accountJsonFilePath, new ObjectMapper().writeValueAsBytes(generatedAccounts));
 
     return generatedAccounts;
   }

--- a/ambry-account/src/test/java/com/github/ambry/account/MySqlAccountServiceTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/MySqlAccountServiceTest.java
@@ -14,7 +14,6 @@
 package com.github.ambry.account;
 
 import com.codahale.metrics.MetricRegistry;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.ambry.account.mysql.MySqlAccountStore;
 import com.github.ambry.account.mysql.MySqlAccountStoreFactory;
 import com.github.ambry.commons.Notifier;
@@ -91,7 +90,7 @@ public class MySqlAccountServiceTest {
     accounts.add(testAccount);
     String filename = BackupFileManager.getBackupFilename(1, SystemTime.getInstance().seconds());
     Path filePath = accountBackupDir.resolve(filename);
-    BackupFileManager.writeAccountsToFile(filePath, new ObjectMapper(), accounts);
+    BackupFileManager.writeAccountsToFile(filePath, accounts);
 
     mySqlAccountService = getAccountService();
 

--- a/ambry-account/src/test/java/com/github/ambry/account/MySqlAccountServiceTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/MySqlAccountServiceTest.java
@@ -14,6 +14,7 @@
 package com.github.ambry.account;
 
 import com.codahale.metrics.MetricRegistry;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.ambry.account.mysql.MySqlAccountStore;
 import com.github.ambry.account.mysql.MySqlAccountStoreFactory;
 import com.github.ambry.commons.Notifier;
@@ -28,10 +29,8 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -88,11 +87,11 @@ public class MySqlAccountServiceTest {
     Account testAccount =
         new AccountBuilder((short) 1, "testAccount", Account.AccountStatus.ACTIVE).lastModifiedTime(lastModifiedTime)
             .build();
-    Map<String, String> accountMap = new HashMap<>();
-    accountMap.put(Short.toString(testAccount.getId()), testAccount.toJson(false).toString());
+    Collection<Account> accounts = new ArrayList<>();
+    accounts.add(testAccount);
     String filename = BackupFileManager.getBackupFilename(1, SystemTime.getInstance().seconds());
     Path filePath = accountBackupDir.resolve(filename);
-    BackupFileManager.writeAccountMapToFile(filePath, accountMap);
+    BackupFileManager.writeAccountsToFile(filePath, new ObjectMapper(), accounts);
 
     mySqlAccountService = getAccountService();
 

--- a/ambry-account/src/test/java/com/github/ambry/account/RouterStoreTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/RouterStoreTest.java
@@ -259,8 +259,8 @@ public class RouterStoreTest {
     assertTrue("Update accounts failed at router store", succeeded);
 
     // verify that fetchAccountMetadata can fetch the accounts we just updated.
-    Map<String, String> accountMap = store.fetchAccountMetadata();
-    assertAccountsEqual(accountMap, allAccounts);
+    Collection<Account> accounts = store.fetchAccountMetadata();
+    assertAccountsEqual(accounts, allAccounts);
 
     List<RouterStore.BlobIDAndVersion> blobIDAndVersions = getBlobIDAndVersionInHelix(count);
     RouterStore.BlobIDAndVersion blobIDAndVersion = null;
@@ -271,7 +271,7 @@ public class RouterStoreTest {
       }
     }
     assertNotNull("Version " + version + " expected", blobIDAndVersion);
-    accountMap = store.readAccountMetadataFromBlobID(blobIDAndVersion.getBlobID());
+    Map<String, String> accountMap = store.readAccountMetadataFromBlobID(blobIDAndVersion.getBlobID());
     assertAccountsEqual(accountMap, allAccounts);
   }
 
@@ -297,17 +297,37 @@ public class RouterStoreTest {
   }
 
   /**
-   * Compare the account map in json string with the account map from id to account.
-   * @param accountMap The account map ini json string.
-   * @param accounts The account map from id to account.
+   * Compare the account collection in json string with the account map from id to account.
+   * @param accounts The account collection in json string.
+   * @param accountMap The account map from id to account.
    */
-  private void assertAccountsEqual(Map<String, String> accountMap, Map<Short, Account> accounts) {
-    AccountInfoMap accountInfoMap = new AccountInfoMap(accountServiceMetrics, accountMap);
+  private void assertAccountsEqual(Collection<Account> accounts, Map<Short, Account> accountMap) {
+    AccountInfoMap accountInfoMap = new AccountInfoMap(accounts);
+    assertAccountInfoMapSameAccountWithAccountMap(accountInfoMap, accountMap);
+  }
+
+  /**
+   * Compare the account map in json string with the account map from id to account.
+   * @param accounts The account map in json string.
+   * @param accountMap The account map from id to account.
+   */
+  private void assertAccountsEqual(Map<String, String> accounts, Map<Short, Account> accountMap) {
+    AccountInfoMap accountInfoMap = new AccountInfoMap(accountServiceMetrics, accounts);
+    assertAccountInfoMapSameAccountWithAccountMap(accountInfoMap, accountMap);
+  }
+
+  /**
+   * Compare the accounts in {@link AccountInfoMap} with the account map from id to account.
+   * @param accountInfoMap The {@link AccountInfoMap}.
+   * @param accountMap The account map from id to account.
+   */
+  private void assertAccountInfoMapSameAccountWithAccountMap(AccountInfoMap accountInfoMap,
+      Map<Short, Account> accountMap) {
     Collection<Account> obtainedAccounts = accountInfoMap.getAccounts();
 
-    assertEquals("Account size doesn't match", obtainedAccounts.size(), accounts.size());
+    assertEquals("Account size doesn't match", obtainedAccounts.size(), obtainedAccounts.size());
     for (Account obtainedAccount : obtainedAccounts) {
-      Account expectedAccount = accounts.get(obtainedAccount.getId());
+      Account expectedAccount = accountMap.get(obtainedAccount.getId());
       assertEquals("Account mismatched", expectedAccount, obtainedAccount);
     }
   }

--- a/ambry-api/src/main/java/com/github/ambry/account/Account.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/Account.java
@@ -95,6 +95,7 @@ public class Account {
    */
   public static final short HELIX_ACCOUNT_SERVICE_ACCOUNT_ID = -2;
   public static final short UNINITIALIZED_ACCOUNT_ID = -3;
+  public static final String UNINITIALIZED_ACCOUNT_NAME = "__uninitialized_acount_name__";
   public static final QuotaResourceType QUOTA_RESOURCE_TYPE_DEFAULT_VALUE = QuotaResourceType.CONTAINER;
   // static variables
   static final String JSON_VERSION_KEY = "version";

--- a/ambry-api/src/main/java/com/github/ambry/account/Account.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/Account.java
@@ -94,7 +94,6 @@ public class Account {
    * The id for to save account metadata in ambry.
    */
   public static final short HELIX_ACCOUNT_SERVICE_ACCOUNT_ID = -2;
-  public static final short UNINITIALIZED_ACCOUNT_ID = -3;
   public static final QuotaResourceType QUOTA_RESOURCE_TYPE_DEFAULT_VALUE = QuotaResourceType.CONTAINER;
   // static variables
   static final String JSON_VERSION_KEY = "version";

--- a/ambry-api/src/main/java/com/github/ambry/account/Account.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/Account.java
@@ -95,7 +95,6 @@ public class Account {
    */
   public static final short HELIX_ACCOUNT_SERVICE_ACCOUNT_ID = -2;
   public static final short UNINITIALIZED_ACCOUNT_ID = -3;
-  public static final String UNINITIALIZED_ACCOUNT_NAME = "__uninitialized_acount_name__";
   public static final QuotaResourceType QUOTA_RESOURCE_TYPE_DEFAULT_VALUE = QuotaResourceType.CONTAINER;
   // static variables
   static final String JSON_VERSION_KEY = "version";

--- a/ambry-api/src/main/java/com/github/ambry/account/AccountBuilder.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/AccountBuilder.java
@@ -34,8 +34,8 @@ import static com.github.ambry.account.Account.*;
 @JsonPOJOBuilder(withPrefix = "")
 public class AccountBuilder {
   private short id = UNINITIALIZED_ACCOUNT_ID;
-  private String name = UNINITIALIZED_ACCOUNT_NAME;
-  private AccountStatus status = AccountStatus.ACTIVE;
+  private String name = null;
+  private AccountStatus status = null;
   private QuotaResourceType quotaResourceType = QUOTA_RESOURCE_TYPE_DEFAULT_VALUE;
   private int snapshotVersion = SNAPSHOT_VERSION_DEFAULT_VALUE;
   private long lastModifiedTime = LAST_MODIFIED_TIME_DEFAULT_VALUE;
@@ -223,8 +223,8 @@ public class AccountBuilder {
    * @throws IllegalStateException If any required fields is not set or there is inconsistency in containers.
    */
   public Account build() {
-    if (id == UNINITIALIZED_ACCOUNT_ID || name.equals(UNINITIALIZED_ACCOUNT_NAME)) {
-      throw new IllegalStateException("Account id or account name is not present");
+    if (id == UNINITIALIZED_ACCOUNT_ID) {
+      throw new IllegalStateException("Account id is not present");
     }
     // Did we check the container parent account id here?
     for (Map.Entry<Short, Container> entry : idToContainerMetadataMap.entrySet()) {

--- a/ambry-api/src/main/java/com/github/ambry/account/AccountBuilder.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/AccountBuilder.java
@@ -33,9 +33,9 @@ import static com.github.ambry.account.Account.*;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonPOJOBuilder(withPrefix = "")
 public class AccountBuilder {
-  private short id;
-  private String name;
-  private AccountStatus status;
+  private short id = UNINITIALIZED_ACCOUNT_ID;
+  private String name = UNINITIALIZED_ACCOUNT_NAME;
+  private AccountStatus status = AccountStatus.ACTIVE;
   private QuotaResourceType quotaResourceType = QUOTA_RESOURCE_TYPE_DEFAULT_VALUE;
   private int snapshotVersion = SNAPSHOT_VERSION_DEFAULT_VALUE;
   private long lastModifiedTime = LAST_MODIFIED_TIME_DEFAULT_VALUE;
@@ -223,6 +223,9 @@ public class AccountBuilder {
    * @throws IllegalStateException If any required fields is not set or there is inconsistency in containers.
    */
   public Account build() {
+    if (id == UNINITIALIZED_ACCOUNT_ID || name.equals(UNINITIALIZED_ACCOUNT_NAME)) {
+      throw new IllegalStateException("Account id or account name is not present");
+    }
     // Did we check the container parent account id here?
     for (Map.Entry<Short, Container> entry : idToContainerMetadataMap.entrySet()) {
       if (entry.getValue().getParentAccountId() == UNINITIALIZED_ACCOUNT_ID) {

--- a/ambry-api/src/main/java/com/github/ambry/account/AccountBuilder.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/AccountBuilder.java
@@ -33,7 +33,7 @@ import static com.github.ambry.account.Account.*;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonPOJOBuilder(withPrefix = "")
 public class AccountBuilder {
-  private short id = UNINITIALIZED_ACCOUNT_ID;
+  private Short id = null;
   private String name = null;
   private AccountStatus status = null;
   private QuotaResourceType quotaResourceType = QUOTA_RESOURCE_TYPE_DEFAULT_VALUE;
@@ -223,12 +223,12 @@ public class AccountBuilder {
    * @throws IllegalStateException If any required fields is not set or there is inconsistency in containers.
    */
   public Account build() {
-    if (id == UNINITIALIZED_ACCOUNT_ID) {
+    if (id == null) {
       throw new IllegalStateException("Account id is not present");
     }
     // Did we check the container parent account id here?
     for (Map.Entry<Short, Container> entry : idToContainerMetadataMap.entrySet()) {
-      if (entry.getValue().getParentAccountId() == UNINITIALIZED_ACCOUNT_ID) {
+      if (entry.getValue().getParentAccountId() == Container.UNKNOWN_CONTAINER_PARENT_ACCOUNT_ID) {
         entry.setValue(new ContainerBuilder(entry.getValue()).setParentAccountId(id).build());
       }
     }

--- a/ambry-api/src/main/java/com/github/ambry/account/AccountBuilder.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/AccountBuilder.java
@@ -14,6 +14,9 @@
 package com.github.ambry.account;
 
 import com.github.ambry.quota.QuotaResourceType;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -27,6 +30,8 @@ import static com.github.ambry.account.Account.*;
  * in two ways: 1) from an existing {@link Account} object; and 2) by supplying required fields of an {@link Account}.
  * This class is not thread safe.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonPOJOBuilder(withPrefix = "")
 public class AccountBuilder {
   private short id;
   private String name;
@@ -56,6 +61,12 @@ public class AccountBuilder {
       idToContainerMetadataMap.put(container.getId(), container);
     }
     quotaResourceType = origin.getQuotaResourceType();
+  }
+
+  /**
+   * Constructor for jackson to deserialize {@link Account}.
+   */
+  public AccountBuilder() {
   }
 
   /**
@@ -93,6 +104,7 @@ public class AccountBuilder {
    * @param id The id to set.
    * @return This builder.
    */
+  @JsonProperty(ACCOUNT_ID_KEY)
   public AccountBuilder id(short id) {
     this.id = id;
     return this;
@@ -103,6 +115,7 @@ public class AccountBuilder {
    * @param name The name to set.
    * @return This builder.
    */
+  @JsonProperty(ACCOUNT_NAME_KEY)
   public AccountBuilder name(String name) {
     this.name = name;
     return this;
@@ -210,6 +223,12 @@ public class AccountBuilder {
    * @throws IllegalStateException If any required fields is not set or there is inconsistency in containers.
    */
   public Account build() {
+    // Did we check the container parent account id here?
+    for (Map.Entry<Short, Container> entry : idToContainerMetadataMap.entrySet()) {
+      if (entry.getValue().getParentAccountId() == UNINITIALIZED_ACCOUNT_ID) {
+        entry.setValue(new ContainerBuilder(entry.getValue()).setParentAccountId(id).build());
+      }
+    }
     return new Account(id, name, status, aclInheritedByContainer, snapshotVersion, idToContainerMetadataMap.values(),
         lastModifiedTime, quotaResourceType);
   }

--- a/ambry-api/src/main/java/com/github/ambry/account/AccountCollectionSerde.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/AccountCollectionSerde.java
@@ -34,6 +34,7 @@ import org.json.JSONObject;
  */
 public class AccountCollectionSerde {
   private static final String ACCOUNTS_KEY = Operations.ACCOUNTS;
+  private static final ObjectMapper objectMapper = new ObjectMapper();
 
   /**
    * Serialize a collection of accounts to a json object that can be used in requests/responses.
@@ -46,8 +47,12 @@ public class AccountCollectionSerde {
     return new JSONObject().put(ACCOUNTS_KEY, accountArray);
   }
 
-  public static byte[] serializeAccountsInJson(ObjectMapper objectMapper, Collection<Account> accounts)
-      throws IOException {
+  /**
+   * Serialize a collection of accounts to json bytes that can be used in requests/responses.
+   * @param accounts the {@link Account}s to serialize.
+   * @return the serialized bytes in json format.
+   */
+  public static byte[] serializeAccountsInJson(Collection<Account> accounts) throws IOException {
     Map<String, Collection<Account>> resultObj = new HashMap<>();
     resultObj.put(ACCOUNTS_KEY, accounts);
     return objectMapper.writeValueAsBytes(resultObj);
@@ -72,8 +77,12 @@ public class AccountCollectionSerde {
     }
   }
 
-  public static Collection<Account> accountsFromInputStreamInJson(ObjectMapper objectMapper, InputStream inputStream)
-      throws IOException {
+  /**
+   * Deserialize a collection of {@link Account} in json from given InputStream.
+   * @param inputStream the {@link InputStream} that contains serialized json bytes.
+   * @return a {@link Collection} of {@link Account}s.
+   */
+  public static Collection<Account> accountsFromInputStreamInJson(InputStream inputStream) throws IOException {
     Map<String, Collection<Account>> map =
         objectMapper.readValue(inputStream, new TypeReference<Map<String, Collection<Account>>>() {
         });
@@ -102,8 +111,12 @@ public class AccountCollectionSerde {
     return new JSONObject().put(Account.CONTAINERS_KEY, containerArray);
   }
 
-  public static byte[] serializeContainersInJson(ObjectMapper objectMapper, Collection<Container> containers)
-      throws IOException {
+  /**
+   * Serialize a collection of containers to json bytes that can be used in requests/responses.
+   * @param containers the {@link Container}s to serialize.
+   * @return the serialized bytes in json format.
+   */
+  public static byte[] serializeContainersInJson(Collection<Container> containers) throws IOException {
     Map<String, Collection<Container>> resultObj = new HashMap<>();
     resultObj.put(Account.CONTAINERS_KEY, containers);
     return objectMapper.writeValueAsBytes(resultObj);
@@ -129,8 +142,14 @@ public class AccountCollectionSerde {
     }
   }
 
-  public static Collection<Container> containersFromInputStreamInJson(ObjectMapper objectMapper,
-      InputStream inputStream, short accountId) throws IOException {
+  /**
+   * Deserialize a collection of {@link Container}s in json from given InputStream.
+   * @param inputStream the {@link InputStream} that contains serialized json bytes.
+   * @param accountId the account id for these containers.
+   * @return a {@link Collection} of {@link Container}s.
+   */
+  public static Collection<Container> containersFromInputStreamInJson(InputStream inputStream, short accountId)
+      throws IOException {
     Map<String, Collection<Container>> map =
         objectMapper.readValue(inputStream, new TypeReference<Map<String, Collection<Container>>>() {
         });

--- a/ambry-api/src/main/java/com/github/ambry/account/Container.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/Container.java
@@ -117,11 +117,6 @@ public class Container {
   public static final short HELIX_ACCOUNT_SERVICE_CONTAINER_ID = -2;
 
   /**
-   * The id to use when deserializing from json string but no container id is present.
-   */
-  public static final short UNINITIALIZED_CONTAINER_ID = -3;
-
-  /**
    * The id for the containers to be associated with the blobs that are put without specifying a target container,
    * but are specified public. {@link #DEFAULT_PUBLIC_CONTAINER} is one of the containers that use it.
    */

--- a/ambry-api/src/main/java/com/github/ambry/account/Container.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/Container.java
@@ -13,6 +13,9 @@
  */
 package com.github.ambry.account;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
@@ -54,6 +57,7 @@ import org.json.JSONObject;
  *  {@link AccountBuilder}.
  *  </p>
  */
+@JsonDeserialize(builder = ContainerBuilder.class)
 public class Container {
 
   // constants
@@ -338,12 +342,15 @@ public class Container {
           LAST_MODIFIED_TIME_DEFAULT_VALUE, SNAPSHOT_VERSION_DEFAULT_VALUE);
 
   // container field variables
+  @JsonProperty(CONTAINER_ID_KEY)
   private final short id;
+  @JsonProperty(CONTAINER_NAME_KEY)
   private final String name;
   private final ContainerStatus status;
   private final long deleteTriggerTime;
   private final String description;
   private final boolean encrypted;
+  @JsonProperty(PREVIOUSLY_ENCRYPTED_KEY)
   private final boolean previouslyEncrypted;
   private final boolean cacheable;
   private final boolean backupEnabled;
@@ -351,12 +358,15 @@ public class Container {
   private final String replicationPolicy;
   private final boolean ttlRequired;
   private final boolean securePathRequired;
+  @JsonProperty(OVERRIDE_ACCOUNT_ACL_KEY)
   private final boolean overrideAccountAcl;
   private final NamedBlobMode namedBlobMode;
   private final Set<String> contentTypeWhitelistForFilenamesOnDownload;
   private final short parentAccountId;
   private final long lastModifiedTime;
   private final int snapshotVersion;
+  @JsonProperty(JSON_VERSION_KEY)
+  private final int version = JSON_VERSION_2; // the default version is 2
 
   /**
    * Constructing an {@link Container} object from container metadata.
@@ -721,6 +731,7 @@ public class Container {
    * Gets the if of the {@link Account} that owns this container.
    * @return The id of the parent {@link Account} of this container.
    */
+  @JsonIgnore
   public short getParentAccountId() {
     return parentAccountId;
   }

--- a/ambry-api/src/main/java/com/github/ambry/account/Container.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/Container.java
@@ -117,6 +117,11 @@ public class Container {
   public static final short HELIX_ACCOUNT_SERVICE_CONTAINER_ID = -2;
 
   /**
+   * The id to use when deserializing from json string but no container id is present.
+   */
+  public static final short UNINITIALIZED_CONTAINER_ID = -3;
+
+  /**
    * The id for the containers to be associated with the blobs that are put without specifying a target container,
    * but are specified public. {@link #DEFAULT_PUBLIC_CONTAINER} is one of the containers that use it.
    */
@@ -132,6 +137,11 @@ public class Container {
    * The name of {@link #UNKNOWN_CONTAINER}.
    */
   public static final String UNKNOWN_CONTAINER_NAME = "ambry-unknown-container";
+
+  /**
+   * The name to use when deserializing from json string but no container name is present.
+   */
+  public static final String UNINITIALIZED_CONTAINER_NAME = "__uninitialized_container_name__";
 
   /**
    * The name for the containers to be associated with the blobs that are put without specifying a target container,

--- a/ambry-api/src/main/java/com/github/ambry/account/Container.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/Container.java
@@ -139,11 +139,6 @@ public class Container {
   public static final String UNKNOWN_CONTAINER_NAME = "ambry-unknown-container";
 
   /**
-   * The name to use when deserializing from json string but no container name is present.
-   */
-  public static final String UNINITIALIZED_CONTAINER_NAME = "__uninitialized_container_name__";
-
-  /**
    * The name for the containers to be associated with the blobs that are put without specifying a target container,
    * but are specified public. {@link #DEFAULT_PUBLIC_CONTAINER} is one of the containers that use it.
    */

--- a/ambry-api/src/main/java/com/github/ambry/account/ContainerBuilder.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/ContainerBuilder.java
@@ -13,6 +13,9 @@
  */
 package com.github.ambry.account;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import java.util.Set;
 
 import static com.github.ambry.account.Container.*;
@@ -24,13 +27,15 @@ import static com.github.ambry.account.Container.*;
  * in two ways: 1) from an existing {@link Container} object; and 2) by supplying required fields of a {@link Container}.
  * This class is not thread safe.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonPOJOBuilder(withPrefix="set")
 public class ContainerBuilder {
   // necessary
   private short id;
   private String name;
   private ContainerStatus status;
-  private String description;
-  private short parentAccountId;
+  private short parentAccountId = Account.UNINITIALIZED_ACCOUNT_ID;
+  private String description = "";
 
   // optional
   private long deleteTriggerTime = CONTAINER_DELETE_TRIGGER_TIME_DEFAULT_VALUE;
@@ -81,6 +86,12 @@ public class ContainerBuilder {
   }
 
   /**
+   * Constructor for jackson to deserialize {@link Container}.
+   */
+  public ContainerBuilder() {
+  }
+
+  /**
    * Constructor for a {@link ContainerBuilder} taking individual arguments.
    * @param id The id of the {@link Container} to build.
    * @param name The name of the {@link Container}.
@@ -101,6 +112,7 @@ public class ContainerBuilder {
    * @param id The ID to set.
    * @return This builder.
    */
+  @JsonProperty(CONTAINER_ID_KEY)
   public ContainerBuilder setId(short id) {
     this.id = id;
     return this;
@@ -111,6 +123,7 @@ public class ContainerBuilder {
    * @param name The name to set.
    * @return This builder.
    */
+  @JsonProperty(CONTAINER_NAME_KEY)
   public ContainerBuilder setName(String name) {
     this.name = name;
     return this;

--- a/ambry-api/src/main/java/com/github/ambry/account/ContainerBuilder.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/ContainerBuilder.java
@@ -31,10 +31,10 @@ import static com.github.ambry.account.Container.*;
 @JsonPOJOBuilder(withPrefix = "set")
 public class ContainerBuilder {
   // necessary
-  private short id = UNINITIALIZED_CONTAINER_ID;
+  private Short id = null;
   private String name = null;
   private ContainerStatus status = null;
-  private short parentAccountId = Account.UNINITIALIZED_ACCOUNT_ID;
+  private Short parentAccountId = null;
   private String description = "";
 
   // optional
@@ -306,12 +306,13 @@ public class ContainerBuilder {
    * @throws IllegalStateException If any required fields is not set.
    */
   public Container build() {
-    if (id == UNINITIALIZED_CONTAINER_ID) {
+    if (id == null) {
       throw new IllegalStateException("Container id or container name is not present");
     }
     return new Container(id, name, status, description, encrypted, previouslyEncrypted || encrypted, cacheable,
         mediaScanDisabled, replicationPolicy, ttlRequired, securePathRequired,
-        contentTypeWhitelistForFilenamesOnDownload, backupEnabled, overrideAccountAcl, namedBlobMode, parentAccountId,
-        deleteTriggerTime, lastModifiedTime, snapshotVersion);
+        contentTypeWhitelistForFilenamesOnDownload, backupEnabled, overrideAccountAcl, namedBlobMode,
+        parentAccountId == null ? UNKNOWN_CONTAINER_PARENT_ACCOUNT_ID : parentAccountId.shortValue(), deleteTriggerTime, lastModifiedTime,
+        snapshotVersion);
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/account/ContainerBuilder.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/ContainerBuilder.java
@@ -28,12 +28,12 @@ import static com.github.ambry.account.Container.*;
  * This class is not thread safe.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonPOJOBuilder(withPrefix="set")
+@JsonPOJOBuilder(withPrefix = "set")
 public class ContainerBuilder {
   // necessary
-  private short id;
-  private String name;
-  private ContainerStatus status;
+  private short id = UNINITIALIZED_CONTAINER_ID;
+  private String name = UNINITIALIZED_CONTAINER_NAME;
+  private ContainerStatus status = ContainerStatus.ACTIVE;
   private short parentAccountId = Account.UNINITIALIZED_ACCOUNT_ID;
   private String description = "";
 
@@ -306,6 +306,9 @@ public class ContainerBuilder {
    * @throws IllegalStateException If any required fields is not set.
    */
   public Container build() {
+    if (id == UNINITIALIZED_CONTAINER_ID || name.equals(UNINITIALIZED_CONTAINER_NAME)) {
+      throw new IllegalStateException("Container id or container name is not present");
+    }
     return new Container(id, name, status, description, encrypted, previouslyEncrypted || encrypted, cacheable,
         mediaScanDisabled, replicationPolicy, ttlRequired, securePathRequired,
         contentTypeWhitelistForFilenamesOnDownload, backupEnabled, overrideAccountAcl, namedBlobMode, parentAccountId,

--- a/ambry-api/src/main/java/com/github/ambry/account/ContainerBuilder.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/ContainerBuilder.java
@@ -32,8 +32,8 @@ import static com.github.ambry.account.Container.*;
 public class ContainerBuilder {
   // necessary
   private short id = UNINITIALIZED_CONTAINER_ID;
-  private String name = UNINITIALIZED_CONTAINER_NAME;
-  private ContainerStatus status = ContainerStatus.ACTIVE;
+  private String name = null;
+  private ContainerStatus status = null;
   private short parentAccountId = Account.UNINITIALIZED_ACCOUNT_ID;
   private String description = "";
 
@@ -306,7 +306,7 @@ public class ContainerBuilder {
    * @throws IllegalStateException If any required fields is not set.
    */
   public Container build() {
-    if (id == UNINITIALIZED_CONTAINER_ID || name.equals(UNINITIALIZED_CONTAINER_NAME)) {
+    if (id == UNINITIALIZED_CONTAINER_ID) {
       throw new IllegalStateException("Container id or container name is not present");
     }
     return new Container(id, name, status, description, encrypted, previouslyEncrypted || encrypted, cacheable,

--- a/ambry-api/src/test/java/com/github/ambry/account/AccountContainerTest.java
+++ b/ambry-api/src/test/java/com/github/ambry/account/AccountContainerTest.java
@@ -14,8 +14,15 @@
 package com.github.ambry.account;
 
 import com.github.ambry.quota.QuotaResourceType;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -36,6 +43,7 @@ import org.junit.runners.Parameterized;
 import static com.github.ambry.account.Account.*;
 import static com.github.ambry.account.Container.*;
 import static org.junit.Assert.*;
+import static org.junit.Assume.*;
 
 
 /**
@@ -806,6 +814,26 @@ public class AccountContainerTest {
     refContainers.add(updatedContainer);
     Account accountWithModifiedContainers = new AccountBuilder(refAccountId, refAccountName, refAccountStatus).build();
     assertFalse("Two accounts should not be equal.", accountWithContainers.equals(accountWithModifiedContainers));
+  }
+
+  @Test
+  public void testAccountAndContainerSerDe() throws IOException {
+    assumeTrue(Container.getCurrentJsonVersion() == JSON_VERSION_2);
+    // Make sure the JSONObject string can be deserialized to jackson object
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    try (Writer writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8)) {
+      refAccountJson.write(writer);
+    }
+    ObjectMapper objectMapper = new ObjectMapper();
+    Account deserialized = objectMapper.readValue(outputStream.toByteArray(), Account.class);
+    Account fromJson = Account.fromJson(refAccountJson);
+    assertTrue(deserialized.equals(fromJson));
+
+    // Make sure jackson string can be deserialized to JSONObject object
+    String serialized = objectMapper.writer(new DefaultPrettyPrinter()).writeValueAsString(deserialized);
+    JSONObject jsonObject = new JSONObject(serialized);
+    fromJson = Account.fromJson(jsonObject);
+    assertTrue(deserialized.equals(fromJson));
   }
 
   /**

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/GetAccountsHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/GetAccountsHandler.java
@@ -14,11 +14,13 @@
 
 package com.github.ambry.frontend;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.ambry.account.Account;
 import com.github.ambry.account.AccountCollectionSerde;
 import com.github.ambry.account.AccountService;
 import com.github.ambry.account.AccountServiceException;
 import com.github.ambry.account.Container;
+import com.github.ambry.commons.ByteBufferReadableStreamChannel;
 import com.github.ambry.commons.Callback;
 import com.github.ambry.rest.RestRequest;
 import com.github.ambry.rest.RestRequestMetrics;
@@ -27,6 +29,7 @@ import com.github.ambry.rest.RestServiceErrorCode;
 import com.github.ambry.rest.RestServiceException;
 import com.github.ambry.rest.RestUtils;
 import com.github.ambry.router.ReadableStreamChannel;
+import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.GregorianCalendar;
@@ -39,6 +42,7 @@ import static com.github.ambry.frontend.Operations.*;
 
 class GetAccountsHandler {
   private static final Logger LOGGER = LoggerFactory.getLogger(GetAccountsHandler.class);
+  private final ObjectMapper objectMapper = new ObjectMapper();
 
   private final SecurityService securityService;
   private final AccountService accountService;
@@ -118,16 +122,17 @@ class GetAccountsHandler {
      */
     private Callback<Void> securityPostProcessRequestCallback() {
       return buildCallback(frontendMetrics.getAccountsSecurityPostProcessRequestMetrics, securityCheckResult -> {
-        ReadableStreamChannel channel;
+        byte[] serialized;
         if (RestUtils.getRequestPath(restRequest).matchesOperation(ACCOUNTS_CONTAINERS)) {
           LOGGER.debug("Received request for getting single container with arguments: {}", restRequest.getArgs());
           Container container = getContainer();
-          channel =
-              serializeJsonToChannel(AccountCollectionSerde.containersToJson(Collections.singletonList(container)));
+          serialized =
+              AccountCollectionSerde.serializeContainersInJson(objectMapper, Collections.singletonList(container));
           restResponseChannel.setHeader(RestUtils.Headers.TARGET_ACCOUNT_ID, container.getParentAccountId());
         } else {
-          channel = serializeJsonToChannel(AccountCollectionSerde.accountsToJson(getAccounts()));
+          serialized = AccountCollectionSerde.serializeAccountsInJson(objectMapper, getAccounts());
         }
+        ReadableStreamChannel channel = new ByteBufferReadableStreamChannel(ByteBuffer.wrap(serialized));
         restResponseChannel.setHeader(RestUtils.Headers.DATE, new GregorianCalendar().getTime());
         restResponseChannel.setHeader(RestUtils.Headers.CONTENT_TYPE, RestUtils.JSON_CONTENT_TYPE);
         restResponseChannel.setHeader(RestUtils.Headers.CONTENT_LENGTH, channel.getSize());

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/GetAccountsHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/GetAccountsHandler.java
@@ -14,7 +14,6 @@
 
 package com.github.ambry.frontend;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.ambry.account.Account;
 import com.github.ambry.account.AccountCollectionSerde;
 import com.github.ambry.account.AccountService;
@@ -42,7 +41,6 @@ import static com.github.ambry.frontend.Operations.*;
 
 class GetAccountsHandler {
   private static final Logger LOGGER = LoggerFactory.getLogger(GetAccountsHandler.class);
-  private final ObjectMapper objectMapper = new ObjectMapper();
 
   private final SecurityService securityService;
   private final AccountService accountService;
@@ -126,11 +124,10 @@ class GetAccountsHandler {
         if (RestUtils.getRequestPath(restRequest).matchesOperation(ACCOUNTS_CONTAINERS)) {
           LOGGER.debug("Received request for getting single container with arguments: {}", restRequest.getArgs());
           Container container = getContainer();
-          serialized =
-              AccountCollectionSerde.serializeContainersInJson(objectMapper, Collections.singletonList(container));
+          serialized = AccountCollectionSerde.serializeContainersInJson(Collections.singletonList(container));
           restResponseChannel.setHeader(RestUtils.Headers.TARGET_ACCOUNT_ID, container.getParentAccountId());
         } else {
-          serialized = AccountCollectionSerde.serializeAccountsInJson(objectMapper, getAccounts());
+          serialized = AccountCollectionSerde.serializeAccountsInJson(getAccounts());
         }
         ReadableStreamChannel channel = new ByteBufferReadableStreamChannel(ByteBuffer.wrap(serialized));
         restResponseChannel.setHeader(RestUtils.Headers.DATE, new GregorianCalendar().getTime());

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/PostAccountsHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/PostAccountsHandler.java
@@ -14,7 +14,6 @@
 
 package com.github.ambry.frontend;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.ambry.account.Account;
 import com.github.ambry.account.AccountCollectionSerde;
 import com.github.ambry.account.AccountService;
@@ -53,7 +52,6 @@ class PostAccountsHandler {
   private final AccountService accountService;
   private final FrontendConfig frontendConfig;
   private final FrontendMetrics frontendMetrics;
-  private final ObjectMapper objectMapper = new ObjectMapper();
 
   /**
    * Constructs a handler for handling requests updating account metadata.
@@ -149,7 +147,7 @@ class PostAccountsHandler {
           logger.debug("Got request for {} with payload", ACCOUNTS_CONTAINERS);
           Pair<Account, Collection<Container>> accountAndUpdatedContainers = updateContainers(channel);
           outputChannel = new ByteBufferReadableStreamChannel(ByteBuffer.wrap(
-              AccountCollectionSerde.serializeContainersInJson(objectMapper, accountAndUpdatedContainers.getSecond())));
+              AccountCollectionSerde.serializeContainersInJson(accountAndUpdatedContainers.getSecond())));
           restResponseChannel.setHeader(RestUtils.Headers.TARGET_ACCOUNT_ID,
               accountAndUpdatedContainers.getFirst().getId());
         } else {
@@ -189,7 +187,7 @@ class PostAccountsHandler {
       Collection<Container> containersToUpdate;
       try {
         containersToUpdate =
-            AccountCollectionSerde.containersFromInputStreamInJson(objectMapper, channel.consumeContentAsInputStream(),
+            AccountCollectionSerde.containersFromInputStreamInJson(channel.consumeContentAsInputStream(),
                 accountId);
       } catch (IOException e) {
         throw new RestServiceException("Bad container update request body", e, RestServiceErrorCode.BadRequest);
@@ -211,8 +209,7 @@ class PostAccountsHandler {
     private void updateAccounts(RetainingAsyncWritableChannel channel) throws RestServiceException {
       Collection<Account> accountsToUpdate;
       try {
-        accountsToUpdate =
-            AccountCollectionSerde.accountsFromInputStreamInJson(objectMapper, channel.consumeContentAsInputStream());
+        accountsToUpdate = AccountCollectionSerde.accountsFromInputStreamInJson(channel.consumeContentAsInputStream());
       } catch (IOException e) {
         throw new RestServiceException("Bad account update request body", e, RestServiceErrorCode.BadRequest);
       }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/PostAccountsHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/PostAccountsHandler.java
@@ -14,6 +14,7 @@
 
 package com.github.ambry.frontend;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.ambry.account.Account;
 import com.github.ambry.account.AccountCollectionSerde;
 import com.github.ambry.account.AccountService;
@@ -31,11 +32,10 @@ import com.github.ambry.rest.RestServiceException;
 import com.github.ambry.rest.RestUtils;
 import com.github.ambry.router.ReadableStreamChannel;
 import com.github.ambry.utils.Pair;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.GregorianCalendar;
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,6 +53,7 @@ class PostAccountsHandler {
   private final AccountService accountService;
   private final FrontendConfig frontendConfig;
   private final FrontendMetrics frontendMetrics;
+  private final ObjectMapper objectMapper = new ObjectMapper();
 
   /**
    * Constructs a handler for handling requests updating account metadata.
@@ -143,16 +144,16 @@ class PostAccountsHandler {
      */
     private Callback<Long> fetchAccountUpdateBodyCallback(RetainingAsyncWritableChannel channel) {
       return buildCallback(frontendMetrics.postAccountsReadRequestMetrics, bytesRead -> {
-        JSONObject jsonPayload = readJsonFromChannel(channel);
         ReadableStreamChannel outputChannel;
         if (RestUtils.getRequestPath(restRequest).matchesOperation(ACCOUNTS_CONTAINERS)) {
-          logger.debug("Got request for {} with payload {}", ACCOUNTS_CONTAINERS, jsonPayload);
-          Pair<Account, JSONObject> accountAndUpdatedContainers = updateContainers(jsonPayload);
-          outputChannel = serializeJsonToChannel(accountAndUpdatedContainers.getSecond());
+          logger.debug("Got request for {} with payload", ACCOUNTS_CONTAINERS);
+          Pair<Account, Collection<Container>> accountAndUpdatedContainers = updateContainers(channel);
+          outputChannel = new ByteBufferReadableStreamChannel(ByteBuffer.wrap(
+              AccountCollectionSerde.serializeContainersInJson(objectMapper, accountAndUpdatedContainers.getSecond())));
           restResponseChannel.setHeader(RestUtils.Headers.TARGET_ACCOUNT_ID,
               accountAndUpdatedContainers.getFirst().getId());
         } else {
-          updateAccounts(jsonPayload);
+          updateAccounts(channel);
           outputChannel = new ByteBufferReadableStreamChannel(ByteBuffer.allocate(0));
         }
         restResponseChannel.setHeader(RestUtils.Headers.DATE, new GregorianCalendar().getTime());
@@ -164,11 +165,12 @@ class PostAccountsHandler {
 
     /**
      * Process the request json and call {@link AccountService#updateContainers} to add or update containers.
-     * @param containersPayload the request json containing the containers to update.
+     * @param channel The {@link RetainingAsyncWritableChannel} to read the bytes out
      * @return a pair of account and its updated containers.
      * @throws RestServiceException
      */
-    private Pair<Account, JSONObject> updateContainers(JSONObject containersPayload) throws RestServiceException {
+    private Pair<Account, Collection<Container>> updateContainers(RetainingAsyncWritableChannel channel)
+        throws RestServiceException {
       Short accountId = RestUtils.getNumericalHeader(restRequest.getArgs(), RestUtils.Headers.TARGET_ACCOUNT_ID, false,
           Short::parseShort);
       String accountName = RestUtils.getHeader(restRequest.getArgs(), RestUtils.Headers.TARGET_ACCOUNT_NAME, false);
@@ -186,13 +188,15 @@ class PostAccountsHandler {
 
       Collection<Container> containersToUpdate;
       try {
-        containersToUpdate = AccountCollectionSerde.containersFromJson(containersPayload, accountId);
-      } catch (JSONException e) {
+        containersToUpdate =
+            AccountCollectionSerde.containersFromInputStreamInJson(objectMapper, channel.consumeContentAsInputStream(),
+                accountId);
+      } catch (IOException e) {
         throw new RestServiceException("Bad container update request body", e, RestServiceErrorCode.BadRequest);
       }
       try {
         Collection<Container> updatedContainers = accountService.updateContainers(accountName, containersToUpdate);
-        return new Pair<>(account, AccountCollectionSerde.containersToJson(updatedContainers));
+        return new Pair<>(account, updatedContainers);
       } catch (AccountServiceException ex) {
         throw new RestServiceException("Container update failed for accountId " + accountId,
             RestServiceErrorCode.getRestServiceErrorCode(ex.getErrorCode()));
@@ -201,14 +205,15 @@ class PostAccountsHandler {
 
     /**
      * Process the request json and call {@link AccountService#updateAccounts} to update accounts.
-     * @param accountUpdateJson the request json containing the accounts to update.
+     * @param channel The {@link RetainingAsyncWritableChannel} to read the bytes out
      * @throws RestServiceException
      */
-    private void updateAccounts(JSONObject accountUpdateJson) throws RestServiceException {
+    private void updateAccounts(RetainingAsyncWritableChannel channel) throws RestServiceException {
       Collection<Account> accountsToUpdate;
       try {
-        accountsToUpdate = AccountCollectionSerde.accountsFromJson(accountUpdateJson);
-      } catch (JSONException e) {
+        accountsToUpdate =
+            AccountCollectionSerde.accountsFromInputStreamInJson(objectMapper, channel.consumeContentAsInputStream());
+      } catch (IOException e) {
         throw new RestServiceException("Bad account update request body", e, RestServiceErrorCode.BadRequest);
       }
       try {

--- a/ambry-tools/src/integration-test/java/com/github/ambry/account/AccountUpdateToolTest.java
+++ b/ambry-tools/src/integration-test/java/com/github/ambry/account/AccountUpdateToolTest.java
@@ -14,6 +14,7 @@
 package com.github.ambry.account;
 
 import com.codahale.metrics.MetricRegistry;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.ambry.clustermap.HelixStoreOperator;
 import com.github.ambry.commons.HelixNotifier;
 import com.github.ambry.config.HelixAccountServiceConfig;
@@ -22,6 +23,8 @@ import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.utils.TestUtils;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -298,12 +301,7 @@ public class AccountUpdateToolTest {
    * @throws Exception Any unexpected exception.
    */
   private static void writeAccountsToFile(Collection<Account> accounts, String filePath) throws Exception {
-    JSONArray accountArray = new JSONArray();
-    for (Account account : accounts) {
-      // AccountUpdateTool will re-serialize, so we do not want the snapshot version to be incremented twice.
-      accountArray.put(account.toJson(false));
-    }
-    writeJsonArrayToFile(accountArray, filePath);
+    Files.write(Paths.get(filePath), new ObjectMapper().writeValueAsBytes(accounts));
   }
 
   /**

--- a/ambry-tools/src/main/java/com/github/ambry/account/ServiceIdAccountGenTool.java
+++ b/ambry-tools/src/main/java/com/github/ambry/account/ServiceIdAccountGenTool.java
@@ -14,17 +14,22 @@
 
 package com.github.ambry.account;
 
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.ambry.tools.util.ToolUtils;
-import com.github.ambry.utils.Utils;
+import java.io.BufferedWriter;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import joptsimple.ArgumentAcceptingOptionSpec;
 import joptsimple.NonOptionArgumentSpec;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
-import org.json.JSONArray;
 import org.json.JSONException;
 
 
@@ -83,8 +88,8 @@ public class ServiceIdAccountGenTool {
    */
   private static void generateAccounts(List<String> serviceIds, String outputFile, short startingAccountId)
       throws JSONException, IOException {
+    Collection<Account> accounts = new ArrayList<>();
     short curAccountId = startingAccountId;
-    JSONArray accounts = new JSONArray();
     for (String serviceId : serviceIds) {
       Container defaultPublicContainer =
           new ContainerBuilder(Container.DEFAULT_PUBLIC_CONTAINER).setParentAccountId(curAccountId).build();
@@ -92,9 +97,11 @@ public class ServiceIdAccountGenTool {
           new ContainerBuilder(Container.DEFAULT_PRIVATE_CONTAINER).setParentAccountId(curAccountId).build();
       Account account = new AccountBuilder(curAccountId, serviceId, Account.AccountStatus.ACTIVE).containers(
           Arrays.asList(defaultPublicContainer, defaultPrivateContainer)).build();
-      accounts.put(account.toJson(true));
+      accounts.add(account);
       curAccountId++;
     }
-    Utils.writeJsonArrayToFile(accounts, outputFile);
+    try (BufferedWriter writer = Files.newBufferedWriter(Paths.get(outputFile))) {
+      new ObjectMapper().writer(new DefaultPrettyPrinter()).writeValue(writer, accounts);
+    }
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -181,6 +181,7 @@ project(':ambry-api') {
         compile "io.dropwizard.metrics:metrics-core:$metricsVersion"
         compile "com.fasterxml.jackson.core:jackson-core:$jacksonVersion"
         compile "com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion"
+        compile "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
         compile "io.netty:netty-buffer:$nettyVersion"
         testCompile project(':ambry-clustermap')
         testCompile project(':ambry-test-utils')


### PR DESCRIPTION
Use jackson annotation to serialize and deserialize Account and Container, so we don't have to write toJson and fromJson method each time we have a new field added to account or container.
Still keep fromJson and toJson method to make sure this PR won't change anything.
Will remove it after it's tested with requests.