### PR TITLE
Adding test cases and relax constraint for setting active segment in PersistentIndex

### DIFF
--- a/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
@@ -277,16 +277,12 @@ class PersistentIndex {
   }
 
   /**
-   * If index recovery succeed and last log segment is empty due to auto close segment feature, the last log segment should be set as active log segment.
+   * If index recovery succeed and last log segment is empty due to auto close segment feature, the last log segment
+   * should be set as active log segment.
    * @return {@code true} if the recovery succeed and last log segment is empty.
    */
   private boolean shouldSetActiveLogSegmentToAutoClosedSegment() {
-    LogSegment currentSecondLastLogSegment = log.getPrevSegment(log.getLastSegment());
-    if (currentSecondLastLogSegment == null) {
-      return false;
-    }
-    Offset currentSecondLastLogSegmentEndOffSet = new Offset(currentSecondLastLogSegment.getName(), currentSecondLastLogSegment.getEndOffset());
-    return getCurrentEndOffset().equals(currentSecondLastLogSegmentEndOffSet) && log.getLastSegment().isEmpty();
+    return log.getLastSegment().isEmpty() && getCurrentEndOffset().compareTo(log.getEndOffset()) < 0;
   }
 
   /**


### PR DESCRIPTION
Previously when getCurrentEndOffset().equals(currentSecondLastLogSegmentEndOffSet) && log.getLastSegment().isEmpty(), we will notice that the last log segment don't have data and corresponding index, so at that time, we will set last log segment as active segment. There's one more case that if we have two log segments which has been auto created, the last log segment still need to be set as active segment, and the second last log segment will be compacted through compaction later.