### PR TITLE
[BANDWIDTH_THROTTLING] Introduce QuotaConfigs for specifying resource quotas and frontend CU capacity as json.

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/QuotaConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/QuotaConfig.java
@@ -33,10 +33,14 @@ public class QuotaConfig {
       QUOTA_CONFIG_PREFIX + "request.enforcer.source.pair.info.json";
   public static final String QUOTA_MANAGER_FACTORY = QUOTA_CONFIG_PREFIX + "manager.factory";
   public static final String QUOTA_ACCOUNTING_UNIT = QUOTA_CONFIG_PREFIX + "accounting.unit";
+  public static final String RESOURCE_CU_QUOTA_IN_JSON = QUOTA_CONFIG_PREFIX + "resource.cu.quota.in.json";
+  public static final String FRONTEND_CU_CAPACITY_IN_JSON = QUOTA_CONFIG_PREFIX + "frontend.cu.capacity.in.json";
   public static final String DEFAULT_QUOTA_MANAGER_FACTORY = "com.github.ambry.quota.AmbryQuotaManagerFactory";
   public static final String DEFAULT_QUOTA_THROTTLING_MODE = QuotaMode.TRACKING.name();
   public static final boolean DEFAULT_THROTTLE_IN_PROGRESS_REQUESTS = false;
   public static final long DEFAULT_QUOTA_ACCOUNTING_UNIT = 1024; //1kb
+  public static final String DEFAULT_CU_QUOTA_IN_JSON = "{}";
+  public static final String DEFAULT_FRONTEND_BANDWIDTH_CAPACITY_IN_JSON = "{}";
   public StorageQuotaConfig storageQuotaConfig;
 
 
@@ -95,6 +99,51 @@ public class QuotaConfig {
   public long quotaAccountingUnit;
 
   /**
+   * A JSON string representing CU quota for all accounts and containers. eg:
+   * {
+   *   "101": {
+   *     "1": {
+   *       "rcu": 1024000000,
+   *       "wcu": 1024000000
+   *     },
+   *     "1": {
+   *       "rcu": 258438456,
+   *       "wcu": 258438456
+   *     },
+   *   },
+   *   "102": {
+   *     "1": {
+   *       "rcu": 1024000000,
+   *       "wcu": 1024000000
+   *     }
+   *   },
+   *   "103": {
+   *     "rcu": 10737418240,
+   *     "wcu": 10737418240
+   *   }
+   * }
+   * The key of the top object is the account id and the key of the inner object is the container id.
+   * If there is no inner object, then the quota is for account.
+   * Each quota comprises of a rcu value representing read capacity unit quota, and a wcu value
+   * representing write capacity unit quota.
+   */
+
+  @Config(RESOURCE_CU_QUOTA_IN_JSON)
+  @Default("{}")
+  public final String resourceCUQuotaInJson;
+  /**
+   * A JSON string representing bandwidth capacity of frontend node in terms of read capacity unit and write capacity unit.
+   * {
+   *   "rcu": 1024000000,
+   *   "wcu": 1024000000
+   * }
+   */
+
+  @Config(FRONTEND_CU_CAPACITY_IN_JSON)
+  @Default("{}")
+  public final String frontendCUCapacityInJson;
+
+  /**
    * Constructor for {@link QuotaConfig}.
    * @param verifiableProperties {@link VerifiableProperties} object.
    */
@@ -109,6 +158,9 @@ public class QuotaConfig {
     throttleInProgressRequests =
         verifiableProperties.getBoolean(THROTTLE_IN_PROGRESS_REQUESTS, DEFAULT_THROTTLE_IN_PROGRESS_REQUESTS);
     quotaAccountingUnit = verifiableProperties.getLong(QUOTA_ACCOUNTING_UNIT, DEFAULT_QUOTA_ACCOUNTING_UNIT);
+    resourceCUQuotaInJson = verifiableProperties.getString(RESOURCE_CU_QUOTA_IN_JSON, DEFAULT_CU_QUOTA_IN_JSON);
+    frontendCUCapacityInJson =
+        verifiableProperties.getString(FRONTEND_CU_CAPACITY_IN_JSON, DEFAULT_FRONTEND_BANDWIDTH_CAPACITY_IN_JSON);
   }
 
   /**

--- a/ambry-quota/src/main/java/com/github/ambry/quota/capacityunit/CapacityUnit.java
+++ b/ambry-quota/src/main/java/com/github/ambry/quota/capacityunit/CapacityUnit.java
@@ -15,7 +15,7 @@ package com.github.ambry.quota.capacityunit;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.ambry.quota.QuotaName;
-import com.google.common.util.concurrent.AtomicDouble;
+import java.util.concurrent.atomic.AtomicLong;
 import org.codehaus.jackson.annotate.JsonIgnore;
 
 
@@ -26,21 +26,21 @@ public class CapacityUnit {
   static final String RCU_FIELD_NAME = "rcu";
   static final String WCU_FIELD_NAME = "wcu";
 
-  private final AtomicDouble rcu;
-  private final AtomicDouble wcu;
+  private final AtomicLong rcu;
+  private final AtomicLong wcu;
 
   /**
    * Constructor for {@link CapacityUnit}.
    */
   public CapacityUnit() {
-    rcu = new AtomicDouble(0);
-    wcu = new AtomicDouble(0);
+    rcu = new AtomicLong(0);
+    wcu = new AtomicLong(0);
   }
 
   @JsonIgnore
   public CapacityUnit(JsonNode jsonNode) {
-    this.rcu = new AtomicDouble(jsonNode.get(RCU_FIELD_NAME).asLong());
-    this.wcu = new AtomicDouble(jsonNode.get(WCU_FIELD_NAME).asLong());
+    this.rcu = new AtomicLong(jsonNode.get(RCU_FIELD_NAME).asLong());
+    this.wcu = new AtomicLong(jsonNode.get(WCU_FIELD_NAME).asLong());
   }
 
   @JsonIgnore
@@ -49,7 +49,7 @@ public class CapacityUnit {
   }
 
   @JsonIgnore
-  public double getQuotaValue(QuotaName quotaName) {
+  public long getQuotaValue(QuotaName quotaName) {
     switch (quotaName) {
       case READ_CAPACITY_UNIT:
         return rcu.get();
@@ -63,7 +63,7 @@ public class CapacityUnit {
   /**
    * @return Read Capacity Unit quota value.
    */
-  public double getRcu() {
+  public long getRcu() {
     return rcu.get();
   }
 
@@ -77,7 +77,7 @@ public class CapacityUnit {
   /**
    * @return Write Capacity Unit quota value.
    */
-  public double getWcu() {
+  public long getWcu() {
     return wcu.get();
   }
 

--- a/ambry-quota/src/main/java/com/github/ambry/quota/capacityunit/CapacityUnit.java
+++ b/ambry-quota/src/main/java/com/github/ambry/quota/capacityunit/CapacityUnit.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2022 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.quota.capacityunit;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.github.ambry.quota.QuotaName;
+import com.google.common.util.concurrent.AtomicDouble;
+import org.codehaus.jackson.annotate.JsonIgnore;
+
+
+/**
+ * Class encapsulating the Read_Capacity_Unit and Write_Capacity_Unit quotas or usage for resource.
+ */
+public class CapacityUnit {
+  static final String RCU_FIELD_NAME = "rcu";
+  static final String WCU_FIELD_NAME = "wcu";
+
+  private final AtomicDouble rcu;
+  private final AtomicDouble wcu;
+
+  /**
+   * Constructor for {@link CapacityUnit}.
+   */
+  public CapacityUnit() {
+    rcu = new AtomicDouble(0);
+    wcu = new AtomicDouble(0);
+  }
+
+  @JsonIgnore
+  public CapacityUnit(JsonNode jsonNode) {
+    this.rcu = new AtomicDouble(jsonNode.get(RCU_FIELD_NAME).asLong());
+    this.wcu = new AtomicDouble(jsonNode.get(WCU_FIELD_NAME).asLong());
+  }
+
+  @JsonIgnore
+  public static boolean isQuotaNode(JsonNode jsonNode) {
+    return jsonNode.has(WCU_FIELD_NAME);
+  }
+
+  @JsonIgnore
+  public double getQuotaValue(QuotaName quotaName) {
+    switch (quotaName) {
+      case READ_CAPACITY_UNIT:
+        return rcu.get();
+      case WRITE_CAPACITY_UNIT:
+        return wcu.get();
+      default:
+        throw new IllegalArgumentException("Invalid quota name: " + quotaName.name());
+    }
+  }
+
+  /**
+   * @return Read Capacity Unit quota value.
+   */
+  public double getRcu() {
+    return rcu.get();
+  }
+
+  /**
+   * Set the Read Capacity Unit quota to the specified value.
+   */
+  public void setRcu(long rcu) {
+    this.rcu.set(rcu);
+  }
+
+  /**
+   * @return Write Capacity Unit quota value.
+   */
+  public double getWcu() {
+    return wcu.get();
+  }
+
+  /**
+   * Set the Write Capacity Unit quota to the specified value.
+   */
+  public void setWcu(long wcu) {
+    this.wcu.set(wcu);
+  }
+}

--- a/ambry-quota/src/main/java/com/github/ambry/quota/capacityunit/JsonCUQuotaDataProviderUtil.java
+++ b/ambry-quota/src/main/java/com/github/ambry/quota/capacityunit/JsonCUQuotaDataProviderUtil.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2022 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.quota.capacityunit;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.github.ambry.account.Account;
+import com.github.ambry.account.AccountService;
+import com.github.ambry.account.Container;
+import com.github.ambry.config.QuotaConfig;
+import com.github.ambry.quota.QuotaResource;
+import com.github.ambry.quota.QuotaResourceType;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+
+/**
+ * Data provider for CU quota defined in {@link QuotaConfig}.
+ */
+public class JsonCUQuotaDataProviderUtil {
+
+  /**
+   * Util to parse the provided json string into resource quotas and create a {@link Map} of QuotaResource id and
+   * {@link CapacityUnit} from json configs.
+   * @param resourceCUQuotaInJson Json string containing resource quota values.
+   * @param accountService The {@link AccountService} to use.
+   * @throws IOException in case of any exception.
+   */
+  public static Map<String, CapacityUnit> getCUQuotasFromJson(String resourceCUQuotaInJson,
+      AccountService accountService) throws IOException {
+    Map<String, CapacityUnit> quota = new HashMap<>();
+    ObjectMapper objectMapper = new ObjectMapper();
+    if (resourceCUQuotaInJson != null && !resourceCUQuotaInJson.trim().isEmpty()) {
+      Map<String, MapOrQuota> tempQuotas =
+          objectMapper.readValue(resourceCUQuotaInJson, new TypeReference<Map<String, MapOrQuota>>() {
+          });
+      for (Map.Entry<String, MapOrQuota> entry : tempQuotas.entrySet()) {
+        final Account account = accountService.getAccountById(Short.parseShort(entry.getKey()));
+        if (account == null) {
+          throw new IllegalStateException("No account id " + entry.getKey() + " is found in the account service");
+        }
+        if (account.getQuotaResourceType() == QuotaResourceType.ACCOUNT && !entry.getValue().isQuota
+            || account.getQuotaResourceType() != QuotaResourceType.ACCOUNT && entry.getValue().isQuota) {
+          throw new IllegalStateException(
+              "Account " + entry.getKey() + " quota enforcement type is different from account metadata: "
+                  + account.getQuotaResourceType());
+        }
+        if (entry.getValue().isQuota()) {
+          quota.put(QuotaResource.fromAccount(account).getResourceId(), entry.getValue().getQuota());
+        } else {
+          for (Map.Entry<String, CapacityUnit> containerQuotaEntry : entry.getValue().getContainerQuotas().entrySet()) {
+            String containerIdStr = containerQuotaEntry.getKey();
+            Container container = account.getContainerById(Short.parseShort(containerIdStr));
+            if (container == null) {
+              throw new IllegalStateException(
+                  "No container id " + containerIdStr + " is found in the account service under account "
+                      + entry.getKey());
+            }
+            quota.put(QuotaResource.fromContainer(container).getResourceId(), containerQuotaEntry.getValue());
+          }
+        }
+      }
+    }
+    return quota;
+  }
+
+  /**
+   * Util to create frontend {@link CapacityUnit} capacity from the provided json string representation.
+   * @param frontendCUCapacityInJson frontend capacity unit in json string.
+   * @return CapacityUnit object representing frontend's CU capacity.
+   * @throws IOException in case of any exception.
+   */
+  public static CapacityUnit getFeCUCapacityFromJson(String frontendCUCapacityInJson) throws IOException {
+    ObjectMapper objectMapper = new ObjectMapper();
+    return objectMapper.readValue(frontendCUCapacityInJson, CapacityUnit.class);
+  }
+
+  /**
+   * A helper class to represent a number or a map of string to number. This is used in deserializing json string from
+   * configuration for account/container quota.
+   */
+  @JsonDeserialize(using = MapOrQuotaDeserializer.class)
+  public static class MapOrQuota {
+    private final Map<String, CapacityUnit> containerQuotas;
+    private final CapacityUnit quota;
+    private final boolean isQuota;
+
+    /**
+     * Constructor for {@link MapOrQuota} class.
+     * @param quota {@link CapacityUnit} object.
+     */
+    public MapOrQuota(CapacityUnit quota) {
+      containerQuotas = null;
+      this.quota = quota;
+      isQuota = true;
+    }
+
+    /**
+     * Constructor for {@link MapOrQuota} class.
+     * @param containerQuotas {@link Map} of container id to {@link CapacityUnit} object.
+     */
+    public MapOrQuota(Map<String, CapacityUnit> containerQuotas) {
+      this.containerQuotas = containerQuotas;
+      this.quota = null;
+      this.isQuota = false;
+    }
+
+    /**
+     * @return {@code true} if this object represents quota. {@code false} if this represents a Map.
+     */
+    public boolean isQuota() {
+      return isQuota;
+    }
+
+    /**
+     * @return CapacityUnit object.
+     */
+    public CapacityUnit getQuota() {
+      return quota;
+    }
+
+    /**
+     * @return Map of container id to {@link CapacityUnit}.
+     */
+    public Map<String, CapacityUnit> getContainerQuotas() {
+      return containerQuotas;
+    }
+  }
+
+  /**
+   * Custom deserializer for {@link MapOrQuota}.
+   */
+  static class MapOrQuotaDeserializer extends StdDeserializer<MapOrQuota> {
+    public MapOrQuotaDeserializer() {
+      this(null);
+    }
+
+    public MapOrQuotaDeserializer(Class<?> vc) {
+      super(vc);
+    }
+
+    @Override
+    public MapOrQuota deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+      JsonNode node = jp.getCodec().readTree(jp);
+      if (CapacityUnit.isQuotaNode(node)) {
+        return new MapOrQuota(new CapacityUnit(node));
+      } else {
+        Map<String, CapacityUnit> innerMap = new HashMap<>();
+        Iterator<Map.Entry<String, JsonNode>> iterator = node.fields();
+        while (iterator.hasNext()) {
+          Map.Entry<String, JsonNode> entry = iterator.next();
+          innerMap.put(entry.getKey(), new CapacityUnit(entry.getValue()));
+        }
+        return new MapOrQuota(innerMap);
+      }
+    }
+  }
+}

--- a/ambry-quota/src/test/java/com/github/ambry/quota/JsonCUQuotaDataProviderUtilTest.java
+++ b/ambry-quota/src/test/java/com/github/ambry/quota/JsonCUQuotaDataProviderUtilTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2022 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.quota;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.ambry.account.Account;
+import com.github.ambry.account.AccountBuilder;
+import com.github.ambry.account.AccountServiceException;
+import com.github.ambry.account.Container;
+import com.github.ambry.account.ContainerBuilder;
+import com.github.ambry.account.InMemAccountService;
+import com.github.ambry.quota.capacityunit.CapacityUnit;
+import com.github.ambry.quota.capacityunit.JsonCUQuotaDataProviderUtil;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class JsonCUQuotaDataProviderUtilTest {
+  private static final String DEFAULT_CU_QUOTA_IN_JSON =
+      "{\n" + "    \"101\": {\n" + "        \"1\": {\n" + "            \"rcu\": 1024000000,\n"
+          + "            \"wcu\": 1024000000\n" + "        },\n" + "        \"2\": {\n"
+          + "            \"rcu\": 258438456,\n" + "            \"wcu\": 258438456\n" + "        }\n" + "    },\n"
+          + "    \"102\": {\n" + "        \"1\": {\n" + "            \"rcu\": 1024000000,\n"
+          + "            \"wcu\": 1024000000\n" + "        }\n" + "    },\n" + "    \"103\": {\n"
+          + "        \"rcu\": 10737418240,\n" + "        \"wcu\": 10737418240\n" + "    }\n" + "}";
+  private static final String DEFAULT_FRONTEND_CAPACITY_JSON =
+      "{\n" + "      \"wcu\": 1024,\n" + "      \"rcu\": 1024\n" + "  }";
+  private static final String EMPTY_JSON = "{}";
+
+  /**
+   * Create {@link Account} object with specified quota and accountId.
+   * @param mapOrQuota quota of the account.
+   * @param accountId id of the account.
+   * @return Account object.
+   */
+  private static Account createAccountForQuota(JsonCUQuotaDataProviderUtil.MapOrQuota mapOrQuota, String accountId) {
+    AccountBuilder accountBuilder = new AccountBuilder();
+    accountBuilder.id(Short.parseShort(accountId));
+    accountBuilder.name(accountId);
+    List<Container> containers = new ArrayList<>();
+    if (!mapOrQuota.isQuota()) {
+      for (String containerId : mapOrQuota.getContainerQuotas().keySet()) {
+        containers.add(createContainer(containerId));
+      }
+    }
+    accountBuilder.containers(containers);
+    accountBuilder.status(Account.AccountStatus.ACTIVE);
+    if (mapOrQuota.isQuota()) {
+      accountBuilder.quotaResourceType(QuotaResourceType.ACCOUNT);
+    } else {
+      accountBuilder.quotaResourceType(QuotaResourceType.CONTAINER);
+    }
+    return accountBuilder.build();
+  }
+
+  /**
+   * Create a {@link Container} with the specified containerId.
+   * @param containerId id of the container.
+   * @return Container object.
+   */
+  private static Container createContainer(String containerId) {
+    ContainerBuilder containerBuilder = new ContainerBuilder();
+    containerBuilder.setId(Short.parseShort(containerId));
+    containerBuilder.setName(containerId);
+    containerBuilder.setStatus(Container.ContainerStatus.ACTIVE);
+    return containerBuilder.build();
+  }
+
+  @Test
+  public void testGetCUQuotasFromJson() throws IOException, AccountServiceException {
+    InMemAccountService accountService = new InMemAccountService(false, false);
+    ObjectMapper objectMapper = new ObjectMapper();
+    Map<String, JsonCUQuotaDataProviderUtil.MapOrQuota> testQuotas = objectMapper.readValue(DEFAULT_CU_QUOTA_IN_JSON,
+        new TypeReference<Map<String, JsonCUQuotaDataProviderUtil.MapOrQuota>>() {
+        });
+    for (String s : testQuotas.keySet()) {
+      accountService.updateAccounts(Collections.singletonList(createAccountForQuota(testQuotas.get(s), s)));
+    }
+    Map<String, CapacityUnit> quotas =
+        JsonCUQuotaDataProviderUtil.getCUQuotasFromJson(DEFAULT_CU_QUOTA_IN_JSON, accountService);
+
+    Assert.assertEquals(4, quotas.size());
+    Assert.assertEquals(1024000000, (long) quotas.get("101_1").getRcu());
+    Assert.assertEquals(1024000000, (long) quotas.get("101_1").getWcu());
+    Assert.assertEquals(258438456, (long) quotas.get("101_2").getRcu());
+    Assert.assertEquals(258438456, (long) quotas.get("101_2").getWcu());
+    Assert.assertEquals(1024000000, (long) quotas.get("102_1").getRcu());
+    Assert.assertEquals(1024000000, (long) quotas.get("102_1").getWcu());
+    Assert.assertEquals(10737418240L, (long) quotas.get("103").getRcu());
+    Assert.assertEquals(10737418240L, (long) quotas.get("103").getWcu());
+  }
+
+  @Test
+  public void testGetCUQuotasFromJsonForEmptyJsonString() throws IOException, AccountServiceException {
+    InMemAccountService accountService = new InMemAccountService(false, false);
+    ObjectMapper objectMapper = new ObjectMapper();
+    Map<String, JsonCUQuotaDataProviderUtil.MapOrQuota> testQuotas =
+        objectMapper.readValue(EMPTY_JSON, new TypeReference<Map<String, JsonCUQuotaDataProviderUtil.MapOrQuota>>() {
+        });
+    for (String s : testQuotas.keySet()) {
+      accountService.updateAccounts(Collections.singletonList(createAccountForQuota(testQuotas.get(s), s)));
+    }
+    Map<String, CapacityUnit> quotas = JsonCUQuotaDataProviderUtil.getCUQuotasFromJson(EMPTY_JSON, accountService);
+
+    Assert.assertEquals(0, quotas.size());
+  }
+
+  @Test
+  public void testGetFeCUCapacityFromJson() throws IOException {
+    CapacityUnit feCapacityUnit = JsonCUQuotaDataProviderUtil.getFeCUCapacityFromJson(DEFAULT_FRONTEND_CAPACITY_JSON);
+    Assert.assertEquals(1024, (long) feCapacityUnit.getRcu());
+    Assert.assertEquals(1024, (long) feCapacityUnit.getWcu());
+  }
+
+  @Test
+  public void testGetFeCUCapacityFromJsonForEmptyJson() throws IOException {
+    CapacityUnit feCapacityUnit = JsonCUQuotaDataProviderUtil.getFeCUCapacityFromJson(EMPTY_JSON);
+    Assert.assertEquals(0, (long) feCapacityUnit.getRcu());
+    Assert.assertEquals(0, (long) feCapacityUnit.getWcu());
+  }
+}


### PR DESCRIPTION
This PR does the ground work for implementation of `InMemoryCUQuotaSource` class (which will come as a subsequent PR once this is checked in). The `InMemoryCUQuotaSource` class will be the default Capacity Unit QuotaSource implementation for open source code.

1. This PR introduces `CapacityUnit` class that will be used by InMemoryCUQuotaSource class to encapsulate CU Quotas as well as CU Usage. Instances of CapacityUnit can be used to represent quota as well as usage.
2. This PR introduces QuotaConfigs for specifying resource quotas and frontend CU capacity as json. These configs will be used by `InMemoryCUQuotaSource` to setup quotas for accounts and containers during startup. 
3. This PR also introduces `JsonCUQuotaDataProviderUtil` class with utility methods to deserialize the new quota configs that provide the Capacity Unit quota data.

The `CapacityUnit` class and `JsonCUQuotaDataProviderUtil` will be used during instantiation of `InMemoryCUQuotaSource` class to initialize the QuotaSource implementation with quota values for Accounts and Containers.
