### PR TITLE
Add addl azure auth and key storage options

### DIFF
--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/ADAuthBasedStorageClient.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/ADAuthBasedStorageClient.java
@@ -101,8 +101,7 @@ public class ADAuthBasedStorageClient extends StorageClient {
     if (accessTokenRef == null) {
       // This means the object is not initialized yet, because this method was called from base class's constructor.
       accessTokenRef = new AtomicReference<>(accessToken);
-      tokenRefreshScheduler =
-          Utils.newScheduler(1, AD_AUTH_TOKEN_REFRESHER_PREFIX, false);
+      tokenRefreshScheduler = Utils.newScheduler(1, AD_AUTH_TOKEN_REFRESHER_PREFIX, false);
       scheduledFutureRef = new AtomicReference<>(null);
     } else {
       accessTokenRef.set(accessToken);
@@ -141,7 +140,8 @@ public class ADAuthBasedStorageClient extends StorageClient {
    */
   private IAuthenticationResult getAccessTokenByClientCredentialGrant(AzureCloudConfig azureCloudConfig)
       throws MalformedURLException, InterruptedException, ExecutionException {
-    //TODO should proxy be specified while building token?
+    // If a proxy is required, properties must either be set at the jvm level,
+    // or ClientSecretCredentialStorageClient should be used
     ConfidentialClientApplication app = ConfidentialClientApplication.builder(azureCloudConfig.azureStorageClientId,
         ClientCredentialFactory.createFromSecret(azureCloudConfig.azureStorageSecret))
         .authority(azureCloudConfig.azureStorageAuthority)

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudConfig.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudConfig.java
@@ -216,14 +216,16 @@ public class AzureCloudConfig {
   public final String azureIdentitySecret;
 
   /**
-   * Azure AAD identity client secret. For use with {@code ClientSecretCredential} auth.
+   * Azure AAD identity proxy host. This is a separate config from other services since there are cases where a proxy
+   * is required only for AAD (since AAD doesn't support private endpoints).
+   * For use with {@code ClientSecretCredential} auth.
    */
   @Config(AZURE_IDENTITY_PROXY_HOST)
   @Default("")
   public final String azureIdentityProxyHost;
 
   /**
-   * Azure AAD identity client secret. For use with {@code ClientSecretCredential} auth.
+   * Azure AAD identity proxy port. For use with {@code ClientSecretCredential} auth.
    */
   @Config(AZURE_IDENTITY_PROXY_PORT)
   @Default("3128")

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudConfig.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudConfig.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.cloud.azure;
 
+import com.github.ambry.config.CloudConfig;
 import com.github.ambry.config.Config;
 import com.github.ambry.config.Default;
 import com.github.ambry.config.VerifiableProperties;
@@ -28,12 +29,19 @@ public class AzureCloudConfig {
   public static final String COSMOS_COLLECTION_LINK = "cosmos.collection.link";
   public static final String COSMOS_DELETED_CONTAINER_COLLECTION_LINK = "cosmos.deleted.container.collection.link";
   public static final String COSMOS_KEY = "cosmos.key";
+  public static final String COSMOS_KEY_SECRET_NAME = "cosmos.key.secret.name";
+  public static final String COSMOS_VAULT_URL = "cosmos.vault.url";
   public static final String COSMOS_DIRECT_HTTPS = "cosmos.direct.https";
   public static final String AZURE_STORAGE_AUTHORITY = "azure.storage.authority";
   public static final String AZURE_STORAGE_CLIENTID = "azure.storage.clientId";
   public static final String AZURE_STORAGE_SECRET = "azure.storage.secret";
   public static final String AZURE_STORAGE_SCOPE = "azure.storage.scope";
   public static final String AZURE_STORAGE_ENDPOINT = "azure.storage.endpoint";
+  public static final String AZURE_IDENTITY_TENANT_ID = "azure.identity.tenant.id";
+  public static final String AZURE_IDENTITY_CLIENT_ID = "azure.identity.client.id";
+  public static final String AZURE_IDENTITY_SECRET = "azure.identity.secret";
+  public static final String AZURE_IDENTITY_PROXY_HOST = "azure.identity.proxy.host";
+  public static final String AZURE_IDENTITY_PROXY_PORT = "azure.identity.proxy.port";
   public static final String COSMOS_QUERY_BATCH_SIZE = "cosmos.query.batch.size";
   public static final String COSMOS_CONTAINER_DELETION_BATCH_SIZE = "cosmos.container.deletion.batch.size";
   public static final String COSMOS_REQUEST_CHARGE_THRESHOLD = "cosmos.request.charge.threshold";
@@ -91,7 +99,24 @@ public class AzureCloudConfig {
    * The Cosmos DB connection key.
    */
   @Config(COSMOS_KEY)
+  @Default("")
   public final String cosmosKey;
+
+  /**
+   * The name of the secret in an Azure KeyVault containing the key to connect to Cosmos DB.
+   * Used as an alternative to configuring the key directly in {@link #COSMOS_KEY}.
+   */
+  @Config(COSMOS_KEY_SECRET_NAME)
+  @Default("")
+  public final String cosmosKeySecretName;
+
+  /**
+   * The URL for the Azure KeyVault containing the cosmos key.
+   * Used as an alternative to configuring the key directly in {@link #COSMOS_KEY}.
+   */
+  @Config(COSMOS_VAULT_URL)
+  @Default("")
+  public final String cosmosVaultUrl;
 
   @Config(AZURE_PURGE_BATCH_SIZE)
   @Default("100")
@@ -170,6 +195,41 @@ public class AzureCloudConfig {
   public final String azureStorageEndpoint;
 
   /**
+   * Azure AAD identity tenant id. For use with {@code ClientSecretCredential} auth.
+   */
+  @Config(AZURE_IDENTITY_TENANT_ID)
+  @Default("")
+  public final String azureIdentityTenantId;
+
+  /**
+   * Azure AAD identity client id. For use with {@code ClientSecretCredential} auth.
+   */
+  @Config(AZURE_IDENTITY_CLIENT_ID)
+  @Default("")
+  public final String azureIdentityClientId;
+
+  /**
+   * Azure AAD identity client secret. For use with {@code ClientSecretCredential} auth.
+   */
+  @Config(AZURE_IDENTITY_SECRET)
+  @Default("")
+  public final String azureIdentitySecret;
+
+  /**
+   * Azure AAD identity client secret. For use with {@code ClientSecretCredential} auth.
+   */
+  @Config(AZURE_IDENTITY_PROXY_HOST)
+  @Default("")
+  public final String azureIdentityProxyHost;
+
+  /**
+   * Azure AAD identity client secret. For use with {@code ClientSecretCredential} auth.
+   */
+  @Config(AZURE_IDENTITY_PROXY_PORT)
+  @Default("3128")
+  public final int azureIdentityProxyPort;
+
+  /**
    * Factory class to instantiate azure storage client.
    */
   @Config(AZURE_STORAGE_CLIENT_CLASS)
@@ -198,12 +258,19 @@ public class AzureCloudConfig {
     cosmosEndpoint = verifiableProperties.getString(COSMOS_ENDPOINT);
     cosmosCollectionLink = verifiableProperties.getString(COSMOS_COLLECTION_LINK);
     cosmosDeletedContainerCollectionLink = verifiableProperties.getString(COSMOS_DELETED_CONTAINER_COLLECTION_LINK, "");
-    cosmosKey = verifiableProperties.getString(COSMOS_KEY);
+    cosmosKey = verifiableProperties.getString(COSMOS_KEY, "");
+    cosmosKeySecretName = verifiableProperties.getString(COSMOS_KEY_SECRET_NAME, "");
+    cosmosVaultUrl = verifiableProperties.getString(COSMOS_VAULT_URL, "");
     azureStorageAuthority = verifiableProperties.getString(AZURE_STORAGE_AUTHORITY, "");
     azureStorageClientId = verifiableProperties.getString(AZURE_STORAGE_CLIENTID, "");
     azureStorageSecret = verifiableProperties.getString(AZURE_STORAGE_SECRET, "");
     azureStorageScope = verifiableProperties.getString(AZURE_STORAGE_SCOPE, "");
     azureStorageEndpoint = verifiableProperties.getString(AZURE_STORAGE_ENDPOINT, "");
+    azureIdentityTenantId = verifiableProperties.getString(AZURE_IDENTITY_TENANT_ID, "");
+    azureIdentityClientId = verifiableProperties.getString(AZURE_IDENTITY_CLIENT_ID, "");
+    azureIdentitySecret = verifiableProperties.getString(AZURE_IDENTITY_SECRET, "");
+    azureIdentityProxyHost = verifiableProperties.getString(AZURE_IDENTITY_PROXY_HOST, "");
+    azureIdentityProxyPort = verifiableProperties.getInt(AZURE_IDENTITY_PROXY_PORT, CloudConfig.DEFAULT_VCR_PROXY_PORT);
     cosmosQueryBatchSize = verifiableProperties.getInt(COSMOS_QUERY_BATCH_SIZE, DEFAULT_QUERY_BATCH_SIZE);
     cosmosContinuationTokenLimitKb =
         verifiableProperties.getInt(COSMOS_CONTINUATION_TOKEN_LIMIT_KB, DEFAULT_COSMOS_CONTINUATION_TOKEN_LIMIT);

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureUtils.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureUtils.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.cloud.azure;
+
+import com.azure.core.http.HttpClient;
+import com.azure.core.http.ProxyOptions;
+import com.azure.core.http.netty.NettyAsyncHttpClientBuilder;
+import com.azure.identity.ClientSecretCredential;
+import com.azure.identity.ClientSecretCredentialBuilder;
+import java.net.InetSocketAddress;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Utils for working with various Azure services
+ */
+class AzureUtils {
+  private static final Logger logger = LoggerFactory.getLogger(AzureUtils.class);
+
+  /**
+   * Check that required configs are present for constructing a {@link ClientSecretCredential}.
+   * @param azureCloudConfig the configs.
+   */
+  static void validateAzureIdentityConfigs(AzureCloudConfig azureCloudConfig) {
+    if (azureCloudConfig.azureIdentityTenantId.isEmpty() || azureCloudConfig.azureIdentityClientId.isEmpty()
+        || azureCloudConfig.azureIdentitySecret.isEmpty()) {
+      throw new IllegalArgumentException(
+          String.format("One of the required configs for using ClientSecretCredential (%s, %s, %s) is missing",
+              AzureCloudConfig.AZURE_IDENTITY_TENANT_ID, AzureCloudConfig.AZURE_IDENTITY_CLIENT_ID,
+              AzureCloudConfig.AZURE_IDENTITY_SECRET));
+    }
+  }
+
+  /**
+   * @param azureCloudConfig the {@link AzureCloudConfig} to source credential configs from.
+   * @return the {@link ClientSecretCredential}.
+   */
+  static ClientSecretCredential getClientSecretCredential(AzureCloudConfig azureCloudConfig) {
+    ClientSecretCredentialBuilder builder =
+        new ClientSecretCredentialBuilder().tenantId(azureCloudConfig.azureIdentityTenantId)
+            .clientId(azureCloudConfig.azureStorageClientId)
+            .clientSecret(azureCloudConfig.azureStorageSecret);
+    if (!azureCloudConfig.azureIdentityProxyHost.isEmpty()) {
+      logger.info("Using proxy for ClientSecretCredential: {}:{}", azureCloudConfig.azureIdentityProxyHost,
+          azureCloudConfig.azureIdentityProxyPort);
+      ProxyOptions proxyOptions = new ProxyOptions(ProxyOptions.Type.HTTP,
+          new InetSocketAddress(azureCloudConfig.azureIdentityProxyHost, azureCloudConfig.azureIdentityProxyPort));
+      HttpClient httpClient = new NettyAsyncHttpClientBuilder().proxy(proxyOptions).build();
+      builder.httpClient(httpClient);
+    }
+    return builder.build();
+  }
+}

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/ClientSecretCredentialStorageClient.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/ClientSecretCredentialStorageClient.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2021 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.cloud.azure;
+
+import com.azure.core.http.HttpClient;
+import com.azure.core.util.Configuration;
+import com.azure.identity.ClientSecretCredential;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
+import com.azure.storage.blob.batch.BlobBatchClient;
+import com.azure.storage.blob.models.BlobStorageException;
+import com.azure.storage.common.policy.RequestRetryOptions;
+import com.github.ambry.config.CloudConfig;
+import java.net.MalformedURLException;
+import java.util.concurrent.ExecutionException;
+
+
+/**
+ * {@link StorageClient} implementation for AD based authentication using a {@link ClientSecretCredential} instead
+ * of the lower level msal4j library. The credential impl internally handles refreshing the token before it expires.
+ */
+public class ClientSecretCredentialStorageClient extends StorageClient {
+
+  /**
+   * Constructor for {@link ClientSecretCredentialStorageClient} object.
+   * @param cloudConfig {@link CloudConfig} object.
+   * @param azureCloudConfig {@link AzureCloudConfig} object.
+   * @param azureMetrics {@link AzureMetrics} object.
+   * @param blobLayoutStrategy {@link AzureBlobLayoutStrategy} object.
+   */
+  public ClientSecretCredentialStorageClient(CloudConfig cloudConfig, AzureCloudConfig azureCloudConfig,
+      AzureMetrics azureMetrics, AzureBlobLayoutStrategy blobLayoutStrategy) {
+    super(cloudConfig, azureCloudConfig, azureMetrics, blobLayoutStrategy);
+  }
+
+  /**
+   * Constructor for {@link ClientSecretCredentialStorageClient} object for testing.
+   * @param blobServiceClient {@link BlobServiceClient} object.
+   * @param blobBatchClient {@link BlobBatchClient} object.
+   * @param azureMetrics {@link AzureMetrics} object.
+   * @param blobLayoutStrategy {@link AzureBlobLayoutStrategy} object.
+   */
+  public ClientSecretCredentialStorageClient(BlobServiceClient blobServiceClient, BlobBatchClient blobBatchClient,
+      AzureMetrics azureMetrics, AzureBlobLayoutStrategy blobLayoutStrategy) {
+    super(blobServiceClient, blobBatchClient, azureMetrics, blobLayoutStrategy);
+  }
+
+  /**
+   * @param httpClient {@link HttpClient} object.
+   * @param configuration {@link Configuration} object.
+   * @param retryOptions {@link RequestRetryOptions} object.
+   * @param azureCloudConfig {@link AzureCloudConfig} object.
+   * @return BlobServiceClient object.
+   * @throws MalformedURLException
+   * @throws InterruptedException
+   * @throws ExecutionException
+   */
+  @Override
+  protected BlobServiceClient buildBlobServiceClient(HttpClient httpClient, Configuration configuration,
+      RequestRetryOptions retryOptions, AzureCloudConfig azureCloudConfig) {
+    return new BlobServiceClientBuilder().credential(AzureUtils.getClientSecretCredential(azureCloudConfig))
+        .endpoint(azureCloudConfig.azureStorageEndpoint)
+        .httpClient(httpClient)
+        .retryOptions(retryOptions)
+        .configuration(configuration)
+        .buildClient();
+  }
+
+  @Override
+  protected void validateABSAuthConfigs(AzureCloudConfig azureCloudConfig) {
+    AzureUtils.validateAzureIdentityConfigs(azureCloudConfig);
+  }
+
+  @Override
+  protected boolean handleExceptionAndHintRetry(BlobStorageException blobStorageException) {
+    // no need to request a retry on 403 since the credential impl handles token refresh internally.
+    return false;
+  }
+}

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/CosmosDataAccessor.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/CosmosDataAccessor.java
@@ -13,6 +13,8 @@
  */
 package com.github.ambry.cloud.azure;
 
+import com.azure.security.keyvault.secrets.SecretClient;
+import com.azure.security.keyvault.secrets.SecretClientBuilder;
 import com.codahale.metrics.Timer;
 import com.github.ambry.account.Container;
 import com.github.ambry.cloud.CloudBlobMetadata;
@@ -115,7 +117,7 @@ public class CosmosDataAccessor {
     }
     // TODO: test option to set connectionPolicy.setEnableEndpointDiscovery(false);
     asyncDocumentClient = new AsyncDocumentClient.Builder().withServiceEndpoint(azureCloudConfig.cosmosEndpoint)
-        .withMasterKeyOrResourceToken(azureCloudConfig.cosmosKey)
+        .withMasterKeyOrResourceToken(getCosmosKey(azureCloudConfig))
         .withConnectionPolicy(connectionPolicy)
         .withConsistencyLevel(ConsistencyLevel.Session)
         .build();
@@ -816,5 +818,25 @@ public class CosmosDataAccessor {
     RequestOptions options = new RequestOptions();
     options.setPartitionKey(new PartitionKey(partitionPath));
     return options;
+  }
+
+  /**
+   * Fetch the key either directly from configs, or indirectly by looking for it in an Azure KeyVault.
+   * @param azureCloudConfig the config
+   * @return the CosmosDB key.
+   */
+  private static String getCosmosKey(AzureCloudConfig azureCloudConfig) {
+    if (!azureCloudConfig.cosmosKey.isEmpty()) {
+      return azureCloudConfig.cosmosKey;
+    }
+    if (azureCloudConfig.cosmosKeySecretName.isEmpty() || azureCloudConfig.cosmosVaultUrl.isEmpty()) {
+      throw new IllegalArgumentException(
+          String.format("One of the required configs for fetching the cosmos key from a keyvault (%s, %s) missing",
+              AzureCloudConfig.COSMOS_KEY_SECRET_NAME, AzureCloudConfig.COSMOS_VAULT_URL));
+    }
+    SecretClient secretClient = new SecretClientBuilder().vaultUrl(azureCloudConfig.cosmosVaultUrl)
+        .credential(AzureUtils.getClientSecretCredential(azureCloudConfig))
+        .buildClient();
+    return secretClient.getSecret(azureCloudConfig.cosmosKeySecretName).getValue();
   }
 }

--- a/ambry-cloud/src/test/java/com/github/ambry/cloud/azure/AzureIntegrationTest.java
+++ b/ambry-cloud/src/test/java/com/github/ambry/cloud/azure/AzureIntegrationTest.java
@@ -82,7 +82,7 @@ public class AzureIntegrationTest {
   private byte dataCenterId = 66;
   private short accountId = 101;
   private short containerId = 5;
-  private long testPartition = 666;
+  private long testPartition = Integer.MAX_VALUE;
   // one day retention
   private int retentionPeriodDays = 1;
   private String propFileName = "azure-test.properties";
@@ -97,7 +97,8 @@ public class AzureIntegrationTest {
   @Parameterized.Parameters
   public static List<Object[]> data() {
     return Arrays.asList(new Object[][]{{ADAuthBasedStorageClient.class.getCanonicalName()},
-        {ConnectionStringBasedStorageClient.class.getCanonicalName()}});
+        {ConnectionStringBasedStorageClient.class.getCanonicalName()},
+        {ClientSecretCredentialStorageClient.class.getCanonicalName()}});
   }
 
   /**
@@ -194,8 +195,7 @@ public class AzureIntegrationTest {
     }
     CloudBlobMetadata metadata =
         getBlobMetadataWithRetry(Collections.singletonList(blobId), partitionId.toPathString(), cloudRequestAgent,
-            azureDest).
-            get(blobId.getID());
+            azureDest).get(blobId.getID());
     assertEquals(expirationTime, metadata.getExpirationTime());
 
     // delete blob

--- a/ambry-cloud/src/test/resources/azure-test.properties
+++ b/ambry-cloud/src/test/resources/azure-test.properties
@@ -19,4 +19,6 @@ azure.storage.clientId=
 azure.storage.secret=
 azure.storage.scope=
 azure.storage.endpoint=
-
+azure.identity.tenant.id
+azure.identity.client.id=
+azure.identity.secret=

--- a/build.gradle
+++ b/build.gradle
@@ -431,6 +431,8 @@ project(':ambry-cloud') {
             project(':ambry-rest')
         compile "com.azure:azure-storage-blob:$azureStorageBlobVersion"
         compile "com.azure:azure-storage-blob-batch:$azureStorageBlobBatchVersion"
+        compile "com.azure:azure-identity:$azureIdentityVersion"
+        compile "com.azure:azure-security-keyvault-secrets:$azureSecurityKeyvaultSecretsVersion"
         compile "io.dropwizard.metrics:metrics-core:$metricsVersion"
         compile "io.dropwizard.metrics:metrics-jmx:$metricsVersion"
         compile "com.microsoft.azure:azure-cosmosdb:$azureCosmosDbVersion"

--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -27,6 +27,8 @@ ext {
     azureCosmosDbVersion = "2.6.3"
     azureMsal4jVersion="1.7.1"
     azureMsalClientCredentialVersion="1.0.0"
+    azureIdentityVersion= "1.3.6"
+    azureSecurityKeyvaultSecretsVersion="4.2.2"
     conscryptVersion = "2.2.1"
     jimFsVersion = "1.1"
     mysqlConnectorVersion = "8.0.21"


### PR DESCRIPTION
Provide a way to fetch a Cosmos DB from an azure keyvault protected by
RBAC instead of directly storing the key in configs.

Provide a StorageClient impl that uses the azure-identity library. This
library internally handles token refresh and may be preferable to the
lower level msal4j library after we have verified it.