### PR TITLE
[BANDWIDTH_THROTTLING] Add methods to QuotaChargeCallback to check if request should be throttled and if quota exceeding is allowed.

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/quota/QuotaChargeCallback.java
+++ b/ambry-api/src/main/java/com/github/ambry/quota/QuotaChargeCallback.java
@@ -40,7 +40,7 @@ public interface QuotaChargeCallback {
     RequestCostPolicy requestCostPolicy = new UserQuotaRequestCostPolicy(quotaManager.getQuotaConfig());
     return new QuotaChargeCallback() {
       @Override
-      public void chargeQuota(long chunkSize) throws RouterException {
+      public void charge(long chunkSize) throws RouterException {
         try {
           Map<QuotaName, Double> requestCost = requestCostPolicy.calculateRequestQuotaCharge(restRequest, chunkSize)
               .entrySet()
@@ -65,8 +65,18 @@ public interface QuotaChargeCallback {
       }
 
       @Override
-      public void chargeQuota() throws RouterException {
-        chargeQuota(quotaManager.getQuotaConfig().quotaAccountingUnit);
+      public void charge() throws RouterException {
+        charge(quotaManager.getQuotaConfig().quotaAccountingUnit);
+      }
+
+      @Override
+      public boolean check() {
+        return false;
+      }
+
+      @Override
+      public boolean quotaExceedAllowed() {
+        return false;
       }
     };
   }
@@ -76,12 +86,24 @@ public interface QuotaChargeCallback {
    * @param chunkSize of the chunk.
    * @throws RouterException In case request needs to be throttled.
    */
-  void chargeQuota(long chunkSize) throws RouterException;
+  void charge(long chunkSize) throws RouterException;
 
   /**
    * Callback method that can be used to charge quota usage for a request or part of a request. Call this method
    * when the quota charge doesn't depend on the chunk size.
    * @throws RouterException In case request needs to be throttled.
    */
-  void chargeQuota() throws RouterException;
+  void charge() throws RouterException;
+
+  /**
+   * Check if request should be throttled based on quota usage.
+   * @return {@code true} if request usage exceeds limit and request should be throttled. {@code false} otherwise.
+   */
+  boolean check();
+
+  /**
+   * Check if usage is allowed to exceed the quota limit.
+   * @return {@code true} if usage is allowed to exceed the quota limit. {@code false} otherwise.
+   */
+  boolean quotaExceedAllowed();
 }

--- a/ambry-router/src/main/java/com/github/ambry/router/BatchOperationCallbackTracker.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/BatchOperationCallbackTracker.java
@@ -88,7 +88,7 @@ class BatchOperationCallbackTracker {
     if (completed.compareAndSet(false, true)) {
       if (quotaChargeCallback != null) {
         try {
-          quotaChargeCallback.chargeQuota();
+          quotaChargeCallback.charge();
         } catch (RouterException rEx) {
           LOGGER.info("Exception {} while charging quota for ttl operation", rEx.toString());
         }

--- a/ambry-router/src/main/java/com/github/ambry/router/DeleteOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/DeleteOperation.java
@@ -311,7 +311,7 @@ class DeleteOperation {
       }
       if (quotaChargeCallback != null) {
         try {
-          quotaChargeCallback.chargeQuota();
+          quotaChargeCallback.charge();
         } catch (RouterException routerException) {
           logger.error("Exception  {} in quota charge event listener during delete operation", routerException.toString());
         }

--- a/ambry-router/src/main/java/com/github/ambry/router/GetBlobInfoOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/GetBlobInfoOperation.java
@@ -445,7 +445,7 @@ class GetBlobInfoOperation extends GetOperation {
     if (operationCompleted && operationCallbackInvoked.compareAndSet(false, true)) {
       if (quotaChargeCallback != null) {
         try {
-          quotaChargeCallback.chargeQuota();
+          quotaChargeCallback.charge();
         } catch (RouterException routerException) {
           // No exception should be thrown when doing quota charge for blobinfo operation.
           logger.trace("Unexpected exception {} thrown on handling quota event for {}", routerException, blobId);

--- a/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
@@ -853,11 +853,11 @@ class GetBlobOperation extends GetOperation {
         if (state != ChunkState.Complete && quotaChargeCallback != null && chunkException == null) {
           try {
             if (chunkSize != -1) {
-              quotaChargeCallback.chargeQuota(chunkSize);
+              quotaChargeCallback.charge(chunkSize);
             } else {
               if (this instanceof FirstGetChunk && ((FirstGetChunk) this).blobType == BlobType.DataBlob
                   && blobInfo != null) {
-                quotaChargeCallback.chargeQuota(blobInfo.getBlobProperties().getBlobSize());
+                quotaChargeCallback.charge(blobInfo.getBlobProperties().getBlobSize());
               }
               // other cases mean that either this was a metadata blob, or there was an error.
             }

--- a/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
@@ -1345,7 +1345,7 @@ class PutOperation {
         // the chunk is complete now. We can charge against quota for the chunk if its not a metadata chunk.
         if (quotaChargeCallback != null && !(this instanceof MetadataPutChunk) && chunkException == null) {
           try {
-            quotaChargeCallback.chargeQuota(chunkBlobProperties.getBlobSize());
+            quotaChargeCallback.charge(chunkBlobProperties.getBlobSize());
           } catch (RouterException rEx) {
             // For now we only log for quota charge exceptions for in progress requests.
             logger.info("Exception {} while handling quota charge event", rEx.toString());

--- a/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateOperation.java
@@ -333,7 +333,7 @@ class TtlUpdateOperation {
       }
       if (quotaChargeCallback != null) {
         try {
-          quotaChargeCallback.chargeQuota();
+          quotaChargeCallback.charge();
         } catch (RouterException rEx) {
           LOGGER.info("Exception {} while charging quota for ttl update operation.", rEx.toString());
         }

--- a/ambry-router/src/main/java/com/github/ambry/router/UndeleteOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/UndeleteOperation.java
@@ -364,7 +364,7 @@ public class UndeleteOperation {
       }
       if (quotaChargeCallback != null) {
         try {
-          quotaChargeCallback.chargeQuota();
+          quotaChargeCallback.charge();
         } catch (RouterException routerException) {
           LOGGER.info("Exception {} while charging quota for undelete operation", routerException.toString());
         }

--- a/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterQuotaCallbackTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterQuotaCallbackTest.java
@@ -20,7 +20,6 @@ import com.github.ambry.commons.RetainingAsyncWritableChannel;
 import com.github.ambry.config.QuotaConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.messageformat.BlobInfo;
-import com.github.ambry.messageformat.MessageFormatException;
 import com.github.ambry.messageformat.MessageFormatRecord;
 import com.github.ambry.protocol.GetOption;
 import com.github.ambry.quota.AmbryQuotaManager;
@@ -119,14 +118,24 @@ public class NonBlockingRouterQuotaCallbackTest extends NonBlockingRouterTestBas
       // then the requests go through even in case of exception.
       QuotaChargeCallback quotaChargeCallback = new QuotaChargeCallback() {
         @Override
-        public void chargeQuota(long chunkSize) throws RouterException {
+        public void charge(long chunkSize) throws RouterException {
           listenerCalledCount.addAndGet(chunkSize);
           throw new RouterException("Quota exceeded.", RouterErrorCode.TooManyRequests);
         }
 
         @Override
-        public void chargeQuota() throws RouterException {
-          chargeQuota(quotaAccountingSize);
+        public void charge() throws RouterException {
+          charge(quotaAccountingSize);
+        }
+
+        @Override
+        public boolean check() {
+          return false;
+        }
+
+        @Override
+        public boolean quotaExceedAllowed() {
+          return false;
         }
       };
 

--- a/ambry-router/src/test/java/com/github/ambry/router/PutManagerTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/PutManagerTest.java
@@ -392,11 +392,21 @@ public class PutManagerTest {
           throw new RuntimeException("Throwing an exception in the user callback");
         }, new QuotaChargeCallback() {
           @Override
-          public void chargeQuota(long chunkSize) {
+          public void charge(long chunkSize) {
           }
 
           @Override
-          public void chargeQuota() {
+          public void charge() {
+          }
+
+          @Override
+          public boolean check() {
+            return false;
+          }
+
+          @Override
+          public boolean quotaExceedAllowed() {
+            return false;
           }
         });
     submitPutsAndAssertSuccess(false);

--- a/ambry-test-utils/src/main/java/com/github/ambry/quota/QuotaTestUtils.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/quota/QuotaTestUtils.java
@@ -95,11 +95,21 @@ public class QuotaTestUtils {
   public static QuotaChargeCallback createDummyQuotaChargeEventListener() {
     return new QuotaChargeCallback() {
       @Override
-      public void chargeQuota(long chunkSize) throws RouterException {
+      public void charge(long chunkSize) throws RouterException {
       }
 
       @Override
-      public void chargeQuota() throws RouterException {
+      public void charge() throws RouterException {
+      }
+
+      @Override
+      public boolean check() {
+        return false;
+      }
+
+      @Override
+      public boolean quotaExceedAllowed() {
+        return false;
       }
     };
   }

--- a/ambry-tools/src/main/java/com/github/ambry/tools/admin/ConcurrencyTestTool.java
+++ b/ambry-tools/src/main/java/com/github/ambry/tools/admin/ConcurrencyTestTool.java
@@ -103,13 +103,23 @@ public class ConcurrencyTestTool {
   private static final Random random = new Random();
   private static final QuotaChargeCallback QUOTA_CHARGE_EVENT_LISTENER = new QuotaChargeCallback() {
     @Override
-    public void chargeQuota(long chunkSize) {
+    public void charge(long chunkSize) {
 
     }
 
     @Override
-    public void chargeQuota() {
+    public void charge() {
 
+    }
+
+    @Override
+    public boolean check() {
+      return false;
+    }
+
+    @Override
+    public boolean quotaExceedAllowed() {
+      return false;
     }
   };
 


### PR DESCRIPTION
For bandwidth throttling implementation, we will need to do separate checks in Operation Controller about:

- should the request be throttled for a resource (shouldThrottle)
- should a request be allowed even if quota is breached (quotaExceedAllowed).

Separate checks are needed for these two cases, because number of chunk requests to server, drained from the queue will depend on a quota resource's quota usage, as well as frontend's overall usage.

Currently the implementation of new methods is dummy. Future PRs will fill up the implementation.