### PR TITLE
Use asynchronous Azure storage APIs

### DIFF
--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/ADAuthBasedStorageClient.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/ADAuthBasedStorageClient.java
@@ -14,10 +14,9 @@
 package com.github.ambry.cloud.azure;
 
 import com.azure.core.credential.AccessToken;
-import com.azure.core.credential.TokenCredential;
-import com.azure.core.credential.TokenRequestContext;
 import com.azure.core.http.HttpClient;
 import com.azure.core.util.Configuration;
+import com.azure.storage.blob.BlobServiceAsyncClient;
 import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.BlobServiceClientBuilder;
 import com.azure.storage.blob.batch.BlobBatchClient;
@@ -46,8 +45,9 @@ import reactor.core.publisher.Mono;
  */
 public class ADAuthBasedStorageClient extends StorageClient {
   private static final String AD_AUTH_TOKEN_REFRESHER_PREFIX = "AdAuthTokenRefresher";
-  private ScheduledExecutorService tokenRefreshScheduler;
-  private AtomicReference<ScheduledFuture<?>> scheduledFutureRef;
+  private final ScheduledExecutorService tokenRefreshScheduler =
+      Utils.newScheduler(1, AD_AUTH_TOKEN_REFRESHER_PREFIX, false);
+  private final AtomicReference<ScheduledFuture<?>> scheduledFutureRef = new AtomicReference<>(null);
   private AtomicReference<AccessToken> accessTokenRef;
 
   /**
@@ -60,6 +60,10 @@ public class ADAuthBasedStorageClient extends StorageClient {
   public ADAuthBasedStorageClient(CloudConfig cloudConfig, AzureCloudConfig azureCloudConfig, AzureMetrics azureMetrics,
       AzureBlobLayoutStrategy blobLayoutStrategy) {
     super(cloudConfig, azureCloudConfig, azureMetrics, blobLayoutStrategy);
+    // schedule a task to refresh token and create new storage sync and async clients before it expires.
+    scheduledFutureRef.set(tokenRefreshScheduler.schedule(() -> refreshTokenAndStorageClients(),
+        (long) ((accessTokenRef.get().getExpiresAt().toEpochSecond() - OffsetDateTime.now().toEpochSecond())
+            * azureCloudConfig.azureStorageClientRefreshFactor), TimeUnit.SECONDS));
   }
 
   /**
@@ -68,10 +72,11 @@ public class ADAuthBasedStorageClient extends StorageClient {
    * @param blobBatchClient {@link BlobBatchClient} object.
    * @param azureMetrics {@link AzureMetrics} object.
    * @param blobLayoutStrategy {@link AzureBlobLayoutStrategy} object.
+   * @param azureCloudConfig {@link AzureCloudConfig} object.
    */
   public ADAuthBasedStorageClient(BlobServiceClient blobServiceClient, BlobBatchClient blobBatchClient,
-      AzureMetrics azureMetrics, AzureBlobLayoutStrategy blobLayoutStrategy) {
-    super(blobServiceClient, blobBatchClient, azureMetrics, blobLayoutStrategy);
+      AzureMetrics azureMetrics, AzureBlobLayoutStrategy blobLayoutStrategy, AzureCloudConfig azureCloudConfig) {
+    super(blobServiceClient, blobBatchClient, azureMetrics, blobLayoutStrategy, azureCloudConfig);
   }
 
   /**
@@ -81,41 +86,39 @@ public class ADAuthBasedStorageClient extends StorageClient {
    * @param retryOptions {@link RequestRetryOptions} object.
    * @param azureCloudConfig {@link AzureCloudConfig} object.
    * @return BlobServiceClient object.
-   * @throws MalformedURLException
-   * @throws InterruptedException
-   * @throws ExecutionException
    */
   @Override
   protected BlobServiceClient buildBlobServiceClient(HttpClient httpClient, Configuration configuration,
       RequestRetryOptions retryOptions, AzureCloudConfig azureCloudConfig)
-      throws MalformedURLException, InterruptedException, ExecutionException {
-    IAuthenticationResult iAuthenticationResult = getAccessTokenByClientCredentialGrant(azureCloudConfig);
-    AccessToken accessToken = new AccessToken(iAuthenticationResult.accessToken(),
-        iAuthenticationResult.expiresOnDate().toInstant().atOffset(OffsetDateTime.now().getOffset()));
-    TokenCredential tokenCredential = new TokenCredential() {
-      @Override
-      public Mono<AccessToken> getToken(TokenRequestContext request) {
-        return Mono.just(accessToken);
-      }
-    };
+      throws MalformedURLException, ExecutionException, InterruptedException {
     if (accessTokenRef == null) {
-      // This means the object is not initialized yet, because this method was called from base class's constructor.
-      accessTokenRef = new AtomicReference<>(accessToken);
-      tokenRefreshScheduler = Utils.newScheduler(1, AD_AUTH_TOKEN_REFRESHER_PREFIX, false);
-      scheduledFutureRef = new AtomicReference<>(null);
-    } else {
-      accessTokenRef.set(accessToken);
+      // This means the token is not yet created because we are building storage client for the first time from
+      //base class's constructor. Create token before building storage client.
+      refreshToken();
     }
-    // schedule a task to refresh token.
-    scheduledFutureRef.set(tokenRefreshScheduler.schedule(() -> refreshStorageClient(),
-        (long) ((accessToken.getExpiresAt().toEpochSecond() - OffsetDateTime.now().toEpochSecond())
-            * azureCloudConfig.azureStorageClientRefreshFactor), TimeUnit.SECONDS));
-    return new BlobServiceClientBuilder().credential(tokenCredential)
+    return new BlobServiceClientBuilder().credential(request -> Mono.just(accessTokenRef.get()))
         .endpoint(azureCloudConfig.azureStorageEndpoint)
         .httpClient(httpClient)
         .retryOptions(retryOptions)
         .configuration(configuration)
         .buildClient();
+  }
+
+  @Override
+  protected BlobServiceAsyncClient buildBlobServiceAsyncClient(HttpClient httpClient, Configuration configuration,
+      RequestRetryOptions retryOptions, AzureCloudConfig azureCloudConfig)
+      throws MalformedURLException, InterruptedException, ExecutionException {
+    if (accessTokenRef == null) {
+      // This means the token is not yet created because we are building storage client for the first time from
+      //base class's constructor. Create token before building storage client.
+      refreshToken();
+    }
+    return new BlobServiceClientBuilder().credential(request -> Mono.just(accessTokenRef.get()))
+        .endpoint(azureCloudConfig.azureStorageEndpoint)
+        .httpClient(httpClient)
+        .retryOptions(retryOptions)
+        .configuration(configuration)
+        .buildAsyncClient();
   }
 
   @Override
@@ -161,7 +164,7 @@ public class ADAuthBasedStorageClient extends StorageClient {
         // to attempt token refresh at the same time. It is expected that as a result of token refresh, accessTokenRef
         // will updated with the new token.
         if (accessTokenRef.get().isExpired()) {
-          refreshStorageClient();
+          refreshTokenAndStorageClients();
         }
       }
       return true;
@@ -170,17 +173,50 @@ public class ADAuthBasedStorageClient extends StorageClient {
   }
 
   /**
-   * Refreshes AD authentication token and creates a new ABS client with the new token.
+   * Refreshes AD authentication token and creates a new ABS client with the new token. Also, it schedules a task
+   * for repeating this step before the obtained token expires.
    */
-  private synchronized void refreshStorageClient() {
-    // if a task is scheduled to refresh token then remove it.
-    if (scheduledFutureRef.get() != null) {
-      scheduledFutureRef.get().cancel(false);
-      scheduledFutureRef.set(null);
-    }
+  private synchronized void refreshTokenAndStorageClients() {
     azureMetrics.absTokenRefreshAttemptCount.inc();
-    BlobServiceClient blobServiceClient = createBlobStorageClient();
-    setClientReferences(blobServiceClient);
-    logger.info("Token refresh done.");
+    try {
+      // if a task is already scheduled to refresh token then remove it.
+      if (scheduledFutureRef.get() != null) {
+        scheduledFutureRef.get().cancel(false);
+        scheduledFutureRef.set(null);
+      }
+
+      // Refresh Token
+      refreshToken();
+
+      // Create new sync and async storage clients with refreshed token.
+      if (azureCloudConfig.useAsyncAzureAPIs) {
+        BlobServiceAsyncClient blobServiceAsyncClient = createBlobStorageAsyncClient();
+        setAsyncClientReferences(blobServiceAsyncClient);
+      } else {
+        BlobServiceClient blobServiceClient = createBlobStorageClient();
+        setClientReferences(blobServiceClient);
+      }
+
+      logger.info("Token refresh done.");
+
+      // schedule a task to refresh token again and create new storage sync and async clients before it expires.
+      scheduledFutureRef.set(tokenRefreshScheduler.schedule(this::refreshTokenAndStorageClients,
+          (long) ((accessTokenRef.get().getExpiresAt().toEpochSecond() - OffsetDateTime.now().toEpochSecond())
+              * azureCloudConfig.azureStorageClientRefreshFactor), TimeUnit.SECONDS));
+    } catch (MalformedURLException | InterruptedException | ExecutionException ex) {
+      logger.error("Error building ABS blob service client: {}", ex.getMessage());
+      throw new IllegalStateException(ex);
+    }
+  }
+
+  private void refreshToken() throws MalformedURLException, ExecutionException, InterruptedException {
+    IAuthenticationResult iAuthenticationResult = getAccessTokenByClientCredentialGrant(azureCloudConfig);
+    AccessToken accessToken = new AccessToken(iAuthenticationResult.accessToken(),
+        iAuthenticationResult.expiresOnDate().toInstant().atOffset(OffsetDateTime.now().getOffset()));
+    if (accessTokenRef == null) {
+      accessTokenRef = new AtomicReference<>(accessToken);
+    } else {
+      accessTokenRef.set(accessToken);
+    }
   }
 }

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureBlobDataAccessor.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureBlobDataAccessor.java
@@ -94,14 +94,15 @@ public class AzureBlobDataAccessor {
    * @param blobBatchClient the {@link BlobBatchClient} to use.
    * @param clusterName the cluster name to use.
    * @param azureMetrics the {@link AzureMetrics} to use.
+   * @param azureCloudConfig {@link AzureCloudConfig} object.
    */
   AzureBlobDataAccessor(BlobServiceClient blobServiceClient, BlobBatchClient blobBatchClient, String clusterName,
-      AzureMetrics azureMetrics) {
+      AzureMetrics azureMetrics, AzureCloudConfig azureCloudConfig) {
     this.blobLayoutStrategy = new AzureBlobLayoutStrategy(clusterName);
     try {
       this.storageClient =
           Utils.getObj(AzureCloudConfig.DEFAULT_AZURE_STORAGE_CLIENT_CLASS, blobServiceClient, blobBatchClient,
-              azureMetrics, blobLayoutStrategy);
+              azureMetrics, blobLayoutStrategy, azureCloudConfig);
     } catch (ReflectiveOperationException roEx) {
       throw new IllegalArgumentException("Unable to instantiate storage client: " + roEx.getMessage(), roEx);
     }

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudConfig.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudConfig.java
@@ -69,6 +69,7 @@ public class AzureCloudConfig {
   public static final String DEFAULT_CONTAINER_STRATEGY = "Partition";
   public static final String DEFAULT_AZURE_STORAGE_CLIENT_CLASS =
       "com.github.ambry.cloud.azure.ConnectionStringBasedStorageClient";
+  public static final String USE_ASYNC_AZURE_APIS = "use.async.azure.apis";
 
   /**
    * The Azure Blob Storage connection string.
@@ -255,6 +256,14 @@ public class AzureCloudConfig {
   @Config(AZURE_STORAGE_CLIENT_REFRESH_FACTOR)
   public double azureStorageClientRefreshFactor;
 
+  /**
+   * Flag indicating whether to use asynchronous Azure APIs for uploading and downloading of blobs. This is
+   * temporary and can be removed once we move to use only asynchronous methods.
+   */
+  @Config(USE_ASYNC_AZURE_APIS)
+  @Default("false")
+  public final boolean useAsyncAzureAPIs;
+
   public AzureCloudConfig(VerifiableProperties verifiableProperties) {
     azureStorageConnectionString = verifiableProperties.getString(AZURE_STORAGE_CONNECTION_STRING, "");
     cosmosEndpoint = verifiableProperties.getString(COSMOS_ENDPOINT);
@@ -295,5 +304,6 @@ public class AzureCloudConfig {
         DEFAULT_CONTAINER_COMPACTION_COSMOS_QUERY_LIMIT, 1, Integer.MAX_VALUE);
     azureStorageClientRefreshFactor = verifiableProperties.getDoubleInRange(AZURE_STORAGE_CLIENT_REFRESH_FACTOR,
         DEFAULT_AZURE_STORAGE_CLIENT_REFRESH_FACTOR, 0.0, 1.0);
+    useAsyncAzureAPIs = verifiableProperties.getBoolean(USE_ASYNC_AZURE_APIS, false);
   }
 }

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestination.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestination.java
@@ -131,14 +131,15 @@ class AzureCloudDestination implements CloudDestination {
       ClusterMap clusterMap, boolean isVcr, Properties configProps) throws CloudStorageException {
     this.azureMetrics = azureMetrics;
     this.blobLayoutStrategy = new AzureBlobLayoutStrategy(clusterName);
-    this.azureBlobDataAccessor = new AzureBlobDataAccessor(storageClient, blobBatchClient, clusterName, azureMetrics);
+    this.cloudConfig = new CloudConfig(new VerifiableProperties(configProps));
+    AzureCloudConfig azureCloudConfig = new AzureCloudConfig(new VerifiableProperties(configProps));
+    this.azureBlobDataAccessor =
+        new AzureBlobDataAccessor(storageClient, blobBatchClient, clusterName, azureMetrics, azureCloudConfig);
     this.queryBatchSize = AzureCloudConfig.DEFAULT_QUERY_BATCH_SIZE;
     VcrMetrics vcrMetrics = new VcrMetrics(new MetricRegistry());
     this.cosmosDataAccessor =
         new CosmosDataAccessor(asyncDocumentClient, cosmosCollectionLink, cosmosDeletedContainerCollectionLink,
             vcrMetrics, azureMetrics);
-    this.cloudConfig = new CloudConfig(new VerifiableProperties(configProps));
-    AzureCloudConfig azureCloudConfig = new AzureCloudConfig(new VerifiableProperties(configProps));
     this.azureStorageCompactor =
         new AzureStorageCompactor(azureBlobDataAccessor, cosmosDataAccessor, cloudConfig, vcrMetrics, azureMetrics);
     this.azureContainerCompactor =

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/ClientSecretCredentialStorageClient.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/ClientSecretCredentialStorageClient.java
@@ -16,14 +16,13 @@ package com.github.ambry.cloud.azure;
 import com.azure.core.http.HttpClient;
 import com.azure.core.util.Configuration;
 import com.azure.identity.ClientSecretCredential;
+import com.azure.storage.blob.BlobServiceAsyncClient;
 import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.BlobServiceClientBuilder;
 import com.azure.storage.blob.batch.BlobBatchClient;
 import com.azure.storage.blob.models.BlobStorageException;
 import com.azure.storage.common.policy.RequestRetryOptions;
 import com.github.ambry.config.CloudConfig;
-import java.net.MalformedURLException;
-import java.util.concurrent.ExecutionException;
 
 
 /**
@@ -50,10 +49,11 @@ public class ClientSecretCredentialStorageClient extends StorageClient {
    * @param blobBatchClient {@link BlobBatchClient} object.
    * @param azureMetrics {@link AzureMetrics} object.
    * @param blobLayoutStrategy {@link AzureBlobLayoutStrategy} object.
+   * @param azureCloudConfig {@link AzureCloudConfig} object.
    */
   public ClientSecretCredentialStorageClient(BlobServiceClient blobServiceClient, BlobBatchClient blobBatchClient,
-      AzureMetrics azureMetrics, AzureBlobLayoutStrategy blobLayoutStrategy) {
-    super(blobServiceClient, blobBatchClient, azureMetrics, blobLayoutStrategy);
+      AzureMetrics azureMetrics, AzureBlobLayoutStrategy blobLayoutStrategy, AzureCloudConfig azureCloudConfig) {
+    super(blobServiceClient, blobBatchClient, azureMetrics, blobLayoutStrategy, azureCloudConfig);
   }
 
   /**
@@ -62,9 +62,6 @@ public class ClientSecretCredentialStorageClient extends StorageClient {
    * @param retryOptions {@link RequestRetryOptions} object.
    * @param azureCloudConfig {@link AzureCloudConfig} object.
    * @return BlobServiceClient object.
-   * @throws MalformedURLException
-   * @throws InterruptedException
-   * @throws ExecutionException
    */
   @Override
   protected BlobServiceClient buildBlobServiceClient(HttpClient httpClient, Configuration configuration,
@@ -75,6 +72,25 @@ public class ClientSecretCredentialStorageClient extends StorageClient {
         .retryOptions(retryOptions)
         .configuration(configuration)
         .buildClient();
+  }
+
+  /**
+   * Build {@link BlobServiceAsyncClient}.
+   * @param httpClient {@link HttpClient} object.
+   * @param configuration {@link Configuration} object.
+   * @param retryOptions {@link RequestRetryOptions} object.
+   * @param azureCloudConfig {@link AzureCloudConfig} object.
+   * @return {@link BlobServiceAsyncClient} object.
+   */
+  @Override
+  protected BlobServiceAsyncClient buildBlobServiceAsyncClient(HttpClient httpClient, Configuration configuration,
+      RequestRetryOptions retryOptions, AzureCloudConfig azureCloudConfig) {
+    return new BlobServiceClientBuilder().credential(AzureUtils.getClientSecretCredential(azureCloudConfig))
+        .endpoint(azureCloudConfig.azureStorageEndpoint)
+        .httpClient(httpClient)
+        .retryOptions(retryOptions)
+        .configuration(configuration)
+        .buildAsyncClient();
   }
 
   @Override

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/ConnectionStringBasedStorageClient.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/ConnectionStringBasedStorageClient.java
@@ -15,6 +15,7 @@ package com.github.ambry.cloud.azure;
 
 import com.azure.core.http.HttpClient;
 import com.azure.core.util.Configuration;
+import com.azure.storage.blob.BlobServiceAsyncClient;
 import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.BlobServiceClientBuilder;
 import com.azure.storage.blob.batch.BlobBatchClient;
@@ -46,10 +47,11 @@ public class ConnectionStringBasedStorageClient extends StorageClient {
    * @param blobBatchClient {@link BlobBatchClient} object.
    * @param azureMetrics {@link AzureMetrics} object.
    * @param blobLayoutStrategy {@link AzureBlobLayoutStrategy} object.
+   * @param azureCloudConfig {@link AzureCloudConfig} object.
    */
   public ConnectionStringBasedStorageClient(BlobServiceClient blobServiceClient, BlobBatchClient blobBatchClient,
-      AzureMetrics azureMetrics, AzureBlobLayoutStrategy blobLayoutStrategy) {
-    super(blobServiceClient, blobBatchClient, azureMetrics, blobLayoutStrategy);
+      AzureMetrics azureMetrics, AzureBlobLayoutStrategy blobLayoutStrategy, AzureCloudConfig azureCloudConfig) {
+    super(blobServiceClient, blobBatchClient, azureMetrics, blobLayoutStrategy, azureCloudConfig);
   }
 
   @Override
@@ -60,6 +62,16 @@ public class ConnectionStringBasedStorageClient extends StorageClient {
         .retryOptions(retryOptions)
         .configuration(configuration)
         .buildClient();
+  }
+
+  @Override
+  protected BlobServiceAsyncClient buildBlobServiceAsyncClient(HttpClient httpClient, Configuration configuration,
+      RequestRetryOptions retryOptions, AzureCloudConfig azureCloudConfig) {
+    return new BlobServiceClientBuilder().connectionString(azureCloudConfig.azureStorageConnectionString)
+        .httpClient(httpClient)
+        .retryOptions(retryOptions)
+        .configuration(configuration)
+        .buildAsyncClient();
   }
 
   /**

--- a/ambry-cloud/src/test/java/com/github/ambry/cloud/azure/AzureBlobDataAccessorTest.java
+++ b/ambry-cloud/src/test/java/com/github/ambry/cloud/azure/AzureBlobDataAccessorTest.java
@@ -81,7 +81,8 @@ public class AzureBlobDataAccessorTest {
     blobId = AzureTestUtils.generateBlobId();
     AzureTestUtils.setConfigProperties(configProps);
     azureMetrics = new AzureMetrics(new MetricRegistry());
-    dataAccessor = new AzureBlobDataAccessor(mockServiceClient, mockBatchClient, clusterName, azureMetrics);
+    dataAccessor = new AzureBlobDataAccessor(mockServiceClient, mockBatchClient, clusterName, azureMetrics,
+        new AzureCloudConfig(new VerifiableProperties(configProps)));
   }
 
   /**
@@ -277,7 +278,8 @@ public class AzureBlobDataAccessorTest {
     AzureCloudConfig azureConfig = new AzureCloudConfig(new VerifiableProperties(configProps));
     AzureBlobLayoutStrategy blobLayoutStrategy = new AzureBlobLayoutStrategy(clusterName, azureConfig);
     ADAuthBasedStorageClient adAuthBasedStorageClient =
-        spy(new ADAuthBasedStorageClient(mockServiceClient, mockBatchClient, azureMetrics, blobLayoutStrategy));
+        spy(new ADAuthBasedStorageClient(mockServiceClient, mockBatchClient, azureMetrics, blobLayoutStrategy,
+            new AzureCloudConfig(new VerifiableProperties(configProps))));
     BlobStorageException mockBlobStorageException = mock(BlobStorageException.class);
     when(mockBlockBlobClient.downloadWithResponse(null, null, null, null, false, null, Context.NONE)).thenThrow(
         mockBlobStorageException).thenReturn(null);

--- a/ambry-cloud/src/test/java/com/github/ambry/cloud/azure/AzureStorageCompactorTest.java
+++ b/ambry-cloud/src/test/java/com/github/ambry/cloud/azure/AzureStorageCompactorTest.java
@@ -97,14 +97,15 @@ public class AzureStorageCompactorTest {
     int lookbackDays =
         CloudConfig.DEFAULT_RETENTION_DAYS + numQueryBuckets * CloudConfig.DEFAULT_COMPACTION_QUERY_BUCKET_DAYS;
     configProps.setProperty(CloudConfig.CLOUD_COMPACTION_LOOKBACK_DAYS, String.valueOf(lookbackDays));
+    AzureTestUtils.setConfigProperties(configProps);
     buildCompactor(configProps);
   }
 
   private void buildCompactor(Properties configProps) throws Exception {
     CloudConfig cloudConfig = new CloudConfig(new VerifiableProperties(configProps));
     VcrMetrics vcrMetrics = new VcrMetrics(new MetricRegistry());
-    azureBlobDataAccessor =
-        new AzureBlobDataAccessor(mockServiceClient, mockBlobBatchClient, clusterName, azureMetrics);
+    azureBlobDataAccessor = new AzureBlobDataAccessor(mockServiceClient, mockBlobBatchClient, clusterName, azureMetrics,
+        new AzureCloudConfig(new VerifiableProperties(configProps)));
     cosmosDataAccessor =
         new CosmosDataAccessor(mockumentClient, collectionLink, cosmosDeletedContainerCollectionLink, vcrMetrics,
             azureMetrics);


### PR DESCRIPTION
This change will use asynchronous Azure storage APIs in code but will block on the response until rest of the cloud store code is refactored to handle responses asynchronously. 