### PR TITLE
Fix NullPointerException when journal is empty

### DIFF
--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
@@ -401,8 +401,8 @@ class BlobStoreCompactor {
       }
       // should be outside the range of the journal
       Offset segmentEndOffset = new Offset(segment.getName(), segment.getEndOffset());
-      if (srcIndex.journal.getFirstOffset() != null
-          && segmentEndOffset.compareTo(srcIndex.journal.getFirstOffset()) >= 0) {
+      Offset journalFirstOffset = srcIndex.journal.getFirstOffset();
+      if (journalFirstOffset != null && segmentEndOffset.compareTo(journalFirstOffset) >= 0) {
         throw new IllegalArgumentException("Some of the offsets provided for compaction are within the journal");
       }
       prevSegmentName = segment.getName();

--- a/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
@@ -312,8 +312,10 @@ class PersistentIndex {
    */
   private void removeIndexEntryNotBelongsToLastLogSegmentFromJournal() {
     LogSegmentName lastLogSegmentName = log.getLastSegment().getName();
-    while (journal.getFirstOffset() != null && !journal.getFirstOffset().getName().equals(lastLogSegmentName)) {
-      journal.removeSpecificValueInJournal(journal.getFirstOffset());
+    Offset journalFirstOffset = journal.getFirstOffset();
+    while (journalFirstOffset != null && !journalFirstOffset.getName().equals(lastLogSegmentName)) {
+      journal.removeSpecificValueInJournal(journalFirstOffset);
+      journalFirstOffset = journal.getFirstOffset();
     }
   }
 
@@ -1275,7 +1277,8 @@ class PersistentIndex {
         // recheck to make sure that offsetToStart hasn't slipped out of the journal. It is possible (but highly
         // improbable) that the offset has slipped out of the journal and has been compacted b/w the time of getting
         // entries from the journal to when another view of the index segments was obtained.
-        if (entries != null && offsetToStart.compareTo(journal.getFirstOffset()) >= 0) {
+        Offset journalFirstOffset = journal.getFirstOffset();
+        if (entries != null && journalFirstOffset != null && offsetToStart.compareTo(journalFirstOffset) >= 0) {
           startTimeInMs = time.milliseconds();
           logger.trace("Index : {} retrieving from journal from offset {} total entries {}", dataDir, offsetToStart,
               entries.size());


### PR DESCRIPTION
Fix race condition when we call journal.getFirstOffset method, it returns null because journal is just cleaned up due to autoCloseLastLogSegment but not covered by "entries != null".