### PR TITLE
Get previousStats from mysql db instead of localBackupFile

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/AccountStatsMySqlConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/AccountStatsMySqlConfig.java
@@ -62,15 +62,12 @@ public class AccountStatsMySqlConfig {
   @Default("")
   public final String domainNamesToRemove;
 
-
   /**
    * Number of connections and threads to use for executing transactions.
    */
   @Config(POOL_SIZE)
   @Default("2")
   public final int poolSize;
-
-  /**
 
   /**
    * Negative numbers means disable batch. 0 means unlimited batch size. Any positive number means the size of each batch.


### PR DESCRIPTION
Previously we will get the previousStats from localBackUpFile, which will cause some consistency issue between localBackupFile and mysql database. This pr is target to fix this issue.