### PR TITLE
Cloud get blob operation test

### DIFF
--- a/ambry-network/src/main/java/com/github/ambry/network/LocalRequestResponseChannel.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/LocalRequestResponseChannel.java
@@ -125,6 +125,8 @@ public class LocalRequestResponseChannel implements RequestResponseChannel {
     payload.writeTo(new ByteBufferChannel(ByteBuffer.wrap(SIZE_BYTE_ARRAY)));
     WritableByteChannel byteChannel = Channels.newChannel(new ByteBufOutputStream(buffer));
     payload.writeTo(byteChannel);
+    // Just like MockSelector, LocalRequestResponseChannel needs to release the sends' resources after completed.
+    payload.release();
     return buffer;
   }
 

--- a/ambry-router/src/test/java/com/github/ambry/router/CloudGetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/CloudGetBlobOperationTest.java
@@ -1,0 +1,159 @@
+/**
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.router;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import com.github.ambry.cloud.LatchBasedInMemoryCloudDestination;
+import com.github.ambry.network.CompositeNetworkClient;
+
+/**
+ * Tests for {@link GetBlobOperation}
+ * This class creates a {@link NonBlockingRouter} with a {@link MockServer} and
+ * a {@link LatchBasedInMemoryCloudDestination} and does puts through it.
+ * The gets, are done directly by the tests - that is, the tests create {@link GetBlobOperation} and get requests from
+ * it and then use a {@link CompositeNetworkClient} directly to send requests to and get responses
+ * from the {@link MockServer} and the {@link LatchBasedInMemoryCloudDestination}.
+ */
+@RunWith(Parameterized.class)
+public class CloudGetBlobOperationTest extends GetBlobOperationTest {
+
+  /**
+   * Running for both {@link SimpleOperationTracker} and {@link AdaptiveOperationTracker} with and without encryption,
+   * also include one Cloud Backed Data Center.
+   * @return an array of {{@link SimpleOperationTracker}, Non-Encrypted, includeCloudDC},
+   * {{@link AdaptiveOperationTracker}, Encrypted, includeCloudDC}
+   * and {{@link AdaptiveOperationTracker}, Non-Encrypted, includeCloudDC}
+   */
+  @Parameterized.Parameters
+  public static List<Object[]> data() {
+    return Arrays.asList(new Object[][]{
+        {SimpleOperationTracker.class.getSimpleName(), false, true},
+        {AdaptiveOperationTracker.class.getSimpleName(), false, true},
+        {AdaptiveOperationTracker.class.getSimpleName(), true, true}
+    });
+  }
+
+  public CloudGetBlobOperationTest(String operationTrackerType, boolean testEncryption, boolean includeCloudDc) throws Exception {
+    super(operationTrackerType, testEncryption, includeCloudDc);
+  }
+
+  /*
+   * For the following tests, it runs the same test as GetBlobOperation Test. So disable them in CloudGetBlobOperationTest.
+   */
+  @Test
+  public void testInstantiation() {}
+  @Test
+  public void testSimpleBlobGetSuccess() throws Exception {}
+  @Test
+  public void testSimpleBlobRawMode() throws Exception {}
+  @Test
+  public void testSimpleBlobGetChunkIdsOnly() throws Exception {}
+  @Test
+  public void testCompositeBlobRawMode() throws Exception {}
+  @Test
+  public void testCompositeBlobGetChunkIdsOnly() throws Exception {}
+  @Test
+  public void testZeroSizedBlobGetSuccess() throws Exception {}
+  @Test
+  public void testMissingDataChunkException() throws Exception {}
+  @Test
+  public void testCompositeBlobChunkSizeMultipleGetSuccess() throws Exception {}
+  @Test
+  public void testCompositeBlobNotChunkSizeMultipleGetSuccess() throws Exception {}
+  @Test
+  public void testNetworkClientTimeoutAllFailure() throws Exception {}
+  @Test
+  public void testRouterRequestTimeoutAllFailure() throws Exception {}
+  @Test
+  public void testTimeoutRequestUpdateHistogramByDefault() throws Exception {}
+  @Test
+  public void testRequestTimeoutAndBlobNotFoundLocalTimeout() throws Exception {}
+  @Test
+  public void testTimeoutAndBlobNotFoundInOriginDc() throws Exception {}
+  @Test
+  public void testBlobNotFoundCase() throws Exception {}
+  @Test
+  public void testGetBlobFromNewAddedNode() throws Exception {}
+  @Test
+  public void testAuthorizationFailureOverrideAll() throws Exception {}
+  @Test
+  public void testKMSFailure() throws Exception {}
+  @Test
+  public void testCryptoServiceFailure() throws Exception {}
+  @Test
+  public void testReadNotCalledBeforeChunkArrival() throws Exception {}
+  @Test
+  public void testDelayedChunks() throws Exception {}
+  @Test
+  public void testDataChunkFailure() throws Exception {}
+  @Test
+  public void testBlobSizeReplacement() throws Exception {}
+  @Test
+  public void testLegacyBlobGetSuccess() throws Exception {}
+  @Test
+  public void testRangeRequestSimpleBlob() throws Exception {}
+  @Test
+  public void testRangeRequestCompositeBlob() throws Exception {}
+  @Test
+  public void testRangeRequestEmptyBlob() throws Exception {}
+  @Test
+  public void testEarlyReadableStreamChannelClose() throws Exception {}
+  @Test
+  public void testSetOperationException() throws Exception {}
+
+  /**
+   * Disk backed DC returns either Disk Down or Not Found.
+   * Cloud backed DC returns Not Found.
+   */
+  @Test
+  public void testCombinedDiskDownAndNotFoundCase() throws Exception {
+    super.testCombinedDiskDownAndNotFoundCase();
+  }
+
+  /**
+   * We don't have Cloud Server Error Mock layer yet.
+   * So this test case is not applicable.
+   */
+  @Test
+  public void testErrorPrecedenceWithSpecialCase() throws Exception {
+
+  }
+
+  /**
+   * Disk backed DC hit server failure while Cloud backed DC returns Not Found.
+   */
+  public void testFailureOnServerErrors() throws Exception {
+    super.testFailureOnServerErrors();
+  }
+
+  /**
+   * Disk backed DC returns different kinds of errors while cloud backed DC returns Not Found.
+   */
+  @Test
+  public void testSuccessInThePresenceOfVariousErrors() throws Exception {
+    super.testSuccessInThePresenceOfVariousErrors();
+  }
+
+  /**
+   * Disk backed DC all returns failure but cloud backed DC returns the Blob information successfully.
+   */
+  @Test
+  public void testFailoverToAzure() throws Exception {
+    super.testFailoverToAzure();
+  }
+}

--- a/ambry-router/src/test/java/com/github/ambry/router/CloudRouterTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/CloudRouterTest.java
@@ -39,6 +39,7 @@ import java.util.Map;
 import java.util.Properties;
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -71,6 +72,10 @@ public class CloudRouterTest extends NonBlockingRouterTest {
   public CloudRouterTest(boolean testEncryption, int metadataContentVersion) throws Exception {
     super(testEncryption, metadataContentVersion, true);
   }
+  @Before
+  public void before() {
+    nettyByteBufLeakHelper.beforeTest();
+  }
 
   @After
   public void after() {
@@ -79,6 +84,7 @@ public class CloudRouterTest extends NonBlockingRouterTest {
       router.close();
     }
     Assert.assertEquals("Current operations count should be 0", 0, NonBlockingRouter.currentOperationsCount.get());
+    nettyByteBufLeakHelper.afterTest();
   }
 
   /**

--- a/ambry-router/src/test/java/com/github/ambry/router/MockCompositeNetworkClient.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/MockCompositeNetworkClient.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.router;
+
+import com.github.ambry.clustermap.DataNodeId;
+import com.github.ambry.network.CompositeNetworkClient;
+import com.github.ambry.network.NetworkClient;
+import com.github.ambry.network.RequestInfo;
+import com.github.ambry.network.ResponseInfo;
+import java.util.List;
+import java.util.Set;
+
+
+/**
+ * A mock class used for verifying whether certain methods of the {@link CompositeNetworkClient} gets called in certain
+ * tests and how many responses are received by the client.
+ */
+class MockCompositeNetworkClient implements NetworkClient {
+  private boolean wokenUp = false;
+  private int responseCount = 0;
+  private int processedResponseCount = 0;
+  NetworkClient compNetworkClient;
+
+  /**
+   * Construct a MockCompositeNetworkClient with mock components.
+   */
+  public MockCompositeNetworkClient(NetworkClient client)  {
+    compNetworkClient = client;
+  }
+
+  /**
+   * Wake up the MockNetworkClient. This simply sets a flag that indicates that the method was invoked.
+   */
+  @Override
+  public void wakeup() {
+    compNetworkClient.wakeup();
+    wokenUp = true;
+  }
+
+  /**
+   * This updates the processed request count along with normal send and poll actions.
+   * {@inheritDoc}
+   */
+  @Override
+  public List<ResponseInfo> sendAndPoll(List<RequestInfo> requestsToSend, Set<Integer> requestsToDrop,
+      int pollTimeoutMs) {
+    processedResponseCount = responseCount;
+    List<ResponseInfo> responseInfoList = compNetworkClient.sendAndPoll(requestsToSend, requestsToDrop, pollTimeoutMs);
+    responseCount += responseInfoList.size();
+    return responseInfoList;
+  }
+
+  /**
+   * Warm up connections to dataNodes in a specified time window.
+   * @param dataNodeIds warm up target nodes.
+   * @param connectionWarmUpPercentagePerDataNode percentage of max connections would like to establish in the warmup.
+   * @param timeForWarmUp max time to wait for connections' establish in milliseconds.
+   * @param responseInfoList records responses from disconnected connections.
+   * @return number of connections established successfully.
+   */
+  @Override
+  public int warmUpConnections(List<DataNodeId> dataNodeIds, int connectionWarmUpPercentagePerDataNode, long timeForWarmUp,
+      List<ResponseInfo> responseInfoList) {
+    return compNetworkClient.warmUpConnections(
+        dataNodeIds, connectionWarmUpPercentagePerDataNode, timeForWarmUp, responseInfoList);
+  }
+
+  @Override
+  public void close() {
+    compNetworkClient.close();
+  }
+
+  /**
+   * This returns the wokenUp status of this object and clears the status.
+   * @return true if this MockNetworkClient was woken up since the last call to this method.
+   */
+  boolean getAndClearWokenUpStatus() {
+    boolean ret = wokenUp;
+    wokenUp = false;
+    return ret;
+  }
+
+  /**
+   * Get the number of responses received by the client before the current
+   * {@link CompositeNetworkClient#sendAndPoll(List, Set, int)} call.
+   * @return the number of processed responses.
+   */
+  int getProcessedResponseCount() {
+    return processedResponseCount;
+  }
+
+  /**
+   * Reset the processed response count to zero
+   */
+  void resetProcessedResponseCount() {
+    responseCount = 0;
+    processedResponseCount = 0;
+  }
+}
+

--- a/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockClusterMap.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockClusterMap.java
@@ -70,7 +70,6 @@ public class MockClusterMap implements ClusterMap {
   public String cloudDatacenterName;
   // allow this to be changed to support some tests
   private String localDatacenterName;
-  private final static String LOCAL_DC = "DC3";
 
   private final MockPartitionId specialPartition;
   private ClusterMapChangeListener clusterMapChangeListener = null;
@@ -88,14 +87,14 @@ public class MockClusterMap implements ClusterMap {
    * on the test machine.
    */
   public MockClusterMap() throws IOException {
-    this(false, true, 9, 3, 3, false, false, LOCAL_DC);
+    this(false, true, 9, 3, 3, false, false, null);
   }
 
   public MockClusterMap(boolean enableSSLPorts, boolean enableHttp2Ports, int numNodes, int numMountPointsPerNode,
       int numDefaultStoresPerMountPoint, boolean createOnlyDefaultPartitionClass, boolean includeCloudDc)
       throws IOException {
     this(enableSSLPorts, enableHttp2Ports, numNodes, numMountPointsPerNode, numDefaultStoresPerMountPoint,
-        createOnlyDefaultPartitionClass, includeCloudDc, LOCAL_DC);
+        createOnlyDefaultPartitionClass, includeCloudDc, null);
   }
 
   /**
@@ -172,8 +171,12 @@ public class MockClusterMap implements ClusterMap {
       }
       dataNodes.add(dataNodeId);
       dcToDataNodes.computeIfAbsent(dcName, name -> new ArrayList<>()).add(dataNodeId);
+      localDatacenterName = dcName;
     }
-    localDatacenterName = localDcName;
+    if (localDcName != null) {
+      // if caller specifies the local data center name, use the one specified.
+      localDatacenterName = localDcName;
+    }
     partitions = new HashMap<>();
 
     // create partitions

--- a/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockClusterMap.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockClusterMap.java
@@ -67,9 +67,10 @@ public class MockClusterMap implements ClusterMap {
   private int currentPlainTextPort = PLAIN_TEXT_PORT_START_NUMBER;
   private int currentSSLPort = SSL_PORT_START_NUMBER;
   private int currentHttp2Port = HTTP2_PORT_START_NUMBER;
-
+  public String cloudDatacenterName;
   // allow this to be changed to support some tests
   private String localDatacenterName;
+  private final static String LOCAL_DC = "DC3";
 
   private final MockPartitionId specialPartition;
   private ClusterMapChangeListener clusterMapChangeListener = null;
@@ -87,7 +88,14 @@ public class MockClusterMap implements ClusterMap {
    * on the test machine.
    */
   public MockClusterMap() throws IOException {
-    this(false, true, 9, 3, 3, false, false);
+    this(false, true, 9, 3, 3, false, false, LOCAL_DC);
+  }
+
+  public MockClusterMap(boolean enableSSLPorts, boolean enableHttp2Ports, int numNodes, int numMountPointsPerNode,
+      int numDefaultStoresPerMountPoint, boolean createOnlyDefaultPartitionClass, boolean includeCloudDc)
+      throws IOException {
+    this(enableSSLPorts, enableHttp2Ports, numNodes, numMountPointsPerNode, numDefaultStoresPerMountPoint,
+        createOnlyDefaultPartitionClass, includeCloudDc, LOCAL_DC);
   }
 
   /**
@@ -122,9 +130,10 @@ public class MockClusterMap implements ClusterMap {
    * @param includeCloudDc {@code true} to make DC1 a "cloud" DC: one with a single {@link ReplicaType#CLOUD_BACKED}
    *                       replica for each partition in the cluster map. The virtual datanode created for the cloud DC
    *                       does not count against {@code numNodes}.
+   * @param localDcName name of the local data center
    */
   public MockClusterMap(boolean enableSSLPorts, boolean enableHttp2Ports, int numNodes, int numMountPointsPerNode,
-      int numDefaultStoresPerMountPoint, boolean createOnlyDefaultPartitionClass, boolean includeCloudDc)
+      int numDefaultStoresPerMountPoint, boolean createOnlyDefaultPartitionClass, boolean includeCloudDc, String localDcName)
       throws IOException {
     this.enableSSLPorts = enableSSLPorts;
     this.enableHttp2Ports = enableHttp2Ports;
@@ -141,9 +150,9 @@ public class MockClusterMap implements ClusterMap {
       MockDataNodeId virtualNode = createDataNode(getListOfPorts(DataNodeId.UNKNOWN_PORT, null, null), dcName, 0);
       dataNodes.add(virtualNode);
       dcToDataNodes.computeIfAbsent(dcName, name -> new ArrayList<>()).add(virtualNode);
-      cloudDc = dcName;
+      cloudDatacenterName = dcName;
     } else {
-      cloudDc = null;
+      cloudDatacenterName = null;
     }
     for (int i = 0; i < numNodes; i++) {
       if (i % 3 == 0) {
@@ -163,8 +172,8 @@ public class MockClusterMap implements ClusterMap {
       }
       dataNodes.add(dataNodeId);
       dcToDataNodes.computeIfAbsent(dcName, name -> new ArrayList<>()).add(dataNodeId);
-      localDatacenterName = dcName;
     }
+    localDatacenterName = localDcName;
     partitions = new HashMap<>();
 
     // create partitions
@@ -181,7 +190,7 @@ public class MockClusterMap implements ClusterMap {
       // 2 everywhere else
       List<MockDataNodeId> nodeIds = new ArrayList<>();
       dcToDataNodes.forEach((dc, mockDataNodeIds) -> {
-        if (!dc.equals(cloudDc)) {
+        if (!dc.equals(cloudDatacenterName)) {
           nodeIds.addAll(mockDataNodeIds.subList(0, localDatacenterName.equals(dc) ? 3 : 2));
         }
       });
@@ -348,7 +357,15 @@ public class MockClusterMap implements ClusterMap {
    * @return new {@link PartitionId}
    */
   public PartitionId createNewPartition(List<MockDataNodeId> dataNodes) {
-    int mountPathIndexToUse = (new Random()).nextInt(this.dataNodes.get(0).getMountPaths().size());
+    int mountPathSize;
+    if (cloudDatacenterName == null) {
+      mountPathSize = this.dataNodes.get(0).getMountPaths().size();
+    } else {
+      // the get(0) is cloud DC which doesn't have mount path. So we use get(1) DC.
+      mountPathSize = this.dataNodes.get(1).getMountPaths().size();
+    }
+
+    int mountPathIndexToUse = (new Random()).nextInt(mountPathSize);
     return createNewPartition(dataNodes, mountPathIndexToUse);
   }
 


### PR DESCRIPTION
Created MockCompositeNetworkClient to test Get Blob Operation together with Cloud Backed data center.
Some limitations or comments:
1. Disk backed Server and Cloud backed Server have different mock implementations. May need unify mock layer interface for both of them. With unified mock layer, we can add more test cases.
2. So far we couldn't simulate different kinds of return error from cloud backed server, related to item 1.
3. Do we have standard alone test to verify that Cloud Backed data center will return status which is compatible with disk backed data center?
4. For all the GetBlobOperation tests inherited, we can run them in CloudGetBlobOperation. But for the ones, it won't add more value, I disable them.
5. I build the tree from the LocalRequestResponseChannel, so the memory leak fix is inherited. Will remove it in the next version.

There are some "Jing TODO" in the code, need some discussion with the team. For example,
1. Do we need test SPECIAL_PARTITION_CLASS for testBlobSizeReplacement?
2. lifeVersion got back from cloud backed server and disk backed server is different.
3. hasFailedOnNotFound, discussion about the fix.