### PR TITLE
Differentiate between not found errors and errors possibly due to offline replicas in OperationTracker

### DIFF
--- a/ambry-router/src/main/java/com/github/ambry/router/DeleteOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/DeleteOperation.java
@@ -305,6 +305,10 @@ class DeleteOperation {
     if (operationTracker.isDone() || operationCompleted) {
       if (operationTracker.hasSucceeded()) {
         operationException.set(null);
+      } else if(operationTracker.maybeFailedDueToOfflineReplicas()) {
+        operationException.set(
+            new RouterException("DeleteOperation failed possibly because some replicas are unavailable",
+                RouterErrorCode.AmbryUnavailable));
       } else if (operationTracker.hasFailedOnNotFound()) {
         operationException.set(
             new RouterException("DeleteOperation failed because of BlobNotFound", RouterErrorCode.BlobDoesNotExist));

--- a/ambry-router/src/main/java/com/github/ambry/router/GetBlobInfoOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/GetBlobInfoOperation.java
@@ -435,6 +435,9 @@ class GetBlobInfoOperation extends GetOperation {
     if (progressTracker.isDone()) {
       if (progressTracker.hasSucceeded()) {
         operationException.set(null);
+      } else if (operationTracker.maybeFailedDueToOfflineReplicas()) {
+        operationException.set(new RouterException("GetBlobInfoOperation failed possibly because of offline replicas",
+            RouterErrorCode.AmbryUnavailable));
       } else if (operationTracker.hasFailedOnNotFound()) {
         operationException.set(new RouterException("GetBlobInfoOperation failed because of BlobNotFound",
             RouterErrorCode.BlobDoesNotExist));

--- a/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
@@ -842,6 +842,9 @@ class GetBlobOperation extends GetOperation {
       if (progressTracker.isDone()) {
         if (progressTracker.hasSucceeded() && !retainChunkExceptionOnSuccess) {
           chunkException = null;
+        } else if (chunkOperationTracker.maybeFailedDueToOfflineReplicas()) {
+          chunkException =
+              buildChunkException("Get Chunk failed possibly because of offline replicas", RouterErrorCode.AmbryUnavailable);
         } else if (chunkOperationTracker.hasFailedOnNotFound()) {
           chunkException =
               buildChunkException("Get Chunk failed because of BlobNotFound", RouterErrorCode.BlobDoesNotExist);

--- a/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterMetrics.java
@@ -208,6 +208,8 @@ public class NonBlockingRouterMetrics {
 
   public final Counter failedOnOriginatingDcNotFoundCount;
   public final Counter failedOnTotalNotFoundCount;
+  public final Counter failedMaybeDueToOriginatingDcOfflineReplicasCount;
+  public final Counter failedMaybeDueToTotalOfflineReplicasCount;
 
   // Workload characteristics
   public final AgeAtAccessMetrics ageAtGet;
@@ -492,6 +494,12 @@ public class NonBlockingRouterMetrics {
         metricRegistry.counter(MetricRegistry.name(SimpleOperationTracker.class, "FailedOnOriginatingDcNotFoundCount"));
     failedOnTotalNotFoundCount =
         metricRegistry.counter(MetricRegistry.name(SimpleOperationTracker.class, "FailedOnTotalNotFoundCount"));
+    failedMaybeDueToTotalOfflineReplicasCount =
+        metricRegistry.counter(MetricRegistry.name(SimpleOperationTracker.class,
+            "FailedMaybeDueToTotalOfflineReplicasCount"));
+    failedMaybeDueToOriginatingDcOfflineReplicasCount =
+        metricRegistry.counter(MetricRegistry.name(SimpleOperationTracker.class,
+            "FailedMaybeDueToOriginatingDcOfflineReplicasCount"));
 
     // Workload
     ageAtGet = new AgeAtAccessMetrics(metricRegistry, "OnGet");

--- a/ambry-router/src/main/java/com/github/ambry/router/OperationTracker.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/OperationTracker.java
@@ -54,6 +54,15 @@ interface OperationTracker {
   boolean hasSucceeded();
 
   /**
+   * Return {@code true} if the blob is not found in available replicas, and there are offline replicas where blob might
+   * have existed.
+   *
+   * @return {@code true} if the operation failed because of eligible replicas' {@link TrackedRequestFinalState#NOT_FOUND} and
+   * some replicas being offline.
+   */
+  boolean maybeFailedDueToOfflineReplicas();
+
+  /**
    * Return {@code true} only if the number of NOT_FOUND responses from originating DC passes the threshold.
    * It also means hasSucceeded would return {@code false}.
    *

--- a/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateOperation.java
@@ -327,6 +327,10 @@ class TtlUpdateOperation {
     if (operationTracker.isDone() || operationCompleted) {
       if (operationTracker.hasSucceeded()) {
         operationException.set(null);
+      } else if (operationTracker.maybeFailedDueToOfflineReplicas()) {
+        operationException.set(
+            new RouterException("TtlUpdateOperation failed possibly because of offline replicas",
+                RouterErrorCode.AmbryUnavailable));
       } else if (operationTracker.hasFailedOnNotFound()) {
         operationException.set(
             new RouterException("TtlUpdateOperation failed because of BlobNotFound", RouterErrorCode.BlobDoesNotExist));


### PR DESCRIPTION
In cases where OperationTracker fails operation due to not found, differentiate it with unavailable error if some eligible replicas could have been offline during that time.