### PR TITLE
SafeRelease netty ByteBuf in GetBlobOperations and fix race condition in PutOperation

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/network/NetworkClient.java
+++ b/ambry-api/src/main/java/com/github/ambry/network/NetworkClient.java
@@ -29,6 +29,7 @@ public interface NetworkClient extends Closeable {
    * Attempt to send the given requests and poll for responses from the network.
    * Any requests that cannot be sent out are added to a queue. Every time this method is called, it will first
    * attempt sending the requests in the queue (or time them out) and then attempt sending the newly added requests.
+   * The implementation of this method would have to eventually release the {@link RequestInfo#getRequest()}.
    * @param requestsToSend the list of {@link RequestInfo} representing the requests that need to be sent out. This
    *                     could be empty.
    * @param requestsToDrop the list of correlation IDs representing the requests that can be dropped by

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2NetworkClient.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2NetworkClient.java
@@ -21,7 +21,6 @@ import com.github.ambry.network.NetworkClientErrorCode;
 import com.github.ambry.network.RequestInfo;
 import com.github.ambry.network.ResponseInfo;
 import com.github.ambry.protocol.RequestOrResponse;
-import com.github.ambry.utils.Utils;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
@@ -32,7 +31,6 @@ import io.netty.channel.pool.ChannelPoolMap;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http2.Http2StreamFrameToHttpObjectCodec;
 import io.netty.util.AttributeKey;
-import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 import java.net.InetSocketAddress;
@@ -147,7 +145,6 @@ public class Http2NetworkClient implements NetworkClient {
                         }
                       }
                     }
-                    // When success, handler would release the request.
                   } else {
                     http2ClientMetrics.http2StreamWriteAndFlushErrorCount.inc();
                     logger.warn("Stream {} {} writeAndFlush fail. Cause: {}", streamChannel.hashCode(), streamChannel,
@@ -157,7 +154,6 @@ public class Http2NetworkClient implements NetworkClient {
                       http2ClientResponseHandler.getResponseInfoQueue()
                           .put(new ResponseInfo(requestInfoFromChannelAttr, NetworkClientErrorCode.NetworkError, null));
                     }
-                    ReferenceCountUtil.safeRelease(requestInfo.getRequest());
                   }
                 }
               });

--- a/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
@@ -38,6 +38,7 @@ import com.github.ambry.protocol.Crc32Impl;
 import com.github.ambry.protocol.PutRequest;
 import com.github.ambry.protocol.PutResponse;
 import com.github.ambry.quota.QuotaChargeCallback;
+import com.github.ambry.rest.NettyRequest;
 import com.github.ambry.rest.RestRequest;
 import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.store.StoreKey;
@@ -47,7 +48,6 @@ import com.github.ambry.utils.Utils;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.ReferenceCountUtil;
 import java.nio.ByteBuffer;
 import java.security.GeneralSecurityException;
@@ -1775,11 +1775,12 @@ class PutOperation {
    * @return
    */
   private String makeTouchMessage() {
-    if (restRequest == null) {
+    if (restRequest == null || restRequest.getRestRequestContext() == null) {
       return "";
     }
-    ChannelHandlerContext ctx = (ChannelHandlerContext) restRequest.getRestRequestContext();
-    return restRequest.getUri() + " " + ctx.channel().toString();
+    String channelStr =
+        ((NettyRequest.NettyRequestContext) restRequest.getRestRequestContext()).getChannel().toString();
+    return restRequest.getUri() + " " + channelStr;
   }
 
   /**

--- a/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
@@ -623,7 +623,7 @@ class PutOperation {
       if (operationCompleted) {
         PutChunk lastChunk = getBuildingChunk();
         if (lastChunk != null) {
-          logger.info("Clear unfinished chunk since operation from " + touchMessage + " is completed");
+          logger.info("Clear unfinished chunk since operation from [" + touchMessage + "] is completed");
           // call release blob content, not clear, since clear should only be used in the main thread.
           lastChunk.releaseBlobContent();
         }
@@ -632,7 +632,7 @@ class PutOperation {
         // thread. There might a chance when callback runs, the last chunk is still building and then change to complete.
         for (PutChunk chunk : putChunks) {
           if (chunk.isReady() || chunk.isComplete()) {
-            logger.info("Clear unfinished chunk(in complete) since operation from " + touchMessage + " is completed");
+            logger.info("Clear unfinished chunk(in complete) since operation from [" + touchMessage + "] is completed");
             chunk.releaseBlobContent();
           }
         }

--- a/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
@@ -1223,7 +1223,7 @@ class PutOperation {
           // If we are here, then the operation is completed and the exception could be null, in this case,
           // we have to release the content in the result.
           if (result != null) {
-            ReferenceCountUtil.safeRelease(result);
+            result.release();
           }
         }
       }


### PR DESCRIPTION
We are experiencing a memory leak in ambry frontend. According to the ambry logs as well as the netty leak detector log messages, it seems like there are two different ways memory leak might happen in the frontend.

1.  I am seeing some exception stack trace in GetBlobOperation that this IllegalReferenceCounter caused BlobReadableStreamChannel to fail. This might cause memory leak.
```2021/11/07 12:17:35.291 ERROR [ResourceLeakDetector] [epollEventLoopGroup-4-27] [ambry-frontend] [] LEAK: ByteBuf.release() was not called before it's garbage-collected. See https://netty.io/wiki/reference-counted-objects.html for more information.
Recent access records:
#1:
        com.github.ambry.router.GetBlobOperation$BlobDataReadableStreamChannel$1.onCompletion(GetBlobOperation.java:422)
        com.github.ambry.router.GetBlobOperation$BlobDataReadableStreamChannel$1.onCompletion(GetBlobOperation.java:412)
        com.github.ambry.rest.NettyResponseChannel$Chunk.resolveChunk(NettyResponseChannel.java:909)
```

2. PutOperation has a race condition. PutManager calls PutOperation.fillChunks method in OperationController's thread. PutOperation's ChunkFillerChannel's callback is invoked at different thread. When the client closes the connection before Post is finished, frontend would detect that the channel is inactive and close the channel, which would result in closing the ChunkFillerChannel in PutOperation. Closing ChunkFillerChannel would then release all the data held by the "Complete" or "Ready" PutChunk. But at the same time, the fillChunks method, which runs in a different thread, might change PutChunk's state from "Building" to "Ready", which will not be released some time.

