### PR TITLE
Fix lag calculation granularity issue for index based token

### DIFF
--- a/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
@@ -1567,7 +1567,7 @@ class PersistentIndex {
       throw new IllegalArgumentException("Offset is invalid: " + offset + "; LogSegment: " + logSegment);
     }
     int numPrecedingLogSegments = getLogSegmentToIndexSegmentMapping(indexSegments).headMap(offset.getName()).size();
-    return numPrecedingLogSegments * log.getSegmentCapacity() + log.getSegmentCapacity() - getTotalOffsetAfterTokenPointedStoreKey(indexBasedToken);
+    return numPrecedingLogSegments * log.getSegmentCapacity() + log.getEndOffset().getOffset() - getTotalOffsetAfterTokenPointedStoreKey(indexBasedToken);
   }
 
   /**

--- a/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
@@ -1439,7 +1439,19 @@ class PersistentIndex {
       ConcurrentSkipListMap<Offset, IndexSegment> indexSegments) {
     long bytesRead = 0;
     if (token.getType().equals(FindTokenType.IndexBased)) {
-      bytesRead = getAbsolutePositionInLogForOffset(token.getOffset(), indexSegments);
+      try {
+        if (token.getOffset().equals(validIndexSegments.lastKey())) {
+          bytesRead = getAbsoluteReadBytesFromIndexBasedToken(token, indexSegments);
+        } else {
+          bytesRead = getAbsolutePositionInLogForOffset(token.getOffset(), indexSegments);
+        }
+      } catch (StoreException e) {
+        //If get read bytes from storeKey fails, use the start offset in index based token.
+        logger.error(
+            "Store exception on getAbsoluteReadBytesFromIndexBasedToken request with error code {} in datadir {} ",
+            e.getErrorCode(), dataDir);
+        bytesRead = getAbsolutePositionInLogForOffset(token.getOffset(), indexSegments);
+      }
     } else if (token.getType().equals(FindTokenType.JournalBased)) {
       if (messageEntries.size() > 0) {
         bytesRead = getAbsolutePositionInLogForOffset(token.getOffset(), indexSegments) + messageEntries.get(
@@ -1530,6 +1542,50 @@ class PersistentIndex {
     }
     int numPrecedingLogSegments = getLogSegmentToIndexSegmentMapping(indexSegments).headMap(offset.getName()).size();
     return numPrecedingLogSegments * log.getSegmentCapacity() + offset.getOffset();
+  }
+
+  /**
+   * @return the absolute read bytes represented by token.
+   * @throws StoreException
+   */
+  long getAbsoluteReadBytesFromIndexBasedToken(StoreFindToken indexBasedToken) throws StoreException {
+    return getAbsoluteReadBytesFromIndexBasedToken(indexBasedToken, validIndexSegments);
+  }
+
+  /**
+   * Get the absolute read bytes from index based token {@link StoreKey}.
+   * @param indexBasedToken the point until which the log has been read.
+   * @param indexSegments the list of index segments to use.
+   * @return the absolute read bytes represented by token.
+   * @throws StoreException
+   */
+  private long getAbsoluteReadBytesFromIndexBasedToken(StoreFindToken indexBasedToken, ConcurrentSkipListMap<Offset, IndexSegment> indexSegments)
+      throws StoreException {
+    Offset offset = indexBasedToken.getOffset();
+    LogSegment logSegment = log.getSegment(offset.getName());
+    if (logSegment == null || offset.getOffset() > logSegment.getEndOffset()) {
+      throw new IllegalArgumentException("Offset is invalid: " + offset + "; LogSegment: " + logSegment);
+    }
+    int numPrecedingLogSegments = getLogSegmentToIndexSegmentMapping(indexSegments).headMap(offset.getName()).size();
+    return numPrecedingLogSegments * log.getSegmentCapacity() + log.getSegmentCapacity() - getTotalOffsetAfterTokenPointedStoreKey(indexBasedToken);
+  }
+
+  /**
+   * Get the absolute read bytes after index based token {@link StoreKey}.
+   * @param indexBasedToken the point until which the log has been read.
+   * @return the absolute read bytes after index based token {@link StoreKey}.
+   * @throws StoreException
+   */
+  private long getTotalOffsetAfterTokenPointedStoreKey(StoreFindToken indexBasedToken) throws StoreException {
+    StoreKey storeKey = indexBasedToken.getStoreKey();
+    List<MessageInfo> entries = new ArrayList<>();
+    IndexSegment indexSegment = validIndexSegments.get(indexBasedToken.getOffset());
+    indexSegment.getEntriesSince(storeKey, new FindEntriesCondition(Long.MAX_VALUE), entries, new AtomicLong(0), false);
+    long totalSizeNotReplicated = 0;
+    for (MessageInfo messageInfo : entries) {
+      totalSizeNotReplicated += messageInfo.getSize();
+    }
+    return totalSizeNotReplicated;
   }
 
   /**

--- a/ambry-store/src/test/java/com/github/ambry/store/IndexTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/IndexTest.java
@@ -1023,9 +1023,10 @@ public class IndexTest {
    * @throws StoreException
    */
   @Test
-  public void findEntriesSinceAfterAutoCloseLastLogsegmentTest() throws StoreException {
+  public void findEntriesSinceAfterAutoCloseLastLogSegmentTest() throws StoreException {
     state.addPutEntries(7, CuratedLogIndexState.PUT_RECORD_SIZE, Utils.Infinite_Time);
     state.addDeleteEntry(state.getIdToDeleteFromIndexSegment(state.referenceIndex.lastKey(), false));
+    state.addPutEntries(3, CuratedLogIndexState.PUT_RECORD_SIZE, Utils.Infinite_Time);
 
     if (isLogSegmented) {
       CompactionPolicySwitchInfo compactionPolicySwitchInfo =
@@ -1043,7 +1044,7 @@ public class IndexTest {
       TreeMap<MockId, TreeSet<IndexValue>> lastIndexSegment = state.referenceIndex.get(lastIndexSegmentStartOffset);
       Map.Entry<MockId, TreeSet<IndexValue>> lastIndexSegmentFirstEntry = lastIndexSegment.firstEntry();
       long maxTotalSizeOfEntries =
-          getSizeOfAllValues(state.referenceIndex.get(secondLastSegmentStartOffset).lastEntry().getValue());
+          getSizeOfAllValues(state.referenceIndex.get(lastIndexSegmentStartOffset).firstEntry().getValue());
 
       MockId lastId = state.referenceIndex.get(secondLastSegmentStartOffset).lastKey();
       StoreFindToken startToken =
@@ -1055,7 +1056,7 @@ public class IndexTest {
               state.incarnationId, segmentOfToken.getResetKey(), segmentOfToken.getResetKeyType(),
               segmentOfToken.getResetKeyLifeVersion());
       try {
-        expectedEndToken.setBytesRead(state.index.getAbsoluteReadBytesFromIndexBasedToken(startToken));
+        expectedEndToken.setBytesRead(state.index.getAbsoluteReadBytesFromIndexBasedToken(expectedEndToken));
       } catch (StoreException e) {
         expectedEndToken.setBytesRead(state.index.getAbsolutePositionInLogForOffset(lastIndexSegmentStartOffset));
       }
@@ -1069,11 +1070,12 @@ public class IndexTest {
       startToken =
           new StoreFindToken(lastId, lastIndexSegmentStartOffset, state.sessionId, state.incarnationId, null, null,
               UNINITIALIZED_RESET_KEY_VERSION);
+      Map.Entry<MockId, TreeSet<IndexValue>> lastIndexSegmentLastEntry = lastIndexSegment.lastEntry();
       expectedEndToken =
-          new StoreFindToken(lastIndexSegmentFirstEntry.getKey(), lastIndexSegmentStartOffset, state.sessionId,
+          new StoreFindToken(lastIndexSegmentLastEntry.getKey(), lastIndexSegmentStartOffset, state.sessionId,
               state.incarnationId, null, null, UNINITIALIZED_RESET_KEY_VERSION);
       try {
-        expectedEndToken.setBytesRead(state.index.getAbsoluteReadBytesFromIndexBasedToken(startToken));
+        expectedEndToken.setBytesRead(state.index.getAbsoluteReadBytesFromIndexBasedToken(expectedEndToken));
       } catch (StoreException e) {
         expectedEndToken.setBytesRead(state.index.getAbsolutePositionInLogForOffset(lastIndexSegmentStartOffset));
       }

--- a/ambry-store/src/test/java/com/github/ambry/store/IndexTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/IndexTest.java
@@ -1018,6 +1018,73 @@ public class IndexTest {
   }
 
   /**
+   * Tests {@link PersistentIndex#findEntriesSince(FindToken, long)} when last log segment gets auto closed and token
+   * points to the last index segment.
+   * @throws StoreException
+   */
+  @Test
+  public void findEntriesSinceAfterAutoCloseLastLogsegmentTest() throws StoreException {
+    state.addPutEntries(7, CuratedLogIndexState.PUT_RECORD_SIZE, Utils.Infinite_Time);
+    state.addDeleteEntry(state.getIdToDeleteFromIndexSegment(state.referenceIndex.lastKey(), false));
+
+    if (isLogSegmented) {
+      CompactionPolicySwitchInfo compactionPolicySwitchInfo =
+          new CompactionPolicySwitchInfo(System.currentTimeMillis(), true);
+      backUpCompactionPolicyInfo(tempDir.toString(), compactionPolicySwitchInfo);
+      if (state.log.autoCloseLastLogSegmentIfQualified()) {
+        //refresh journal.
+        state.index.journal.cleanUpJournal();
+      }
+
+      //1. index based token points to last entry of second last index segment + 1 -> index based token points to first
+      //entry of last Index segment
+      Offset lastIndexSegmentStartOffset = state.referenceIndex.lastKey();
+      Offset secondLastSegmentStartOffset = state.referenceIndex.lowerKey(lastIndexSegmentStartOffset);
+      TreeMap<MockId, TreeSet<IndexValue>> lastIndexSegment = state.referenceIndex.get(lastIndexSegmentStartOffset);
+      Map.Entry<MockId, TreeSet<IndexValue>> lastIndexSegmentFirstEntry = lastIndexSegment.firstEntry();
+      long maxTotalSizeOfEntries =
+          getSizeOfAllValues(state.referenceIndex.get(secondLastSegmentStartOffset).lastEntry().getValue());
+
+      MockId lastId = state.referenceIndex.get(secondLastSegmentStartOffset).lastKey();
+      StoreFindToken startToken =
+          new StoreFindToken(lastId, secondLastSegmentStartOffset, state.sessionId, state.incarnationId, null, null,
+              UNINITIALIZED_RESET_KEY_VERSION);
+      IndexSegment segmentOfToken = state.index.getIndexSegments().get(lastIndexSegmentStartOffset);
+      StoreFindToken expectedEndToken =
+          new StoreFindToken(lastIndexSegmentFirstEntry.getKey(), lastIndexSegmentStartOffset, state.sessionId,
+              state.incarnationId, segmentOfToken.getResetKey(), segmentOfToken.getResetKeyType(),
+              segmentOfToken.getResetKeyLifeVersion());
+      try {
+        expectedEndToken.setBytesRead(state.index.getAbsoluteReadBytesFromIndexBasedToken(startToken));
+      } catch (StoreException e) {
+        expectedEndToken.setBytesRead(state.index.getAbsolutePositionInLogForOffset(lastIndexSegmentStartOffset));
+      }
+      Set<MockId> expectedKeys = new HashSet<>();
+      expectedKeys.add(lastIndexSegmentFirstEntry.getKey());
+      doFindEntriesSinceTest(startToken, maxTotalSizeOfEntries, expectedKeys, expectedEndToken);
+
+      //2. index based token points to last entry of last index segment -> index based token points to last entry of last
+      //Index segment
+      lastId = state.referenceIndex.get(lastIndexSegmentStartOffset).lastKey();
+      startToken =
+          new StoreFindToken(lastId, lastIndexSegmentStartOffset, state.sessionId, state.incarnationId, null, null,
+              UNINITIALIZED_RESET_KEY_VERSION);
+      expectedEndToken =
+          new StoreFindToken(lastIndexSegmentFirstEntry.getKey(), lastIndexSegmentStartOffset, state.sessionId,
+              state.incarnationId, null, null, UNINITIALIZED_RESET_KEY_VERSION);
+      try {
+        expectedEndToken.setBytesRead(state.index.getAbsoluteReadBytesFromIndexBasedToken(startToken));
+      } catch (StoreException e) {
+        expectedEndToken.setBytesRead(state.index.getAbsolutePositionInLogForOffset(lastIndexSegmentStartOffset));
+      }
+      expectedKeys = new HashSet<>();
+      maxTotalSizeOfEntries =
+          getSizeOfAllValues(state.referenceIndex.get(lastIndexSegmentStartOffset).lastEntry().getValue());
+      doFindEntriesSinceTest(startToken, maxTotalSizeOfEntries, expectedKeys, expectedEndToken);
+    }
+  }
+
+  /**
    * Tests behaviour of {@link PersistentIndex#findEntriesSince(FindToken, long)} on crash-restart of index and some
    * recovery. Specifically tests cases where tokens have been handed out before the "crash" failure.
    * @throws IOException
@@ -2381,8 +2448,7 @@ public class IndexTest {
    * @param newLogSegment {@code true} if this is a new log segment. {@code false} otherwise
    * @throws StoreException
    */
-  private void fillLastLogSegmentToCapacity(int numberOfEntries, boolean newLogSegment)
-      throws StoreException {
+  private void fillLastLogSegmentToCapacity(int numberOfEntries, boolean newLogSegment) throws StoreException {
     if (newLogSegment) {
       // to ensure a new log segment is created. If not, find the remaining size below will fail
       state.addPutEntries(1, PUT_RECORD_SIZE, Utils.Infinite_Time);


### PR DESCRIPTION
This pr supports to calculate the accurate value of lag when index based token points to last index segment, so when replication successfully finished, we are able to see the lag goes down to zero.