### PR TITLE
Fix a bug in throttler

### DIFF
--- a/ambry-utils/src/main/java/com/github/ambry/utils/Throttler.java
+++ b/ambry-utils/src/main/java/com/github/ambry/utils/Throttler.java
@@ -79,7 +79,7 @@ public class Throttler {
             }
           }
         }
-        periodStartNs = now;
+        periodStartNs = time.nanoseconds();
         observedSoFar = 0;
       }
     }
@@ -89,7 +89,7 @@ public class Throttler {
    * Update desiredRatePerSec for this throttler.
    * @param desiredRatePerSec the new desiredRatePerSec
    */
-  public void updateDesiredRatePerSecond(double desiredRatePerSec){
+  public void updateDesiredRatePerSecond(double desiredRatePerSec) {
     synchronized (lock) {
       this.desiredRatePerSec = desiredRatePerSec;
     }

--- a/ambry-utils/src/test/java/com/github/ambry/utils/ThrottlerTest.java
+++ b/ambry-utils/src/test/java/com/github/ambry/utils/ThrottlerTest.java
@@ -38,12 +38,13 @@ public class ThrottlerTest {
     time.setCurrentMilliseconds(11);
     throttler.maybeThrottle(100);
     Assert.assertEquals(1500, time.milliseconds());
+    time.setCurrentMilliseconds(time.milliseconds() + 11);
     throttler.maybeThrottle(500);
-    Assert.assertEquals(5011, time.milliseconds());
+    Assert.assertEquals(6500, time.milliseconds());
     throttler.disable();
     // no more sleeps after disable
     throttler.maybeThrottle(500);
-    Assert.assertEquals(5011, time.milliseconds());
+    Assert.assertEquals(6500, time.milliseconds());
   }
 
   /**

--- a/ambry-utils/src/test/java/com/github/ambry/utils/ThrottlerTest.java
+++ b/ambry-utils/src/test/java/com/github/ambry/utils/ThrottlerTest.java
@@ -81,4 +81,15 @@ public class ThrottlerTest {
     throttler.maybeThrottle(150);
     Assert.assertEquals(1500, time.milliseconds());
   }
+
+  @Test
+  public void testWithRealTime() throws Exception {
+    Time time = SystemTime.getInstance();
+    long now = time.seconds();
+    Throttler throttler = new Throttler(100, -1, true, time);
+    Thread.sleep(10);
+    throttler.maybeThrottle(500);
+    throttler.maybeThrottle(300);
+    Assert.assertTrue(time.seconds() - now > 7);
+  }
 }


### PR DESCRIPTION
This PR would fix a bug in the throttler.

The bug works like this
1. If we have a throttler to throttle rate at 100 per second and we call maybeThrottle for 1000
2. It will sleep for 10 seconds so the rate would be 100 per second.
3. If we call maybeThrottle for 500 right away, we are expecting it to sleep for 5 seconds, but it will not sleep at all. 

This is the bug, it's caused by the error when setting the `periodStartNs`. If we have a sleep in the previous maybeThrottle call, then the `periodStartNs` will be set to a wrong value.
For example, if at t = 0, we call maybeThrottle for 1000, then we have to sleep for 10 second, but since the `periodStartNs` is set to now, which is 0, when we wake up from the sleep, our time still remains at 10 second ago.

This PR would fix that.