### PR TITLE
clean up chunks in put manager

### DIFF
--- a/ambry-router/src/main/java/com/github/ambry/router/PutManager.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/PutManager.java
@@ -141,7 +141,8 @@ class PutManager {
    * @param quotaChargeCallback {@link QuotaChargeCallback} object.
    */
   void submitPutBlobOperation(BlobProperties blobProperties, byte[] userMetaData, ReadableStreamChannel channel,
-      PutBlobOptions options, FutureResult<String> futureResult, Callback<String> callback, QuotaChargeCallback quotaChargeCallback) {
+      PutBlobOptions options, FutureResult<String> futureResult, Callback<String> callback,
+      QuotaChargeCallback quotaChargeCallback) {
     String partitionClass = getPartitionClass(blobProperties);
     PutOperation putOperation =
         PutOperation.forUpload(routerConfig, routerMetrics, clusterMap, notificationSystem, accountService,
@@ -265,6 +266,7 @@ class PutManager {
       routerMetrics.operationFailureWithUnsetExceptionCount.inc();
     }
     if (e != null) {
+      op.cleanupChunks();
       blobId = null;
       routerMetrics.onPutBlobError(e, op.isEncryptionEnabled(), op.isStitchOperation());
       routerCallback.scheduleDeletes(op.getSuccessfullyPutChunkIdsIfCompositeDirectUpload(), op.getServiceId());

--- a/ambry-router/src/main/java/com/github/ambry/router/PutManager.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/PutManager.java
@@ -337,6 +337,7 @@ class PutManager {
       synchronized (chunkFillerSynchronizer) {
         if (isChunkFillerThreadAsleep) {
           chunkFillerThreadMaySleep = false;
+          forceChunkFillerThreadToSleep = false;
           chunkFillerSynchronizer.notify();
         }
       }

--- a/ambry-router/src/main/java/com/github/ambry/router/PutManager.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/PutManager.java
@@ -30,6 +30,7 @@ import com.github.ambry.quota.QuotaChargeCallback;
 import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
 import com.google.common.collect.Lists;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -58,6 +59,7 @@ class PutManager {
   private final Object chunkFillerSynchronizer = new Object();
   private volatile boolean isChunkFillerThreadAsleep = false;
   private volatile boolean chunkFillerThreadMaySleep = false;
+  private volatile boolean forceChunkFillerThreadToSleep = false;
   // This helps the PutManager quickly find the appropriate PutOperation to hand over the response to.
   // Requests are added before they are sent out and get cleaned up as and when responses come in.
   // Because there is a guaranteed response from the NetworkClient for every request sent out, entries
@@ -315,6 +317,18 @@ class PutManager {
   }
 
   /**
+   * Return an unmodifiable set of put operations.
+   * @return
+   */
+  Set<PutOperation> getPutOperations() {
+    return Collections.unmodifiableSet(putOperations);
+  }
+
+  void forceChunkFillerThreadToSleep() {
+    forceChunkFillerThreadToSleep = true;
+  }
+
+  /**
    * Close the PutManager.
    * First notify the chunkFillerThread about closing and wait for it to exit. Then, complete all existing operations.
    */
@@ -348,6 +362,7 @@ class PutManager {
       // the RequestResponseHandler thread when it is in poll() or handleResponse(). In order to avoid the completion
       // from happening twice, complete it here only if the remove was successful.
       if (putOperations.remove(op)) {
+        op.cleanupChunks();
         Exception e = new RouterException("Aborted operation because Router is closed.", RouterErrorCode.RouterClosed);
         routerMetrics.operationDequeuingRate.mark();
         routerMetrics.operationAbortCount.inc();
@@ -373,9 +388,9 @@ class PutManager {
               chunkFillerThreadMaySleep = false;
             }
           }
-          if (chunkFillerThreadMaySleep) {
+          if (chunkFillerThreadMaySleep || forceChunkFillerThreadToSleep) {
             synchronized (chunkFillerSynchronizer) {
-              while (chunkFillerThreadMaySleep && isOpen.get()) {
+              while ((chunkFillerThreadMaySleep || forceChunkFillerThreadToSleep) && isOpen.get()) {
                 isChunkFillerThreadAsleep = true;
                 chunkFillerSynchronizer.wait();
               }

--- a/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
@@ -1082,6 +1082,14 @@ class PutOperation {
     }
 
     /**
+     * True is the data in this chunk is released.
+     * @return
+     */
+    synchronized boolean isDataReleased() {
+      return buf == null;
+    }
+
+    /**
      * @return {@code true} if chunk is a MetadataChunk. {@code false} otherwise. Since this is a regular chunk,
      * false is returned
      */

--- a/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
@@ -471,7 +471,8 @@ class PutOperation {
   }
 
   /**
-   * Release the blob content of chunks, including building chunk.
+   * Release the blob content of chunks, including building chunk, excluding encrypted chunks since encrypted chunks have
+   * other thread to release the data.
    */
   private synchronized void releaseDataForAllChunks() {
     for (PutChunk chunk : putChunks) {

--- a/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
@@ -459,7 +459,7 @@ class PutOperation {
   /**
    * release all the chunk {@link ByteBuf} resource when the operation is done.
    */
-  private void releaseResource() {
+  private synchronized void clearReadyChunks() {
     for (PutChunk chunk : putChunks) {
       logger.debug("{}: Chunk {} state: {}", loggingContext, chunk.getChunkIndex(), chunk.getState());
       // Only release the chunk in ready or complete mode. Filler thread will release the chunk in building mode
@@ -470,9 +470,30 @@ class PutOperation {
     }
   }
 
+  /**
+   * Release the blob content of chunks, including building chunk.
+   */
+  private synchronized void releaseDataForAllChunks() {
+    for (PutChunk chunk : putChunks) {
+      if (chunk.isBuilding() || chunk.isReady() || chunk.isComplete()) {
+        logger.info("{}: Clear unfinished chunk {} {} since operation is completed", loggingContext,
+            chunk.getChunkIndex(), chunk.getState());
+        chunk.releaseBlobContent();
+      }
+    }
+  }
+
   void setOperationCompleted() {
     operationCompleted = true;
-    releaseResource();
+    clearReadyChunks();
+  }
+
+  /**
+   * Clean up the chunks to release any data buffer. This should be invoked when terminating the operation with
+   * an exception.
+   */
+  public void cleanupChunks() {
+    releaseDataForAllChunks();
   }
 
   /**
@@ -636,13 +657,7 @@ class PutOperation {
         // Go over the put chunk list and release building, ready and complete chunks. This is because the multi-threading.
         // We have callback in chunk.readInto to release all the ready and complete chunks but that's in different
         // thread. There might a chance when callback runs, the last chunk is still building and then change to complete.
-        for (PutChunk chunk : putChunks) {
-          if (chunk.isBuilding() || chunk.isReady() || chunk.isComplete()) {
-            logger.info("{}: Clear unfinished chunk {} {} since operation is completed", loggingContext,
-                chunk.getChunkIndex(), chunk.getState());
-            chunk.releaseBlobContent();
-          }
-        }
+        releaseDataForAllChunks();
       }
     } catch (Exception e) {
       RouterException routerException = e instanceof RouterException ? (RouterException) e

--- a/ambry-router/src/test/java/com/github/ambry/router/PutManagerTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/PutManagerTest.java
@@ -24,6 +24,7 @@ import com.github.ambry.commons.BlobIdFactory;
 import com.github.ambry.commons.ByteBufferReadableStreamChannel;
 import com.github.ambry.commons.Callback;
 import com.github.ambry.commons.LoggingNotificationSystem;
+import com.github.ambry.commons.ResponseHandler;
 import com.github.ambry.config.CryptoServiceConfig;
 import com.github.ambry.config.KMSConfig;
 import com.github.ambry.config.RouterConfig;
@@ -128,7 +129,7 @@ public class PutManagerTest {
     this.testEncryption = testEncryption;
     this.metadataContentVersion = metadataContentVersion;
     // random chunkSize in the range [2, 1 MB]
-    chunkSize = random.nextInt(1024 * 1024) + 2;
+    chunkSize = random.nextInt(1024 * 1024) + 100;
     requestParallelism = 3;
     successTarget = 2;
     mockSelectorState.set(MockSelectorState.Good);
@@ -763,6 +764,57 @@ public class PutManagerTest {
   }
 
   /**
+   * Test when channel is closed while chunk filler thread is not responding, PutManager would release the data chunks.
+   * @throws Exception
+   */
+  @Test
+  public void testChunkFillerSleepWithBuildingChunk() throws Exception {
+    VerifiableProperties vProps = getRouterConfigInVerifiableProperties();
+    MockNetworkClient networkClient =
+        new MockNetworkClientFactory(vProps, mockSelectorState, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
+            CHECKOUT_TIMEOUT_MS, mockServerLayout, mockTime).getMockNetworkClient();
+    PutManager manager = new PutManager(mockClusterMap, new ResponseHandler(mockClusterMap), notificationSystem,
+        new RouterConfig(vProps), new NonBlockingRouterMetrics(mockClusterMap, null),
+        new RouterCallback(networkClient, null), "0", kms, cryptoService, cryptoJobHandler, accountService, mockTime,
+        MockClusterMap.DEFAULT_PARTITION_CLASS);
+    BlobProperties blobProperties =
+        new BlobProperties(-1, "serviceId", "memberId", "contentType", false, Utils.Infinite_Time,
+            Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM), false, null, null, null);
+    byte[] userMetadata = new byte[10];
+    byte[] content = new byte[chunkSize / 4];
+    random.nextBytes(content);
+    MockReadableStreamChannel channel =
+        new MockReadableStreamChannel(chunkSize / 2, false); // make sure we are not sending the entire chunk
+    FutureResult<String> future = new FutureResult<>();
+    manager.submitPutBlobOperation(blobProperties, userMetadata, channel, PutBlobOptions.DEFAULT, future, null, null);
+    channel.write(ByteBuffer.wrap(content));
+
+    // Sleep until
+    // Op has a building chunk
+    // Chunk Filler is sleeping
+    PutOperation op = manager.getPutOperations().iterator().next();
+    Assert.assertFalse(op.isOperationComplete());
+    PutOperation.PutChunk putChunk = op.putChunks.iterator().next();
+    Assert.assertTrue(putChunk.isBuilding());
+
+    manager.forceChunkFillerThreadToSleep();
+    Thread chunkFillerThread = TestUtils.getThreadByThisName("ChunkFillerThread");
+    Assert.assertTrue("ChunkFillerThread should have gone to WAITING state as there are no active operations",
+        waitForThreadState(chunkFillerThread, Thread.State.WAITING));
+
+    channel.beBad();
+    channel.write(ByteBuffer.wrap(content));
+
+    Assert.assertTrue(op.isOperationComplete());
+    Assert.assertTrue(putChunk.isBuilding());
+
+    manager.poll(new ArrayList<>(), new HashSet<>());
+    Assert.assertEquals(0, manager.getPutOperations().size());
+
+    manager.close();
+  }
+
+  /**
    * Test that the size in BlobProperties is ignored for puts, by attempting puts with varying values for size in
    * BlobProperties.
    */
@@ -928,11 +980,7 @@ public class PutManagerTest {
 
   // Methods used by the tests
 
-  /**
-   * @return Return a {@link NonBlockingRouter} created with default {@link VerifiableProperties}
-   */
-  private NonBlockingRouter getNonBlockingRouter() throws IOException, GeneralSecurityException,
-                                                          ReflectiveOperationException {
+  private VerifiableProperties getRouterConfigInVerifiableProperties() {
     Properties properties = new Properties();
     properties.setProperty("router.hostname", "localhost");
     properties.setProperty("router.datacenter.name", LOCAL_DC);
@@ -940,7 +988,15 @@ public class PutManagerTest {
     properties.setProperty("router.put.request.parallelism", Integer.toString(requestParallelism));
     properties.setProperty("router.put.success.target", Integer.toString(successTarget));
     properties.setProperty("router.metadata.content.version", String.valueOf(metadataContentVersion));
-    VerifiableProperties vProps = new VerifiableProperties(properties);
+    return new VerifiableProperties(properties);
+  }
+
+  /**
+   * @return Return a {@link NonBlockingRouter} created with default {@link VerifiableProperties}
+   */
+  private NonBlockingRouter getNonBlockingRouter()
+      throws IOException, GeneralSecurityException, ReflectiveOperationException {
+    VerifiableProperties vProps = getRouterConfigInVerifiableProperties();
     if (testEncryption && instantiateEncryptionCast) {
       setupEncryptionCast(vProps);
     }

--- a/ambry-router/src/test/java/com/github/ambry/router/PutManagerTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/PutManagerTest.java
@@ -809,6 +809,7 @@ public class PutManagerTest {
     Assert.assertTrue(putChunk.isBuilding());
 
     manager.poll(new ArrayList<>(), new HashSet<>());
+    Assert.assertTrue(putChunk.isDataReleased());
     Assert.assertEquals(0, manager.getPutOperations().size());
     NonBlockingRouter.currentOperationsCount.incrementAndGet(); // Make sure this static field's value stay the same
     manager.close();

--- a/ambry-router/src/test/java/com/github/ambry/router/PutManagerTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/PutManagerTest.java
@@ -810,7 +810,7 @@ public class PutManagerTest {
 
     manager.poll(new ArrayList<>(), new HashSet<>());
     Assert.assertEquals(0, manager.getPutOperations().size());
-
+    NonBlockingRouter.currentOperationsCount.incrementAndGet(); // Make sure this static field's value stay the same
     manager.close();
   }
 


### PR DESCRIPTION
There is a bug in the PutManager that could cause memory leak.
When the client is uploading a blob and the connection is terminated, we would set the operation to be completed in the callback. However, we only release the ready and completed chunks in the callback method, not the building chunk. We are expecting the chunk filler thread would release the building chunk, however, the chunk filler thread might be sleeping and this operation would be removed by put manager. In this case, the building chunk is never released. 

This PR would fix this issue by releasing all the chunks in PutManager when the operation is removed.