### PR TITLE
If previous stats based didn't run successfully, still need to close last log segment

### DIFF
--- a/ambry-store/src/main/java/com/github/ambry/store/CompactionManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/CompactionManager.java
@@ -288,12 +288,12 @@ class CompactionManager {
                     metrics.markCompactionStart(true);
                     compactionStarted = true;
                     store.compact(details, bundleReadBuffer);
-                    if (storeConfig.storeAutoCloseLastLogSegmentEnabled && store.getReplicaId().isSealed()) {
-                      store.closeLastLogSegmentIfQualified();
-                    }
                   } else {
                     storesNoCompaction++;
                     logger.info("{} is not eligible for compaction due to empty compaction details", store);
+                  }
+                  if (storeConfig.storeAutoCloseLastLogSegmentEnabled && store.getReplicaId().isSealed()) {
+                    store.closeLastLogSegmentIfQualified();
                   }
                 }
               } catch (Exception e) {


### PR DESCRIPTION
If the stats based compaction has not been kicked off because the details are null, we still need to auto close the last log segment. 