### PR TITLE
Change the quota logging level to debug to avoid excess logging.

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/quota/QuotaChargeCallback.java
+++ b/ambry-api/src/main/java/com/github/ambry/quota/QuotaChargeCallback.java
@@ -52,7 +52,7 @@ public interface QuotaChargeCallback {
                 && quotaManager.getQuotaConfig().throttleInProgressRequests) {
               throw new RouterException("RequestQuotaExceeded", RouterErrorCode.TooManyRequests);
             } else {
-              logger.info("Quota exceeded for an in progress request.");
+              logger.debug("Quota exceeded for an in progress request.");
             }
           }
         } catch (Exception ex) {


### PR DESCRIPTION
We are logging enough quota usage metrics and we also have quota alerts set. So we don't need this extra logging.