### PR TITLE
Add some log messages to root cause partition map mismatch in recovery cluster

### DIFF
--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PartitionLayout.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PartitionLayout.java
@@ -269,10 +269,15 @@ class PartitionLayout {
    */
   public Partition getPartition(InputStream stream) throws IOException {
     byte[] partitionBytes = Partition.readPartitionBytesFromStream(stream);
-    logger.info("Partition bytes from stream: " + Arrays.toString(partitionBytes));
+    logger.info("Partition bytes from stream: " + deserializePartitionBytes(partitionBytes));
     logger.info("Partition map state: " + toString());
-    logger.info("Partition map keys: " + partitionMap.keySet().stream().map(key -> Arrays.toString(key.array())).collect(Collectors.joining()));
+    logger.info("Partition map keys: " + partitionMap.keySet().stream().map(key -> deserializePartitionBytes(key.array())).collect(Collectors.joining()));
     return partitionMap.get(ByteBuffer.wrap(partitionBytes));
+  }
+
+  private String deserializePartitionBytes(byte[] bytes) {
+    ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
+    return "Partition version: " + byteBuffer.getShort() + " id: " + byteBuffer.getLong();
   }
 
   public JSONObject toJSONObject() throws JSONException {

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PartitionLayout.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PartitionLayout.java
@@ -17,6 +17,7 @@ import com.github.ambry.config.ClusterMapConfig;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -268,6 +269,9 @@ class PartitionLayout {
    */
   public Partition getPartition(InputStream stream) throws IOException {
     byte[] partitionBytes = Partition.readPartitionBytesFromStream(stream);
+    logger.info("Partition bytes from stream: " + Arrays.toString(partitionBytes));
+    logger.info("Partition map state: " + toString());
+    logger.info("Partition map keys: " + partitionMap.keySet().stream().map(key -> Arrays.toString(key.array())).collect(Collectors.joining()));
     return partitionMap.get(ByteBuffer.wrap(partitionBytes));
   }
 

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/RecoveryTestClusterAgentsFactory.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/RecoveryTestClusterAgentsFactory.java
@@ -51,6 +51,7 @@ public class RecoveryTestClusterAgentsFactory implements ClusterAgentsFactory {
     PartitionLayout partitionLayout =
         new PartitionLayout(new HardwareLayout(clusterMapConfig.clustermapRecoveryTestHardwareLayout, clusterMapConfig),
             clusterMapConfig.clustermapRecoveryTestPartitionLayout, clusterMapConfig);
+    logger.info("Initialized partition layout in RecoveryTestClusterAgentsFactory: " + partitionLayout.toString());
     staticClusterAgentsFactory = new StaticClusterAgentsFactory(clusterMapConfig, partitionLayout);
     helixClusterAgentsFactory =
         new HelixClusterAgentsFactory(clusterMapConfig, staticClusterAgentsFactory.getMetricRegistry());


### PR DESCRIPTION
We have observed that during replication, the recovery test cluster map's static map is not able to find the partition being replicated from the replication data stream obtained from remote. Adding some logs here to root cause the issue.