### PR TITLE
Avoid serialization of requests when using LocalNetworkClient

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/network/RequestInfo.java
+++ b/ambry-api/src/main/java/com/github/ambry/network/RequestInfo.java
@@ -15,7 +15,6 @@ package com.github.ambry.network;
 
 import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.quota.Chargeable;
-import com.github.ambry.quota.QuotaResource;
 
 
 /**
@@ -28,6 +27,7 @@ public class RequestInfo {
   private final SendWithCorrelationId request;
   private final ReplicaId replicaId;
   private final Chargeable chargeable;
+  private final long requestCreateTime;
   private long streamSendTime = -1;
   private long streamHeaderFrameReceiveTime = -1;
   public int responseFramesCount = 0;
@@ -40,12 +40,14 @@ public class RequestInfo {
    * @param replicaId the {@link ReplicaId} associated with this request.
    * @param chargeable the {@link Chargeable} associated with this request.
    */
-  public RequestInfo(String host, Port port, SendWithCorrelationId request, ReplicaId replicaId, Chargeable chargeable) {
+  public RequestInfo(String host, Port port, SendWithCorrelationId request, ReplicaId replicaId,
+      Chargeable chargeable) {
     this.host = host;
     this.port = port;
     this.request = request;
     this.replicaId = replicaId;
     this.chargeable = chargeable;
+    requestCreateTime = System.currentTimeMillis();
   }
 
   /**
@@ -97,6 +99,13 @@ public class RequestInfo {
 
   public void setStreamSendTime(long streamSendTime) {
     this.streamSendTime = streamSendTime;
+  }
+
+  /**
+   * @return creation time of this request in msec.
+   */
+  public long getRequestCreateTime() {
+    return requestCreateTime;
   }
 
   @Override

--- a/ambry-api/src/main/java/com/github/ambry/network/ResponseInfo.java
+++ b/ambry-api/src/main/java/com/github/ambry/network/ResponseInfo.java
@@ -16,6 +16,7 @@ package com.github.ambry.network;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.utils.AbstractByteBufHolder;
 import io.netty.buffer.ByteBuf;
+import io.netty.util.ReferenceCountUtil;
 
 
 /**
@@ -28,7 +29,14 @@ public class ResponseInfo extends AbstractByteBufHolder<ResponseInfo> {
   private final RequestInfo requestInfo;
   private final NetworkClientErrorCode error;
   private final DataNodeId dataNode;
+  /**
+   * Response received from network in the form of serialized bytes.
+   */
   private ByteBuf content;
+  /**
+   * Response received within the same process in the form of {@code Send} java object.
+   */
+  private Send response;
 
   /**
    * Constructs a ResponseInfo with the given parameters.
@@ -55,6 +63,23 @@ public class ResponseInfo extends AbstractByteBufHolder<ResponseInfo> {
   }
 
   /**
+   * Constructs a ResponseInfo with the given parameters. This is used when responses are received in the same process
+   * via {@code LocalNetworkClient} in the form of {@link Send} objects instead of deserialized bytes.
+   * @param requestInfo the {@link RequestInfo} associated with this response.
+   * @param error the error encountered in sending this request, if there is any.
+   * @param dataNode the {@link DataNodeId} of this request.
+   * @param response response received in the form of {@link Send} implementation. This is used when to send and receive
+   *                responses in the same process by using local queues.
+   */
+  public ResponseInfo(RequestInfo requestInfo, NetworkClientErrorCode error, DataNodeId dataNode, Send response) {
+    this.requestInfo = requestInfo;
+    this.error = error;
+    this.content = null;
+    this.dataNode = dataNode;
+    this.response = response;
+  }
+
+  /**
    * @return the {@link RequestInfo} associated with this response.
    */
   public RequestInfo getRequestInfo() {
@@ -75,6 +100,14 @@ public class ResponseInfo extends AbstractByteBufHolder<ResponseInfo> {
     return dataNode;
   }
 
+  /**
+   * @return response in the form of {@link Send} implementation. This is used to send and receive responses in the same
+   * process using local queues.
+   */
+  public Send getResponse() {
+    return response;
+  }
+
   @Override
   public String toString() {
     return "ResponseInfo{requestInfo=" + requestInfo + ", error=" + error + ", response=" + content + ", dataNode="
@@ -89,5 +122,24 @@ public class ResponseInfo extends AbstractByteBufHolder<ResponseInfo> {
   @Override
   public ResponseInfo replace(ByteBuf content) {
     return new ResponseInfo(requestInfo, error, content, dataNode);
+  }
+
+  /**
+   * Override the release method since we also need to release {@link ResponseInfo#response} in case it is not null.
+   * @return
+   */
+  @Override
+  public boolean release() {
+
+    if (response != null) {
+      ReferenceCountUtil.safeRelease(response);
+      response = null;
+    }
+
+    if (content != null) {
+      ReferenceCountUtil.safeRelease(content);
+      content = null;
+    }
+    return false;
   }
 }

--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageFormatInputStream.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageFormatInputStream.java
@@ -17,8 +17,6 @@ import com.github.ambry.utils.CrcInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**

--- a/ambry-network/src/main/java/com/github/ambry/network/LocalRequestResponseChannel.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/LocalRequestResponseChannel.java
@@ -14,15 +14,7 @@
 package com.github.ambry.network;
 
 import com.github.ambry.utils.BatchBlockingQueue;
-import com.github.ambry.utils.ByteBufferChannel;
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufOutputStream;
-import io.netty.buffer.Unpooled;
-import java.io.IOException;
 import java.io.InputStream;
-import java.nio.ByteBuffer;
-import java.nio.channels.Channels;
-import java.nio.channels.WritableByteChannel;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
@@ -41,8 +33,6 @@ public class LocalRequestResponseChannel implements RequestResponseChannel {
   private static final Logger logger = LoggerFactory.getLogger(LocalRequestResponseChannel.class);
   private BlockingQueue<NetworkRequest> requestQueue = new LinkedBlockingQueue<>();
   private Map<Integer, BatchBlockingQueue<ResponseInfo>> responseMap = new ConcurrentHashMap<>();
-  // buffer to hold size header that we strip off payloads. Only use this array to discard bytes since it is shared.
-  private static final byte[] SIZE_BYTE_ARRAY = new byte[Long.BYTES];
   private static final ResponseInfo WAKEUP_MARKER = new ResponseInfo(null, null, null);
 
   @Override
@@ -66,15 +56,13 @@ public class LocalRequestResponseChannel implements RequestResponseChannel {
 
   @Override
   public void sendResponse(Send payloadToSend, NetworkRequest originalRequest, ServerNetworkResponseMetrics metrics) {
-    try {
-      LocalChannelRequest localRequest = (LocalChannelRequest) originalRequest;
-      ResponseInfo responseInfo = new ResponseInfo(localRequest.requestInfo, null, byteBufFromPayload(payloadToSend));
-      BatchBlockingQueue<ResponseInfo> responseQueue = getResponseQueue(localRequest.processorId);
-      responseQueue.put(responseInfo);
-      logger.debug("Added response for {}, size now {}", localRequest.processorId, responseQueue.size());
-    } catch (IOException ex) {
-      logger.error("Could not extract response", ex);
-    }
+    LocalChannelRequest localRequest = (LocalChannelRequest) originalRequest;
+    ResponseInfo responseInfo =
+        new ResponseInfo(localRequest.requestInfo, null, localRequest.requestInfo.getReplicaId().getDataNodeId(),
+            payloadToSend);
+    BatchBlockingQueue<ResponseInfo> responseQueue = getResponseQueue(localRequest.processorId);
+    responseQueue.put(responseInfo);
+    logger.debug("Added response for {}, size now {}", localRequest.processorId, responseQueue.size());
   }
 
   /**
@@ -115,39 +103,22 @@ public class LocalRequestResponseChannel implements RequestResponseChannel {
   }
 
   /**
-   * Utility to extract a {@link ByteBuf} from a {@link Send} object, skipping the size header.
-   * @param payload the payload whose bytes we want.
-   */
-  static ByteBuf byteBufFromPayload(Send payload) throws IOException {
-    int bufferSize = (int) payload.sizeInBytes() - SIZE_BYTE_ARRAY.length;
-    ByteBuf buffer = Unpooled.buffer(bufferSize);
-    // Skip the size header
-    payload.writeTo(new ByteBufferChannel(ByteBuffer.wrap(SIZE_BYTE_ARRAY)));
-    WritableByteChannel byteChannel = Channels.newChannel(new ByteBufOutputStream(buffer));
-    payload.writeTo(byteChannel);
-    payload.release();
-    return buffer;
-  }
-
-  /**
    * A {@link NetworkRequest} implementation that works with {@link LocalRequestResponseChannel}.
    */
-  static class LocalChannelRequest implements NetworkRequest {
+  public static class LocalChannelRequest implements NetworkRequest {
     private RequestInfo requestInfo;
-    private InputStream input;
     private long startTimeInMs;
     private int processorId;
 
-    LocalChannelRequest(RequestInfo requestInfo, int processorId, InputStream input) {
+    LocalChannelRequest(RequestInfo requestInfo, int processorId) {
       this.requestInfo = requestInfo;
       this.processorId = processorId;
-      this.input = input;
       startTimeInMs = System.currentTimeMillis();
     }
 
     @Override
     public InputStream getInputStream() {
-      return input;
+      return null;
     }
 
     @Override
@@ -156,9 +127,19 @@ public class LocalRequestResponseChannel implements RequestResponseChannel {
     }
 
     @Override
+    public boolean release() {
+      // release related request content
+      return requestInfo.getRequest().release();
+    }
+
+    @Override
     public String toString() {
-      return "LocalChannelRequest{" + "requestInfo=" + requestInfo + ", input=" + input + ", startTimeInMs="
-          + startTimeInMs + ", processorId=" + processorId + '}';
+      return "LocalChannelRequest{" + "requestInfo=" + requestInfo + ", startTimeInMs=" + startTimeInMs
+          + ", processorId=" + processorId + '}';
+    }
+
+    public RequestInfo getRequestInfo() {
+      return requestInfo;
     }
   }
 }

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2NetworkClient.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2NetworkClient.java
@@ -20,7 +20,6 @@ import com.github.ambry.network.NetworkClient;
 import com.github.ambry.network.NetworkClientErrorCode;
 import com.github.ambry.network.RequestInfo;
 import com.github.ambry.network.ResponseInfo;
-import com.github.ambry.protocol.RequestOrResponse;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
@@ -104,8 +103,7 @@ public class Http2NetworkClient implements NetworkClient {
     for (RequestInfo requestInfo : requestsToSend) {
       long streamInitiateTime = System.currentTimeMillis();
 
-      RequestOrResponse request = (RequestOrResponse) (requestInfo.getRequest());
-      long waitingTime = streamInitiateTime - request.requestCreateTime;
+      long waitingTime = streamInitiateTime - requestInfo.getRequestCreateTime();
       http2ClientMetrics.requestToNetworkClientLatencyMs.update(waitingTime);
 
       this.pools.get(InetSocketAddress.createUnresolved(requestInfo.getHost(), requestInfo.getPort().getPort()))

--- a/ambry-network/src/test/java/com/github/ambry/network/LocalNetworkClientTest.java
+++ b/ambry-network/src/test/java/com/github/ambry/network/LocalNetworkClientTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2021 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ */
+package com.github.ambry.network;
+
+import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.clustermap.MockReplicaId;
+import com.github.ambry.clustermap.ReplicaType;
+import com.github.ambry.config.NetworkConfig;
+import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.utils.MockTime;
+import com.github.ambry.utils.TestUtils;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+
+/**
+ * Test {@link LocalNetworkClient} and {@link LocalNetworkClientFactory}.
+ */
+public class LocalNetworkClientTest {
+
+  public static final int POLL_TIMEOUT_MS = 100;
+  private int nextCorrelationId = 0;
+  private final LocalRequestResponseChannel mockLocalRequestResponseChannel;
+  private final LocalNetworkClientFactory factory;
+  private final NetworkMetrics networkMetrics;
+
+  public LocalNetworkClientTest() {
+    mockLocalRequestResponseChannel = mock(LocalRequestResponseChannel.class);
+    networkMetrics = new NetworkMetrics(new MetricRegistry());
+    factory = new LocalNetworkClientFactory(mockLocalRequestResponseChannel,
+        new NetworkConfig(new VerifiableProperties(new Properties())), networkMetrics, new MockTime());
+  }
+
+  /**
+   * Test {@link LocalNetworkClientFactory}
+   */
+  @Test
+  public void testFactory() {
+    int processorId = 0;
+    LocalNetworkClient localNetworkClient1 = factory.getNetworkClient();
+    LocalNetworkClient localNetworkClient2 = factory.getNetworkClient();
+    assertNotNull("Network client is null", localNetworkClient1);
+    assertNotNull("Network client is null", localNetworkClient2);
+    assertEquals("Processor id of network client is wrong", processorId++, localNetworkClient1.getProcessorId());
+    assertEquals("Processor id of network client is wrong", processorId, localNetworkClient2.getProcessorId());
+  }
+
+  /**
+   * Test {@link LocalNetworkClient#sendAndPoll}
+   */
+  @Test
+  public void testSendAndPoll() throws Exception {
+
+    NetworkClient localNetworkClient = factory.getNetworkClient();
+
+    // 1. response is received for sent request
+    List<RequestInfo> requestInfoList = Collections.singletonList(getRequestInfo());
+    List<ResponseInfo> expectedResponseInfoList = Collections.singletonList(
+        new ResponseInfo(requestInfoList.get(0), null, requestInfoList.get(0).getReplicaId().getDataNodeId(),
+            new SocketRequestResponseChannelTest.MockSend()));
+    when(mockLocalRequestResponseChannel.receiveResponses(anyInt(), anyInt())).thenReturn(expectedResponseInfoList);
+    List<ResponseInfo> responseInfoList =
+        localNetworkClient.sendAndPoll(requestInfoList, Collections.emptySet(), POLL_TIMEOUT_MS);
+    assertEquals("Unexpected response list", expectedResponseInfoList, responseInfoList);
+    verify(mockLocalRequestResponseChannel).sendRequest(argThat(argument -> {
+      RequestInfo requestInfo = ((LocalRequestResponseChannel.LocalChannelRequest) argument).getRequestInfo();
+      return requestInfo.equals(requestInfoList.get(0));
+    }));
+
+    // 2. verify empty response is handled
+    resetMocks();
+    when(mockLocalRequestResponseChannel.receiveResponses(anyInt(), anyInt())).thenReturn(Collections.emptyList());
+    responseInfoList = localNetworkClient.sendAndPoll(requestInfoList, Collections.emptySet(), POLL_TIMEOUT_MS);
+    Assert.assertEquals("No responses are expected at this time", 0, responseInfoList.size());
+
+    // 3. When LocalRequestResponseChannel throws exception, metrics should be updated
+    resetMocks();
+    doThrow(new RuntimeException()).when(mockLocalRequestResponseChannel).sendRequest(any());
+    localNetworkClient.sendAndPoll(requestInfoList, Collections.emptySet(), POLL_TIMEOUT_MS);
+    assertEquals("Expected count of network client exceptions to be 1", 1,
+        networkMetrics.networkClientException.getCount());
+
+    // 4. calling sendAndPoll after the network client is closed should throw exception
+    resetMocks();
+    localNetworkClient.close();
+    TestUtils.assertException(IllegalStateException.class,
+        () -> localNetworkClient.sendAndPoll(requestInfoList, Collections.emptySet(), POLL_TIMEOUT_MS), null);
+  }
+
+  /**
+   * Test {@link LocalNetworkClient#wakeup}
+   */
+  @Test
+  public void testWakeup() {
+    LocalNetworkClient localNetworkClient = factory.getNetworkClient();
+    localNetworkClient.wakeup();
+    verify(mockLocalRequestResponseChannel).wakeup(eq(localNetworkClient.getProcessorId()));
+  }
+
+  /**
+   * Test {@link LocalNetworkClient#close}
+   */
+  @Test
+  public void testClose() {
+    LocalNetworkClient localNetworkClient = factory.getNetworkClient();
+    localNetworkClient.close();
+    assertTrue("Network client should be closed", localNetworkClient.isClosed());
+  }
+
+  /**
+   * @return a new {@link RequestInfo} with a new correlation ID.
+   */
+  private RequestInfo getRequestInfo() {
+    return new RequestInfo("a", new Port(1, PortType.SSL), new MockSend(nextCorrelationId++),
+        new MockReplicaId(ReplicaType.CLOUD_BACKED));
+  }
+
+  private void resetMocks() {
+    reset(mockLocalRequestResponseChannel);
+  }
+}

--- a/ambry-network/src/test/java/com/github/ambry/network/LocalNetworkClientTest.java
+++ b/ambry-network/src/test/java/com/github/ambry/network/LocalNetworkClientTest.java
@@ -130,7 +130,7 @@ public class LocalNetworkClientTest {
    */
   private RequestInfo getRequestInfo() {
     return new RequestInfo("a", new Port(1, PortType.SSL), new MockSend(nextCorrelationId++),
-        new MockReplicaId(ReplicaType.CLOUD_BACKED));
+        new MockReplicaId(ReplicaType.CLOUD_BACKED), null);
   }
 
   private void resetMocks() {

--- a/ambry-network/src/test/java/com/github/ambry/network/LocalRequestResponseChannelTest.java
+++ b/ambry-network/src/test/java/com/github/ambry/network/LocalRequestResponseChannelTest.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2021 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.network;
+
+import com.github.ambry.clustermap.MockReplicaId;
+import com.github.ambry.clustermap.ReplicaType;
+import com.github.ambry.network.LocalRequestResponseChannel.LocalChannelRequest;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+public class LocalRequestResponseChannelTest {
+  private int nextCorrelationId = 0;
+
+  @Test
+  public void testSendAndReceive() throws InterruptedException {
+
+    LocalRequestResponseChannel channel = new LocalRequestResponseChannel();
+    final int pollTimeoutInMs = 100;
+    final int processorId1 = 1;
+    final int processorId2 = 2;
+    List<ResponseInfo> responseInfoList;
+
+    // 1. verify request is sent and response is received correctly
+    NetworkRequest networkRequest1 = new LocalChannelRequest(getRequestInfo(), processorId1);
+    channel.sendRequest(networkRequest1);
+    assertEquals("Mismatch in request sent and received", networkRequest1, channel.receiveRequest());
+    Send response1 = new SocketRequestResponseChannelTest.MockSend();
+    channel.sendResponse(response1, networkRequest1, null);
+    responseInfoList = channel.receiveResponses(processorId1, pollTimeoutInMs);
+    assertEquals("Mismatch in response sent and received", response1, responseInfoList.get(0).getResponse());
+
+    // 2. verify multiple requests and responses
+    NetworkRequest networkRequest2 = new LocalChannelRequest(getRequestInfo(), processorId1);
+    NetworkRequest networkRequest3 = new LocalChannelRequest(getRequestInfo(), processorId1);
+    channel.sendRequest(networkRequest2);
+    assertEquals("Mismatch in request sent and received", networkRequest2, channel.receiveRequest());
+    channel.sendRequest(networkRequest3);
+    assertEquals("Mismatch in request sent and received", networkRequest3, channel.receiveRequest());
+    Send response2 = new SocketRequestResponseChannelTest.MockSend();
+    channel.sendResponse(response2, networkRequest2, null);
+    Send response3 = new SocketRequestResponseChannelTest.MockSend();
+    channel.sendResponse(response3, networkRequest3, null);
+    responseInfoList = channel.receiveResponses(processorId1, pollTimeoutInMs);
+    assertEquals("Mismatch in number of responses", 2, responseInfoList.size());
+    assertEquals("Mismatch in response sent and received", response2, responseInfoList.get(0).getResponse());
+    assertEquals("Mismatch in response sent and received", response3, responseInfoList.get(1).getResponse());
+
+    // 3. verify requests and responses for multiple processors
+    NetworkRequest networkRequest4 = new LocalChannelRequest(getRequestInfo(), processorId1);
+    NetworkRequest networkRequest5 = new LocalChannelRequest(getRequestInfo(), processorId2);
+    channel.sendRequest(networkRequest4);
+    assertEquals("Mismatch in request sent and received", networkRequest4, channel.receiveRequest());
+    channel.sendRequest(networkRequest5);
+    assertEquals("Mismatch in request sent and received", networkRequest5, channel.receiveRequest());
+    Send response4 = new SocketRequestResponseChannelTest.MockSend();
+    Send response5 = new SocketRequestResponseChannelTest.MockSend();
+    channel.sendResponse(response4, networkRequest4, null);
+    channel.sendResponse(response5, networkRequest5, null);
+    responseInfoList = channel.receiveResponses(processorId1, pollTimeoutInMs);
+    assertEquals("Mismatch in number of responses", 1, responseInfoList.size());
+    assertEquals("Mismatch in response sent and received", response4, responseInfoList.get(0).getResponse());
+    responseInfoList = channel.receiveResponses(processorId2, pollTimeoutInMs);
+    assertEquals("Mismatch in number of responses", 1, responseInfoList.size());
+    assertEquals("Mismatch in response sent and received", response5, responseInfoList.get(0).getResponse());
+
+    // 4. test wakeup
+    int largePollTimeoutMs = 10000;
+    long startTimeMs = System.currentTimeMillis();
+    CompletableFuture<List<ResponseInfo>> pollFuture =
+        CompletableFuture.supplyAsync(() -> channel.receiveResponses(processorId1, largePollTimeoutMs));
+    channel.wakeup(processorId1);
+    responseInfoList = pollFuture.join();
+    long timeTaken = System.currentTimeMillis() - startTimeMs;
+    assertTrue("Took too long to receive responses with wakeup call: " + timeTaken, timeTaken < largePollTimeoutMs);
+    assertEquals("Unexpected responses received", Collections.emptyList(), responseInfoList);
+    assertEquals("Response list size wrong", 0, responseInfoList.size());
+  }
+
+  /**
+   * @return a new {@link RequestInfo} with a new correlation ID.
+   */
+  private RequestInfo getRequestInfo() {
+    return new RequestInfo("a", new Port(1, PortType.SSL), new com.github.ambry.network.MockSend(nextCorrelationId++),
+        new MockReplicaId(ReplicaType.CLOUD_BACKED));
+  }
+}

--- a/ambry-network/src/test/java/com/github/ambry/network/LocalRequestResponseChannelTest.java
+++ b/ambry-network/src/test/java/com/github/ambry/network/LocalRequestResponseChannelTest.java
@@ -97,6 +97,6 @@ public class LocalRequestResponseChannelTest {
    */
   private RequestInfo getRequestInfo() {
     return new RequestInfo("a", new Port(1, PortType.SSL), new com.github.ambry.network.MockSend(nextCorrelationId++),
-        new MockReplicaId(ReplicaType.CLOUD_BACKED));
+        new MockReplicaId(ReplicaType.CLOUD_BACKED), null);
   }
 }

--- a/ambry-network/src/test/java/com/github/ambry/network/SocketRequestResponseChannelTest.java
+++ b/ambry-network/src/test/java/com/github/ambry/network/SocketRequestResponseChannelTest.java
@@ -49,7 +49,7 @@ public class SocketRequestResponseChannelTest {
     }
   }
 
-  class MockSend extends AbstractByteBufHolder<MockSend> implements Send {
+  static class MockSend extends AbstractByteBufHolder<MockSend> implements Send {
     public int sendcall = 1;
 
     @Override

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/GetResponse.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/GetResponse.java
@@ -29,7 +29,6 @@ import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.channels.WritableByteChannel;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 
@@ -86,6 +85,10 @@ public class GetResponse extends Response {
 
   public InputStream getInputStream() {
     return stream;
+  }
+
+  public Send getDataToSend() {
+    return toSend;
   }
 
   public List<PartitionResponseInfo> getPartitionResponseInfoList() {

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/PutRequest.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/PutRequest.java
@@ -121,7 +121,6 @@ public class PutRequest extends RequestOrResponse {
     this.blobEncryptionKey = blobEncryptionKey;
     this.blob = materializedBlob;
     this.crc = crc32Impl;
-    this.crcByteBuf = PooledByteBufAllocator.DEFAULT.ioBuffer(CRC_SIZE_IN_BYTES);
     this.blobStream = null;
     this.crcValue = null;
   }
@@ -139,7 +138,7 @@ public class PutRequest extends RequestOrResponse {
    * @param blobStream the {@link InputStream} containing the data associated with the blob.
    * @param crc the crc associated with this request.
    */
-  private PutRequest(int correlationId, String clientId, BlobId blobId, BlobProperties blobProperties,
+  public PutRequest(int correlationId, String clientId, BlobId blobId, BlobProperties blobProperties,
       ByteBuffer userMetadata, long blobSize, BlobType blobType, ByteBuffer blobEncryptionKey, InputStream blobStream,
       Long crc) {
     super(RequestOrResponseType.PutRequest, currentVersion, correlationId, clientId);
@@ -223,6 +222,7 @@ public class PutRequest extends RequestOrResponse {
       // change it back to 0 since we are going to write it to the channel later.
       bb.position(0);
     }
+    crcByteBuf = PooledByteBufAllocator.DEFAULT.ioBuffer(CRC_SIZE_IN_BYTES);
     crcByteBuf.writeLong(crc.getValue());
 
     // Now construct the real bufferToSend, which should be a composite ByteBuf.
@@ -362,6 +362,14 @@ public class PutRequest extends RequestOrResponse {
    */
   public ByteBuffer getBlobEncryptionKey() {
     return blobEncryptionKey;
+  }
+
+  /**
+   * @return the buffer carrying blob content in this request at the ambry-frontend. This could be {@code null} if the
+   * blob is serialized and sent out.
+   */
+  public ByteBuf getBlob() {
+    return blob;
   }
 
   /**

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/RequestOrResponse.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/RequestOrResponse.java
@@ -40,7 +40,6 @@ public abstract class RequestOrResponse extends AbstractByteBufHolder<RequestOrR
   protected ByteBuf bufferToSend;
   protected ByteBuffer byteBufferToSend;
   protected static final Logger logger = LoggerFactory.getLogger(RequestOrResponse.class);
-  public final long requestCreateTime;
 
   private static final int Request_Response_Size_In_Bytes = 8;
   private static final int Request_Response_Type_Size_In_Bytes = 2;
@@ -54,7 +53,6 @@ public abstract class RequestOrResponse extends AbstractByteBufHolder<RequestOrR
     this.correlationId = correlationId;
     this.clientId = clientId;
     this.bufferToSend = null;
-    this.requestCreateTime = System.currentTimeMillis();
   }
 
   public RequestOrResponseType getRequestType() {

--- a/ambry-router/src/main/java/com/github/ambry/router/RouterUtils.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/RouterUtils.java
@@ -48,7 +48,7 @@ import org.slf4j.LoggerFactory;
 /**
  * This is a utility class used by Router.
  */
-class RouterUtils {
+public class RouterUtils {
 
   private static final Logger logger = LoggerFactory.getLogger(RouterUtils.class);
 
@@ -273,7 +273,7 @@ class RouterUtils {
    * @param sentResponse {@link Response} object constructed at sender side.
    * @return {@link Response} object constructed at receiver side.
    */
-  private static Response mapToReceivedResponse(Response sentResponse) {
+  public static Response mapToReceivedResponse(Response sentResponse) {
     Response receivedResponse;
     if (sentResponse instanceof GetResponse) {
       GetResponse getResponse = (GetResponse) sentResponse;

--- a/ambry-router/src/main/java/com/github/ambry/router/RouterUtils.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/RouterUtils.java
@@ -22,15 +22,20 @@ import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.ResponseHandler;
 import com.github.ambry.config.RouterConfig;
+import com.github.ambry.network.LocalNetworkClient;
 import com.github.ambry.network.NetworkClientErrorCode;
 import com.github.ambry.network.Port;
 import com.github.ambry.network.PortType;
 import com.github.ambry.network.ResponseInfo;
+import com.github.ambry.protocol.DeleteResponse;
+import com.github.ambry.protocol.GetResponse;
+import com.github.ambry.protocol.PutResponse;
 import com.github.ambry.protocol.Response;
 import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.utils.NettyByteBufDataInputStream;
 import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.Utils;
+import io.netty.buffer.ByteBufInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicReference;
@@ -195,6 +200,7 @@ class RouterUtils {
    * @param errorExtractor extract the {@link ServerErrorCode} to send to {@link ResponseHandler#onEvent}.
    * @return the extracted {@link Response} if there is one; null otherwise.
    */
+  @SuppressWarnings("unchecked")
   static <R extends Response> R extractResponseAndNotifyResponseHandler(ResponseHandler responseHandler,
       NonBlockingRouterMetrics routerMetrics, ResponseInfo responseInfo, Deserializer<R> deserializer,
       Function<R, ServerErrorCode> errorExtractor) {
@@ -203,8 +209,16 @@ class RouterUtils {
     NetworkClientErrorCode networkClientErrorCode = responseInfo.getError();
     if (networkClientErrorCode == null) {
       try {
-        DataInputStream dis = new NettyByteBufDataInputStream(responseInfo.content());
-        response = deserializer.readFrom(dis);
+        if (responseInfo.getResponse() != null) {
+          // If this responseInfo already has the deserialized java object, we can reference it directly. This is
+          // applicable when we are receiving responses from Azure APIs in frontend. The responses from Azure are
+          // handled in {@code AmbryRequest} class methods using a thread pool running with in the frontend. These
+          // responses are then sent using local queues in {@code LocalRequestResponseChannel}.
+          response = (R) mapToReceivedResponse((Response) responseInfo.getResponse());
+        } else {
+          DataInputStream dis = new NettyByteBufDataInputStream(responseInfo.content());
+          response = deserializer.readFrom(dis);
+        }
         responseHandler.onEvent(replicaId, errorExtractor.apply(response));
       } catch (Exception e) {
         // Ignore. There is no value in notifying the response handler.
@@ -244,5 +258,31 @@ class RouterUtils {
      * @throws IOException on deserialization errors.
      */
     T readFrom(DataInputStream stream) throws IOException;
+  }
+
+  /**
+   * This method is applicable when we are processing responses received from Azure APIs in Frontend via {@link LocalNetworkClient}.
+   * The responses received from Azure are constructed as java objects such as {@link GetResponse}, {@link PutResponse} in
+   * {@link com.github.ambry.protocol.AmbryRequests} class methods from {@link com.github.ambry.protocol.RequestHandler}
+   * threads running within the Frontend itself. The content in these responses is available as buffer but we access it
+   * as stream in the Frontend router. Hence, we create new Response objects by having a stream enclose the buffer.
+   *
+   * At the moment, only {@link GetResponse} carries content and needs to be constructed again as below. Other responses
+   * like {@link PutResponse}, {@link DeleteResponse}, etc which don't carry any content don't need to be reconstructed
+   * and can be referenced as they are.
+   * @param sentResponse {@link Response} object constructed at sender side.
+   * @return {@link Response} object constructed at receiver side.
+   */
+  private static Response mapToReceivedResponse(Response sentResponse) {
+    Response receivedResponse;
+    if (sentResponse instanceof GetResponse) {
+      GetResponse getResponse = (GetResponse) sentResponse;
+      receivedResponse = new GetResponse(getResponse.getCorrelationId(), getResponse.getClientId(),
+          getResponse.getPartitionResponseInfoList(), new ByteBufInputStream(getResponse.getDataToSend().content()),
+          getResponse.getError());
+    } else {
+      receivedResponse = sentResponse;
+    }
+    return receivedResponse;
   }
 }

--- a/ambry-router/src/test/java/com/github/ambry/router/CloudOperationTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/CloudOperationTest.java
@@ -127,10 +127,8 @@ public class CloudOperationTest {
    */
   @Parameterized.Parameters
   public static List<Object[]> data() {
-    return Arrays.asList(new Object[][]{
-      {SimpleOperationTracker.class.getSimpleName()},
-      {AdaptiveOperationTracker.class.getSimpleName()}
-    });
+    return Arrays.asList(new Object[][]{{SimpleOperationTracker.class.getSimpleName()},
+        {AdaptiveOperationTracker.class.getSimpleName()}});
   }
 
   @Before
@@ -173,24 +171,26 @@ public class CloudOperationTest {
     CloudDestinationFactory cloudDestinationFactory =
         Utils.getObj(cloudConfig.cloudDestinationFactoryClass, vprops, mockClusterMap.getMetricRegistry(),
             mockClusterMap);
-    cloudDestination = (LatchBasedInMemoryCloudDestination)cloudDestinationFactory.getCloudDestination();
+    cloudDestination = (LatchBasedInMemoryCloudDestination) cloudDestinationFactory.getCloudDestination();
     RequestHandlerPool requestHandlerPool =
         CloudRouterFactory.getRequestHandlerPool(vprops, mockClusterMap, cloudDestination, cloudConfig);
 
     Map<ReplicaType, NetworkClientFactory> childFactories = new EnumMap<>(ReplicaType.class);
     // requestHandlerPool and its thread pool handle the cloud blob operations.
-    LocalNetworkClientFactory cloudClientFactory = new LocalNetworkClientFactory((LocalRequestResponseChannel) requestHandlerPool.getChannel(),
-        new NetworkConfig(vprops), new NetworkMetrics(routerMetrics.getMetricRegistry()), time);
+    LocalNetworkClientFactory cloudClientFactory =
+        new LocalNetworkClientFactory((LocalRequestResponseChannel) requestHandlerPool.getChannel(),
+            new NetworkConfig(vprops), new NetworkMetrics(routerMetrics.getMetricRegistry()), time);
     childFactories.put(ReplicaType.CLOUD_BACKED, cloudClientFactory);
 
-    MockNetworkClientFactory diskClientFactory = new MockNetworkClientFactory(vprops, mockSelectorState, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
-        CHECKOUT_TIMEOUT_MS, mockServerLayout, time);
+    MockNetworkClientFactory diskClientFactory =
+        new MockNetworkClientFactory(vprops, mockSelectorState, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
+            CHECKOUT_TIMEOUT_MS, mockServerLayout, time);
     childFactories.put(ReplicaType.DISK_BACKED, diskClientFactory);
 
     NetworkClientFactory networkClientFactory = new CompositeNetworkClientFactory(childFactories);
-    router = new NonBlockingRouter(routerConfig, routerMetrics,
-        networkClientFactory, new LoggingNotificationSystem(), mockClusterMap, null, null, null,
-        new InMemAccountService(false, true), time, MockClusterMap.DEFAULT_PARTITION_CLASS);
+    router = new NonBlockingRouter(routerConfig, routerMetrics, networkClientFactory, new LoggingNotificationSystem(),
+        mockClusterMap, null, null, null, new InMemAccountService(false, true), time,
+        MockClusterMap.DEFAULT_PARTITION_CLASS);
 
     NetworkClient compNetworkClient = networkClientFactory.getNetworkClient();
     mockNetworkClient = new MockCompositeNetworkClient(compNetworkClient);
@@ -207,7 +207,8 @@ public class CloudOperationTest {
    * @throws Exception Any unexpected exception
    */
   private BlobId doDirectPut(BlobProperties blobProperties, byte[] userMetadata, ByteBuf blobContent) throws Exception {
-    List<PartitionId> writablePartitionIds = mockClusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS);
+    List<PartitionId> writablePartitionIds =
+        mockClusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS);
     PartitionId partitionId = writablePartitionIds.get(random.nextInt(writablePartitionIds.size()));
     BlobId blobId = new BlobId(routerConfig.routerBlobidCurrentVersion, BlobId.BlobIdType.NATIVE,
         mockClusterMap.getLocalDatacenterId(), blobProperties.getAccountId(), blobProperties.getContainerId(),
@@ -256,8 +257,9 @@ public class CloudOperationTest {
   private String doDirectPut() throws Exception {
     // a blob size that is greater than the maxChunkSize and is not a multiple of it. Will result in a composite blob.
     int blobSize = maxChunkSize * random.nextInt(10) + random.nextInt(maxChunkSize - 1) + 1;
-    BlobProperties blobProperties = new BlobProperties(blobSize, "serviceId", "memberId", "contentType", false, Utils.Infinite_Time,
-        Utils.getRandomShort(random), Utils.getRandomShort(random), false, null, null, null);
+    BlobProperties blobProperties =
+        new BlobProperties(blobSize, "serviceId", "memberId", "contentType", false, Utils.Infinite_Time,
+            Utils.getRandomShort(random), Utils.getRandomShort(random), false, null, null, null);
     byte[] userMetadata = new byte[10];
     random.nextBytes(userMetadata);
     byte[] putContent = new byte[blobSize];
@@ -300,10 +302,9 @@ public class CloudOperationTest {
    * @param options options of the get blob operation
    * @throws Exception Any unexpected exception
    */
-  private void getBlobAndAssertSuccess(final BlobId blobId,
-      final short expectedLifeVersion, final int expectedBlobSize, final BlobProperties expectedBlobProperties,
-      final byte[] expectedUserMetadata, final byte[] expectPutContent, final GetBlobOptionsInternal options)
-      throws Exception {
+  private void getBlobAndAssertSuccess(final BlobId blobId, final short expectedLifeVersion, final int expectedBlobSize,
+      final BlobProperties expectedBlobProperties, final byte[] expectedUserMetadata, final byte[] expectPutContent,
+      final GetBlobOptionsInternal options) throws Exception {
     final CountDownLatch readCompleteLatch = new CountDownLatch(1);
     final AtomicLong readCompleteResult = new AtomicLong(0);
     // callback to compare the data
@@ -319,7 +320,8 @@ public class CloudOperationTest {
                 RouterTestHelpers.arePersistedFieldsEquivalent(expectedBlobProperties, blobInfo.getBlobProperties()));
             Assert.assertEquals("Blob size should in received blobProperties should be the same as actual",
                 expectedBlobSize, blobInfo.getBlobProperties().getBlobSize());
-            Assert.assertArrayEquals("User metadata must be the same", expectedUserMetadata, blobInfo.getUserMetadata());
+            Assert.assertArrayEquals("User metadata must be the same", expectedUserMetadata,
+                blobInfo.getUserMetadata());
             Assert.assertEquals("LifeVersion mismatch", expectedLifeVersion, blobInfo.getLifeVersion());
             break;
           case Data:
@@ -329,8 +331,8 @@ public class CloudOperationTest {
             blobInfo = result.getBlobResult.getBlobInfo();
             Assert.assertTrue("Blob properties must be the same",
                 RouterTestHelpers.arePersistedFieldsEquivalent(expectedBlobProperties, blobInfo.getBlobProperties()));
-            Assert.assertEquals("Blob size should in received blobProperties should be the same as actual", expectedBlobSize,
-                blobInfo.getBlobProperties().getBlobSize());
+            Assert.assertEquals("Blob size should in received blobProperties should be the same as actual",
+                expectedBlobSize, blobInfo.getBlobProperties().getBlobSize());
             Assert.assertNull("Unexpected blob data in operation result", result.getBlobResult.getBlobDataChannel());
             Assert.assertEquals("LifeVersion mismatch", expectedLifeVersion, blobInfo.getLifeVersion());
         }
@@ -343,7 +345,8 @@ public class CloudOperationTest {
         Utils.newThread(() -> {
           Future<Long> readIntoFuture = result.getBlobResult.getBlobDataChannel().readInto(asyncWritableChannel, null);
           assertBlobReadSuccess(options.getBlobOptions, readIntoFuture, asyncWritableChannel,
-              result.getBlobResult.getBlobDataChannel(), readCompleteLatch, readCompleteResult, expectedBlobSize, expectPutContent);
+              result.getBlobResult.getBlobDataChannel(), readCompleteLatch, readCompleteResult, expectedBlobSize,
+              expectPutContent);
         }, false).start();
       } else {
         readCompleteLatch.countDown();
@@ -365,8 +368,15 @@ public class CloudOperationTest {
       op.poll(requestRegistrationCallback);
       List<ResponseInfo> responses = sendAndWaitForResponses(requestRegistrationCallback.getRequestsToSend());
       for (ResponseInfo responseInfo : responses) {
-        DataInputStream dis = new NettyByteBufDataInputStream(responseInfo.content());
-        GetResponse getResponse = responseInfo.getError() == null ? GetResponse.readFrom(dis, mockClusterMap) : null;
+        GetResponse getResponse =
+            RouterUtils.extractResponseAndNotifyResponseHandler(responseHandler, routerMetrics, responseInfo,
+                stream -> GetResponse.readFrom(stream, mockClusterMap), response -> {
+                  ServerErrorCode serverError = response.getError();
+                  if (serverError == ServerErrorCode.No_Error) {
+                    serverError = response.getPartitionResponseInfoList().get(0).getErrorCode();
+                  }
+                  return serverError;
+                });
         op.handleResponse(responseInfo, getResponse);
         responseInfo.release();
       }
@@ -406,8 +416,7 @@ public class CloudOperationTest {
    */
   private void assertBlobReadSuccess(GetBlobOptions options, Future<Long> readIntoFuture,
       ByteBufferAsyncWritableChannel asyncWritableChannel, ReadableStreamChannel readableStreamChannel,
-      CountDownLatch readCompleteLatch, AtomicLong readCompleteResult,
-      final int blobSize, final byte[] putContent) {
+      CountDownLatch readCompleteLatch, AtomicLong readCompleteResult, final int blobSize, final byte[] putContent) {
     try {
       ByteBuffer putContentBuf;
       Assert.assertTrue("Not intended to test raw mode.", options == null || !options.isRawMode());
@@ -436,8 +445,7 @@ public class CloudOperationTest {
         asyncWritableChannel.resolveOldestChunk(null);
       } while (readBytes < bytesToRead);
       written = readIntoFuture.get();
-      Assert.assertEquals("the returned length in the future should be the length of data written", readBytes,
-          written);
+      Assert.assertEquals("the returned length in the future should be the length of data written", readBytes, written);
       Assert.assertNull("There should be no more data in the channel", asyncWritableChannel.getNextChunk(0));
       readableStreamChannel.close();
       readCompleteResult.set(written);
@@ -458,10 +466,8 @@ public class CloudOperationTest {
     String blobId = doDirectPut();
 
     // All other DCs except LOCAL_DC will return Blob_Not_Found
-    List<MockServer> localDcServers = mockServers
-        .stream()
-        .filter(s -> s.getDataCenter().equals(LOCAL_DC))
-        .collect(Collectors.toList());
+    List<MockServer> localDcServers =
+        mockServers.stream().filter(s -> s.getDataCenter().equals(LOCAL_DC)).collect(Collectors.toList());
     mockServers.forEach(s -> {
       if (!localDcServers.contains(s)) {
         s.setServerErrorForAllRequests(ServerErrorCode.Blob_Not_Found);
@@ -497,8 +503,9 @@ public class CloudOperationTest {
   public void testGetBlobFailoverToAzureAndCheckData() throws Exception {
     // a blob size that is greater than the maxChunkSize and is not a multiple of it. Will result in a composite blob.
     int blobSize = maxChunkSize * random.nextInt(10) + random.nextInt(maxChunkSize - 1) + 1;
-    BlobProperties blobProperties = new BlobProperties(blobSize, "serviceId", "memberId", "contentType", false, Utils.Infinite_Time,
-       Utils.getRandomShort(random), Utils.getRandomShort(random), false, null, null, null);
+    BlobProperties blobProperties =
+        new BlobProperties(blobSize, "serviceId", "memberId", "contentType", false, Utils.Infinite_Time,
+            Utils.getRandomShort(random), Utils.getRandomShort(random), false, null, null, null);
     byte[] userMetadata = new byte[10];
     random.nextBytes(userMetadata);
     byte[] putContent = new byte[blobSize];
@@ -509,8 +516,9 @@ public class CloudOperationTest {
     putContentBuf.release();
 
     // Confirm we can get the blob from the local dc.
-    GetBlobOptionsInternal options = new GetBlobOptionsInternal(new GetBlobOptionsBuilder().build(), false, routerMetrics.ageAtGet);
-    getBlobAndAssertSuccess(blobId, (short)0, blobSize, blobProperties, userMetadata, putContent, options);
+    GetBlobOptionsInternal options =
+        new GetBlobOptionsInternal(new GetBlobOptionsBuilder().build(), false, routerMetrics.ageAtGet);
+    getBlobAndAssertSuccess(blobId, (short) 0, blobSize, blobProperties, userMetadata, putContent, options);
 
     // Local DC will fail with different errors but cloud will return the blob data.
     ArrayList<MockServer> mockServersArray = new ArrayList<>(mockServers);
@@ -525,7 +533,7 @@ public class CloudOperationTest {
       mockServer.setServerErrorForAllRequests(code);
     }
     // cloud DC will return the data
-    getBlobAndAssertSuccess(blobId, (short)0, blobSize, blobProperties, userMetadata, putContent, options);
+    getBlobAndAssertSuccess(blobId, (short) 0, blobSize, blobProperties, userMetadata, putContent, options);
   }
 
   /**
@@ -533,7 +541,7 @@ public class CloudOperationTest {
    * Test both cases that cloud colo succeeds or fails.
    */
   @Test
-  public void testTtlUpdateFailoverToAzure()  throws Exception {
+  public void testTtlUpdateFailoverToAzure() throws Exception {
     String blobId = doDirectPut();
 
     // configure all the disk backed server will return failure
@@ -550,8 +558,7 @@ public class CloudOperationTest {
       Throwable t = e.getCause();
       assertTrue("Cause should be RouterException", t instanceof RouterException);
       // ServerErrorCode.Blob_Expired will be transferred to RouterErrorCode.BlobExpired
-      assertSame("ErrorCode mismatch",
-          ((RouterException) t).getErrorCode(), RouterErrorCode.BlobExpired);
+      assertSame("ErrorCode mismatch", ((RouterException) t).getErrorCode(), RouterErrorCode.BlobExpired);
     }
   }
 
@@ -576,8 +583,8 @@ public class CloudOperationTest {
       Throwable t = e.getCause();
       assertTrue("Cause should be RouterException", t instanceof RouterException);
       // ServerErrorCode.Data_Corrupt will be transferred to RouterErrorCode.UnexpectedInternalError
-      assertTrue("ErrorCode mismatch",
-          ((RouterException) t).getErrorCode() == RouterErrorCode.BlobDoesNotExist || ((RouterException) t).getErrorCode() == RouterErrorCode.UnexpectedInternalError);
+      assertTrue("ErrorCode mismatch", ((RouterException) t).getErrorCode() == RouterErrorCode.BlobDoesNotExist
+          || ((RouterException) t).getErrorCode() == RouterErrorCode.UnexpectedInternalError);
     }
   }
 
@@ -591,19 +598,21 @@ public class CloudOperationTest {
 
     mockServers.forEach(s -> s.setServerErrorForAllRequests(ServerErrorCode.Data_Corrupt));
     // although all disk colo will fail, cloud colo will return it successfully.
-    router.getBlob(blobId, new GetBlobOptionsBuilder().operationType(GetBlobOptions.OperationType.BlobInfo).build()).get();
+    router.getBlob(blobId, new GetBlobOptionsBuilder().operationType(GetBlobOptions.OperationType.BlobInfo).build())
+        .get();
 
     // inject error for cloud colo as well.
     cloudDestination.setServerErrorForAllRequests(StoreErrorCodes.ID_Not_Found);
     try {
-      router.getBlob(blobId, new GetBlobOptionsBuilder().operationType(GetBlobOptions.OperationType.BlobInfo).build()).get();
+      router.getBlob(blobId, new GetBlobOptionsBuilder().operationType(GetBlobOptions.OperationType.BlobInfo).build())
+          .get();
       fail("Expecting exception");
     } catch (ExecutionException e) {
       Throwable t = e.getCause();
       assertTrue("Cause should be RouterException", t instanceof RouterException);
       // ServerErrorCode.Data_Corrupt will be transferred to RouterErrorCode.UnexpectedInternalError
-      assertTrue("ErrorCode mismatch",
-          ((RouterException) t).getErrorCode() == RouterErrorCode.BlobDoesNotExist || ((RouterException) t).getErrorCode() == RouterErrorCode.UnexpectedInternalError);
+      assertTrue("ErrorCode mismatch", ((RouterException) t).getErrorCode() == RouterErrorCode.BlobDoesNotExist
+          || ((RouterException) t).getErrorCode() == RouterErrorCode.UnexpectedInternalError);
     }
   }
 
@@ -628,8 +637,7 @@ public class CloudOperationTest {
       Throwable t = e.getCause();
       assertTrue("Cause should be RouterException", t instanceof RouterException);
       // ServerErrorCode.IO_Error or StoreErrorCodes.Unknown_Error will be transferred to RouterErrorCode.UnexpectedInternalError
-      assertSame("ErrorCode mismatch",
-          ((RouterException) t).getErrorCode(), RouterErrorCode.UnexpectedInternalError);
+      assertSame("ErrorCode mismatch", ((RouterException) t).getErrorCode(), RouterErrorCode.UnexpectedInternalError);
     }
   }
 
@@ -668,7 +676,8 @@ public class CloudOperationTest {
         LatchBasedInMemoryCloudDestinationFactory.class.getName());
     properties.setProperty(CloudConfig.VCR_MIN_TTL_DAYS, "0");
 
-    properties.setProperty("kms.default.container.key", "B374A26A71490437AA024E4FADD5B497FDFF1A8EA6FF12F6FB65AF2720B59CCF");
+    properties.setProperty("kms.default.container.key",
+        "B374A26A71490437AA024E4FADD5B497FDFF1A8EA6FF12F6FB65AF2720B59CCF");
     return properties;
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -241,8 +241,7 @@ project(':ambry-network') {
         compile project(':ambry-api'),
                 project(':ambry-utils'),
                 project(':ambry-commons'),
-                project(':ambry-clustermap'),
-                project(':ambry-protocol')
+                project(':ambry-clustermap')
         compile "io.netty:netty-all:$nettyVersion"
         compile "io.netty:netty-tcnative-boringssl-static:$nettyTcnativeVersion"
         compile "io.netty:netty-transport-native-epoll:$nettyVersion"
@@ -356,7 +355,8 @@ project(':ambry-protocol') {
                 project(':ambry-clustermap'),
                 project(':ambry-messageformat'),
                 project(':ambry-utils'),
-                project(':ambry-commons')
+                project(':ambry-commons'),
+                project(':ambry-network')
         testCompile project(':ambry-test-utils')
     }
 }


### PR DESCRIPTION
Avoid serialization/deserialization of request when using LocalNetworkClient for cloud facing router. These requests are sent from cloud router (in ambry frontend) to AmbryRequest API methods via local queues (running in the same process) and can be referenced directly via the java objects without serializing to byte streams.