### PR TITLE
Fixed the netty memory leak in LocalRequestResponseChannel

### DIFF
--- a/ambry-network/src/main/java/com/github/ambry/network/LocalRequestResponseChannel.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/LocalRequestResponseChannel.java
@@ -125,6 +125,8 @@ public class LocalRequestResponseChannel implements RequestResponseChannel {
     payload.writeTo(new ByteBufferChannel(ByteBuffer.wrap(SIZE_BYTE_ARRAY)));
     WritableByteChannel byteChannel = Channels.newChannel(new ByteBufOutputStream(buffer));
     payload.writeTo(byteChannel);
+    // Just like MockSelector, LocalRequestResponseChannel needs to release the sends' resources after completed.
+    payload.release();
     return buffer;
   }
 

--- a/ambry-router/src/test/java/com/github/ambry/router/CloudRouterTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/CloudRouterTest.java
@@ -39,6 +39,7 @@ import java.util.Map;
 import java.util.Properties;
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -71,6 +72,10 @@ public class CloudRouterTest extends NonBlockingRouterTest {
   public CloudRouterTest(boolean testEncryption, int metadataContentVersion) throws Exception {
     super(testEncryption, metadataContentVersion, true);
   }
+  @Before
+  public void before() {
+    nettyByteBufLeakHelper.beforeTest();
+  }
 
   @After
   public void after() {
@@ -79,6 +84,7 @@ public class CloudRouterTest extends NonBlockingRouterTest {
       router.close();
     }
     Assert.assertEquals("Current operations count should be 0", 0, NonBlockingRouter.currentOperationsCount.get());
+    nettyByteBufLeakHelper.afterTest();
   }
 
   /**


### PR DESCRIPTION
Release payload after it was sent to the channel.
Verified the fix with CloudRouterTest unit tests.

Enabled Netty ByteBuf Leak Detector in CloudRouterTest. 
Netty was able to detect the payload memory leak.
With the fix, the CloudRouterTest passed.