### PR TITLE
Set http2/ssl port in VCR instance config

### DIFF
--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/HelixVcrClusterParticipant.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/HelixVcrClusterParticipant.java
@@ -53,6 +53,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static com.github.ambry.clustermap.ClusterMapUtils.*;
+import static org.apache.helix.model.InstanceConfig.InstanceConfigProperty.*;
 
 
 /**
@@ -200,6 +201,8 @@ public class HelixVcrClusterParticipant implements VcrClusterParticipant {
     if (cloudConfig.vcrHttp2Port != null) {
       instanceConfig.getRecord().setSimpleField(HTTP2_PORT_STR, Integer.toString(cloudConfig.vcrHttp2Port));
     }
+    // Set HELIX_ENABLED to be true. Listeners take action only when this value is True.
+    instanceConfig.setInstanceEnabled(true);
     helixAdmin.setInstanceConfig(vcrClusterName, vcrInstanceName, instanceConfig);
     logger.info("Participated in HelixVcrCluster successfully.");
   }

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/HelixVcrClusterParticipant.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/HelixVcrClusterParticipant.java
@@ -38,12 +38,11 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixManager;
 import org.apache.helix.HelixManagerFactory;
 import org.apache.helix.InstanceType;
+import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.participant.StateMachineEngine;
 import org.apache.helix.task.Task;
 import org.apache.helix.task.TaskCallbackContext;
@@ -52,6 +51,8 @@ import org.apache.helix.task.TaskFactory;
 import org.apache.helix.task.TaskStateModelFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static com.github.ambry.clustermap.ClusterMapUtils.*;
 
 
 /**
@@ -191,6 +192,15 @@ public class HelixVcrClusterParticipant implements VcrClusterParticipant {
     }
     manager.connect();
     helixAdmin = manager.getClusterManagmentTool();
+
+    InstanceConfig instanceConfig = helixAdmin.getInstanceConfig(vcrClusterName, vcrInstanceName);
+    if (cloudConfig.vcrSslPort != null) {
+      instanceConfig.getRecord().setSimpleField(SSL_PORT_STR, Integer.toString(cloudConfig.vcrSslPort));
+    }
+    if (cloudConfig.vcrHttp2Port != null) {
+      instanceConfig.getRecord().setSimpleField(HTTP2_PORT_STR, Integer.toString(cloudConfig.vcrHttp2Port));
+    }
+    helixAdmin.setInstanceConfig(vcrClusterName, vcrInstanceName, instanceConfig);
     logger.info("Participated in HelixVcrCluster successfully.");
   }
 

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/HelixVcrClusterSpectator.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/HelixVcrClusterSpectator.java
@@ -57,8 +57,6 @@ public class HelixVcrClusterSpectator implements VcrClusterSpectator {
 
   @Override
   public void spectate() throws Exception {
-    Map<String, DcZkInfo> dataCenterToZkAddress =
-        parseDcJsonAndPopulateDcInfo(clusterMapConfig.clusterMapDcsZkConnectStrings);
     HelixFactory helixFactory = new HelixFactory();
     String selfInstanceName =
         ClusterMapUtils.getInstanceName(clusterMapConfig.clusterMapHostName, clusterMapConfig.clusterMapPort);
@@ -68,17 +66,12 @@ public class HelixVcrClusterSpectator implements VcrClusterSpectator {
     // zk connection fails on both data centers, then things like replication between data centers might just stop.
     // For now, since we have only one fabric in cloud, and the spectator is being used for only cloud to store replication, this will work.
     // Once we add more fabrics, we should revisit this.
-    for (DcZkInfo dcZkInfo : dataCenterToZkAddress.values()) {
-      // only handle vcr clusters for now
-      if (dcZkInfo.getReplicaType() == ReplicaType.CLOUD_BACKED) {
-        HelixManager helixManager =
-            helixFactory.getZkHelixManagerAndConnect(cloudConfig.vcrClusterName, selfInstanceName,
-                InstanceType.SPECTATOR, dcZkInfo.getZkConnectStrs().get(0));
+    HelixManager helixManager =
+        helixFactory.getZkHelixManagerAndConnect(cloudConfig.vcrClusterName, selfInstanceName, InstanceType.SPECTATOR,
+            cloudConfig.vcrClusterZkConnectString);
 
-        helixManager.addInstanceConfigChangeListener(this);
-        helixManager.addLiveInstanceChangeListener(this);
-      }
-    }
+    helixManager.addInstanceConfigChangeListener(this);
+    helixManager.addLiveInstanceChangeListener(this);
   }
 
   @Override

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/HelixVcrClusterSpectator.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/HelixVcrClusterSpectator.java
@@ -15,13 +15,11 @@ package com.github.ambry.cloud;
 
 import com.github.ambry.clustermap.ClusterMapUtils;
 import com.github.ambry.clustermap.HelixFactory;
-import com.github.ambry.clustermap.ReplicaType;
 import com.github.ambry.clustermap.VcrClusterSpectator;
 import com.github.ambry.config.CloudConfig;
 import com.github.ambry.config.ClusterMapConfig;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 import org.apache.helix.HelixManager;
 import org.apache.helix.InstanceType;
 import org.apache.helix.NotificationContext;
@@ -29,8 +27,6 @@ import org.apache.helix.api.listeners.InstanceConfigChangeListener;
 import org.apache.helix.api.listeners.LiveInstanceChangeListener;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.LiveInstance;
-
-import static com.github.ambry.clustermap.ClusterMapUtils.*;
 
 
 /**

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/CloudDataNode.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/CloudDataNode.java
@@ -75,6 +75,8 @@ public class CloudDataNode implements DataNodeId {
     this.isSslEnabled = sslEnabledDataCenters.contains(dataCenterName);
     validateHostName(clusterMapConfig.clusterMapResolveHostnames, hostName);
     validatePorts(plainTextPort, sslPort, http2Port, isSslEnabled);
+    logger.info("CloudDataNode {} created. Plaintext Port {}, SSL Port {} HTTP2 Port {}", hostName, plainTextPort,
+        sslPort, http2Port);
   }
 
   @Override

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/CloudDataNode.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/CloudDataNode.java
@@ -38,6 +38,7 @@ public class CloudDataNode implements DataNodeId {
   private final Port http2Port;
   private final String dataCenterName;
   private final boolean isSslEnabled;
+  private final boolean enableHttp2Replication;
   private final List<String> sslEnabledDataCenters;
   private static final Logger logger = LoggerFactory.getLogger(CloudDataNode.class);
 
@@ -57,6 +58,7 @@ public class CloudDataNode implements DataNodeId {
     this.dataCenterName = clusterMapConfig.clusterMapDatacenterName;
     this.sslEnabledDataCenters = Utils.splitString(clusterMapConfig.clusterMapSslEnabledDatacenters, ",");
     this.isSslEnabled = sslEnabledDataCenters.contains(dataCenterName);
+    this.enableHttp2Replication = clusterMapConfig.clusterMapEnableHttp2Replication;
     validateHostName(clusterMapConfig.clusterMapResolveHostnames, hostName);
     validatePorts(plainTextPort, sslPort, http2Port, isSslEnabled);
   }
@@ -73,6 +75,7 @@ public class CloudDataNode implements DataNodeId {
     this.dataCenterName = dataCenterName;
     this.sslEnabledDataCenters = Utils.splitString(clusterMapConfig.clusterMapSslEnabledDatacenters, ",");
     this.isSslEnabled = sslEnabledDataCenters.contains(dataCenterName);
+    this.enableHttp2Replication = clusterMapConfig.clusterMapEnableHttp2Replication;
     validateHostName(clusterMapConfig.clusterMapResolveHostnames, hostName);
     validatePorts(plainTextPort, sslPort, http2Port, isSslEnabled);
     logger.info("CloudDataNode {} created. Plaintext Port {}, SSL Port {} HTTP2 Port {}", hostName, plainTextPort,
@@ -119,7 +122,10 @@ public class CloudDataNode implements DataNodeId {
 
   @Override
   public Port getPortToConnectTo() {
-    return isSslEnabled ? sslPort : plainTextPort;
+    if (enableHttp2Replication) {
+      return http2Port;
+    }
+    return sslEnabledDataCenters.contains(getDatacenterName()) ? sslPort : plainTextPort;
   }
 
   @Override

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
@@ -69,8 +69,8 @@ public class ClusterMapUtils {
   static final String REPLICAS_STR_SEPARATOR = ":";
   static final String REPLICAS_CAPACITY_STR = "replicaCapacityInBytes";
   static final String REPLICA_TYPE_STR = "replicaType";
-  static final String SSL_PORT_STR = "sslPort";
-  static final String HTTP2_PORT_STR = "http2Port";
+  public static final String SSL_PORT_STR = "sslPort";
+  public static final String HTTP2_PORT_STR = "http2Port";
   static final String RACKID_STR = "rackId";
   static final String SEALED_STR = "SEALED";
   static final String STOPPED_REPLICAS_STR = "STOPPED";

--- a/ambry-replication/src/main/java/com/github/ambry/replication/CloudToStoreReplicationManager.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/CloudToStoreReplicationManager.java
@@ -130,6 +130,7 @@ public class CloudToStoreReplicationManager extends ReplicationEngine {
 
     started = true;
     startupLatch.countDown();
+    logger.info("CloudToStoreReplicationManager started.");
   }
 
   /**
@@ -174,7 +175,8 @@ public class CloudToStoreReplicationManager extends ReplicationEngine {
           partitionName);
       return;
     }
-    CloudReplica peerCloudReplica = new CloudReplica(partitionId, getCloudDataNode());
+    DataNodeId cloudDataNode = getCloudDataNode();
+    CloudReplica peerCloudReplica = new CloudReplica(partitionId, cloudDataNode);
     FindTokenFactory findTokenFactory =
         tokenHelper.getFindTokenFactoryFromReplicaType(peerCloudReplica.getReplicaType());
     RemoteReplicaInfo remoteReplicaInfo =
@@ -189,7 +191,8 @@ public class CloudToStoreReplicationManager extends ReplicationEngine {
     partitionToPartitionInfo.put(partitionId, partitionInfo);
     mountPathToPartitionInfos.computeIfAbsent(localReplica.getMountPath(), key -> ConcurrentHashMap.newKeySet())
         .add(partitionInfo);
-    logger.info("Cloud Partition {} added to {}", partitionName, dataNodeId);
+    logger.info("Cloud Partition {} added to {}. CloudNode {} port {}", partitionName, dataNodeId, cloudDataNode,
+        cloudDataNode.getPortToConnectTo());
 
     // Reload replication token if exist.
     reloadReplicationTokenIfExists(localReplica, remoteReplicaInfos);

--- a/ambry-replication/src/main/java/com/github/ambry/replication/CloudToStoreReplicationManager.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/CloudToStoreReplicationManager.java
@@ -57,7 +57,6 @@ import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.LiveInstance;
 
 import static com.github.ambry.clustermap.ClusterMapUtils.*;
-import static org.apache.helix.model.InstanceConfig.InstanceConfigProperty.*;
 
 
 /**

--- a/ambry-replication/src/main/java/com/github/ambry/replication/CloudToStoreReplicationManager.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/CloudToStoreReplicationManager.java
@@ -310,6 +310,8 @@ public class CloudToStoreReplicationManager extends ReplicationEngine {
               clusterMapConfig.clustermapVcrDatacenterName, clusterMapConfig);
           newInstanceNameToCloudDataNode.put(instanceName, cloudDataNode);
           newVcrNodes.add(cloudDataNode);
+          logger.info("Instance config change. VCR Node {} added. SslPort: {}, Http2Port: {}", cloudDataNode, sslPort,
+              http2Port);
         }
       }
 

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -16,6 +16,7 @@ package com.github.ambry.replication;
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
+import com.github.ambry.clustermap.CloudDataNode;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.PartitionId;
@@ -1048,6 +1049,9 @@ public class ReplicaThread implements Runnable {
       if (exchangeMetadataResponse.serverErrorCode == ServerErrorCode.No_Error) {
         Set<StoreKey> missingStoreKeys = exchangeMetadataResponse.getMissingStoreKeys();
         if (missingStoreKeys.size() > 0) {
+          if (remoteNode instanceof CloudDataNode) {
+            logger.trace("Getting blobs from CloudDataNode: {}", missingStoreKeys);
+          }
           ArrayList<BlobId> keysToFetch = new ArrayList<BlobId>();
           for (StoreKey storeKey : missingStoreKeys) {
             keysToFetch.add((BlobId) storeKey);

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -1050,7 +1050,7 @@ public class ReplicaThread implements Runnable {
         Set<StoreKey> missingStoreKeys = exchangeMetadataResponse.getMissingStoreKeys();
         if (missingStoreKeys.size() > 0) {
           if (remoteNode instanceof CloudDataNode) {
-            logger.trace("Getting blobs from CloudDataNode: {}", missingStoreKeys);
+            logger.trace("Replicating blobs from CloudDataNode: {}", missingStoreKeys);
           }
           ArrayList<BlobId> keysToFetch = new ArrayList<BlobId>();
           for (StoreKey storeKey : missingStoreKeys) {


### PR DESCRIPTION
Currently, storage node get VCR http2/ssl port via VCR's instance config change notification. However, http2/ssl port in VCR instance config is not set yet.
This PR set http2/ssl port in VCR instance config and listeners take action only when HELIX_ENABLE is true to avoid adding VCR twice. 