### PR TITLE
Only add instance name once in CloudToStoreReplicationManager

### DIFF
--- a/ambry-replication/src/main/java/com/github/ambry/replication/CloudToStoreReplicationManager.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/CloudToStoreReplicationManager.java
@@ -300,17 +300,22 @@ public class CloudToStoreReplicationManager extends ReplicationEngine {
         if (instanceConfig.getRecord().getBooleanField(VCR_HELIX_CONFIG_READY, false)) {
           // only when VCR_HELIX_CONFIG_READY, we take action on it.
           String instanceName = instanceConfig.getInstanceName();
-          Port sslPort =
-              getSslPortStr(instanceConfig) == null ? null : new Port(getSslPortStr(instanceConfig), PortType.SSL);
-          Port http2Port = getHttp2PortStr(instanceConfig) == null ? null
-              : new Port(getHttp2PortStr(instanceConfig), PortType.HTTP2);
-          CloudDataNode cloudDataNode = new CloudDataNode(instanceConfig.getHostName(),
-              new Port(Integer.parseInt(instanceConfig.getPort()), PortType.PLAINTEXT), sslPort, http2Port,
-              clusterMapConfig.clustermapVcrDatacenterName, clusterMapConfig);
-          newInstanceNameToCloudDataNode.put(instanceName, cloudDataNode);
-          newVcrNodes.add(cloudDataNode);
-          logger.info("Instance config change. VCR Node {} added. SslPort: {}, Http2Port: {}", cloudDataNode, sslPort,
-              http2Port);
+          if (!newInstanceNameToCloudDataNode.containsKey(instanceName)) {
+            // only create CloudDataNode in the first time.
+            Port sslPort =
+                getSslPortStr(instanceConfig) == null ? null : new Port(getSslPortStr(instanceConfig), PortType.SSL);
+            Port http2Port = getHttp2PortStr(instanceConfig) == null ? null
+                : new Port(getHttp2PortStr(instanceConfig), PortType.HTTP2);
+            CloudDataNode cloudDataNode = new CloudDataNode(instanceConfig.getHostName(),
+                new Port(Integer.parseInt(instanceConfig.getPort()), PortType.PLAINTEXT), sslPort, http2Port,
+                clusterMapConfig.clustermapVcrDatacenterName, clusterMapConfig);
+            newInstanceNameToCloudDataNode.put(instanceName, cloudDataNode);
+            newVcrNodes.add(cloudDataNode);
+            logger.info("Instance config change. VCR Node {} added. SslPort: {}, Http2Port: {}", cloudDataNode, sslPort,
+                http2Port);
+          } else {
+            logger.info("Instance {} exists. Skipping.", instanceName);
+          }
         } else {
           logger.info("Instance config change received, but VCR_HELIX_CONFIG_READY is false. Instance: {}:{}",
               instanceConfig.getHostName(), instanceConfig.getPort());


### PR DESCRIPTION
To avoid CloudDataNode up/down caused instance config notification to listeners. Check if instance name exits or not first.