### PR TITLE
If crc is null, don't error out as COLLISION

### DIFF
--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -348,7 +348,8 @@ public class BlobStore implements Store {
     for (MessageInfo info : messageSetToWrite.getMessageSetInfo()) {
       if (index.findKey(info.getStoreKey(), fileSpan,
           EnumSet.of(PersistentIndex.IndexEntryType.PUT, PersistentIndex.IndexEntryType.DELETE)) != null) {
-        if (index.wasRecentlySeen(info)) {
+        if (info.getCrc() == null || index.journal.getCrcOfKey(info.getStoreKey()) == null || index.wasRecentlySeen(
+            info)) {
           existingIdenticalEntries++;
           metrics.identicalPutAttemptCount.inc();
         } else {

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -348,8 +348,7 @@ public class BlobStore implements Store {
     for (MessageInfo info : messageSetToWrite.getMessageSetInfo()) {
       if (index.findKey(info.getStoreKey(), fileSpan,
           EnumSet.of(PersistentIndex.IndexEntryType.PUT, PersistentIndex.IndexEntryType.DELETE)) != null) {
-        if (info.getCrc() == null || index.journal.getCrcOfKey(info.getStoreKey()) == null || index.wasRecentlySeen(
-            info)) {
+        if (index.wasRecentlySeenOrCrcIsNull(info)) {
           existingIdenticalEntries++;
           metrics.identicalPutAttemptCount.inc();
         } else {

--- a/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
@@ -917,7 +917,7 @@ class PersistentIndex {
    */
   boolean wasRecentlySeen(MessageInfo info) {
     Long crcInJournal = journal.getCrcOfKey(info.getStoreKey());
-    return info.getCrc() != null && info.getCrc().equals(crcInJournal);
+    return info.getCrc().equals(crcInJournal);
   }
 
   /**

--- a/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
@@ -911,13 +911,14 @@ class PersistentIndex {
   }
 
   /**
-   * Returns true if the given message was recently seen by this Index.
+   * Returns true if the given message was recently seen by this Index or crc is null from either {@link MessageInfo} or
+   * {@link Journal}.
    * @param info the {@link MessageInfo} to check.
    * @return true if the exact message was recently added to this index; false otherwise.
    */
-  boolean wasRecentlySeen(MessageInfo info) {
+  boolean wasRecentlySeenOrCrcIsNull(MessageInfo info) {
     Long crcInJournal = journal.getCrcOfKey(info.getStoreKey());
-    return info.getCrc().equals(crcInJournal);
+    return info.getCrc() == null || crcInJournal == null || info.getCrc().equals(crcInJournal);
   }
 
   /**


### PR DESCRIPTION
Previously if the message info crc is null or journal crc is null, inside the checkWriteSetStateInStore we will treat it as COLLIDING. Actually when the replication data is outside of journal, the crc could be null and in this case we will treat it as duplicate instead of COLLISION, because we will check if it's the duplicate data by below constraints:
index.findKey(info.getStoreKey(), fileSpan,
          EnumSet.of(PersistentIndex.IndexEntryType.PUT, PersistentIndex.IndexEntryType.DELETE)) != null 
And since we are not able to get the crc, we can't determine it as COLLISION.