### PR TITLE
[StorageQuota] Adding EnforcementPolicy to enforce storage quota based on clustermap

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/StorageQuotaConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StorageQuotaConfig.java
@@ -124,7 +124,7 @@ public class StorageQuotaConfig {
   public final long adaptiveEnforcementClusterMapUpdateIntervalMs;
 
   /**
-   * Threshold in percentage when percentage of writable partitions drops below this threshold, we adaptive enforcement
+   * Threshold in percentage when percentage of writable partitions drops below this threshold, the adaptive enforcement
    * policy will start throttling upload requests.
    */
   @Config(ADAPTIVE_ENFORCEMENT_WRITEABLE_PARTITION_THRESHOLD)

--- a/ambry-api/src/main/java/com/github/ambry/config/StorageQuotaConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StorageQuotaConfig.java
@@ -27,6 +27,13 @@ public class StorageQuotaConfig {
   public static final String MYSQL_STORE_RETRY_MAX_COUNT = STORAGE_QUOTA_PREFIX + "mysql.store.retry.max.count";
   public static final String SHOULD_THROTTLE = STORAGE_QUOTA_PREFIX + "should.throttle";
   public static final String USE_PHYSICAL_STORAGE = STORAGE_QUOTA_PREFIX + "use.physical.storage";
+  public static final String ENFORCEMENT_POLICY_FACTORY = STORAGE_QUOTA_PREFIX + "enforcement.policy.factory";
+  public static final String ADAPTIVE_ENFORCEMENT_CLUSTERMAP_UPDATE_INTERVAL_MS =
+      STORAGE_QUOTA_PREFIX + "adaptive.enforcement.clustermap.update.interval.ms";
+  public static final String ADAPTIVE_ENFORCEMENT_WRITEABLE_PARTITION_THRESHOLD =
+      STORAGE_QUOTA_PREFIX + "adaptive.enforcement.writable.partition.threshold";
+  public static final String DEFAULT_ENFORCEMENT_POLICY_FACTORY =
+      "com.github.ambry.quota.storage.SimpleStorageQuotaEnforcementPolicyFactory";
 
   /**
    * The interval in milliseconds for refresher to refresh storage usage from its source.
@@ -103,6 +110,28 @@ public class StorageQuotaConfig {
   public final boolean usePhysicalStorage;
 
   /**
+   * The factory class for {@link com.github.ambry.quota.storage.StorageQuotaEnforcementPolicy}.
+   */
+  @Config(ENFORCEMENT_POLICY_FACTORY)
+  @Default(DEFAULT_ENFORCEMENT_POLICY_FACTORY)
+  public final String enforcementPolicyFactory;
+
+  /**
+   * Interval to update clustermap data in adaptive enforcement policy.
+   */
+  @Config(ADAPTIVE_ENFORCEMENT_CLUSTERMAP_UPDATE_INTERVAL_MS)
+  @Default("10 * 60 * 1000")
+  public final long adaptiveEnforcementClusterMapUpdateIntervalMs;
+
+  /**
+   * Threshold in percentage when percentage of writable partitions drops below this threshold, we adaptive enforcement
+   * policy will start throttling upload requests.
+   */
+  @Config(ADAPTIVE_ENFORCEMENT_WRITEABLE_PARTITION_THRESHOLD)
+  @Default("25")
+  public final int adaptiveEnforcementWritablePartitionThreshold;
+
+  /**
    * Constructor to create a {@link StorageQuotaConfig}.
    * @param verifiableProperties The {@link VerifiableProperties} that contains all the properties.
    */
@@ -116,5 +145,11 @@ public class StorageQuotaConfig {
     mysqlMonthlyBaseFetchOffsetSec = verifiableProperties.getLong(MYSQL_MONTHLY_BASE_FETCH_OFFSET_SEC, 60 * 60);
     shouldThrottle = verifiableProperties.getBoolean(SHOULD_THROTTLE, true);
     usePhysicalStorage = verifiableProperties.getBoolean(USE_PHYSICAL_STORAGE, false);
+    enforcementPolicyFactory =
+        verifiableProperties.getString(ENFORCEMENT_POLICY_FACTORY, DEFAULT_ENFORCEMENT_POLICY_FACTORY);
+    adaptiveEnforcementClusterMapUpdateIntervalMs =
+        verifiableProperties.getLong(ADAPTIVE_ENFORCEMENT_CLUSTERMAP_UPDATE_INTERVAL_MS, 10 * 60 * 1000);
+    adaptiveEnforcementWritablePartitionThreshold =
+        verifiableProperties.getIntInRange(ADAPTIVE_ENFORCEMENT_WRITEABLE_PARTITION_THRESHOLD, 25, 1, 99);
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/quota/storage/StorageQuotaEnforcementPolicy.java
+++ b/ambry-api/src/main/java/com/github/ambry/quota/storage/StorageQuotaEnforcementPolicy.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2021 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.quota.storage;
+
+/**
+ * The interface to decide whether to throttle a request based on the storage quota and usage.
+ */
+public interface StorageQuotaEnforcementPolicy {
+  /**
+   * Return true if the request should be throttled, otherwise, return false.
+   * @param storageQuota The storage quota.
+   * @param currentUsage The current usage.
+   * @return
+   */
+  boolean shouldThrottleRequest(long storageQuota, long currentUsage);
+}

--- a/ambry-api/src/main/java/com/github/ambry/quota/storage/StorageQuotaEnforcementPolicyFactory.java
+++ b/ambry-api/src/main/java/com/github/ambry/quota/storage/StorageQuotaEnforcementPolicyFactory.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2021 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.quota.storage;
+
+/**
+ * Factory interface to return a {@link StorageQuotaEnforcementPolicy}.
+ */
+public interface StorageQuotaEnforcementPolicyFactory {
+  /**
+   * Return an {@link StorageQuotaEnforcementPolicy}.
+   * @return
+   */
+  StorageQuotaEnforcementPolicy getPolicy();
+}

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestServiceFactory.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestServiceFactory.java
@@ -97,8 +97,7 @@ public class FrontendRestRequestServiceFactory implements RestRequestServiceFact
               clusterMapConfig, clusterMap.getMetricRegistry()).getAccountStatsStore();
       QuotaConfig quotaConfig = new QuotaConfig(verifiableProperties);
       QuotaManager quotaManager = ((QuotaManagerFactory) Utils.getObj(quotaConfig.quotaManagerFactory, quotaConfig,
-          new MaxThrottlePolicy(quotaConfig), accountService, accountStatsStore,
-          clusterMap.getMetricRegistry())).getQuotaManager();
+          new MaxThrottlePolicy(quotaConfig), accountService, accountStatsStore, clusterMap)).getQuotaManager();
       SecurityServiceFactory securityServiceFactory =
           Utils.getObj(frontendConfig.securityServiceFactory, verifiableProperties, clusterMap, accountService,
               urlSigningService, idSigningService, accountAndContainerInjector, quotaManager);

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/AmbrySecurityServiceTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/AmbrySecurityServiceTest.java
@@ -130,7 +130,7 @@ public class AmbrySecurityServiceTest {
       ACCOUNT_SERVICE.updateAccounts(Collections.singletonList(InMemAccountService.UNKNOWN_ACCOUNT));
       QuotaConfig quotaConfig = QuotaTestUtils.createQuotaConfig(Collections.emptyMap(), false, QuotaMode.TRACKING);
       QUOTA_MANAGER =
-          new AmbryQuotaManager(quotaConfig, new MaxThrottlePolicy(quotaConfig), mock(AccountService.class), null,
+          new AmbryQuotaManager(quotaConfig, new MaxThrottlePolicy(quotaConfig), mock(AccountService.class), null, null,
               new MetricRegistry());
     } catch (Exception e) {
       throw new IllegalStateException(e);

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceFactoryTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceFactoryTest.java
@@ -50,7 +50,7 @@ public class FrontendRestRequestServiceFactoryTest {
       QuotaConfig quotaConfig = QuotaTestUtils.createQuotaConfig(Collections.emptyMap(), false, QuotaMode.TRACKING);
       QUOTA_MANAGER =
           new AmbryQuotaManager(quotaConfig, new MaxThrottlePolicy(quotaConfig), Mockito.mock(AccountService.class),
-              null, new MetricRegistry());
+              null, null, new MetricRegistry());
     } catch (Exception e) {
       throw new IllegalStateException(e);
     }

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
@@ -136,7 +136,7 @@ public class FrontendRestRequestServiceTest {
       QuotaConfig quotaConfig = QuotaTestUtils.createQuotaConfig(Collections.emptyMap(), false, QuotaMode.TRACKING);
       QUOTA_MANAGER =
           new AmbryQuotaManager(quotaConfig, new MaxThrottlePolicy(quotaConfig), Mockito.mock(AccountService.class),
-              null, new MetricRegistry());
+              null, null, new MetricRegistry());
     } catch (Exception e) {
       throw new IllegalStateException(e);
     }

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/PostBlobHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/PostBlobHandlerTest.java
@@ -113,7 +113,7 @@ public class PostBlobHandlerTest {
         QuotaConfig quotaConfig = QuotaTestUtils.createQuotaConfig(Collections.emptyMap(), false, QuotaMode.TRACKING);
         QUOTA_MANAGER =
             new AmbryQuotaManager(quotaConfig, new MaxThrottlePolicy(quotaConfig), Mockito.mock(AccountService.class),
-                null, new MetricRegistry());
+                null, null, new MetricRegistry());
       } catch (Exception e) {
         throw new IllegalStateException(e);
       }

--- a/ambry-quota/src/main/java/com/github/ambry/quota/AmbryQuotaManager.java
+++ b/ambry-quota/src/main/java/com/github/ambry/quota/AmbryQuotaManager.java
@@ -19,6 +19,7 @@ import com.codahale.metrics.Timer;
 import com.github.ambry.account.Account;
 import com.github.ambry.account.AccountService;
 import com.github.ambry.accountstats.AccountStatsStore;
+import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.config.QuotaConfig;
 import com.github.ambry.messageformat.BlobInfo;
 import com.github.ambry.rest.RestRequest;
@@ -55,11 +56,13 @@ public class AmbryQuotaManager implements QuotaManager {
    * @param throttlePolicy {@link ThrottlePolicy} object that makes the overall recommendation.
    * @param accountService {@link AccountService} object to get all the accounts and container information.
    * @param accountStatsStore {@link AccountStatsStore} object to get all the account stats related information.
+   * @param clusterMap {@link ClusterMap} object.
    * @param metricRegistry {@link MetricRegistry} object for creating quota metrics.
    * @throws ReflectiveOperationException in case of any exception.
    */
   public AmbryQuotaManager(QuotaConfig quotaConfig, ThrottlePolicy throttlePolicy, AccountService accountService,
-      AccountStatsStore accountStatsStore, MetricRegistry metricRegistry) throws ReflectiveOperationException {
+      AccountStatsStore accountStatsStore, ClusterMap clusterMap, MetricRegistry metricRegistry)
+      throws ReflectiveOperationException {
     Map<String, String> quotaEnforcerSourceMap =
         parseQuotaEnforcerAndSourceInfo(quotaConfig.requestQuotaEnforcerSourcePairInfoJson);
     Map<String, QuotaSource> quotaSourceObjectMap =
@@ -68,7 +71,7 @@ public class AmbryQuotaManager implements QuotaManager {
     for (String quotaEnforcerFactory : quotaEnforcerSourceMap.keySet()) {
       requestQuotaEnforcers.add(((QuotaEnforcerFactory) Utils.getObj(quotaEnforcerFactory, quotaConfig,
           quotaSourceObjectMap.get(quotaEnforcerSourceMap.get(quotaEnforcerFactory)),
-          accountStatsStore)).getRequestQuotaEnforcer());
+          accountStatsStore, clusterMap)).getRequestQuotaEnforcer());
     }
     this.throttlePolicy = throttlePolicy;
     this.quotaConfig = quotaConfig;

--- a/ambry-quota/src/main/java/com/github/ambry/quota/AmbryQuotaManagerFactory.java
+++ b/ambry-quota/src/main/java/com/github/ambry/quota/AmbryQuotaManagerFactory.java
@@ -13,9 +13,9 @@
  */
 package com.github.ambry.quota;
 
-import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.account.AccountService;
 import com.github.ambry.accountstats.AccountStatsStore;
+import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.config.QuotaConfig;
 
 
@@ -30,13 +30,13 @@ public class AmbryQuotaManagerFactory implements QuotaManagerFactory {
    * @param throttlePolicy {@link ThrottlePolicy} object.
    * @param accountService {@link AccountService} object.
    * @param accountStatsStore {@link AccountStatsStore} object.
-   * @param metricRegistry {@link MetricRegistry} object.
+   * @param clusterMap {@link ClusterMap} object.
    * @throws ReflectiveOperationException
    */
   public AmbryQuotaManagerFactory(QuotaConfig quotaConfig, ThrottlePolicy throttlePolicy, AccountService accountService,
-      AccountStatsStore accountStatsStore, MetricRegistry metricRegistry) throws ReflectiveOperationException {
-    quotaManager =
-        new AmbryQuotaManager(quotaConfig, throttlePolicy, accountService, accountStatsStore, metricRegistry);
+      AccountStatsStore accountStatsStore, ClusterMap clusterMap) throws ReflectiveOperationException {
+    quotaManager = new AmbryQuotaManager(quotaConfig, throttlePolicy, accountService, accountStatsStore, clusterMap,
+        clusterMap.getMetricRegistry());
   }
 
   @Override

--- a/ambry-quota/src/main/java/com/github/ambry/quota/capacityunit/AmbryCapacityUnitQuotaEnforcerFactory.java
+++ b/ambry-quota/src/main/java/com/github/ambry/quota/capacityunit/AmbryCapacityUnitQuotaEnforcerFactory.java
@@ -14,10 +14,11 @@
 package com.github.ambry.quota.capacityunit;
 
 import com.github.ambry.accountstats.AccountStatsStore;
+import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.config.QuotaConfig;
 import com.github.ambry.quota.QuotaEnforcer;
-import com.github.ambry.quota.QuotaSource;
 import com.github.ambry.quota.QuotaEnforcerFactory;
+import com.github.ambry.quota.QuotaSource;
 
 
 /**
@@ -31,9 +32,10 @@ public class AmbryCapacityUnitQuotaEnforcerFactory implements QuotaEnforcerFacto
    * @param quotaConfig {@link QuotaConfig} object.
    * @param quotaSource {@link QuotaSource} object.
    * @param accountStatsStore the {@link AccountStatsStore}.
+   * @param clusterMap the {@link ClusterMap}.
    */
   public AmbryCapacityUnitQuotaEnforcerFactory(QuotaConfig quotaConfig, QuotaSource quotaSource,
-      AccountStatsStore accountStatsStore) {
+      AccountStatsStore accountStatsStore, ClusterMap clusterMap) {
     quotaEnforcer = new AmbryCapacityUnitQuotaEnforcer(quotaSource);
   }
 

--- a/ambry-quota/src/main/java/com/github/ambry/quota/storage/AdaptiveStorageQuotaEnforcementPolicyFactory.java
+++ b/ambry-quota/src/main/java/com/github/ambry/quota/storage/AdaptiveStorageQuotaEnforcementPolicyFactory.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2021 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.quota.storage;
+
+import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.config.StorageQuotaConfig;
+import com.github.ambry.utils.SystemTime;
+import com.github.ambry.utils.Time;
+
+
+/**
+ * Implementation of {@link StorageQuotaEnforcementPolicyFactory} to return a {@link AdaptiveStorageQuotaEnforcementPolicy}.
+ */
+public class AdaptiveStorageQuotaEnforcementPolicyFactory implements StorageQuotaEnforcementPolicyFactory {
+  private final AdaptiveStorageQuotaEnforcementPolicy policy;
+
+  /**
+   * Constructor to instantiate {@link AdaptiveStorageQuotaEnforcementPolicyFactory}.
+   * @param clusterMap The {@link ClusterMap} object.
+   * @param config The {@link StorageQuotaConfig} object.
+   */
+  public AdaptiveStorageQuotaEnforcementPolicyFactory(ClusterMap clusterMap, StorageQuotaConfig config) {
+    policy = new AdaptiveStorageQuotaEnforcementPolicy(clusterMap, SystemTime.getInstance(), config);
+  }
+
+  @Override
+  public StorageQuotaEnforcementPolicy getPolicy() {
+    return policy;
+  }
+}
+
+class AdaptiveStorageQuotaEnforcementPolicy implements StorageQuotaEnforcementPolicy {
+  private final ClusterMap clusterMap;
+  private final StorageQuotaConfig config;
+  private final Time time;
+  private volatile long lastClusterMapUpdateTimeMs;
+  private volatile int currentClusterMapWritablePartitionPercentage;
+
+  public AdaptiveStorageQuotaEnforcementPolicy(ClusterMap clusterMap, Time time, StorageQuotaConfig config) {
+    this.clusterMap = clusterMap;
+    this.time = time;
+    this.config = config;
+    this.lastClusterMapUpdateTimeMs = time.milliseconds();
+    updateClusterMapWritablePartitionPercentage();
+  }
+
+  @Override
+  public boolean shouldThrottleRequest(long storageQuota, long currentUsage) {
+    synchronized (this) {
+      if (time.milliseconds() - lastClusterMapUpdateTimeMs >= config.adaptiveEnforcementClusterMapUpdateIntervalMs) {
+        lastClusterMapUpdateTimeMs = time.milliseconds();
+        updateClusterMapWritablePartitionPercentage();
+      }
+    }
+    return currentUsage >= storageQuota
+        && currentClusterMapWritablePartitionPercentage <= config.adaptiveEnforcementWritablePartitionThreshold;
+  }
+
+  private void updateClusterMapWritablePartitionPercentage() {
+    this.currentClusterMapWritablePartitionPercentage =
+        100 * clusterMap.getWritablePartitionIds(null).size() / clusterMap.getAllPartitionIds(null).size();
+  }
+}

--- a/ambry-quota/src/main/java/com/github/ambry/quota/storage/SimpleStorageQuotaEnforcementPolicyFactory.java
+++ b/ambry-quota/src/main/java/com/github/ambry/quota/storage/SimpleStorageQuotaEnforcementPolicyFactory.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2021 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.quota.storage;
+
+import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.config.StorageQuotaConfig;
+
+
+/**
+ * Implementation of {@link StorageQuotaEnforcementPolicyFactory} to return a {@link SimpleStorageQuotaEnforcementPolicy}.
+ */
+public class SimpleStorageQuotaEnforcementPolicyFactory implements StorageQuotaEnforcementPolicyFactory {
+  private final SimpleStorageQuotaEnforcementPolicy policy;
+
+  /**
+   * Constructor to instantiate {@link SimpleStorageQuotaEnforcementPolicyFactory}.
+   * @param clusterMap The {@link ClusterMap} object.
+   * @param config The {@link StorageQuotaConfig} object.
+   */
+  public SimpleStorageQuotaEnforcementPolicyFactory(ClusterMap clusterMap, StorageQuotaConfig config) {
+    policy = new SimpleStorageQuotaEnforcementPolicy();
+  }
+
+  @Override
+  public StorageQuotaEnforcementPolicy getPolicy() {
+    return policy;
+  }
+}
+
+/**
+ * A simple {@link StorageQuotaEnforcementPolicy} implementation. When the current usage is equal or greater than the
+ * quota, we start throttling.
+ */
+class SimpleStorageQuotaEnforcementPolicy implements StorageQuotaEnforcementPolicy {
+  @Override
+  public boolean shouldThrottleRequest(long storageQuota, long currentUsage) {
+    return currentUsage >= storageQuota;
+  }
+}

--- a/ambry-quota/src/main/java/com/github/ambry/quota/storage/StorageQuotaEnforcerFactory.java
+++ b/ambry-quota/src/main/java/com/github/ambry/quota/storage/StorageQuotaEnforcerFactory.java
@@ -14,10 +14,12 @@
 package com.github.ambry.quota.storage;
 
 import com.github.ambry.accountstats.AccountStatsStore;
+import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.config.QuotaConfig;
 import com.github.ambry.quota.QuotaEnforcer;
 import com.github.ambry.quota.QuotaEnforcerFactory;
 import com.github.ambry.quota.QuotaSource;
+import com.github.ambry.utils.Utils;
 
 
 /**
@@ -31,11 +33,15 @@ public class StorageQuotaEnforcerFactory implements QuotaEnforcerFactory {
    * @param quotaConfig the {@link QuotaConfig}.
    * @param quotaSource the {@link QuotaSource}.
    * @param accountStatsStore the {@link AccountStatsStore}.
+   * @param clusterMap the {@link ClusterMap}.
    * @throws Exception
    */
   public StorageQuotaEnforcerFactory(QuotaConfig quotaConfig, QuotaSource quotaSource,
-      AccountStatsStore accountStatsStore) throws Exception {
-    quotaEnforcer = new StorageQuotaEnforcer(quotaConfig.storageQuotaConfig, quotaSource, accountStatsStore);
+      AccountStatsStore accountStatsStore, ClusterMap clusterMap) throws Exception {
+    StorageQuotaEnforcementPolicy policy =
+        ((StorageQuotaEnforcementPolicyFactory) Utils.getObj(quotaConfig.storageQuotaConfig.enforcementPolicyFactory,
+            clusterMap, quotaConfig.storageQuotaConfig)).getPolicy();
+    quotaEnforcer = new StorageQuotaEnforcer(quotaConfig.storageQuotaConfig, quotaSource, accountStatsStore, policy);
   }
 
   @Override

--- a/ambry-quota/src/test/java/com/github/ambry/quota/AmbryQuotaManagerUpdateNotificationTest.java
+++ b/ambry-quota/src/test/java/com/github/ambry/quota/AmbryQuotaManagerUpdateNotificationTest.java
@@ -52,7 +52,7 @@ public class AmbryQuotaManagerUpdateNotificationTest {
         new AccountServiceForConsumerTest(new AccountServiceConfig(verifiableProperties),
             new AccountServiceMetrics(metricRegistry), null);
     AmbryQuotaManager ambryQuotaManager =
-        new AmbryQuotaManager(quotaConfig, throttlePolicy, accountService, null, metricRegistry);
+        new AmbryQuotaManager(quotaConfig, throttlePolicy, accountService, null, null, metricRegistry);
     UnlimitedQuotaSource quotaSource = (UnlimitedQuotaSource) getQuotaSourceMember(ambryQuotaManager);
     assertTrue("updated accounts should be empty", quotaSource.getQuotaResourceList().isEmpty());
 

--- a/ambry-quota/src/test/java/com/github/ambry/quota/storage/StorageQuotaEnforcementPolicyTest.java
+++ b/ambry-quota/src/test/java/com/github/ambry/quota/storage/StorageQuotaEnforcementPolicyTest.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright 2021 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.quota.storage;
+
+import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.clustermap.MockPartitionId;
+import com.github.ambry.clustermap.PartitionId;
+import com.github.ambry.config.StorageQuotaConfig;
+import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.utils.MockTime;
+import com.github.ambry.utils.SystemTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.mockito.Mockito.*;
+
+
+/**
+ * Unit test for various {@link StorageQuotaEnforcementPolicy}s.
+ */
+public class StorageQuotaEnforcementPolicyTest {
+
+  /**
+   * Unit test for {@link SimpleStorageQuotaEnforcementPolicy}.
+   */
+  @Test
+  public void testSimpleStorageQuotaEnforcementPolicy() {
+    StorageQuotaEnforcementPolicy policy = new SimpleStorageQuotaEnforcementPolicy();
+    Assert.assertTrue(policy.shouldThrottleRequest(1000, 1000));
+    Assert.assertTrue(policy.shouldThrottleRequest(1000, 1001));
+    Assert.assertFalse(policy.shouldThrottleRequest(1000, 500));
+  }
+
+  /**
+   * Unit test for {@link AdaptiveStorageQuotaEnforcementPolicy}.
+   */
+  @Test
+  public void testAdaptiveStorageQuotaEnforcementPolicy() {
+    ClusterMap clusterMap = mock(ClusterMap.class);
+    MockTime mockTime = new MockTime(SystemTime.getInstance().milliseconds());
+    // make threshold as 25, which means as long writable partition is more than 25% of the all partitions, we don't throttle
+    when(clusterMap.getWritablePartitionIds(any())).thenAnswer(invocation -> makePartitionIdList(30));
+    when(clusterMap.getAllPartitionIds(any())).thenAnswer(invocation -> makePartitionIdList(100));
+
+    AdaptiveStorageQuotaEnforcementPolicy policy =
+        new AdaptiveStorageQuotaEnforcementPolicy(clusterMap, mockTime, makeStorageQuotaConfig(10 * 60 * 1000, 25));
+
+    Assert.assertFalse(policy.shouldThrottleRequest(1000, 1000));
+    Assert.assertFalse(policy.shouldThrottleRequest(1000, 1001));
+    Assert.assertFalse(policy.shouldThrottleRequest(1000, 500));
+
+    // Change the writable partition number, but the cached value will not get updated, should throttle return false.
+    when(clusterMap.getWritablePartitionIds(any())).thenAnswer(invocation -> makePartitionIdList(10));
+    Assert.assertFalse(policy.shouldThrottleRequest(1000, 1000));
+    Assert.assertFalse(policy.shouldThrottleRequest(1000, 1001));
+    Assert.assertFalse(policy.shouldThrottleRequest(1000, 500));
+
+    // Sleep for more than the update interval, now it should start throttling.
+    mockTime.sleep(10 * 60 * 1000 + 1);
+    Assert.assertTrue(policy.shouldThrottleRequest(1000, 1000));
+    Assert.assertTrue(policy.shouldThrottleRequest(1000, 1001));
+    Assert.assertFalse(policy.shouldThrottleRequest(1000, 500));
+  }
+
+  /**
+   * Making a list of partitions with the given size.
+   * @param num The number of partitions to return.
+   * @return
+   */
+  private List<? extends PartitionId> makePartitionIdList(int num) {
+    ArrayList<PartitionId> result = new ArrayList<>(num);
+    for (int i = 0; i < num; i++) {
+      result.add(new MockPartitionId(i, "default"));
+    }
+    return result;
+  }
+
+  /**
+   * Making a {@link StorageQuotaConfig} with the given values.
+   * @param interval The interval in ms to update clustermap value is adaptive enforcement policy
+   * @param threshold The writable partition percentage threshold in adaptive enforcement policy
+   * @return
+   */
+  private StorageQuotaConfig makeStorageQuotaConfig(long interval, int threshold) {
+    Properties prop = new Properties();
+    prop.setProperty(StorageQuotaConfig.ADAPTIVE_ENFORCEMENT_CLUSTERMAP_UPDATE_INTERVAL_MS, String.valueOf(interval));
+    prop.setProperty(StorageQuotaConfig.ADAPTIVE_ENFORCEMENT_WRITEABLE_PARTITION_THRESHOLD, String.valueOf(threshold));
+    return new StorageQuotaConfig(new VerifiableProperties(prop));
+  }
+}

--- a/ambry-quota/src/test/java/com/github/ambry/quota/storage/StorageQuotaEnforcerTest.java
+++ b/ambry-quota/src/test/java/com/github/ambry/quota/storage/StorageQuotaEnforcerTest.java
@@ -55,7 +55,8 @@ public class StorageQuotaEnforcerTest {
   public void testInitEmptyStorageUsage() {
     JSONStringStorageQuotaSource quotaSource =
         new JSONStringStorageQuotaSource(new HashMap<>(), new InMemAccountService(false, false));
-    StorageQuotaEnforcer enforcer = new StorageQuotaEnforcer(config, quotaSource, (StorageUsageRefresher) null);
+    StorageQuotaEnforcer enforcer = new StorageQuotaEnforcer(config, quotaSource, (StorageUsageRefresher) null,
+        new SimpleStorageQuotaEnforcementPolicy());
     enforcer.initStorageUsage(Collections.EMPTY_MAP);
     assertEquals(Collections.EMPTY_MAP, enforcer.getStorageUsages());
   }
@@ -93,7 +94,7 @@ public class StorageQuotaEnforcerTest {
 
     StorageQuotaEnforcer enforcer =
         new StorageQuotaEnforcer(config, new JSONStringStorageQuotaSource(new HashMap<>(), accountService),
-            (StorageUsageRefresher) null);
+            (StorageUsageRefresher) null, new SimpleStorageQuotaEnforcementPolicy());
     enforcer.initStorageUsage(containerUsage);
     assertEquals(expectedStorageUsages, enforcer.getStorageUsages());
   }
@@ -131,7 +132,7 @@ public class StorageQuotaEnforcerTest {
     }
     StorageQuotaEnforcer enforcer =
         new StorageQuotaEnforcer(config, new JSONStringStorageQuotaSource(new HashMap<>(), accountService),
-            (StorageUsageRefresher) null);
+            (StorageUsageRefresher) null, new SimpleStorageQuotaEnforcementPolicy());
     enforcer.initStorageUsage(containerUsage);
 
     StorageUsageRefresher.Listener listener = enforcer.getUsageRefresherListener();
@@ -213,7 +214,7 @@ public class StorageQuotaEnforcerTest {
       }
     }
     JSONStringStorageQuotaSource quotaSource = new JSONStringStorageQuotaSource(storageQuota, accountService);
-    StorageQuotaEnforcer enforcer = new StorageQuotaEnforcer(config, quotaSource, (StorageUsageRefresher) null);
+    StorageQuotaEnforcer enforcer = new StorageQuotaEnforcer(config, quotaSource, (StorageUsageRefresher) null, new SimpleStorageQuotaEnforcementPolicy());
     enforcer.initStorageUsage(Collections.EMPTY_MAP);
 
     for (Map.Entry<String, Map<String, Long>> accountEntry : containerUsage.entrySet()) {

--- a/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterQuotaCallbackTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterQuotaCallbackTest.java
@@ -20,7 +20,6 @@ import com.github.ambry.commons.RetainingAsyncWritableChannel;
 import com.github.ambry.config.QuotaConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.messageformat.BlobInfo;
-import com.github.ambry.messageformat.MessageFormatException;
 import com.github.ambry.messageformat.MessageFormatRecord;
 import com.github.ambry.protocol.GetOption;
 import com.github.ambry.quota.AmbryQuotaManager;
@@ -288,7 +287,7 @@ public class NonBlockingRouterQuotaCallbackTest extends NonBlockingRouterTestBas
     public ChargeTesterQuotaManager(QuotaConfig quotaConfig, ThrottlePolicy throttlePolicy,
         AccountService accountService, AccountStatsStore accountStatsStore, MetricRegistry metricRegistry,
         AtomicInteger chargeCalledCount) throws ReflectiveOperationException {
-      super(quotaConfig, throttlePolicy, accountService, accountStatsStore, metricRegistry);
+      super(quotaConfig, throttlePolicy, accountService, accountStatsStore, null, metricRegistry);
       this.chargeCalledCount = chargeCalledCount;
     }
 

--- a/ambry-test-utils/src/main/java/com/github/ambry/quota/RejectQuotaEnforcerFactory.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/quota/RejectQuotaEnforcerFactory.java
@@ -14,6 +14,7 @@
 package com.github.ambry.quota;
 
 import com.github.ambry.accountstats.AccountStatsStore;
+import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.config.QuotaConfig;
 
 
@@ -28,9 +29,10 @@ public class RejectQuotaEnforcerFactory implements QuotaEnforcerFactory {
    * @param quotaConfig {@link QuotaConfig} object.
    * @param quotaSource {@link QuotaSource} object.
    * @param accountStatsStore the {@link AccountStatsStore}.
+   * @param clusterMap the {@link ClusterMap}.
    */
   public RejectQuotaEnforcerFactory(QuotaConfig quotaConfig, QuotaSource quotaSource,
-      AccountStatsStore accountStatsStore) {
+      AccountStatsStore accountStatsStore, ClusterMap clusterMap) {
     this.rejectQuotaEnforcer = new RejectRequestQuotaEnforcer(quotaSource);
   }
 


### PR DESCRIPTION
1. Add a new interface StorageQuotaEnforcementPolicy
2. Add two implementations of such interface
    2.1 A simple enforcement policy, once the current usage exceeds storage quota, throttle the request
    2.2 An adaptive enforcement policy, who also takes cluster capacity into consideration. If the cluster has more than 25% of partitions are writable, don't throttle.