### PR TITLE
Remove old stats format from frontend

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com/github/ambry/rest/RestUtils.java
@@ -268,12 +268,6 @@ public class RestUtils {
      * Request header to carry {@link StatsReportType} for GetStatsReport request.
      */
     public final static String GET_STATS_REPORT_TYPE = "x-ambry-stats-type";
-
-    /**
-     * Request header to request new format. Set it to be true so that ambry would return new format stats that includes
-     * new storage stats information.
-     */
-    public final static String GET_STATS_NEW_FORMAT = "x-ambry-stats-new-format";
   }
 
   public static final class TrackingHeaders {

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/GetStatsReportHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/GetStatsReportHandler.java
@@ -116,8 +116,6 @@ class GetStatsReportHandler {
       return buildCallback(metrics.getStatsReportSecurityPostProcessRequestMetrics, securityCheckResult -> {
         String clusterName = RestUtils.getHeader(restRequest.getArgs(), RestUtils.Headers.CLUSTER_NAME, true);
         String reportType = RestUtils.getHeader(restRequest.getArgs(), RestUtils.Headers.GET_STATS_REPORT_TYPE, true);
-        boolean newFormatRequested =
-            RestUtils.getBooleanHeader(restRequest.getArgs(), RestUtils.Headers.GET_STATS_NEW_FORMAT, false);
         StatsReportType statsReportType;
         try {
           statsReportType = StatsReportType.valueOf(reportType);
@@ -126,38 +124,20 @@ class GetStatsReportHandler {
               RestServiceErrorCode.BadRequest);
         }
         Object result;
-        if (!newFormatRequested) {
-          switch (statsReportType) {
-            case ACCOUNT_REPORT:
-              result = accountStatsStore.queryAggregatedAccountStatsByClusterName(clusterName);
-              break;
-            case PARTITION_CLASS_REPORT:
-              result = accountStatsStore.queryAggregatedPartitionClassStatsByClusterName(clusterName);
-              break;
-            default:
-              throw new RestServiceException("StatsReportType " + statsReportType + "not supported",
-                  RestServiceErrorCode.BadRequest);
-          }
-          if (result == null) {
-            throw new RestServiceException("StatsReport not found for clusterName " + clusterName,
-                RestServiceErrorCode.NotFound);
-          }
-        } else {
-          switch (statsReportType) {
-            case ACCOUNT_REPORT:
-              result = accountStatsStore.queryAggregatedAccountStorageStatsByClusterName(clusterName);
-              break;
-            case PARTITION_CLASS_REPORT:
-              result = accountStatsStore.queryAggregatedPartitionClassStorageStatsByClusterName(clusterName);
-              break;
-            default:
-              throw new RestServiceException("StatsReportType " + statsReportType + "not supported",
-                  RestServiceErrorCode.BadRequest);
-          }
-          if (result == null) {
-            throw new RestServiceException("StatsReport not found for clusterName " + clusterName,
-                RestServiceErrorCode.NotFound);
-          }
+        switch (statsReportType) {
+          case ACCOUNT_REPORT:
+            result = accountStatsStore.queryAggregatedAccountStorageStatsByClusterName(clusterName);
+            break;
+          case PARTITION_CLASS_REPORT:
+            result = accountStatsStore.queryAggregatedPartitionClassStorageStatsByClusterName(clusterName);
+            break;
+          default:
+            throw new RestServiceException("StatsReportType " + statsReportType + "not supported",
+                RestServiceErrorCode.BadRequest);
+        }
+        if (result == null) {
+          throw new RestServiceException("StatsReport not found for clusterName " + clusterName,
+              RestServiceErrorCode.NotFound);
         }
         try {
           byte[] jsonBytes = mapper.writeValueAsBytes(result);

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
@@ -76,6 +76,9 @@ import com.github.ambry.router.RouterErrorCode;
 import com.github.ambry.router.RouterException;
 import com.github.ambry.server.StatsReportType;
 import com.github.ambry.server.StatsSnapshot;
+import com.github.ambry.server.StorageStatsUtilTest;
+import com.github.ambry.server.storagestats.AggregatedAccountStorageStats;
+import com.github.ambry.server.storagestats.AggregatedPartitionClassStorageStats;
 import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.TestUtils;
@@ -1024,26 +1027,28 @@ public class FrontendRestRequestServiceTest {
    */
   @Test
   public void getStatsReportTest() throws Exception {
-    StatsSnapshot accountStatsSnapshot =
-        TestUtils.makeAccountStatsSnapshotFromContainerStorageMap(TestUtils.makeStorageMap(10, 10, 10000, 1000));
-    StatsSnapshot partitionClassStatsSnapshot =
-        TestUtils.makeAggregatedPartitionClassStats(new String[]{"PartitionClass1", "PartitionClass2"}, 10, 10);
+    AggregatedAccountStorageStats aggregatedAccountStorageStats = new AggregatedAccountStorageStats(
+        StorageStatsUtilTest.generateRandomAggregatedAccountStorageStats((short) 1, 10, 10, 1000L, 2, 100));
+    AggregatedPartitionClassStorageStats aggregatedPartitionClassStorageStats =
+        new AggregatedPartitionClassStorageStats(
+            StorageStatsUtilTest.generateRandomAggregatedPartitionClassStorageStats(new String[]{"default", "newClass"},
+                (short) 1, 10, 10, 1000L, 2, 100));
     doAnswer(invocation -> {
       String clusterName = invocation.getArgument(0);
       if (clusterName.equals(CLUSTER_NAME)) {
-        return accountStatsSnapshot;
+        return aggregatedAccountStorageStats;
       } else {
         return null;
       }
-    }).when(accountStatsStore).queryAggregatedAccountStatsByClusterName(anyString());
+    }).when(accountStatsStore).queryAggregatedAccountStorageStatsByClusterName(anyString());
     doAnswer(invocation -> {
       String clusterName = invocation.getArgument(0);
       if (clusterName.equals(CLUSTER_NAME)) {
-        return partitionClassStatsSnapshot;
+        return aggregatedPartitionClassStorageStats;
       } else {
         return null;
       }
-    }).when(accountStatsStore).queryAggregatedPartitionClassStatsByClusterName(anyString());
+    }).when(accountStatsStore).queryAggregatedPartitionClassStorageStatsByClusterName(anyString());
     ObjectMapper mapper = new ObjectMapper();
 
     // construct a request to get account stats
@@ -1053,9 +1058,8 @@ public class FrontendRestRequestServiceTest {
     RestRequest request = createRestRequest(RestMethod.GET, Operations.STATS_REPORT, headers, null);
     MockRestResponseChannel restResponseChannel = new MockRestResponseChannel();
     doOperation(request, restResponseChannel);
-    StatsSnapshot accountStatsFromService =
-        mapper.readValue(restResponseChannel.getResponseBody(), StatsSnapshot.class);
-    assertEquals(accountStatsSnapshot, accountStatsFromService);
+    assertEquals("Storage stats mismatch", aggregatedAccountStorageStats.getStorageStats(),
+        mapper.readValue(restResponseChannel.getResponseBody(), AggregatedAccountStorageStats.class).getStorageStats());
 
     // construct a request to get partition class stats
     headers = new JSONObject();
@@ -1064,9 +1068,9 @@ public class FrontendRestRequestServiceTest {
     request = createRestRequest(RestMethod.GET, Operations.STATS_REPORT, headers, null);
     restResponseChannel = new MockRestResponseChannel();
     doOperation(request, restResponseChannel);
-    StatsSnapshot partitionClassStatsFromService =
-        mapper.readValue(restResponseChannel.getResponseBody(), StatsSnapshot.class);
-    assertEquals(partitionClassStatsSnapshot, partitionClassStatsFromService);
+    assertEquals("Storage stats mismatch", aggregatedPartitionClassStorageStats.getStorageStats(),
+        mapper.readValue(restResponseChannel.getResponseBody(), AggregatedPartitionClassStorageStats.class)
+            .getStorageStats());
 
     // test clustername not found case to ensure that it goes through the exception path
     headers = new JSONObject();

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
@@ -75,7 +75,6 @@ import com.github.ambry.router.Router;
 import com.github.ambry.router.RouterErrorCode;
 import com.github.ambry.router.RouterException;
 import com.github.ambry.server.StatsReportType;
-import com.github.ambry.server.StatsSnapshot;
 import com.github.ambry.server.StorageStatsUtilTest;
 import com.github.ambry.server.storagestats.AggregatedAccountStorageStats;
 import com.github.ambry.server.storagestats.AggregatedPartitionClassStorageStats;


### PR DESCRIPTION
We currently support stats reports in two formats, this PR would remove the old format and only support new format.