### PR TITLE
Fix content length clamping issue in frontend

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/FrontendConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/FrontendConfig.java
@@ -127,7 +127,7 @@ public class FrontendConfig {
    */
   @Config("frontend.chunked.get.response.threshold.in.bytes")
   @Default("8192")
-  public final Integer chunkedGetResponseThresholdInBytes;
+  public final long chunkedGetResponseThresholdInBytes;
 
   /**
    * Boolean indicator to specify if frontend should allow the post requests that carry serviceId used as target
@@ -258,7 +258,7 @@ public class FrontendConfig {
     pathPrefixesToRemove = Collections.unmodifiableList(
         pathPrefixesFromConfig.stream().map(this::stripLeadingAndTrailingSlash).collect(Collectors.toList()));
     chunkedGetResponseThresholdInBytes =
-        verifiableProperties.getInt("frontend.chunked.get.response.threshold.in.bytes", 8192);
+        verifiableProperties.getLong("frontend.chunked.get.response.threshold.in.bytes", 8192);
     allowServiceIdBasedPostRequest =
         verifiableProperties.getBoolean("frontend.allow.service.id.based.post.request", true);
     attachTrackingInfo = verifiableProperties.getBoolean("frontend.attach.tracking.info", true);

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendIntegrationTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendIntegrationTest.java
@@ -32,12 +32,9 @@ import com.github.ambry.commons.SSLFactory;
 import com.github.ambry.commons.TestSSLUtils;
 import com.github.ambry.config.FrontendConfig;
 import com.github.ambry.config.NettyConfig;
-import com.github.ambry.config.QuotaConfig;
 import com.github.ambry.config.SSLConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.protocol.GetOption;
-import com.github.ambry.quota.AmbryQuotaManager;
-import com.github.ambry.quota.QuotaName;
 import com.github.ambry.rest.NettyClient;
 import com.github.ambry.rest.NettyClient.ResponseParts;
 import com.github.ambry.rest.RestMethod;
@@ -236,7 +233,7 @@ public class FrontendIntegrationTest extends FrontendIntegrationTestBase {
     Account refAccount = ACCOUNT_SERVICE.createAndAddRandomAccount();
     Container publicContainer = refAccount.getContainerById(Container.DEFAULT_PUBLIC_CONTAINER_ID);
     Container privateContainer = refAccount.getContainerById(Container.DEFAULT_PRIVATE_CONTAINER_ID);
-    int refContentSize = FRONTEND_CONFIG.chunkedGetResponseThresholdInBytes * 3;
+    int refContentSize = (int) FRONTEND_CONFIG.chunkedGetResponseThresholdInBytes * 3;
 
     // with valid account and containers
     for (int i = 0; i < 2; i++) {
@@ -255,8 +252,8 @@ public class FrontendIntegrationTest extends FrontendIntegrationTestBase {
     doPostGetHeadUpdateDeleteUndeleteTest(refContentSize, null, null, "unknown_service_id", false, null, null, false);
     doPostGetHeadUpdateDeleteUndeleteTest(refContentSize, null, null, "unknown_service_id", true, null, null, false);
     // different sizes
-    for (int contentSize : new int[]{0, FRONTEND_CONFIG.chunkedGetResponseThresholdInBytes - 1,
-        FRONTEND_CONFIG.chunkedGetResponseThresholdInBytes, refContentSize}) {
+    for (int contentSize : new int[]{0, (int) FRONTEND_CONFIG.chunkedGetResponseThresholdInBytes - 1,
+        (int) FRONTEND_CONFIG.chunkedGetResponseThresholdInBytes, refContentSize}) {
       doPostGetHeadUpdateDeleteUndeleteTest(contentSize, refAccount, publicContainer, refAccount.getName(),
           !publicContainer.isCacheable(), refAccount.getName(), publicContainer.getName(), false);
     }
@@ -272,7 +269,7 @@ public class FrontendIntegrationTest extends FrontendIntegrationTestBase {
     Container refContainer = refAccount.getContainerById(Container.DEFAULT_PUBLIC_CONTAINER_ID);
     doPostGetHeadUpdateDeleteUndeleteTest(0, refAccount, refContainer, refAccount.getName(),
         !refContainer.isCacheable(), refAccount.getName(), refContainer.getName(), true);
-    doPostGetHeadUpdateDeleteUndeleteTest(FRONTEND_CONFIG.chunkedGetResponseThresholdInBytes * 3, refAccount,
+    doPostGetHeadUpdateDeleteUndeleteTest((int) FRONTEND_CONFIG.chunkedGetResponseThresholdInBytes * 3, refAccount,
         refContainer, refAccount.getName(), !refContainer.isCacheable(), refAccount.getName(), refContainer.getName(),
         true);
 

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendQuotaIntegrationTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendQuotaIntegrationTest.java
@@ -219,7 +219,7 @@ public class FrontendQuotaIntegrationTest extends FrontendIntegrationTestBase {
    */
   @Test
   public void postGetHeadUpdateDeleteUndeleteTest() throws Exception {
-    int refContentSize = FRONTEND_CONFIG.chunkedGetResponseThresholdInBytes * 3;
+    int refContentSize = (int) FRONTEND_CONFIG.chunkedGetResponseThresholdInBytes * 3;
     ACCOUNT = ACCOUNT_SERVICE.createAndAddRandomAccount();
     CONTAINER = ACCOUNT.getContainerById(Container.DEFAULT_PUBLIC_CONTAINER_ID);
     doPostGetHeadUpdateDeleteUndeleteTest(refContentSize, ACCOUNT, CONTAINER, ACCOUNT.getName(),
@@ -266,7 +266,7 @@ public class FrontendQuotaIntegrationTest extends FrontendIntegrationTestBase {
   void verifyGetBlobResponse(NettyClient.ResponseParts responseParts, ByteRange range, boolean resolveRangeOnEmptyBlob,
       HttpHeaders expectedHeaders, boolean isPrivate, ByteBuffer expectedContent, String accountName,
       String containerName) throws RestServiceException {
-    if (!throttleRequest  || quotaMode == QuotaMode.TRACKING) {
+    if (!throttleRequest || quotaMode == QuotaMode.TRACKING) {
       super.verifyGetBlobResponse(responseParts, range, resolveRangeOnEmptyBlob, expectedHeaders, isPrivate,
           expectedContent, accountName, containerName);
     } else {
@@ -296,7 +296,7 @@ public class FrontendQuotaIntegrationTest extends FrontendIntegrationTestBase {
   @Override
   void verifyGetHeadResponse(HttpResponse response, HttpHeaders expectedHeaders, ByteRange range, boolean isPrivate,
       String accountName, String containerName, NettyClient.ResponseParts responseParts) throws RestServiceException {
-    if (!throttleRequest  || quotaMode == QuotaMode.TRACKING) {
+    if (!throttleRequest || quotaMode == QuotaMode.TRACKING) {
       super.verifyGetHeadResponse(response, expectedHeaders, range, isPrivate, accountName, containerName,
           responseParts);
     } else {
@@ -324,7 +324,7 @@ public class FrontendQuotaIntegrationTest extends FrontendIntegrationTestBase {
   @Override
   void verifyGetNotModifiedBlobResponse(HttpResponse response, boolean isPrivate,
       NettyClient.ResponseParts responseParts) {
-    if (!throttleRequest  || quotaMode == QuotaMode.TRACKING) {
+    if (!throttleRequest || quotaMode == QuotaMode.TRACKING) {
       super.verifyGetNotModifiedBlobResponse(response, isPrivate, responseParts);
     } else {
       assertEquals("Unexpected response status", HttpResponseStatus.TOO_MANY_REQUESTS, response.status());
@@ -345,7 +345,7 @@ public class FrontendQuotaIntegrationTest extends FrontendIntegrationTestBase {
   @Override
   void verifyUserMetadataResponse(HttpResponse response, HttpHeaders expectedHeaders, byte[] usermetadata,
       NettyClient.ResponseParts responseParts) {
-    if (!throttleRequest  || quotaMode == QuotaMode.TRACKING) {
+    if (!throttleRequest || quotaMode == QuotaMode.TRACKING) {
       super.verifyUserMetadataResponse(response, expectedHeaders, usermetadata, responseParts);
     } else {
       assertEquals("Unexpected response status", HttpResponseStatus.TOO_MANY_REQUESTS, response.status());

--- a/ambry-rest/src/main/java/com/github/ambry/rest/NettyRequest.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/NettyRequest.java
@@ -13,8 +13,8 @@
  */
 package com.github.ambry.rest;
 
-import com.github.ambry.router.AsyncWritableChannel;
 import com.github.ambry.commons.Callback;
+import com.github.ambry.router.AsyncWritableChannel;
 import com.github.ambry.router.FutureResult;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
@@ -59,6 +59,7 @@ import org.slf4j.LoggerFactory;
  * A wrapper over {@link HttpRequest} and all the {@link HttpContent} associated with the request.
  */
 public class NettyRequest implements RestRequest {
+  static final long UNKNOWN_CONTENT_LENGTH = -1L;
   // If the write of at least {@code bufferWatermark} amount of data is unacknowledged, reading from the channel will be
   // temporarily suspended. It will be resumed when the amount of data unacknowledged drops below this number. If this
   // is <=0, it is assumed that there is no limit on the size of unacknowledged data.
@@ -171,7 +172,7 @@ public class NettyRequest implements RestRequest {
             RestServiceErrorCode.InvalidArgs);
       }
     } else {
-      size = HttpUtil.getContentLength(request, -1L);
+      size = HttpUtil.getContentLength(request, UNKNOWN_CONTENT_LENGTH);
     }
 
     // query params.

--- a/ambry-rest/src/main/java/com/github/ambry/rest/NettyResponseChannel.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/NettyResponseChannel.java
@@ -564,7 +564,7 @@ class NettyResponseChannel implements RestResponseChannel {
     if (errReason != null) {
       response.headers().set(FAILURE_REASON_HEADER, errReason);
     }
-    if(errHeaders != null) {
+    if (errHeaders != null) {
       errHeaders.forEach((errHeaderKey, errHeaderVal) -> response.headers().set(errHeaderKey, errHeaderVal));
     }
     if (restServiceErrorCode != null && HttpStatusClass.CLIENT_ERROR.contains(status.code())) {
@@ -609,7 +609,7 @@ class NettyResponseChannel implements RestResponseChannel {
       } else if (request.getRestMethod().equals(RestMethod.POST)) {
         shouldKeepAlive = false;
       } else if (request.getRestMethod().equals(RestMethod.PUT) && (HttpUtil.isTransferEncodingChunked(request.request)
-          || HttpUtil.getContentLength(request.request, 0L) > 0)) {
+          || HttpUtil.getContentLength(request.request, NettyRequest.UNKNOWN_CONTENT_LENGTH) > 0)) {
         shouldKeepAlive = false;
       }
     }
@@ -873,8 +873,9 @@ class NettyResponseChannel implements RestResponseChannel {
       chunksToWriteCount.incrementAndGet();
 
       // if channel becomes inactive, no one set finalResponseMetadata. It's possible finalResponseMetadata is null.
-      long contentLength = finalResponseMetadata == null ? -1 : HttpUtil.getContentLength(finalResponseMetadata, -1);
-      isLast = contentLength != -1 && writeCompleteThreshold >= contentLength;
+      long contentLength = finalResponseMetadata == null ? NettyRequest.UNKNOWN_CONTENT_LENGTH
+          : HttpUtil.getContentLength(finalResponseMetadata, NettyRequest.UNKNOWN_CONTENT_LENGTH);
+      isLast = contentLength != NettyRequest.UNKNOWN_CONTENT_LENGTH && writeCompleteThreshold >= contentLength;
     }
 
     /**
@@ -961,7 +962,7 @@ class NettyResponseChannel implements RestResponseChannel {
     @Override
     public HttpContent readChunk(ByteBufAllocator allocator) throws Exception {
       long chunkDispenseStartTime = System.currentTimeMillis();
-      logger.trace("Servicing request for next chunk on channel {}", ctx.channel());
+      logger.trace("Servicing request for next chunk on channel {} {}", ctx.channel(), progress.get());
       HttpContent content = null;
       Chunk chunk = chunksToWrite.poll();
       if (chunk != null) {
@@ -990,7 +991,7 @@ class NettyResponseChannel implements RestResponseChannel {
 
     @Override
     public long length() {
-      return HttpUtil.getContentLength(finalResponseMetadata, -1);
+      return HttpUtil.getContentLength(finalResponseMetadata, NettyRequest.UNKNOWN_CONTENT_LENGTH);
     }
 
     @Override

--- a/ambry-rest/src/test/java/com/github/ambry/rest/NettyResponseChannelTest.java
+++ b/ambry-rest/src/test/java/com/github/ambry/rest/NettyResponseChannelTest.java
@@ -221,7 +221,7 @@ public class NettyResponseChannelTest {
       // first outbound has to be response.
       HttpResponse response = channel.readOutbound();
       assertEquals("Unexpected response status", HttpResponseStatus.OK, response.status());
-      long contentLength = HttpUtil.getContentLength(response, -1);
+      long contentLength = HttpUtil.getContentLength(response, NettyRequest.UNKNOWN_CONTENT_LENGTH);
       assertEquals("Unexpected Content-Length", MockNettyMessageProcessor.CHUNK.length * i, contentLength);
       if (contentLength == 0) {
         // special case. Since Content-Length is set, the response should be an instance of FullHttpResponse.
@@ -274,7 +274,8 @@ public class NettyResponseChannelTest {
     channel.writeInbound(httpRequest);
     // There should be a response.
     response = channel.readOutbound();
-    assertEquals("Response must have Content-Length set to 0", 0, HttpUtil.getContentLength(response, -1));
+    assertEquals("Response must have Content-Length set to 0", 0,
+        HttpUtil.getContentLength(response, NettyRequest.UNKNOWN_CONTENT_LENGTH));
     assertEquals("Unexpected response status", HttpResponseStatus.OK, response.status());
     // since Content-Length is set, the response should be an instance of FullHttpResponse.
     assertTrue("Response not instance of FullHttpResponse", response instanceof FullHttpResponse);


### PR DESCRIPTION
Netty has two  content length related helper methods:
  public static long getContentLength(HttpMessage message, long defaultValue)
  public static int getContentLength(HttpMessage message, int defaultValue)
We were calling getContentLength(message, -1) instead of getContentLength(message, -1L)
in a couple places, which lead to the length used to tell when the request is fully sent
out getting clamped to an int, which made requests pause after 2 GB of
data was sent.

After fixing this, the download  of greater than 2 GB objects with the content-length
response headers works. This bug did not affect
transfer-encoding:chunked serving since a different end condition for
telling when the response is fully sent is used there.