### PR TITLE
Revert "Add new columns to container storage stats tables (#1943)"

### DIFF
--- a/ambry-mysql/src/integration-test/java/com/github/ambry/accountstats/PartitionClassReportsDaoTest.java
+++ b/ambry-mysql/src/integration-test/java/com/github/ambry/accountstats/PartitionClassReportsDaoTest.java
@@ -159,12 +159,12 @@ public class PartitionClassReportsDaoTest {
     dao.insertPartitionClassName(clusterName1, className1);
 
     final Map<String, Map<Short, Map<Short, Long>>> usagesInDB = new HashMap<>();
-    final Map<String, Map<Short, Map<Short, Long>>> physicalUsagesInDB = new HashMap<>();
-    dao.queryAggregatedPartitionClassReport(clusterName, (partitionClassName, accountId, containerStats, updatedAt) -> {
-      usagesInDB.computeIfAbsent(partitionClassName, k -> new HashMap<>())
-          .computeIfAbsent(accountId, k -> new HashMap<>())
-          .put(containerStats.getContainerId(), containerStats.getLogicalStorageUsage());
-    });
+    dao.queryAggregatedPartitionClassReport(clusterName,
+        (partitionClassName, accountId, containerId, storageUsage, updatedAt) -> {
+          usagesInDB.computeIfAbsent(partitionClassName, k -> new HashMap<>())
+              .computeIfAbsent(accountId, k -> new HashMap<>())
+              .put(containerId, storageUsage);
+        });
     assertTrue(usagesInDB.isEmpty());
 
     final int numAccount = 100;
@@ -195,17 +195,13 @@ public class PartitionClassReportsDaoTest {
       }
       batch.flush();
       dao.queryAggregatedPartitionClassReport(clusterName,
-          (partitionClassName, accountId, containerStats, updatedAt) -> {
+          (partitionClassName, accountId, containerId, storageUsage, updatedAt) -> {
             usagesInDB.computeIfAbsent(partitionClassName, k -> new HashMap<>())
                 .computeIfAbsent(accountId, k -> new HashMap<>())
-                .put(containerStats.getContainerId(), containerStats.getLogicalStorageUsage());
-            physicalUsagesInDB.computeIfAbsent(partitionClassName, k -> new HashMap<>())
-                .computeIfAbsent(accountId, k -> new HashMap<>())
-                .put(containerStats.getContainerId(), containerStats.getPhysicalStorageUsage());
+                .put(containerId, storageUsage);
           });
 
       assertEquals(classNameAccountContainerUsages, usagesInDB);
-      assertEquals(classNameAccountContainerUsages, physicalUsagesInDB);
     }
   }
 

--- a/ambry-mysql/src/main/java/com/github/ambry/accountstats/AccountReportsDao.java
+++ b/ambry-mysql/src/main/java/com/github/ambry/accountstats/AccountReportsDao.java
@@ -15,7 +15,6 @@ package com.github.ambry.accountstats;
 
 import com.github.ambry.mysql.BatchUpdater;
 import com.github.ambry.mysql.MySqlMetrics;
-import com.github.ambry.server.storagestats.ContainerStorageStats;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -37,21 +36,17 @@ public class AccountReportsDao {
   public static final String ACCOUNT_ID_COLUMN = "accountId";
   public static final String CONTAINER_ID_COLUMN = "containerId";
   public static final String STORAGE_USAGE_COLUMN = "storageUsage";
-  public static final String PHYSICAL_STORAGE_USAGE_COLUMN = "physicalStorageUsage";
-  public static final String NUMBER_OF_BLOBS_COLUMN = "numberOfBlobs";
   public static final String UPDATED_AT_COLUMN = "updatedAt";
 
   private static final Logger logger = LoggerFactory.getLogger(AccountReportsDao.class);
   private static final String insertSql = String.format(
-      "INSERT INTO %s (%s, %s, %s, %s, %s, %s, %s, %s, %s) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NOW()) ON DUPLICATE KEY UPDATE %s=?, %s=?, %s=?, %s=NOW()",
+      "INSERT INTO %s (%s, %s, %s, %s, %s, %s, %s) VALUES (?, ?, ?, ?, ?, ?, NOW()) ON DUPLICATE KEY UPDATE %s=?, %s=NOW()",
       ACCOUNT_REPORTS_TABLE, CLUSTER_NAME_COLUMN, HOSTNAME_COLUMN, PARTITION_ID_COLUMN, ACCOUNT_ID_COLUMN,
-      CONTAINER_ID_COLUMN, STORAGE_USAGE_COLUMN, PHYSICAL_STORAGE_USAGE_COLUMN, NUMBER_OF_BLOBS_COLUMN,
-      UPDATED_AT_COLUMN, STORAGE_USAGE_COLUMN, PHYSICAL_STORAGE_USAGE_COLUMN, NUMBER_OF_BLOBS_COLUMN,
-      UPDATED_AT_COLUMN);
+      CONTAINER_ID_COLUMN, STORAGE_USAGE_COLUMN, UPDATED_AT_COLUMN, STORAGE_USAGE_COLUMN, UPDATED_AT_COLUMN);
   private static final String querySqlForClusterAndHost =
-      String.format("SELECT %s, %s, %s, %s, %s, %s, %s FROM %s WHERE %s = ? AND %s = ?", PARTITION_ID_COLUMN,
-          ACCOUNT_ID_COLUMN, CONTAINER_ID_COLUMN, STORAGE_USAGE_COLUMN, PHYSICAL_STORAGE_USAGE_COLUMN,
-          NUMBER_OF_BLOBS_COLUMN, UPDATED_AT_COLUMN, ACCOUNT_REPORTS_TABLE, CLUSTER_NAME_COLUMN, HOSTNAME_COLUMN);
+      String.format("SELECT %s, %s, %s, %s, %s FROM %s WHERE %s = ? AND %s = ?", PARTITION_ID_COLUMN, ACCOUNT_ID_COLUMN,
+          CONTAINER_ID_COLUMN, STORAGE_USAGE_COLUMN, UPDATED_AT_COLUMN, ACCOUNT_REPORTS_TABLE, CLUSTER_NAME_COLUMN,
+          HOSTNAME_COLUMN);
   private static final String deletePartitionSql =
       String.format("DELETE FROM %s WHERE %s=? AND %s=? AND %s=?", ACCOUNT_REPORTS_TABLE, CLUSTER_NAME_COLUMN,
           HOSTNAME_COLUMN, PARTITION_ID_COLUMN);
@@ -85,9 +80,6 @@ public class AccountReportsDao {
    */
   void updateStorageUsage(String clusterName, String hostname, int partitionId, short accountId, short containerId,
       long storageUsage) throws SQLException {
-    // TODO: adding real physical storage usage and number of blobs here
-    long physicalStorageUsage = storageUsage;
-    long numberOfBlobs = 1L;
     try (Connection connection = dataSource.getConnection()) {
       try (PreparedStatement insertStatement = connection.prepareStatement(insertSql)) {
         long startTimeMs = System.currentTimeMillis();
@@ -99,11 +91,7 @@ public class AccountReportsDao {
         insertStatement.setInt(4, accountId);
         insertStatement.setInt(5, containerId);
         insertStatement.setLong(6, storageUsage);
-        insertStatement.setLong(7, physicalStorageUsage);
-        insertStatement.setLong(8, numberOfBlobs);
-        insertStatement.setLong(9, storageUsage);
-        insertStatement.setLong(10, physicalStorageUsage);
-        insertStatement.setLong(11, numberOfBlobs);
+        insertStatement.setLong(7, storageUsage);
         insertStatement.executeUpdate();
         metrics.writeTimeMs.update(System.currentTimeMillis() - startTimeMs);
         metrics.writeSuccessCount.inc();
@@ -118,14 +106,13 @@ public class AccountReportsDao {
 
   /**
    * Query container storage usage for given {@code clusterName} and {@code hostname}. The result will be applied to the
-   * {@link ContainerStorageStatsFunction}.
+   * {@link ContainerUsageFunction}.
    * @param clusterName The clusterName.
    * @param hostname The hostname.
-   * @param func The {@link ContainerStorageStatsFunction} to call to process each container storage usage.
+   * @param func The {@link ContainerUsageFunction} to call to process each container storage usage.
    * @throws SQLException
    */
-  void queryStorageUsageForHost(String clusterName, String hostname, ContainerStorageStatsFunction func)
-      throws SQLException {
+  void queryStorageUsageForHost(String clusterName, String hostname, ContainerUsageFunction func) throws SQLException {
     try (Connection connection = dataSource.getConnection()) {
       try (PreparedStatement queryStatement = connection.prepareStatement(querySqlForClusterAndHost)) {
         long startTimeMs = System.currentTimeMillis();
@@ -137,12 +124,8 @@ public class AccountReportsDao {
             int accountId = resultSet.getInt(ACCOUNT_ID_COLUMN);
             int containerId = resultSet.getInt(CONTAINER_ID_COLUMN);
             long storageUsage = resultSet.getLong(STORAGE_USAGE_COLUMN);
-            long physicalStorageUsage = resultSet.getLong(PHYSICAL_STORAGE_USAGE_COLUMN);
-            long numberOfBlobs = resultSet.getLong(NUMBER_OF_BLOBS_COLUMN);
             long updatedAtMs = resultSet.getTimestamp(UPDATED_AT_COLUMN).getTime();
-            func.apply(partitionId, (short) accountId,
-                new ContainerStorageStats((short) containerId, storageUsage, physicalStorageUsage, numberOfBlobs),
-                updatedAtMs);
+            func.apply(partitionId, (short) accountId, (short) containerId, storageUsage, updatedAtMs);
           }
         }
         metrics.readTimeMs.update(System.currentTimeMillis() - startTimeMs);
@@ -269,9 +252,6 @@ public class AccountReportsDao {
      */
     public void addUpdateToBatch(String clusterName, String hostname, int partitionId, short accountId,
         short containerId, long storageUsage) throws SQLException {
-      // TODO: adding real physical storage usage and number of blobs here
-      long physicalStorageUsage = storageUsage;
-      long numberOfBlobs = 1L;
       addUpdateToBatch(statement -> {
         statement.setString(1, clusterName);
         statement.setString(2, hostname);
@@ -279,11 +259,7 @@ public class AccountReportsDao {
         statement.setInt(4, accountId);
         statement.setInt(5, containerId);
         statement.setLong(6, storageUsage);
-        statement.setLong(7, physicalStorageUsage);
-        statement.setLong(8, numberOfBlobs);
-        statement.setLong(9, storageUsage);
-        statement.setLong(10, physicalStorageUsage);
-        statement.setLong(11, numberOfBlobs);
+        statement.setLong(7, storageUsage);
       });
     }
   }

--- a/ambry-mysql/src/main/java/com/github/ambry/accountstats/AggregatedContainerUsageFunction.java
+++ b/ambry-mysql/src/main/java/com/github/ambry/accountstats/AggregatedContainerUsageFunction.java
@@ -13,18 +13,7 @@
  */
 package com.github.ambry.accountstats;
 
-import com.github.ambry.server.storagestats.ContainerStorageStats;
-
-
-/**
- * A callback function to call when processing aggregated container storage stats.
- */
 @FunctionalInterface
-public interface AggregatedContainerStorageStatsFunction {
-  /**
-   * Process container storage usage.
-   * @param accountId The account id.
-   * @param containerStats The {@link ContainerStorageStats}
-   */
-  void apply(short accountId, ContainerStorageStats containerStats);
+public interface AggregatedContainerUsageFunction {
+  void apply(short accountId, short containerId, long storageUsage);
 }

--- a/ambry-mysql/src/main/java/com/github/ambry/accountstats/ContainerUsageFunction.java
+++ b/ambry-mysql/src/main/java/com/github/ambry/accountstats/ContainerUsageFunction.java
@@ -13,21 +13,19 @@
  */
 package com.github.ambry.accountstats;
 
-import com.github.ambry.server.storagestats.ContainerStorageStats;
-
-
 /**
- * A callback function to call when processing container storage stats.
+ * A callback function to call when processing container storage usage.
  */
 @FunctionalInterface
-public interface ContainerStorageStatsFunction {
+public interface ContainerUsageFunction {
 
   /**
-   * Process container storage stats.
+   * Process container storage usage.
    * @param partitionId The partition id.
    * @param accountId The account id.
-   * @param containerStats The {@link ContainerStorageStats}
+   * @param containerId The container id.
+   * @param storageUsage The storage usage in bytes for this container.
    * @param updatedAtMs The timestamp in milliseconds when this data is updated.
    */
-  void apply(int partitionId, short accountId, ContainerStorageStats containerStats, long updatedAtMs);
+  void apply(int partitionId, short accountId, short containerId, long storageUsage, long updatedAtMs);
 }

--- a/ambry-mysql/src/main/java/com/github/ambry/accountstats/PartitionClassContainerUsageFunction.java
+++ b/ambry-mysql/src/main/java/com/github/ambry/accountstats/PartitionClassContainerUsageFunction.java
@@ -13,21 +13,19 @@
  */
 package com.github.ambry.accountstats;
 
-import com.github.ambry.server.storagestats.ContainerStorageStats;
-
-
 /**
- * A callback function to call when processing aggregated partition class container storage stats.
+ * A callback function to call when processing aggregated partition class container usage.
  */
 @FunctionalInterface
-public interface PartitionClassContainerStorageStatsFunction {
+public interface PartitionClassContainerUsageFunction {
 
   /**
-   * Process aggregated partition class container storage stats.
+   * Process aggregated partition class container usage.
    * @param partitionClassName The partition class name
-   * @param accountId The account id
-   * @param containerStats The {@link ContainerStorageStats}
-   * @param updatedAt The updated at time in milliseconds
+   * @param accountId the account id
+   * @param containerId the container id
+   * @param storageUsage the storage usage
+   * @param updatedAt the updated at time in milliseconds
    */
-  void apply(String partitionClassName, short accountId, ContainerStorageStats containerStats, long updatedAt);
+  void apply(String partitionClassName, short accountId, short containerId, long storageUsage, long updatedAt);
 }

--- a/ambry-mysql/src/main/java/com/github/ambry/accountstats/PartitionClassReportsDao.java
+++ b/ambry-mysql/src/main/java/com/github/ambry/accountstats/PartitionClassReportsDao.java
@@ -15,7 +15,6 @@ package com.github.ambry.accountstats;
 
 import com.github.ambry.mysql.BatchUpdater;
 import com.github.ambry.mysql.MySqlMetrics;
-import com.github.ambry.server.storagestats.ContainerStorageStats;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -47,8 +46,6 @@ public class PartitionClassReportsDao {
   private static final String ACCOUNT_ID_COLUMN = "accountId";
   private static final String CONTAINER_ID_COLUMN = "containerId";
   private static final String STORAGE_USAGE_COLUMN = "storageUsage";
-  private static final String PHYSICAL_STORAGE_USAGE_COLUMN = "physicalStorageUsage";
-  private static final String NUMBER_OF_BLOBS_COLUMN = "numberOfBlobs";
   private static final String UPDATED_AT_COLUMN = "updatedAt";
 
   /**
@@ -91,17 +88,15 @@ public class PartitionClassReportsDao {
 
   /**
    * eg: INSERT INTO AggregatedPartitionClassReports
-   *     SELECT id, 101, 201, 12345, 23456, 321, NOW()
+   *     SELECT id, 101, 201, 12345, NOW()
    *     FROM PartitionClassNames WHERE clusterName = "ambry-test" AND name = "default"
-   *     ON DUPLICATE KEY UPDATE storageUsage=12345, physicalStorageUsage=23456, numberOfBlobs=321, updatedAt=NOW();
-   *  101 is the account id, 201 is the container id, 12345 is the storage usage, 23456 is the physical storage usage, 321 is the number of blobs.
+   *     ON DUPLICATE KEY UPDATE storageUsage=12345, updatedAt=NOW();
+   *  101 is the account id, 201 is the container id, 12345 is the storage usage.
    */
   private static final String insertAggregatedSql = String.format(
-      "INSERT INTO %s (%s, %s, %s, %s, %s, %s, %s) SELECT %s, ?, ?, ?, ?, ?, NOW() FROM %s WHERE %s=? AND %s=? ON DUPLICATE KEY UPDATE %s=?, %s=?, %s=?, %s=NOW()",
-      AGGREGATED_PARTITION_CLASS_REPORTS_TABLE, PARTITION_CLASS_ID_COLUMN, ACCOUNT_ID_COLUMN, CONTAINER_ID_COLUMN,
-      STORAGE_USAGE_COLUMN, PHYSICAL_STORAGE_USAGE_COLUMN, NUMBER_OF_BLOBS_COLUMN, UPDATED_AT_COLUMN, ID_COLUMN,
-      PARTITION_CLASS_NAMES_TABLE, CLUSTER_NAME_COLUMN, NAME_COLUMN, STORAGE_USAGE_COLUMN,
-      PHYSICAL_STORAGE_USAGE_COLUMN, NUMBER_OF_BLOBS_COLUMN, UPDATED_AT_COLUMN);
+      "INSERT INTO %s SELECT %s, ?, ?, ?, NOW() FROM %s WHERE %s=? AND %s=? ON DUPLICATE KEY UPDATE %s=?, %s=NOW()",
+      AGGREGATED_PARTITION_CLASS_REPORTS_TABLE, ID_COLUMN, PARTITION_CLASS_NAMES_TABLE, CLUSTER_NAME_COLUMN,
+      NAME_COLUMN, STORAGE_USAGE_COLUMN, UPDATED_AT_COLUMN);
 
   /**
    * eg : DELETE FROM AggregatedPartitionClassReports
@@ -116,18 +111,17 @@ public class PartitionClassReportsDao {
           CLUSTER_NAME_COLUMN, NAME_COLUMN, ACCOUNT_ID_COLUMN, CONTAINER_ID_COLUMN);
 
   /**
-   * eg: SELECT TableA.name, accountId, containerId, storageUsage, physicalStorageUsage, numberOfBlobs, updatedAt
+   * eg: SELECT TableA.name, accountId, containerId, storageUsage, updatedAt
    *     FROM AggregatedPartitionClassReport INNER JOIN (
    *         SELECT * FROM PartitionClassNames WHERE clusterName="ambry-test"
    *     ) TableA
    *     WHERE TableA.id = AggregatedPartitionClassReports.partitionClassId;
    */
   private static final String queryAggregatedSql = String.format(
-      "SELECT TableA.%s, %s, %s, %s, %s, %s, %s FROM %s " + "INNER JOIN (SELECT * FROM %s WHERE %s = ?) TableA"
+      "SELECT TableA.%s, %s, %s, %s, %s FROM %s " + "INNER JOIN (SELECT * FROM %s WHERE %s = ?) TableA"
           + " WHERE TableA.%s = %s.%s;", NAME_COLUMN, ACCOUNT_ID_COLUMN, CONTAINER_ID_COLUMN, STORAGE_USAGE_COLUMN,
-      PHYSICAL_STORAGE_USAGE_COLUMN, NUMBER_OF_BLOBS_COLUMN, UPDATED_AT_COLUMN,
-      AGGREGATED_PARTITION_CLASS_REPORTS_TABLE, PARTITION_CLASS_NAMES_TABLE, CLUSTER_NAME_COLUMN, ID_COLUMN,
-      AGGREGATED_PARTITION_CLASS_REPORTS_TABLE, PARTITION_CLASS_ID_COLUMN);
+      UPDATED_AT_COLUMN, AGGREGATED_PARTITION_CLASS_REPORTS_TABLE, PARTITION_CLASS_NAMES_TABLE, CLUSTER_NAME_COLUMN,
+      ID_COLUMN, AGGREGATED_PARTITION_CLASS_REPORTS_TABLE, PARTITION_CLASS_ID_COLUMN);
 
   private final DataSource dataSource;
   private final MySqlMetrics metrics;
@@ -137,7 +131,7 @@ public class PartitionClassReportsDao {
    * @param dataSource The {@link DataSource}.
    * @param metrics The {@link MySqlMetrics}.
    */
-  PartitionClassReportsDao(DataSource dataSource, MySqlMetrics metrics) {
+  PartitionClassReportsDao(DataSource  dataSource, MySqlMetrics metrics) {
     this.dataSource = Objects.requireNonNull(dataSource, "DataSource is empty");
     this.metrics = Objects.requireNonNull(metrics, "MySqlMetrics is empty");
   }
@@ -293,12 +287,12 @@ public class PartitionClassReportsDao {
 
   /**
    * Query container storage usage for given {@code clusterName}. This usage is aggregated under each partition class name.
-   * The results will be applied to the given {@link PartitionClassContainerStorageStatsFunction}.
+   * The results will be applied to the given {@link PartitionClassContainerUsageFunction}.
    * @param clusterName The clusterName.
    * @param func The callback to apply query results
    * @throws SQLException
    */
-  void queryAggregatedPartitionClassReport(String clusterName, PartitionClassContainerStorageStatsFunction func)
+  void queryAggregatedPartitionClassReport(String clusterName, PartitionClassContainerUsageFunction func)
       throws SQLException {
     try (Connection connection = dataSource.getConnection()) {
       try (PreparedStatement queryStatement = connection.prepareStatement(queryAggregatedSql)) {
@@ -307,14 +301,11 @@ public class PartitionClassReportsDao {
         try (ResultSet rs = queryStatement.executeQuery()) {
           while (rs.next()) {
             String partitionClassName = rs.getString(1);
-            int accountId = rs.getInt(ACCOUNT_ID_COLUMN);
-            int containerId = rs.getInt(CONTAINER_ID_COLUMN);
-            long usage = rs.getLong(STORAGE_USAGE_COLUMN);
-            long physicalStorageUsage = rs.getLong(PHYSICAL_STORAGE_USAGE_COLUMN);
-            long numberOfBlobs = rs.getLong(NUMBER_OF_BLOBS_COLUMN);
-            long updatedAt = rs.getTimestamp(UPDATED_AT_COLUMN).getTime();
-            func.apply(partitionClassName, (short) accountId,
-                new ContainerStorageStats((short) containerId, usage, physicalStorageUsage, numberOfBlobs), updatedAt);
+            int accountId = rs.getInt(2);
+            int containerId = rs.getInt(3);
+            long usage = rs.getLong(4);
+            long updatedAt = rs.getTimestamp(5).getTime();
+            func.apply(partitionClassName, (short) accountId, (short) containerId, usage, updatedAt);
           }
         }
         metrics.readTimeMs.update(System.currentTimeMillis() - startTimeMs);
@@ -382,20 +373,13 @@ public class PartitionClassReportsDao {
      */
     public void addUpdateToBatch(String clusterName, String partitionClassName, short accountId, short containerId,
         long usage) throws SQLException {
-      // TODO: adding real physical storage usage and number of blobs here
-      long physicalStorageUsage = usage;
-      long numberOfBlobs = 1;
       addUpdateToBatch(statement -> {
         statement.setInt(1, accountId);
         statement.setInt(2, containerId);
         statement.setLong(3, usage);
-        statement.setLong(4, physicalStorageUsage);
-        statement.setLong(5, numberOfBlobs);
-        statement.setString(6, clusterName);
-        statement.setString(7, partitionClassName);
-        statement.setLong(8, usage);
-        statement.setLong(9, physicalStorageUsage);
-        statement.setLong(10, numberOfBlobs);
+        statement.setString(4, clusterName);
+        statement.setString(5, partitionClassName);
+        statement.setLong(6, usage);
       });
     }
   }

--- a/ambry-mysql/src/main/resources/AmbryContainerStorageStats.ddl
+++ b/ambry-mysql/src/main/resources/AmbryContainerStorageStats.ddl
@@ -19,15 +19,13 @@
  */
 CREATE TABLE IF NOT EXISTS AccountReports
 (
-    clusterName          VARCHAR(25) NOT NULL,
-    hostname             VARCHAR(30) NOT NULL,
-    partitionId          INT         NOT NULL,
-    accountId            INT         NOT NULL,
-    containerId          INT         NOT NULL,
-    storageUsage         BIGINT      NOT NULL, /* logical storage usage */
-    physicalStorageUsage BIGINT      NOT NULL, /* physical storage usage */
-    numberOfBlobs        BIGINT      NOT NULL, /* number of blobs, include blobs at all states, even for compaction */
-    updatedAt            TIMESTAMP   NOT NULL,
+    clusterName  VARCHAR(25) NOT NULL,
+    hostname     VARCHAR(30) NOT NULL,
+    partitionId  INT         NOT NULL,
+    accountId    INT         NOT NULL,
+    containerId  INT         NOT NULL,
+    storageUsage BIGINT      NOT NULL,
+    updatedAt    TIMESTAMP   NOT NULL,
 
     PRIMARY KEY (clusterName, hostname, partitionId, accountId, containerId),
     INDEX updatedAtIndex (updatedAt)
@@ -36,27 +34,16 @@ CREATE TABLE IF NOT EXISTS AccountReports
     COLLATE utf8_bin;
 
 /**
-  We have to add physicalStorageUsage and numberOfBlobs to the existing AccountReports table.
-  We would like to set physicalStorageUsage's value to be the same as storageUsage and the numberOfBlobs to be 0
-
-  ALTER TABLE AccountReports ADD numberOfBlobs BIGINT NOT NULL DEFAULT 0;
-  ALTER TABLE AccountReports ADD physicalStorageUsage BIGINT NOT NULL DEFAULT 0;
-  Update AccountReports SET physicalStorageUsage = storageUsage;
-*/
-
-/**
  * This table is created to store aggregated account storage usage. An aggregation task will be activated to read all
  * the container storage usages from table AcountReports and generate an aggregated stats and write it back to this table.
  */
 CREATE TABLE IF NOT EXISTS AggregatedAccountReports
 (
-    clusterName          VARCHAR(25) NOT NULL,
-    accountId            INT         NOT NULL,
-    containerId          INT         NOT NULL,
-    storageUsage         BIGINT      NOT NULL, /* logical storage usage */
-    physicalStorageUsage BIGINT      NOT NULL, /* physical storage usage */
-    numberOfBlobs        BIGINT      NOT NULL,
-    updatedAt            TIMESTAMP   NOT NULL,
+    clusterName  VARCHAR(25) NOT NULL,
+    accountId    INT         NOT NULL,
+    containerId  INT         NOT NULL,
+    storageUsage BIGINT      NOT NULL,
+    updatedAt    TIMESTAMP   NOT NULL,
 
     PRIMARY KEY (clusterName, accountId, containerId)
 )
@@ -64,25 +51,11 @@ CREATE TABLE IF NOT EXISTS AggregatedAccountReports
     COLLATE utf8_bin;
 
 /**
-  We have to add physicalStorageUsage and numberOfBlobs to the existing AggregatedAccountReports table.
-  We would like to set physicalStorageUsage's value to be the same as storageUsage and the numberOfBlobs to be 0
-
-  ALTER TABLE AggregatedAccountReports ADD numberOfBlobs BIGINT NOT NULL DEFAULT 0;
-  ALTER TABLE AggregatedAccountReports ADD physicalStorageUsage BIGINT NOT NULL DEFAULT 0;
-  Update AggregatedAccountReports SET physicalStorageUsage = storageUsage;
- */
-
-/**
  * This table is created to keep a copy of aggregated container storage usage from table AggregatedAccountReports at the
  * beginning of each month. The schema of this table is the same as table AggregatedAccountReports. The data is directly
  * copied it every month.
  */
 CREATE TABLE IF NOT EXISTS MonthlyAggregatedAccountReports LIKE AggregatedAccountReports;
-/**
-  ALTER TABLE MonthlyAggregatedAccountReports ADD numberOfBlobs BIGINT NOT NULL DEFAULT 0;
-  ALTER TABLE MonthlyAggregatedAccountReports ADD physicalStorageUsage BIGINT NOT NULL DEFAULT 0;
-  Update MonthlyAggregatedAccountReports SET physicalStorageUsage = storageUsage;
- */
 
 /**
  * This table is created to record when the data in table MonthlyAggregatedAccountReports is copied.
@@ -136,24 +109,13 @@ CREATE TABLE IF NOT EXISTS Partitions
  */
 CREATE TABLE IF NOT EXISTS AggregatedPartitionClassReports
 (
-    partitionClassId     SMALLINT  NOT NULL,
-    accountId            INT       NOT NULL,
-    containerId          INT       NOT NULL,
-    storageUsage         BIGINT    NOT NULL,
-    physicalStorageUsage BIGINT    NOT NULL, /* physical storage usage */
-    numberOfBlobs        BIGINT    NOT NULL,
-    updatedAt            TIMESTAMP NOT NULL,
+    partitionClassId SMALLINT  NOT NULL,
+    accountId        INT       NOT NULL,
+    containerId      INT       NOT NULL,
+    storageUsage     BIGINT    NOT NULL,
+    updatedAt        TIMESTAMP NOT NULL,
 
     PRIMARY KEY (partitionClassId, accountId, containerId)
 )
     CHARACTER SET utf8
     COLLATE utf8_bin;
-
-/**
-  We have to add physicalStorageUsage and numberOfBlobs to the existing AggregatedPartitionClassReports table.
-  We would like to set physicalStorageUsage's value to be the same as storageUsage and the numberOfBlobs to be 0
-
-  ALTER TABLE AggregatedPartitionClassReports ADD numberOfBlobs BIGINT NOT NULL DEFAULT 0;
-  ALTER TABLE AggregatedPartitionClassReports ADD physicalStorageUsage BIGINT NOT NULL DEFAULT 0;
-  Update AggregatedPartitionClassReports SET physicalStorageUsage = storageUsage;
- */

--- a/ambry-mysql/src/test/java/com/github/ambry/accountstats/AccountReportsDaoTest.java
+++ b/ambry-mysql/src/test/java/com/github/ambry/accountstats/AccountReportsDaoTest.java
@@ -63,8 +63,6 @@ public class AccountReportsDaoTest {
     when(mockResultSet.getInt(eq(AccountReportsDao.ACCOUNT_ID_COLUMN))).thenReturn(queryAccountId);
     when(mockResultSet.getInt(eq(AccountReportsDao.CONTAINER_ID_COLUMN))).thenReturn(queryContainerId);
     when(mockResultSet.getLong(eq(AccountReportsDao.STORAGE_USAGE_COLUMN))).thenReturn(queryStorageUsage);
-    when(mockResultSet.getLong(eq(AccountReportsDao.PHYSICAL_STORAGE_USAGE_COLUMN))).thenReturn(queryStorageUsage);
-    when(mockResultSet.getLong(eq(AccountReportsDao.NUMBER_OF_BLOBS_COLUMN))).thenReturn(1L);
     when(mockResultSet.getTimestamp(eq(AccountReportsDao.UPDATED_AT_COLUMN))).thenReturn(
         new Timestamp(SystemTime.getInstance().milliseconds()));
     when(mockQueryStatement.executeQuery()).thenReturn(mockResultSet);
@@ -116,13 +114,11 @@ public class AccountReportsDaoTest {
   @Test
   public void testQueryStorageUsageForHost() throws Exception {
     accountReportsDao.queryStorageUsageForHost(clusterName, hostname,
-        (partitionId, accountId, containerStats, updatedAt) -> {
+        (partitionId, accountId, containerId, storageUsage, updatedAt) -> {
           assertEquals("Partition id mismatch", queryPartitionId, partitionId);
           assertEquals("Account id mismatch", queryAccountId, accountId);
-          assertEquals("Container id mismatch", queryContainerId, containerStats.getContainerId());
-          assertEquals("Storage usage mismatch", queryStorageUsage, containerStats.getLogicalStorageUsage());
-          assertEquals("Physical storage usage mismatch", queryStorageUsage, containerStats.getPhysicalStorageUsage());
-          assertEquals("Number of blobs mismatch", 1L, containerStats.getNumberOfBlobs());
+          assertEquals("Container id mismatch", queryContainerId, containerId);
+          assertEquals("Storage usage mismatch", queryStorageUsage, storageUsage);
         });
     verify(mockConnection).prepareStatement(anyString());
     assertEquals("Read success count should be 1", 1, metrics.readSuccessCount.getCount());

--- a/ambry-test-utils/src/main/java/com/github/ambry/utils/TestUtils.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/utils/TestUtils.java
@@ -588,7 +588,7 @@ public class TestUtils {
       for (int ia = 0; ia < numAccount; ia++) {
         for (int ic = 0; ic < numContainer; ic++) {
           String key = Utils.partitionClassStatsAccountContainerKey((short) ia, (short) ic);
-          classNameStats.getSubMap().put(key, new StatsSnapshot(Math.abs(random.nextLong() % maxValue), null));
+          classNameStats.getSubMap().put(key, new StatsSnapshot(random.nextLong() % maxValue, null));
         }
       }
       long classNameValue = classNameStats.getSubMap().values().stream().mapToLong(StatsSnapshot::getValue).sum();


### PR DESCRIPTION
This reverts commit bb9a4effc7303b30f9d47951349baff8c8f038e8.

Found a place where the current code is not forward compatible with the new schema update. I have to publish a new PR to fix that. And only after we can then revert this revert.