### PR TITLE
Add physical storage usage and number of blobs in BlobStoreStats

### DIFF
--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -497,7 +497,7 @@ public class BlobStore implements Store {
             FileSpan fileSpan = new FileSpan(indexEntries.get(0).getValue().getOffset(), endOffsetOfLastMessage);
             index.addToIndex(indexEntries, fileSpan);
             for (IndexEntry newEntry : indexEntries) {
-              blobStoreStats.handleNewPutEntry(newEntry.getValue());
+              blobStoreStats.handleNewPutEntry(newEntry.getKey(), newEntry.getValue());
             }
             logger.trace("Store : {} message set written to index ", dataDir);
             checkCapacityAndUpdateReplicaStatusDelegate();
@@ -771,7 +771,8 @@ public class BlobStore implements Store {
               index.markAsPermanent(info.getStoreKey(), fileSpan, null, info.getOperationTimeMs(),
                   MessageInfo.LIFE_VERSION_FROM_FRONTEND);
           endOffsetOfLastMessage = fileSpan.getEndOffset();
-          blobStoreStats.handleNewTtlUpdateEntry(ttlUpdateValue, indexValuesToUpdate.get(correspondingPutIndex++));
+          blobStoreStats.handleNewTtlUpdateEntry(info.getStoreKey(), ttlUpdateValue,
+              indexValuesToUpdate.get(correspondingPutIndex++));
         }
         logger.trace("Store : {} ttl update has been marked in the index ", dataDir);
       }

--- a/ambry-store/src/main/java/com/github/ambry/store/ScanResults.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/ScanResults.java
@@ -204,6 +204,13 @@ class ScanResults {
     updateNestedMapHelper(containerBaseBucket, accountId, containerId, value);
   }
 
+  /**
+   * Update the physical storage usage and store key for the givne account and container.
+   * @param accountId The account id
+   * @param containerId The container id
+   * @param usage The new physical storage usage
+   * @param key The new store key
+   */
   void updateContainerPhysicalStorageUsageAndStoreKey(short accountId, short containerId, long usage, StoreKey key) {
     updateNestedMapHelper(containerPhysicalStorageUsage, accountId, containerId, usage);
     containerStoreKeys.computeIfAbsent(accountId, k -> new HashMap<>())

--- a/ambry-store/src/main/java/com/github/ambry/store/ScanResults.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/ScanResults.java
@@ -15,11 +15,15 @@
 package com.github.ambry.store;
 
 import com.github.ambry.utils.Pair;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.NavigableMap;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 import static com.github.ambry.store.StatsUtils.*;
 
@@ -46,10 +50,10 @@ class ScanResults {
   // baseBucket   [              ]    [                  ]    [                 ]   .....
   //
   // T0+1H is the first key in the deltaBuckets. All the deltas that happen before T0+1H but after T0 will be added to
-  // its value. T0+2H is the second key in the deltaBucket. All the deltas that happen before T0+2H but after T0+1H will
+  // its value. T0+2H is the second key in the deltaBuckets. All the deltas that happen before T0+2H but after T0+1H will
   // be added to its value. But what are deltas? This is an example to show the answer.
   //
-  // Now let's go through some IndexValues as
+  // Now let's go through some IndexValues like below:
   // 1. PUT[ID1]: created at T0-1D, but will expire at T0+2.5H
   // 2. PUT[ID2]: created at T0-1D, permanent blob
   // The validSize at T0 should be PUT[ID1] + PUT[ID2] because PUT[ID1] haven't expired yet. But we know at T0+2.5H, the
@@ -59,7 +63,7 @@ class ScanResults {
   // PUT[ID1]+PUT[ID2]   [              ]    [                  ]    [ -PUT[ID1]     ]   .....
   // Please notice that the delta is negative. So when we pick any point of time and add the base validSize and all the
   // delta values in the buckets before this point of time, we will get the correct answer. For instance, validSize of
-  // T0 is PUT[ID1]+PUT[ID2], validSize of T0+1H is PUT[ID1]+PUT[ID2]+delta of T0+1H. And validSize of T0+2H is PUT[ID1]
+  // T0 is PUT[ID1]+PUT[ID2], validSize of T0+1H is PUT[ID1]+PUT[ID2]+delta of T0+1H. And validSize of T0+3H is PUT[ID1]
   // +PUT[ID2]-PUT[ID1] because the delta of T0+3H bucket is -PUT[ID1].
   //
   // As new IndexValue comes in, we have to deal with them and fill the delta for them as well.
@@ -86,6 +90,11 @@ class ScanResults {
   final long containerForecastStartTimeMs;
   final long containerLastBucketTimeMs;
   final long containerForecastEndTimeMs;
+
+  // This is for container physical storage usage, it doesn't have to take delta into consideration, so it's more like a base
+  // bucket for valid  storage usage.
+  private final Map<Short, Map<Short, Long>> containerPhysicalStorageUsage = new ConcurrentHashMap<>();
+  private final Map<Short, Map<Short, Set<StoreKey>>> containerStoreKeys = new ConcurrentHashMap<>();
 
   // LogSegment buckets keep track of valid IndexValue size in each log segments. So the base value of log segment bucket
   // is a map, whose key is the log segment name and the value is the sum of valid IndexValues' sizes. To test if an
@@ -195,6 +204,13 @@ class ScanResults {
     updateNestedMapHelper(containerBaseBucket, accountId, containerId, value);
   }
 
+  void updateContainerPhysicalStorageUsageAndStoreKey(short accountId, short containerId, long usage, StoreKey key) {
+    updateNestedMapHelper(containerPhysicalStorageUsage, accountId, containerId, usage);
+    containerStoreKeys.computeIfAbsent(accountId, k -> new HashMap<>())
+        .computeIfAbsent(containerId, k -> new HashSet<>())
+        .add(key);
+  }
+
   /**
    * Update the log segment base value bucket with the given value.
    * @param logSegmentName the log segment name of the map entry to be updated
@@ -296,5 +312,19 @@ class ScanResults {
       }
     }
     return validSizePerContainer;
+  }
+
+  Map<Short, Map<Short, Long>> getContainerPhysicalStorageUsage() {
+    return Collections.unmodifiableMap(containerPhysicalStorageUsage);
+  }
+
+  Map<Short, Map<Short, Long>> getContainerNumberOfStoreKeys() {
+    Map<Short, Map<Short, Long>> numberOfStoreKeysPerContainer = new HashMap<>();
+    containerStoreKeys.entrySet()
+        .forEach(ent -> numberOfStoreKeysPerContainer.put(ent.getKey(), ent.getValue()
+            .entrySet()
+            .stream()
+            .collect(Collectors.toMap(Map.Entry::getKey, entry -> (long) entry.getValue().size()))));
+    return numberOfStoreKeysPerContainer;
   }
 }

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreStatsTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreStatsTest.java
@@ -153,10 +153,10 @@ public class BlobStoreStatsTest {
   public void testContainerValidDataSize() throws StoreException {
     assumeTrue(!bucketingEnabled);
     BlobStoreStats blobStoreStats = setupBlobStoreStats(0, 0);
-    verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, state.time.milliseconds());
+    verifyContainerStorageStatsAndGetTotalValidSize(blobStoreStats, state.time.milliseconds());
     // advance time
     advanceTimeToNextSecond();
-    verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, state.time.milliseconds());
+    verifyContainerStorageStatsAndGetTotalValidSize(blobStoreStats, state.time.milliseconds());
     blobStoreStats.close();
   }
 
@@ -210,7 +210,7 @@ public class BlobStoreStatsTest {
     long totalLogSegmentValidSizeBeforePuts =
         verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(timeInMsBeforePuts, 0L));
     long totalContainerValidSizeBeforePuts =
-        verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, timeInMsBeforePuts);
+        verifyContainerStorageStatsAndGetTotalValidSize(blobStoreStats, timeInMsBeforePuts);
 
     // 3 puts
     state.addPutEntries(3, PUT_RECORD_SIZE, Utils.Infinite_Time);
@@ -219,7 +219,7 @@ public class BlobStoreStatsTest {
     long totalLogSegmentValidSizeAfterPuts =
         verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(timeInMsAfterPuts, 0L));
     long totalContainerValidSizeAfterPuts =
-        verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, timeInMsAfterPuts);
+        verifyContainerStorageStatsAndGetTotalValidSize(blobStoreStats, timeInMsAfterPuts);
     long expectedIncrement = 3 * PUT_RECORD_SIZE;
     assertEquals("Put entries are not properly counted for log segment valid size", totalLogSegmentValidSizeAfterPuts,
         totalLogSegmentValidSizeBeforePuts + expectedIncrement);
@@ -248,7 +248,7 @@ public class BlobStoreStatsTest {
     long totalLogSegmentValidSizeBeforePuts =
         verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(timeInMsBeforePuts, 0L));
     long totalContainerValidSizeBeforePuts =
-        verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, state.time.milliseconds());
+        verifyContainerStorageStatsAndGetTotalValidSize(blobStoreStats, state.time.milliseconds());
 
     // 1 put with no expiry
     state.addPutEntries(1, PUT_RECORD_SIZE, Utils.Infinite_Time);
@@ -264,7 +264,7 @@ public class BlobStoreStatsTest {
     long totalLogSegmentValidSizeAfterPuts =
         verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(timeInMsAfterPuts, 0L));
     long totalContainerValidSizeAfterPuts =
-        verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, timeInMsAfterPuts);
+        verifyContainerStorageStatsAndGetTotalValidSize(blobStoreStats, timeInMsAfterPuts);
     assertEquals("Put entries with expiry are not properly counted for log segment valid size",
         totalLogSegmentValidSizeAfterPuts, totalLogSegmentValidSizeBeforePuts + expectedDeltaAfterPut);
     assertEquals("Put entries with expiry are not properly counted for container valid size",
@@ -278,7 +278,7 @@ public class BlobStoreStatsTest {
     long totalLogSegmentValidSizeAfterExpiration =
         verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(timeInMsAfterExpiration, 0L));
     long totalContainerValidSizeAfterExpiration =
-        verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, timeInMsAfterExpiration);
+        verifyContainerStorageStatsAndGetTotalValidSize(blobStoreStats, timeInMsAfterExpiration);
     assertEquals("Expired put entries are not properly counted for log segment valid size",
         totalLogSegmentValidSizeAfterExpiration, totalLogSegmentValidSizeBeforePuts + expectedDeltaAfterExpiration);
     assertEquals("Expired put entries are not properly counted for container valid size",
@@ -309,7 +309,7 @@ public class BlobStoreStatsTest {
     long totalLogSegmentValidSizeBeforeDeletes =
         verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(timeInMsBeforeDeletes, 0L));
     long totalContainerValidSizeBeforeDeletes =
-        verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, timeInMsBeforeDeletes);
+        verifyContainerStorageStatsAndGetTotalValidSize(blobStoreStats, timeInMsBeforeDeletes);
 
     // advance time to the next seconds before adding the deletes
     advanceTimeToNextSecond();
@@ -321,7 +321,7 @@ public class BlobStoreStatsTest {
     long totalLogSegmentValidSizeBeforeDeletesRelevant =
         verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(timeInMsBeforeDeletes, 0L));
     long totalContainerValidSizeBeforeDeletesRelevant =
-        verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, timeInMsBeforeDeletes);
+        verifyContainerStorageStatsAndGetTotalValidSize(blobStoreStats, timeInMsBeforeDeletes);
     assertEquals("Delete entries are not properly counted for log segment valid size",
         totalLogSegmentValidSizeBeforeDeletesRelevant,
         totalLogSegmentValidSizeBeforeDeletes + expectedDeltaBeforeDeletesRelevant);
@@ -335,7 +335,7 @@ public class BlobStoreStatsTest {
     long totalLogSegmentValidSizeAfterDeletes =
         verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(timeInMsAfterDeletes, 0L));
     long totalContainerValidSizeAfterDeletes =
-        verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, timeInMsAfterDeletes);
+        verifyContainerStorageStatsAndGetTotalValidSize(blobStoreStats, timeInMsAfterDeletes);
     long expectedLogSegmentDecrement = 2 * (PUT_RECORD_SIZE - DELETE_RECORD_SIZE);
     long expectedContainerDecrement = 2 * PUT_RECORD_SIZE;
     assertEquals("Delete entries are not properly counted for log segment valid size",
@@ -378,7 +378,7 @@ public class BlobStoreStatsTest {
     long totalLogSegmentValidSizeBeforeUndeletes =
         verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(timeInMsBeforeUndeletes, 0L));
     long totalContainerValidSizeBeforeUndeletes =
-        verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, timeInMsBeforeUndeletes);
+        verifyContainerStorageStatsAndGetTotalValidSize(blobStoreStats, timeInMsBeforeUndeletes);
 
     state.addUndeleteEntry(firstId);
     state.addUndeleteEntry(secondId);
@@ -390,7 +390,7 @@ public class BlobStoreStatsTest {
     long totalLogSegmentValidSizeAfterUndeletes =
         verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(timeInMsAfterUndeletes, 0L));
     long totalContainerValidSizeAfterUndeletes =
-        verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, timeInMsAfterUndeletes);
+        verifyContainerStorageStatsAndGetTotalValidSize(blobStoreStats, timeInMsAfterUndeletes);
     assertEquals("Undelete entries are not properly counted for container valid size",
         totalContainerValidSizeAfterUndeletes, totalContainerValidSizeBeforeUndeletes + expectedContainerIncrement);
     assertEquals("Undelete entries are not properly counted for log segment valid size",
@@ -401,7 +401,7 @@ public class BlobStoreStatsTest {
     totalLogSegmentValidSizeAfterUndeletes =
         verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(timeInMsAfterUndeletes, 0L));
     totalContainerValidSizeAfterUndeletes =
-        verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, timeInMsAfterUndeletes);
+        verifyContainerStorageStatsAndGetTotalValidSize(blobStoreStats, timeInMsAfterUndeletes);
     assertEquals("Undelete entries are not properly counted for container valid size",
         totalContainerValidSizeAfterUndeletes, totalContainerValidSizeBeforeUndeletes + expectedContainerIncrement);
     assertEquals("Undelete entries are not properly counted for log segment valid size",
@@ -446,7 +446,7 @@ public class BlobStoreStatsTest {
     BlobStoreStats blobStoreStats = setupBlobStoreStats(bucketCount, logSegmentForecastOffsetMs);
     // proceed only when the scan is started
     assertTrue("IndexScanner took too long to start", scanStartedLatch.await(5, TimeUnit.SECONDS));
-    verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, state.time.milliseconds());
+    verifyContainerStorageStatsAndGetTotalValidSize(blobStoreStats, state.time.milliseconds());
     for (long i = state.beginningTime; i <= state.time.milliseconds() + TEST_TIME_INTERVAL_IN_MS;
         i += TEST_TIME_INTERVAL_IN_MS) {
       verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(i, 0L));
@@ -458,13 +458,13 @@ public class BlobStoreStatsTest {
         i += TEST_TIME_INTERVAL_IN_MS) {
       verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(i, 0L));
     }
-    verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, state.time.milliseconds());
+    verifyContainerStorageStatsAndGetTotalValidSize(blobStoreStats, state.time.milliseconds());
     // advance time near the end of log segment forecast time
     state.advanceTime(logSegmentForecastEndTimeInMs - state.time.milliseconds() - 1);
     verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(state.time.milliseconds(), Time.MsPerSec));
     // advance time near the end of container forecast time
     state.advanceTime(containerForecastEndTimeInMs - state.time.milliseconds() - 1);
-    verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, state.time.milliseconds());
+    verifyContainerStorageStatsAndGetTotalValidSize(blobStoreStats, state.time.milliseconds());
     assertEquals("Throttle count mismatch from expected value", expectedThrottleCount,
         mockThrottler.throttleCount.get());
     blobStoreStats.close();
@@ -492,7 +492,7 @@ public class BlobStoreStatsTest {
     assertTrue("IndexScanner took too long to start", scanStartedLatch.await(5, TimeUnit.SECONDS));
     advanceTimeToNextSecond();
     verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(state.time.milliseconds(), 0L));
-    verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, state.time.milliseconds());
+    verifyContainerStorageStatsAndGetTotalValidSize(blobStoreStats, state.time.milliseconds());
     int throttleCountBeforeRequests = mockThrottler.throttleCount.get();
     // add 3 put that are expiring within forecast range
     long expiresAtInMs = ((long) bucketCount - 2) * BUCKET_SPAN_IN_MS;
@@ -586,7 +586,7 @@ public class BlobStoreStatsTest {
     for (long i = 0; i <= state.time.milliseconds() + TEST_TIME_INTERVAL_IN_MS; i += TEST_TIME_INTERVAL_IN_MS) {
       verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(i, 0L));
     }
-    verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, state.time.milliseconds());
+    verifyContainerStorageStatsAndGetTotalValidSize(blobStoreStats, state.time.milliseconds());
     // add 3 put with no expiry
     newPutEntries = state.addPutEntries(3, PUT_RECORD_SIZE, Utils.Infinite_Time);
     for (IndexEntry entry : newPutEntries) {
@@ -608,12 +608,12 @@ public class BlobStoreStatsTest {
     for (long i = 0; i <= state.time.milliseconds() + TEST_TIME_INTERVAL_IN_MS; i += TEST_TIME_INTERVAL_IN_MS) {
       verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(i, 0L));
     }
-    verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, state.time.milliseconds());
+    verifyContainerStorageStatsAndGetTotalValidSize(blobStoreStats, state.time.milliseconds());
     // advance time beyond expiration of the blobs and verify no double counting for expiration and delete
     long timeToLiveInMs = expiresAtInMs - state.time.milliseconds() < 0 ? 0 : expiresAtInMs - state.time.milliseconds();
     state.advanceTime(timeToLiveInMs + Time.MsPerSec);
     verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(state.time.milliseconds(), 0L));
-    verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, state.time.milliseconds());
+    verifyContainerStorageStatsAndGetTotalValidSize(blobStoreStats, state.time.milliseconds());
     assertEquals("Throttle count mismatch from expected value", throttleCountBeforeRequests,
         mockThrottler.throttleCount.get());
     blobStoreStats.close();
@@ -695,11 +695,11 @@ public class BlobStoreStatsTest {
         i += TEST_TIME_INTERVAL_IN_MS) {
       verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(i, 0L));
     }
-    verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, state.time.milliseconds());
+    verifyContainerStorageStatsAndGetTotalValidSize(blobStoreStats, state.time.milliseconds());
     long timeToLiveInMs = expiresAtInMs - state.time.milliseconds() < 0 ? 0 : expiresAtInMs - state.time.milliseconds();
     state.advanceTime(timeToLiveInMs + Time.MsPerSec);
     advanceTimeToNextSecond();
-    verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, state.time.milliseconds());
+    verifyContainerStorageStatsAndGetTotalValidSize(blobStoreStats, state.time.milliseconds());
     blobStoreStats.close();
   }
 
@@ -723,7 +723,7 @@ public class BlobStoreStatsTest {
     // proceed only when the scan is started
     assertTrue("IndexScanner took too long to start", scanStartedLatch.await(5, TimeUnit.SECONDS));
     verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(initialScanTimeInMs, 0L));
-    verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, initialScanTimeInMs);
+    verifyContainerStorageStatsAndGetTotalValidSize(blobStoreStats, initialScanTimeInMs);
     state.advanceTime(expiresAtInMs - state.time.milliseconds());
     // hold the next scan
     CountDownLatch scanHoldLatch = new CountDownLatch(1);
@@ -733,16 +733,16 @@ public class BlobStoreStatsTest {
     mockThrottler.isThrottlerStarted = false;
     assertTrue("IndexScanner took too long to start", scanStartedLatch.await(5, TimeUnit.SECONDS));
     verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(initialScanTimeInMs, 0L));
-    verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, initialScanTimeInMs);
+    verifyContainerStorageStatsAndGetTotalValidSize(blobStoreStats, initialScanTimeInMs);
     // expectedThrottleCount + 1 because the next scan already started and the throttle count is incremented
     assertEquals("Throttle count mismatch from expected value", expectedThrottleCount + 1,
         mockThrottler.throttleCount.get());
     // request something outside of the forecast coverage
     verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(0L, 0L));
-    verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, 0L);
+    verifyContainerStorageStatsAndGetTotalValidSize(blobStoreStats, 0L);
     // resume the scan and make a request that will wait for the scan to complete
     scanHoldLatch.countDown();
-    verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, state.time.milliseconds());
+    verifyContainerStorageStatsAndGetTotalValidSize(blobStoreStats, state.time.milliseconds());
     verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(state.time.milliseconds(), 0L));
     // first two are from the two bucketing scans and the later three are from the requests that are outside of
     // forecast coverage
@@ -760,12 +760,12 @@ public class BlobStoreStatsTest {
     state = new CuratedLogIndexState(true, tempDir, false, false, true, true, false, false);
     int bucketCount = bucketingEnabled ? 1 : 0;
     BlobStoreStats blobStoreStats = setupBlobStoreStats(bucketCount, 0);
-    verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, state.time.milliseconds());
+    verifyContainerStorageStatsAndGetTotalValidSize(blobStoreStats, state.time.milliseconds());
     verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(state.time.milliseconds(), 0));
     blobStoreStats.close();
     state.addPutEntries(3, PUT_RECORD_SIZE, Utils.Infinite_Time);
     blobStoreStats = setupBlobStoreStats(bucketCount, 0);
-    verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, state.time.milliseconds());
+    verifyContainerStorageStatsAndGetTotalValidSize(blobStoreStats, state.time.milliseconds());
     verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(state.time.milliseconds(), 0));
     blobStoreStats.close();
   }
@@ -786,7 +786,7 @@ public class BlobStoreStatsTest {
     if (!TestUtils.checkAndSleep(() -> blobStoreStats.isRecentEntryQueueEnabled(), 10000)) {
       throw new TimeoutException("Time out to wait for IndexScanner to finish");
     }
-    verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, state.time.milliseconds());
+    verifyContainerStorageStatsAndGetTotalValidSize(blobStoreStats, state.time.milliseconds());
     verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(state.time.milliseconds(), 0));
     long expiresAtInMs = state.time.milliseconds() + ((long) bucketCount - 2) * BUCKET_SPAN_IN_MS;
     // 3 new puts with expiry
@@ -807,14 +807,14 @@ public class BlobStoreStatsTest {
     blobStoreStats.handleNewPutEntry(null, new MockIndexValue(queueProcessedLatch, state.index.getCurrentEndOffset()));
     assertTrue("QueueProcessor took too long to process the new entries",
         queueProcessedLatch.await(3, TimeUnit.SECONDS));
-    verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, state.time.milliseconds());
+    verifyContainerStorageStatsAndGetTotalValidSize(blobStoreStats, state.time.milliseconds());
     verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(state.time.milliseconds(), 0));
     advanceTimeToNextSecond();
-    verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, state.time.milliseconds());
+    verifyContainerStorageStatsAndGetTotalValidSize(blobStoreStats, state.time.milliseconds());
     verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(state.time.milliseconds(), 0));
     long timeToLiveInMs = expiresAtInMs - state.time.milliseconds() < 0 ? 0 : expiresAtInMs - state.time.milliseconds();
     state.advanceTime(timeToLiveInMs + Time.MsPerSec);
-    verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, state.time.milliseconds());
+    verifyContainerStorageStatsAndGetTotalValidSize(blobStoreStats, state.time.milliseconds());
     verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(state.time.milliseconds(), 0));
     blobStoreStats.close();
   }
@@ -838,7 +838,7 @@ public class BlobStoreStatsTest {
     // proceed only when the scan is started
     assertTrue("IndexScanner took too long to start", scanStartedLatch.await(5, TimeUnit.SECONDS));
     advanceTimeToNextSecond();
-    verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, state.time.milliseconds());
+    verifyContainerStorageStatsAndGetTotalValidSize(blobStoreStats, state.time.milliseconds());
     verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(state.time.milliseconds(), 0));
     scanHoldLatch.countDown();
     assertTrue("Throttle count is lower than the expected minimum throttle count",
@@ -855,7 +855,7 @@ public class BlobStoreStatsTest {
     BlobStoreStats blobStoreStats = setupBlobStoreStats(bucketCount, 0);
     blobStoreStats.close();
     try {
-      verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, state.time.milliseconds());
+      verifyContainerStorageStatsAndGetTotalValidSize(blobStoreStats, state.time.milliseconds());
       fail("Expected StoreException thrown upon request when BlobStoreStats is closing");
     } catch (StoreException e) {
       assertEquals("Mismatch on expected error code", StoreErrorCodes.Store_Shutting_Down, e.getErrorCode());
@@ -890,7 +890,7 @@ public class BlobStoreStatsTest {
     // proceed only when the scan is started
     assertTrue("IndexScanner took too long to start", scanStartedLatch.await(5, TimeUnit.SECONDS));
     // ensure the scan is complete before proceeding
-    verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, state.time.milliseconds());
+    verifyContainerStorageStatsAndGetTotalValidSize(blobStoreStats, state.time.milliseconds());
     int throttleCountBeforeRequests = mockThrottler.throttleCount.get();
     TimeRange timeRange = new TimeRange(logSegmentForecastStartTimeMs, Time.MsPerSec);
     assertEquals("Unexpected collection time", timeRange.getEndTimeInMs(),
@@ -1185,7 +1185,7 @@ public class BlobStoreStatsTest {
    * @param referenceTimeInMs the reference time in ms until which deletes and expiration are relevant
    * @return the total valid data size of all containers (from all serviceIds)
    */
-  private long verifyContainerStorageStatsAndGeTotalValidSize(BlobStoreStats blobStoreStats, long referenceTimeInMs)
+  private long verifyContainerStorageStatsAndGetTotalValidSize(BlobStoreStats blobStoreStats, long referenceTimeInMs)
       throws StoreException {
     Map<String, Pair<AtomicLong, AtomicLong>> deleteTombstoneStats = generateDeleteTombstoneStats();
     Map<Short, Map<Short, ContainerStorageStats>> actualContainerStorageStatsMap =

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreStatsTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreStatsTest.java
@@ -19,6 +19,7 @@ import com.github.ambry.account.Account;
 import com.github.ambry.account.Container;
 import com.github.ambry.server.StatsReportType;
 import com.github.ambry.server.StatsSnapshot;
+import com.github.ambry.server.storagestats.ContainerStorageStats;
 import com.github.ambry.utils.MockTime;
 import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.SystemTime;
@@ -152,10 +153,10 @@ public class BlobStoreStatsTest {
   public void testContainerValidDataSize() throws StoreException {
     assumeTrue(!bucketingEnabled);
     BlobStoreStats blobStoreStats = setupBlobStoreStats(0, 0);
-    verifyAndGetContainerValidSize(blobStoreStats, state.time.milliseconds());
+    verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, state.time.milliseconds());
     // advance time
     advanceTimeToNextSecond();
-    verifyAndGetContainerValidSize(blobStoreStats, state.time.milliseconds());
+    verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, state.time.milliseconds());
     blobStoreStats.close();
   }
 
@@ -208,7 +209,8 @@ public class BlobStoreStatsTest {
     long timeInMsBeforePuts = state.time.milliseconds();
     long totalLogSegmentValidSizeBeforePuts =
         verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(timeInMsBeforePuts, 0L));
-    long totalContainerValidSizeBeforePuts = verifyAndGetContainerValidSize(blobStoreStats, timeInMsBeforePuts);
+    long totalContainerValidSizeBeforePuts =
+        verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, timeInMsBeforePuts);
 
     // 3 puts
     state.addPutEntries(3, PUT_RECORD_SIZE, Utils.Infinite_Time);
@@ -216,7 +218,8 @@ public class BlobStoreStatsTest {
     long timeInMsAfterPuts = state.time.milliseconds();
     long totalLogSegmentValidSizeAfterPuts =
         verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(timeInMsAfterPuts, 0L));
-    long totalContainerValidSizeAfterPuts = verifyAndGetContainerValidSize(blobStoreStats, timeInMsAfterPuts);
+    long totalContainerValidSizeAfterPuts =
+        verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, timeInMsAfterPuts);
     long expectedIncrement = 3 * PUT_RECORD_SIZE;
     assertEquals("Put entries are not properly counted for log segment valid size", totalLogSegmentValidSizeAfterPuts,
         totalLogSegmentValidSizeBeforePuts + expectedIncrement);
@@ -244,7 +247,8 @@ public class BlobStoreStatsTest {
     long timeInMsBeforePuts = state.time.milliseconds();
     long totalLogSegmentValidSizeBeforePuts =
         verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(timeInMsBeforePuts, 0L));
-    long totalContainerValidSizeBeforePuts = verifyAndGetContainerValidSize(blobStoreStats, state.time.milliseconds());
+    long totalContainerValidSizeBeforePuts =
+        verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, state.time.milliseconds());
 
     // 1 put with no expiry
     state.addPutEntries(1, PUT_RECORD_SIZE, Utils.Infinite_Time);
@@ -259,7 +263,8 @@ public class BlobStoreStatsTest {
     long timeInMsAfterPuts = state.time.milliseconds();
     long totalLogSegmentValidSizeAfterPuts =
         verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(timeInMsAfterPuts, 0L));
-    long totalContainerValidSizeAfterPuts = verifyAndGetContainerValidSize(blobStoreStats, timeInMsAfterPuts);
+    long totalContainerValidSizeAfterPuts =
+        verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, timeInMsAfterPuts);
     assertEquals("Put entries with expiry are not properly counted for log segment valid size",
         totalLogSegmentValidSizeAfterPuts, totalLogSegmentValidSizeBeforePuts + expectedDeltaAfterPut);
     assertEquals("Put entries with expiry are not properly counted for container valid size",
@@ -273,7 +278,7 @@ public class BlobStoreStatsTest {
     long totalLogSegmentValidSizeAfterExpiration =
         verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(timeInMsAfterExpiration, 0L));
     long totalContainerValidSizeAfterExpiration =
-        verifyAndGetContainerValidSize(blobStoreStats, timeInMsAfterExpiration);
+        verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, timeInMsAfterExpiration);
     assertEquals("Expired put entries are not properly counted for log segment valid size",
         totalLogSegmentValidSizeAfterExpiration, totalLogSegmentValidSizeBeforePuts + expectedDeltaAfterExpiration);
     assertEquals("Expired put entries are not properly counted for container valid size",
@@ -303,7 +308,8 @@ public class BlobStoreStatsTest {
     long timeInMsBeforeDeletes = state.time.milliseconds();
     long totalLogSegmentValidSizeBeforeDeletes =
         verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(timeInMsBeforeDeletes, 0L));
-    long totalContainerValidSizeBeforeDeletes = verifyAndGetContainerValidSize(blobStoreStats, timeInMsBeforeDeletes);
+    long totalContainerValidSizeBeforeDeletes =
+        verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, timeInMsBeforeDeletes);
 
     // advance time to the next seconds before adding the deletes
     advanceTimeToNextSecond();
@@ -315,7 +321,7 @@ public class BlobStoreStatsTest {
     long totalLogSegmentValidSizeBeforeDeletesRelevant =
         verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(timeInMsBeforeDeletes, 0L));
     long totalContainerValidSizeBeforeDeletesRelevant =
-        verifyAndGetContainerValidSize(blobStoreStats, timeInMsBeforeDeletes);
+        verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, timeInMsBeforeDeletes);
     assertEquals("Delete entries are not properly counted for log segment valid size",
         totalLogSegmentValidSizeBeforeDeletesRelevant,
         totalLogSegmentValidSizeBeforeDeletes + expectedDeltaBeforeDeletesRelevant);
@@ -328,7 +334,8 @@ public class BlobStoreStatsTest {
     long timeInMsAfterDeletes = state.time.milliseconds();
     long totalLogSegmentValidSizeAfterDeletes =
         verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(timeInMsAfterDeletes, 0L));
-    long totalContainerValidSizeAfterDeletes = verifyAndGetContainerValidSize(blobStoreStats, timeInMsAfterDeletes);
+    long totalContainerValidSizeAfterDeletes =
+        verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, timeInMsAfterDeletes);
     long expectedLogSegmentDecrement = 2 * (PUT_RECORD_SIZE - DELETE_RECORD_SIZE);
     long expectedContainerDecrement = 2 * PUT_RECORD_SIZE;
     assertEquals("Delete entries are not properly counted for log segment valid size",
@@ -371,7 +378,7 @@ public class BlobStoreStatsTest {
     long totalLogSegmentValidSizeBeforeUndeletes =
         verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(timeInMsBeforeUndeletes, 0L));
     long totalContainerValidSizeBeforeUndeletes =
-        verifyAndGetContainerValidSize(blobStoreStats, timeInMsBeforeUndeletes);
+        verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, timeInMsBeforeUndeletes);
 
     state.addUndeleteEntry(firstId);
     state.addUndeleteEntry(secondId);
@@ -382,7 +389,8 @@ public class BlobStoreStatsTest {
         2 * PUT_RECORD_SIZE - 2 * DELETE_RECORD_SIZE + 2 * UNDELETE_RECORD_SIZE + TTL_UPDATE_RECORD_SIZE;
     long totalLogSegmentValidSizeAfterUndeletes =
         verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(timeInMsAfterUndeletes, 0L));
-    long totalContainerValidSizeAfterUndeletes = verifyAndGetContainerValidSize(blobStoreStats, timeInMsAfterUndeletes);
+    long totalContainerValidSizeAfterUndeletes =
+        verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, timeInMsAfterUndeletes);
     assertEquals("Undelete entries are not properly counted for container valid size",
         totalContainerValidSizeAfterUndeletes, totalContainerValidSizeBeforeUndeletes + expectedContainerIncrement);
     assertEquals("Undelete entries are not properly counted for log segment valid size",
@@ -392,7 +400,8 @@ public class BlobStoreStatsTest {
     state.addDeleteEntry(secondId, null, (short) 2);
     totalLogSegmentValidSizeAfterUndeletes =
         verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(timeInMsAfterUndeletes, 0L));
-    totalContainerValidSizeAfterUndeletes = verifyAndGetContainerValidSize(blobStoreStats, timeInMsAfterUndeletes);
+    totalContainerValidSizeAfterUndeletes =
+        verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, timeInMsAfterUndeletes);
     assertEquals("Undelete entries are not properly counted for container valid size",
         totalContainerValidSizeAfterUndeletes, totalContainerValidSizeBeforeUndeletes + expectedContainerIncrement);
     assertEquals("Undelete entries are not properly counted for log segment valid size",
@@ -437,7 +446,7 @@ public class BlobStoreStatsTest {
     BlobStoreStats blobStoreStats = setupBlobStoreStats(bucketCount, logSegmentForecastOffsetMs);
     // proceed only when the scan is started
     assertTrue("IndexScanner took too long to start", scanStartedLatch.await(5, TimeUnit.SECONDS));
-    verifyAndGetContainerValidSize(blobStoreStats, state.time.milliseconds());
+    verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, state.time.milliseconds());
     for (long i = state.beginningTime; i <= state.time.milliseconds() + TEST_TIME_INTERVAL_IN_MS;
         i += TEST_TIME_INTERVAL_IN_MS) {
       verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(i, 0L));
@@ -449,13 +458,13 @@ public class BlobStoreStatsTest {
         i += TEST_TIME_INTERVAL_IN_MS) {
       verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(i, 0L));
     }
-    verifyAndGetContainerValidSize(blobStoreStats, state.time.milliseconds());
+    verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, state.time.milliseconds());
     // advance time near the end of log segment forecast time
     state.advanceTime(logSegmentForecastEndTimeInMs - state.time.milliseconds() - 1);
     verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(state.time.milliseconds(), Time.MsPerSec));
     // advance time near the end of container forecast time
     state.advanceTime(containerForecastEndTimeInMs - state.time.milliseconds() - 1);
-    verifyAndGetContainerValidSize(blobStoreStats, state.time.milliseconds());
+    verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, state.time.milliseconds());
     assertEquals("Throttle count mismatch from expected value", expectedThrottleCount,
         mockThrottler.throttleCount.get());
     blobStoreStats.close();
@@ -483,7 +492,7 @@ public class BlobStoreStatsTest {
     assertTrue("IndexScanner took too long to start", scanStartedLatch.await(5, TimeUnit.SECONDS));
     advanceTimeToNextSecond();
     verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(state.time.milliseconds(), 0L));
-    verifyAndGetContainerValidSize(blobStoreStats, state.time.milliseconds());
+    verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, state.time.milliseconds());
     int throttleCountBeforeRequests = mockThrottler.throttleCount.get();
     // add 3 put that are expiring within forecast range
     long expiresAtInMs = ((long) bucketCount - 2) * BUCKET_SPAN_IN_MS;
@@ -491,14 +500,14 @@ public class BlobStoreStatsTest {
     // add a put that will expire outside of the forecast coverage
     newPutEntries.addAll(state.addPutEntries(1, PUT_RECORD_SIZE, ((long) bucketCount) * BUCKET_SPAN_IN_MS));
     for (IndexEntry entry : newPutEntries) {
-      blobStoreStats.handleNewPutEntry(entry.getValue());
+      blobStoreStats.handleNewPutEntry(entry.getKey(), entry.getValue());
     }
     // add a long expired put
     List<IndexEntry> expiredPutEntries = state.addPutEntries(1, PUT_RECORD_SIZE, 0);
     // add a put that will expire immediately
     expiredPutEntries.addAll(state.addPutEntries(1, PUT_RECORD_SIZE, state.time.milliseconds()));
     for (IndexEntry entry : expiredPutEntries) {
-      blobStoreStats.handleNewPutEntry(entry.getValue());
+      blobStoreStats.handleNewPutEntry(entry.getKey(), entry.getValue());
     }
     advanceTimeToNextSecond();
     // delete the first new put that is expiring
@@ -512,7 +521,7 @@ public class BlobStoreStatsTest {
     long soonExpiredTimeInMs = state.time.milliseconds() + (10 * BUCKET_SPAN_IN_MS);
     List<IndexEntry> soonExpiredPutEntries = state.addPutEntries(2, PUT_RECORD_SIZE, soonExpiredTimeInMs);
     for (IndexEntry entry : soonExpiredPutEntries) {
-      blobStoreStats.handleNewPutEntry(entry.getValue());
+      blobStoreStats.handleNewPutEntry(entry.getKey(), entry.getValue());
       newTtlUpdate(blobStoreStats, (MockId) entry.getKey());
     }
     // Delete first entry
@@ -532,7 +541,7 @@ public class BlobStoreStatsTest {
     long expiredForUndeleteEntries = state.time.milliseconds() + 100 * BUCKET_SPAN_IN_MS;
     List<IndexEntry> toUndeleteEntries = state.addPutEntries(7, PUT_RECORD_SIZE, expiredForUndeleteEntries);
     for (IndexEntry entry : toUndeleteEntries) {
-      blobStoreStats.handleNewPutEntry(entry.getValue());
+      blobStoreStats.handleNewPutEntry(entry.getKey(), entry.getValue());
     }
     MockId id1 = getIdToDelete(toUndeleteEntries.get(0).getKey());
     newDelete(blobStoreStats, id1);
@@ -571,23 +580,23 @@ public class BlobStoreStatsTest {
     newUndelete(blobStoreStats, id7);
 
     // a probe put with a latch to inform us about the state of the queue
-    blobStoreStats.handleNewPutEntry(new MockIndexValue(queueProcessedLatch, state.index.getCurrentEndOffset()));
+    blobStoreStats.handleNewPutEntry(null, new MockIndexValue(queueProcessedLatch, state.index.getCurrentEndOffset()));
     assertTrue("QueueProcessor took too long to process the new entries",
         queueProcessedLatch.await(Long.MAX_VALUE, TimeUnit.SECONDS));
     for (long i = 0; i <= state.time.milliseconds() + TEST_TIME_INTERVAL_IN_MS; i += TEST_TIME_INTERVAL_IN_MS) {
       verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(i, 0L));
     }
-    verifyAndGetContainerValidSize(blobStoreStats, state.time.milliseconds());
+    verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, state.time.milliseconds());
     // add 3 put with no expiry
     newPutEntries = state.addPutEntries(3, PUT_RECORD_SIZE, Utils.Infinite_Time);
     for (IndexEntry entry : newPutEntries) {
-      blobStoreStats.handleNewPutEntry(entry.getValue());
+      blobStoreStats.handleNewPutEntry(entry.getKey(), entry.getValue());
     }
     // delete one of the newly added put
     newDelete(blobStoreStats, state.getIdToDeleteFromIndexSegment(state.referenceIndex.lastKey(), false));
     queueProcessedLatch = new CountDownLatch(1);
     // a probe put with a latch to inform us about the state of the queue
-    blobStoreStats.handleNewPutEntry(new MockIndexValue(queueProcessedLatch, state.index.getCurrentEndOffset()));
+    blobStoreStats.handleNewPutEntry(null, new MockIndexValue(queueProcessedLatch, state.index.getCurrentEndOffset()));
     assertTrue("QueueProcessor took too long to process the new entries",
         queueProcessedLatch.await(Long.MAX_VALUE, TimeUnit.SECONDS));
     // note: advance time only after all new deletes are added to avoid the scenario where an index segment's last
@@ -599,12 +608,12 @@ public class BlobStoreStatsTest {
     for (long i = 0; i <= state.time.milliseconds() + TEST_TIME_INTERVAL_IN_MS; i += TEST_TIME_INTERVAL_IN_MS) {
       verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(i, 0L));
     }
-    verifyAndGetContainerValidSize(blobStoreStats, state.time.milliseconds());
+    verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, state.time.milliseconds());
     // advance time beyond expiration of the blobs and verify no double counting for expiration and delete
     long timeToLiveInMs = expiresAtInMs - state.time.milliseconds() < 0 ? 0 : expiresAtInMs - state.time.milliseconds();
     state.advanceTime(timeToLiveInMs + Time.MsPerSec);
     verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(state.time.milliseconds(), 0L));
-    verifyAndGetContainerValidSize(blobStoreStats, state.time.milliseconds());
+    verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, state.time.milliseconds());
     assertEquals("Throttle count mismatch from expected value", throttleCountBeforeRequests,
         mockThrottler.throttleCount.get());
     blobStoreStats.close();
@@ -644,7 +653,7 @@ public class BlobStoreStatsTest {
     // 6 new puts with no expiry
     newPutEntries.addAll(state.addPutEntries(6, PUT_RECORD_SIZE, Utils.Infinite_Time));
     for (IndexEntry entry : newPutEntries) {
-      blobStoreStats.handleNewPutEntry(entry.getValue());
+      blobStoreStats.handleNewPutEntry(entry.getKey(), entry.getValue());
     }
     List<MockId> newDeletes = new ArrayList<>();
     // 1 delete from the first index segment
@@ -664,7 +673,7 @@ public class BlobStoreStatsTest {
     // 3 new puts with no expiry
     newPutEntries = state.addPutEntries(3, PUT_RECORD_SIZE, Utils.Infinite_Time);
     for (IndexEntry entry : newPutEntries) {
-      blobStoreStats.handleNewPutEntry(entry.getValue());
+      blobStoreStats.handleNewPutEntry(entry.getKey(), entry.getValue());
     }
     newDeletes.clear();
     // 1 delete from the last index segment
@@ -678,7 +687,7 @@ public class BlobStoreStatsTest {
     secondCheckpointHoldLatch.countDown();
     // a probe put with a latch to inform us about the state of the queue
     CountDownLatch queueProcessedLatch = new CountDownLatch(1);
-    blobStoreStats.handleNewPutEntry(new MockIndexValue(queueProcessedLatch, state.index.getCurrentEndOffset()));
+    blobStoreStats.handleNewPutEntry(null, new MockIndexValue(queueProcessedLatch, state.index.getCurrentEndOffset()));
     assertTrue("QueueProcessor took too long to process the new entries",
         queueProcessedLatch.await(3, TimeUnit.SECONDS));
     // verifying log segment from beginning time of the state, since most of the deletes and expiration starting from this time.
@@ -686,11 +695,11 @@ public class BlobStoreStatsTest {
         i += TEST_TIME_INTERVAL_IN_MS) {
       verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(i, 0L));
     }
-    verifyAndGetContainerValidSize(blobStoreStats, state.time.milliseconds());
+    verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, state.time.milliseconds());
     long timeToLiveInMs = expiresAtInMs - state.time.milliseconds() < 0 ? 0 : expiresAtInMs - state.time.milliseconds();
     state.advanceTime(timeToLiveInMs + Time.MsPerSec);
     advanceTimeToNextSecond();
-    verifyAndGetContainerValidSize(blobStoreStats, state.time.milliseconds());
+    verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, state.time.milliseconds());
     blobStoreStats.close();
   }
 
@@ -714,7 +723,7 @@ public class BlobStoreStatsTest {
     // proceed only when the scan is started
     assertTrue("IndexScanner took too long to start", scanStartedLatch.await(5, TimeUnit.SECONDS));
     verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(initialScanTimeInMs, 0L));
-    verifyAndGetContainerValidSize(blobStoreStats, initialScanTimeInMs);
+    verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, initialScanTimeInMs);
     state.advanceTime(expiresAtInMs - state.time.milliseconds());
     // hold the next scan
     CountDownLatch scanHoldLatch = new CountDownLatch(1);
@@ -724,16 +733,16 @@ public class BlobStoreStatsTest {
     mockThrottler.isThrottlerStarted = false;
     assertTrue("IndexScanner took too long to start", scanStartedLatch.await(5, TimeUnit.SECONDS));
     verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(initialScanTimeInMs, 0L));
-    verifyAndGetContainerValidSize(blobStoreStats, initialScanTimeInMs);
+    verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, initialScanTimeInMs);
     // expectedThrottleCount + 1 because the next scan already started and the throttle count is incremented
     assertEquals("Throttle count mismatch from expected value", expectedThrottleCount + 1,
         mockThrottler.throttleCount.get());
     // request something outside of the forecast coverage
     verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(0L, 0L));
-    verifyAndGetContainerValidSize(blobStoreStats, 0L);
+    verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, 0L);
     // resume the scan and make a request that will wait for the scan to complete
     scanHoldLatch.countDown();
-    verifyAndGetContainerValidSize(blobStoreStats, state.time.milliseconds());
+    verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, state.time.milliseconds());
     verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(state.time.milliseconds(), 0L));
     // first two are from the two bucketing scans and the later three are from the requests that are outside of
     // forecast coverage
@@ -751,12 +760,12 @@ public class BlobStoreStatsTest {
     state = new CuratedLogIndexState(true, tempDir, false, false, true, true, false, false);
     int bucketCount = bucketingEnabled ? 1 : 0;
     BlobStoreStats blobStoreStats = setupBlobStoreStats(bucketCount, 0);
-    verifyAndGetContainerValidSize(blobStoreStats, state.time.milliseconds());
+    verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, state.time.milliseconds());
     verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(state.time.milliseconds(), 0));
     blobStoreStats.close();
     state.addPutEntries(3, PUT_RECORD_SIZE, Utils.Infinite_Time);
     blobStoreStats = setupBlobStoreStats(bucketCount, 0);
-    verifyAndGetContainerValidSize(blobStoreStats, state.time.milliseconds());
+    verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, state.time.milliseconds());
     verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(state.time.milliseconds(), 0));
     blobStoreStats.close();
   }
@@ -777,7 +786,7 @@ public class BlobStoreStatsTest {
     if (!TestUtils.checkAndSleep(() -> blobStoreStats.isRecentEntryQueueEnabled(), 10000)) {
       throw new TimeoutException("Time out to wait for IndexScanner to finish");
     }
-    verifyAndGetContainerValidSize(blobStoreStats, state.time.milliseconds());
+    verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, state.time.milliseconds());
     verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(state.time.milliseconds(), 0));
     long expiresAtInMs = state.time.milliseconds() + ((long) bucketCount - 2) * BUCKET_SPAN_IN_MS;
     // 3 new puts with expiry
@@ -785,7 +794,7 @@ public class BlobStoreStatsTest {
     // 3 new put with no expiry
     newPutEntries.addAll(state.addPutEntries(3, PUT_RECORD_SIZE, Utils.Infinite_Time));
     for (IndexEntry entry : newPutEntries) {
-      blobStoreStats.handleNewPutEntry(entry.getValue());
+      blobStoreStats.handleNewPutEntry(entry.getKey(), entry.getValue());
     }
     // delete one of the put with expiry
     MockId putWithExpiry = getIdToDelete(newPutEntries.get(0).getKey());
@@ -795,17 +804,17 @@ public class BlobStoreStatsTest {
     newDelete(blobStoreStats, putWithoutExpiry);
     // a probe put with a latch to inform us about the state of the queue
     CountDownLatch queueProcessedLatch = new CountDownLatch(1);
-    blobStoreStats.handleNewPutEntry(new MockIndexValue(queueProcessedLatch, state.index.getCurrentEndOffset()));
+    blobStoreStats.handleNewPutEntry(null, new MockIndexValue(queueProcessedLatch, state.index.getCurrentEndOffset()));
     assertTrue("QueueProcessor took too long to process the new entries",
         queueProcessedLatch.await(3, TimeUnit.SECONDS));
-    verifyAndGetContainerValidSize(blobStoreStats, state.time.milliseconds());
+    verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, state.time.milliseconds());
     verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(state.time.milliseconds(), 0));
     advanceTimeToNextSecond();
-    verifyAndGetContainerValidSize(blobStoreStats, state.time.milliseconds());
+    verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, state.time.milliseconds());
     verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(state.time.milliseconds(), 0));
     long timeToLiveInMs = expiresAtInMs - state.time.milliseconds() < 0 ? 0 : expiresAtInMs - state.time.milliseconds();
     state.advanceTime(timeToLiveInMs + Time.MsPerSec);
-    verifyAndGetContainerValidSize(blobStoreStats, state.time.milliseconds());
+    verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, state.time.milliseconds());
     verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(state.time.milliseconds(), 0));
     blobStoreStats.close();
   }
@@ -829,7 +838,7 @@ public class BlobStoreStatsTest {
     // proceed only when the scan is started
     assertTrue("IndexScanner took too long to start", scanStartedLatch.await(5, TimeUnit.SECONDS));
     advanceTimeToNextSecond();
-    verifyAndGetContainerValidSize(blobStoreStats, state.time.milliseconds());
+    verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, state.time.milliseconds());
     verifyAndGetLogSegmentValidSize(blobStoreStats, new TimeRange(state.time.milliseconds(), 0));
     scanHoldLatch.countDown();
     assertTrue("Throttle count is lower than the expected minimum throttle count",
@@ -846,7 +855,7 @@ public class BlobStoreStatsTest {
     BlobStoreStats blobStoreStats = setupBlobStoreStats(bucketCount, 0);
     blobStoreStats.close();
     try {
-      verifyAndGetContainerValidSize(blobStoreStats, state.time.milliseconds());
+      verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, state.time.milliseconds());
       fail("Expected StoreException thrown upon request when BlobStoreStats is closing");
     } catch (StoreException e) {
       assertEquals("Mismatch on expected error code", StoreErrorCodes.Store_Shutting_Down, e.getErrorCode());
@@ -881,7 +890,7 @@ public class BlobStoreStatsTest {
     // proceed only when the scan is started
     assertTrue("IndexScanner took too long to start", scanStartedLatch.await(5, TimeUnit.SECONDS));
     // ensure the scan is complete before proceeding
-    verifyAndGetContainerValidSize(blobStoreStats, state.time.milliseconds());
+    verifyContainerStorageStatsAndGeTotalValidSize(blobStoreStats, state.time.milliseconds());
     int throttleCountBeforeRequests = mockThrottler.throttleCount.get();
     TimeRange timeRange = new TimeRange(logSegmentForecastStartTimeMs, Time.MsPerSec);
     assertEquals("Unexpected collection time", timeRange.getEndTimeInMs(),
@@ -920,34 +929,32 @@ public class BlobStoreStatsTest {
   @Test
   public void testConvertStoreUsageToStatsSnapshot() {
     Random random = new Random();
-    Map<Short, Map<Short, Long>> utilizationMap = new HashMap<>();
+    Map<Short, Map<Short, ContainerStorageStats>> statsMap = new HashMap<>();
     Map<String, StatsSnapshot> accountSubMap = new HashMap<>();
     Map<String, StatsSnapshot> accountContainerPairSubMap = new HashMap<>();
 
     long total = 0;
     for (int i = 0; i < 10; i++) {
       Map<String, StatsSnapshot> containerSubMap = new HashMap<>();
-      Map<Short, Long> innerUtilizationMap = new HashMap<>();
+      Map<Short, ContainerStorageStats> innerStatsMap = new HashMap<>();
       long subTotal = 0;
       for (int j = 0; j < 3; j++) {
         long randValue = random.nextInt(10000);
         subTotal += randValue;
-        innerUtilizationMap.put((short) j, randValue);
+        innerStatsMap.put((short) j, new ContainerStorageStats((short) j, randValue, randValue + 1, 1L));
         containerSubMap.put(Utils.statsContainerKey((short) j), new StatsSnapshot(randValue, null));
         accountContainerPairSubMap.put(Utils.partitionClassStatsAccountContainerKey((short) i, (short) j),
             new StatsSnapshot(randValue, null));
       }
       total += subTotal;
-      utilizationMap.put((short) i, innerUtilizationMap);
+      statsMap.put((short) i, innerStatsMap);
       accountSubMap.put(Utils.statsAccountKey((short) i), new StatsSnapshot(subTotal, containerSubMap));
     }
     StatsSnapshot expectAccountSnapshot = new StatsSnapshot(total, accountSubMap);
-    StatsSnapshot convertedAccountStatsSnapshot =
-        BlobStoreStats.convertStoreUsageToAccountStatsSnapshot(utilizationMap);
+    StatsSnapshot convertedAccountStatsSnapshot = BlobStoreStats.convertStoreUsageToAccountStatsSnapshot(statsMap);
     assertEquals("Mismatch between the converted Account StatsSnapshot and expected StatsSnapshot",
         expectAccountSnapshot, convertedAccountStatsSnapshot);
-    StatsSnapshot convertedContainerStatsSnapshot =
-        BlobStoreStats.convertStoreUsageToContainerStatsSnapshot(utilizationMap);
+    StatsSnapshot convertedContainerStatsSnapshot = BlobStoreStats.convertStoreUsageToContainerStatsSnapshot(statsMap);
     StatsSnapshot expectContainerSnapshot = new StatsSnapshot(total, accountContainerPairSubMap);
     assertEquals("Mismatch between the converted Container StatsSnapshot and expected StatsSnapshot",
         expectContainerSnapshot, convertedContainerStatsSnapshot);
@@ -967,25 +974,25 @@ public class BlobStoreStatsTest {
 
     while (true) {
       long deleteAndExpirationRefTimeInMs = state.time.milliseconds();
-      Map<Short, Map<Short, Long>> utilizationMap =
-          blobStoreStats.getValidDataSizeByContainer(deleteAndExpirationRefTimeInMs);
+      Map<Short, Map<Short, ContainerStorageStats>> statsMap =
+          blobStoreStats.getContainerStorageStats(deleteAndExpirationRefTimeInMs);
       Optional.ofNullable(accountIdToExclude).orElse(Collections.EMPTY_LIST).
-          forEach(id -> utilizationMap.remove(id));
+          forEach(id -> statsMap.remove(id));
 
       // Verify account stats snapshot
       Map<StatsReportType, StatsSnapshot> snapshotsByType =
           blobStoreStats.getStatsSnapshots(EnumSet.of(StatsReportType.ACCOUNT_REPORT), deleteAndExpirationRefTimeInMs,
               accountIdToExclude);
-      verifyStatsSnapshots(utilizationMap, snapshotsByType, EnumSet.of(StatsReportType.ACCOUNT_REPORT));
+      verifyStatsSnapshots(statsMap, snapshotsByType, EnumSet.of(StatsReportType.ACCOUNT_REPORT));
       // Verify partition class stats snapshot
       snapshotsByType = blobStoreStats.getStatsSnapshots(EnumSet.of(StatsReportType.PARTITION_CLASS_REPORT),
           deleteAndExpirationRefTimeInMs, accountIdToExclude);
-      verifyStatsSnapshots(utilizationMap, snapshotsByType, EnumSet.of(StatsReportType.PARTITION_CLASS_REPORT));
+      verifyStatsSnapshots(statsMap, snapshotsByType, EnumSet.of(StatsReportType.PARTITION_CLASS_REPORT));
       // Verify all types of stats snapshots
       Map<StatsReportType, StatsSnapshot> allStatsSnapshots =
           blobStoreStats.getStatsSnapshots(EnumSet.allOf(StatsReportType.class), deleteAndExpirationRefTimeInMs,
               accountIdToExclude);
-      verifyStatsSnapshots(utilizationMap, allStatsSnapshots, EnumSet.allOf(StatsReportType.class));
+      verifyStatsSnapshots(statsMap, allStatsSnapshots, EnumSet.allOf(StatsReportType.class));
       if (accountIdToExclude == null) {
         accountIdToExclude = Arrays.asList(allAccountIds.get(0), (short) (maxAccountId + 1));
       } else {
@@ -996,12 +1003,12 @@ public class BlobStoreStatsTest {
 
   /**
    * Verify the correctness of specified stats snapshots fetched from {@link BlobStoreStats}
-   * @param accountContainerUtilizationMap the map of account to each container quota map. The container quota map presents
+   * @param accountContainerStatsMap the map of account to each container quota map. The container quota map presents
    *                                 each container name to its valid data size
    * @param snapshotsByType the map of {@link StatsReportType} to {@link StatsSnapshot} to be verified
    * @param typesToVerify the {@link StatsReportType} to be verified
    */
-  private void verifyStatsSnapshots(Map<Short, Map<Short, Long>> accountContainerUtilizationMap,
+  private void verifyStatsSnapshots(Map<Short, Map<Short, ContainerStorageStats>> accountContainerStatsMap,
       Map<StatsReportType, StatsSnapshot> snapshotsByType, EnumSet<StatsReportType> typesToVerify) {
     for (StatsReportType type : typesToVerify) {
       switch (type) {
@@ -1009,19 +1016,19 @@ public class BlobStoreStatsTest {
           Map<String, StatsSnapshot> accountToSnapshot =
               snapshotsByType.get(StatsReportType.ACCOUNT_REPORT).getSubMap();
           assertEquals("Mismatch on number of accounts for " + StatsReportType.ACCOUNT_REPORT,
-              accountContainerUtilizationMap.size(), accountToSnapshot.size());
-          for (Map.Entry<Short, Map<Short, Long>> accountToContainerEntry : accountContainerUtilizationMap.entrySet()) {
-            Map<Short, Long> containerUtilizationMap = accountToContainerEntry.getValue();
+              accountContainerStatsMap.size(), accountToSnapshot.size());
+          for (Map.Entry<Short, Map<Short, ContainerStorageStats>> accountToContainerEntry : accountContainerStatsMap.entrySet()) {
+            Map<Short, ContainerStorageStats> containerStatsMap = accountToContainerEntry.getValue();
             Map<String, StatsSnapshot> containerToSnapshot =
                 accountToSnapshot.get(Utils.statsAccountKey(accountToContainerEntry.getKey())).getSubMap();
-            assertEquals("Mismatch on number of containers", containerUtilizationMap.size(),
-                containerToSnapshot.size());
-            for (Map.Entry<Short, Long> containerEntry : containerUtilizationMap.entrySet()) {
+            assertEquals("Mismatch on number of containers", containerStatsMap.size(), containerToSnapshot.size());
+            for (Map.Entry<Short, ContainerStorageStats> containerEntry : containerStatsMap.entrySet()) {
 
               // Ensure container value and name in ACCOUNT_SNAPSHOT match that in UtilizationMap
               assertNotNull("Expected container: " + containerEntry.getKey() + " doesn't exist",
                   containerToSnapshot.get(Utils.statsContainerKey(containerEntry.getKey())));
-              assertEquals("Mismatch on value of container in account snapshot", containerEntry.getValue().longValue(),
+              assertEquals("Mismatch on value of container in account snapshot",
+                  containerEntry.getValue().getLogicalStorageUsage(),
                   containerToSnapshot.get(Utils.statsContainerKey(containerEntry.getKey())).getValue());
             }
           }
@@ -1029,9 +1036,9 @@ public class BlobStoreStatsTest {
         case PARTITION_CLASS_REPORT:
           Map<String, StatsSnapshot> acctContPairToSnapshot =
               snapshotsByType.get(StatsReportType.PARTITION_CLASS_REPORT).getSubMap();
-          for (Map.Entry<Short, Map<Short, Long>> accountToContainerEntry : accountContainerUtilizationMap.entrySet()) {
-            Map<Short, Long> containerUtilizationMap = accountToContainerEntry.getValue();
-            for (Map.Entry<Short, Long> containerEntry : containerUtilizationMap.entrySet()) {
+          for (Map.Entry<Short, Map<Short, ContainerStorageStats>> accountToContainerEntry : accountContainerStatsMap.entrySet()) {
+            Map<Short, ContainerStorageStats> containerStatsMap = accountToContainerEntry.getValue();
+            for (Map.Entry<Short, ContainerStorageStats> containerEntry : containerStatsMap.entrySet()) {
               // Ensure account_container value and name in CONTAINER_SNAPSHOT match that in UtilizationMap
               String accountContainerName =
                   Utils.partitionClassStatsAccountContainerKey(accountToContainerEntry.getKey(),
@@ -1039,7 +1046,8 @@ public class BlobStoreStatsTest {
               assertNotNull("Expected account_container pair: " + accountContainerName + " doesn't exist",
                   acctContPairToSnapshot.get(accountContainerName));
               assertEquals("Mismatch on value of container in container snapshot",
-                  containerEntry.getValue().longValue(), acctContPairToSnapshot.get(accountContainerName).getValue());
+                  containerEntry.getValue().getLogicalStorageUsage(),
+                  acctContPairToSnapshot.get(accountContainerName).getValue());
             }
           }
           break;
@@ -1159,7 +1167,7 @@ public class BlobStoreStatsTest {
     state.makePermanent(idToUpdate, false);
     IndexValue ttlUpdateValue =
         state.getExpectedValue(idToUpdate, EnumSet.of(PersistentIndex.IndexEntryType.TTL_UPDATE), null);
-    blobStoreStats.handleNewTtlUpdateEntry(ttlUpdateValue, originalPut);
+    blobStoreStats.handleNewTtlUpdateEntry(idToUpdate, ttlUpdateValue, originalPut);
   }
 
   /**
@@ -1177,46 +1185,51 @@ public class BlobStoreStatsTest {
    * @param referenceTimeInMs the reference time in ms until which deletes and expiration are relevant
    * @return the total valid data size of all containers (from all serviceIds)
    */
-  private long verifyAndGetContainerValidSize(BlobStoreStats blobStoreStats, long referenceTimeInMs)
+  private long verifyContainerStorageStatsAndGeTotalValidSize(BlobStoreStats blobStoreStats, long referenceTimeInMs)
       throws StoreException {
     Map<String, Pair<AtomicLong, AtomicLong>> deleteTombstoneStats = generateDeleteTombstoneStats();
-    Map<Short, Map<Short, Long>> actualContainerValidSizeMap =
-        blobStoreStats.getValidDataSizeByContainer(referenceTimeInMs);
-    Map<Short, Map<Short, Long>> expectedContainerValidSizeMap =
-        getValidSizeByContainer(referenceTimeInMs, state.time.milliseconds(), deleteTombstoneStats);
+    Map<Short, Map<Short, ContainerStorageStats>> actualContainerStorageStatsMap =
+        blobStoreStats.getContainerStorageStats(referenceTimeInMs);
+    Map<Short, Map<Short, ContainerStorageStats>> expectedContainerStorageStatsMap =
+        getContainerStorageStats(referenceTimeInMs, state.time.milliseconds(), deleteTombstoneStats);
     long totalValidSize = 0L;
 
-    for (Map.Entry<Short, Map<Short, Long>> expectedContainerValidSizeEntry : expectedContainerValidSizeMap.entrySet()) {
-      short accountId = expectedContainerValidSizeEntry.getKey();
-      assertTrue("Expected accountId: " + accountId + " not found", actualContainerValidSizeMap.containsKey(accountId));
-      Map<Short, Long> innerMap = expectedContainerValidSizeEntry.getValue();
-      for (Map.Entry<Short, Long> innerEntry : innerMap.entrySet()) {
+    for (Map.Entry<Short, Map<Short, ContainerStorageStats>> expectedContainerStorageStatsEntry : expectedContainerStorageStatsMap
+        .entrySet()) {
+      short accountId = expectedContainerStorageStatsEntry.getKey();
+      assertTrue("Expected accountId: " + accountId + " not found",
+          actualContainerStorageStatsMap.containsKey(accountId));
+      Map<Short, ContainerStorageStats> innerMap = expectedContainerStorageStatsEntry.getValue();
+      for (Map.Entry<Short, ContainerStorageStats> innerEntry : innerMap.entrySet()) {
         short containerId = innerEntry.getKey();
         assertTrue("Expected containerId: " + containerId + " not found in accountId: " + accountId,
-            innerMap.containsKey(containerId));
-        long expectedContainerValidSize = innerEntry.getValue();
-        long actualContainerValidSize = actualContainerValidSizeMap.get(accountId).get(containerId);
-        assertEquals("Valid data size mismatch for accountId: " + accountId + " containerId: " + containerId,
-            expectedContainerValidSize, actualContainerValidSize);
-        totalValidSize += expectedContainerValidSize;
+            actualContainerStorageStatsMap.get(accountId).containsKey(containerId));
+        ContainerStorageStats expectedContainerStorageStats = innerEntry.getValue();
+        ContainerStorageStats actualContainerStorageStats =
+            actualContainerStorageStatsMap.get(accountId).get(containerId);
+        assertEquals("Storage stats mismatch for accountId: " + accountId + " containerId: " + containerId,
+            expectedContainerStorageStats, actualContainerStorageStats);
+        totalValidSize += expectedContainerStorageStats.getLogicalStorageUsage();
       }
-      if (innerMap.size() != actualContainerValidSizeMap.get(accountId).size()) {
+      if (innerMap.size() != actualContainerStorageStatsMap.get(accountId).size()) {
         // make sure all the new items have value 0
-        for (Map.Entry<Short, Long> actualContainerEntry : actualContainerValidSizeMap.get(accountId).entrySet()) {
+        for (Map.Entry<Short, ContainerStorageStats> actualContainerEntry : actualContainerStorageStatsMap.get(
+            accountId).entrySet()) {
           if (!innerMap.containsKey(actualContainerEntry.getKey())) {
             assertEquals(
                 "Expecting 0 value for account id " + accountId + " and container " + actualContainerEntry.getKey(), 0,
-                actualContainerEntry.getValue().longValue());
+                actualContainerEntry.getValue().getLogicalStorageUsage());
           }
         }
       }
-      actualContainerValidSizeMap.remove(accountId);
+      actualContainerStorageStatsMap.remove(accountId);
     }
-    for (Map.Entry<Short, Map<Short, Long>> actualContainerValidSizeEntry : actualContainerValidSizeMap.entrySet()) {
+    for (Map.Entry<Short, Map<Short, ContainerStorageStats>> actualContainerValidSizeEntry : actualContainerStorageStatsMap
+        .entrySet()) {
       if (actualContainerValidSizeEntry.getValue().size() != 0) {
-        for (Map.Entry<Short, Long> mapEntry : actualContainerValidSizeEntry.getValue().entrySet()) {
+        for (Map.Entry<Short, ContainerStorageStats> mapEntry : actualContainerValidSizeEntry.getValue().entrySet()) {
           assertEquals("Additional values found in actual container valid size map for service "
-              + actualContainerValidSizeEntry.getKey(), 0, mapEntry.getValue().longValue());
+              + actualContainerValidSizeEntry.getKey(), 0, mapEntry.getValue().getLogicalStorageUsage());
         }
       }
     }
@@ -1285,23 +1298,36 @@ public class BlobStoreStatsTest {
    * @param deleteTombstoneStats a hashmap that tracks stats related delete tombstones in log segments.
    * @return a nested {@link Map} of serviceId to containerId to valid data size
    */
-  private Map<Short, Map<Short, Long>> getValidSizeByContainer(long deleteReferenceTimeInMs,
+  private Map<Short, Map<Short, ContainerStorageStats>> getContainerStorageStats(long deleteReferenceTimeInMs,
       long expiryReferenceTimeInMs, Map<String, Pair<AtomicLong, AtomicLong>> deleteTombstoneStats) {
-    Map<Short, Map<Short, Long>> containerValidSizeMap = new HashMap<>();
+    Map<Short, Map<Short, ContainerStorageStats>> containerStorageStats = new HashMap<>();
+    Map<Short, Map<Short, Long>> validSizeMap = new HashMap<>();
+    Map<Short, Map<Short, Long>> physicalSizeMap = new HashMap<>();
+    Map<Short, Map<Short, Set<StoreKey>>> storeKeyMap = new HashMap<>();
     Pair<Set<MockId>, Set<MockId>> expiredDeletes = new Pair<>(new HashSet<>(), new HashSet<>());
     for (Offset indSegStartOffset : state.referenceIndex.keySet()) {
-      List<IndexEntry> validEntries =
-          state.getValidIndexEntriesForIndexSegment(indSegStartOffset, deleteReferenceTimeInMs, expiryReferenceTimeInMs,
-              null, deleteTombstoneStats, expiredDeletes, true);
-      for (IndexEntry indexEntry : validEntries) {
-        IndexValue indexValue = indexEntry.getValue();
-        if (indexValue.isPut()) {
-          StatsUtils.updateNestedMapHelper(containerValidSizeMap, indexValue.getAccountId(),
-              indexValue.getContainerId(), indexValue.getSize());
-        }
+      state.getValidIndexEntriesForIndexSegment(indSegStartOffset, deleteReferenceTimeInMs, expiryReferenceTimeInMs,
+          null, deleteTombstoneStats, expiredDeletes, true, (entry, isValid) -> {
+            IndexValue indexValue = entry.getValue();
+            if (indexValue.isPut() && isValid) {
+              StatsUtils.updateNestedMapHelper(validSizeMap, indexValue.getAccountId(), indexValue.getContainerId(),
+                  indexValue.getSize());
+            }
+            StatsUtils.updateNestedMapHelper(physicalSizeMap, indexValue.getAccountId(), indexValue.getContainerId(),
+                indexValue.getSize());
+            storeKeyMap.computeIfAbsent(indexValue.getAccountId(), k -> new HashMap<>())
+                .computeIfAbsent(indexValue.getContainerId(), k -> new HashSet<>())
+                .add(entry.getKey());
+          });
+    }
+    for (short accountId : validSizeMap.keySet()) {
+      for (short containerId : validSizeMap.get(accountId).keySet()) {
+        containerStorageStats.computeIfAbsent(accountId, k -> new HashMap<>())
+            .put(containerId, new ContainerStorageStats(containerId, validSizeMap.get(accountId).get(containerId),
+                physicalSizeMap.get(accountId).get(containerId), storeKeyMap.get(accountId).get(containerId).size()));
       }
     }
-    return containerValidSizeMap;
+    return containerStorageStats;
   }
 
   private void verifyDeleteTombstoneStats(BlobStoreStats blobStoreStats,

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
@@ -3286,7 +3286,7 @@ public class BlobStoreTest {
     }
 
     @Override
-    public void handleNewPutEntry(IndexValue putValue) {
+    public void handleNewPutEntry(StoreKey key, IndexValue putValue) {
       this.currentValue = putValue;
       this.originalPutValue = null;
       this.previousValue = null;
@@ -3301,7 +3301,7 @@ public class BlobStoreTest {
     }
 
     @Override
-    public void handleNewTtlUpdateEntry(IndexValue ttlUpdateValue, IndexValue originalPutValue) {
+    public void handleNewTtlUpdateEntry(StoreKey key, IndexValue ttlUpdateValue, IndexValue originalPutValue) {
       this.currentValue = ttlUpdateValue;
       this.originalPutValue = originalPutValue;
       this.previousValue = null;

--- a/ambry-store/src/test/java/com/github/ambry/store/CuratedLogIndexState.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CuratedLogIndexState.java
@@ -164,8 +164,8 @@ class CuratedLogIndexState {
     this(isLogSegmented, tempDir, false, true, addTtlUpdates, addUndeletes, false, false);
   }
 
-  CuratedLogIndexState(boolean isLogSegmented, File tempDir, boolean addTtlUpdates, boolean addUndeletes, boolean enableResetKey)
-      throws IOException, StoreException {
+  CuratedLogIndexState(boolean isLogSegmented, File tempDir, boolean addTtlUpdates, boolean addUndeletes,
+      boolean enableResetKey) throws IOException, StoreException {
     this(isLogSegmented, tempDir, false, true, addTtlUpdates, addUndeletes, enableResetKey, false);
   }
 
@@ -187,7 +187,8 @@ class CuratedLogIndexState {
    * @throws StoreException
    */
   CuratedLogIndexState(boolean isLogSegmented, File tempDir, boolean hardDeleteEnabled, boolean initState,
-      boolean addTtlUpdates, boolean addUndeletes, boolean enableResetKey, boolean enableAutoCloseLastLogSegment) throws IOException, StoreException {
+      boolean addTtlUpdates, boolean addUndeletes, boolean enableResetKey, boolean enableAutoCloseLastLogSegment)
+      throws IOException, StoreException {
     this.isLogSegmented = isLogSegmented;
     // advance time here so when we set delete's operation time to 0, it will fall within retention day.
     advanceTime(TimeUnit.HOURS.toMillis(CuratedLogIndexState.deleteRetentionHour));
@@ -897,7 +898,7 @@ class CuratedLogIndexState {
     while (indexSegmentStartOffset != null && indexSegmentStartOffset.getName().equals(segment.getName())) {
       validEntries.addAll(
           getValidIndexEntriesForIndexSegment(indexSegmentStartOffset, deleteReferenceTimeMs, expiryReferenceTimeMs,
-              fileSpanUnderCompaction, deleteTombstoneStats, expiredDeletes, invalidateExpiredDelete));
+              fileSpanUnderCompaction, deleteTombstoneStats, expiredDeletes, invalidateExpiredDelete, null));
       indexSegmentStartOffset = referenceIndex.higherKey(indexSegmentStartOffset);
     }
     return validEntries;
@@ -1590,7 +1591,7 @@ class CuratedLogIndexState {
   List<IndexEntry> getValidIndexEntriesForIndexSegment(Offset indexSegmentStartOffset, long deleteReferenceTimeMs,
       long expiryReferenceTimeMs, FileSpan fileSpanUnderCompaction,
       Map<String, Pair<AtomicLong, AtomicLong>> deleteTombstoneStats, Pair<Set<MockId>, Set<MockId>> expiredDeletes,
-      boolean invalidateExpiredDelete) {
+      boolean invalidateExpiredDelete, BlobStoreStats.IndexEntryAction action) {
     List<IndexEntry> validEntries = new ArrayList<>();
     if (referenceIndex.containsKey(indexSegmentStartOffset)) {
       for (Map.Entry<MockId, TreeSet<IndexValue>> indexSegmentEntry : referenceIndex.get(indexSegmentStartOffset)
@@ -1602,14 +1603,16 @@ class CuratedLogIndexState {
         while (iter.hasNext()) {
           IndexValue currentValue = iter.next();
           IndexEntry currentEntry = new IndexEntry(key, currentValue);
+          boolean isValid = false;
           if (currentValue.isUndelete()) {
             if (latestValue.isUndelete() && latestValue.getLifeVersion() == currentValue.getLifeVersion()) {
               validEntries.add(currentEntry);
+              isValid = true;
             }
           } else if (currentValue.isDelete()) {
             if (latestValue.isDelete() && latestValue.getLifeVersion() == currentValue.getLifeVersion()) {
               // check if this is a delete tombstone left by compaction
-              boolean isValid = true;
+              isValid = true;
               try {
                 if (getExpectedValue(key, true) == null) {
                   if (currentValue.getExpiresAtMs() == Utils.Infinite_Time || currentValue.isTtlUpdate()) {
@@ -1640,31 +1643,38 @@ class CuratedLogIndexState {
             }
           } else if (currentValue.isTtlUpdate()) {
             IndexValue putValue = getExpectedValue(key, EnumSet.of(PersistentIndex.IndexEntryType.PUT), null);
-            if (putValue == null) {
-              continue;
-            }
-            if (latestValue.isDelete()) {
-              if (latestValue.getOperationTimeInMs() >= deleteReferenceTimeMs
-                  || isTtlUpdateEntryValidWhenFinalStateIsDeleteAndRetention(key, currentValue,
-                  fileSpanUnderCompaction)) {
+            if (putValue != null) {
+              if (latestValue.isDelete()) {
+                if (latestValue.getOperationTimeInMs() >= deleteReferenceTimeMs
+                    || isTtlUpdateEntryValidWhenFinalStateIsDeleteAndRetention(key, currentValue,
+                    fileSpanUnderCompaction)) {
+                  validEntries.add(currentEntry);
+                  isValid = true;
+                }
+              } else {
                 validEntries.add(currentEntry);
+                isValid = true;
               }
-            } else {
-              validEntries.add(currentEntry);
             }
           } else {
             // current index value is PUT
             if (!isExpiredAt(key, expiryReferenceTimeMs)) {
               if (latestValue.isPut()) {
-                validEntries.add(new IndexEntry(key, currentValue));
+                validEntries.add(currentEntry);
+                isValid = true;
               } else if (latestValue.isDelete()) {
                 if (latestValue.getOperationTimeInMs() >= deleteReferenceTimeMs) {
                   validEntries.add(currentEntry);
+                  isValid = true;
                 }
               } else {
                 validEntries.add(currentEntry);
+                isValid = true;
               }
             }
+          }
+          if (action != null) {
+            action.accept(currentEntry, isValid);
           }
         }
       }

--- a/ambry-store/src/test/java/com/github/ambry/store/CuratedLogIndexState.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CuratedLogIndexState.java
@@ -1643,18 +1643,19 @@ class CuratedLogIndexState {
             }
           } else if (currentValue.isTtlUpdate()) {
             IndexValue putValue = getExpectedValue(key, EnumSet.of(PersistentIndex.IndexEntryType.PUT), null);
-            if (putValue != null) {
-              if (latestValue.isDelete()) {
-                if (latestValue.getOperationTimeInMs() >= deleteReferenceTimeMs
-                    || isTtlUpdateEntryValidWhenFinalStateIsDeleteAndRetention(key, currentValue,
-                    fileSpanUnderCompaction)) {
-                  validEntries.add(currentEntry);
-                  isValid = true;
-                }
-              } else {
+            if (putValue == null) {
+              continue;
+            }
+            if (latestValue.isDelete()) {
+              if (latestValue.getOperationTimeInMs() >= deleteReferenceTimeMs
+                  || isTtlUpdateEntryValidWhenFinalStateIsDeleteAndRetention(key, currentValue,
+                  fileSpanUnderCompaction)) {
                 validEntries.add(currentEntry);
                 isValid = true;
               }
+            } else {
+              validEntries.add(currentEntry);
+              isValid = true;
             }
           } else {
             // current index value is PUT


### PR DESCRIPTION
Add physical storage usage and number of blobs in the BlobStoreStats.

We don't return these two new info right now, since we don't want to change the interface. But this PR would expose them in the test cases so we can test them.

Also adding this to the ScanResult in the BlobStoreStats.