### PR TITLE
Remove reading the last updated timestamp for container deletion in constructor.

### DIFF
--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureContainerCompactor.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureContainerCompactor.java
@@ -80,7 +80,6 @@ public class AzureContainerCompactor implements CloudContainerCompactor {
     requestAgent = new CloudRequestAgent(cloudConfig, vcrMetrics);
     this.queryLimit = azureCloudConfig.containerCompactionCosmosQueryLimit;
     this.containerDeletionQueryBatchSize = azureCloudConfig.cosmosContainerDeletionBatchSize;
-    this.latestContainerDeletionTimestamp = getLatestContainerDeletionTime();
     azureMetrics.trackLatestContainerDeletionTimestamp(this);
   }
 

--- a/ambry-cloud/src/test/java/com/github/ambry/cloud/azure/AzureCloudDestinationTest.java
+++ b/ambry-cloud/src/test/java/com/github/ambry/cloud/azure/AzureCloudDestinationTest.java
@@ -434,7 +434,6 @@ public class AzureCloudDestinationTest {
     metadataMap = azureDest.getBlobMetadata(singleBlobList);
     assertTrue("Expected empty map", metadataMap.isEmpty());
     verify(mockBlockBlobClient, times(2)).getPropertiesWithResponse(any(), any(), any());
-    verify(mockBlockBlobClient).downloadWithResponse(any(), any(), any(), any(), anyBoolean(), any(), any());
     verifyZeroInteractions(mockumentClient);
 
     //
@@ -454,7 +453,6 @@ public class AzureCloudDestinationTest {
     assertEquals("Expected map of one", 1, metadataMap.size());
     verify(mockumentClient).queryDocuments(anyString(), any(SqlQuerySpec.class), any(FeedOptions.class));
     verify(mockBlockBlobClient, times(2)).getPropertiesWithResponse(any(), any(), any());
-    verify(mockBlockBlobClient, times(2)).downloadWithResponse(any(), any(), any(), any(), anyBoolean(), any(), any());
   }
 
   /** Test querying metadata. */


### PR DESCRIPTION
Its not required to read last updated timestamp in constructor of `AmbryContainerCompactor`. This gets computed when `deprecateContainers` is called anyways. Removing it from constructor, because sometimes it causes vcr startup to fail, even if container compaction is disabled in cloud.