### PR TITLE
Ignore client terminations when using Netty native IO

### DIFF
--- a/ambry-utils/src/main/java/com/github/ambry/utils/Utils.java
+++ b/ambry-utils/src/main/java/com/github/ambry/utils/Utils.java
@@ -53,7 +53,6 @@ import java.util.Properties;
 import java.util.Random;
 import java.util.RandomAccess;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -1205,9 +1204,14 @@ public class Utils {
    * @return {@code true} this cause indicates a possible early termination from the client. {@code false} otherwise.
    */
   public static boolean isPossibleClientTermination(Throwable cause) {
-    return cause instanceof IOException && (CLIENT_RESET_EXCEPTION_MSG.equals(cause.getMessage())
-        || CLIENT_BROKEN_PIPE_EXCEPTION_MSG.equals(cause.getMessage()) || SSL_ENGINE_CLOSED_EXCEPTION_MSG.equals(
-        cause.getMessage()));
+    if (cause instanceof IOException) {
+      String msg = cause.getMessage();
+      if (msg != null) {
+        return msg.endsWith(CLIENT_RESET_EXCEPTION_MSG) || msg.endsWith(CLIENT_BROKEN_PIPE_EXCEPTION_MSG)
+            || msg.endsWith(SSL_ENGINE_CLOSED_EXCEPTION_MSG);
+      }
+    }
+    return false;
   }
 
   /**

--- a/ambry-utils/src/test/java/com/github/ambry/utils/UtilsTest.java
+++ b/ambry-utils/src/test/java/com/github/ambry/utils/UtilsTest.java
@@ -15,6 +15,9 @@ package com.github.ambry.utils;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.epoll.Epoll;
+import io.netty.channel.kqueue.KQueue;
+import io.netty.channel.unix.Errors;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.File;
@@ -588,6 +591,12 @@ public class UtilsTest {
   public void clientTerminationWrapAndRecognizeTest() {
     Exception exception = new IOException("Connection reset by peer");
     assertTrue("Should be declared as a client termination", Utils.isPossibleClientTermination(exception));
+
+    // Netty native IO exceptions should also be caught
+    if (Epoll.isAvailable()) {
+      exception = Errors.newIOException("method", Errors.ERRNO_ECONNRESET_NEGATIVE);
+      assertTrue("Should be declared as a client termination", Utils.isPossibleClientTermination(exception));
+    }
 
     exception = new IOException("Broken pipe");
     assertTrue("Should be declared as a client termination", Utils.isPossibleClientTermination(exception));

--- a/build.gradle
+++ b/build.gradle
@@ -158,9 +158,9 @@ project(':ambry-utils') {
         compile "commons-codec:commons-codec:$commonsVersion"
         compile "org.json:json:$jsonVersion"
         compile "net.sf.jopt-simple:jopt-simple:$joptSimpleVersion"
-        compile "io.netty:netty-buffer:$nettyVersion"
         compile "io.netty:netty-all:$nettyVersion"
         testCompile project(":ambry-test-utils")
+        testCompile "io.netty:netty-transport-native-epoll:$nettyVersion"
     }
 }
 
@@ -182,7 +182,6 @@ project(':ambry-api') {
         compile "com.fasterxml.jackson.core:jackson-core:$jacksonVersion"
         compile "com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion"
         compile "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
-        compile "io.netty:netty-buffer:$nettyVersion"
         testCompile project(':ambry-clustermap')
         testCompile project(':ambry-test-utils')
     }
@@ -397,7 +396,6 @@ project(':ambry-router') {
                 project(':ambry-rest')
         compile "io.dropwizard.metrics:metrics-core:$metricsVersion"
         compile "org.bouncycastle:bcpkix-jdk15on:$bouncycastleVersion"
-        compile "io.netty:netty-buffer:$nettyVersion"
         testCompile project(':ambry-test-utils')
         testCompile project(path: ':ambry-network', configuration: 'testArchives')
         testCompile project(path: ':ambry-cloud', configuration: 'testArchives')


### PR DESCRIPTION
Netty prefixes exceptions thrown by their native IO (epoll) layer with a
method name. This means that our old code for detecting when a client
has terminated a connection no longer works when using the native IO
libraries. This change will do a suffix detection instead which will
catch both forms of the exception message.