### PR TITLE
Fix filespan for testing and stop auto close log segment when last log segment is empty.

### DIFF
--- a/ambry-store/src/main/java/com/github/ambry/store/Log.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/Log.java
@@ -473,7 +473,7 @@ class Log implements Write {
    * @throws StoreException if any store exception occurred as part of ensuring capacity.
    */
   boolean autoCloseLastLogSegmentIfQualified() throws StoreException {
-    if (compactionPolicySwitchInfoCounterValueReached()) {
+    if (compactionPolicySwitchInfoCounterValueReached() && !activeSegment.isEmpty()) {
       //ensure the capacity to open the new log segment and allocate new log segment.
       //if not able to close the last log segment, continue running the compaction.
       try {

--- a/ambry-store/src/test/java/com/github/ambry/store/CuratedLogIndexState.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CuratedLogIndexState.java
@@ -257,7 +257,7 @@ class CuratedLogIndexState {
     }
     List<IndexEntry> indexEntries = new ArrayList<>(count);
     Offset expectedJournalLastOffset = null;
-    Offset endOffsetOfPrevMsg = index.getCurrentEndOffset();
+    Offset endOffsetOfPrevMsg = log.getEndOffset();
     for (int i = 0; i < count; i++) {
       byte[] dataWritten = appendToLog(size);
       FileSpan fileSpan = log.getFileSpanForMessage(endOffsetOfPrevMsg, size);


### PR DESCRIPTION
This pr target to support:
1. If the last log segment is empty, no need to auto close it.
2.Update the endOffsetOfPrevMsg to log.getEndOffset() for testing to match the real design.