### PR TITLE
Don't keep all blobIds in blob store stats, only record number of put keys

### DIFF
--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreStats.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreStats.java
@@ -365,13 +365,13 @@ class BlobStoreStats implements StoreStats, Closeable {
     }
     Map<Short, Map<Short, Long>> validSizeMap = null;
     Map<Short, Map<Short, Long>> physicalUsageMap = null;
-    Map<Short, Map<Short, Long>> numberStoreKeyMap = null;
+    //Map<Short, Map<Short, Long>> numberStoreKeyMap = null;
     ScanResults currentScanResults = scanResults.get();
     if (currentScanResults != null && isWithinRange(currentScanResults.containerForecastStartTimeMs,
         currentScanResults.containerForecastEndTimeMs, referenceTimeInMs)) {
       validSizeMap = currentScanResults.getValidSizePerContainer(referenceTimeInMs);
       physicalUsageMap = currentScanResults.getContainerPhysicalStorageUsage();
-      numberStoreKeyMap = currentScanResults.getContainerNumberOfStoreKeys();
+      //numberStoreKeyMap = currentScanResults.getContainerNumberOfStoreKeys();
     } else {
       if (isScanning && isWithinRange(indexScanner.newScanResults.containerForecastStartTimeMs,
           indexScanner.newScanResults.containerForecastEndTimeMs, referenceTimeInMs)) {
@@ -384,7 +384,7 @@ class BlobStoreStats implements StoreStats, Closeable {
                   currentScanResults.containerForecastEndTimeMs, referenceTimeInMs)) {
                 validSizeMap = currentScanResults.getValidSizePerContainer(referenceTimeInMs);
                 physicalUsageMap = currentScanResults.getContainerPhysicalStorageUsage();
-                numberStoreKeyMap = currentScanResults.getContainerNumberOfStoreKeys();
+                //numberStoreKeyMap = currentScanResults.getContainerNumberOfStoreKeys();
               }
             } else {
               metrics.blobStoreStatsIndexScannerErrorCount.inc();
@@ -396,7 +396,7 @@ class BlobStoreStats implements StoreStats, Closeable {
                 currentScanResults.containerForecastEndTimeMs, referenceTimeInMs)) {
               validSizeMap = currentScanResults.getValidSizePerContainer(referenceTimeInMs);
               physicalUsageMap = currentScanResults.getContainerPhysicalStorageUsage();
-              numberStoreKeyMap = currentScanResults.getContainerNumberOfStoreKeys();
+              //numberStoreKeyMap = currentScanResults.getContainerNumberOfStoreKeys();
             }
           }
         } catch (InterruptedException e) {
@@ -420,7 +420,7 @@ class BlobStoreStats implements StoreStats, Closeable {
       for (short containerId : validSizeMap.get(accountId).keySet()) {
         retValue.computeIfAbsent(accountId, k -> new HashMap<>())
             .put(containerId, new ContainerStorageStats(containerId, validSizeMap.get(accountId).get(containerId),
-                physicalUsageMap.get(accountId).get(containerId), numberStoreKeyMap.get(accountId).get(containerId)));
+                physicalUsageMap.get(accountId).get(containerId), 1));
       }
     }
     return retValue;

--- a/ambry-store/src/main/java/com/github/ambry/store/ScanResults.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/ScanResults.java
@@ -17,7 +17,6 @@ package com.github.ambry.store;
 import com.github.ambry.utils.Pair;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Set;
@@ -213,9 +212,10 @@ class ScanResults {
    */
   void updateContainerPhysicalStorageUsageAndStoreKey(short accountId, short containerId, long usage, StoreKey key) {
     updateNestedMapHelper(containerPhysicalStorageUsage, accountId, containerId, usage);
-    containerStoreKeys.computeIfAbsent(accountId, k -> new HashMap<>())
-        .computeIfAbsent(containerId, k -> new HashSet<>())
-        .add(key);
+    // Disable this for now.
+    //containerStoreKeys.computeIfAbsent(accountId, k -> new HashMap<>())
+    //    .computeIfAbsent(containerId, k -> new HashSet<>())
+    //    .add(key);
   }
 
   /**

--- a/ambry-store/src/main/java/com/github/ambry/store/ScanResults.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/ScanResults.java
@@ -19,10 +19,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.NavigableMap;
-import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 
 import static com.github.ambry.store.StatsUtils.*;
 
@@ -93,7 +91,7 @@ class ScanResults {
   // This is for container physical storage usage, it doesn't have to take delta into consideration, so it's more like a base
   // bucket for valid  storage usage.
   private final Map<Short, Map<Short, Long>> containerPhysicalStorageUsage = new ConcurrentHashMap<>();
-  private final Map<Short, Map<Short, Set<StoreKey>>> containerStoreKeys = new ConcurrentHashMap<>();
+  private final Map<Short, Map<Short, Long>> containerNumberOfStoreKeys = new ConcurrentHashMap<>();
 
   // LogSegment buckets keep track of valid IndexValue size in each log segments. So the base value of log segment bucket
   // is a map, whose key is the log segment name and the value is the sum of valid IndexValues' sizes. To test if an
@@ -208,14 +206,12 @@ class ScanResults {
    * @param accountId The account id
    * @param containerId The container id
    * @param usage The new physical storage usage
-   * @param key The new store key
+   * @param newKey The number of new keys to add
    */
-  void updateContainerPhysicalStorageUsageAndStoreKey(short accountId, short containerId, long usage, StoreKey key) {
+  void updateContainerPhysicalStorageUsageAndStoreKey(short accountId, short containerId, long usage, long newKey) {
     updateNestedMapHelper(containerPhysicalStorageUsage, accountId, containerId, usage);
-    // Disable this for now.
-    //containerStoreKeys.computeIfAbsent(accountId, k -> new HashMap<>())
-    //    .computeIfAbsent(containerId, k -> new HashSet<>())
-    //    .add(key);
+    containerNumberOfStoreKeys.computeIfAbsent(accountId, k -> new HashMap<>())
+        .compute(containerId, (k, v) -> v == null ? newKey : v.longValue() + newKey);
   }
 
   /**
@@ -326,12 +322,6 @@ class ScanResults {
   }
 
   Map<Short, Map<Short, Long>> getContainerNumberOfStoreKeys() {
-    Map<Short, Map<Short, Long>> numberOfStoreKeysPerContainer = new HashMap<>();
-    containerStoreKeys.entrySet()
-        .forEach(ent -> numberOfStoreKeysPerContainer.put(ent.getKey(), ent.getValue()
-            .entrySet()
-            .stream()
-            .collect(Collectors.toMap(Map.Entry::getKey, entry -> (long) entry.getValue().size()))));
-    return numberOfStoreKeysPerContainer;
+    return Collections.unmodifiableMap(containerNumberOfStoreKeys);
   }
 }


### PR DESCRIPTION
Don't keep a set of blob ids for each account container, since it has a huge memory footprint.