### PR TITLE
Server certificate validation

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/Http2ClientConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/Http2ClientConfig.java
@@ -36,6 +36,7 @@ public class Http2ClientConfig {
   public static final String HTTP2_BLOCKING_CHANNEL_RECEIVE_TIMEOUT_MS = "http2.blocking.channel.receive.timeout.ms";
   public static final String HTTP2_BLOCKING_CHANNEL_POOL_SHUTDOWN_TIMEOUT_MS =
       "http2.blocking.channel.pool.shutdown.timeout.ms";
+  public static final String HTTP2_PEER_CERTIFICATE_SAN_REGEX = "http2.peer.certificate.san.regex";
 
   /**
    * HTTP/2 connection idle time before we close it. -1 means no idle close.
@@ -150,6 +151,13 @@ public class Http2ClientConfig {
   @Default("3000")
   public final int http2BlockingChannelPoolShutdownTimeoutMs;
 
+  /**
+   * The expected subject alternative name within the server SSL certificate
+   */
+  @Config(HTTP2_PEER_CERTIFICATE_SAN_REGEX)
+  @Default("")
+  public final String http2PeerCertificateSanRegex;
+
   public Http2ClientConfig(VerifiableProperties verifiableProperties) {
     idleConnectionTimeoutMs = verifiableProperties.getLong(HTTP2_IDLE_CONNECTION_TIMEOUT_MS, -1);
     http2MinConnectionPerPort =
@@ -172,5 +180,7 @@ public class Http2ClientConfig {
     http2BlockingChannelReceiveTimeoutMs = verifiableProperties.getInt(HTTP2_BLOCKING_CHANNEL_RECEIVE_TIMEOUT_MS, 5000);
     http2BlockingChannelPoolShutdownTimeoutMs =
         verifiableProperties.getInt(HTTP2_BLOCKING_CHANNEL_POOL_SHUTDOWN_TIMEOUT_MS, 3000);
+    http2PeerCertificateSanRegex =
+        verifiableProperties.getString(HTTP2_PEER_CERTIFICATE_SAN_REGEX, "");
   }
 }

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ChannelPoolHandler.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ChannelPoolHandler.java
@@ -45,19 +45,22 @@ public class Http2ChannelPoolHandler extends AbstractChannelPoolHandler {
   private final int port;
   private final Http2ClientConfig http2ClientConfig;
   private final ConnectionInboundExceptionHandler connectionInboundExceptionHandler;
-
+  private final Http2ClientMetrics http2ClientMetrics;
   /**
    * Construct a {@link Http2ChannelPoolHandler}.
    * @param sslFactory the {@link SSLFactory} to use for generating {@link javax.net.ssl.SSLEngine} instances,
    *                   or {@code null} if SSL is not enabled in this pipeline.
    * @param http2ClientConfig the {@link Http2ClientConfig}
+   * @param http2ClientMetrics the {@link Http2ClientMetrics}
    */
-  public Http2ChannelPoolHandler(SSLFactory sslFactory, String host, int port, Http2ClientConfig http2ClientConfig) {
+  public Http2ChannelPoolHandler(SSLFactory sslFactory, String host, int port, Http2ClientConfig http2ClientConfig,
+      Http2ClientMetrics http2ClientMetrics) {
     this.sslFactory = sslFactory;
     this.host = host;
     this.port = port;
     this.http2ClientConfig = http2ClientConfig;
     this.connectionInboundExceptionHandler = new ConnectionInboundExceptionHandler();
+    this.http2ClientMetrics = http2ClientMetrics;
   }
 
   @Override
@@ -65,6 +68,9 @@ public class Http2ChannelPoolHandler extends AbstractChannelPoolHandler {
     ChannelPipeline pipeline = ch.pipeline();
     SslHandler sslHandler = new SslHandler(sslFactory.createSSLEngine(host, port, SSLFactory.Mode.CLIENT));
     pipeline.addLast(sslHandler);
+    pipeline.addLast(
+        new Http2PeerCertificateValidator(http2ClientConfig.http2PeerCertificateSanRegex,
+            http2ClientMetrics));
     pipeline.addLast(Http2FrameCodecBuilder.forClient()
         .initialSettings(Http2Settings.defaultSettings()
             .maxFrameSize(http2ClientConfig.http2FrameMaxSize)

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ChannelPoolHandler.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ChannelPoolHandler.java
@@ -68,9 +68,10 @@ public class Http2ChannelPoolHandler extends AbstractChannelPoolHandler {
     ChannelPipeline pipeline = ch.pipeline();
     SslHandler sslHandler = new SslHandler(sslFactory.createSSLEngine(host, port, SSLFactory.Mode.CLIENT));
     pipeline.addLast(sslHandler);
-    pipeline.addLast(
-        new Http2PeerCertificateValidator(http2ClientConfig.http2PeerCertificateSanRegex,
-            http2ClientMetrics));
+    if (!http2ClientConfig.http2PeerCertificateSanRegex.trim().isEmpty()) {
+      pipeline.addLast(
+          new Http2PeerCertificateValidator(http2ClientConfig.http2PeerCertificateSanRegex, http2ClientMetrics));
+    }
     pipeline.addLast(Http2FrameCodecBuilder.forClient()
         .initialSettings(Http2Settings.defaultSettings()
             .maxFrameSize(http2ClientConfig.http2FrameMaxSize)

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ClientMetrics.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ClientMetrics.java
@@ -59,6 +59,8 @@ public class Http2ClientMetrics {
   public final Counter http2ParentExceptionCount;
   public final Counter http2StreamExceptionCount;
 
+  public final Counter http2ServerCertificateValidationFailureCount;
+
   public Http2ClientMetrics(MetricRegistry registry) {
     this.registry = registry;
     http2ConnectionAcquireTime =
@@ -109,6 +111,9 @@ public class Http2ClientMetrics {
         registry.counter(MetricRegistry.name(Http2NetworkClient.class, "Http2ParentExceptionCount"));
     http2StreamExceptionCount =
         registry.counter(MetricRegistry.name(Http2NetworkClient.class, "Http2StreamExceptionCount"));
+
+    http2ServerCertificateValidationFailureCount =
+        registry.counter(MetricRegistry.name(Http2NetworkClient.class, "http2ServerCertificateValidationFailureCount"));
   }
 
   void registerNettyPendingTasksGauge(EventLoopGroup eventLoopGroup) {

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2MultiplexedChannelPool.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2MultiplexedChannelPool.java
@@ -100,7 +100,8 @@ public class Http2MultiplexedChannelPool implements ChannelPool {
       ChannelInitializer streamChannelInitializer) {
     this(new SimpleChannelPool(createBootStrap(eventLoopGroup, http2ClientConfig, inetSocketAddress),
             new Http2ChannelPoolHandler(sslFactory, inetSocketAddress.getHostName(), inetSocketAddress.getPort(),
-                http2ClientConfig)), eventLoopGroup, ConcurrentHashMap.newKeySet(), inetSocketAddress, http2ClientConfig,
+                http2ClientConfig, http2ClientMetrics)),
+        eventLoopGroup, ConcurrentHashMap.newKeySet(), inetSocketAddress, http2ClientConfig,
         http2ClientMetrics, streamChannelInitializer);
   }
 

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2PeerCertificateValidator.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2PeerCertificateValidator.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.network.http2;
+
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.ssl.SslHandler;
+import java.security.Principal;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.Collection;
+import java.util.List;
+import java.util.regex.Pattern;
+import javax.net.ssl.SSLSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Handler that validates the peer certificate on the new HTTP2 connection.
+ */
+@ChannelHandler.Sharable
+public class Http2PeerCertificateValidator extends ChannelInboundHandlerAdapter {
+  private static final Logger logger = LoggerFactory.getLogger(Http2PeerCertificateValidator.class);
+  private final String http2PeerCertificateSanRegex;
+  private final Http2ClientMetrics http2ClientMetrics;
+
+  public Http2PeerCertificateValidator(String http2PeerCertificateSanRegex,
+      Http2ClientMetrics http2ClientMetrics) {
+    this.http2PeerCertificateSanRegex = http2PeerCertificateSanRegex;
+    this.http2ClientMetrics = http2ClientMetrics;
+  }
+
+  @Override
+  public void channelActive(ChannelHandlerContext ctx) throws Exception {
+    logger.trace("Channel Active " + ctx.channel().remoteAddress());
+    validateSslConnection(ctx);
+    super.channelActive(ctx);
+  }
+
+  @Override
+  public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+    logger.trace("Channel Inactive " + ctx.channel().remoteAddress());
+    super.channelInactive(ctx);
+  }
+
+  /**
+   * Listen to the handshake future for the SSL termination, then apply the security policies, potentialy closing the
+   * connection in case security check fails.
+   * @param ctx the {@link ChannelHandlerContext}.
+   */
+  private void validateSslConnection(ChannelHandlerContext ctx) throws Exception {
+    if (http2PeerCertificateSanRegex.isEmpty()) {
+      logger.info("(TDBG) validateSslConnection => regex is empty");
+
+      return;
+    }
+    SslHandler sslHandler = ctx.channel().pipeline().get(SslHandler.class);
+    if (sslHandler == null) {
+      return;
+    }
+    sslHandler.handshakeFuture().addListener(future -> {
+      if (!future.isSuccess()) {
+        logger.error("SSL handshake failed for channel: {}", ctx.channel(), future.cause());
+        return;
+      }
+      try {
+        SSLSession sslSession = sslHandler.engine().getSession();
+        Certificate[] peerCertificates = sslSession.getPeerCertificates();
+        for (Certificate cert : peerCertificates) {
+          if (cert instanceof X509Certificate) {
+            X509Certificate x509Certificate = (X509Certificate) cert;
+            Principal p = x509Certificate.getSubjectDN();
+
+            Collection<?> subjectAltNames = x509Certificate.getSubjectAlternativeNames();
+            if (subjectAltNames == null) {
+              continue;
+            }
+            int numSanName = 0;
+            for (Object subjectAltName : subjectAltNames) {
+              numSanName++;
+              List<?> entry = (List<?>) subjectAltName;
+              if (entry == null || entry.size() < 2) {
+                continue;
+              }
+              Integer altNameType = (Integer) entry.get(0);
+              String altName = (String) entry.get(1);
+              if (altNameType == null || altName == null) {
+                continue;
+              }
+
+              logger.info("(TDBG) validateSslConnection => SAN[" + numSanName + "] => type: " + altNameType + " name: " + altName + " Regex: " + http2PeerCertificateSanRegex);
+              if (Pattern.matches(http2PeerCertificateSanRegex, altName)) {
+                return;
+              }
+            }
+          }
+        }
+      } catch (Exception e) {
+        logger.error("Exception thrown, peer certificate validation failed for channel: {}", ctx.channel(), e);
+      }
+      logger.error("Peer certificate validation failed for channel: {}", ctx.channel());
+      http2ClientMetrics.http2ServerCertificateValidationFailureCount.inc();
+      ctx.channel().close();
+    });
+  }
+}

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2PeerCertificateValidator.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2PeerCertificateValidator.java
@@ -62,9 +62,7 @@ public class Http2PeerCertificateValidator extends ChannelInboundHandlerAdapter 
    * @param ctx the {@link ChannelHandlerContext}.
    */
   private void validateSslConnection(ChannelHandlerContext ctx) throws Exception {
-    if (http2PeerCertificateSanRegex.isEmpty()) {
-      logger.info("(TDBG) validateSslConnection => regex is empty");
-
+    if (http2PeerCertificateSanRegex.trim().isEmpty()) {
       return;
     }
     SslHandler sslHandler = ctx.channel().pipeline().get(SslHandler.class);

--- a/ambry-network/src/test/java/com/github/ambry/network/http2/Http2PeerCertificateValidatorTest.java
+++ b/ambry-network/src/test/java/com/github/ambry/network/http2/Http2PeerCertificateValidatorTest.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.network.http2;
+
+import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.commons.TestSSLUtils;
+import com.github.ambry.rest.MockSSLEngine;
+import com.github.ambry.rest.MockSSLSession;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.Channel;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.ssl.ClientAuth;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslHandler;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
+import io.netty.util.concurrent.Promise;
+import java.security.KeyPair;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.Optional;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLException;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+/**
+ * Unit tests for {@link Http2PeerCertificateValidator}
+ */
+public class Http2PeerCertificateValidatorTest {
+  /**
+   * Sets up the mock securityservice {@link Http2PeerCertificateValidator} to use.
+   */
+  public Http2PeerCertificateValidatorTest() {
+
+  }
+
+  /**
+   * Test the code flow where {@link Http2PeerCertificateValidator} waits for the SSL handshake complete event and
+   * apply security policy from channelActive method.
+   * @throws Exception
+   */
+  @Test
+  public void securityCheckerTest() throws Exception {
+
+    GeneralNames subjectAltNames = new GeneralNames(new GeneralName[]{
+        new GeneralName(GeneralName.uniformResourceIdentifier,
+            "urn:li:servicePrincipal(foo-name;foo-tag;i001)"),
+        new GeneralName(GeneralName.dNSName, "ca-00001.foo.com"),
+        new GeneralName(GeneralName.iPAddress, "1.1.1.1")});
+
+    //certificate validation success case, channel should not be closed.
+    Http2ClientMetrics metrics = new Http2ClientMetrics(new MetricRegistry());
+    EmbeddedChannel channel = createChannelSsl(subjectAltNames, "urn:li:servicePrincipal\\(foo-name;foo-tag;.*\\) ?", metrics);
+    SslHandler sslHandler = channel.pipeline().get(SslHandler.class);
+    Promise<Channel> promise = (Promise<Channel>) sslHandler.handshakeFuture();
+    promise.setSuccess(channel);
+    assertTrue("channel should not be closed", channel.isActive());
+    assertEquals("validation success counter mismatch", 0,
+        metrics.http2ServerCertificateValidationFailureCount.getCount());
+
+    //certificate validation is disabled with empty regex, channel should not be closed.
+    channel = createChannelSsl(subjectAltNames, "", metrics);
+    sslHandler = channel.pipeline().get(SslHandler.class);
+    promise = (Promise<Channel>) sslHandler.handshakeFuture();
+    promise.setSuccess(channel);
+    assertTrue("channel should not be closed", channel.isActive());
+    assertEquals("validation success counter mismatch", 0,
+        metrics.http2ServerCertificateValidationFailureCount.getCount());
+
+    //security validation failure case (service closed), channel should be closed.
+    channel = createChannelSsl(subjectAltNames, "invalid.*", metrics);
+    sslHandler = channel.pipeline().get(SslHandler.class);
+    promise = (Promise<Channel>) sslHandler.handshakeFuture();
+    promise.setSuccess(channel);
+    assertTrue("channel should be closed", !channel.isActive());
+    assertEquals("validation success counter mismatch", 1,
+        metrics.http2ServerCertificateValidationFailureCount.getCount());
+  }
+
+  //helpers
+  //general
+
+  /**
+   * Creates an {@link EmbeddedChannel} that incorporates an instance of {@link Http2PeerCertificateValidator}
+   * @return an {@link EmbeddedChannel} that incorporates an instance of {@link Http2PeerCertificateValidator}
+   *         and an {@link SslHandler}.
+   */
+  private EmbeddedChannel createChannelSsl(GeneralNames subjectAltNames, String regex,
+      Http2ClientMetrics http2ClientMetrics) {
+    SslContext sslContext;
+    X509Certificate cert;
+
+    try {
+      KeyPair cKP = TestSSLUtils.generateKeyPair("RSA");
+      cert = TestSSLUtils.generateCertificate("CN=localhost, O=client", cKP, 30, "SHA1withRSA",
+          Optional.of(subjectAltNames));
+
+      SelfSignedCertificate localCert = new SelfSignedCertificate();
+      sslContext = SslContextBuilder.forServer(localCert.certificate(), localCert.privateKey())
+          .clientAuth(ClientAuth.REQUIRE)
+          .build();
+    } catch (CertificateException | SSLException | NoSuchAlgorithmException e) {
+      throw new IllegalStateException(e);
+    }
+    SSLEngine sslEngine = sslContext.newEngine(ByteBufAllocator.DEFAULT);
+    SSLEngine mockSSLEngine =
+        new MockSSLEngine(sslEngine, new MockSSLSession(sslEngine.getSession(), new Certificate[]{cert}));
+    SslHandler sslHandler = new SslHandler(mockSSLEngine);
+    EmbeddedChannel channel = new EmbeddedChannel(sslHandler, new Http2PeerCertificateValidator(regex, http2ClientMetrics));
+    // EmbeddedChannel channel = new EmbeddedChannel(new RouterSecurityHandler(regex));
+    return channel;
+  }
+}
+

--- a/ambry-network/src/test/java/com/github/ambry/network/http2/Http2PeerCertificateValidatorTest.java
+++ b/ambry-network/src/test/java/com/github/ambry/network/http2/Http2PeerCertificateValidatorTest.java
@@ -134,7 +134,6 @@ public class Http2PeerCertificateValidatorTest {
         new MockSSLEngine(sslEngine, new MockSSLSession(sslEngine.getSession(), new Certificate[]{cert}));
     SslHandler sslHandler = new SslHandler(mockSSLEngine);
     EmbeddedChannel channel = new EmbeddedChannel(sslHandler, new Http2PeerCertificateValidator(regex, http2ClientMetrics));
-    // EmbeddedChannel channel = new EmbeddedChannel(new RouterSecurityHandler(regex));
     return channel;
   }
 }

--- a/ambry-network/src/test/java/com/github/ambry/network/http2/Http2PeerCertificateValidatorTest.java
+++ b/ambry-network/src/test/java/com/github/ambry/network/http2/Http2PeerCertificateValidatorTest.java
@@ -85,6 +85,15 @@ public class Http2PeerCertificateValidatorTest {
     assertEquals("validation success counter mismatch", 0,
         metrics.http2ServerCertificateValidationFailureCount.getCount());
 
+    //certificate validation is disabled with empty regex, channel should not be closed.
+    channel = createChannelSsl(subjectAltNames, " ", metrics);
+    sslHandler = channel.pipeline().get(SslHandler.class);
+    promise = (Promise<Channel>) sslHandler.handshakeFuture();
+    promise.setSuccess(channel);
+    assertTrue("channel should not be closed", channel.isActive());
+    assertEquals("validation success counter mismatch", 0,
+        metrics.http2ServerCertificateValidationFailureCount.getCount());
+
     //security validation failure case (service closed), channel should be closed.
     channel = createChannelSsl(subjectAltNames, "invalid.*", metrics);
     sslHandler = channel.pipeline().get(SslHandler.class);

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryMain.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryMain.java
@@ -45,8 +45,8 @@ public class AmbryMain {
           Utils.getObj(clusterMapConfig.clusterMapClusterAgentsFactory, clusterMapConfig,
               options.hardwareLayoutFilePath, options.partitionLayoutFilePath);
       logger.info("Bootstrapping AmbryServer");
-//      VcrClusterAgentsFactory vcrClusterAgentsFactory = Utils.getObj(cloudConfig.vcrClusterAgentsFactoryClass);
-      ambryServer = new AmbryServer(verifiableProperties, clusterAgentsFactory, (VcrClusterAgentsFactory) null,
+      VcrClusterAgentsFactory vcrClusterAgentsFactory = Utils.getObj(cloudConfig.vcrClusterAgentsFactoryClass);
+      ambryServer = new AmbryServer(verifiableProperties, clusterAgentsFactory, vcrClusterAgentsFactory,
           SystemTime.getInstance());
       // attach shutdown handler to catch control-c
       Runtime.getRuntime().addShutdownHook(new Thread() {

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryMain.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryMain.java
@@ -45,8 +45,8 @@ public class AmbryMain {
           Utils.getObj(clusterMapConfig.clusterMapClusterAgentsFactory, clusterMapConfig,
               options.hardwareLayoutFilePath, options.partitionLayoutFilePath);
       logger.info("Bootstrapping AmbryServer");
-      VcrClusterAgentsFactory vcrClusterAgentsFactory = Utils.getObj(cloudConfig.vcrClusterAgentsFactoryClass);
-      ambryServer = new AmbryServer(verifiableProperties, clusterAgentsFactory, vcrClusterAgentsFactory,
+//      VcrClusterAgentsFactory vcrClusterAgentsFactory = Utils.getObj(cloudConfig.vcrClusterAgentsFactoryClass);
+      ambryServer = new AmbryServer(verifiableProperties, clusterAgentsFactory, (VcrClusterAgentsFactory) null,
           SystemTime.getInstance());
       // attach shutdown handler to catch control-c
       Runtime.getRuntime().addShutdownHook(new Thread() {

--- a/ambry-test-utils/src/main/java/com/github/ambry/rest/MockSSLEngine.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/rest/MockSSLEngine.java
@@ -26,7 +26,7 @@ import javax.net.ssl.SSLSession;
  * A mock of {@link SSLEngine} that either delegates to a passed in {@link SSLEngine}, or returns the provided
  * objects.
  */
-class MockSSLEngine extends SSLEngine {
+public class MockSSLEngine extends SSLEngine {
   private final SSLEngine delegateEngine;
   private final SSLSession sessionToReturn;
 
@@ -34,7 +34,7 @@ class MockSSLEngine extends SSLEngine {
    * @param delegateEngine An {@link SSLEngine} to delegate to in most cases.
    * @param sessionToReturn If not {@code null}, return this certificate in {@link #getSession()} instead of delegating.
    */
-  MockSSLEngine(SSLEngine delegateEngine, SSLSession sessionToReturn) {
+  public MockSSLEngine(SSLEngine delegateEngine, SSLSession sessionToReturn) {
     this.delegateEngine = delegateEngine;
     this.sessionToReturn = sessionToReturn;
   }


### PR DESCRIPTION
Verify server identity on the router via Subject Alternative Names part of the certificate if the newly introduced ambry.http2PeerCertificateSanRegex parameter is set. 

If the parameter is set, server tries to match at least one of the subject alternative names to the corresponding regular expression. In the case of failure, router closes the channel established between the server.