### PR TITLE
Enforcing socketRequestMaxSize

### DIFF
--- a/ambry-network/src/main/java/com/github/ambry/network/Transmission.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/Transmission.java
@@ -75,7 +75,8 @@ public abstract class Transmission {
   }
 
   protected void initializeNetworkReceive() {
-    networkReceive = new NetworkReceive(getConnectionId(), new BoundedNettyByteBufReceive(), time);
+    networkReceive =
+        new NetworkReceive(getConnectionId(), new BoundedNettyByteBufReceive(config.socketRequestMaxBytes), time);
   }
 
   /**

--- a/ambry-network/src/test/java/com/github/ambry/network/SocketNetworkClientTest.java
+++ b/ambry-network/src/test/java/com/github/ambry/network/SocketNetworkClientTest.java
@@ -775,7 +775,7 @@ class MockBoundedNettyByteBufReceive extends BoundedNettyByteBufReceive {
    * @param correlationId the correlation id associated with this object.
    */
   public MockBoundedNettyByteBufReceive(int correlationId) {
-    super(PooledByteBufAllocator.DEFAULT.directBuffer(16).writeInt(correlationId), 16);
+    super(PooledByteBufAllocator.DEFAULT.directBuffer(16).writeInt(correlationId), 16, 100 * 1024 * 1024);
   }
 }
 

--- a/ambry-router/src/test/java/com/github/ambry/router/MockServer.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/MockServer.java
@@ -122,7 +122,7 @@ class MockServer {
     response.release();
     ByteBuffer payload = channel.getBuffer();
     payload.flip();
-    BoundedNettyByteBufReceive receive = new BoundedNettyByteBufReceive();
+    BoundedNettyByteBufReceive receive = new BoundedNettyByteBufReceive(100 * 1024 * 1024);
     receive.readFrom(Channels.newChannel(new ByteBufferInputStream(payload)));
     return receive;
   }


### PR DESCRIPTION
We are moving to http2 stack on all frontends and servers so this is probably unsolicited, but nevertheless, we should protect the socket stack from exploding.