### PR TITLE
[Compaction] Fix NPE when TTL_UPDATE has not prior PUT

### DIFF
--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
@@ -1627,6 +1627,12 @@ class BlobStoreCompactor {
         } else {
           previousKey = currentKey;
           previousLatestState = currentLatestState = srcIndex.findKey(currentKey);
+          if (currentLatestState == null) {
+            // Only one case this would happen, an TTL_UPDATE indexValue that has no PUT before, this is because the put
+            // is already compacted but TTL_UPDATE is not compacted.
+            previousLatestState = currentLatestState =
+                srcIndex.findKey(currentKey, null, EnumSet.allOf(PersistentIndex.IndexEntryType.class));
+          }
         }
 
         if (currentValue.isUndelete()) {

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
@@ -1656,9 +1656,9 @@ class BlobStoreCompactor {
           }
         } else if (currentValue.isTtlUpdate()) {
           if (currentLatestState == null) {
-            // Only one case this would happen, an TTL_UPDATE indexValue that has no PUT before, this is because the put
-            // is already compacted but TTL_UPDATE is not compacted. PUT is compacted because it's deleted and DELETE is
-            // compacted because we clean up the DELETE tombstone
+            // Under only one circumstance would this happen, an TTL_UPDATE index value has no PUT before and no DELETE after.
+            // This is because the PUT is already compacted due to DELETE is out of retention and DELETE is compacted due to
+            // DELETE tombstone clean up. But TTL_UPDATE is in different log segment from PUT and DELETE so it never gets compacted.
             continue;
           }
           if (currentLatestState.isPut()) {

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
@@ -1780,7 +1780,7 @@ public class BlobStoreCompactorTest {
     state.addDeleteEntry((MockId) p15.getKey(), null, (short) 1);
     state.addPutEntries(1, PUT_RECORD_SIZE, Utils.Infinite_Time);
 
-    // Index Segment 1.6 T -> T, Put already compacted
+    // Index Segment 1.6 T -> [], Put already compacted
     MockId p16id = state.getUniqueId();
     state.makePermanent(p16id, true);
     state.addPutEntries(4, PUT_RECORD_SIZE, Utils.Infinite_Time);
@@ -1962,8 +1962,8 @@ public class BlobStoreCompactorTest {
     // Before compaction, the records in the log are
     // P11 U11 U11 T11 P| P12 T12 U12 U12 P| P13 T13 U13 U13 P| P14 T14 D14 D14 P| P15 T15 D15 D15 P | T16 P P P P
     // After compaction, the records in the log are
-    // P11 U11 T11 P P12| T12 U12 P P13 T13| U13 P D14 P D15| P T16 P P P | P
-    cleanedUpSize = us + us + us + (ps + ts + ds) + (ps + ts + ds);
+    // P11 U11 T11 P P12| T12 U12 P P13 T13| U13 P D14 P D15| P P P P P
+    cleanedUpSize = us + us + us + (ps + ts + ds) + (ps + ts + ds) + ts;
     compactedLogSegmentName = logSegmentName.getNextGenerationName();
     assertEquals("End offset of log segment not as expected after compaction",
         endOffsetOfSegmentBeforeCompaction - cleanedUpSize,
@@ -2029,17 +2029,6 @@ public class BlobStoreCompactorTest {
     verifyIndexEntry(indexEntries.get(4), (MockId) p15.getKey(), currentExpectedOffset, ds, Utils.Infinite_Time, true,
         true, false, (short) 1);
     currentExpectedOffset += ds;
-
-    // Get the entries in the fourth segment
-    segment = indexSegments.higherEntry(segment.getStartOffset()).getValue();
-    indexEntries.clear();
-    assertEquals("LogSegment name mismatch", compactedLogSegmentName, segment.getStartOffset().getName());
-    segment.getIndexEntriesSince(null, condition, indexEntries, new AtomicLong(0), false, false);
-    Collections.sort(indexEntries, PersistentIndex.INDEX_ENTRIES_OFFSET_COMPARATOR);
-    currentExpectedOffset += ps; // skip one put
-    verifyIndexEntry(indexEntries.get(1), p16id, currentExpectedOffset, ts, Utils.Infinite_Time, false, true, false,
-        (short) 0);
-    currentExpectedOffset +=  ts + 3 * ps; // skip three puts
 
     // no clean shutdown file should exist
     assertFalse("Clean shutdown file not deleted",


### PR DESCRIPTION
This PR would fix a NPE caused by TTL_UPDATE index value having no PUT index value before. This case could happen when the PUT and TTL_UPDATE don't belong to the same log segment, but PUT's log segment is compacted and PUT is gone, while TTL_UPDATE is still there. 

The order of events that causes this case:
1. Create PUT in log segment 1
2. Create TTL_UPDATE in log segment 2
3. Create DELETE in log segment 3
4. DELETE is out of retention
5. Compact log segment 1 and PUT is removed
6. Compact log segment 3 and DELETE id removed because it's now a tombstone.