### PR TITLE
[Quota] Add logic to turn request quota on and off individually

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/QuotaConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/QuotaConfig.java
@@ -37,12 +37,6 @@ public class QuotaConfig {
   public static final boolean DEFAULT_THROTTLE_IN_PROGRESS_REQUESTS = false;
   public StorageQuotaConfig storageQuotaConfig;
 
-  /**
-   * Config to enable throttling on customer's account or container.
-   */
-  @Config(REQUEST_THROTTLING_ENABLED)
-  @Default("false")
-  public boolean requestThrottlingEnabled;
 
   /**
    * Serialized json containing pairs of enforcer classes and corresponding source classes.
@@ -73,10 +67,18 @@ public class QuotaConfig {
   public String quotaManagerFactory;
 
   /**
-   * The mode in which quota throttling is being done (TRACKING/THROTTLING).
+   * The mode in which quota throttling is being done (TRACKING/THROTTLING). To throttle the requests, you have to change
+   * the mode to THROTTLING and turn on requestThrottlingEnabled or storageQuotaConfig.shouldThrottle (or both).
    */
   @Config(THROTTLING_MODE)
   public QuotaMode throttlingMode;
+
+  /**
+   * Config to enable request throttling on customer's account or container.
+   */
+  @Config(REQUEST_THROTTLING_ENABLED)
+  @Default("true")
+  public boolean requestThrottlingEnabled;
 
   /**
    * Should requests in progress be throttled if they exceed their quota.
@@ -90,7 +92,7 @@ public class QuotaConfig {
    */
   public QuotaConfig(VerifiableProperties verifiableProperties) {
     storageQuotaConfig = new StorageQuotaConfig(verifiableProperties);
-    requestThrottlingEnabled = verifiableProperties.getBoolean(REQUEST_THROTTLING_ENABLED, false);
+    requestThrottlingEnabled = verifiableProperties.getBoolean(REQUEST_THROTTLING_ENABLED, true);
     requestQuotaEnforcerSourcePairInfoJson =
         verifiableProperties.getString(REQUEST_QUOTA_ENFORCER_SOURCE_PAIR_INFO_JSON,
             buildDefaultQuotaEnforcerSourceInfoPairJson().toString());

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestServiceFactory.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestServiceFactory.java
@@ -99,7 +99,7 @@ public class FrontendRestRequestServiceFactory implements RestRequestServiceFact
               clusterMap.getMetricRegistry()).getAccountStatsStore();
       QuotaConfig quotaConfig = new QuotaConfig(verifiableProperties);
       QuotaManager quotaManager =
-          ((QuotaManagerFactory) Utils.getObj(quotaConfig.quotaManagerFactory, quotaConfig, new MaxThrottlePolicy(),
+          ((QuotaManagerFactory) Utils.getObj(quotaConfig.quotaManagerFactory, quotaConfig, new MaxThrottlePolicy(quotaConfig),
               accountService, accountStatsStore, clusterMap.getMetricRegistry())).getQuotaManager();
       SecurityServiceFactory securityServiceFactory =
           Utils.getObj(frontendConfig.securityServiceFactory, verifiableProperties, clusterMap, accountService,

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/AmbrySecurityServiceTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/AmbrySecurityServiceTest.java
@@ -23,6 +23,7 @@ import com.github.ambry.commons.Callback;
 import com.github.ambry.commons.HostLevelThrottler;
 import com.github.ambry.config.FrontendConfig;
 import com.github.ambry.config.HostThrottleConfig;
+import com.github.ambry.config.QuotaConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.messageformat.BlobInfo;
 import com.github.ambry.messageformat.BlobProperties;
@@ -127,9 +128,10 @@ public class AmbrySecurityServiceTest {
               false, Utils.Infinite_Time, REF_ACCOUNT.getId(), REF_CONTAINER.getId(), false, null, null, null),
           RestUtils.buildUserMetadata(USER_METADATA), DEFAULT_LIFEVERSION);
       ACCOUNT_SERVICE.updateAccounts(Collections.singletonList(InMemAccountService.UNKNOWN_ACCOUNT));
+      QuotaConfig quotaConfig = QuotaTestUtils.createQuotaConfig(Collections.emptyMap(), false, QuotaMode.TRACKING);
       QUOTA_MANAGER =
-          new AmbryQuotaManager(QuotaTestUtils.createQuotaConfig(Collections.emptyMap(), false, QuotaMode.TRACKING),
-              new MaxThrottlePolicy(), mock(AccountService.class), null, new MetricRegistry());
+          new AmbryQuotaManager(quotaConfig, new MaxThrottlePolicy(quotaConfig), mock(AccountService.class), null,
+              new MetricRegistry());
     } catch (Exception e) {
       throw new IllegalStateException(e);
     }

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceFactoryTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceFactoryTest.java
@@ -20,6 +20,7 @@ import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.commons.CommonTestUtils;
 import com.github.ambry.config.FrontendConfig;
+import com.github.ambry.config.QuotaConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.quota.AmbryQuotaManager;
 import com.github.ambry.quota.MaxThrottlePolicy;
@@ -46,9 +47,10 @@ public class FrontendRestRequestServiceFactoryTest {
 
   static {
     try {
+      QuotaConfig quotaConfig = QuotaTestUtils.createQuotaConfig(Collections.emptyMap(), false, QuotaMode.TRACKING);
       QUOTA_MANAGER =
-          new AmbryQuotaManager(QuotaTestUtils.createQuotaConfig(Collections.emptyMap(), false, QuotaMode.TRACKING),
-              new MaxThrottlePolicy(), Mockito.mock(AccountService.class), null, new MetricRegistry());
+          new AmbryQuotaManager(quotaConfig, new MaxThrottlePolicy(quotaConfig), Mockito.mock(AccountService.class),
+              null, new MetricRegistry());
     } catch (Exception e) {
       throw new IllegalStateException(e);
     }

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
@@ -34,6 +34,7 @@ import com.github.ambry.commons.ByteBufferReadableStreamChannel;
 import com.github.ambry.commons.Callback;
 import com.github.ambry.commons.CommonTestUtils;
 import com.github.ambry.config.FrontendConfig;
+import com.github.ambry.config.QuotaConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.messageformat.BlobInfo;
 import com.github.ambry.messageformat.BlobProperties;
@@ -41,8 +42,8 @@ import com.github.ambry.named.NamedBlobDb;
 import com.github.ambry.named.NamedBlobRecord;
 import com.github.ambry.protocol.GetOption;
 import com.github.ambry.quota.AmbryQuotaManager;
-import com.github.ambry.quota.QuotaChargeCallback;
 import com.github.ambry.quota.MaxThrottlePolicy;
+import com.github.ambry.quota.QuotaChargeCallback;
 import com.github.ambry.quota.QuotaManager;
 import com.github.ambry.quota.QuotaMode;
 import com.github.ambry.quota.QuotaTestUtils;
@@ -131,9 +132,10 @@ public class FrontendRestRequestServiceTest {
 
   static {
     try {
+      QuotaConfig quotaConfig = QuotaTestUtils.createQuotaConfig(Collections.emptyMap(), false, QuotaMode.TRACKING);
       QUOTA_MANAGER =
-          new AmbryQuotaManager(QuotaTestUtils.createQuotaConfig(Collections.emptyMap(), false, QuotaMode.TRACKING),
-              new MaxThrottlePolicy(), Mockito.mock(AccountService.class), null, new MetricRegistry());
+          new AmbryQuotaManager(quotaConfig, new MaxThrottlePolicy(quotaConfig), Mockito.mock(AccountService.class),
+              null, new MetricRegistry());
     } catch (Exception e) {
       throw new IllegalStateException(e);
     }
@@ -3141,7 +3143,8 @@ class FrontendTestRouter implements Router {
   String undeleteServiceId = null;
 
   @Override
-  public Future<GetBlobResult> getBlob(String blobId, GetBlobOptions options, Callback<GetBlobResult> callback, QuotaChargeCallback quotaChargeCallback) {
+  public Future<GetBlobResult> getBlob(String blobId, GetBlobOptions options, Callback<GetBlobResult> callback,
+      QuotaChargeCallback quotaChargeCallback) {
     GetBlobResult result;
     switch (options.getOperationType()) {
       case BlobInfo:

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/PostBlobHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/PostBlobHandlerTest.java
@@ -26,6 +26,7 @@ import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.commons.ByteBufferReadableStreamChannel;
 import com.github.ambry.config.FrontendConfig;
+import com.github.ambry.config.QuotaConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.quota.AmbryQuotaManager;
@@ -109,9 +110,10 @@ public class PostBlobHandlerTest {
       REF_CONTAINER = REF_ACCOUNT.getContainerById(Container.DEFAULT_PRIVATE_CONTAINER_ID);
       REF_CONTAINER_WITH_TTL_REQUIRED = REF_ACCOUNT.getContainerById(Container.DEFAULT_PUBLIC_CONTAINER_ID);
       try {
+        QuotaConfig quotaConfig = QuotaTestUtils.createQuotaConfig(Collections.emptyMap(), false, QuotaMode.TRACKING);
         QUOTA_MANAGER =
-            new AmbryQuotaManager(QuotaTestUtils.createQuotaConfig(Collections.emptyMap(), false, QuotaMode.TRACKING),
-                new MaxThrottlePolicy(), Mockito.mock(AccountService.class), null, new MetricRegistry());
+            new AmbryQuotaManager(quotaConfig, new MaxThrottlePolicy(quotaConfig), Mockito.mock(AccountService.class),
+                null, new MetricRegistry());
       } catch (Exception e) {
         throw new IllegalStateException(e);
       }

--- a/ambry-quota/src/main/java/com/github/ambry/quota/AmbryQuotaManager.java
+++ b/ambry-quota/src/main/java/com/github/ambry/quota/AmbryQuotaManager.java
@@ -96,7 +96,7 @@ public class AmbryQuotaManager implements QuotaManager {
 
   @Override
   public ThrottlingRecommendation getThrottleRecommendation(RestRequest restRequest) {
-    if (!quotaConfig.requestThrottlingEnabled || requestQuotaEnforcers.isEmpty()) {
+    if (requestQuotaEnforcers.isEmpty()) {
       return null;
     }
     ThrottlingRecommendation throttlingRecommendation = null;
@@ -127,7 +127,7 @@ public class AmbryQuotaManager implements QuotaManager {
 
   @Override
   public ThrottlingRecommendation charge(RestRequest restRequest) {
-    if (!quotaConfig.requestThrottlingEnabled || requestQuotaEnforcers.isEmpty()) {
+    if (requestQuotaEnforcers.isEmpty()) {
       return null;
     }
     ThrottlingRecommendation throttlingRecommendation;

--- a/ambry-quota/src/main/java/com/github/ambry/quota/MaxThrottlePolicy.java
+++ b/ambry-quota/src/main/java/com/github/ambry/quota/MaxThrottlePolicy.java
@@ -14,6 +14,7 @@
 package com.github.ambry.quota;
 
 import com.github.ambry.config.QuotaConfig;
+import com.github.ambry.config.StorageQuotaConfig;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import java.util.Collections;
 import java.util.HashMap;
@@ -25,6 +26,10 @@ import java.util.Map;
  * An implementation of {@link ThrottlePolicy} that creates a {@link ThrottlingRecommendation} to throttle if any one of
  * {@link QuotaRecommendation} recommendation is to throttle, and takes the max of retry after time interval. Also
  * groups the quota usage for all the quotas.
+ *
+ * This Policy also respect the settings in the {@link QuotaConfig}. If the {@link QuotaConfig#requestThrottlingEnabled} is
+ * false, we don't throttle on {@link QuotaName#READ_CAPACITY_UNIT} and {@link QuotaName#WRITE_CAPACITY_UNIT}. If the
+ * {@link StorageQuotaConfig#shouldThrottle} is false, we don't throttle on {@link QuotaName#STORAGE_IN_GB}.
  */
 public class MaxThrottlePolicy implements ThrottlePolicy {
   static final long DEFAULT_RETRY_AFTER_MS = ThrottlingRecommendation.NO_RETRY_AFTER_MS;

--- a/ambry-quota/src/main/java/com/github/ambry/quota/storage/StorageQuotaEnforcer.java
+++ b/ambry-quota/src/main/java/com/github/ambry/quota/storage/StorageQuotaEnforcer.java
@@ -161,7 +161,7 @@ public class StorageQuotaEnforcer implements QuotaEnforcer {
       // There is no quota set for the given account/container
       return NO_QUOTA_VALUE_RECOMMENDATION;
     }
-    boolean shouldThrottle = config.shouldThrottle && currentUsage >= quotaValue;
+    boolean shouldThrottle = currentUsage >= quotaValue;
     float usagePercentage = currentUsage >= quotaValue ? 100f : ((float) currentUsage) / quotaValue * 100f;
     return new QuotaRecommendation(shouldThrottle, usagePercentage, QuotaName.STORAGE_IN_GB,
         shouldThrottle ? HTTP_STATUS_THROTTLE : HTTP_STATUS_ALLOW, NO_RETRY);

--- a/ambry-quota/src/test/java/com/github/ambry/quota/AmbryQuotaManagerUpdateNotificationTest.java
+++ b/ambry-quota/src/test/java/com/github/ambry/quota/AmbryQuotaManagerUpdateNotificationTest.java
@@ -44,10 +44,10 @@ public class AmbryQuotaManagerUpdateNotificationTest {
   @Test
   public void ambryQuotaManagerUpdateNotificationTest() throws Exception {
     VerifiableProperties verifiableProperties = new VerifiableProperties(new Properties());
-    ThrottlePolicy throttlePolicy = new MaxThrottlePolicy();
     MetricRegistry metricRegistry = new MetricRegistry();
 
     QuotaConfig quotaConfig = new QuotaConfig(verifiableProperties);
+    ThrottlePolicy throttlePolicy = new MaxThrottlePolicy(quotaConfig);
     AccountServiceForConsumerTest accountService =
         new AccountServiceForConsumerTest(new AccountServiceConfig(verifiableProperties),
             new AccountServiceMetrics(metricRegistry), null);

--- a/ambry-quota/src/test/java/com/github/ambry/quota/MaxThrottlePolicyTest.java
+++ b/ambry-quota/src/test/java/com/github/ambry/quota/MaxThrottlePolicyTest.java
@@ -13,11 +13,14 @@
  */
 package com.github.ambry.quota;
 
+import com.github.ambry.config.QuotaConfig;
+import com.github.ambry.config.VerifiableProperties;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -31,12 +34,12 @@ public class MaxThrottlePolicyTest {
   /** Test for {@link MaxThrottlePolicy#recommend}*/
   @Test
   public void testRecommend() {
-    MaxThrottlePolicy maxThrottlePolicy = new MaxThrottlePolicy();
+    MaxThrottlePolicy maxThrottlePolicy =
+        new MaxThrottlePolicy(new QuotaConfig(new VerifiableProperties(new Properties())));
 
     // test for empty quota recommendation list
     ThrottlingRecommendation throttlingRecommendation = maxThrottlePolicy.recommend(Collections.emptyList());
-    assertEquals(ThrottlingRecommendation.NO_RETRY_AFTER_MS,
-        throttlingRecommendation.getRetryAfterMs());
+    assertEquals(ThrottlingRecommendation.NO_RETRY_AFTER_MS, throttlingRecommendation.getRetryAfterMs());
     assertEquals(QuotaUsageLevel.HEALTHY, throttlingRecommendation.getQuotaUsageLevel());
     assertEquals(HttpResponseStatus.OK.code(), throttlingRecommendation.getRecommendedHttpStatus());
     assertEquals(false, throttlingRecommendation.shouldThrottle());

--- a/ambry-quota/src/test/java/com/github/ambry/quota/MaxThrottlePolicyTest.java
+++ b/ambry-quota/src/test/java/com/github/ambry/quota/MaxThrottlePolicyTest.java
@@ -14,10 +14,12 @@
 package com.github.ambry.quota;
 
 import com.github.ambry.config.QuotaConfig;
+import com.github.ambry.config.StorageQuotaConfig;
 import com.github.ambry.config.VerifiableProperties;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -132,6 +134,104 @@ public class MaxThrottlePolicyTest {
     verifyThrottlingRecommendation(QuotaUsageLevel.EXCEEDED, true,
         Collections.singletonMap(QuotaName.READ_CAPACITY_UNIT, (float) 101.0),
         HttpResponseStatus.TOO_MANY_REQUESTS.code(), 5, throttlingRecommendation);
+
+    // Test when the request throttling is disabled
+    Properties prop = new Properties();
+    prop.setProperty(QuotaConfig.REQUEST_THROTTLING_ENABLED, "false");
+    maxThrottlePolicy = new MaxThrottlePolicy(new QuotaConfig(new VerifiableProperties(prop)));
+
+    // test for a request quota recommendation.
+    quotaRecommendation =
+        new QuotaRecommendation(true, 101, QuotaName.READ_CAPACITY_UNIT, HttpResponseStatus.TOO_MANY_REQUESTS.code(),
+            5);
+    throttlingRecommendation = maxThrottlePolicy.recommend(Collections.singletonList(quotaRecommendation));
+    verifyThrottlingRecommendation(QuotaUsageLevel.EXCEEDED, false,
+        Collections.singletonMap(QuotaName.READ_CAPACITY_UNIT, (float) 101.0),
+        HttpResponseStatus.TOO_MANY_REQUESTS.code(), 5, throttlingRecommendation);
+
+    quotaRecommendationList.clear();
+    quotaRecommendationList.add(quotaRecommendation);
+    quotaRecommendationList.add(
+        new QuotaRecommendation(true, 101, QuotaName.STORAGE_IN_GB, HttpResponseStatus.TOO_MANY_REQUESTS.code(), 5));
+    throttlingRecommendation = maxThrottlePolicy.recommend(quotaRecommendationList);
+    verifyThrottlingRecommendation(QuotaUsageLevel.EXCEEDED, true, new HashMap<QuotaName, Float>() {
+      {
+        put(QuotaName.READ_CAPACITY_UNIT, (float) 101.0);
+        put(QuotaName.STORAGE_IN_GB, (float) 101.0);
+      }
+    }, HttpResponseStatus.TOO_MANY_REQUESTS.code(), 5, throttlingRecommendation);
+
+    // Test when the storage quota throttling is disabled
+    prop = new Properties();
+    prop.setProperty(StorageQuotaConfig.SHOULD_THROTTLE, "false");
+    maxThrottlePolicy = new MaxThrottlePolicy(new QuotaConfig(new VerifiableProperties(prop)));
+
+    // test for a storage quota recommendation.
+    quotaRecommendation =
+        new QuotaRecommendation(true, 101, QuotaName.STORAGE_IN_GB, HttpResponseStatus.TOO_MANY_REQUESTS.code(), 5);
+    throttlingRecommendation = maxThrottlePolicy.recommend(Collections.singletonList(quotaRecommendation));
+    verifyThrottlingRecommendation(QuotaUsageLevel.EXCEEDED, false,
+        Collections.singletonMap(QuotaName.STORAGE_IN_GB, (float) 101.0), HttpResponseStatus.TOO_MANY_REQUESTS.code(),
+        5, throttlingRecommendation);
+
+    quotaRecommendationList.clear();
+    quotaRecommendationList.add(quotaRecommendation);
+    quotaRecommendationList.add(
+        new QuotaRecommendation(true, 101, QuotaName.READ_CAPACITY_UNIT, HttpResponseStatus.TOO_MANY_REQUESTS.code(),
+            5));
+    throttlingRecommendation = maxThrottlePolicy.recommend(quotaRecommendationList);
+    verifyThrottlingRecommendation(QuotaUsageLevel.EXCEEDED, true, new HashMap<QuotaName, Float>() {
+      {
+        put(QuotaName.READ_CAPACITY_UNIT, (float) 101.0);
+        put(QuotaName.STORAGE_IN_GB, (float) 101.0);
+      }
+    }, HttpResponseStatus.TOO_MANY_REQUESTS.code(), 5, throttlingRecommendation);
+
+    // Test when both quota throttling are disabled
+    prop = new Properties();
+    prop.setProperty(StorageQuotaConfig.SHOULD_THROTTLE, "false");
+    prop.setProperty(QuotaConfig.REQUEST_THROTTLING_ENABLED, "false");
+    maxThrottlePolicy = new MaxThrottlePolicy(new QuotaConfig(new VerifiableProperties(prop)));
+
+    quotaRecommendation =
+        new QuotaRecommendation(true, 101, QuotaName.READ_CAPACITY_UNIT, HttpResponseStatus.TOO_MANY_REQUESTS.code(),
+            5);
+    throttlingRecommendation = maxThrottlePolicy.recommend(Collections.singletonList(quotaRecommendation));
+    verifyThrottlingRecommendation(QuotaUsageLevel.EXCEEDED, false,
+        Collections.singletonMap(QuotaName.READ_CAPACITY_UNIT, (float) 101.0),
+        HttpResponseStatus.TOO_MANY_REQUESTS.code(), 5, throttlingRecommendation);
+
+    quotaRecommendation =
+        new QuotaRecommendation(true, 101, QuotaName.WRITE_CAPACITY_UNIT, HttpResponseStatus.TOO_MANY_REQUESTS.code(),
+            5);
+    throttlingRecommendation = maxThrottlePolicy.recommend(Collections.singletonList(quotaRecommendation));
+    verifyThrottlingRecommendation(QuotaUsageLevel.EXCEEDED, false,
+        Collections.singletonMap(QuotaName.WRITE_CAPACITY_UNIT, (float) 101.0),
+        HttpResponseStatus.TOO_MANY_REQUESTS.code(), 5, throttlingRecommendation);
+
+    quotaRecommendation =
+        new QuotaRecommendation(true, 101, QuotaName.STORAGE_IN_GB, HttpResponseStatus.TOO_MANY_REQUESTS.code(), 5);
+    throttlingRecommendation = maxThrottlePolicy.recommend(Collections.singletonList(quotaRecommendation));
+    verifyThrottlingRecommendation(QuotaUsageLevel.EXCEEDED, false,
+        Collections.singletonMap(QuotaName.STORAGE_IN_GB, (float) 101.0), HttpResponseStatus.TOO_MANY_REQUESTS.code(),
+        5, throttlingRecommendation);
+
+    quotaRecommendationList.clear();
+    quotaRecommendationList.add(quotaRecommendation);
+    quotaRecommendationList.add(
+        new QuotaRecommendation(true, 101, QuotaName.READ_CAPACITY_UNIT, HttpResponseStatus.TOO_MANY_REQUESTS.code(),
+            5));
+    quotaRecommendationList.add(
+        new QuotaRecommendation(true, 101, QuotaName.WRITE_CAPACITY_UNIT, HttpResponseStatus.TOO_MANY_REQUESTS.code(),
+            5));
+    throttlingRecommendation = maxThrottlePolicy.recommend(quotaRecommendationList);
+    verifyThrottlingRecommendation(QuotaUsageLevel.EXCEEDED, false, new HashMap<QuotaName, Float>() {
+      {
+        put(QuotaName.READ_CAPACITY_UNIT, (float) 101.0);
+        put(QuotaName.WRITE_CAPACITY_UNIT, (float) 101.0);
+        put(QuotaName.STORAGE_IN_GB, (float) 101.0);
+      }
+    }, HttpResponseStatus.TOO_MANY_REQUESTS.code(), 5, throttlingRecommendation);
   }
 
   /**

--- a/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterQuotaCallbackTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterQuotaCallbackTest.java
@@ -70,7 +70,7 @@ public class NonBlockingRouterQuotaCallbackTest extends NonBlockingRouterTestBas
       boolean throttleInProgressRequests) throws Exception {
     super(testEncryption, metadataContentVersion, false);
     this.throttlingMode = QuotaMode.valueOf(quotaModeStr);
-    this.throttleInProgressRequests  = throttleInProgressRequests;
+    this.throttleInProgressRequests = throttleInProgressRequests;
   }
 
   /**
@@ -79,22 +79,23 @@ public class NonBlockingRouterQuotaCallbackTest extends NonBlockingRouterTestBas
    */
   @Parameterized.Parameters
   public static List<Object[]> data() {
-    return Arrays.asList(new Object[][]{{false, MessageFormatRecord.Metadata_Content_Version_V2, QuotaMode.THROTTLING.name(), true},
-        {false, MessageFormatRecord.Metadata_Content_Version_V3, QuotaMode.THROTTLING.name(), true},
-        {true, MessageFormatRecord.Metadata_Content_Version_V2, QuotaMode.THROTTLING.name(), true},
-        {true, MessageFormatRecord.Metadata_Content_Version_V3, QuotaMode.THROTTLING.name(), true},
-        {false, MessageFormatRecord.Metadata_Content_Version_V2, QuotaMode.TRACKING.name(), true},
-        {false, MessageFormatRecord.Metadata_Content_Version_V3, QuotaMode.TRACKING.name(), true},
-        {true, MessageFormatRecord.Metadata_Content_Version_V2, QuotaMode.TRACKING.name(), true},
-        {true, MessageFormatRecord.Metadata_Content_Version_V3, QuotaMode.TRACKING.name(), true},
-        {false, MessageFormatRecord.Metadata_Content_Version_V2, QuotaMode.THROTTLING.name(), false},
-        {false, MessageFormatRecord.Metadata_Content_Version_V3, QuotaMode.THROTTLING.name(), false},
-        {true, MessageFormatRecord.Metadata_Content_Version_V2, QuotaMode.THROTTLING.name(), false},
-        {true, MessageFormatRecord.Metadata_Content_Version_V3, QuotaMode.THROTTLING.name(), false},
-        {false, MessageFormatRecord.Metadata_Content_Version_V2, QuotaMode.TRACKING.name(), false},
-        {false, MessageFormatRecord.Metadata_Content_Version_V3, QuotaMode.TRACKING.name(), false},
-        {true, MessageFormatRecord.Metadata_Content_Version_V2, QuotaMode.TRACKING.name(), false},
-        {true, MessageFormatRecord.Metadata_Content_Version_V3, QuotaMode.TRACKING.name(), false}});
+    return Arrays.asList(
+        new Object[][]{{false, MessageFormatRecord.Metadata_Content_Version_V2, QuotaMode.THROTTLING.name(), true},
+            {false, MessageFormatRecord.Metadata_Content_Version_V3, QuotaMode.THROTTLING.name(), true},
+            {true, MessageFormatRecord.Metadata_Content_Version_V2, QuotaMode.THROTTLING.name(), true},
+            {true, MessageFormatRecord.Metadata_Content_Version_V3, QuotaMode.THROTTLING.name(), true},
+            {false, MessageFormatRecord.Metadata_Content_Version_V2, QuotaMode.TRACKING.name(), true},
+            {false, MessageFormatRecord.Metadata_Content_Version_V3, QuotaMode.TRACKING.name(), true},
+            {true, MessageFormatRecord.Metadata_Content_Version_V2, QuotaMode.TRACKING.name(), true},
+            {true, MessageFormatRecord.Metadata_Content_Version_V3, QuotaMode.TRACKING.name(), true},
+            {false, MessageFormatRecord.Metadata_Content_Version_V2, QuotaMode.THROTTLING.name(), false},
+            {false, MessageFormatRecord.Metadata_Content_Version_V3, QuotaMode.THROTTLING.name(), false},
+            {true, MessageFormatRecord.Metadata_Content_Version_V2, QuotaMode.THROTTLING.name(), false},
+            {true, MessageFormatRecord.Metadata_Content_Version_V3, QuotaMode.THROTTLING.name(), false},
+            {false, MessageFormatRecord.Metadata_Content_Version_V2, QuotaMode.TRACKING.name(), false},
+            {false, MessageFormatRecord.Metadata_Content_Version_V3, QuotaMode.TRACKING.name(), false},
+            {true, MessageFormatRecord.Metadata_Content_Version_V2, QuotaMode.TRACKING.name(), false},
+            {true, MessageFormatRecord.Metadata_Content_Version_V3, QuotaMode.TRACKING.name(), false}});
   }
 
   /**
@@ -126,8 +127,11 @@ public class NonBlockingRouterQuotaCallbackTest extends NonBlockingRouterTestBas
       expectedChargeCallbackCount += numChunks;
       assertEquals(expectedChargeCallbackCount, listenerCalledCount.get());
       RetainingAsyncWritableChannel retainingAsyncWritableChannel = new RetainingAsyncWritableChannel();
-      router.getBlob(compositeBlobId, new GetBlobOptionsBuilder().build(), null, quotaChargeCallback).get()
-          .getBlobDataChannel().readInto(retainingAsyncWritableChannel, null).get();
+      router.getBlob(compositeBlobId, new GetBlobOptionsBuilder().build(), null, quotaChargeCallback)
+          .get()
+          .getBlobDataChannel()
+          .readInto(retainingAsyncWritableChannel, null)
+          .get();
       expectedChargeCallbackCount += numChunks;
       // read out all the chunks to make sure all the chunks are consumed and accounted for.
       retainingAsyncWritableChannel.consumeContentAsInputStream().close();
@@ -192,8 +196,11 @@ public class NonBlockingRouterQuotaCallbackTest extends NonBlockingRouterTestBas
 
       retainingAsyncWritableChannel = new RetainingAsyncWritableChannel();
       expectedChargeCallbackCount += 3;
-      router.getBlob(stitchedBlobId, new GetBlobOptionsBuilder().build(), null, quotaChargeCallback).get()
-          .getBlobDataChannel().readInto(retainingAsyncWritableChannel, null).get();
+      router.getBlob(stitchedBlobId, new GetBlobOptionsBuilder().build(), null, quotaChargeCallback)
+          .get()
+          .getBlobDataChannel()
+          .readInto(retainingAsyncWritableChannel, null)
+          .get();
       // read out all the chunks to make sure all the chunks are consumed and accounted for.
       retainingAsyncWritableChannel.consumeContentAsInputStream().close();
       assertEquals(expectedChargeCallbackCount, listenerCalledCount.get());
@@ -221,9 +228,10 @@ public class NonBlockingRouterQuotaCallbackTest extends NonBlockingRouterTestBas
       setRouter();
       assertExpectedThreadCounts(2, 1);
       AtomicInteger listenerCalledCount = new AtomicInteger(0);
+      QuotaConfig quotaConfig = new QuotaConfig(new VerifiableProperties(new Properties()));
       QuotaManager quotaManager =
-          new ChargeTesterQuotaManager(new QuotaConfig(new VerifiableProperties(new Properties())), new MaxThrottlePolicy(),
-              accountService, null, new MetricRegistry(), listenerCalledCount);
+          new ChargeTesterQuotaManager(quotaConfig, new MaxThrottlePolicy(quotaConfig), accountService, null,
+              new MetricRegistry(), listenerCalledCount);
       QuotaChargeCallback quotaChargeCallback = QuotaChargeCallback.buildQuotaChargeCallback(null, quotaManager, true);
 
       int blobSize = 3000;
@@ -265,8 +273,9 @@ public class NonBlockingRouterQuotaCallbackTest extends NonBlockingRouterTestBas
      * @param metricRegistry {@link MetricRegistry} object for creating quota metrics.
      * @throws ReflectiveOperationException in case of any exception.
      */
-    public ChargeTesterQuotaManager(QuotaConfig quotaConfig, ThrottlePolicy throttlePolicy, AccountService accountService,
-        AccountStatsStore accountStatsStore, MetricRegistry metricRegistry, AtomicInteger chargeCalledCount) throws ReflectiveOperationException {
+    public ChargeTesterQuotaManager(QuotaConfig quotaConfig, ThrottlePolicy throttlePolicy,
+        AccountService accountService, AccountStatsStore accountStatsStore, MetricRegistry metricRegistry,
+        AtomicInteger chargeCalledCount) throws ReflectiveOperationException {
       super(quotaConfig, throttlePolicy, accountService, accountStatsStore, metricRegistry);
       this.chargeCalledCount = chargeCalledCount;
     }
@@ -274,7 +283,7 @@ public class NonBlockingRouterQuotaCallbackTest extends NonBlockingRouterTestBas
     @Override
     public ThrottlingRecommendation charge(RestRequest restRequest) {
       ThrottlingRecommendation throttlingRecommendation = super.charge(restRequest);
-      if(throttlingRecommendation != null) {
+      if (throttlingRecommendation != null) {
         chargeCalledCount.incrementAndGet();
       }
       return throttlingRecommendation;


### PR DESCRIPTION
Before this PR, we have "requestThrottlingEnabled" to control all the enforcers in the ambry quota manager. So it's very hard to turn off request quota enforcer at the same time keep storage quota enforcer. 
After this PR, we change the semantic of "requetThrottlingEnabled" to only control the request quota enforcer. In way, if we want to only enable throttling on storage quota enforcer, we should set this flag to false and request quota enforcer would continue working on tracking mode.