### PR TITLE
Adding rest request to key management service

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/router/GetBlobOptions.java
+++ b/ambry-api/src/main/java/com/github/ambry/router/GetBlobOptions.java
@@ -119,6 +119,9 @@ public class GetBlobOptions {
     return blobSegmentIdx != NO_BLOB_SEGMENT_IDX_SPECIFIED;
   }
 
+  /**
+   * @return The {@link RestRequest} that triggered this get operation.
+   */
   public RestRequest getRestRequest() {
     return restRequest;
   }
@@ -126,7 +129,7 @@ public class GetBlobOptions {
   @Override
   public String toString() {
     return "GetBlobOptions{operationType=" + operationType + ", getOption=" + getOption + ", range=" + range
-        + ", rawMode=" + rawMode + ", blobSegmentIdx=" + blobSegmentIdx + '}';
+        + ", rawMode=" + rawMode + ", blobSegmentIdx=" + blobSegmentIdx + ", restRequest=" + restRequest + '}';
   }
 
   @Override
@@ -140,12 +143,12 @@ public class GetBlobOptions {
     GetBlobOptions that = (GetBlobOptions) o;
     return resolveRangeOnEmptyBlob == that.resolveRangeOnEmptyBlob && rawMode == that.rawMode
         && blobSegmentIdx == that.blobSegmentIdx && operationType == that.operationType && getOption == that.getOption
-        && Objects.equals(range, that.range);
+        && Objects.equals(range, that.range) && Objects.equals(restRequest, that.restRequest);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(operationType, getOption, range, resolveRangeOnEmptyBlob, rawMode, blobSegmentIdx);
+    return Objects.hash(operationType, getOption, range, resolveRangeOnEmptyBlob, rawMode, blobSegmentIdx, restRequest);
   }
 
   /**

--- a/ambry-api/src/main/java/com/github/ambry/router/GetBlobOptions.java
+++ b/ambry-api/src/main/java/com/github/ambry/router/GetBlobOptions.java
@@ -16,6 +16,7 @@ package com.github.ambry.router;
 
 import com.github.ambry.commons.Callback;
 import com.github.ambry.protocol.GetOption;
+import com.github.ambry.rest.RestRequest;
 import java.util.Objects;
 
 
@@ -32,6 +33,7 @@ public class GetBlobOptions {
   // Flag indicating whether to return the raw blob payload without deserialization.
   private final boolean rawMode;
   private final int blobSegmentIdx;
+  private final RestRequest restRequest;
   public static final int NO_BLOB_SEGMENT_IDX_SPECIFIED = -1;
 
   /**
@@ -45,9 +47,10 @@ public class GetBlobOptions {
    * @param rawMode a system flag indicating that the raw bytes should be returned.
    * @param blobSegmentIdx if not NO_BLOB_SEGMENT_IDX_SPECIFIED, the blob segment requested to be returned (only
    *                       relevant for metadata blobs)
+   * @param restRequest the {@link RestRequest} that triggered this get operation.
    */
   GetBlobOptions(OperationType operationType, GetOption getOption, ByteRange range, boolean resolveRangeOnEmptyBlob,
-      boolean rawMode, int blobSegmentIdx) {
+      boolean rawMode, int blobSegmentIdx, RestRequest restRequest) {
     if (operationType == null || getOption == null) {
       throw new IllegalArgumentException("operationType and getOption must be defined");
     }
@@ -63,6 +66,7 @@ public class GetBlobOptions {
     this.resolveRangeOnEmptyBlob = resolveRangeOnEmptyBlob;
     this.rawMode = rawMode;
     this.blobSegmentIdx = blobSegmentIdx;
+    this.restRequest = restRequest;
   }
 
   /**
@@ -113,6 +117,10 @@ public class GetBlobOptions {
    */
   public boolean hasBlobSegmentIdx() {
     return blobSegmentIdx != NO_BLOB_SEGMENT_IDX_SPECIFIED;
+  }
+
+  public RestRequest getRestRequest() {
+    return restRequest;
   }
 
   @Override

--- a/ambry-api/src/main/java/com/github/ambry/router/GetBlobOptionsBuilder.java
+++ b/ambry-api/src/main/java/com/github/ambry/router/GetBlobOptionsBuilder.java
@@ -72,7 +72,7 @@ public class GetBlobOptionsBuilder {
   }
 
   /**
-   * @param restRequest The {@link RestRequest} that triggered this get operationt.
+   * @param restRequest The {@link RestRequest} that triggered this get operation.
    * @return this builder.
    */
   public GetBlobOptionsBuilder restRequest(RestRequest restRequest) {

--- a/ambry-api/src/main/java/com/github/ambry/router/GetBlobOptionsBuilder.java
+++ b/ambry-api/src/main/java/com/github/ambry/router/GetBlobOptionsBuilder.java
@@ -15,6 +15,7 @@
 package com.github.ambry.router;
 
 import com.github.ambry.protocol.GetOption;
+import com.github.ambry.rest.RestRequest;
 
 import static com.github.ambry.router.GetBlobOptions.*;
 
@@ -29,6 +30,7 @@ public class GetBlobOptionsBuilder {
   private ByteRange range = null;
   private boolean resolveRangeOnEmptyBlob = false;
   private boolean rawMode = false;
+  private RestRequest restRequest = null;
   private int blobSegmentIdx = NO_BLOB_SEGMENT_IDX_SPECIFIED;
 
   /**
@@ -70,6 +72,15 @@ public class GetBlobOptionsBuilder {
   }
 
   /**
+   * @param restRequest The {@link RestRequest} that triggered this get operationt.
+   * @return this builder.
+   */
+  public GetBlobOptionsBuilder restRequest(RestRequest restRequest) {
+    this.restRequest = restRequest;
+    return this;
+  }
+
+  /**
    * @param rawMode the raw mode flag for this get request.
    * If rawMode is true, the returned {@link GetBlobResult} will contain the raw (unserialized) blob payload in the
    * data channel and null blobInfo.  This option cannot be used in conjunction with a byte range.
@@ -93,6 +104,7 @@ public class GetBlobOptionsBuilder {
    * @return the {@link GetBlobOptions} built.
    */
   public GetBlobOptions build() {
-    return new GetBlobOptions(operationType, getOption, range, resolveRangeOnEmptyBlob, rawMode, blobSegmentIdx);
+    return new GetBlobOptions(operationType, getOption, range, resolveRangeOnEmptyBlob, rawMode, blobSegmentIdx,
+        restRequest);
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/router/KeyManagementService.java
+++ b/ambry-api/src/main/java/com/github/ambry/router/KeyManagementService.java
@@ -15,6 +15,7 @@ package com.github.ambry.router;
 
 import com.github.ambry.account.Account;
 import com.github.ambry.account.Container;
+import com.github.ambry.rest.RestRequest;
 import java.io.Closeable;
 import java.security.GeneralSecurityException;
 
@@ -22,7 +23,7 @@ import java.security.GeneralSecurityException;
 /**
  * Interface that defines the Key management service. KMS is responsible for maintaining keys for every
  * unique pair of AccountId and ContainerId that is registered with the KMS
- * Every caller is expected to register before making any {@link #getKey(short, short)} calls.
+ * Every caller is expected to register before making any {@link #getKey(RestRequest, short, short)} calls.
  * T refers to the Key type that this {@link KeyManagementService} will generate and return.
  * Ensure that {@link CryptoService} implementation is compatible with the key type that
  * {@link KeyManagementService} generates
@@ -47,21 +48,23 @@ public interface KeyManagementService<T> extends Closeable {
   /**
    * Fetches the key associated with the pair of AccountId and ContainerId. User is expected to have
    * registered using {@link #register(short, short)} for this pair before fetching keys.
+   * @param restRequest the {@link RestRequest} to use
    * @param accountId refers to the id of the {@link Account} for which key is expected
    * @param containerId refers to the id of the {@link Container} for which key is expected
    * @return T the key associated with the accountId and containerId
    * @throws {@link GeneralSecurityException} on KMS unavailability or if key is not registered
    */
-  T getKey(short accountId, short containerId) throws GeneralSecurityException;
+  T getKey(RestRequest restRequest, short accountId, short containerId) throws GeneralSecurityException;
 
   /**
    * Fetches the key associated with the specified context. User is expected to have
    * registered using {@link #register(String)} for this context before fetching keys.
+   * @param restRequest the {@link RestRequest} to use
    * @param context refers to the context for which key is expected
    * @return T the key associated with the context
    * @throws {@link GeneralSecurityException} on KMS unavailability or if key is not registered
    */
-  T getKey(String context) throws GeneralSecurityException;
+  T getKey(RestRequest restRequest, String context) throws GeneralSecurityException;
 
   /**
    * Generate and return a random key (of type T)

--- a/ambry-api/src/main/java/com/github/ambry/router/KeyManagementService.java
+++ b/ambry-api/src/main/java/com/github/ambry/router/KeyManagementService.java
@@ -48,7 +48,8 @@ public interface KeyManagementService<T> extends Closeable {
   /**
    * Fetches the key associated with the pair of AccountId and ContainerId. User is expected to have
    * registered using {@link #register(short, short)} for this pair before fetching keys.
-   * @param restRequest the {@link RestRequest} to use
+   * @param restRequest the {@link RestRequest} to use. A null pointer might be passed for this argument, service has to
+   *                    be able to deal with null {@link RestRequest}.
    * @param accountId refers to the id of the {@link Account} for which key is expected
    * @param containerId refers to the id of the {@link Container} for which key is expected
    * @return T the key associated with the accountId and containerId
@@ -59,7 +60,8 @@ public interface KeyManagementService<T> extends Closeable {
   /**
    * Fetches the key associated with the specified context. User is expected to have
    * registered using {@link #register(String)} for this context before fetching keys.
-   * @param restRequest the {@link RestRequest} to use
+   * @param restRequest the {@link RestRequest} to use. A null pointer might be passed for this argument, service has to
+   *                    be able to deal with null {@link RestRequest}.
    * @param context refers to the context for which key is expected
    * @return T the key associated with the context
    * @throws {@link GeneralSecurityException} on KMS unavailability or if key is not registered

--- a/ambry-api/src/main/java/com/github/ambry/router/PutBlobOptions.java
+++ b/ambry-api/src/main/java/com/github/ambry/router/PutBlobOptions.java
@@ -16,6 +16,7 @@
 package com.github.ambry.router;
 
 import com.github.ambry.rest.RestRequest;
+import java.util.Objects;
 
 
 /**
@@ -54,6 +55,9 @@ public class PutBlobOptions {
     return maxUploadSize;
   }
 
+  /**
+   * @return The {@link RestRequest} that triggered this put operation.
+   */
   public RestRequest getRestRequest() {
     return restRequest;
   }
@@ -68,18 +72,18 @@ public class PutBlobOptions {
     }
 
     PutBlobOptions options = (PutBlobOptions) o;
-    return chunkUpload == options.chunkUpload && maxUploadSize == options.maxUploadSize;
+    return chunkUpload == options.chunkUpload && maxUploadSize == options.maxUploadSize && Objects.equals(restRequest,
+        options.restRequest);
   }
 
   @Override
   public int hashCode() {
-    int result = (chunkUpload ? 1 : 0);
-    result = 31 * result + (int) (maxUploadSize ^ (maxUploadSize >>> 32));
-    return result;
+    return Objects.hash(chunkUpload, maxUploadSize, restRequest);
   }
 
   @Override
   public String toString() {
-    return "PutBlobOptions{" + "chunkUpload=" + chunkUpload + ", maxUploadSize=" + maxUploadSize + '}';
+    return "PutBlobOptions{" + "chunkUpload=" + chunkUpload + ", maxUploadSize=" + maxUploadSize + ", restRequest="
+        + restRequest + '}';
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/router/PutBlobOptions.java
+++ b/ambry-api/src/main/java/com/github/ambry/router/PutBlobOptions.java
@@ -15,6 +15,9 @@
 
 package com.github.ambry.router;
 
+import com.github.ambry.rest.RestRequest;
+
+
 /**
  * Represents any options associated with a putBlob request.
  */
@@ -22,15 +25,18 @@ public class PutBlobOptions {
   public static final PutBlobOptions DEFAULT = new PutBlobOptionsBuilder().build();
   private final boolean chunkUpload;
   private final long maxUploadSize;
+  private final RestRequest restRequest;
 
   /**
    * @param chunkUpload {@code true} to indicate that the {@code putBlob()} call is for a single data chunk of a
    *                    stitched blob.
    * @param maxUploadSize the max size of the uploaded blob in bytes. To be enforced by the router. Can be null.
+   * @param restRequest The {@link RestRequest} that triggered this put operation.
    */
-  public PutBlobOptions(boolean chunkUpload, long maxUploadSize) {
+  public PutBlobOptions(boolean chunkUpload, long maxUploadSize, RestRequest restRequest) {
     this.chunkUpload = chunkUpload;
     this.maxUploadSize = maxUploadSize;
+    this.restRequest = restRequest;
   }
 
   /**
@@ -46,6 +52,10 @@ public class PutBlobOptions {
    */
   public long getMaxUploadSize() {
     return maxUploadSize;
+  }
+
+  public RestRequest getRestRequest() {
+    return restRequest;
   }
 
   @Override

--- a/ambry-api/src/main/java/com/github/ambry/router/PutBlobOptionsBuilder.java
+++ b/ambry-api/src/main/java/com/github/ambry/router/PutBlobOptionsBuilder.java
@@ -15,12 +15,16 @@
 
 package com.github.ambry.router;
 
+import com.github.ambry.rest.RestRequest;
+
+
 /**
  * A builder for {@link PutBlobOptions} objects.
  */
 public class PutBlobOptionsBuilder {
   private boolean chunkUpload = false;
   private long maxUploadSize = Long.MAX_VALUE;
+  private RestRequest restRequest = null;
 
   /**
    * @param chunkUpload {@code true} to indicate that this is an upload of a data chunk of a stitched upload.
@@ -41,9 +45,18 @@ public class PutBlobOptionsBuilder {
   }
 
   /**
+   * @param restRequest The {@link RestRequest} that triggered this put operation.
+   * @return this builder.
+   */
+  public PutBlobOptionsBuilder restRequest(RestRequest restRequest) {
+    this.restRequest = restRequest;
+    return this;
+  }
+
+  /**
    * @return the {@link PutBlobOptions} built.
    */
   public PutBlobOptions build() {
-    return new PutBlobOptions(chunkUpload, maxUploadSize);
+    return new PutBlobOptions(chunkUpload, maxUploadSize, restRequest);
   }
 }

--- a/ambry-api/src/test/java/com/github/ambry/router/PutBlobOptionsTest.java
+++ b/ambry-api/src/test/java/com/github/ambry/router/PutBlobOptionsTest.java
@@ -15,6 +15,10 @@
 
 package com.github.ambry.router;
 
+import com.github.ambry.rest.MockRestRequest;
+import com.github.ambry.rest.RestMethod;
+import com.github.ambry.rest.RestRequest;
+import org.json.JSONObject;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.*;
@@ -30,13 +34,19 @@ public class PutBlobOptionsTest {
    * @throws Exception
    */
   @Test
-  public void testOptions() {
+  public void testOptions() throws Exception {
     PutBlobOptions options = new PutBlobOptionsBuilder().chunkUpload(true).build();
     assertTrue("chunkUpload from options not as expected.", options.isChunkUpload());
     assertEquals("maxUploadSize from options not as expected.", Long.MAX_VALUE, options.getMaxUploadSize());
     options = new PutBlobOptionsBuilder().chunkUpload(false).maxUploadSize(3).build();
     assertFalse("chunkUpload from options not as expected.", options.isChunkUpload());
     assertEquals("maxUploadSize from options not as expected.", 3, options.getMaxUploadSize());
+    JSONObject header = new JSONObject();
+    header.put(MockRestRequest.URI_KEY, "/");
+    header.put(MockRestRequest.REST_METHOD_KEY, RestMethod.GET.name());
+    RestRequest restRequest = new MockRestRequest(header, null);
+    options = new PutBlobOptionsBuilder().restRequest(restRequest).build();
+    assertEquals("RestRequest mismatch", restRequest, options.getRestRequest());
   }
 
   /**
@@ -48,7 +58,8 @@ public class PutBlobOptionsTest {
     PutBlobOptions b = new PutBlobOptionsBuilder().chunkUpload(true).maxUploadSize(3).build();
     assertEquals("PutBlobOptions should be equal", a, b);
     assertEquals("PutBlobOptions hashcodes should be equal", a.hashCode(), b.hashCode());
-    assertEquals("toString output not as expected", "PutBlobOptions{chunkUpload=true, maxUploadSize=3}", a.toString());
+    assertEquals("toString output not as expected",
+        "PutBlobOptions{chunkUpload=true, maxUploadSize=3, restRequest=null}", a.toString());
     b = new PutBlobOptionsBuilder().chunkUpload(false).maxUploadSize(3).build();
     assertThat("PutBlobOptions should not be equal.", a, not(b));
   }

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobCryptoAgentImpl.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobCryptoAgentImpl.java
@@ -43,7 +43,7 @@ public class CloudBlobCryptoAgentImpl implements CloudBlobCryptoAgent {
     this.cryptoService = cryptoService;
     this.kms = kms;
     this.context = context;
-    contextKey = kms.getKey(context);
+    contextKey = kms.getKey(null, context);
   }
 
   @Override

--- a/ambry-router/src/main/java/com/github/ambry/router/GetBlobInfoOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/GetBlobInfoOperation.java
@@ -368,7 +368,7 @@ class GetBlobInfoOperation extends GetOperation {
       decryptJobMetricsTracker.onJobSubmission();
       long startTimeMs = System.currentTimeMillis();
       cryptoJobHandler.submitJob(
-          new DecryptJob(blobId, encryptionKey.duplicate(), null, userMetadata, cryptoService, kms,
+          new DecryptJob(blobId, encryptionKey.duplicate(), null, userMetadata, cryptoService, kms, options.getBlobOptions,
               decryptJobMetricsTracker, (DecryptJob.DecryptJobResult result, Exception exception) -> {
             decryptJobMetricsTracker.onJobResultProcessingStart();
             logger.trace("Handling decrypt job callback results for {}", blobId);

--- a/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
@@ -1233,7 +1233,7 @@ class PutOperation {
         cryptoJobHandler.submitJob(
             new EncryptJob(passedInBlobProperties.getAccountId(), passedInBlobProperties.getContainerId(),
                 isMetadataChunk() ? null : buf.retainedDuplicate(), ByteBuffer.wrap(chunkUserMetadata),
-                kms.getRandomKey(), cryptoService, kms, encryptJobMetricsTracker, this::encryptionCallback));
+                kms.getRandomKey(), cryptoService, kms, options, encryptJobMetricsTracker, this::encryptionCallback));
       } catch (GeneralSecurityException e) {
         encryptJobMetricsTracker.incrementOperationError();
         logger.trace("Exception thrown while generating random key for chunk at index {}", chunkIndex, e);

--- a/ambry-router/src/main/java/com/github/ambry/router/SingleKeyManagementService.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/SingleKeyManagementService.java
@@ -16,6 +16,7 @@ package com.github.ambry.router;
 import com.github.ambry.account.Account;
 import com.github.ambry.account.Container;
 import com.github.ambry.config.KMSConfig;
+import com.github.ambry.rest.RestRequest;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import javax.crypto.KeyGenerator;
@@ -26,7 +27,7 @@ import org.bouncycastle.util.encoders.Hex;
 
 /**
  * Single {@link KeyManagementService} which returns a default key {@link SecretKeySpec} for any
- * {@link #getKey(short, short)} calls, but a different random key for any {@link #getRandomKey()} calls.
+ * {@link #getKey(RestRequest, short, short)} calls, but a different random key for any {@link #getRandomKey()} calls.
  */
 public class SingleKeyManagementService implements KeyManagementService<SecretKeySpec> {
   private final SecretKeySpec secretKeySpec;
@@ -37,7 +38,7 @@ public class SingleKeyManagementService implements KeyManagementService<SecretKe
   /**
    * Instantiates {@link SingleKeyManagementService} with {@link KMSConfig} and a default container key which is hex string.
    * @param config {@link KMSConfig} to fetch configs from
-   * @param defaultContainerKey the default container key that will be returned for all {@link #getKey(short, short)} calls
+   * @param defaultContainerKey the default container key that will be returned for all {@link #getKey(RestRequest, short, short)} calls
    * @throws GeneralSecurityException
    */
   public SingleKeyManagementService(KMSConfig config, String defaultContainerKey) throws GeneralSecurityException {
@@ -65,18 +66,20 @@ public class SingleKeyManagementService implements KeyManagementService<SecretKe
 
   /**
    * Fetches the key associated with the pair of AccountId and ContainerId. {@link SingleKeyManagementService} returns
-   * the default key for all {@link #getKey(short, short)}}
+   * the default key for all {@link #getKey(RestRequest, short, short)}}
+   * @param restRequest the {@link RestRequest} to use
    * @param accountId refers to the id of the {@link Account} for which key is expected
    * @param containerId refers to the id of the {@link Container} for which key is expected
    * @return {@link SecretKeySpec} the key associated with the accountId and containerId
    */
   @Override
-  public SecretKeySpec getKey(short accountId, short containerId) throws GeneralSecurityException {
-    return getKey(accountId + ":" + containerId);
+  public SecretKeySpec getKey(RestRequest restRequest, short accountId, short containerId)
+      throws GeneralSecurityException {
+    return getKey(restRequest, accountId + ":" + containerId);
   }
 
   @Override
-  public SecretKeySpec getKey(String context) throws GeneralSecurityException {
+  public SecretKeySpec getKey(RestRequest restRequest, String context) throws GeneralSecurityException {
     if (enabled) {
       return secretKeySpec;
     } else {

--- a/ambry-router/src/test/java/com/github/ambry/router/ChunkFillTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/ChunkFillTest.java
@@ -338,7 +338,7 @@ public class ChunkFillTest {
       for (int i = 0; i < numChunks; i++) {
         DecryptJob decryptJob =
             new DecryptJob(compositeBlobIds[i], compositeEncryptionKeys[i], compositeBuffers[i], null, cryptoService,
-                kms, new CryptoJobMetricsTracker(routerMetrics.decryptJobMetrics), (result, exception) -> {
+                kms, null, new CryptoJobMetricsTracker(routerMetrics.decryptJobMetrics), (result, exception) -> {
               Assert.assertNull("Exception shouldn't have been thrown", exception);
               ByteBuf decryptedBlobContent = result.getDecryptedBlobContent();
               int chunkSize = decryptedBlobContent.readableBytes();

--- a/ambry-router/src/test/java/com/github/ambry/router/CryptoJobHandlerTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/CryptoJobHandlerTest.java
@@ -196,7 +196,7 @@ public class CryptoJobHandlerTest {
       if (i < closeOnCount) {
         cryptoJobHandler.submitJob(
             new EncryptJob(testData.blobId.getAccountId(), testData.blobId.getContainerId(), testData.blobContent,
-                testData.userMetadata, perBlobKey, cryptoService, kms,
+                testData.userMetadata, perBlobKey, cryptoService, kms, null,
                 new CryptoJobMetricsTracker(routerMetrics.encryptJobMetrics),
                 (EncryptJob.EncryptJobResult result, Exception exception) -> {
                   encryptCallBackCount.countDown();
@@ -208,7 +208,7 @@ public class CryptoJobHandlerTest {
       } else {
         encryptJobs.add(
             new EncryptJob(testData.blobId.getAccountId(), testData.blobId.getContainerId(), testData.blobContent,
-                testData.userMetadata, perBlobKey, cryptoService, kms,
+                testData.userMetadata, perBlobKey, cryptoService, kms, null,
                 new CryptoJobMetricsTracker(routerMetrics.encryptJobMetrics),
                 (EncryptJob.EncryptJobResult result, Exception exception) -> {
                   encryptCallBackCount.countDown();
@@ -229,7 +229,7 @@ public class CryptoJobHandlerTest {
     TestBlobData probeData = getRandomBlob(referenceClusterMap);
     cryptoJobHandler.submitJob(
         new EncryptJob(probeData.blobId.getAccountId(), probeData.blobId.getContainerId(), probeData.blobContent,
-            probeData.userMetadata, perBlobKey, cryptoService, kms,
+            probeData.userMetadata, perBlobKey, cryptoService, kms, null,
             new CryptoJobMetricsTracker(routerMetrics.encryptJobMetrics),
             (EncryptJob.EncryptJobResult result, Exception exception) -> {
               result.getEncryptedBlobContent().release();
@@ -258,14 +258,14 @@ public class CryptoJobHandlerTest {
     for (int i = 0; i < testDataCount; i++) {
       TestBlobData testData = getRandomBlob(referenceClusterMap);
       cryptoJobHandler.submitJob(new EncryptJob(testData.blobId.getAccountId(), testData.blobId.getContainerId(),
-          testData.blobContent.retainedDuplicate(), testData.userMetadata, perBlobKey, cryptoService, kms,
+          testData.blobContent.retainedDuplicate(), testData.userMetadata, perBlobKey, cryptoService, kms, null,
           new CryptoJobMetricsTracker(routerMetrics.encryptJobMetrics),
           (EncryptJob.EncryptJobResult encryptJobResult, Exception exception) -> {
             assertNotNull("Encrypted content should not be null", encryptJobResult.getEncryptedBlobContent());
             assertNotNull("Encrypted key should not be null", encryptJobResult.getEncryptedKey());
             decryptJobs.add(new DecryptJob(testData.blobId, encryptJobResult.getEncryptedKey(),
                 encryptJobResult.getEncryptedBlobContent(), encryptJobResult.getEncryptedUserMetadata(), cryptoService,
-                kms, new CryptoJobMetricsTracker(routerMetrics.decryptJobMetrics),
+                kms, null, new CryptoJobMetricsTracker(routerMetrics.decryptJobMetrics),
                 (DecryptJob.DecryptJobResult decryptJobResult, Exception e) -> {
                   if (e == null) {
                     assertEquals("BlobId mismatch ", testData.blobId, decryptJobResult.getBlobId());
@@ -301,7 +301,7 @@ public class CryptoJobHandlerTest {
     TestBlobData probeData = getRandomBlob(referenceClusterMap);
     cryptoJobHandler.submitJob(
         new EncryptJob(probeData.blobId.getAccountId(), probeData.blobId.getContainerId(), probeData.blobContent,
-            probeData.userMetadata, perBlobKey, cryptoService, kms,
+            probeData.userMetadata, perBlobKey, cryptoService, kms, null,
             new CryptoJobMetricsTracker(routerMetrics.encryptJobMetrics),
             (EncryptJob.EncryptJobResult result, Exception exception) -> {
               result.getEncryptedBlobContent().release();
@@ -325,7 +325,7 @@ public class CryptoJobHandlerTest {
 
     cryptoJobHandler.submitJob(
         new EncryptJob(randomData.blobId.getAccountId(), randomData.blobId.getContainerId(), randomData.blobContent,
-            randomData.userMetadata, perBlobKey, cryptoService, kms,
+            randomData.userMetadata, perBlobKey, cryptoService, kms, null,
             new CryptoJobMetricsTracker(routerMetrics.encryptJobMetrics),
             (EncryptJob.EncryptJobResult result, Exception exception) -> {
               fail("Callback should not have been called since CryptoWorker is closed");
@@ -333,7 +333,7 @@ public class CryptoJobHandlerTest {
 
     cryptoJobHandler.submitJob(
         new DecryptJob(randomData.blobId, randomData.blobContent.nioBuffer(), randomData.blobContent,
-            randomData.userMetadata, cryptoService, kms, new CryptoJobMetricsTracker(routerMetrics.decryptJobMetrics),
+            randomData.userMetadata, cryptoService, kms, null, new CryptoJobMetricsTracker(routerMetrics.decryptJobMetrics),
             (DecryptJob.DecryptJobResult result, Exception exception) -> {
               fail("Callback should not have been called since CryptoWorker is closed");
             }));
@@ -370,7 +370,7 @@ public class CryptoJobHandlerTest {
     ByteBuffer userMetadata = mode != Mode.Data ? randomData.userMetadata : null;
     cryptoJobHandler.submitJob(
         new EncryptJob(randomData.blobId.getAccountId(), randomData.blobId.getContainerId(), content, userMetadata,
-            perBlobKey, cryptoService, kms, new CryptoJobMetricsTracker(routerMetrics.encryptJobMetrics),
+            perBlobKey, cryptoService, kms, null, new CryptoJobMetricsTracker(routerMetrics.encryptJobMetrics),
             new EncryptCallbackVerifier(randomData.blobId, false, encryptCallBackCount,
                 new DecryptCallbackVerifier(randomData.blobId, content != null ? content.retainedDuplicate() : null,
                     userMetadata, false, decryptCallBackCount), mode)));
@@ -388,7 +388,7 @@ public class CryptoJobHandlerTest {
     CountDownLatch encryptCallBackCount = new CountDownLatch(1);
     cryptoJobHandler.submitJob(
         new EncryptJob(testData.blobId.getAccountId(), testData.blobId.getContainerId(), testData.blobContent,
-            testData.userMetadata, perBlobKey, cryptoService, kms,
+            testData.userMetadata, perBlobKey, cryptoService, kms, null,
             new CryptoJobMetricsTracker(routerMetrics.encryptJobMetrics),
             new EncryptCallbackVerifier(testData.blobId, true, encryptCallBackCount, null, Mode.Both)));
     awaitCountDownLatch(encryptCallBackCount, ENCRYPT_JOB_TYPE);
@@ -408,7 +408,7 @@ public class CryptoJobHandlerTest {
     CountDownLatch encryptCallBackCount = new CountDownLatch(1);
     CountDownLatch decryptCallBackCount = new CountDownLatch(1);
     cryptoJobHandler.submitJob(new EncryptJob(testData.blobId.getAccountId(), testData.blobId.getContainerId(),
-        testData.blobContent.retainedDuplicate(), testData.userMetadata, perBlobKey, cryptoService, kms,
+        testData.blobContent.retainedDuplicate(), testData.userMetadata, perBlobKey, cryptoService, kms, null,
         new CryptoJobMetricsTracker(routerMetrics.encryptJobMetrics),
         (EncryptJob.EncryptJobResult encryptJobResult, Exception exception) -> {
           encryptCallBackCount.countDown();
@@ -424,7 +424,7 @@ public class CryptoJobHandlerTest {
           }
           cryptoJobHandler.submitJob(new DecryptJob(testData.blobId, encryptJobResult.getEncryptedKey(),
               encryptJobResult.getEncryptedBlobContent(), encryptJobResult.getEncryptedUserMetadata(), cryptoService,
-              kms, new CryptoJobMetricsTracker(routerMetrics.decryptJobMetrics),
+              kms, null, new CryptoJobMetricsTracker(routerMetrics.decryptJobMetrics),
               (DecryptJob.DecryptJobResult result, Exception e) -> {
                 decryptCallBackCount.countDown();
                 assertNotNull("Exception should have been thrown to decrypt contents for " + testData.blobId, e);
@@ -474,7 +474,7 @@ public class CryptoJobHandlerTest {
         assertNotNull("Encrypted key should not be null", encryptJobResult.getEncryptedKey());
         cryptoJobHandler.submitJob(new DecryptJob(blobId, encryptJobResult.getEncryptedKey(),
             encryptedBlobContent != null ? encryptedBlobContent.retainedDuplicate() : null,
-            encryptJobResult.getEncryptedUserMetadata(), cryptoService, kms,
+            encryptJobResult.getEncryptedUserMetadata(), cryptoService, kms, null,
             new CryptoJobMetricsTracker(routerMetrics.decryptJobMetrics), (result, e) -> {
           decryptCallBackVerifier.onCompletion(result, e);
         }));

--- a/ambry-router/src/test/java/com/github/ambry/router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/GetBlobOperationTest.java
@@ -283,7 +283,7 @@ public class GetBlobOperationTest {
       FutureResult<EncryptJob.EncryptJobResult> futureResult = new FutureResult<>();
       cryptoJobHandler.submitJob(new EncryptJob(blobProperties.getAccountId(), blobProperties.getContainerId(),
           blobType == BlobType.MetadataBlob ? null : blobContent.retainedDuplicate(), userMetadataBuf.duplicate(),
-          kms.getRandomKey(), cryptoService, kms, new CryptoJobMetricsTracker(routerMetrics.encryptJobMetrics),
+          kms.getRandomKey(), cryptoService, kms, null, new CryptoJobMetricsTracker(routerMetrics.encryptJobMetrics),
           futureResult::done));
       EncryptJob.EncryptJobResult result = futureResult.get(5, TimeUnit.SECONDS);
       blobEncryptionKey = result.getEncryptedKey();

--- a/ambry-router/src/test/java/com/github/ambry/router/MockKeyManagementService.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/MockKeyManagementService.java
@@ -25,6 +25,7 @@ import javax.crypto.spec.SecretKeySpec;
  */
 class MockKeyManagementService extends SingleKeyManagementService {
   AtomicReference<GeneralSecurityException> exceptionToThrow = new AtomicReference<>();
+  AtomicReference<RestRequest> currentRestRequest = new AtomicReference<>();
 
   MockKeyManagementService(KMSConfig KMSConfig, String defaultKey) throws GeneralSecurityException {
     super(KMSConfig, defaultKey);
@@ -33,10 +34,19 @@ class MockKeyManagementService extends SingleKeyManagementService {
   @Override
   public SecretKeySpec getKey(RestRequest restRequest, short accountId, short containerId)
       throws GeneralSecurityException {
+    currentRestRequest.set(restRequest);
     if (exceptionToThrow.get() != null) {
       throw exceptionToThrow.get();
     } else {
       return super.getKey(restRequest, accountId, containerId);
     }
+  }
+
+  /**
+   * Return the restRequest that just passed to this service.
+   * @return
+   */
+  public RestRequest getCurrentRestRequest() {
+    return currentRestRequest.get();
   }
 }

--- a/ambry-router/src/test/java/com/github/ambry/router/MockKeyManagementService.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/MockKeyManagementService.java
@@ -14,6 +14,7 @@
 package com.github.ambry.router;
 
 import com.github.ambry.config.KMSConfig;
+import com.github.ambry.rest.RestRequest;
 import java.security.GeneralSecurityException;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.crypto.spec.SecretKeySpec;
@@ -30,11 +31,12 @@ class MockKeyManagementService extends SingleKeyManagementService {
   }
 
   @Override
-  public SecretKeySpec getKey(short accountId, short containerId) throws GeneralSecurityException {
+  public SecretKeySpec getKey(RestRequest restRequest, short accountId, short containerId)
+      throws GeneralSecurityException {
     if (exceptionToThrow.get() != null) {
       throw exceptionToThrow.get();
     } else {
-      return super.getKey(accountId, containerId);
+      return super.getKey(restRequest, accountId, containerId);
     }
   }
 }

--- a/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTestBase.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTestBase.java
@@ -64,8 +64,6 @@ import java.util.stream.Collectors;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import static com.github.ambry.router.RouterTestHelpers.*;
 import static com.github.ambry.utils.TestUtils.*;
@@ -89,7 +87,7 @@ public class NonBlockingRouterTestBase {
   protected static final int USER_METADATA_SIZE = 10;
   protected final AtomicReference<MockSelectorState> mockSelectorState = new AtomicReference<>(MockSelectorState.Good);
   protected final MockTime mockTime;
-  protected final KeyManagementService kms;
+  protected final MockKeyManagementService kms;
   protected final String singleKeyForKMS;
   protected final CryptoService cryptoService;
   protected final MockClusterMap mockClusterMap;
@@ -132,7 +130,7 @@ public class NonBlockingRouterTestBase {
     NonBlockingRouter.currentOperationsCount.set(0);
     VerifiableProperties vProps = new VerifiableProperties(new Properties());
     singleKeyForKMS = TestUtils.getRandomKey(SingleKeyManagementServiceTest.DEFAULT_KEY_SIZE_CHARS);
-    kms = new SingleKeyManagementService(new KMSConfig(vProps), singleKeyForKMS);
+    kms = new MockKeyManagementService(new KMSConfig(vProps), singleKeyForKMS);
     cryptoService = new GCMCryptoService(new CryptoServiceConfig(vProps));
     cryptoJobHandler = new CryptoJobHandler(CryptoJobHandlerTest.DEFAULT_THREAD_COUNT);
     accountService = new InMemAccountService(false, true);
@@ -550,10 +548,10 @@ public class NonBlockingRouterTestBase {
     setOperationParams();
     Assert.assertFalse("The original ttl should not be infinite for this test to work",
         putBlobProperties.getTimeToLiveInSeconds() == Utils.Infinite_Time);
-    String blobId = router.putBlob(putBlobProperties, putUserMetadata, putChannel, new PutBlobOptionsBuilder().build()).get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-    assertTtl(router, Collections.singleton(blobId), TTL_SECS);
-    router.updateBlobTtl(blobId, updateServiceId, Utils.Infinite_Time)
+    String blobId = router.putBlob(putBlobProperties, putUserMetadata, putChannel, new PutBlobOptionsBuilder().build())
         .get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    assertTtl(router, Collections.singleton(blobId), TTL_SECS);
+    router.updateBlobTtl(blobId, updateServiceId, Utils.Infinite_Time).get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
     // if more than one chunk is created, also account for metadata blob
     notificationSystem.checkNotifications(numChunks == 1 ? 1 : numChunks + 1, updateServiceId, Utils.Infinite_Time);
     assertTtl(router, Collections.singleton(blobId), Utils.Infinite_Time);

--- a/ambry-router/src/test/java/com/github/ambry/router/PutManagerTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/PutManagerTest.java
@@ -1101,7 +1101,7 @@ public class PutManagerTest {
         // reason to directly call run() instead of spinning up a thread instead of calling start() is that, any exceptions or
         // assertion failures in non main thread will not fail the test.
         new DecryptJob(origBlobId, request.getBlobEncryptionKey().duplicate(), null, userMetadata, cryptoService, kms,
-            new CryptoJobMetricsTracker(metrics.decryptJobMetrics), (result, exception) -> {
+            null, new CryptoJobMetricsTracker(metrics.decryptJobMetrics), (result, exception) -> {
           assertNull("Exception should not be thrown", exception);
           assertEquals("BlobId mismatch", origBlobId, result.getBlobId());
           assertArrayEquals("UserMetadata mismatch", requestAndResult.putUserMetadata,
@@ -1132,7 +1132,7 @@ public class PutManagerTest {
         // reason to directly call run() instead of spinning up a thread instead of calling start() is that, any exceptions or
         // assertion failures in non main thread will not fail the test.
         new DecryptJob(origBlobId, request.getBlobEncryptionKey().duplicate(), Unpooled.wrappedBuffer(content),
-            userMetadata, cryptoService, kms, new CryptoJobMetricsTracker(metrics.decryptJobMetrics),
+            userMetadata, cryptoService, kms, null, new CryptoJobMetricsTracker(metrics.decryptJobMetrics),
             (result, exception) -> {
               assertNull("Exception should not be thrown", exception);
               assertEquals("BlobId mismatch", origBlobId, result.getBlobId());
@@ -1178,7 +1178,7 @@ public class PutManagerTest {
         // assertion failures in non main thread will not fail the test.
         new DecryptJob(dataBlobPutRequest.getBlobId(), dataBlobPutRequest.getBlobEncryptionKey().duplicate(),
             Unpooled.wrappedBuffer(dataBlobContent), dataBlobPutRequest.getUsermetadata().duplicate(), cryptoService,
-            kms, new CryptoJobMetricsTracker(metrics.decryptJobMetrics), (result, exception) -> {
+            kms, null, new CryptoJobMetricsTracker(metrics.decryptJobMetrics), (result, exception) -> {
           Assert.assertNull("Exception should not be thrown", exception);
           assertEquals("BlobId mismatch", dataBlobPutRequest.getBlobId(), result.getBlobId());
           Assert.assertArrayEquals("UserMetadata mismatch", originalUserMetadata,

--- a/ambry-router/src/test/java/com/github/ambry/router/SingleKeyManagementServiceTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/SingleKeyManagementServiceTest.java
@@ -18,6 +18,7 @@ import com.github.ambry.account.Account;
 import com.github.ambry.account.Container;
 import com.github.ambry.config.KMSConfig;
 import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.rest.RestRequest;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
 import java.security.GeneralSecurityException;
@@ -41,7 +42,7 @@ public class SingleKeyManagementServiceTest {
   private static final MetricRegistry REGISTRY = new MetricRegistry();
 
   /**
-   * Test {@link SingleKeyManagementService#getKey(short, short)}
+   * Test {@link SingleKeyManagementService#getKey(RestRequest, short, short)}
    */
   @Test
   public void testSingleKMS() throws Exception {
@@ -55,7 +56,7 @@ public class SingleKeyManagementServiceTest {
       KeyManagementService<SecretKeySpec> kms =
           new SingleKeyManagementServiceFactory(verifiableProperties, CLUSTER_NAME, REGISTRY).getKeyManagementService();
       SecretKeySpec keyFromKMS =
-          kms.getKey(Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM));
+          kms.getKey(null, Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM));
       Assert.assertEquals("Secret key mismatch ", secretKeySpec, keyFromKMS);
     }
   }
@@ -90,7 +91,7 @@ public class SingleKeyManagementServiceTest {
         new SingleKeyManagementServiceFactory(verifiableProperties, CLUSTER_NAME, REGISTRY).getKeyManagementService();
     kms.close();
     try {
-      kms.getKey(Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID);
+      kms.getKey(null, Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID);
       Assert.fail("getKey() on KMS should have failed as KMS is closed");
     } catch (GeneralSecurityException e) {
     }


### PR DESCRIPTION
Passing RestRequest to key management service fo provide extra request information to key management service getKey method.
Passing it through GetBlobOptions and PutBlobOpitions.