### PR TITLE
Fix some NonBlockingRouter tests.

### DIFF
--- a/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTest.java
@@ -121,22 +121,25 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
    */
   @Test
   public void testNonBlockingRouterFactory() throws Exception {
-    Properties props = getNonBlockingRouterProperties("NotInClusterMap");
-    VerifiableProperties verifiableProperties = new VerifiableProperties((props));
     try {
-      router = (NonBlockingRouter) new NonBlockingRouterFactory(verifiableProperties, mockClusterMap,
-          new LoggingNotificationSystem(), null, accountService).getRouter();
-      Assert.fail("NonBlockingRouterFactory instantiation should have failed because the router datacenter is not in "
-          + "the cluster map");
-    } catch (IllegalStateException e) {
+      Properties props = getNonBlockingRouterProperties("NotInClusterMap");
+      VerifiableProperties verifiableProperties = new VerifiableProperties((props));
+      try {
+        router = (NonBlockingRouter) new NonBlockingRouterFactory(verifiableProperties, mockClusterMap, new LoggingNotificationSystem(), null, accountService).getRouter();
+        Assert.fail("NonBlockingRouterFactory instantiation should have failed because the router datacenter is not in "
+            + "the cluster map");
+      } catch (IllegalStateException e) {
+      }
+      props = getNonBlockingRouterProperties("DC1");
+      verifiableProperties = new VerifiableProperties((props));
+      router = (NonBlockingRouter) new NonBlockingRouterFactory(verifiableProperties, mockClusterMap, new LoggingNotificationSystem(), null, accountService).getRouter();
+      assertExpectedThreadCounts(2, 1);
+    } finally {
+      if (router != null) {
+        router.close();
+        assertExpectedThreadCounts(0, 0);
+      }
     }
-    props = getNonBlockingRouterProperties("DC1");
-    verifiableProperties = new VerifiableProperties((props));
-    router = (NonBlockingRouter) new NonBlockingRouterFactory(verifiableProperties, mockClusterMap,
-        new LoggingNotificationSystem(), null, accountService).getRouter();
-    assertExpectedThreadCounts(2, 1);
-    router.close();
-    assertExpectedThreadCounts(0, 0);
   }
 
   /**
@@ -144,15 +147,20 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
    */
   @Test
   public void testRouterBasic() throws Exception {
-    setRouter();
-    assertExpectedThreadCounts(2, 1);
-    testRouterBasicForRegularBlob();
-    testRouterBasicForStitchedBlob();
-    router.close();
-    assertExpectedThreadCounts(0, 0);
+    try {
+      setRouter();
+      assertExpectedThreadCounts(2, 1);
+      testRouterBasicForRegularBlob();
+      testRouterBasicForStitchedBlob();
+    } finally {
+      if (router != null) {
+        router.close();
+        assertExpectedThreadCounts(0, 0);
 
-    //submission after closing should return a future that is already done.
-    assertClosed();
+        //submission after closing should return a future that is already done.
+        assertClosed();
+      }
+    }
   }
 
   /**
@@ -259,106 +267,110 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
    */
   @Test
   public void testUndeleteBasic() throws Exception {
-    assumeTrue(!testEncryption && !includeCloudDc);
-    // Setting put and delete parallelism to 2, same as the put and delete success target.
-    // If put or delete requests' parallelism is 3 (default value), when we ensure all the servers has the correspoding
-    // requests, it might have override by the dangling request.
-    // For example, when deleting a blob, there are three delete requests being sent to the mock server. But only two of
-    // them required to be acknowledged. There is a chance that when we undelete this blob, this third unacknowledged
-    // delete request would override the undelete state.
-    setRouter(getNonBlockingRouterProperties("DC1", 3, 2), mockServerLayout, new LoggingNotificationSystem());
-    assertExpectedThreadCounts(2, 1);
+    try {
+      assumeTrue(!testEncryption && !includeCloudDc);
+      // Setting put and delete parallelism to 2, same as the put and delete success target.
+      // If put or delete requests' parallelism is 3 (default value), when we ensure all the servers has the correspoding
+      // requests, it might have override by the dangling request.
+      // For example, when deleting a blob, there are three delete requests being sent to the mock server. But only two of
+      // them required to be acknowledged. There is a chance that when we undelete this blob, this third unacknowledged
+      // delete request would override the undelete state.
+      setRouter(getNonBlockingRouterProperties("DC1", 3, 2), mockServerLayout, new LoggingNotificationSystem());
+      assertExpectedThreadCounts(2, 1);
 
-    // 1. Test undelete a composite blob
-    List<String> blobIds = new ArrayList<>();
-    for (int i = 0; i < 2; i++) {
+      // 1. Test undelete a composite blob
+      List<String> blobIds = new ArrayList<>();
+      for (int i = 0; i < 2; i++) {
+        setOperationParams();
+        String blobId = router.putBlob(putBlobProperties, putUserMetadata, putChannel, PutBlobOptions.DEFAULT).get();
+        ensurePutInAllServers(blobId, mockServerLayout);
+        logger.debug("Put blob {}", blobId);
+        blobIds.add(blobId);
+      }
       setOperationParams();
-      String blobId = router.putBlob(putBlobProperties, putUserMetadata, putChannel, PutBlobOptions.DEFAULT).get();
-      ensurePutInAllServers(blobId, mockServerLayout);
-      logger.debug("Put blob {}", blobId);
-      blobIds.add(blobId);
-    }
-    setOperationParams();
-    List<ChunkInfo> chunksToStitch = blobIds.stream()
-        .map(blobId -> new ChunkInfo(blobId, PUT_CONTENT_SIZE, Utils.Infinite_Time))
-        .collect(Collectors.toList());
-    String stitchedBlobId = router.stitchBlob(putBlobProperties, putUserMetadata, chunksToStitch).get();
-    ensureStitchInAllServers(stitchedBlobId, mockServerLayout, chunksToStitch, PUT_CONTENT_SIZE);
-    blobIds.add(stitchedBlobId);
+      List<ChunkInfo> chunksToStitch = blobIds.stream()
+          .map(blobId -> new ChunkInfo(blobId, PUT_CONTENT_SIZE, Utils.Infinite_Time))
+          .collect(Collectors.toList());
+      String stitchedBlobId = router.stitchBlob(putBlobProperties, putUserMetadata, chunksToStitch).get();
+      ensureStitchInAllServers(stitchedBlobId, mockServerLayout, chunksToStitch, PUT_CONTENT_SIZE);
+      blobIds.add(stitchedBlobId);
 
-    for (String blobId : blobIds) {
-      router.getBlob(blobId, new GetBlobOptionsBuilder().build()).get();
-      router.deleteBlob(blobId, null).get();
-      ensureDeleteInAllServers(blobId, mockServerLayout);
-      try {
+      for (String blobId : blobIds) {
         router.getBlob(blobId, new GetBlobOptionsBuilder().build()).get();
+        router.deleteBlob(blobId, null).get();
+        ensureDeleteInAllServers(blobId, mockServerLayout);
+        try {
+          router.getBlob(blobId, new GetBlobOptionsBuilder().build()).get();
+        } catch (ExecutionException e) {
+          RouterException r = (RouterException) e.getCause();
+          Assert.assertEquals("BlobDeleted error is expected", RouterErrorCode.BlobDeleted, r.getErrorCode());
+        }
+        router.getBlob(blobId, new GetBlobOptionsBuilder().getOption(GetOption.Include_Deleted_Blobs).build()).get();
+        router.getBlob(blobId, new GetBlobOptionsBuilder().getOption(GetOption.Include_All).build()).get();
+      }
+      // StitchedBlob is a composite blob
+      router.undeleteBlob(stitchedBlobId, "undelete_server_id").get();
+      for (String blobId : blobIds) {
+        ensureUndeleteInAllServers(blobId, mockServerLayout);
+      }
+      // Now we should be able to fetch all the blobs
+      for (String blobId : blobIds) {
+        router.getBlob(blobId, new GetBlobOptionsBuilder().build()).get();
+      }
+
+      // 2. Test undelete a simple blob
+      setOperationParams();
+      String simpleBlobId = router.putBlob(putBlobProperties, putUserMetadata, putChannel, PutBlobOptions.DEFAULT).get();
+      ensurePutInAllServers(simpleBlobId, mockServerLayout);
+      router.getBlob(simpleBlobId, new GetBlobOptionsBuilder().build()).get();
+      router.deleteBlob(simpleBlobId, null).get();
+      ensureDeleteInAllServers(simpleBlobId, mockServerLayout);
+
+      try {
+        router.getBlob(simpleBlobId, new GetBlobOptionsBuilder().build()).get();
       } catch (ExecutionException e) {
         RouterException r = (RouterException) e.getCause();
         Assert.assertEquals("BlobDeleted error is expected", RouterErrorCode.BlobDeleted, r.getErrorCode());
       }
-      router.getBlob(blobId, new GetBlobOptionsBuilder().getOption(GetOption.Include_Deleted_Blobs).build()).get();
-      router.getBlob(blobId, new GetBlobOptionsBuilder().getOption(GetOption.Include_All).build()).get();
-    }
-    // StitchedBlob is a composite blob
-    router.undeleteBlob(stitchedBlobId, "undelete_server_id").get();
-    for (String blobId : blobIds) {
-      ensureUndeleteInAllServers(blobId, mockServerLayout);
-    }
-    // Now we should be able to fetch all the blobs
-    for (String blobId : blobIds) {
-      router.getBlob(blobId, new GetBlobOptionsBuilder().build()).get();
-    }
-
-    // 2. Test undelete a simple blob
-    setOperationParams();
-    String simpleBlobId = router.putBlob(putBlobProperties, putUserMetadata, putChannel, PutBlobOptions.DEFAULT).get();
-    ensurePutInAllServers(simpleBlobId, mockServerLayout);
-    router.getBlob(simpleBlobId, new GetBlobOptionsBuilder().build()).get();
-    router.deleteBlob(simpleBlobId, null).get();
-    ensureDeleteInAllServers(simpleBlobId, mockServerLayout);
-
-    try {
+      router.getBlob(simpleBlobId, new GetBlobOptionsBuilder().getOption(GetOption.Include_Deleted_Blobs).build()).get();
+      router.getBlob(simpleBlobId, new GetBlobOptionsBuilder().getOption(GetOption.Include_All).build()).get();
+      router.undeleteBlob(simpleBlobId, "undelete_server_id").get();
+      ensureUndeleteInAllServers(simpleBlobId, mockServerLayout);
       router.getBlob(simpleBlobId, new GetBlobOptionsBuilder().build()).get();
-    } catch (ExecutionException e) {
-      RouterException r = (RouterException) e.getCause();
-      Assert.assertEquals("BlobDeleted error is expected", RouterErrorCode.BlobDeleted, r.getErrorCode());
-    }
-    router.getBlob(simpleBlobId, new GetBlobOptionsBuilder().getOption(GetOption.Include_Deleted_Blobs).build()).get();
-    router.getBlob(simpleBlobId, new GetBlobOptionsBuilder().getOption(GetOption.Include_All).build()).get();
-    router.undeleteBlob(simpleBlobId, "undelete_server_id").get();
-    ensureUndeleteInAllServers(simpleBlobId, mockServerLayout);
-    router.getBlob(simpleBlobId, new GetBlobOptionsBuilder().build()).get();
 
-    // 3. Test delete after undelete
-    router.deleteBlob(simpleBlobId, null).get();
-    ensureDeleteInAllServers(simpleBlobId, mockServerLayout);
+      // 3. Test delete after undelete
+      router.deleteBlob(simpleBlobId, null).get();
+      ensureDeleteInAllServers(simpleBlobId, mockServerLayout);
 
-    try {
+      try {
+        router.getBlob(simpleBlobId, new GetBlobOptionsBuilder().build()).get();
+      } catch (ExecutionException e) {
+        RouterException r = (RouterException) e.getCause();
+        Assert.assertEquals("BlobDeleted error is expected", RouterErrorCode.BlobDeleted, r.getErrorCode());
+      }
+      router.getBlob(simpleBlobId, new GetBlobOptionsBuilder().getOption(GetOption.Include_Deleted_Blobs).build()).get();
+      router.getBlob(simpleBlobId, new GetBlobOptionsBuilder().getOption(GetOption.Include_All).build()).get();
+
+      // 4. Test undelete more than once
+      router.undeleteBlob(simpleBlobId, "undelete_server_id").get();
+      ensureUndeleteInAllServers(simpleBlobId, mockServerLayout);
       router.getBlob(simpleBlobId, new GetBlobOptionsBuilder().build()).get();
-    } catch (ExecutionException e) {
-      RouterException r = (RouterException) e.getCause();
-      Assert.assertEquals("BlobDeleted error is expected", RouterErrorCode.BlobDeleted, r.getErrorCode());
+
+      // 5. Undelete the same blob again
+      router.undeleteBlob(simpleBlobId, "undelete_server_id").get();
+
+      // 6. Test ttl update after undelete
+      router.updateBlobTtl(simpleBlobId, null, Utils.Infinite_Time);
+      router.getBlob(simpleBlobId, new GetBlobOptionsBuilder().build()).get();
+    } finally {
+      if (router != null) {
+        router.close();
+        assertExpectedThreadCounts(0, 0);
+
+        //submission after closing should return a future that is already done.
+        assertClosed();
+      }
     }
-    router.getBlob(simpleBlobId, new GetBlobOptionsBuilder().getOption(GetOption.Include_Deleted_Blobs).build()).get();
-    router.getBlob(simpleBlobId, new GetBlobOptionsBuilder().getOption(GetOption.Include_All).build()).get();
-
-    // 4. Test undelete more than once
-    router.undeleteBlob(simpleBlobId, "undelete_server_id").get();
-    ensureUndeleteInAllServers(simpleBlobId, mockServerLayout);
-    router.getBlob(simpleBlobId, new GetBlobOptionsBuilder().build()).get();
-
-    // 5. Undelete the same blob again
-    router.undeleteBlob(simpleBlobId, "undelete_server_id").get();
-
-    // 6. Test ttl update after undelete
-    router.updateBlobTtl(simpleBlobId, null, Utils.Infinite_Time);
-    router.getBlob(simpleBlobId, new GetBlobOptionsBuilder().build()).get();
-
-    router.close();
-    assertExpectedThreadCounts(0, 0);
-
-    //submission after closing should return a future that is already done.
-    assertClosed();
   }
 
   /**
@@ -367,49 +379,52 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
    */
   @Test
   public void testUndeleteWithNotificationSystem() throws Exception {
-    assumeTrue(!includeCloudDc);
+    try {
+      assumeTrue(!includeCloudDc);
 
-    final CountDownLatch undeletesDoneLatch = new CountDownLatch(2);
-    final Set<String> blobsThatAreUndeleted = new HashSet<>();
-    LoggingNotificationSystem undeleteTrackingNotificationSystem = new LoggingNotificationSystem() {
-      @Override
-      public void onBlobUndeleted(String blobId, String serviceId, Account account, Container container) {
-        blobsThatAreUndeleted.add(blobId);
-        undeletesDoneLatch.countDown();
+      final CountDownLatch undeletesDoneLatch = new CountDownLatch(2);
+      final Set<String> blobsThatAreUndeleted = new HashSet<>();
+      LoggingNotificationSystem undeleteTrackingNotificationSystem = new LoggingNotificationSystem() {
+        @Override
+        public void onBlobUndeleted(String blobId, String serviceId, Account account, Container container) {
+          blobsThatAreUndeleted.add(blobId);
+          undeletesDoneLatch.countDown();
+        }
+      };
+      setRouter(getNonBlockingRouterProperties("DC1"), mockServerLayout, undeleteTrackingNotificationSystem);
+
+      List<String> blobIds = new ArrayList<>();
+      for (int i = 0; i < 4; i++) {
+        setOperationParams();
+        String blobId = router.putBlob(putBlobProperties, putUserMetadata, putChannel, PutBlobOptions.DEFAULT).get();
+        ensurePutInAllServers(blobId, mockServerLayout);
+        blobIds.add(blobId);
       }
-    };
-    setRouter(getNonBlockingRouterProperties("DC1"), mockServerLayout, undeleteTrackingNotificationSystem);
-
-    List<String> blobIds = new ArrayList<>();
-    for (int i = 0; i < 4; i++) {
       setOperationParams();
-      String blobId = router.putBlob(putBlobProperties, putUserMetadata, putChannel, PutBlobOptions.DEFAULT).get();
-      ensurePutInAllServers(blobId, mockServerLayout);
+      List<ChunkInfo> chunksToStitch = blobIds.stream()
+          .map(blobId -> new ChunkInfo(blobId, PUT_CONTENT_SIZE, Utils.Infinite_Time))
+          .collect(Collectors.toList());
+      String blobId = router.stitchBlob(putBlobProperties, putUserMetadata, chunksToStitch).get();
+      ensureStitchInAllServers(blobId, mockServerLayout, chunksToStitch, PUT_CONTENT_SIZE);
       blobIds.add(blobId);
+      Set<String> blobsToBeUndeleted = getBlobsInServers(mockServerLayout);
+
+      router.getBlob(blobId, new GetBlobOptionsBuilder().build()).get();
+      router.deleteBlob(blobId, null).get();
+      for (String chunkBlobId : blobIds) {
+        ensureDeleteInAllServers(chunkBlobId, mockServerLayout);
+      }
+      router.undeleteBlob(blobId, "undelete_server_id").get();
+
+      Assert.assertTrue("Undelete should not take longer than " + AWAIT_TIMEOUT_MS, undeletesDoneLatch.await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+      Assert.assertTrue("All blobs in server are deleted", blobsThatAreUndeleted.containsAll(blobsToBeUndeleted));
+      Assert.assertTrue("Only blobs in server are undeleted", blobsToBeUndeleted.containsAll(blobsThatAreUndeleted));
+    } finally {
+      if (router != null) {
+        router.close();
+        assertClosed();
+      }
     }
-    setOperationParams();
-    List<ChunkInfo> chunksToStitch = blobIds.stream()
-        .map(blobId -> new ChunkInfo(blobId, PUT_CONTENT_SIZE, Utils.Infinite_Time))
-        .collect(Collectors.toList());
-    String blobId = router.stitchBlob(putBlobProperties, putUserMetadata, chunksToStitch).get();
-    ensureStitchInAllServers(blobId, mockServerLayout, chunksToStitch, PUT_CONTENT_SIZE);
-    blobIds.add(blobId);
-    Set<String> blobsToBeUndeleted = getBlobsInServers(mockServerLayout);
-
-    router.getBlob(blobId, new GetBlobOptionsBuilder().build()).get();
-    router.deleteBlob(blobId, null).get();
-    for (String chunkBlobId : blobIds) {
-      ensureDeleteInAllServers(chunkBlobId, mockServerLayout);
-    }
-    router.undeleteBlob(blobId, "undelete_server_id").get();
-
-    Assert.assertTrue("Undelete should not take longer than " + AWAIT_TIMEOUT_MS,
-        undeletesDoneLatch.await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-    Assert.assertTrue("All blobs in server are deleted", blobsThatAreUndeleted.containsAll(blobsToBeUndeleted));
-    Assert.assertTrue("Only blobs in server are undeleted", blobsToBeUndeleted.containsAll(blobsThatAreUndeleted));
-
-    router.close();
-    assertClosed();
   }
 
   /**
@@ -418,78 +433,80 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
    */
   @Test
   public void testUndeleteFailure() throws Exception {
-    assumeTrue(!testEncryption && !includeCloudDc);
-    setRouter();
-    assertExpectedThreadCounts(2, 1);
-
-    // 1. Test undelete a non-exist blob
-    setOperationParams();
-    String nonExistBlobId = new BlobId(routerConfig.routerBlobidCurrentVersion, BlobId.BlobIdType.NATIVE,
-        mockClusterMap.getLocalDatacenterId(), putBlobProperties.getAccountId(), putBlobProperties.getContainerId(),
-        mockClusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false,
-        BlobId.BlobDataType.DATACHUNK).getID();
     try {
-      router.getBlob(nonExistBlobId, new GetBlobOptionsBuilder().build()).get();
-      fail("Should fail because of non-existed id");
-    } catch (ExecutionException e) {
-      RouterException r = (RouterException) e.getCause();
-      Assert.assertEquals("BlobDoesNotExist error is expected", RouterErrorCode.BlobDoesNotExist, r.getErrorCode());
-    }
-    try {
-      router.undeleteBlob(nonExistBlobId, "undelete_server_id").get();
-      fail("Should fail because of non-existed id");
-    } catch (ExecutionException e) {
-      RouterException r = (RouterException) e.getCause();
-      Assert.assertEquals("BlobDoesNotExist error is expected", RouterErrorCode.BlobDoesNotExist, r.getErrorCode());
-    }
+      assumeTrue(!testEncryption && !includeCloudDc);
+      setRouter();
+      assertExpectedThreadCounts(2, 1);
 
-    // 2. Test not-deleted blob
-    setOperationParams();
-    String notDeletedBlobId =
-        router.putBlob(putBlobProperties, putUserMetadata, putChannel, PutBlobOptions.DEFAULT).get();
-    ensurePutInAllServers(notDeletedBlobId, mockServerLayout);
-    router.getBlob(notDeletedBlobId, new GetBlobOptionsBuilder().build()).get();
-    try {
-      router.undeleteBlob(notDeletedBlobId, "undelete_server_id").get();
-      fail("Should fail because of not-deleted id");
-    } catch (ExecutionException e) {
-      RouterException r = (RouterException) e.getCause();
-      Assert.assertEquals("BlobNotDeleted error is expected", RouterErrorCode.BlobNotDeleted, r.getErrorCode());
-    }
+      // 1. Test undelete a non-exist blob
+      setOperationParams();
+      String nonExistBlobId = new BlobId(routerConfig.routerBlobidCurrentVersion, BlobId.BlobIdType.NATIVE,
+          mockClusterMap.getLocalDatacenterId(), putBlobProperties.getAccountId(), putBlobProperties.getContainerId(),
+          mockClusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false, BlobId.BlobDataType.DATACHUNK).getID();
+      try {
+        router.getBlob(nonExistBlobId, new GetBlobOptionsBuilder().build()).get();
+        fail("Should fail because of non-existed id");
+      } catch (ExecutionException e) {
+        RouterException r = (RouterException) e.getCause();
+        Assert.assertEquals("BlobDoesNotExist error is expected", RouterErrorCode.BlobDoesNotExist, r.getErrorCode());
+      }
+      try {
+        router.undeleteBlob(nonExistBlobId, "undelete_server_id").get();
+        fail("Should fail because of non-existed id");
+      } catch (ExecutionException e) {
+        RouterException r = (RouterException) e.getCause();
+        Assert.assertEquals("BlobDoesNotExist error is expected", RouterErrorCode.BlobDoesNotExist, r.getErrorCode());
+      }
 
-    // 3. Test lifeVersion conflict blob
-    setOperationParams();
-    String conflictBlobId =
-        router.putBlob(putBlobProperties, putUserMetadata, putChannel, PutBlobOptions.DEFAULT).get();
-    ensurePutInAllServers(conflictBlobId, mockServerLayout);
-    router.getBlob(conflictBlobId, new GetBlobOptionsBuilder().build()).get();
-    router.deleteBlob(conflictBlobId, null).get();
-    ensureDeleteInAllServers(conflictBlobId, mockServerLayout); // All lifeVersion should be 0
-    int count = 0;
-    for (MockServer server : mockServerLayout.getMockServers()) {
-      server.getBlobs().get(conflictBlobId).lifeVersion = 3;
-      count++;
-      if (count == 4) {
-        // Only change 4 servers, since they are 3 datacenters and 9 servers. If we chang less than 4 servers, eg 3, then
-        // this 3 changes might be distributed to 3 datacenters and undelete can still reach global quorum.
-        break;
+      // 2. Test not-deleted blob
+      setOperationParams();
+      String notDeletedBlobId =
+          router.putBlob(putBlobProperties, putUserMetadata, putChannel, PutBlobOptions.DEFAULT).get();
+      ensurePutInAllServers(notDeletedBlobId, mockServerLayout);
+      router.getBlob(notDeletedBlobId, new GetBlobOptionsBuilder().build()).get();
+      try {
+        router.undeleteBlob(notDeletedBlobId, "undelete_server_id").get();
+        fail("Should fail because of not-deleted id");
+      } catch (ExecutionException e) {
+        RouterException r = (RouterException) e.getCause();
+        Assert.assertEquals("BlobNotDeleted error is expected", RouterErrorCode.BlobNotDeleted, r.getErrorCode());
+      }
+
+      // 3. Test lifeVersion conflict blob
+      setOperationParams();
+      String conflictBlobId =
+          router.putBlob(putBlobProperties, putUserMetadata, putChannel, PutBlobOptions.DEFAULT).get();
+      ensurePutInAllServers(conflictBlobId, mockServerLayout);
+      router.getBlob(conflictBlobId, new GetBlobOptionsBuilder().build()).get();
+      router.deleteBlob(conflictBlobId, null).get();
+      ensureDeleteInAllServers(conflictBlobId, mockServerLayout); // All lifeVersion should be 0
+      int count = 0;
+      for (MockServer server : mockServerLayout.getMockServers()) {
+        server.getBlobs().get(conflictBlobId).lifeVersion = 3;
+        count++;
+        if (count == 4) {
+          // Only change 4 servers, since they are 3 datacenters and 9 servers. If we chang less than 4 servers, eg 3, then
+          // this 3 changes might be distributed to 3 datacenters and undelete can still reach global quorum.
+          break;
+        }
+      }
+
+      try {
+        router.undeleteBlob(conflictBlobId, "undelete_server_id").get();
+        fail("Should fail because of lifeVersion conflict");
+      } catch (ExecutionException e) {
+        RouterException r = (RouterException) e.getCause();
+        Assert.assertEquals("LifeVersionConflict error is expected", RouterErrorCode.LifeVersionConflict, r.getErrorCode());
+      }
+    } finally {
+      if (router != null) {
+        router.close();
+        assertExpectedThreadCounts(0, 0);
+
+        //submission after closing should return a future that is already done.
+        assertClosed();
       }
     }
-
-    try {
-      router.undeleteBlob(conflictBlobId, "undelete_server_id").get();
-      fail("Should fail because of lifeVersion conflict");
-    } catch (ExecutionException e) {
-      RouterException r = (RouterException) e.getCause();
-      Assert.assertEquals("LifeVersionConflict error is expected", RouterErrorCode.LifeVersionConflict,
-          r.getErrorCode());
-    }
-
-    router.close();
-    assertExpectedThreadCounts(0, 0);
-
-    //submission after closing should return a future that is already done.
-    assertClosed();
   }
 
   /**
@@ -498,53 +515,57 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
    */
   @Test
   public void testNullArguments() throws Exception {
-    setRouter();
-    assertExpectedThreadCounts(2, 1);
-    setOperationParams();
+    try {
+      setRouter();
+      assertExpectedThreadCounts(2, 1);
+      setOperationParams();
 
-    try {
-      router.getBlob(null, new GetBlobOptionsBuilder().build());
-      Assert.fail("null blobId should have resulted in IllegalArgumentException");
-    } catch (IllegalArgumentException expected) {
-    }
-    try {
-      router.getBlob("", null);
-      Assert.fail("null options should have resulted in IllegalArgumentException");
-    } catch (IllegalArgumentException expected) {
-    }
-    try {
-      router.putBlob(putBlobProperties, putUserMetadata, null, new PutBlobOptionsBuilder().build());
-      Assert.fail("null channel should have resulted in IllegalArgumentException");
-    } catch (IllegalArgumentException expected) {
-    }
-    try {
-      router.putBlob(null, putUserMetadata, putChannel, new PutBlobOptionsBuilder().build());
-      Assert.fail("null blobProperties should have resulted in IllegalArgumentException");
-    } catch (IllegalArgumentException expected) {
-    }
-    try {
-      router.deleteBlob(null, null);
-      Assert.fail("null blobId should have resulted in IllegalArgumentException");
-    } catch (IllegalArgumentException expected) {
-    }
-    try {
-      router.updateBlobTtl(null, null, Utils.Infinite_Time);
-      Assert.fail("null blobId should have resulted in IllegalArgumentException");
-    } catch (IllegalArgumentException expected) {
-    }
+      try {
+        router.getBlob(null, new GetBlobOptionsBuilder().build());
+        Assert.fail("null blobId should have resulted in IllegalArgumentException");
+      } catch (IllegalArgumentException expected) {
+      }
+      try {
+        router.getBlob("", null);
+        Assert.fail("null options should have resulted in IllegalArgumentException");
+      } catch (IllegalArgumentException expected) {
+      }
+      try {
+        router.putBlob(putBlobProperties, putUserMetadata, null, new PutBlobOptionsBuilder().build());
+        Assert.fail("null channel should have resulted in IllegalArgumentException");
+      } catch (IllegalArgumentException expected) {
+      }
+      try {
+        router.putBlob(null, putUserMetadata, putChannel, new PutBlobOptionsBuilder().build());
+        Assert.fail("null blobProperties should have resulted in IllegalArgumentException");
+      } catch (IllegalArgumentException expected) {
+      }
+      try {
+        router.deleteBlob(null, null);
+        Assert.fail("null blobId should have resulted in IllegalArgumentException");
+      } catch (IllegalArgumentException expected) {
+      }
+      try {
+        router.updateBlobTtl(null, null, Utils.Infinite_Time);
+        Assert.fail("null blobId should have resulted in IllegalArgumentException");
+      } catch (IllegalArgumentException expected) {
+      }
 
-    try {
-      router.undeleteBlob(null, null);
-      Assert.fail("null blobId should have resulted in IllegalArgumentException");
-    } catch (IllegalArgumentException expected) {
+      try {
+        router.undeleteBlob(null, null);
+        Assert.fail("null blobId should have resulted in IllegalArgumentException");
+      } catch (IllegalArgumentException expected) {
+      }
+      // null user metadata should work.
+      router.putBlob(putBlobProperties, null, putChannel, new PutBlobOptionsBuilder().build()).get();
+    } finally {
+      if (router != null) {
+        router.close();
+        assertExpectedThreadCounts(0, 0);
+        //submission after closing should return a future that is already done.
+        assertClosed();
+      }
     }
-    // null user metadata should work.
-    router.putBlob(putBlobProperties, null, putChannel, new PutBlobOptionsBuilder().build()).get();
-
-    router.close();
-    assertExpectedThreadCounts(0, 0);
-    //submission after closing should return a future that is already done.
-    assertClosed();
   }
 
   /**
@@ -552,20 +573,24 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
    */
   @Test
   public void testRouterPartitionsUnavailable() throws Exception {
-    setRouter();
-    setOperationParams();
-    mockClusterMap.markAllPartitionsUnavailable();
     try {
-      router.putBlob(putBlobProperties, putUserMetadata, putChannel, new PutBlobOptionsBuilder().build()).get();
-      Assert.fail("Put should have failed if there are no partitions");
-    } catch (Exception e) {
-      RouterException r = (RouterException) e.getCause();
-      Assert.assertEquals("Should have received AmbryUnavailable error", RouterErrorCode.AmbryUnavailable,
-          r.getErrorCode());
+      setRouter();
+      setOperationParams();
+      mockClusterMap.markAllPartitionsUnavailable();
+      try {
+        router.putBlob(putBlobProperties, putUserMetadata, putChannel, new PutBlobOptionsBuilder().build()).get();
+        Assert.fail("Put should have failed if there are no partitions");
+      } catch (Exception e) {
+        RouterException r = (RouterException) e.getCause();
+        Assert.assertEquals("Should have received AmbryUnavailable error", RouterErrorCode.AmbryUnavailable, r.getErrorCode());
+      }
+    } finally {
+      if (router != null) {
+        router.close();
+        assertExpectedThreadCounts(0, 0);
+        assertClosed();
+      }
     }
-    router.close();
-    assertExpectedThreadCounts(0, 0);
-    assertClosed();
   }
 
   /**
@@ -575,20 +600,25 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
    */
   @Test
   public void testRouterNoPartitionInLocalDC() throws Exception {
-    // set the local DC to invalid, so that for puts, no partitions are available locally.
-    Properties props = getNonBlockingRouterProperties("invalidDC");
-    setRouter(props, new MockServerLayout(mockClusterMap), new LoggingNotificationSystem());
-    setOperationParams();
     try {
-      router.putBlob(putBlobProperties, putUserMetadata, putChannel, new PutBlobOptionsBuilder().build()).get();
-      Assert.fail("Put should have failed if there are no partitions");
-    } catch (Exception e) {
-      RouterException r = (RouterException) e.getCause();
-      Assert.assertEquals(RouterErrorCode.UnexpectedInternalError, r.getErrorCode());
+      // set the local DC to invalid, so that for puts, no partitions are available locally.
+      Properties props = getNonBlockingRouterProperties("invalidDC");
+      setRouter(props, new MockServerLayout(mockClusterMap), new LoggingNotificationSystem());
+      setOperationParams();
+      try {
+        router.putBlob(putBlobProperties, putUserMetadata, putChannel, new PutBlobOptionsBuilder().build()).get();
+        Assert.fail("Put should have failed if there are no partitions");
+      } catch (Exception e) {
+        RouterException r = (RouterException) e.getCause();
+        Assert.assertEquals(RouterErrorCode.UnexpectedInternalError, r.getErrorCode());
+      }
+    } finally {
+      if (router != null) {
+        router.close();
+        assertExpectedThreadCounts(0, 0);
+        assertClosed();
+      }
     }
-    router.close();
-    assertExpectedThreadCounts(0, 0);
-    assertClosed();
   }
 
   /**
@@ -661,69 +691,72 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
    */
   @Test
   public void testUnsuccessfulPutDataChunkDelete() throws Exception {
-    // Ensure there are 4 chunks.
-    maxPutChunkSize = PUT_CONTENT_SIZE / 4;
-    Properties props = getNonBlockingRouterProperties("DC1");
-    VerifiableProperties verifiableProperties = new VerifiableProperties((props));
-    RouterConfig routerConfig = new RouterConfig(verifiableProperties);
-    MockClusterMap mockClusterMap = new MockClusterMap();
-    MockTime mockTime = new MockTime();
-    MockServerLayout mockServerLayout = new MockServerLayout(mockClusterMap);
-    // Since this test wants to ensure that successfully put data chunks are deleted when the overall put operation
-    // fails, it uses a notification system to track the deletions.
-    final CountDownLatch deletesDoneLatch = new CountDownLatch(2);
-    final Map<String, String> blobsThatAreDeleted = new HashMap<>();
-    LoggingNotificationSystem deleteTrackingNotificationSystem = new LoggingNotificationSystem() {
-      @Override
-      public void onBlobDeleted(String blobId, String serviceId, Account account, Container container) {
-        blobsThatAreDeleted.put(blobId, serviceId);
-        deletesDoneLatch.countDown();
-      }
-    };
-    router = new NonBlockingRouter(routerConfig, new NonBlockingRouterMetrics(mockClusterMap, routerConfig),
-        new MockNetworkClientFactory(verifiableProperties, mockSelectorState, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
-            CHECKOUT_TIMEOUT_MS, mockServerLayout, mockTime), deleteTrackingNotificationSystem, mockClusterMap, kms,
-        cryptoService, cryptoJobHandler, accountService, mockTime, MockClusterMap.DEFAULT_PARTITION_CLASS);
-
-    setOperationParams();
-
-    List<DataNodeId> dataNodeIds = mockClusterMap.getDataNodeIds();
-    List<ServerErrorCode> serverErrorList = new ArrayList<>();
-    // There are 4 chunks for this blob.
-    // All put operations make one request to each local server as there are 3 servers overall in the local DC.
-    // Set the state of the mock servers so that they return success for the first 2 requests in order to succeed
-    // the first two chunks.
-    serverErrorList.add(ServerErrorCode.No_Error);
-    serverErrorList.add(ServerErrorCode.No_Error);
-    // fail requests for third and fourth data chunks including the slipped put attempts:
-    serverErrorList.add(ServerErrorCode.Unknown_Error);
-    serverErrorList.add(ServerErrorCode.Unknown_Error);
-    serverErrorList.add(ServerErrorCode.Unknown_Error);
-    serverErrorList.add(ServerErrorCode.Unknown_Error);
-    // all subsequent requests (no more puts, but there will be deletes) will succeed.
-    for (DataNodeId dataNodeId : dataNodeIds) {
-      MockServer server = mockServerLayout.getMockServer(dataNodeId.getHostname(), dataNodeId.getPort());
-      server.setServerErrors(serverErrorList);
-    }
-
-    // Submit the put operation and wait for it to fail.
     try {
-      router.putBlob(putBlobProperties, putUserMetadata, putChannel, new PutBlobOptionsBuilder().build()).get();
-    } catch (ExecutionException e) {
-      Assert.assertEquals(RouterErrorCode.AmbryUnavailable, ((RouterException) e.getCause()).getErrorCode());
-    }
+      // Ensure there are 4 chunks.
+      maxPutChunkSize = PUT_CONTENT_SIZE / 4;
+      Properties props = getNonBlockingRouterProperties("DC1");
+      VerifiableProperties verifiableProperties = new VerifiableProperties((props));
+      RouterConfig routerConfig = new RouterConfig(verifiableProperties);
+      MockClusterMap mockClusterMap = new MockClusterMap();
+      MockTime mockTime = new MockTime();
+      MockServerLayout mockServerLayout = new MockServerLayout(mockClusterMap);
+      // Since this test wants to ensure that successfully put data chunks are deleted when the overall put operation
+      // fails, it uses a notification system to track the deletions.
+      final CountDownLatch deletesDoneLatch = new CountDownLatch(2);
+      final Map<String, String> blobsThatAreDeleted = new HashMap<>();
+      LoggingNotificationSystem deleteTrackingNotificationSystem = new LoggingNotificationSystem() {
+        @Override
+        public void onBlobDeleted(String blobId, String serviceId, Account account, Container container) {
+          blobsThatAreDeleted.put(blobId, serviceId);
+          deletesDoneLatch.countDown();
+        }
+      };
+      router = new NonBlockingRouter(routerConfig, new NonBlockingRouterMetrics(mockClusterMap, routerConfig),
+          new MockNetworkClientFactory(verifiableProperties, mockSelectorState, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
+              CHECKOUT_TIMEOUT_MS, mockServerLayout, mockTime), deleteTrackingNotificationSystem, mockClusterMap, kms,
+          cryptoService, cryptoJobHandler, accountService, mockTime, MockClusterMap.DEFAULT_PARTITION_CLASS);
 
-    // Now, wait until the deletes of the successfully put blobs are complete.
-    Assert.assertTrue("Deletes should not take longer than " + AWAIT_TIMEOUT_MS,
-        deletesDoneLatch.await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-    for (Map.Entry<String, String> blobIdAndServiceId : blobsThatAreDeleted.entrySet()) {
-      Assert.assertEquals("Unexpected service ID for deleted blob",
-          BackgroundDeleteRequest.SERVICE_ID_PREFIX + putBlobProperties.getServiceId(), blobIdAndServiceId.getValue());
-    }
+      setOperationParams();
 
-    router.close();
-    assertClosed();
-    Assert.assertEquals("All operations should have completed", 0, router.getOperationsCount());
+      List<DataNodeId> dataNodeIds = mockClusterMap.getDataNodeIds();
+      List<ServerErrorCode> serverErrorList = new ArrayList<>();
+      // There are 4 chunks for this blob.
+      // All put operations make one request to each local server as there are 3 servers overall in the local DC.
+      // Set the state of the mock servers so that they return success for the first 2 requests in order to succeed
+      // the first two chunks.
+      serverErrorList.add(ServerErrorCode.No_Error);
+      serverErrorList.add(ServerErrorCode.No_Error);
+      // fail requests for third and fourth data chunks including the slipped put attempts:
+      serverErrorList.add(ServerErrorCode.Unknown_Error);
+      serverErrorList.add(ServerErrorCode.Unknown_Error);
+      serverErrorList.add(ServerErrorCode.Unknown_Error);
+      serverErrorList.add(ServerErrorCode.Unknown_Error);
+      // all subsequent requests (no more puts, but there will be deletes) will succeed.
+      for (DataNodeId dataNodeId : dataNodeIds) {
+        MockServer server = mockServerLayout.getMockServer(dataNodeId.getHostname(), dataNodeId.getPort());
+        server.setServerErrors(serverErrorList);
+      }
+
+      // Submit the put operation and wait for it to fail.
+      try {
+        router.putBlob(putBlobProperties, putUserMetadata, putChannel, new PutBlobOptionsBuilder().build()).get();
+      } catch (ExecutionException e) {
+        Assert.assertEquals(RouterErrorCode.AmbryUnavailable, ((RouterException) e.getCause()).getErrorCode());
+      }
+
+      // Now, wait until the deletes of the successfully put blobs are complete.
+      Assert.assertTrue("Deletes should not take longer than " + AWAIT_TIMEOUT_MS, deletesDoneLatch.await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+      for (Map.Entry<String, String> blobIdAndServiceId : blobsThatAreDeleted.entrySet()) {
+        Assert.assertEquals("Unexpected service ID for deleted blob", BackgroundDeleteRequest.SERVICE_ID_PREFIX + putBlobProperties.getServiceId(),
+            blobIdAndServiceId.getValue());
+      }
+    } finally {
+      if (router != null) {
+        router.close();
+        assertClosed();
+        Assert.assertEquals("All operations should have completed", 0, router.getOperationsCount());
+      }
+    }
   }
 
   /**
@@ -731,79 +764,80 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
    */
   @Test
   public void testSuccessfulPutDataChunkDelete() throws Exception {
-    // This test is somehow probabilistic. Since it is not possible to devise a mocking to enforce the occurrence of
-    // slipped puts given we cannot control the order of the hosts requests are sent and not all requests are sent when
-    // put requests are guaranteed to fail/succeed. So, we are setting the number of chunks and max attempts high enough
-    // to guarantee that slipped puts would eventually happen and operation would succeed.
-    maxPutChunkSize = PUT_CONTENT_SIZE / 8;
-    final int NUM_MAX_ATTEMPTS = 100;
-    Properties props = getNonBlockingRouterProperties("DC1");
-    props.setProperty("router.max.slipped.put.attempts", Integer.toString(NUM_MAX_ATTEMPTS));
-    VerifiableProperties verifiableProperties = new VerifiableProperties((props));
-    RouterConfig routerConfig = new RouterConfig(verifiableProperties);
-    MockClusterMap mockClusterMap = new MockClusterMap();
-    MockTime mockTime = new MockTime();
-    MockServerLayout mockServerLayout = new MockServerLayout(mockClusterMap);
-    // Since this test wants to ensure that successfully put data chunks are deleted when the overall put operation
-    // succeeds but some chunks succeed only after a retry, it uses a notification system to track the deletions.
-    final CountDownLatch deletesDoneLatch = new CountDownLatch(1);
-    final Map<String, String> blobsThatAreDeleted = new HashMap<>();
-    LoggingNotificationSystem deleteTrackingNotificationSystem = new LoggingNotificationSystem() {
-      @Override
-      public void onBlobDeleted(String blobId, String serviceId, Account account, Container container) {
-        blobsThatAreDeleted.put(blobId, serviceId);
-        deletesDoneLatch.countDown();
+    try {
+      // This test is somehow probabilistic. Since it is not possible to devise a mocking to enforce the occurrence of
+      // slipped puts given we cannot control the order of the hosts requests are sent and not all requests are sent when
+      // put requests are guaranteed to fail/succeed. So, we are setting the number of chunks and max attempts high enough
+      // to guarantee that slipped puts would eventually happen and operation would succeed.
+      maxPutChunkSize = PUT_CONTENT_SIZE / 8;
+      final int NUM_MAX_ATTEMPTS = 100;
+      Properties props = getNonBlockingRouterProperties("DC1");
+      props.setProperty("router.max.slipped.put.attempts", Integer.toString(NUM_MAX_ATTEMPTS));
+      VerifiableProperties verifiableProperties = new VerifiableProperties((props));
+      RouterConfig routerConfig = new RouterConfig(verifiableProperties);
+      MockClusterMap mockClusterMap = new MockClusterMap();
+      MockTime mockTime = new MockTime();
+      MockServerLayout mockServerLayout = new MockServerLayout(mockClusterMap);
+      // Since this test wants to ensure that successfully put data chunks are deleted when the overall put operation
+      // succeeds but some chunks succeed only after a retry, it uses a notification system to track the deletions.
+      final CountDownLatch deletesDoneLatch = new CountDownLatch(1);
+      final Map<String, String> blobsThatAreDeleted = new HashMap<>();
+      LoggingNotificationSystem deleteTrackingNotificationSystem = new LoggingNotificationSystem() {
+        @Override
+        public void onBlobDeleted(String blobId, String serviceId, Account account, Container container) {
+          blobsThatAreDeleted.put(blobId, serviceId);
+          deletesDoneLatch.countDown();
+        }
+      };
+      router = new NonBlockingRouter(routerConfig, new NonBlockingRouterMetrics(mockClusterMap, routerConfig),
+          new MockNetworkClientFactory(verifiableProperties, mockSelectorState, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
+              CHECKOUT_TIMEOUT_MS, mockServerLayout, mockTime), deleteTrackingNotificationSystem, mockClusterMap, kms,
+          cryptoService, cryptoJobHandler, accountService, mockTime, MockClusterMap.DEFAULT_PARTITION_CLASS);
+
+      setOperationParams();
+
+      // In each DC, set up the servers such that one node always succeeds and the other nodes return an unknown_error and
+      // no_error alternately. This will make it with a very high probability that there will at least be a time that a
+      // put will succeed on a node but will fail on the other two.
+      List<DataNodeId> dataNodeIds = mockClusterMap.getDataNodeIds();
+      List<ServerErrorCode> serverErrorList = new ArrayList<>();
+      for (int i = 0; i < NUM_MAX_ATTEMPTS; i++) {
+        serverErrorList.add(ServerErrorCode.Unknown_Error);
+        serverErrorList.add(ServerErrorCode.No_Error);
       }
-    };
-    router = new NonBlockingRouter(routerConfig, new NonBlockingRouterMetrics(mockClusterMap, routerConfig),
-        new MockNetworkClientFactory(verifiableProperties, mockSelectorState, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
-            CHECKOUT_TIMEOUT_MS, mockServerLayout, mockTime), deleteTrackingNotificationSystem, mockClusterMap, kms,
-        cryptoService, cryptoJobHandler, accountService, mockTime, MockClusterMap.DEFAULT_PARTITION_CLASS);
-
-    setOperationParams();
-
-    // In each DC, set up the servers such that one node always succeeds and the other nodes return an unknown_error and
-    // no_error alternately. This will make it with a very high probability that there will at least be a time that a
-    // put will succeed on a node but will fail on the other two.
-    List<DataNodeId> dataNodeIds = mockClusterMap.getDataNodeIds();
-    List<ServerErrorCode> serverErrorList = new ArrayList<>();
-    for (int i = 0; i < NUM_MAX_ATTEMPTS; i++) {
-      serverErrorList.add(ServerErrorCode.Unknown_Error);
-      serverErrorList.add(ServerErrorCode.No_Error);
-    }
-    Set<String> healthyNodeDC = new HashSet<>();
-    for (DataNodeId dataNodeId : dataNodeIds) {
-      MockServer server = mockServerLayout.getMockServer(dataNodeId.getHostname(), dataNodeId.getPort());
-      if (healthyNodeDC.contains(dataNodeId.getDatacenterName())) {
-        server.setServerErrors(serverErrorList);
-      } else {
-        server.resetServerErrors();
+      Set<String> healthyNodeDC = new HashSet<>();
+      for (DataNodeId dataNodeId : dataNodeIds) {
+        MockServer server = mockServerLayout.getMockServer(dataNodeId.getHostname(), dataNodeId.getPort());
+        if (healthyNodeDC.contains(dataNodeId.getDatacenterName())) {
+          server.setServerErrors(serverErrorList);
+        } else {
+          server.resetServerErrors();
+        }
+        healthyNodeDC.add(dataNodeId.getDatacenterName());
       }
-      healthyNodeDC.add(dataNodeId.getDatacenterName());
-    }
 
-    // Submit the put operation and wait for it to succeed.
-    String blobId = router.putBlob(
-        putBlobProperties, putUserMetadata, putChannel, new PutBlobOptionsBuilder().build()).get();
+      // Submit the put operation and wait for it to succeed.
+      String blobId =
+          router.putBlob(putBlobProperties, putUserMetadata, putChannel, new PutBlobOptionsBuilder().build()).get();
 
-    // Now, wait until at least one delete happens within AWAIT_TIMEOUT_MS.
-    Assert.assertTrue("Some blobs should have been deleted within " + AWAIT_TIMEOUT_MS,
-        deletesDoneLatch.await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-    // Wait for the rest of the deletes to finish.
-    long waitStart = SystemTime.getInstance().milliseconds();
-    while (router.getBackgroundOperationsCount() != 0
-        && SystemTime.getInstance().milliseconds() < waitStart + AWAIT_TIMEOUT_MS) {
-      Thread.sleep(1000);
+      // Now, wait until at least one delete happens within AWAIT_TIMEOUT_MS.
+      Assert.assertTrue("Some blobs should have been deleted within " + AWAIT_TIMEOUT_MS, deletesDoneLatch.await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+      // Wait for the rest of the deletes to finish.
+      long waitStart = SystemTime.getInstance().milliseconds();
+      while (router.getBackgroundOperationsCount() != 0 && SystemTime.getInstance().milliseconds() < waitStart + AWAIT_TIMEOUT_MS) {
+        Thread.sleep(1000);
+      }
+      for (Map.Entry<String, String> blobIdAndServiceId : blobsThatAreDeleted.entrySet()) {
+        Assert.assertNotSame("We should not be deleting the valid blob by mistake", blobId, blobIdAndServiceId.getKey());
+        Assert.assertEquals("Unexpected service ID for deleted blob", BackgroundDeleteRequest.SERVICE_ID_PREFIX + putBlobProperties.getServiceId(),
+            blobIdAndServiceId.getValue());
+      }
+    } finally {
+      if (router != null) {
+        router.close();
+        assertClosed();
+      }
     }
-    for (Map.Entry<String, String> blobIdAndServiceId : blobsThatAreDeleted.entrySet()) {
-      Assert.assertNotSame("We should not be deleting the valid blob by mistake",
-          blobId, blobIdAndServiceId.getKey());
-      Assert.assertEquals("Unexpected service ID for deleted blob",
-          BackgroundDeleteRequest.SERVICE_ID_PREFIX + putBlobProperties.getServiceId(), blobIdAndServiceId.getValue());
-    }
-
-    router.close();
-    assertClosed();
   }
 
 
@@ -828,82 +862,83 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
   }
 
   protected void testCompositeBlobDataChunksDeleteMaxDeleteOperation(int maxDeleteOperation) throws Exception {
-    // Ensure there are 4 chunks.
-    maxPutChunkSize = PUT_CONTENT_SIZE / 4;
-    Properties props = getNonBlockingRouterProperties("DC1");
-    if (maxDeleteOperation != 0) {
-      props.setProperty(RouterConfig.ROUTER_BACKGROUND_DELETER_MAX_CONCURRENT_OPERATIONS,
-          Integer.toString(maxDeleteOperation));
-    }
-    VerifiableProperties verifiableProperties = new VerifiableProperties((props));
-    RouterConfig routerConfig = new RouterConfig(verifiableProperties);
-    MockClusterMap mockClusterMap = new MockClusterMap();
-    MockTime mockTime = new MockTime();
-    MockServerLayout mockServerLayout = new MockServerLayout(mockClusterMap);
-    // metadata blob + data chunks.
-    final AtomicReference<CountDownLatch> deletesDoneLatch = new AtomicReference<>();
-    final Map<String, String> blobsThatAreDeleted = new HashMap<>();
-    LoggingNotificationSystem deleteTrackingNotificationSystem = new LoggingNotificationSystem() {
-      @Override
-      public void onBlobDeleted(String blobId, String serviceId, Account account, Container container) {
-        blobsThatAreDeleted.put(blobId, serviceId);
-        deletesDoneLatch.get().countDown();
+    try {
+      // Ensure there are 4 chunks.
+      maxPutChunkSize = PUT_CONTENT_SIZE / 4;
+      Properties props = getNonBlockingRouterProperties("DC1");
+      if (maxDeleteOperation != 0) {
+        props.setProperty(RouterConfig.ROUTER_BACKGROUND_DELETER_MAX_CONCURRENT_OPERATIONS, Integer.toString(maxDeleteOperation));
       }
-    };
-    NonBlockingRouterMetrics localMetrics = new NonBlockingRouterMetrics(mockClusterMap, routerConfig);
-    router = new NonBlockingRouter(routerConfig, localMetrics,
-        new MockNetworkClientFactory(verifiableProperties, mockSelectorState, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
-            CHECKOUT_TIMEOUT_MS, mockServerLayout, mockTime), deleteTrackingNotificationSystem, mockClusterMap, kms,
-        cryptoService, cryptoJobHandler, accountService, mockTime, MockClusterMap.DEFAULT_PARTITION_CLASS);
-    setOperationParams();
-    String blobId =
-        router.putBlob(putBlobProperties, putUserMetadata, putChannel, new PutBlobOptionsBuilder().build()).get();
-    String deleteServiceId = "delete-service";
-    Set<String> blobsToBeDeleted = getBlobsInServers(mockServerLayout);
-    int getRequestCount = mockServerLayout.getCount(RequestOrResponseType.GetRequest);
-    // The second iteration is to test the case where the blob was already deleted.
-    // The third iteration is to test the case where the blob has expired.
-    for (int i = 0; i < 3; i++) {
-      if (i == 2) {
-        // Create a clean cluster and put another blob that immediate expires.
-        setOperationParams();
-        putBlobProperties = new BlobProperties(-1, "serviceId", "memberId", "contentType", false, 0,
-            Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM), false, null, null, null);
-        blobId =
-            router.putBlob(putBlobProperties, putUserMetadata, putChannel, new PutBlobOptionsBuilder().build()).get();
-        Set<String> allBlobsInServer = getBlobsInServers(mockServerLayout);
-        allBlobsInServer.removeAll(blobsToBeDeleted);
-        blobsToBeDeleted = allBlobsInServer;
+      VerifiableProperties verifiableProperties = new VerifiableProperties((props));
+      RouterConfig routerConfig = new RouterConfig(verifiableProperties);
+      MockClusterMap mockClusterMap = new MockClusterMap();
+      MockTime mockTime = new MockTime();
+      MockServerLayout mockServerLayout = new MockServerLayout(mockClusterMap);
+      // metadata blob + data chunks.
+      final AtomicReference<CountDownLatch> deletesDoneLatch = new AtomicReference<>();
+      final Map<String, String> blobsThatAreDeleted = new HashMap<>();
+      LoggingNotificationSystem deleteTrackingNotificationSystem = new LoggingNotificationSystem() {
+        @Override
+        public void onBlobDeleted(String blobId, String serviceId, Account account, Container container) {
+          blobsThatAreDeleted.put(blobId, serviceId);
+          deletesDoneLatch.get().countDown();
+        }
+      };
+      NonBlockingRouterMetrics localMetrics = new NonBlockingRouterMetrics(mockClusterMap, routerConfig);
+      router = new NonBlockingRouter(routerConfig, localMetrics,
+          new MockNetworkClientFactory(verifiableProperties, mockSelectorState, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
+              CHECKOUT_TIMEOUT_MS, mockServerLayout, mockTime), deleteTrackingNotificationSystem, mockClusterMap, kms,
+          cryptoService, cryptoJobHandler, accountService, mockTime, MockClusterMap.DEFAULT_PARTITION_CLASS);
+      setOperationParams();
+      String blobId =
+          router.putBlob(putBlobProperties, putUserMetadata, putChannel, new PutBlobOptionsBuilder().build()).get();
+      String deleteServiceId = "delete-service";
+      Set<String> blobsToBeDeleted = getBlobsInServers(mockServerLayout);
+      int getRequestCount = mockServerLayout.getCount(RequestOrResponseType.GetRequest);
+      // The second iteration is to test the case where the blob was already deleted.
+      // The third iteration is to test the case where the blob has expired.
+      for (int i = 0; i < 3; i++) {
+        if (i == 2) {
+          // Create a clean cluster and put another blob that immediate expires.
+          setOperationParams();
+          putBlobProperties = new BlobProperties(-1, "serviceId", "memberId", "contentType", false, 0, Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM), false, null, null, null);
+          blobId =
+              router.putBlob(putBlobProperties, putUserMetadata, putChannel, new PutBlobOptionsBuilder().build()).get();
+          Set<String> allBlobsInServer = getBlobsInServers(mockServerLayout);
+          allBlobsInServer.removeAll(blobsToBeDeleted);
+          blobsToBeDeleted = allBlobsInServer;
+        }
+        blobsThatAreDeleted.clear();
+        deletesDoneLatch.set(new CountDownLatch(5));
+        router.deleteBlob(blobId, deleteServiceId).get();
+        Assert.assertTrue("Deletes should not take longer than " + AWAIT_TIMEOUT_MS,
+            deletesDoneLatch.get().await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue("All blobs in server are deleted", blobsThatAreDeleted.keySet().containsAll(blobsToBeDeleted));
+        Assert.assertTrue("Only blobs in server are deleted", blobsToBeDeleted.containsAll(blobsThatAreDeleted.keySet()));
+
+        for (Map.Entry<String, String> blobIdAndServiceId : blobsThatAreDeleted.entrySet()) {
+          String expectedServiceId = blobIdAndServiceId.getKey().equals(blobId) ? deleteServiceId : BackgroundDeleteRequest.SERVICE_ID_PREFIX + deleteServiceId;
+          Assert.assertEquals("Unexpected service ID for deleted blob", expectedServiceId, blobIdAndServiceId.getValue());
+        }
+        // For 1 chunk deletion attempt, 1 background operation for Get is initiated which results in 2 Get Requests at
+        // the servers.
+        getRequestCount += 2;
+        Assert.assertEquals("Only one attempt of chunk deletion should have been done", getRequestCount,
+            mockServerLayout.getCount(RequestOrResponseType.GetRequest));
       }
-      blobsThatAreDeleted.clear();
+
       deletesDoneLatch.set(new CountDownLatch(5));
-      router.deleteBlob(blobId, deleteServiceId).get();
+      router.deleteBlob(blobId, null).get();
       Assert.assertTrue("Deletes should not take longer than " + AWAIT_TIMEOUT_MS,
           deletesDoneLatch.get().await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-      Assert.assertTrue("All blobs in server are deleted", blobsThatAreDeleted.keySet().containsAll(blobsToBeDeleted));
-      Assert.assertTrue("Only blobs in server are deleted", blobsToBeDeleted.containsAll(blobsThatAreDeleted.keySet()));
-
-      for (Map.Entry<String, String> blobIdAndServiceId : blobsThatAreDeleted.entrySet()) {
-        String expectedServiceId = blobIdAndServiceId.getKey().equals(blobId) ? deleteServiceId
-            : BackgroundDeleteRequest.SERVICE_ID_PREFIX + deleteServiceId;
-        Assert.assertEquals("Unexpected service ID for deleted blob", expectedServiceId, blobIdAndServiceId.getValue());
+      Assert.assertEquals("Get should NOT have been skipped", 0, localMetrics.skippedGetBlobCount.getCount());
+    } finally {
+      if (router != null) {
+        router.close();
+        assertClosed();
+        Assert.assertEquals("All operations should have completed", 0, router.getOperationsCount());
       }
-      // For 1 chunk deletion attempt, 1 background operation for Get is initiated which results in 2 Get Requests at
-      // the servers.
-      getRequestCount += 2;
-      Assert.assertEquals("Only one attempt of chunk deletion should have been done", getRequestCount,
-          mockServerLayout.getCount(RequestOrResponseType.GetRequest));
     }
-
-    deletesDoneLatch.set(new CountDownLatch(5));
-    router.deleteBlob(blobId, null).get();
-    Assert.assertTrue("Deletes should not take longer than " + AWAIT_TIMEOUT_MS,
-        deletesDoneLatch.get().await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-    Assert.assertEquals("Get should NOT have been skipped", 0, localMetrics.skippedGetBlobCount.getCount());
-
-    router.close();
-    assertClosed();
-    Assert.assertEquals("All operations should have completed", 0, router.getOperationsCount());
   }
 
   /**
@@ -925,38 +960,42 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
    */
   @Test
   public void testSimpleBlobDelete() throws Exception {
-    // Ensure there are 4 chunks.
-    maxPutChunkSize = PUT_CONTENT_SIZE;
-    String deleteServiceId = "delete-service";
-    // metadata blob + data chunks.
-    final AtomicInteger deletesInitiated = new AtomicInteger();
-    final AtomicReference<String> receivedDeleteServiceId = new AtomicReference<>();
-    LoggingNotificationSystem deleteTrackingNotificationSystem = new LoggingNotificationSystem() {
-      @Override
-      public void onBlobDeleted(String blobId, String serviceId, Account account, Container container) {
-        deletesInitiated.incrementAndGet();
-        receivedDeleteServiceId.set(serviceId);
+    try {
+      // Ensure there are 4 chunks.
+      maxPutChunkSize = PUT_CONTENT_SIZE;
+      String deleteServiceId = "delete-service";
+      // metadata blob + data chunks.
+      final AtomicInteger deletesInitiated = new AtomicInteger();
+      final AtomicReference<String> receivedDeleteServiceId = new AtomicReference<>();
+      LoggingNotificationSystem deleteTrackingNotificationSystem = new LoggingNotificationSystem() {
+        @Override
+        public void onBlobDeleted(String blobId, String serviceId, Account account, Container container) {
+          deletesInitiated.incrementAndGet();
+          receivedDeleteServiceId.set(serviceId);
+        }
+      };
+      Properties props = getNonBlockingRouterProperties("DC1");
+      setRouter(props, new MockServerLayout(mockClusterMap), deleteTrackingNotificationSystem);
+      setOperationParams();
+      String blobId =
+          router.putBlob(putBlobProperties, putUserMetadata, putChannel, new PutBlobOptionsBuilder().build()).get();
+      router.deleteBlob(blobId, deleteServiceId).get();
+      long waitStart = SystemTime.getInstance().milliseconds();
+      while (router.getBackgroundOperationsCount() != 0 && SystemTime.getInstance().milliseconds() < waitStart + AWAIT_TIMEOUT_MS) {
+        Thread.sleep(1000);
       }
-    };
-    Properties props = getNonBlockingRouterProperties("DC1");
-    setRouter(props, new MockServerLayout(mockClusterMap), deleteTrackingNotificationSystem);
-    setOperationParams();
-    String blobId =
-        router.putBlob(putBlobProperties, putUserMetadata, putChannel, new PutBlobOptionsBuilder().build()).get();
-    router.deleteBlob(blobId, deleteServiceId).get();
-    long waitStart = SystemTime.getInstance().milliseconds();
-    while (router.getBackgroundOperationsCount() != 0
-        && SystemTime.getInstance().milliseconds() < waitStart + AWAIT_TIMEOUT_MS) {
-      Thread.sleep(1000);
+      Assert.assertEquals("All background operations should be complete ", 0, router.getBackgroundOperationsCount());
+      Assert.assertEquals("Only the original blob deletion should have been initiated", 1, deletesInitiated.get());
+      Assert.assertEquals("The delete service ID should match the expected value", deleteServiceId,
+          receivedDeleteServiceId.get());
+      Assert.assertEquals("Get should have been skipped", 1, routerMetrics.skippedGetBlobCount.getCount());
+    } finally {
+      if (router != null) {
+        router.close();
+        assertClosed();
+        Assert.assertEquals("All operations should have completed", 0, router.getOperationsCount());
+      }
     }
-    Assert.assertEquals("All background operations should be complete ", 0, router.getBackgroundOperationsCount());
-    Assert.assertEquals("Only the original blob deletion should have been initiated", 1, deletesInitiated.get());
-    Assert.assertEquals("The delete service ID should match the expected value", deleteServiceId,
-        receivedDeleteServiceId.get());
-    Assert.assertEquals("Get should have been skipped", 1, routerMetrics.skippedGetBlobCount.getCount());
-    router.close();
-    assertClosed();
-    Assert.assertEquals("All operations should have completed", 0, router.getOperationsCount());
   }
 
   /**
@@ -983,74 +1022,73 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
    */
   @Test
   public void testStitchGetUpdateDelete() throws Exception {
-    AtomicReference<CountDownLatch> deletesDoneLatch = new AtomicReference<>();
-    Set<String> deletedBlobs = ConcurrentHashMap.newKeySet();
-    LoggingNotificationSystem deleteTrackingNotificationSystem = new LoggingNotificationSystem() {
-      @Override
-      public void onBlobDeleted(String blobId, String serviceId, Account account, Container container) {
-        deletedBlobs.add(blobId);
-        deletesDoneLatch.get().countDown();
-      }
-    };
-    setRouter(getNonBlockingRouterProperties("DC1"), new MockServerLayout(mockClusterMap),
-        deleteTrackingNotificationSystem);
-    for (int intermediateChunkSize : new int[]{maxPutChunkSize, maxPutChunkSize / 2}) {
-      for (LongStream chunkSizeStream : new LongStream[]{
-          RouterTestHelpers.buildValidChunkSizeStream(3 * intermediateChunkSize, intermediateChunkSize),
-          RouterTestHelpers.buildValidChunkSizeStream(
-              3 * intermediateChunkSize + random.nextInt(intermediateChunkSize - 1) + 1, intermediateChunkSize)}) {
-        // Upload data chunks
-        ByteArrayOutputStream stitchedContentStream = new ByteArrayOutputStream();
-        List<ChunkInfo> chunksToStitch = new ArrayList<>();
-        PrimitiveIterator.OfLong chunkSizeIter = chunkSizeStream.iterator();
-        while (chunkSizeIter.hasNext()) {
-          long chunkSize = chunkSizeIter.nextLong();
-          setOperationParams((int) chunkSize, TTL_SECS);
-          String blobId = router.putBlob(putBlobProperties, putUserMetadata, putChannel,
-              new PutBlobOptionsBuilder().chunkUpload(true).maxUploadSize(PUT_CONTENT_SIZE).build())
-              .get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-          long expirationTime = Utils.addSecondsToEpochTime(putBlobProperties.getCreationTimeInMs(),
-              putBlobProperties.getTimeToLiveInSeconds());
-          chunksToStitch.add(new ChunkInfo(blobId, chunkSize, expirationTime));
-          stitchedContentStream.write(putContent);
+    try {
+      AtomicReference<CountDownLatch> deletesDoneLatch = new AtomicReference<>();
+      Set<String> deletedBlobs = ConcurrentHashMap.newKeySet();
+      LoggingNotificationSystem deleteTrackingNotificationSystem = new LoggingNotificationSystem() {
+        @Override
+        public void onBlobDeleted(String blobId, String serviceId, Account account, Container container) {
+          deletedBlobs.add(blobId);
+          deletesDoneLatch.get().countDown();
         }
-        byte[] expectedContent = stitchedContentStream.toByteArray();
+      };
+      setRouter(getNonBlockingRouterProperties("DC1"), new MockServerLayout(mockClusterMap),
+          deleteTrackingNotificationSystem);
+      for (int intermediateChunkSize : new int[]{maxPutChunkSize, maxPutChunkSize / 2}) {
+        for (LongStream chunkSizeStream : new LongStream[]{RouterTestHelpers.buildValidChunkSizeStream(3 * intermediateChunkSize, intermediateChunkSize),
+            RouterTestHelpers.buildValidChunkSizeStream(
+                3 * intermediateChunkSize + random.nextInt(intermediateChunkSize - 1) + 1, intermediateChunkSize)}) {
+          // Upload data chunks
+          ByteArrayOutputStream stitchedContentStream = new ByteArrayOutputStream();
+          List<ChunkInfo> chunksToStitch = new ArrayList<>();
+          PrimitiveIterator.OfLong chunkSizeIter = chunkSizeStream.iterator();
+          while (chunkSizeIter.hasNext()) {
+            long chunkSize = chunkSizeIter.nextLong();
+            setOperationParams((int) chunkSize, TTL_SECS);
+            String blobId = router.putBlob(putBlobProperties, putUserMetadata, putChannel,
+                new PutBlobOptionsBuilder().chunkUpload(true).maxUploadSize(PUT_CONTENT_SIZE).build()).get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+            long expirationTime = Utils.addSecondsToEpochTime(putBlobProperties.getCreationTimeInMs(), putBlobProperties.getTimeToLiveInSeconds());
+            chunksToStitch.add(new ChunkInfo(blobId, chunkSize, expirationTime));
+            stitchedContentStream.write(putContent);
+          }
+          byte[] expectedContent = stitchedContentStream.toByteArray();
 
-        // Stitch the chunks together
-        setOperationParams(0, TTL_SECS / 2);
-        String stitchedBlobId = router.stitchBlob(putBlobProperties, putUserMetadata, chunksToStitch)
-            .get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+          // Stitch the chunks together
+          setOperationParams(0, TTL_SECS / 2);
+          String stitchedBlobId = router.stitchBlob(putBlobProperties, putUserMetadata, chunksToStitch).get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
 
-        // Fetch the stitched blob
-        GetBlobResult getBlobResult = router.getBlob(stitchedBlobId, new GetBlobOptionsBuilder().build())
-            .get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-        assertTrue("Blob properties must be the same", RouterTestHelpers.arePersistedFieldsEquivalent(putBlobProperties,
-            getBlobResult.getBlobInfo().getBlobProperties()));
-        assertEquals("Unexpected blob size", expectedContent.length,
-            getBlobResult.getBlobInfo().getBlobProperties().getBlobSize());
-        assertArrayEquals("User metadata must be the same", putUserMetadata,
-            getBlobResult.getBlobInfo().getUserMetadata());
-        RouterTestHelpers.compareContent(expectedContent, null, getBlobResult.getBlobDataChannel());
+          // Fetch the stitched blob
+          GetBlobResult getBlobResult = router.getBlob(stitchedBlobId, new GetBlobOptionsBuilder().build()).get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+          assertTrue("Blob properties must be the same", RouterTestHelpers.arePersistedFieldsEquivalent(putBlobProperties,
+              getBlobResult.getBlobInfo().getBlobProperties()));
+          assertEquals("Unexpected blob size", expectedContent.length,
+              getBlobResult.getBlobInfo().getBlobProperties().getBlobSize());
+          assertArrayEquals("User metadata must be the same", putUserMetadata,
+              getBlobResult.getBlobInfo().getUserMetadata());
+          RouterTestHelpers.compareContent(expectedContent, null, getBlobResult.getBlobDataChannel());
 
-        // TtlUpdate the blob.
-        router.updateBlobTtl(stitchedBlobId, "update-service", Utils.Infinite_Time)
-            .get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+          // TtlUpdate the blob.
+          router.updateBlobTtl(stitchedBlobId, "update-service", Utils.Infinite_Time).get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
 
-        // Ensure that TTL was updated on the metadata blob and all data chunks
-        Set<String> allBlobIds = chunksToStitch.stream().map(ChunkInfo::getBlobId).collect(Collectors.toSet());
-        allBlobIds.add(stitchedBlobId);
-        assertTtl(router, allBlobIds, Utils.Infinite_Time);
+          // Ensure that TTL was updated on the metadata blob and all data chunks
+          Set<String> allBlobIds = chunksToStitch.stream().map(ChunkInfo::getBlobId).collect(Collectors.toSet());
+          allBlobIds.add(stitchedBlobId);
+          assertTtl(router, allBlobIds, Utils.Infinite_Time);
 
-        // Delete and ensure that all stitched chunks are deleted
-        deletedBlobs.clear();
-        deletesDoneLatch.set(new CountDownLatch(chunksToStitch.size() + 1));
-        router.deleteBlob(stitchedBlobId, "delete-service").get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-        TestUtils.awaitLatchOrTimeout(deletesDoneLatch.get(), AWAIT_TIMEOUT_MS);
-        assertEquals("Metadata chunk and all data chunks should be deleted", allBlobIds, deletedBlobs);
+          // Delete and ensure that all stitched chunks are deleted
+          deletedBlobs.clear();
+          deletesDoneLatch.set(new CountDownLatch(chunksToStitch.size() + 1));
+          router.deleteBlob(stitchedBlobId, "delete-service").get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+          TestUtils.awaitLatchOrTimeout(deletesDoneLatch.get(), AWAIT_TIMEOUT_MS);
+          assertEquals("Metadata chunk and all data chunks should be deleted", allBlobIds, deletedBlobs);
+        }
+      }
+    } finally {
+      if (router != null) {
+        router.close();
+        assertExpectedThreadCounts(0, 0);
       }
     }
-    router.close();
-    assertExpectedThreadCounts(0, 0);
   }
 
   /**
@@ -1059,33 +1097,38 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
    */
   @Test
   public void testBlobTtlUpdateErrors() throws Exception {
-    String updateServiceId = "update-service";
-    MockServerLayout layout = new MockServerLayout(mockClusterMap);
-    setRouter(getNonBlockingRouterProperties("DC1"), layout, new LoggingNotificationSystem());
-    setOperationParams();
-    String blobId = router.putBlob(putBlobProperties, putUserMetadata, putChannel, new PutBlobOptionsBuilder().build())
-        .get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-    Map<ServerErrorCode, RouterErrorCode> testsAndExpected = new HashMap<>();
-    testsAndExpected.put(ServerErrorCode.Blob_Not_Found, RouterErrorCode.BlobDoesNotExist);
-    testsAndExpected.put(ServerErrorCode.Blob_Deleted, RouterErrorCode.BlobDeleted);
-    testsAndExpected.put(ServerErrorCode.Blob_Expired, RouterErrorCode.BlobExpired);
-    testsAndExpected.put(ServerErrorCode.Disk_Unavailable, RouterErrorCode.BlobDoesNotExist);
-    testsAndExpected.put(ServerErrorCode.Replica_Unavailable, RouterErrorCode.AmbryUnavailable);
-    testsAndExpected.put(ServerErrorCode.Unknown_Error, RouterErrorCode.UnexpectedInternalError);
-    // note that this test makes all nodes return same server error code. For Disk_Unavailable error, the router will
-    // return BlobDoesNotExist because all disks are down (which should be extremely rare) and blob is gone.
-    for (Map.Entry<ServerErrorCode, RouterErrorCode> testAndExpected : testsAndExpected.entrySet()) {
-      layout.getMockServers().forEach(mockServer -> mockServer.setServerErrorForAllRequests(testAndExpected.getKey()));
+    try {
+      String updateServiceId = "update-service";
+      MockServerLayout layout = new MockServerLayout(mockClusterMap);
+      setRouter(getNonBlockingRouterProperties("DC1"), layout, new LoggingNotificationSystem());
+      setOperationParams();
+      String blobId =
+          router.putBlob(putBlobProperties, putUserMetadata, putChannel, new PutBlobOptionsBuilder().build()).get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+      Map<ServerErrorCode, RouterErrorCode> testsAndExpected = new HashMap<>();
+      testsAndExpected.put(ServerErrorCode.Blob_Not_Found, RouterErrorCode.BlobDoesNotExist);
+      testsAndExpected.put(ServerErrorCode.Blob_Deleted, RouterErrorCode.BlobDeleted);
+      testsAndExpected.put(ServerErrorCode.Blob_Expired, RouterErrorCode.BlobExpired);
+      testsAndExpected.put(ServerErrorCode.Disk_Unavailable, RouterErrorCode.BlobDoesNotExist);
+      testsAndExpected.put(ServerErrorCode.Replica_Unavailable, RouterErrorCode.AmbryUnavailable);
+      testsAndExpected.put(ServerErrorCode.Unknown_Error, RouterErrorCode.UnexpectedInternalError);
+      // note that this test makes all nodes return same server error code. For Disk_Unavailable error, the router will
+      // return BlobDoesNotExist because all disks are down (which should be extremely rare) and blob is gone.
+      for (Map.Entry<ServerErrorCode, RouterErrorCode> testAndExpected : testsAndExpected.entrySet()) {
+        layout.getMockServers().forEach(mockServer -> mockServer.setServerErrorForAllRequests(testAndExpected.getKey()));
+        TestCallback<Void> testCallback = new TestCallback<>();
+        Future<Void> future = router.updateBlobTtl(blobId, updateServiceId, Utils.Infinite_Time, testCallback, null);
+        assertFailureAndCheckErrorCode(future, testCallback, testAndExpected.getValue());
+      }
+      layout.getMockServers().forEach(mockServer -> mockServer.setServerErrorForAllRequests(null));
+      // bad blob id
       TestCallback<Void> testCallback = new TestCallback<>();
-      Future<Void> future = router.updateBlobTtl(blobId, updateServiceId, Utils.Infinite_Time, testCallback, null);
-      assertFailureAndCheckErrorCode(future, testCallback, testAndExpected.getValue());
+      Future<Void> future = router.updateBlobTtl("bad-blob-id", updateServiceId, Utils.Infinite_Time, testCallback, null);
+      assertFailureAndCheckErrorCode(future, testCallback, RouterErrorCode.InvalidBlobId);
+    } finally {
+      if (router != null) {
+        router.close();
+      }
     }
-    layout.getMockServers().forEach(mockServer -> mockServer.setServerErrorForAllRequests(null));
-    // bad blob id
-    TestCallback<Void> testCallback = new TestCallback<>();
-    Future<Void> future = router.updateBlobTtl("bad-blob-id", updateServiceId, Utils.Infinite_Time, testCallback, null);
-    assertFailureAndCheckErrorCode(future, testCallback, RouterErrorCode.InvalidBlobId);
-    router.close();
   }
 
   /**
@@ -1094,31 +1137,35 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
    */
   @Test
   public void testBadCallbackForUpdateTtl() throws Exception {
-    MockServerLayout serverLayout = new MockServerLayout(mockClusterMap);
-    setRouter(getNonBlockingRouterProperties("DC1"), serverLayout, new LoggingNotificationSystem());
-    setOperationParams();
-    String blobId = router.putBlob(putBlobProperties, putUserMetadata, putChannel, new PutBlobOptionsBuilder().build())
-        .get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-    putChannel = new ByteBufferReadableStreamChannel(ByteBuffer.wrap(putContent));
-    String blobIdCheck =
-        router.putBlob(putBlobProperties, putUserMetadata, putChannel, new PutBlobOptionsBuilder().build())
-            .get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-    testWithErrorCodes(Collections.singletonMap(ServerErrorCode.No_Error, 9), serverLayout, null, expectedError -> {
-      final CountDownLatch callbackCalled = new CountDownLatch(1);
-      router.updateBlobTtl(blobId, null, Utils.Infinite_Time, (result, exception) -> {
-        callbackCalled.countDown();
-        throw new RuntimeException("Throwing an exception in the user callback");
-      }, null).get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-      assertTrue("Callback not called.", callbackCalled.await(10, TimeUnit.MILLISECONDS));
-      assertEquals("All operations should be finished.", 0, router.getOperationsCount());
-      assertTrue("Router should not be closed", router.isOpen());
-      assertTtl(router, Collections.singleton(blobId), Utils.Infinite_Time);
+    try {
+      MockServerLayout serverLayout = new MockServerLayout(mockClusterMap);
+      setRouter(getNonBlockingRouterProperties("DC1"), serverLayout, new LoggingNotificationSystem());
+      setOperationParams();
+      String blobId =
+          router.putBlob(putBlobProperties, putUserMetadata, putChannel, new PutBlobOptionsBuilder().build()).get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+      putChannel = new ByteBufferReadableStreamChannel(ByteBuffer.wrap(putContent));
+      String blobIdCheck =
+          router.putBlob(putBlobProperties, putUserMetadata, putChannel, new PutBlobOptionsBuilder().build()).get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+      testWithErrorCodes(Collections.singletonMap(ServerErrorCode.No_Error, 9), serverLayout, null, expectedError -> {
+        final CountDownLatch callbackCalled = new CountDownLatch(1);
+        router.updateBlobTtl(blobId, null, Utils.Infinite_Time, (result, exception) -> {
+          callbackCalled.countDown();
+          throw new RuntimeException("Throwing an exception in the user callback");
+        }, null).get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        assertTrue("Callback not called.", callbackCalled.await(10, TimeUnit.MILLISECONDS));
+        assertEquals("All operations should be finished.", 0, router.getOperationsCount());
+        assertTrue("Router should not be closed", router.isOpen());
+        assertTtl(router, Collections.singleton(blobId), Utils.Infinite_Time);
 
-      //Test that TtlUpdateManager is still functional
-      router.updateBlobTtl(blobIdCheck, null, Utils.Infinite_Time).get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-      assertTtl(router, Collections.singleton(blobIdCheck), Utils.Infinite_Time);
-    });
-    router.close();
+        //Test that TtlUpdateManager is still functional
+        router.updateBlobTtl(blobIdCheck, null, Utils.Infinite_Time).get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        assertTtl(router, Collections.singleton(blobIdCheck), Utils.Infinite_Time);
+      });
+    } finally {
+      if (router != null) {
+        router.close();
+      }
+    }
   }
 
   /**
@@ -1126,23 +1173,28 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
    */
   @Test
   public void testMultipleScalingUnit() throws Exception {
-    final int SCALING_UNITS = 3;
-    Properties props = getNonBlockingRouterProperties("DC1");
-    props.setProperty("router.scaling.unit.count", Integer.toString(SCALING_UNITS));
-    setRouter(props, new MockServerLayout(mockClusterMap), new LoggingNotificationSystem());
-    assertExpectedThreadCounts(SCALING_UNITS + 1, SCALING_UNITS);
+    try {
+      final int SCALING_UNITS = 3;
+      Properties props = getNonBlockingRouterProperties("DC1");
+      props.setProperty("router.scaling.unit.count", Integer.toString(SCALING_UNITS));
+      setRouter(props, new MockServerLayout(mockClusterMap), new LoggingNotificationSystem());
+      assertExpectedThreadCounts(SCALING_UNITS + 1, SCALING_UNITS);
 
-    // Submit a few jobs so that all the scaling units get exercised.
-    for (int i = 0; i < SCALING_UNITS * 10; i++) {
-      setOperationParams();
-      router.putBlob(putBlobProperties, putUserMetadata, putChannel, new PutBlobOptionsBuilder().build()).get();
+      // Submit a few jobs so that all the scaling units get exercised.
+      for (int i = 0; i < SCALING_UNITS * 10; i++) {
+        setOperationParams();
+        router.putBlob(putBlobProperties, putUserMetadata, putChannel, new PutBlobOptionsBuilder().build()).get();
+      }
+    } finally {
+      if (router != null) {
+        router.close();
+        assertExpectedThreadCounts(0, 0);
+
+        //submission after closing should return a future that is already done.
+        setOperationParams();
+        assertClosed();
+      }
     }
-    router.close();
-    assertExpectedThreadCounts(0, 0);
-
-    //submission after closing should return a future that is already done.
-    setOperationParams();
-    assertClosed();
   }
 
   /**
@@ -1150,15 +1202,20 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
    */
   @Test
   public void testWarmUpConnectionFailureHandling() throws Exception {
-    Properties props = getNonBlockingRouterProperties("DC3");
-    MockServerLayout mockServerLayout = new MockServerLayout(mockClusterMap);
-    mockSelectorState.set(MockSelectorState.FailConnectionInitiationOnPoll);
-    setRouter(props, mockServerLayout, new LoggingNotificationSystem());
-    for (DataNodeId node : mockClusterMap.getDataNodes()) {
-      assertTrue("Node should be marked as timed out by ResponseHandler.", ((MockDataNodeId) node).isTimedOut());
+    try {
+      Properties props = getNonBlockingRouterProperties("DC3");
+      MockServerLayout mockServerLayout = new MockServerLayout(mockClusterMap);
+      mockSelectorState.set(MockSelectorState.FailConnectionInitiationOnPoll);
+      setRouter(props, mockServerLayout, new LoggingNotificationSystem());
+      for (DataNodeId node : mockClusterMap.getDataNodes()) {
+        assertTrue("Node should be marked as timed out by ResponseHandler.", ((MockDataNodeId) node).isTimedOut());
+      }
+    } finally {
+      if (router != null) {
+        router.close();
+      }
+      mockSelectorState.set(MockSelectorState.Good);
     }
-    router.close();
-    mockSelectorState.set(MockSelectorState.Good);
   }
 
   /**
@@ -1168,33 +1225,38 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
    */
   @Test
   public void testResponseWithNullRequestInfo() throws Exception {
-    Properties props = getNonBlockingRouterProperties("DC1");
-    VerifiableProperties verifiableProperties = new VerifiableProperties((props));
-    RouterConfig routerConfig = new RouterConfig(verifiableProperties);
-    routerMetrics = new NonBlockingRouterMetrics(mockClusterMap, routerConfig);
-    NetworkClient mockNetworkClient = Mockito.mock(NetworkClient.class);
-    Mockito.when(mockNetworkClient.warmUpConnections(anyList(), anyInt(), anyLong(), anyList())).thenReturn(1);
-    doNothing().when(mockNetworkClient).close();
-    List<ResponseInfo> responseInfoList = new ArrayList<>();
-    MockDataNodeId testDataNode = (MockDataNodeId) mockClusterMap.getDataNodeIds().get(0);
-    responseInfoList.add(new ResponseInfo(null, NetworkClientErrorCode.NetworkError, null, testDataNode));
-    // By default, there are 1 operation controller and 1 background deleter thread. We set CountDownLatch to 3 so that
-    // at least one thread has completed calling onResponse() and test node's state has been updated in ResponseHandler
-    CountDownLatch invocationLatch = new CountDownLatch(3);
-    doAnswer(invocation -> {
-      invocationLatch.countDown();
-      return responseInfoList;
-    }).when(mockNetworkClient).sendAndPoll(anyList(), anySet(), anyInt());
-    NetworkClientFactory networkClientFactory = Mockito.mock(NetworkClientFactory.class);
-    Mockito.when(networkClientFactory.getNetworkClient()).thenReturn(mockNetworkClient);
-    NonBlockingRouter testRouter =
-        new NonBlockingRouter(routerConfig, routerMetrics, networkClientFactory, new LoggingNotificationSystem(),
-            mockClusterMap, kms, cryptoService, cryptoJobHandler, accountService, mockTime,
-            MockClusterMap.DEFAULT_PARTITION_CLASS);
-    assertTrue("Invocation latch didn't count to 0 within 10 seconds", invocationLatch.await(10, TimeUnit.SECONDS));
-    // verify the test node is considered timeout
-    assertTrue("The node should be considered timeout", testDataNode.isTimedOut());
-    testRouter.close();
+    NonBlockingRouter testRouter = null;
+    try {
+      Properties props = getNonBlockingRouterProperties("DC1");
+      VerifiableProperties verifiableProperties = new VerifiableProperties((props));
+      RouterConfig routerConfig = new RouterConfig(verifiableProperties);
+      routerMetrics = new NonBlockingRouterMetrics(mockClusterMap, routerConfig);
+      NetworkClient mockNetworkClient = Mockito.mock(NetworkClient.class);
+      Mockito.when(mockNetworkClient.warmUpConnections(anyList(), anyInt(), anyLong(), anyList())).thenReturn(1);
+      doNothing().when(mockNetworkClient).close();
+      List<ResponseInfo> responseInfoList = new ArrayList<>();
+      MockDataNodeId testDataNode = (MockDataNodeId) mockClusterMap.getDataNodeIds().get(0);
+      responseInfoList.add(new ResponseInfo(null, NetworkClientErrorCode.NetworkError, null, testDataNode));
+      // By default, there are 1 operation controller and 1 background deleter thread. We set CountDownLatch to 3 so that
+      // at least one thread has completed calling onResponse() and test node's state has been updated in ResponseHandler
+      CountDownLatch invocationLatch = new CountDownLatch(3);
+      doAnswer(invocation -> {
+        invocationLatch.countDown();
+        return responseInfoList;
+      }).when(mockNetworkClient).sendAndPoll(anyList(), anySet(), anyInt());
+      NetworkClientFactory networkClientFactory = Mockito.mock(NetworkClientFactory.class);
+      Mockito.when(networkClientFactory.getNetworkClient()).thenReturn(mockNetworkClient);
+      testRouter =
+          new NonBlockingRouter(routerConfig, routerMetrics, networkClientFactory, new LoggingNotificationSystem(),
+              mockClusterMap, kms, cryptoService, cryptoJobHandler, accountService, mockTime, MockClusterMap.DEFAULT_PARTITION_CLASS);
+      assertTrue("Invocation latch didn't count to 0 within 10 seconds", invocationLatch.await(10, TimeUnit.SECONDS));
+      // verify the test node is considered timeout
+      assertTrue("The node should be considered timeout", testDataNode.isTimedOut());
+    } finally {
+      if (testRouter != null) {
+        testRouter.close();
+      }
+    }
   }
 
   /**
@@ -1202,97 +1264,103 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
    */
   @Test
   public void testResponseHandling() throws Exception {
-    Properties props = getNonBlockingRouterProperties("DC1");
-    VerifiableProperties verifiableProperties = new VerifiableProperties((props));
-    setOperationParams();
-    final List<ReplicaId> failedReplicaIds = new ArrayList<>();
-    final AtomicInteger successfulResponseCount = new AtomicInteger(0);
-    final AtomicBoolean invalidResponse = new AtomicBoolean(false);
-    ResponseHandler mockResponseHandler = new ResponseHandler(mockClusterMap) {
-      @Override
-      public void onEvent(ReplicaId replicaId, Object e) {
-        if (e instanceof ServerErrorCode) {
-          if (e == ServerErrorCode.No_Error) {
-            successfulResponseCount.incrementAndGet();
+    try {
+      Properties props = getNonBlockingRouterProperties("DC1");
+      VerifiableProperties verifiableProperties = new VerifiableProperties((props));
+      setOperationParams();
+      final List<ReplicaId> failedReplicaIds = new ArrayList<>();
+      final AtomicInteger successfulResponseCount = new AtomicInteger(0);
+      final AtomicBoolean invalidResponse = new AtomicBoolean(false);
+      ResponseHandler mockResponseHandler = new ResponseHandler(mockClusterMap) {
+        @Override
+        public void onEvent(ReplicaId replicaId, Object e) {
+          if (e instanceof ServerErrorCode) {
+            if (e == ServerErrorCode.No_Error) {
+              successfulResponseCount.incrementAndGet();
+            } else {
+              invalidResponse.set(true);
+            }
           } else {
-            invalidResponse.set(true);
+            failedReplicaIds.add(replicaId);
           }
-        } else {
-          failedReplicaIds.add(replicaId);
         }
+      };
+
+      // Instantiate a router just to put a blob successfully.
+      MockServerLayout mockServerLayout = new MockServerLayout(mockClusterMap);
+      setRouter(props, mockServerLayout, new LoggingNotificationSystem());
+      setOperationParams();
+
+      // More extensive test for puts present elsewhere - these statements are here just to exercise the flow within the
+      // NonBlockingRouter class, and to ensure that operations submitted to a router eventually completes.
+      String blobIdStr =
+          router.putBlob(putBlobProperties, putUserMetadata, putChannel, new PutBlobOptionsBuilder().build()).get();
+      BlobId blobId = RouterUtils.getBlobIdFromString(blobIdStr, mockClusterMap);
+      router.close();
+      for (MockServer mockServer : mockServerLayout.getMockServers()) {
+        mockServer.setServerErrorForAllRequests(ServerErrorCode.No_Error);
       }
-    };
 
-    // Instantiate a router just to put a blob successfully.
-    MockServerLayout mockServerLayout = new MockServerLayout(mockClusterMap);
-    setRouter(props, mockServerLayout, new LoggingNotificationSystem());
-    setOperationParams();
+      SocketNetworkClient networkClient =
+          new MockNetworkClientFactory(verifiableProperties, mockSelectorState, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
+              CHECKOUT_TIMEOUT_MS, mockServerLayout, mockTime).getNetworkClient();
+      cryptoJobHandler = new CryptoJobHandler(CryptoJobHandlerTest.DEFAULT_THREAD_COUNT);
+      KeyManagementService localKMS = new MockKeyManagementService(new KMSConfig(verifiableProperties), singleKeyForKMS);
+      putManager = new PutManager(mockClusterMap, mockResponseHandler, new LoggingNotificationSystem(), new RouterConfig(verifiableProperties), new NonBlockingRouterMetrics(mockClusterMap, null),
+          new RouterCallback(networkClient, new ArrayList<>()), "0", localKMS, cryptoService, cryptoJobHandler,
+          accountService, mockTime, MockClusterMap.DEFAULT_PARTITION_CLASS);
+      OperationHelper opHelper = new OperationHelper(OperationType.PUT);
+      testFailureDetectorNotification(opHelper, networkClient, failedReplicaIds, null, successfulResponseCount,
+          invalidResponse, -1);
+      // Test that if a failed response comes before the operation is completed, failure detector is notified.
+      testFailureDetectorNotification(opHelper, networkClient, failedReplicaIds, null, successfulResponseCount,
+          invalidResponse, 0);
+      // Test that if a failed response comes after the operation is completed, failure detector is notified.
+      testFailureDetectorNotification(opHelper, networkClient, failedReplicaIds, null, successfulResponseCount,
+          invalidResponse, PUT_REQUEST_PARALLELISM - 1);
+      testNoResponseNoNotification(opHelper, failedReplicaIds, null, successfulResponseCount, invalidResponse);
+      testResponseDeserializationError(opHelper, networkClient, null);
 
-    // More extensive test for puts present elsewhere - these statements are here just to exercise the flow within the
-    // NonBlockingRouter class, and to ensure that operations submitted to a router eventually completes.
-    String blobIdStr =
-        router.putBlob(putBlobProperties, putUserMetadata, putChannel, new PutBlobOptionsBuilder().build()).get();
-    BlobId blobId = RouterUtils.getBlobIdFromString(blobIdStr, mockClusterMap);
-    router.close();
-    for (MockServer mockServer : mockServerLayout.getMockServers()) {
-      mockServer.setServerErrorForAllRequests(ServerErrorCode.No_Error);
+      opHelper = new OperationHelper(OperationType.GET);
+      getManager = new GetManager(mockClusterMap, mockResponseHandler, new RouterConfig(verifiableProperties), new NonBlockingRouterMetrics(mockClusterMap, null),
+          new RouterCallback(networkClient, new ArrayList<BackgroundDeleteRequest>()), localKMS, cryptoService,
+          cryptoJobHandler, mockTime);
+      testFailureDetectorNotification(opHelper, networkClient, failedReplicaIds, blobId, successfulResponseCount,
+          invalidResponse, -1);
+      // Test that if a failed response comes before the operation is completed, failure detector is notified.
+      testFailureDetectorNotification(opHelper, networkClient, failedReplicaIds, blobId, successfulResponseCount,
+          invalidResponse, 0);
+      // Test that if a failed response comes after the operation is completed, failure detector is notified.
+      testFailureDetectorNotification(opHelper, networkClient, failedReplicaIds, blobId, successfulResponseCount,
+          invalidResponse, GET_REQUEST_PARALLELISM - 1);
+      testNoResponseNoNotification(opHelper, failedReplicaIds, blobId, successfulResponseCount, invalidResponse);
+      testResponseDeserializationError(opHelper, networkClient, blobId);
+
+      opHelper = new OperationHelper(OperationType.DELETE);
+      deleteManager =
+          new DeleteManager(mockClusterMap, mockResponseHandler, accountService, new LoggingNotificationSystem(), new RouterConfig(verifiableProperties), new NonBlockingRouterMetrics(mockClusterMap, null),
+              new RouterCallback(null, new ArrayList<BackgroundDeleteRequest>()), mockTime);
+      testFailureDetectorNotification(opHelper, networkClient, failedReplicaIds, blobId, successfulResponseCount,
+          invalidResponse, -1);
+      // Test that if a failed response comes before the operation is completed, failure detector is notified.
+      testFailureDetectorNotification(opHelper, networkClient, failedReplicaIds, blobId, successfulResponseCount,
+          invalidResponse, 0);
+      // Test that if a failed response comes after the operation is completed, failure detector is notified.
+      testFailureDetectorNotification(opHelper, networkClient, failedReplicaIds, blobId, successfulResponseCount,
+          invalidResponse, DELETE_REQUEST_PARALLELISM - 1);
+      testNoResponseNoNotification(opHelper, failedReplicaIds, blobId, successfulResponseCount, invalidResponse);
+      testResponseDeserializationError(opHelper, networkClient, blobId);
+    } finally {
+      if (putManager != null) {
+        putManager.close();
+      }
+      if (getManager != null) {
+        getManager.close();
+      }
+      if (deleteManager != null) {
+        deleteManager.close();
+      }
     }
-
-    SocketNetworkClient networkClient =
-        new MockNetworkClientFactory(verifiableProperties, mockSelectorState, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
-            CHECKOUT_TIMEOUT_MS, mockServerLayout, mockTime).getNetworkClient();
-    cryptoJobHandler = new CryptoJobHandler(CryptoJobHandlerTest.DEFAULT_THREAD_COUNT);
-    KeyManagementService localKMS = new MockKeyManagementService(new KMSConfig(verifiableProperties), singleKeyForKMS);
-    putManager = new PutManager(mockClusterMap, mockResponseHandler, new LoggingNotificationSystem(),
-        new RouterConfig(verifiableProperties), new NonBlockingRouterMetrics(mockClusterMap, null),
-        new RouterCallback(networkClient, new ArrayList<>()), "0", localKMS, cryptoService, cryptoJobHandler,
-        accountService, mockTime, MockClusterMap.DEFAULT_PARTITION_CLASS);
-    OperationHelper opHelper = new OperationHelper(OperationType.PUT);
-    testFailureDetectorNotification(opHelper, networkClient, failedReplicaIds, null, successfulResponseCount,
-        invalidResponse, -1);
-    // Test that if a failed response comes before the operation is completed, failure detector is notified.
-    testFailureDetectorNotification(opHelper, networkClient, failedReplicaIds, null, successfulResponseCount,
-        invalidResponse, 0);
-    // Test that if a failed response comes after the operation is completed, failure detector is notified.
-    testFailureDetectorNotification(opHelper, networkClient, failedReplicaIds, null, successfulResponseCount,
-        invalidResponse, PUT_REQUEST_PARALLELISM - 1);
-    testNoResponseNoNotification(opHelper, failedReplicaIds, null, successfulResponseCount, invalidResponse);
-    testResponseDeserializationError(opHelper, networkClient, null);
-
-    opHelper = new OperationHelper(OperationType.GET);
-    getManager = new GetManager(mockClusterMap, mockResponseHandler, new RouterConfig(verifiableProperties),
-        new NonBlockingRouterMetrics(mockClusterMap, null),
-        new RouterCallback(networkClient, new ArrayList<BackgroundDeleteRequest>()), localKMS, cryptoService,
-        cryptoJobHandler, mockTime);
-    testFailureDetectorNotification(opHelper, networkClient, failedReplicaIds, blobId, successfulResponseCount,
-        invalidResponse, -1);
-    // Test that if a failed response comes before the operation is completed, failure detector is notified.
-    testFailureDetectorNotification(opHelper, networkClient, failedReplicaIds, blobId, successfulResponseCount,
-        invalidResponse, 0);
-    // Test that if a failed response comes after the operation is completed, failure detector is notified.
-    testFailureDetectorNotification(opHelper, networkClient, failedReplicaIds, blobId, successfulResponseCount,
-        invalidResponse, GET_REQUEST_PARALLELISM - 1);
-    testNoResponseNoNotification(opHelper, failedReplicaIds, blobId, successfulResponseCount, invalidResponse);
-    testResponseDeserializationError(opHelper, networkClient, blobId);
-
-    opHelper = new OperationHelper(OperationType.DELETE);
-    deleteManager =
-        new DeleteManager(mockClusterMap, mockResponseHandler, accountService, new LoggingNotificationSystem(),
-            new RouterConfig(verifiableProperties), new NonBlockingRouterMetrics(mockClusterMap, null),
-            new RouterCallback(null, new ArrayList<BackgroundDeleteRequest>()), mockTime);
-    testFailureDetectorNotification(opHelper, networkClient, failedReplicaIds, blobId, successfulResponseCount,
-        invalidResponse, -1);
-    // Test that if a failed response comes before the operation is completed, failure detector is notified.
-    testFailureDetectorNotification(opHelper, networkClient, failedReplicaIds, blobId, successfulResponseCount,
-        invalidResponse, 0);
-    // Test that if a failed response comes after the operation is completed, failure detector is notified.
-    testFailureDetectorNotification(opHelper, networkClient, failedReplicaIds, blobId, successfulResponseCount,
-        invalidResponse, DELETE_REQUEST_PARALLELISM - 1);
-    testNoResponseNoNotification(opHelper, failedReplicaIds, blobId, successfulResponseCount, invalidResponse);
-    testResponseDeserializationError(opHelper, networkClient, blobId);
-    putManager.close();
-    getManager.close();
-    deleteManager.close();
   }
 
   private RestRequest createRestRequestForPutOperation() throws Exception {

--- a/ambry-router/src/test/java/com/github/ambry/router/RouterTestHelpers.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/RouterTestHelpers.java
@@ -51,7 +51,7 @@ import static org.junit.Assert.*;
  */
 class RouterTestHelpers {
   private static final int AWAIT_TIMEOUT_SECONDS = 10;
-  static final int AWAIT_TIMEOUT_MS = 10000;
+  static final int AWAIT_TIMEOUT_MS = 15000;
   private static final short BLOB_ID_VERSION = CommonTestUtils.getCurrentBlobIdVersion();
 
   /**


### PR DESCRIPTION
Surround NonBlockingRouterTests with try-catch block to make sure cleanup happens for each test, and one test failure doesn't cause subsequent tests to fail. Also change timeout to wait for test operations to complete to 15 secs from 10 secs.

NOTE: The only change in this file is to surround the tests that attempt to close router at the end, with try-catch block. There are no logic changes in this file. Note that it might be possible to unify the cleanup logic by refactoring the code a little. But this change keeps that out of its scope.

