### PR TITLE
Adding more log info and constraints for index segment persist

### DIFF
--- a/ambry-store/src/main/java/com/github/ambry/store/IndexSegment.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/IndexSegment.java
@@ -743,7 +743,8 @@ class IndexSegment implements Iterable<IndexEntry> {
    */
   void writeIndexSegmentToFile(Offset safeEndPoint) throws FileNotFoundException, StoreException {
     if (sealed.get()) {
-      throw new StoreException("Cannot persist sealed index segment", StoreErrorCodes.Illegal_Index_Operation);
+      logger.trace("Cannot persist sealed index segment : {}", indexFile.getAbsolutePath());
+      return;
     }
     if (safeEndPoint.compareTo(startOffset) <= 0) {
       return;

--- a/ambry-store/src/main/java/com/github/ambry/store/Log.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/Log.java
@@ -494,11 +494,12 @@ class Log implements Write {
     // this cannot be null since capacity has either been ensured or has thrown.
     LogSegment nextActiveSegment = segmentsByName.higherEntry(activeSegment.getName()).getValue();
     if (isAutoClosed) {
-      logger.info("Auto close last log segment: {} and create new active segment : {}", activeSegment.getName(),
-          nextActiveSegment.getName());
+      logger.info("DataDir: {}, Auto close last log segment: {} and create new active segment : {}", dataDir,
+          activeSegment.getName(), nextActiveSegment.getName());
     } else {
-      logger.info("Rolling over writes to {} from {} on write of data of size {}. End offset was {} and capacity is {}",
-          nextActiveSegment.getName(), activeSegment.getName(), writeSize, activeSegment.getEndOffset(),
+      logger.info(
+          "DataDir: {}, Rolling over writes to {} from {} on write of data of size {}. End offset was {} and capacity is {}",
+          dataDir, nextActiveSegment.getName(), activeSegment.getName(), writeSize, activeSegment.getEndOffset(),
           activeSegment.getCapacityInBytes());
     }
     activeSegment.dropBufferForAppend();

--- a/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
@@ -2279,6 +2279,7 @@ class PersistentIndex {
             toWrite.writeIndexSegmentToFile(toWrite.getEndOffset());
             toWrite.seal();
           }
+          //Compaction may seal the current last index segment.
           currentInfo.writeIndexSegmentToFile(indexEndOffsetBeforeFlush);
         }
       } catch (FileNotFoundException e) {


### PR DESCRIPTION
This pr supports:
1.  Add more log info for easy trace.
2. Compaction might seal the last index segment, added more constraint to make sure only unsealed index segment will be persisted by this method -> writeIndexSegmentToFile