### PR TITLE
Fix ambry server open source startup

### DIFF
--- a/ambry-server/src/integration-test/java/com/github/ambry/server/MockCluster.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/MockCluster.java
@@ -17,11 +17,9 @@ import com.github.ambry.account.Account;
 import com.github.ambry.account.Container;
 import com.github.ambry.clustermap.ClusterAgentsFactory;
 import com.github.ambry.clustermap.ClusterMap;
-import com.github.ambry.clustermap.VcrClusterAgentsFactory;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.MockClusterAgentsFactory;
 import com.github.ambry.clustermap.MockClusterMap;
-import com.github.ambry.clustermap.MockVcrClusterAgentsFactory;
 import com.github.ambry.clustermap.MockDataNodeId;
 import com.github.ambry.clustermap.MockReplicaId;
 import com.github.ambry.clustermap.PartitionId;
@@ -63,7 +61,6 @@ import static org.junit.Assert.*;
 public class MockCluster {
   private static final Logger logger = LoggerFactory.getLogger(MockCluster.class);
   private final MockClusterAgentsFactory mockClusterAgentsFactory;
-  private MockVcrClusterAgentsFactory mockClusterSpectatorFactory;
   private final MockClusterMap clusterMap;
   private final List<AmbryServer> serverList;
   private boolean serverInitialized = false;
@@ -110,8 +107,6 @@ public class MockCluster {
     clusterMap = mockClusterMap;
     serverList = new ArrayList<>();
     generalDataNodeIndex = 0;
-
-    mockClusterSpectatorFactory = new MockVcrClusterAgentsFactory(cloudDataNodes);
   }
 
   /**
@@ -229,10 +224,6 @@ public class MockCluster {
     return mockClusterAgentsFactory;
   }
 
-  public VcrClusterAgentsFactory getClusterSpectatorFactory() {
-    return mockClusterSpectatorFactory;
-  }
-
   /**
    * Create initialization {@link VerifiableProperties} for server.
    * @param dataNodeId {@link DataNodeId} object of the server initialized.
@@ -280,10 +271,10 @@ public class MockCluster {
     if (mockClusterAgentsFactory != null) {
       server =
           new AmbryServer(createInitProperties(dataNodeId, enableHardDeletes, sslProperties), mockClusterAgentsFactory,
-              mockClusterSpectatorFactory, notificationSystem, time, null);
+              notificationSystem, time, null);
     } else {
       server = new AmbryServer(createInitProperties(dataNodeId, enableHardDeletes, sslProperties),
-          this.mockClusterAgentsFactory, mockClusterSpectatorFactory, notificationSystem, time, null);
+          this.mockClusterAgentsFactory, notificationSystem, time, null);
     }
     return server;
   }

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryMain.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryMain.java
@@ -14,8 +14,7 @@
 package com.github.ambry.server;
 
 import com.github.ambry.clustermap.ClusterAgentsFactory;
-import com.github.ambry.clustermap.VcrClusterAgentsFactory;
-import com.github.ambry.config.CloudConfig;
+import com.github.ambry.commons.LoggingNotificationSystem;
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.utils.InvocationOptions;
@@ -40,13 +39,11 @@ public class AmbryMain {
       Properties properties = Utils.loadProps(options.serverPropsFilePath);
       VerifiableProperties verifiableProperties = new VerifiableProperties(properties);
       ClusterMapConfig clusterMapConfig = new ClusterMapConfig(verifiableProperties);
-      CloudConfig cloudConfig = new CloudConfig(verifiableProperties);
       ClusterAgentsFactory clusterAgentsFactory =
           Utils.getObj(clusterMapConfig.clusterMapClusterAgentsFactory, clusterMapConfig,
               options.hardwareLayoutFilePath, options.partitionLayoutFilePath);
       logger.info("Bootstrapping AmbryServer");
-      VcrClusterAgentsFactory vcrClusterAgentsFactory = Utils.getObj(cloudConfig.vcrClusterAgentsFactoryClass);
-      ambryServer = new AmbryServer(verifiableProperties, clusterAgentsFactory, vcrClusterAgentsFactory,
+      ambryServer = new AmbryServer(verifiableProperties, clusterAgentsFactory, new LoggingNotificationSystem(),
           SystemTime.getInstance());
       // attach shutdown handler to catch control-c
       Runtime.getRuntime().addShutdownHook(new Thread() {

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryServer.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryServer.java
@@ -23,11 +23,10 @@ import com.github.ambry.accountstats.AccountStatsMySqlStoreFactory;
 import com.github.ambry.clustermap.ClusterAgentsFactory;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.ClusterParticipant;
-import com.github.ambry.clustermap.VcrClusterSpectator;
-import com.github.ambry.clustermap.VcrClusterAgentsFactory;
 import com.github.ambry.clustermap.DataNodeId;
+import com.github.ambry.clustermap.VcrClusterAgentsFactory;
+import com.github.ambry.clustermap.VcrClusterSpectator;
 import com.github.ambry.commons.Callback;
-import com.github.ambry.commons.LoggingNotificationSystem;
 import com.github.ambry.commons.NettyInternalMetrics;
 import com.github.ambry.commons.NettySslHttp2Factory;
 import com.github.ambry.commons.SSLFactory;
@@ -108,7 +107,6 @@ public class AmbryServer {
   private static final Logger logger = LoggerFactory.getLogger(AmbryServer.class);
   private final VerifiableProperties properties;
   private final ClusterAgentsFactory clusterAgentsFactory;
-  private final VcrClusterAgentsFactory _vcrClusterAgentsFactory;
   private final Function<MetricRegistry, JmxReporter> reporterFactory;
   private ClusterMap clusterMap;
   private List<ClusterParticipant> clusterParticipants;
@@ -129,19 +127,13 @@ public class AmbryServer {
   private AccountStatsMySqlStore accountStatsMySqlStore = null;
 
   public AmbryServer(VerifiableProperties properties, ClusterAgentsFactory clusterAgentsFactory,
-      VcrClusterAgentsFactory vcrClusterAgentsFactory, Time time) throws InstantiationException {
-    this(properties, clusterAgentsFactory, vcrClusterAgentsFactory, new LoggingNotificationSystem(), time, null);
-  }
-
-  public AmbryServer(VerifiableProperties properties, ClusterAgentsFactory clusterAgentsFactory,
       NotificationSystem notificationSystem, Time time) throws InstantiationException {
-    this(properties, clusterAgentsFactory, null, notificationSystem, time, null);
+    this(properties, clusterAgentsFactory, notificationSystem, time, null);
   }
 
   /**
    * @param properties {@link VerifiableProperties} object containing configs for the server.
    * @param clusterAgentsFactory The {@link ClusterAgentsFactory} to use.
-   * @param vcrClusterAgentsFactory a {@link VcrClusterAgentsFactory} instance. Required if replicating from a VCR.
    * @param notificationSystem the {@link NotificationSystem} to use.
    * @param time The {@link Time} instance to use.
    * @param reporterFactory if non-null, use this function to set up a {@link JmxReporter} with custom settings. If this
@@ -149,11 +141,10 @@ public class AmbryServer {
    * @throws InstantiationException if there was an error during startup.
    */
   public AmbryServer(VerifiableProperties properties, ClusterAgentsFactory clusterAgentsFactory,
-      VcrClusterAgentsFactory vcrClusterAgentsFactory, NotificationSystem notificationSystem, Time time,
-      Function<MetricRegistry, JmxReporter> reporterFactory) throws InstantiationException {
+      NotificationSystem notificationSystem, Time time, Function<MetricRegistry, JmxReporter> reporterFactory)
+      throws InstantiationException {
     this.properties = properties;
     this.clusterAgentsFactory = clusterAgentsFactory;
-    this._vcrClusterAgentsFactory = vcrClusterAgentsFactory;
     this.notificationSystem = notificationSystem;
     this.time = time;
     this.reporterFactory = reporterFactory;
@@ -251,7 +242,9 @@ public class AmbryServer {
 
       if (replicationConfig.replicationEnabledWithVcrCluster) {
         logger.info("Creating Helix cluster spectator for cloud to store replication.");
-        vcrClusterSpectator = _vcrClusterAgentsFactory.getVcrClusterSpectator(cloudConfig, clusterMapConfig);
+        vcrClusterSpectator =
+            ((VcrClusterAgentsFactory) Utils.getObj(cloudConfig.vcrClusterAgentsFactoryClass, cloudConfig,
+                clusterMapConfig, null, null, null, null, null)).getVcrClusterSpectator(cloudConfig, clusterMapConfig);
         cloudToStoreReplicationManager =
             new CloudToStoreReplicationManager(replicationConfig, clusterMapConfig, storeConfig, storageManager,
                 storeKeyFactory, clusterMap, scheduler, nodeId, connectionPool, registry, notificationSystem,

--- a/ambry-server/src/test/java/com/github/ambry/server/AmbryServerTest.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/AmbryServerTest.java
@@ -58,7 +58,7 @@ public class AmbryServerTest {
     props.setProperty("clustermap.host.name", dataNodeId.getHostname());
 
     AmbryServer ambryServer =
-        new AmbryServer(new VerifiableProperties(props), clusterAgentsFactory, null, new LoggingNotificationSystem(),
+        new AmbryServer(new VerifiableProperties(props), clusterAgentsFactory, new LoggingNotificationSystem(),
             SystemTime.getInstance(), reporterFactory);
     ambryServer.startup();
     verify(spyObjectNameFactory, atLeastOnce()).createName(anyString(), anyString(), anyString());


### PR DESCRIPTION
We need `VcrClusterAgentsFactory` object in Ambry server for getting helix cluster updates in `CloudToStoreReplicationManager`. This PR moves the initialization of this factory out from `AmbryServerMain` to `AmbryServer` for the case where its needed.