### PR TITLE
Adding connection idle timeout to hikari pool

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/AccountStatsMySqlConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/AccountStatsMySqlConfig.java
@@ -21,6 +21,7 @@ public class AccountStatsMySqlConfig {
   public static final String POOL_SIZE = PREFIX + "pool.size";
   public static final String UPDATE_BATCH_SIZE = PREFIX + "update.batch.size";
   public static final String ENABLE_REWRITE_BATCHED_STATEMENT = PREFIX + "enable.rewrite.batched.statements";
+  public static final String CONNECTION_IDLE_TIMEOUT = PREFIX + "connection.idle.timeout.ms";
 
   /**
    * Serialized json containing the information about all mysql end points. This information should be of the following form:
@@ -66,7 +67,7 @@ public class AccountStatsMySqlConfig {
    * Number of connections and threads to use for executing transactions.
    */
   @Config(POOL_SIZE)
-  @Default("2")
+  @Default("1")
   public final int poolSize;
 
   /**
@@ -84,11 +85,19 @@ public class AccountStatsMySqlConfig {
   @Default("false")
   public final boolean enableRewriteBatchedStatement;
 
+  /**
+   * Connection idle timeout in ms. Once a connection is idle for more than the timeout, it will be closed by the pool.
+   */
+  @Config(CONNECTION_IDLE_TIMEOUT)
+  @Default("60 * 1000")
+  public final long connectionIdleTimeoutMs;
+
   public AccountStatsMySqlConfig(VerifiableProperties verifiableProperties) {
     dbInfo = verifiableProperties.getString(DB_INFO, "");
     domainNamesToRemove = verifiableProperties.getString(DOMAIN_NAMES_TO_REMOVE, "");
-    poolSize = verifiableProperties.getIntInRange(POOL_SIZE, 2, 1, Integer.MAX_VALUE);
+    poolSize = verifiableProperties.getIntInRange(POOL_SIZE, 1, 1, Integer.MAX_VALUE);
     updateBatchSize = verifiableProperties.getInt(UPDATE_BATCH_SIZE, 0);
     enableRewriteBatchedStatement = verifiableProperties.getBoolean(ENABLE_REWRITE_BATCHED_STATEMENT, false);
+    connectionIdleTimeoutMs = verifiableProperties.getLong(CONNECTION_IDLE_TIMEOUT, 60 * 1000);
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/config/AccountStatsMySqlConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/AccountStatsMySqlConfig.java
@@ -67,7 +67,7 @@ public class AccountStatsMySqlConfig {
    * Number of connections and threads to use for executing transactions.
    */
   @Config(POOL_SIZE)
-  @Default("1")
+  @Default("2")
   public final int poolSize;
 
   /**
@@ -95,7 +95,7 @@ public class AccountStatsMySqlConfig {
   public AccountStatsMySqlConfig(VerifiableProperties verifiableProperties) {
     dbInfo = verifiableProperties.getString(DB_INFO, "");
     domainNamesToRemove = verifiableProperties.getString(DOMAIN_NAMES_TO_REMOVE, "");
-    poolSize = verifiableProperties.getIntInRange(POOL_SIZE, 1, 1, Integer.MAX_VALUE);
+    poolSize = verifiableProperties.getIntInRange(POOL_SIZE, 2, 1, Integer.MAX_VALUE);
     updateBatchSize = verifiableProperties.getInt(UPDATE_BATCH_SIZE, 0);
     enableRewriteBatchedStatement = verifiableProperties.getBoolean(ENABLE_REWRITE_BATCHED_STATEMENT, false);
     connectionIdleTimeoutMs = verifiableProperties.getLong(CONNECTION_IDLE_TIMEOUT, 60 * 1000);

--- a/ambry-mysql/src/main/java/com/github/ambry/accountstats/AccountStatsMySqlStoreFactory.java
+++ b/ambry-mysql/src/main/java/com/github/ambry/accountstats/AccountStatsMySqlStoreFactory.java
@@ -85,6 +85,7 @@ public class AccountStatsMySqlStoreFactory implements AccountStatsStoreFactory {
     hikariConfig.setUsername(dbEndpoint.getUsername());
     hikariConfig.setPassword(dbEndpoint.getPassword());
     hikariConfig.setMaximumPoolSize(accountStatsMySqlConfig.poolSize);
+    hikariConfig.setIdleTimeout(accountStatsMySqlConfig.connectionIdleTimeoutMs);
     // Recommended properties for automatic prepared statement caching
     // https://github.com/brettwooldridge/HikariCP/wiki/MySQL-Configuration
     hikariConfig.addDataSourceProperty("cachePrepStmts", "true");

--- a/ambry-mysql/src/main/java/com/github/ambry/accountstats/AccountStatsMySqlStoreFactory.java
+++ b/ambry-mysql/src/main/java/com/github/ambry/accountstats/AccountStatsMySqlStoreFactory.java
@@ -85,6 +85,7 @@ public class AccountStatsMySqlStoreFactory implements AccountStatsStoreFactory {
     hikariConfig.setUsername(dbEndpoint.getUsername());
     hikariConfig.setPassword(dbEndpoint.getPassword());
     hikariConfig.setMaximumPoolSize(accountStatsMySqlConfig.poolSize);
+    hikariConfig.setMinimumIdle(0);
     hikariConfig.setIdleTimeout(accountStatsMySqlConfig.connectionIdleTimeoutMs);
     // Recommended properties for automatic prepared statement caching
     // https://github.com/brettwooldridge/HikariCP/wiki/MySQL-Configuration


### PR DESCRIPTION
We are using mysql connections in account stats only in two places
1. reporting account stats of local server instance to mysql
2. reading reports from all server instances and aggregate them to generate an aggregated report

First use case would need connection every 10 minutes and second use case would need connection only when the helix picks this server for aggregation task. We can set the idle timeout to 1 minute, so most of the time, we don't need to maintain any connection.