### PR TITLE
[BANDWIDTH_THROTTLING] Remove httpStatus from recommendation coming from QuotaEnforcers.

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/quota/QuotaRecommendation.java
+++ b/ambry-api/src/main/java/com/github/ambry/quota/QuotaRecommendation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2021 LinkedIn Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +23,6 @@ public class QuotaRecommendation {
   private final boolean shouldThrottle;
   private final float usagePercentage;
   private final QuotaName quotaName;
-  private final int recommendedHttpStatus;
   private final long retryAfterMs;
 
   /**
@@ -31,15 +30,12 @@ public class QuotaRecommendation {
    * @param shouldThrottle boolean flag indicating throttling recommendation.
    * @param usagePercentage percentage of resource usage.
    * @param quotaName name of the enforcement that made the recommendation.
-   * @param recommendedHttpStatus recommended http status.
    * @param retryAfterMs time after which request can be retried.
    */
-  public QuotaRecommendation(boolean shouldThrottle, float usagePercentage, QuotaName quotaName,
-      int recommendedHttpStatus, long retryAfterMs) {
+  public QuotaRecommendation(boolean shouldThrottle, float usagePercentage, QuotaName quotaName, long retryAfterMs) {
     this.shouldThrottle = shouldThrottle;
     this.usagePercentage = usagePercentage;
     this.quotaName = quotaName;
-    this.recommendedHttpStatus = recommendedHttpStatus;
     this.retryAfterMs = retryAfterMs;
   }
 
@@ -62,13 +58,6 @@ public class QuotaRecommendation {
    */
   public QuotaName getQuotaName() {
     return quotaName;
-  }
-
-  /**
-   * @return http status recommended by enforcer.
-   */
-  public int getRecommendedHttpStatus() {
-    return recommendedHttpStatus;
   }
 
   /**

--- a/ambry-api/src/main/java/com/github/ambry/quota/QuotaUtils.java
+++ b/ambry-api/src/main/java/com/github/ambry/quota/QuotaUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2021 LinkedIn Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,6 +21,7 @@ import com.github.ambry.rest.RestMethod;
 import com.github.ambry.rest.RestRequest;
 import com.github.ambry.rest.RestServiceException;
 import com.github.ambry.rest.RestUtils;
+import io.netty.handler.codec.http.HttpResponseStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -80,6 +81,15 @@ public class QuotaUtils {
    */
   public static QuotaMethod getQuotaMethod(RestRequest restRequest) {
     return isReadRequest(restRequest) ? QuotaMethod.READ : QuotaMethod.WRITE;
+  }
+
+  /**
+   * Returns recommended {@link HttpResponseStatus} by quota manager based on throttling recommendation.
+   * @param shouldThrottle throttling recommendation.
+   * @return ThrottlePolicy.THROTTLE_HTTP_STATUS if shouldThrottle is {@code true}. ThrottlePolicy.ACCEPT_HTTP_STATUS otherwise.
+   */
+  public static HttpResponseStatus quotaRecommendedHttpResponse(boolean shouldThrottle) {
+    return shouldThrottle ? ThrottlePolicy.THROTTLE_HTTP_STATUS : ThrottlePolicy.ACCEPT_HTTP_STATUS;
   }
 
   /**

--- a/ambry-api/src/main/java/com/github/ambry/quota/ThrottlePolicy.java
+++ b/ambry-api/src/main/java/com/github/ambry/quota/ThrottlePolicy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2021 LinkedIn Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.quota;
 
+import io.netty.handler.codec.http.HttpResponseStatus;
 import java.util.List;
 
 
@@ -20,6 +21,8 @@ import java.util.List;
  * Interface to apply application specific policy to make overall recommendation based on {@link QuotaRecommendation}s.
  */
 public interface ThrottlePolicy {
+  static final HttpResponseStatus ACCEPT_HTTP_STATUS = HttpResponseStatus.OK;
+  static final HttpResponseStatus THROTTLE_HTTP_STATUS = HttpResponseStatus.TOO_MANY_REQUESTS;
 
   /**
    * Provide overall recommendation by merging {@link QuotaRecommendation}s from all quota enforcers.

--- a/ambry-api/src/main/java/com/github/ambry/quota/ThrottlingRecommendation.java
+++ b/ambry-api/src/main/java/com/github/ambry/quota/ThrottlingRecommendation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2021 LinkedIn Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.quota;
 
+import io.netty.handler.codec.http.HttpResponseStatus;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -25,7 +26,7 @@ public class ThrottlingRecommendation {
   public static final long NO_RETRY_AFTER_MS = -1; // No retry needed when request is not throttled.
   private final boolean throttle;
   private final Map<QuotaName, Float> quotaUsagePercentage;
-  private final int recommendedHttpStatus;
+  private final HttpResponseStatus recommendedHttpStatus;
   private final long retryAfterMs;
   private final QuotaUsageLevel quotaUsageLevel;
 
@@ -33,12 +34,12 @@ public class ThrottlingRecommendation {
    * Constructor for {@link ThrottlingRecommendation}.
    * @param throttle flag indicating if request should be throttled.
    * @param quotaUsagePercentage A {@link Map} of {@link QuotaName} to usage percentage.
-   * @param recommendedHttpStatus overall recommended http status.
+   * @param recommendedHttpStatus {@link HttpResponseStatus} representing overall recommended http status.
    * @param retryAfterMs time in ms after which request should be retried. -1 if request is not throttled.
    * @param quotaUsageLevel {@link QuotaUsageLevel} object.
    */
   public ThrottlingRecommendation(boolean throttle, Map<QuotaName, Float> quotaUsagePercentage,
-      int recommendedHttpStatus, long retryAfterMs, QuotaUsageLevel quotaUsageLevel) {
+      HttpResponseStatus recommendedHttpStatus, long retryAfterMs, QuotaUsageLevel quotaUsageLevel) {
     this.throttle = throttle;
     this.quotaUsagePercentage = new HashMap<>(quotaUsagePercentage);
     this.recommendedHttpStatus = recommendedHttpStatus;
@@ -63,7 +64,7 @@ public class ThrottlingRecommendation {
   /**
    * @return http status recommended.
    */
-  public int getRecommendedHttpStatus() {
+  public HttpResponseStatus getRecommendedHttpStatus() {
     return this.recommendedHttpStatus;
   }
 

--- a/ambry-quota/src/main/java/com/github/ambry/quota/MaxThrottlePolicy.java
+++ b/ambry-quota/src/main/java/com/github/ambry/quota/MaxThrottlePolicy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2021 LinkedIn Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,7 +33,6 @@ import java.util.Map;
  */
 public class MaxThrottlePolicy implements ThrottlePolicy {
   static final long DEFAULT_RETRY_AFTER_MS = ThrottlingRecommendation.NO_RETRY_AFTER_MS;
-  static final int DEFAULT_RECOMMENDED_HTTP_STATUS = HttpResponseStatus.OK.code();
   static final QuotaUsageLevel DEFAULT_QUOTA_USAGE_LEVEL = QuotaUsageLevel.HEALTHY;
 
   // Percentage usage at or below this limit is healthy.
@@ -57,7 +56,7 @@ public class MaxThrottlePolicy implements ThrottlePolicy {
   public ThrottlingRecommendation recommend(List<QuotaRecommendation> quotaRecommendations) {
     boolean shouldThrottle = false;
     Map<QuotaName, Float> quotaUsagePercentage = new HashMap<>();
-    int recommendedHttpStatus = DEFAULT_RECOMMENDED_HTTP_STATUS;
+    HttpResponseStatus recommendedHttpStatus = ThrottlePolicy.ACCEPT_HTTP_STATUS;
     long retryAfterMs = DEFAULT_RETRY_AFTER_MS;
     for (QuotaRecommendation recommendation : quotaRecommendations) {
       boolean currentQuotaShouldThrottle = recommendation.shouldThrottle();
@@ -69,7 +68,7 @@ public class MaxThrottlePolicy implements ThrottlePolicy {
       }
       shouldThrottle = shouldThrottle | currentQuotaShouldThrottle;
       quotaUsagePercentage.put(recommendation.getQuotaName(), recommendation.getQuotaUsagePercentage());
-      recommendedHttpStatus = Math.max(recommendation.getRecommendedHttpStatus(), recommendedHttpStatus);
+      recommendedHttpStatus = QuotaUtils.quotaRecommendedHttpResponse(shouldThrottle);
       retryAfterMs = Math.max(recommendation.getRetryAfterMs(), retryAfterMs);
     }
     QuotaUsageLevel quotaUsageLevel = quotaUsagePercentage.isEmpty() ? DEFAULT_QUOTA_USAGE_LEVEL

--- a/ambry-quota/src/main/java/com/github/ambry/quota/capacityunit/AmbryCapacityUnitQuotaEnforcer.java
+++ b/ambry-quota/src/main/java/com/github/ambry/quota/capacityunit/AmbryCapacityUnitQuotaEnforcer.java
@@ -14,10 +14,9 @@
 package com.github.ambry.quota.capacityunit;
 
 import com.github.ambry.messageformat.BlobInfo;
-import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.quota.QuotaEnforcer;
-import com.github.ambry.quota.QuotaName;
 import com.github.ambry.quota.QuotaRecommendation;
+import com.github.ambry.quota.QuotaName;
 import com.github.ambry.quota.QuotaSource;
 import com.github.ambry.rest.RestMethod;
 import com.github.ambry.rest.RestRequest;
@@ -39,8 +38,8 @@ public class AmbryCapacityUnitQuotaEnforcer implements QuotaEnforcer {
    */
   public AmbryCapacityUnitQuotaEnforcer(QuotaSource quotaSource) {
     this.quotaSource = quotaSource;
-    this.allowReadRecommendation = new QuotaRecommendation(false, 0, QuotaName.READ_CAPACITY_UNIT, 200, 0);
-    this.allowWriteRecommendation = new QuotaRecommendation(false, 0, QuotaName.WRITE_CAPACITY_UNIT, 200, 0);
+    this.allowReadRecommendation = new QuotaRecommendation(false, 0, QuotaName.READ_CAPACITY_UNIT, 0);
+    this.allowWriteRecommendation = new QuotaRecommendation(false, 0, QuotaName.WRITE_CAPACITY_UNIT, 0);
   }
 
   @Override

--- a/ambry-quota/src/main/java/com/github/ambry/quota/storage/StorageQuotaEnforcer.java
+++ b/ambry-quota/src/main/java/com/github/ambry/quota/storage/StorageQuotaEnforcer.java
@@ -54,7 +54,7 @@ public class StorageQuotaEnforcer implements QuotaEnforcer {
   private static final long BYTES_IN_GB = 1024 * 1024 * 1024;
   // The quota recommendation returned when there is no quota found for the given account/container.
   private static final QuotaRecommendation NO_QUOTA_VALUE_RECOMMENDATION =
-      new QuotaRecommendation(false, 0.0f, QuotaName.STORAGE_IN_GB, HTTP_STATUS_ALLOW, NO_RETRY);
+      new QuotaRecommendation(false, 0.0f, QuotaName.STORAGE_IN_GB, NO_RETRY);
   protected final StorageUsageRefresher storageUsageRefresher;
   protected final QuotaSource quotaSource;
   protected final StorageQuotaConfig config;
@@ -151,8 +151,7 @@ public class StorageQuotaEnforcer implements QuotaEnforcer {
     }
     boolean shouldThrottle = currentUsage >= quotaValue;
     float usagePercentage = currentUsage >= quotaValue ? 100f : ((float) currentUsage) / quotaValue * 100f;
-    return new QuotaRecommendation(shouldThrottle, usagePercentage, QuotaName.STORAGE_IN_GB,
-        shouldThrottle ? HTTP_STATUS_THROTTLE : HTTP_STATUS_ALLOW, NO_RETRY);
+    return new QuotaRecommendation(shouldThrottle, usagePercentage, QuotaName.STORAGE_IN_GB, NO_RETRY);
   }
 
   /**

--- a/ambry-quota/src/test/java/com/github/ambry/quota/MaxThrottlePolicyTest.java
+++ b/ambry-quota/src/test/java/com/github/ambry/quota/MaxThrottlePolicyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2021 LinkedIn Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -43,97 +43,71 @@ public class MaxThrottlePolicyTest {
     ThrottlingRecommendation throttlingRecommendation = maxThrottlePolicy.recommend(Collections.emptyList());
     assertEquals(ThrottlingRecommendation.NO_RETRY_AFTER_MS, throttlingRecommendation.getRetryAfterMs());
     assertEquals(QuotaUsageLevel.HEALTHY, throttlingRecommendation.getQuotaUsageLevel());
-    assertEquals(HttpResponseStatus.OK.code(), throttlingRecommendation.getRecommendedHttpStatus());
-    assertEquals(false, throttlingRecommendation.shouldThrottle());
+    assertEquals(HttpResponseStatus.OK, throttlingRecommendation.getRecommendedHttpStatus());
+    assertFalse(throttlingRecommendation.shouldThrottle());
     assertTrue(throttlingRecommendation.getQuotaUsagePercentage().isEmpty());
 
     // test for a single quota recommendation.
-    QuotaRecommendation quotaRecommendation =
-        new QuotaRecommendation(true, 101, QuotaName.READ_CAPACITY_UNIT, HttpResponseStatus.TOO_MANY_REQUESTS.code(),
-            5);
+    QuotaRecommendation quotaRecommendation = new QuotaRecommendation(true, 101, QuotaName.READ_CAPACITY_UNIT, 5);
     throttlingRecommendation = maxThrottlePolicy.recommend(Collections.singletonList(quotaRecommendation));
     verifyThrottlingRecommendation(QuotaUsageLevel.EXCEEDED, true,
-        Collections.singletonMap(QuotaName.READ_CAPACITY_UNIT, (float) 101.0),
-        HttpResponseStatus.TOO_MANY_REQUESTS.code(), 5, throttlingRecommendation);
+        Collections.singletonMap(QuotaName.READ_CAPACITY_UNIT, (float) 101.0), ThrottlePolicy.THROTTLE_HTTP_STATUS, 5,
+        throttlingRecommendation);
 
     // test for retry after interval
     List<QuotaRecommendation> quotaRecommendationList = new ArrayList<>();
-    quotaRecommendationList.add(
-        new QuotaRecommendation(false, 101, QuotaName.READ_CAPACITY_UNIT, HttpResponseStatus.TOO_MANY_REQUESTS.code(),
-            5));
-    quotaRecommendationList.add(
-        new QuotaRecommendation(false, 101, QuotaName.READ_CAPACITY_UNIT, HttpResponseStatus.TOO_MANY_REQUESTS.code(),
-            10));
-    quotaRecommendationList.add(
-        new QuotaRecommendation(false, 101, QuotaName.READ_CAPACITY_UNIT, HttpResponseStatus.TOO_MANY_REQUESTS.code(),
-            1));
+    quotaRecommendationList.add(new QuotaRecommendation(false, 101, QuotaName.READ_CAPACITY_UNIT, 5));
+    quotaRecommendationList.add(new QuotaRecommendation(false, 101, QuotaName.READ_CAPACITY_UNIT, 10));
+    quotaRecommendationList.add(new QuotaRecommendation(false, 101, QuotaName.READ_CAPACITY_UNIT, 1));
     throttlingRecommendation = maxThrottlePolicy.recommend(quotaRecommendationList);
     verifyThrottlingRecommendation(QuotaUsageLevel.EXCEEDED, false,
-        Collections.singletonMap(QuotaName.READ_CAPACITY_UNIT, (float) 101.0),
-        HttpResponseStatus.TOO_MANY_REQUESTS.code(), 10, throttlingRecommendation);
+        Collections.singletonMap(QuotaName.READ_CAPACITY_UNIT, (float) 101.0), ThrottlePolicy.ACCEPT_HTTP_STATUS, 10,
+        throttlingRecommendation);
 
-    quotaRecommendationList.add(
-        new QuotaRecommendation(false, 101, QuotaName.READ_CAPACITY_UNIT, HttpResponseStatus.TOO_MANY_REQUESTS.code(),
-            12));
+    quotaRecommendationList.add(new QuotaRecommendation(false, 101, QuotaName.READ_CAPACITY_UNIT, 12));
     throttlingRecommendation = maxThrottlePolicy.recommend(quotaRecommendationList);
     verifyThrottlingRecommendation(QuotaUsageLevel.EXCEEDED, false,
-        Collections.singletonMap(QuotaName.READ_CAPACITY_UNIT, (float) 101.0),
-        HttpResponseStatus.TOO_MANY_REQUESTS.code(), 12, throttlingRecommendation);
+        Collections.singletonMap(QuotaName.READ_CAPACITY_UNIT, (float) 101.0), ThrottlePolicy.ACCEPT_HTTP_STATUS, 12,
+        throttlingRecommendation);
 
     // test for should throttle
     quotaRecommendationList = new ArrayList<>();
-    quotaRecommendationList.add(
-        new QuotaRecommendation(false, 101, QuotaName.READ_CAPACITY_UNIT, HttpResponseStatus.TOO_MANY_REQUESTS.code(),
-            5));
-    quotaRecommendationList.add(
-        new QuotaRecommendation(false, 101, QuotaName.READ_CAPACITY_UNIT, HttpResponseStatus.TOO_MANY_REQUESTS.code(),
-            5));
-    quotaRecommendationList.add(
-        new QuotaRecommendation(false, 101, QuotaName.READ_CAPACITY_UNIT, HttpResponseStatus.TOO_MANY_REQUESTS.code(),
-            5));
+    quotaRecommendationList.add(new QuotaRecommendation(false, 101, QuotaName.READ_CAPACITY_UNIT, 5));
+    quotaRecommendationList.add(new QuotaRecommendation(false, 101, QuotaName.READ_CAPACITY_UNIT, 5));
+    quotaRecommendationList.add(new QuotaRecommendation(false, 101, QuotaName.READ_CAPACITY_UNIT, 5));
     throttlingRecommendation = maxThrottlePolicy.recommend(quotaRecommendationList);
     verifyThrottlingRecommendation(QuotaUsageLevel.EXCEEDED, false,
-        Collections.singletonMap(QuotaName.READ_CAPACITY_UNIT, (float) 101.0),
-        HttpResponseStatus.TOO_MANY_REQUESTS.code(), 5, throttlingRecommendation);
+        Collections.singletonMap(QuotaName.READ_CAPACITY_UNIT, (float) 101.0), ThrottlePolicy.ACCEPT_HTTP_STATUS, 5,
+        throttlingRecommendation);
 
-    quotaRecommendationList.add(
-        new QuotaRecommendation(true, 101, QuotaName.READ_CAPACITY_UNIT, HttpResponseStatus.TOO_MANY_REQUESTS.code(),
-            5));
+    quotaRecommendationList.add(new QuotaRecommendation(true, 101, QuotaName.READ_CAPACITY_UNIT, 5));
     throttlingRecommendation = maxThrottlePolicy.recommend(quotaRecommendationList);
     verifyThrottlingRecommendation(QuotaUsageLevel.EXCEEDED, true,
-        Collections.singletonMap(QuotaName.READ_CAPACITY_UNIT, (float) 101.0),
-        HttpResponseStatus.TOO_MANY_REQUESTS.code(), 5, throttlingRecommendation);
+        Collections.singletonMap(QuotaName.READ_CAPACITY_UNIT, (float) 101.0), ThrottlePolicy.THROTTLE_HTTP_STATUS, 5,
+        throttlingRecommendation);
 
     // test for warning level
     quotaRecommendationList = new ArrayList<>();
-    quotaRecommendationList.add(
-        new QuotaRecommendation(false, 70, QuotaName.READ_CAPACITY_UNIT, HttpResponseStatus.TOO_MANY_REQUESTS.code(),
-            5));
+    quotaRecommendationList.add(new QuotaRecommendation(false, 70, QuotaName.READ_CAPACITY_UNIT, 5));
     throttlingRecommendation = maxThrottlePolicy.recommend(quotaRecommendationList);
     verifyThrottlingRecommendation(QuotaUsageLevel.HEALTHY, false,
-        Collections.singletonMap(QuotaName.READ_CAPACITY_UNIT, (float) 70.0),
-        HttpResponseStatus.TOO_MANY_REQUESTS.code(), 5, throttlingRecommendation);
-    quotaRecommendationList.add(
-        new QuotaRecommendation(false, 81, QuotaName.READ_CAPACITY_UNIT, HttpResponseStatus.TOO_MANY_REQUESTS.code(),
-            5));
+        Collections.singletonMap(QuotaName.READ_CAPACITY_UNIT, (float) 70.0), ThrottlePolicy.ACCEPT_HTTP_STATUS, 5,
+        throttlingRecommendation);
+    quotaRecommendationList.add(new QuotaRecommendation(false, 81, QuotaName.READ_CAPACITY_UNIT, 5));
     throttlingRecommendation = maxThrottlePolicy.recommend(quotaRecommendationList);
     verifyThrottlingRecommendation(QuotaUsageLevel.WARNING, false,
-        Collections.singletonMap(QuotaName.READ_CAPACITY_UNIT, (float) 81.0),
-        HttpResponseStatus.TOO_MANY_REQUESTS.code(), 5, throttlingRecommendation);
-    quotaRecommendationList.add(
-        new QuotaRecommendation(false, 96, QuotaName.READ_CAPACITY_UNIT, HttpResponseStatus.TOO_MANY_REQUESTS.code(),
-            5));
+        Collections.singletonMap(QuotaName.READ_CAPACITY_UNIT, (float) 81.0), ThrottlePolicy.ACCEPT_HTTP_STATUS, 5,
+        throttlingRecommendation);
+    quotaRecommendationList.add(new QuotaRecommendation(false, 96, QuotaName.READ_CAPACITY_UNIT, 5));
     throttlingRecommendation = maxThrottlePolicy.recommend(quotaRecommendationList);
     verifyThrottlingRecommendation(QuotaUsageLevel.CRITICAL, false,
-        Collections.singletonMap(QuotaName.READ_CAPACITY_UNIT, (float) 96.0),
-        HttpResponseStatus.TOO_MANY_REQUESTS.code(), 5, throttlingRecommendation);
-    quotaRecommendationList.add(
-        new QuotaRecommendation(true, 101, QuotaName.READ_CAPACITY_UNIT, HttpResponseStatus.TOO_MANY_REQUESTS.code(),
-            5));
+        Collections.singletonMap(QuotaName.READ_CAPACITY_UNIT, (float) 96.0), ThrottlePolicy.ACCEPT_HTTP_STATUS, 5,
+        throttlingRecommendation);
+    quotaRecommendationList.add(new QuotaRecommendation(true, 101, QuotaName.READ_CAPACITY_UNIT, 5));
     throttlingRecommendation = maxThrottlePolicy.recommend(quotaRecommendationList);
     verifyThrottlingRecommendation(QuotaUsageLevel.EXCEEDED, true,
-        Collections.singletonMap(QuotaName.READ_CAPACITY_UNIT, (float) 101.0),
-        HttpResponseStatus.TOO_MANY_REQUESTS.code(), 5, throttlingRecommendation);
+        Collections.singletonMap(QuotaName.READ_CAPACITY_UNIT, (float) 101.0), ThrottlePolicy.THROTTLE_HTTP_STATUS, 5,
+        throttlingRecommendation);
 
     // Test when the request throttling is disabled
     Properties prop = new Properties();
@@ -141,25 +115,22 @@ public class MaxThrottlePolicyTest {
     maxThrottlePolicy = new MaxThrottlePolicy(new QuotaConfig(new VerifiableProperties(prop)));
 
     // test for a request quota recommendation.
-    quotaRecommendation =
-        new QuotaRecommendation(true, 101, QuotaName.READ_CAPACITY_UNIT, HttpResponseStatus.TOO_MANY_REQUESTS.code(),
-            5);
+    quotaRecommendation = new QuotaRecommendation(true, 101, QuotaName.READ_CAPACITY_UNIT, 5);
     throttlingRecommendation = maxThrottlePolicy.recommend(Collections.singletonList(quotaRecommendation));
     verifyThrottlingRecommendation(QuotaUsageLevel.EXCEEDED, false,
-        Collections.singletonMap(QuotaName.READ_CAPACITY_UNIT, (float) 101.0),
-        HttpResponseStatus.TOO_MANY_REQUESTS.code(), 5, throttlingRecommendation);
+        Collections.singletonMap(QuotaName.READ_CAPACITY_UNIT, (float) 101.0), ThrottlePolicy.ACCEPT_HTTP_STATUS, 5,
+        throttlingRecommendation);
 
     quotaRecommendationList.clear();
     quotaRecommendationList.add(quotaRecommendation);
-    quotaRecommendationList.add(
-        new QuotaRecommendation(true, 101, QuotaName.STORAGE_IN_GB, HttpResponseStatus.TOO_MANY_REQUESTS.code(), 5));
+    quotaRecommendationList.add(new QuotaRecommendation(true, 101, QuotaName.STORAGE_IN_GB, 5));
     throttlingRecommendation = maxThrottlePolicy.recommend(quotaRecommendationList);
     verifyThrottlingRecommendation(QuotaUsageLevel.EXCEEDED, true, new HashMap<QuotaName, Float>() {
       {
         put(QuotaName.READ_CAPACITY_UNIT, (float) 101.0);
         put(QuotaName.STORAGE_IN_GB, (float) 101.0);
       }
-    }, HttpResponseStatus.TOO_MANY_REQUESTS.code(), 5, throttlingRecommendation);
+    }, ThrottlePolicy.THROTTLE_HTTP_STATUS, 5, throttlingRecommendation);
 
     // Test when the storage quota throttling is disabled
     prop = new Properties();
@@ -167,25 +138,22 @@ public class MaxThrottlePolicyTest {
     maxThrottlePolicy = new MaxThrottlePolicy(new QuotaConfig(new VerifiableProperties(prop)));
 
     // test for a storage quota recommendation.
-    quotaRecommendation =
-        new QuotaRecommendation(true, 101, QuotaName.STORAGE_IN_GB, HttpResponseStatus.TOO_MANY_REQUESTS.code(), 5);
+    quotaRecommendation = new QuotaRecommendation(true, 101, QuotaName.STORAGE_IN_GB, 5);
     throttlingRecommendation = maxThrottlePolicy.recommend(Collections.singletonList(quotaRecommendation));
     verifyThrottlingRecommendation(QuotaUsageLevel.EXCEEDED, false,
-        Collections.singletonMap(QuotaName.STORAGE_IN_GB, (float) 101.0), HttpResponseStatus.TOO_MANY_REQUESTS.code(),
-        5, throttlingRecommendation);
+        Collections.singletonMap(QuotaName.STORAGE_IN_GB, (float) 101.0), ThrottlePolicy.ACCEPT_HTTP_STATUS, 5,
+        throttlingRecommendation);
 
     quotaRecommendationList.clear();
     quotaRecommendationList.add(quotaRecommendation);
-    quotaRecommendationList.add(
-        new QuotaRecommendation(true, 101, QuotaName.READ_CAPACITY_UNIT, HttpResponseStatus.TOO_MANY_REQUESTS.code(),
-            5));
+    quotaRecommendationList.add(new QuotaRecommendation(true, 101, QuotaName.READ_CAPACITY_UNIT, 5));
     throttlingRecommendation = maxThrottlePolicy.recommend(quotaRecommendationList);
     verifyThrottlingRecommendation(QuotaUsageLevel.EXCEEDED, true, new HashMap<QuotaName, Float>() {
       {
         put(QuotaName.READ_CAPACITY_UNIT, (float) 101.0);
         put(QuotaName.STORAGE_IN_GB, (float) 101.0);
       }
-    }, HttpResponseStatus.TOO_MANY_REQUESTS.code(), 5, throttlingRecommendation);
+    }, ThrottlePolicy.THROTTLE_HTTP_STATUS, 5, throttlingRecommendation);
 
     // Test when both quota throttling are disabled
     prop = new Properties();
@@ -193,37 +161,28 @@ public class MaxThrottlePolicyTest {
     prop.setProperty(QuotaConfig.REQUEST_THROTTLING_ENABLED, "false");
     maxThrottlePolicy = new MaxThrottlePolicy(new QuotaConfig(new VerifiableProperties(prop)));
 
-    quotaRecommendation =
-        new QuotaRecommendation(true, 101, QuotaName.READ_CAPACITY_UNIT, HttpResponseStatus.TOO_MANY_REQUESTS.code(),
-            5);
+    quotaRecommendation = new QuotaRecommendation(true, 101, QuotaName.READ_CAPACITY_UNIT, 5);
     throttlingRecommendation = maxThrottlePolicy.recommend(Collections.singletonList(quotaRecommendation));
     verifyThrottlingRecommendation(QuotaUsageLevel.EXCEEDED, false,
-        Collections.singletonMap(QuotaName.READ_CAPACITY_UNIT, (float) 101.0),
-        HttpResponseStatus.TOO_MANY_REQUESTS.code(), 5, throttlingRecommendation);
+        Collections.singletonMap(QuotaName.READ_CAPACITY_UNIT, (float) 101.0), ThrottlePolicy.ACCEPT_HTTP_STATUS, 5,
+        throttlingRecommendation);
 
-    quotaRecommendation =
-        new QuotaRecommendation(true, 101, QuotaName.WRITE_CAPACITY_UNIT, HttpResponseStatus.TOO_MANY_REQUESTS.code(),
-            5);
+    quotaRecommendation = new QuotaRecommendation(true, 101, QuotaName.WRITE_CAPACITY_UNIT, 5);
     throttlingRecommendation = maxThrottlePolicy.recommend(Collections.singletonList(quotaRecommendation));
     verifyThrottlingRecommendation(QuotaUsageLevel.EXCEEDED, false,
-        Collections.singletonMap(QuotaName.WRITE_CAPACITY_UNIT, (float) 101.0),
-        HttpResponseStatus.TOO_MANY_REQUESTS.code(), 5, throttlingRecommendation);
+        Collections.singletonMap(QuotaName.WRITE_CAPACITY_UNIT, (float) 101.0), ThrottlePolicy.ACCEPT_HTTP_STATUS, 5,
+        throttlingRecommendation);
 
-    quotaRecommendation =
-        new QuotaRecommendation(true, 101, QuotaName.STORAGE_IN_GB, HttpResponseStatus.TOO_MANY_REQUESTS.code(), 5);
+    quotaRecommendation = new QuotaRecommendation(true, 101, QuotaName.STORAGE_IN_GB, 5);
     throttlingRecommendation = maxThrottlePolicy.recommend(Collections.singletonList(quotaRecommendation));
     verifyThrottlingRecommendation(QuotaUsageLevel.EXCEEDED, false,
-        Collections.singletonMap(QuotaName.STORAGE_IN_GB, (float) 101.0), HttpResponseStatus.TOO_MANY_REQUESTS.code(),
-        5, throttlingRecommendation);
+        Collections.singletonMap(QuotaName.STORAGE_IN_GB, (float) 101.0), ThrottlePolicy.ACCEPT_HTTP_STATUS, 5,
+        throttlingRecommendation);
 
     quotaRecommendationList.clear();
     quotaRecommendationList.add(quotaRecommendation);
-    quotaRecommendationList.add(
-        new QuotaRecommendation(true, 101, QuotaName.READ_CAPACITY_UNIT, HttpResponseStatus.TOO_MANY_REQUESTS.code(),
-            5));
-    quotaRecommendationList.add(
-        new QuotaRecommendation(true, 101, QuotaName.WRITE_CAPACITY_UNIT, HttpResponseStatus.TOO_MANY_REQUESTS.code(),
-            5));
+    quotaRecommendationList.add(new QuotaRecommendation(true, 101, QuotaName.READ_CAPACITY_UNIT, 5));
+    quotaRecommendationList.add(new QuotaRecommendation(true, 101, QuotaName.WRITE_CAPACITY_UNIT, 5));
     throttlingRecommendation = maxThrottlePolicy.recommend(quotaRecommendationList);
     verifyThrottlingRecommendation(QuotaUsageLevel.EXCEEDED, false, new HashMap<QuotaName, Float>() {
       {
@@ -231,7 +190,7 @@ public class MaxThrottlePolicyTest {
         put(QuotaName.WRITE_CAPACITY_UNIT, (float) 101.0);
         put(QuotaName.STORAGE_IN_GB, (float) 101.0);
       }
-    }, HttpResponseStatus.TOO_MANY_REQUESTS.code(), 5, throttlingRecommendation);
+    }, ThrottlePolicy.ACCEPT_HTTP_STATUS, 5, throttlingRecommendation);
   }
 
   /**
@@ -239,12 +198,12 @@ public class MaxThrottlePolicyTest {
    * @param quotaUsageLevel expected value for {@link QuotaUsageLevel}.
    * @param shouldThrottle expected value for throttle recommendation.
    * @param quotaUsageMap expected value for {@link Map} of quota usage.
-   * @param httpStatus expected value for http status.
+   * @param httpStatus {@link HttpResponseStatus} object.
    * @param retryAfterMs expected value for retry interval.
    * @param throttlingRecommendation {@link ThrottlingRecommendation} object to verify.
    */
   private void verifyThrottlingRecommendation(QuotaUsageLevel quotaUsageLevel, boolean shouldThrottle,
-      Map<QuotaName, Float> quotaUsageMap, int httpStatus, long retryAfterMs,
+      Map<QuotaName, Float> quotaUsageMap, HttpResponseStatus httpStatus, long retryAfterMs,
       ThrottlingRecommendation throttlingRecommendation) {
     assertEquals(quotaUsageLevel, throttlingRecommendation.getQuotaUsageLevel());
     assertEquals(shouldThrottle, throttlingRecommendation.shouldThrottle());

--- a/ambry-test-utils/src/main/java/com/github/ambry/quota/RejectRequestQuotaEnforcer.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/quota/RejectRequestQuotaEnforcer.java
@@ -43,13 +43,13 @@ public class RejectRequestQuotaEnforcer implements QuotaEnforcer {
   public QuotaRecommendation chargeAndRecommend(RestRequest restRequest, BlobInfo blobInfo,
       Map<QuotaName, Double> requestCostMap) {
     return new QuotaRecommendation(SHOULD_THROTTLE, DUMMY_REJECTABLE_USAGE_PERCENTAGE, QuotaName.READ_CAPACITY_UNIT,
-        REJECT_HTTP_STATUS, 1);
+        1);
   }
 
   @Override
   public QuotaRecommendation recommend(RestRequest restRequest) {
     return new QuotaRecommendation(SHOULD_THROTTLE, DUMMY_REJECTABLE_USAGE_PERCENTAGE, QuotaName.READ_CAPACITY_UNIT,
-        REJECT_HTTP_STATUS, 1);
+        1);
   }
 
   @Override


### PR DESCRIPTION
This is a refactor only PR, with no logic changes.
1. Remove httpStatus from recommendation coming from QuotaEnforcers.
2. Change recommendedHttpStatus in ThrottlingRecommendation from int to HttpResponseStatus.