### PR TITLE
Remove empty from serialized container storage stats json object

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/server/storagestats/ContainerStorageStats.java
+++ b/ambry-api/src/main/java/com/github/ambry/server/storagestats/ContainerStorageStats.java
@@ -14,6 +14,7 @@
 package com.github.ambry.server.storagestats;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -88,6 +89,7 @@ public class ContainerStorageStats {
    * True if all the storage stats values are 0.
    * @return True if all the stats values are 0.
    */
+  @JsonIgnore
   public boolean isEmpty() {
     return logicalStorageUsage == 0 && physicalStorageUsage == 0 && numberOfBlobs == 0;
   }

--- a/ambry-api/src/test/java/com/github/ambry/server/StorageStatsTest.java
+++ b/ambry-api/src/test/java/com/github/ambry/server/StorageStatsTest.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.server;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.ambry.server.storagestats.AggregatedAccountStorageStats;
 import com.github.ambry.server.storagestats.AggregatedPartitionClassStorageStats;
@@ -50,6 +51,13 @@ public class StorageStatsTest {
     assertContainerStorageStats(stats, containerId, logicalStorageUsage, physicalStorageUsage, numberOfBlobs);
 
     String serialized = objectMapper.writeValueAsString(stats);
+    Map<String, Object> tempMap = objectMapper.readValue(serialized, new TypeReference<Map<String, Object>>() {
+    });
+    // We are only expecting "containerId", "logicalStorageUsage", "physicalStorageUsage" and "numberOfBlobs" in the serialized string
+    Assert.assertEquals(4, tempMap.size());
+    for (String key : new String[]{"containerId", "logicalStorageUsage", "physicalStorageUsage", "numberOfBlobs"}) {
+      Assert.assertTrue(tempMap.containsKey(key));
+    }
     ContainerStorageStats deserialized = objectMapper.readValue(serialized, ContainerStorageStats.class);
     Assert.assertEquals(stats, deserialized);
 


### PR DESCRIPTION
This PR ignores "empty" field in the serialized json object of ContainerStorageStats.