### PR TITLE
    Change default quota resource type to Account.

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/account/Account.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/Account.java
@@ -85,7 +85,7 @@ public class Account {
    * The id for to save account metadata in ambry.
    */
   public static final short HELIX_ACCOUNT_SERVICE_ACCOUNT_ID = -2;
-  public static final QuotaResourceType QUOTA_RESOURCE_TYPE_DEFAULT_VALUE = QuotaResourceType.CONTAINER;
+  public static final QuotaResourceType QUOTA_RESOURCE_TYPE_DEFAULT_VALUE = QuotaResourceType.ACCOUNT;
   // static variables
   static final String JSON_VERSION_KEY = "version";
   static final String ACCOUNT_ID_KEY = "accountId";

--- a/ambry-quota/src/test/java/com/github/ambry/quota/AmbryQuotaManagerUpdateNotificationTest.java
+++ b/ambry-quota/src/test/java/com/github/ambry/quota/AmbryQuotaManagerUpdateNotificationTest.java
@@ -62,7 +62,7 @@ public class AmbryQuotaManagerUpdateNotificationTest {
     Map<Short, Account> idToRefAccountMap = new HashMap<>();
     AccountTestUtils.generateRefAccounts(idToRefAccountMap, new HashMap<>(), accountIdSet, 2, 3);
     accountService.notifyAccountUpdateConsumers(idToRefAccountMap.values());
-    assertEquals("Invalid size of updated containers", quotaSource.getQuotaResourceList().size(), 6);
+    assertEquals("Invalid size of updated accounts", quotaSource.getQuotaResourceList().size(), 2);
   }
 
   /**


### PR DESCRIPTION
Change default quota resource type to Account. This change will ensure that in cases where quotaResourceType is not specified in the AccountService, quota will be enforced at the Account level when applicable.