### PR TITLE
Minor fix for VCR metrics and Helix tool

### DIFF
--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrMetrics.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrMetrics.java
@@ -58,6 +58,7 @@ public class VcrMetrics {
 
   // VCR Automation
   public final Counter vcrHelixUpdateFailCount;
+  public final Counter vcrHelixUpdateSuccessCount;
   public Gauge<Integer> vcrHelixUpdaterGauge;
   public Gauge<Integer> vcrHelixUpdateInProgressGauge;
   public final Counter vcrHelixNotOnSync;
@@ -99,6 +100,8 @@ public class VcrMetrics {
         MetricRegistry.name(DeprecatedContainerCloudSyncTask.class, "DeprecationSyncTaskRegistrationFailureCount"));
     vcrHelixUpdateFailCount =
         registry.counter(MetricRegistry.name(VcrReplicationManager.class, "VcrHelixUpdateFailCount"));
+    vcrHelixUpdateSuccessCount =
+        registry.counter(MetricRegistry.name(VcrReplicationManager.class, "VcrHelixUpdateSuccessCount"));
     vcrHelixNotOnSync =
         registry.counter(MetricRegistry.name(VcrReplicationManager.class, "VcrHelixNotOnSync"));
   }

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicationManager.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicationManager.java
@@ -414,6 +414,7 @@ public class VcrReplicationManager extends ReplicationEngine {
       HelixVcrUtil.updateResourceAndPartition(localDcZkStr, clusterMapConfig.clusterMapClusterName,
           cloudConfig.vcrClusterZkConnectString, cloudConfig.vcrClusterName, vcrHelixConfig,
           cloudConfig.vcrHelixUpdateDryRun);
+      vcrMetrics.vcrHelixUpdateSuccessCount.inc();
     } catch (Exception e) {
       // SRE and DEVs should be alerted on this metric.
       vcrMetrics.vcrHelixUpdateFailCount.inc();

--- a/ambry-server/src/integration-test/java/com/github/ambry/server/VcrAutomationTest.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/VcrAutomationTest.java
@@ -93,7 +93,8 @@ public class VcrAutomationTest {
     DataNodeConfigSourceType dataNodeConfigSourceType = DataNodeConfigSourceType.INSTANCE_CONFIG;
     int zkPort = 2100;
     int numberOfDataNode = 3;
-    int partitionCount = 2;
+    int partitionCount = 9;
+    int newPartitionCount = 13;
 
     String zkHostName = "localhost";
     String zkConnectString = zkHostName + ":" + zkPort;
@@ -184,7 +185,8 @@ public class VcrAutomationTest {
     // vcr server start up done.
 
     // Partition add case:
-    testPartitionLayout = constructInitialPartitionLayoutJSON(testHardwareLayout, partitionCount + 1, null);
+    testPartitionLayout =
+        constructInitialPartitionLayoutJSON(testHardwareLayout, partitionCount + newPartitionCount, null);
     Utils.writeJsonObjectToFile(testPartitionLayout.getPartitionLayout().toJSONObject(), partitionLayoutPath);
 
     HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterPrefix,
@@ -192,8 +194,9 @@ public class VcrAutomationTest {
         HelixBootstrapUpgradeUtil.HelixAdminOperation.BootstrapCluster, dataNodeConfigSourceType, false);
 
     makeSureHelixBalance(vcrServer, helixBalanceVerifier);
-    Assert.assertTrue("Partition assignment is not correct.", TestUtils.checkAndSleep(partitionCount + 1,
-        () -> vcrServer.getVcrClusterParticipant().getAssignedPartitionIds().size(), 5000));
+    Assert.assertTrue("Partition assignment is not correct.",
+        TestUtils.checkAndSleep(partitionCount + newPartitionCount,
+            () -> vcrServer.getVcrClusterParticipant().getAssignedPartitionIds().size(), 5000));
 
     // Partition remove case:
 

--- a/ambry-tools/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeTool.java
+++ b/ambry-tools/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeTool.java
@@ -250,7 +250,7 @@ public class HelixBootstrapUpgradeTool {
     String stateModelDef = options.valueOf(stateModelDefinitionOpt) == null ? ClusterMapConfig.DEFAULT_STATE_MODEL_DEF
         : options.valueOf(stateModelDefinitionOpt);
     DataNodeConfigSourceType dataNodeConfigSourceType =
-        options.valueOf(dataNodeConfigSourceOpt) == null ? DataNodeConfigSourceType.INSTANCE_CONFIG
+        options.valueOf(dataNodeConfigSourceOpt) == null ? DataNodeConfigSourceType.PROPERTY_STORE
             : DataNodeConfigSourceType.valueOf(options.valueOf(dataNodeConfigSourceOpt));
     ArrayList<OptionSpec> listOpt = new ArrayList<>();
     listOpt.add(hardwareLayoutPathOpt);


### PR DESCRIPTION
Use prime number in VCR automation test.
Add a VCR metric.
Use property store as default option in helix bootstrap tool.