### PR TITLE
Add method to change quota mode in quota manager

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/quota/QuotaChargeCallback.java
+++ b/ambry-api/src/main/java/com/github/ambry/quota/QuotaChargeCallback.java
@@ -42,14 +42,13 @@ public interface QuotaChargeCallback {
       @Override
       public void chargeQuota(long chunkSize) throws RouterException {
         try {
-          Map<QuotaName, Double>
-              requestCost = requestCostPolicy.calculateRequestQuotaCharge(restRequest, chunkSize)
+          Map<QuotaName, Double> requestCost = requestCostPolicy.calculateRequestQuotaCharge(restRequest, chunkSize)
               .entrySet()
               .stream()
               .collect(Collectors.toMap(entry -> QuotaName.valueOf(entry.getKey()), entry -> entry.getValue()));
           ThrottlingRecommendation throttlingRecommendation = quotaManager.charge(restRequest, null, requestCost);
           if (throttlingRecommendation != null && throttlingRecommendation.shouldThrottle() && shouldThrottle) {
-            if (quotaManager.getQuotaConfig().throttlingMode == QuotaMode.THROTTLING
+            if (quotaManager.getQuotaMode() == QuotaMode.THROTTLING
                 && quotaManager.getQuotaConfig().throttleInProgressRequests) {
               throw new RouterException("RequestQuotaExceeded", RouterErrorCode.TooManyRequests);
             } else {

--- a/ambry-api/src/main/java/com/github/ambry/quota/QuotaManager.java
+++ b/ambry-api/src/main/java/com/github/ambry/quota/QuotaManager.java
@@ -55,6 +55,19 @@ public interface QuotaManager {
   QuotaConfig getQuotaConfig();
 
   /**
+   * Set {@link QuotaMode} for {@link QuotaManager}.
+   * @param mode The mode to set
+   */
+  void setQuotaMode(QuotaMode mode);
+
+  /**
+   * Use this method to get the {@link QuotaMode} rather than {@link QuotaConfig#throttlingMode} since the {@link QuotaMode}
+   * might be updated by {@link #setQuotaMode}.
+   * @return the {@link QuotaMode}. By default, it will return the {@link QuotaMode} from {@link QuotaConfig}.
+   */
+  QuotaMode getQuotaMode();
+
+  /**
    * Method to shutdown the {@link QuotaManager} and cleanup if required.
    */
   void shutdown();

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbrySecurityService.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbrySecurityService.java
@@ -134,7 +134,7 @@ class AmbrySecurityService implements SecurityService {
         if (quotaManager != null) {
           ThrottlingRecommendation throttlingRecommendation = quotaManager.getThrottleRecommendation(restRequest);
           if (throttlingRecommendation != null && throttlingRecommendation.shouldThrottle()
-              && quotaManager.getQuotaConfig().throttlingMode == QuotaMode.THROTTLING) {
+              && quotaManager.getQuotaMode() == QuotaMode.THROTTLING) {
             Map<String, String> quotaHeaderMap = RestUtils.buildUserQuotaHeadersMap(throttlingRecommendation);
             throw new RestServiceException("User Quota Exceeded", RestServiceErrorCode.TooManyRequests, true, true,
                 quotaHeaderMap);

--- a/ambry-quota/src/main/java/com/github/ambry/quota/AmbryQuotaManager.java
+++ b/ambry-quota/src/main/java/com/github/ambry/quota/AmbryQuotaManager.java
@@ -47,6 +47,7 @@ public class AmbryQuotaManager implements QuotaManager {
   private final ThrottlePolicy throttlePolicy;
   private final QuotaConfig quotaConfig;
   private final QuotaMetrics quotaMetrics;
+  private volatile QuotaMode quotaMode;
 
   /**
    * Constructor for {@link AmbryQuotaManager}.
@@ -72,6 +73,7 @@ public class AmbryQuotaManager implements QuotaManager {
     this.throttlePolicy = throttlePolicy;
     this.quotaConfig = quotaConfig;
     this.quotaMetrics = new QuotaMetrics(metricRegistry);
+    this.quotaMode = quotaConfig.throttlingMode;
     accountService.addAccountUpdateConsumer(this::onAccountUpdateNotification);
   }
 
@@ -148,6 +150,16 @@ public class AmbryQuotaManager implements QuotaManager {
   @Override
   public QuotaConfig getQuotaConfig() {
     return quotaConfig;
+  }
+
+  @Override
+  public void setQuotaMode(QuotaMode mode) {
+    this.quotaMode = mode;
+  }
+
+  @Override
+  public QuotaMode getQuotaMode() {
+    return quotaMode;
   }
 
   /**

--- a/ambry-test-utils/src/main/java/com/github/ambry/quota/QuotaTestUtils.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/quota/QuotaTestUtils.java
@@ -76,6 +76,16 @@ public class QuotaTestUtils {
       }
 
       @Override
+      public void setQuotaMode(QuotaMode mode) {
+
+      }
+
+      @Override
+      public QuotaMode getQuotaMode() {
+        return null;
+      }
+
+      @Override
       public void shutdown() {
 
       }


### PR DESCRIPTION
This PR adds two new methods to `QuotaManager` to set and return the quota mode so that in other places we can change quota mode based on other conditions.