### PR TITLE
[azure] Use correct configs for ClientSecretCredential

### DIFF
--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureUtils.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureUtils.java
@@ -50,8 +50,8 @@ class AzureUtils {
   static ClientSecretCredential getClientSecretCredential(AzureCloudConfig azureCloudConfig) {
     ClientSecretCredentialBuilder builder =
         new ClientSecretCredentialBuilder().tenantId(azureCloudConfig.azureIdentityTenantId)
-            .clientId(azureCloudConfig.azureStorageClientId)
-            .clientSecret(azureCloudConfig.azureStorageSecret);
+            .clientId(azureCloudConfig.azureIdentityClientId)
+            .clientSecret(azureCloudConfig.azureIdentitySecret);
     if (!azureCloudConfig.azureIdentityProxyHost.isEmpty()) {
       logger.info("Using proxy for ClientSecretCredential: {}:{}", azureCloudConfig.azureIdentityProxyHost,
           azureCloudConfig.azureIdentityProxyPort);

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/CosmosDataAccessor.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/CosmosDataAccessor.java
@@ -834,6 +834,8 @@ public class CosmosDataAccessor {
           String.format("One of the required configs for fetching the cosmos key from a keyvault (%s, %s) missing",
               AzureCloudConfig.COSMOS_KEY_SECRET_NAME, AzureCloudConfig.COSMOS_VAULT_URL));
     }
+    // check that all required azure identity configs are present if keyvault lookup is used.
+    AzureUtils.validateAzureIdentityConfigs(azureCloudConfig);
     SecretClient secretClient = new SecretClientBuilder().vaultUrl(azureCloudConfig.cosmosVaultUrl)
         .credential(AzureUtils.getClientSecretCredential(azureCloudConfig))
         .buildClient();


### PR DESCRIPTION
Replace usage of the legacy configs when constructing a
ClientSecretCredential.