### PR TITLE
[BANDWIDTH_THROTTLING] Refactor QuotaChargeCallback implementation into its own file.

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/QuotaConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/QuotaConfig.java
@@ -35,14 +35,16 @@ public class QuotaConfig {
   public static final String QUOTA_ACCOUNTING_UNIT = QUOTA_CONFIG_PREFIX + "accounting.unit";
   public static final String RESOURCE_CU_QUOTA_IN_JSON = QUOTA_CONFIG_PREFIX + "resource.cu.quota.in.json";
   public static final String FRONTEND_CU_CAPACITY_IN_JSON = QUOTA_CONFIG_PREFIX + "frontend.cu.capacity.in.json";
+  public static final String BANDWIDTH_THROTTLING_FEATURE_ENABLED =
+      QUOTA_CONFIG_PREFIX + "bandwidth.throttling.feature.enabled";
   public static final String DEFAULT_QUOTA_MANAGER_FACTORY = "com.github.ambry.quota.AmbryQuotaManagerFactory";
   public static final String DEFAULT_QUOTA_THROTTLING_MODE = QuotaMode.TRACKING.name();
   public static final boolean DEFAULT_THROTTLE_IN_PROGRESS_REQUESTS = false;
   public static final long DEFAULT_QUOTA_ACCOUNTING_UNIT = 1024; //1kb
   public static final String DEFAULT_CU_QUOTA_IN_JSON = "{}";
   public static final String DEFAULT_FRONTEND_BANDWIDTH_CAPACITY_IN_JSON = "{}";
+  public static final boolean DEFAULT_BANDWIDTH_THROTTLING_FEATURE_ENABLED = false;
   public StorageQuotaConfig storageQuotaConfig;
-
 
   /**
    * Serialized json containing pairs of enforcer classes and corresponding source classes.
@@ -127,10 +129,10 @@ public class QuotaConfig {
    * Each quota comprises of a rcu value representing read capacity unit quota, and a wcu value
    * representing write capacity unit quota.
    */
-
   @Config(RESOURCE_CU_QUOTA_IN_JSON)
   @Default("{}")
   public final String resourceCUQuotaInJson;
+
   /**
    * A JSON string representing bandwidth capacity of frontend node in terms of read capacity unit and write capacity unit.
    * {
@@ -138,10 +140,15 @@ public class QuotaConfig {
    *   "wcu": 1024000000
    * }
    */
-
   @Config(FRONTEND_CU_CAPACITY_IN_JSON)
   @Default("{}")
   public final String frontendCUCapacityInJson;
+
+  /**
+   * Flag to identify if the bandwidth throttling feature is enabled.
+   */
+  @Config(BANDWIDTH_THROTTLING_FEATURE_ENABLED)
+  public boolean bandwidthThrottlingFeatureEnabled;
 
   /**
    * Constructor for {@link QuotaConfig}.
@@ -161,6 +168,8 @@ public class QuotaConfig {
     resourceCUQuotaInJson = verifiableProperties.getString(RESOURCE_CU_QUOTA_IN_JSON, DEFAULT_CU_QUOTA_IN_JSON);
     frontendCUCapacityInJson =
         verifiableProperties.getString(FRONTEND_CU_CAPACITY_IN_JSON, DEFAULT_FRONTEND_BANDWIDTH_CAPACITY_IN_JSON);
+    bandwidthThrottlingFeatureEnabled = verifiableProperties.getBoolean(BANDWIDTH_THROTTLING_FEATURE_ENABLED,
+        DEFAULT_BANDWIDTH_THROTTLING_FEATURE_ENABLED);
   }
 
   /**

--- a/ambry-api/src/main/java/com/github/ambry/quota/QuotaChargeCallback.java
+++ b/ambry-api/src/main/java/com/github/ambry/quota/QuotaChargeCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 LinkedIn Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,84 +13,10 @@
  */
 package com.github.ambry.quota;
 
-import com.github.ambry.rest.RestRequest;
-import com.github.ambry.router.RouterErrorCode;
-import com.github.ambry.router.RouterException;
-import java.util.Map;
-import java.util.stream.Collectors;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-
 /**
  * Callback for charging request cost against quota. Used by {@link QuotaEnforcer}s to charge quota for a request.
  */
 public interface QuotaChargeCallback {
-  Logger logger = LoggerFactory.getLogger(QuotaChargeCallback.class);
-
-  /**
-   * Build {@link QuotaChargeCallback} to handle quota compliance of requests.
-   * @param restRequest {@link RestRequest} for which quota is being charged.
-   * @param quotaManager {@link QuotaManager} object responsible for charging the quota.
-   * @param shouldThrottle flag indicating if request should be throttled after charging. Requests like updatettl, delete etc need not be throttled.
-   * @return QuotaChargeCallback object.
-   */
-  static QuotaChargeCallback buildQuotaChargeCallback(RestRequest restRequest, QuotaManager quotaManager,
-      boolean shouldThrottle) {
-    RequestCostPolicy requestCostPolicy = new UserQuotaRequestCostPolicy(quotaManager.getQuotaConfig());
-    return new QuotaChargeCallback() {
-      @Override
-      public void charge(long chunkSize) throws QuotaException {
-        try {
-          Map<QuotaName, Double> requestCost = requestCostPolicy.calculateRequestQuotaCharge(restRequest, chunkSize)
-              .entrySet()
-              .stream()
-              .collect(Collectors.toMap(entry -> QuotaName.valueOf(entry.getKey()), entry -> entry.getValue()));
-          ThrottlingRecommendation throttlingRecommendation = quotaManager.charge(restRequest, null, requestCost);
-          if (throttlingRecommendation != null && throttlingRecommendation.shouldThrottle() && shouldThrottle) {
-            if (quotaManager.getQuotaMode() == QuotaMode.THROTTLING
-                && quotaManager.getQuotaConfig().throttleInProgressRequests) {
-              throw new QuotaException("Exception while charging quota",
-                  new RouterException("RequestQuotaExceeded", RouterErrorCode.TooManyRequests), false);
-            } else {
-              logger.debug("Quota exceeded for an in progress request.");
-            }
-          }
-        } catch (Exception ex) {
-          if (ex.getCause() instanceof RouterException && ((RouterException) ex.getCause()).getErrorCode()
-              .equals(RouterErrorCode.TooManyRequests)) {
-            throw ex;
-          }
-          logger.error("Unexpected exception while charging quota.", ex);
-        }
-      }
-
-      @Override
-      public void charge() throws QuotaException {
-        charge(quotaManager.getQuotaConfig().quotaAccountingUnit);
-      }
-
-      @Override
-      public boolean check() {
-        return false;
-      }
-
-      @Override
-      public boolean quotaExceedAllowed() {
-        return false;
-      }
-
-      @Override
-      public QuotaResource getQuotaResource() throws QuotaException {
-        return QuotaUtils.getQuotaResource(restRequest);
-      }
-
-      @Override
-      public QuotaMethod getQuotaMethod() {
-        return QuotaUtils.getQuotaMethod(restRequest);
-      }
-    };
-  }
 
   /**
    * Callback method that can be used to charge quota usage for a request or part of a request.

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestService.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestService.java
@@ -23,8 +23,8 @@ import com.github.ambry.config.FrontendConfig;
 import com.github.ambry.messageformat.BlobInfo;
 import com.github.ambry.named.NamedBlobDb;
 import com.github.ambry.protocol.GetOption;
-import com.github.ambry.quota.QuotaChargeCallback;
 import com.github.ambry.quota.QuotaManager;
+import com.github.ambry.quota.QuotaUtils;
 import com.github.ambry.rest.RequestPath;
 import com.github.ambry.rest.ResponseStatus;
 import com.github.ambry.rest.RestMethod;
@@ -754,7 +754,7 @@ class FrontendRestRequestService implements RestRequestService {
           if (subResource == null) {
             getCallback.markStartTime();
             router.getBlob(convertedId, getCallback.options, getCallback,
-                QuotaChargeCallback.buildQuotaChargeCallback(restRequest, quotaManager, true));
+                QuotaUtils.buildQuotaChargeCallback(restRequest, quotaManager, true));
           } else {
             switch (subResource) {
               case BlobInfo:
@@ -762,7 +762,7 @@ class FrontendRestRequestService implements RestRequestService {
               case Segment:
                 getCallback.markStartTime();
                 router.getBlob(convertedId, getCallback.options, getCallback,
-                    QuotaChargeCallback.buildQuotaChargeCallback(restRequest, quotaManager, true));
+                    QuotaUtils.buildQuotaChargeCallback(restRequest, quotaManager, true));
                 break;
               case Replicas:
                 response = getReplicasHandler.getReplicas(convertedId, restResponseChannel);
@@ -782,12 +782,12 @@ class FrontendRestRequestService implements RestRequestService {
           router.getBlob(convertedId, new GetBlobOptionsBuilder().operationType(GetBlobOptions.OperationType.BlobInfo)
               .getOption(getOption)
               .restRequest(restRequest)
-              .build(), headCallback, QuotaChargeCallback.buildQuotaChargeCallback(restRequest, quotaManager, false));
+              .build(), headCallback, QuotaUtils.buildQuotaChargeCallback(restRequest, quotaManager, false));
           break;
         case DELETE:
           deleteCallback.markStartTime();
           router.deleteBlob(convertedId, getHeader(restRequest.getArgs(), Headers.SERVICE_ID, false), deleteCallback,
-              QuotaChargeCallback.buildQuotaChargeCallback(restRequest, quotaManager, false));
+              QuotaUtils.buildQuotaChargeCallback(restRequest, quotaManager, false));
           break;
         default:
           throw new IllegalStateException("Unrecognized RestMethod: " + restMethod);

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
@@ -23,8 +23,8 @@ import com.github.ambry.commons.RetryPolicy;
 import com.github.ambry.config.FrontendConfig;
 import com.github.ambry.messageformat.BlobInfo;
 import com.github.ambry.messageformat.BlobProperties;
-import com.github.ambry.quota.QuotaChargeCallback;
 import com.github.ambry.quota.QuotaManager;
+import com.github.ambry.quota.QuotaUtils;
 import com.github.ambry.rest.RequestPath;
 import com.github.ambry.rest.RestRequest;
 import com.github.ambry.rest.RestResponseChannel;
@@ -190,7 +190,7 @@ public class NamedBlobPutHandler {
           PutBlobOptions options = getPutBlobOptionsFromRequest();
           router.putBlob(getPropertiesForRouterUpload(blobInfo), blobInfo.getUserMetadata(), restRequest, options,
               routerPutBlobCallback(blobInfo),
-              QuotaChargeCallback.buildQuotaChargeCallback(restRequest, quotaManager, true));
+              QuotaUtils.buildQuotaChargeCallback(restRequest, quotaManager, true));
         }
       }, uri, LOGGER, finalCallback);
     }
@@ -220,7 +220,7 @@ public class NamedBlobPutHandler {
           bytesRead -> router.stitchBlob(getPropertiesForRouterUpload(blobInfo), blobInfo.getUserMetadata(),
               getChunksToStitch(blobInfo.getBlobProperties(), readJsonFromChannel(channel)),
               routerStitchBlobCallback(blobInfo),
-              QuotaChargeCallback.buildQuotaChargeCallback(restRequest, quotaManager, true)), uri, LOGGER,
+              QuotaUtils.buildQuotaChargeCallback(restRequest, quotaManager, true)), uri, LOGGER,
           finalCallback);
     }
 
@@ -252,7 +252,7 @@ public class NamedBlobPutHandler {
           String serviceId = blobInfo.getBlobProperties().getServiceId();
           retryExecutor.runWithRetries(retryPolicy,
               callback -> router.updateBlobTtl(blobId, serviceId, Utils.Infinite_Time, callback,
-                  QuotaChargeCallback.buildQuotaChargeCallback(restRequest, quotaManager, false)), this::isRetriable,
+                  QuotaUtils.buildQuotaChargeCallback(restRequest, quotaManager, false)), this::isRetriable,
               routerTtlUpdateCallback(blobInfo));
         } else {
           securityService.processResponse(restRequest, restResponseChannel, blobInfo,

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/PostBlobHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/PostBlobHandler.java
@@ -20,8 +20,8 @@ import com.github.ambry.commons.RetainingAsyncWritableChannel;
 import com.github.ambry.config.FrontendConfig;
 import com.github.ambry.messageformat.BlobInfo;
 import com.github.ambry.messageformat.BlobProperties;
-import com.github.ambry.quota.QuotaChargeCallback;
 import com.github.ambry.quota.QuotaManager;
+import com.github.ambry.quota.QuotaUtils;
 import com.github.ambry.rest.RequestPath;
 import com.github.ambry.rest.RestRequest;
 import com.github.ambry.rest.RestResponseChannel;
@@ -185,7 +185,7 @@ class PostBlobHandler {
           PutBlobOptions options = getPutBlobOptionsFromRequest();
           router.putBlob(blobInfo.getBlobProperties(), blobInfo.getUserMetadata(), restRequest, options,
               routerPutBlobCallback(blobInfo),
-              QuotaChargeCallback.buildQuotaChargeCallback(restRequest, quotaManager, true));
+              QuotaUtils.buildQuotaChargeCallback(restRequest, quotaManager, true));
         }
       }, uri, LOGGER, finalCallback);
     }
@@ -202,7 +202,7 @@ class PostBlobHandler {
           bytesRead -> router.stitchBlob(blobInfo.getBlobProperties(), blobInfo.getUserMetadata(),
               getChunksToStitch(blobInfo.getBlobProperties(), readJsonFromChannel(channel)),
               routerStitchBlobCallback(blobInfo),
-              QuotaChargeCallback.buildQuotaChargeCallback(restRequest, quotaManager, false)), uri, LOGGER,
+              QuotaUtils.buildQuotaChargeCallback(restRequest, quotaManager, false)), uri, LOGGER,
           finalCallback);
     }
 

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/TtlUpdateHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/TtlUpdateHandler.java
@@ -16,8 +16,8 @@ package com.github.ambry.frontend;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.Callback;
-import com.github.ambry.quota.QuotaChargeCallback;
 import com.github.ambry.quota.QuotaManager;
+import com.github.ambry.quota.QuotaUtils;
 import com.github.ambry.rest.RestRequest;
 import com.github.ambry.rest.RestRequestMetrics;
 import com.github.ambry.rest.RestResponseChannel;
@@ -144,7 +144,7 @@ class TtlUpdateHandler {
       return buildCallback(metrics.updateBlobTtlSecurityPostProcessRequestMetrics, result -> {
         String serviceId = RestUtils.getHeader(restRequest.getArgs(), RestUtils.Headers.SERVICE_ID, true);
         router.updateBlobTtl(blobId.getID(), serviceId, Utils.Infinite_Time, routerCallback(),
-            QuotaChargeCallback.buildQuotaChargeCallback(restRequest, quotaManager, false));
+            QuotaUtils.buildQuotaChargeCallback(restRequest, quotaManager, false));
       }, restRequest.getUri(), LOGGER, finalCallback);
     }
 

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/UndeleteHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/UndeleteHandler.java
@@ -16,8 +16,8 @@ package com.github.ambry.frontend;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.Callback;
-import com.github.ambry.quota.QuotaChargeCallback;
 import com.github.ambry.quota.QuotaManager;
+import com.github.ambry.quota.QuotaUtils;
 import com.github.ambry.rest.RestRequest;
 import com.github.ambry.rest.RestRequestMetrics;
 import com.github.ambry.rest.RestResponseChannel;
@@ -143,7 +143,7 @@ public class UndeleteHandler {
       return buildCallback(metrics.undeleteBlobSecurityPostProcessRequestMetrics, result -> {
         String serviceId = RestUtils.getHeader(restRequest.getArgs(), RestUtils.Headers.SERVICE_ID, true);
         router.undeleteBlob(blobId.getID(), serviceId, routerCallback(),
-            QuotaChargeCallback.buildQuotaChargeCallback(restRequest, quotaManager, false));
+            QuotaUtils.buildQuotaChargeCallback(restRequest, quotaManager, false));
       }, restRequest.getUri(), LOGGER, finalCallback);
     }
 

--- a/ambry-quota/src/main/java/com/github/ambry/quota/QuotaUtils.java
+++ b/ambry-quota/src/main/java/com/github/ambry/quota/QuotaUtils.java
@@ -115,7 +115,7 @@ public class QuotaUtils {
    */
   public static QuotaChargeCallback buildQuotaChargeCallback(RestRequest restRequest, QuotaManager quotaManager,
       boolean shouldThrottle) {
-    if (quotaManager.getQuotaConfig().bandwidthThrottlingFeatureEnabled) {
+    if (!quotaManager.getQuotaConfig().bandwidthThrottlingFeatureEnabled) {
       return new RejectingQuotaChargeCallback(quotaManager, restRequest, shouldThrottle);
     } else {
       throw new UnsupportedOperationException("Not implemented yet.");

--- a/ambry-quota/src/main/java/com/github/ambry/quota/QuotaUtils.java
+++ b/ambry-quota/src/main/java/com/github/ambry/quota/QuotaUtils.java
@@ -105,4 +105,20 @@ public class QuotaUtils {
         return false;
     }
   }
+
+  /**
+   * Build {@link QuotaChargeCallback} to handle quota compliance of requests.
+   * @param restRequest {@link RestRequest} for which quota is being charged.
+   * @param quotaManager {@link QuotaManager} object responsible for charging the quota.
+   * @param shouldThrottle flag indicating if request should be throttled after charging. Requests like updatettl, delete etc need not be throttled.
+   * @return QuotaChargeCallback object.
+   */
+  public static QuotaChargeCallback buildQuotaChargeCallback(RestRequest restRequest, QuotaManager quotaManager,
+      boolean shouldThrottle) {
+    if (quotaManager.getQuotaConfig().bandwidthThrottlingFeatureEnabled) {
+      return new RejectingQuotaChargeCallback(quotaManager, restRequest, shouldThrottle);
+    } else {
+      throw new UnsupportedOperationException("Not implemented yet.");
+    }
+  }
 }

--- a/ambry-quota/src/main/java/com/github/ambry/quota/RejectingQuotaChargeCallback.java
+++ b/ambry-quota/src/main/java/com/github/ambry/quota/RejectingQuotaChargeCallback.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2022 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.quota;
+
+import com.github.ambry.rest.RestRequest;
+import com.github.ambry.router.RouterErrorCode;
+import com.github.ambry.router.RouterException;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * A {@link QuotaChargeCallback} implementation that will reject requests that exceed their quota.
+ */
+public class RejectingQuotaChargeCallback implements QuotaChargeCallback {
+  private static Logger LOGGER = LoggerFactory.getLogger(QuotaChargeCallback.class);
+  private final QuotaManager quotaManager;
+  private final RestRequest restRequest;
+  private final RequestCostPolicy requestCostPolicy;
+  private final boolean shouldThrottle;
+
+  /**
+   * Constructor for {@link RejectingQuotaChargeCallback}.
+   * @param quotaManager {@link QuotaManager} object responsible for charging the quota.
+   * @param restRequest {@link RestRequest} for which quota is being charged.
+   * @param shouldThrottle flag indicating if request should be throttled after charging. Requests like updatettl, delete etc need not be throttled.
+   */
+  public RejectingQuotaChargeCallback(QuotaManager quotaManager, RestRequest restRequest, boolean shouldThrottle) {
+    this.quotaManager = quotaManager;
+    requestCostPolicy = new UserQuotaRequestCostPolicy(quotaManager.getQuotaConfig());
+    this.restRequest = restRequest;
+    this.shouldThrottle = shouldThrottle;
+  }
+
+  @Override
+  public void charge(long chunkSize) throws QuotaException {
+    try {
+      Map<QuotaName, Double> requestCost = requestCostPolicy.calculateRequestQuotaCharge(restRequest, chunkSize)
+          .entrySet()
+          .stream()
+          .collect(Collectors.toMap(entry -> QuotaName.valueOf(entry.getKey()), Map.Entry::getValue));
+      ThrottlingRecommendation throttlingRecommendation = quotaManager.charge(restRequest, null, requestCost);
+      if (throttlingRecommendation != null && throttlingRecommendation.shouldThrottle() && shouldThrottle) {
+        if (quotaManager.getQuotaMode() == QuotaMode.THROTTLING
+            && quotaManager.getQuotaConfig().throttleInProgressRequests) {
+          throw new QuotaException("Exception while charging quota",
+              new RouterException("RequestQuotaExceeded", RouterErrorCode.TooManyRequests), false);
+        } else {
+          LOGGER.debug("Quota exceeded for an in progress request.");
+        }
+      }
+    } catch (Exception ex) {
+      if (ex.getCause() instanceof RouterException && ((RouterException) ex.getCause()).getErrorCode()
+          .equals(RouterErrorCode.TooManyRequests)) {
+        throw ex;
+      }
+      LOGGER.error("Unexpected exception while charging quota.", ex);
+    }
+  }
+
+  @Override
+  public void charge() throws QuotaException {
+    charge(quotaManager.getQuotaConfig().quotaAccountingUnit);
+  }
+
+  @Override
+  public boolean check() {
+    return false;
+  }
+
+  @Override
+  public boolean quotaExceedAllowed() {
+    return false;
+  }
+
+  @Override
+  public QuotaResource getQuotaResource() throws QuotaException {
+    return QuotaUtils.getQuotaResource(restRequest);
+  }
+
+  @Override
+  public QuotaMethod getQuotaMethod() {
+    return QuotaUtils.getQuotaMethod(restRequest);
+  }
+}


### PR DESCRIPTION
This PR also introduces a quota config to prepare for the QuotaChargeCallback implementation that will be used for Bandwidth Throttling. The main behavior difference between the current QuotaChargeCallback and the new upcoming implementation will be the fact that the new implementation will not reject requests that exceed their CU quota.

This is a refactor only PR with no logic change.