### PR TITLE
Upgrade log4j to 2.17.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ subprojects {
         compile "org.slf4j:slf4j-api:$slf4jVersion"
         testCompile "org.apache.logging.log4j:log4j-core:$log4jVersion"
         testCompile "org.apache.logging.log4j:log4j-api:$log4jVersion"
-        testCompile "org.apache.logging.log4j:log4j-slf-impl:$log4jVersion"
+        testCompile "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
         testCompile "junit:junit:$junitVersion"
         testCompile "org.mockito:mockito-core:2.+"
         testRuntime project(':log4j-test-config')

--- a/build.gradle
+++ b/build.gradle
@@ -94,8 +94,9 @@ subprojects {
 
     dependencies {
         compile "org.slf4j:slf4j-api:$slf4jVersion"
-        testCompile "log4j:log4j:$log4jVersion"
-        testCompile "org.slf4j:slf4j-log4j12:$slf4jVersion"
+        testCompile "org.apache.logging.log4j:log4j-core:$log4jVersion"
+        testCompile "org.apache.logging.log4j:log4j-api:$log4jVersion"
+        testCompile "org.apache.logging.log4j:log4j-slf-impl:$log4jVersion"
         testCompile "junit:junit:$junitVersion"
         testCompile "org.mockito:mockito-core:2.+"
         testRuntime project(':log4j-test-config')
@@ -265,8 +266,9 @@ project(':ambry-server') {
                 project(':ambry-mysql')
         compile "io.dropwizard.metrics:metrics-core:$metricsVersion"
         compile "io.dropwizard.metrics:metrics-jmx:$metricsVersion"
-        runtimeOnly "log4j:log4j:$log4jVersion"
-        runtimeOnly "org.slf4j:slf4j-log4j12:$slf4jVersion"
+        runtimeOnly "org.apache.logging.log4j:log4j-core:$log4jVersion"
+        runtimeOnly "org.apache.logging.log4j:log4j-api:$log4jVersion"
+        runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
         testCompile project(':ambry-router')
         testCompile project(':ambry-cloud')
         testCompile project(':ambry-test-utils')
@@ -376,8 +378,9 @@ project(':ambry-rest') {
         compile "io.netty:netty-tcnative-boringssl-static:$nettyTcnativeVersion"
         compile "io.netty:netty-transport-native-epoll:$nettyVersion"
         compile "javax.servlet:javax.servlet-api:$javaxVersion"
-        runtimeOnly "log4j:log4j:$log4jVersion"
-        runtimeOnly "org.slf4j:slf4j-log4j12:$slf4jVersion"
+        runtimeOnly "org.apache.logging.log4j:log4j-core:$log4jVersion"
+        runtimeOnly "org.apache.logging.log4j:log4j-api:$log4jVersion"
+        runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
         testCompile project(':ambry-test-utils')
         testCompile project(path: ':ambry-api', configuration: 'testArchives')
         testCompile project(path: ':ambry-account', configuration: 'testArchives')

--- a/build.gradle
+++ b/build.gradle
@@ -194,9 +194,7 @@ project(':ambry-account') {
                 project(':ambry-utils'),
                 project(':ambry-commons'),
                 project(':ambry-mysql')
-        compile ("org.apache.helix:helix-core:$helixVersion") {
-            exclude group: "log4j", module: "log4j"
-        }
+        compile "org.apache.helix:helix-core:$helixVersion"
         compile "io.dropwizard.metrics:metrics-core:$metricsVersion"
         compile "org.json:json:$jsonVersion"
         testCompile project(':ambry-test-utils')
@@ -210,14 +208,13 @@ project(':ambry-clustermap') {
         compile project(':ambry-api'),
                 project(':ambry-commons'),
                 project(':ambry-utils')
-        compile ("org.apache.helix:helix-core:$helixVersion") {
-            exclude group: "log4j", module: "log4j"
-        }
+        compile "org.apache.helix:helix-core:$helixVersion"
         compile "io.dropwizard.metrics:metrics-core:$metricsVersion"
         compile "org.json:json:$jsonVersion"
         testCompile project(':ambry-commons')
         testCompile project(':ambry-test-utils')
         testCompile project(path: ':ambry-api', configuration: 'testArchives')
+
     }
 }
 
@@ -229,9 +226,7 @@ project(':ambry-commons') {
         compile "org.conscrypt:conscrypt-openjdk-uber:$conscryptVersion"
         compile "io.netty:netty-all:$nettyVersion"
         compile "io.netty:netty-tcnative-boringssl-static:$nettyTcnativeVersion"
-        compile ("org.apache.helix:helix-core:$helixVersion") {
-            exclude group: "log4j", module: "log4j"
-        }
+        compile "org.apache.helix:helix-core:$helixVersion"
         testCompile project(':ambry-test-utils')
         testCompile project(path: ':ambry-clustermap', configuration: 'testArchives')
     }
@@ -440,9 +435,7 @@ project(':ambry-cloud') {
         compile "io.dropwizard.metrics:metrics-jmx:$metricsVersion"
         compile "com.microsoft.azure:azure-cosmosdb:$azureCosmosDbVersion"
         compile "com.microsoft.azure:msal4j:$azureMsal4jVersion"
-        compile ("org.apache.helix:helix-lock:$helixVersion") {
-            exclude group: "log4j", module: "log4j"
-        }
+        compile "org.apache.helix:helix-lock:$helixVersion"
         testCompile project(':ambry-router')
         testCompile project(':ambry-store')
         testCompile project(':ambry-test-utils')
@@ -469,9 +462,7 @@ project(':ambry-quota') {
             project(':ambry-commons'),
             project(':ambry-mysql'),
             project(':ambry-clustermap')
-        compile ("org.apache.helix:helix-core:$helixVersion") {
-            exclude group: "log4j", module: "log4j"
-        }
+        compile "org.apache.helix:helix-core:$helixVersion"
         testCompile project(':ambry-test-utils')
         testCompile project(':ambry-account')
         testCompile project(path: ':ambry-clustermap', configuration: 'testArchives')
@@ -484,9 +475,7 @@ project(':ambry-mysql') {
         compile project(':ambry-utils')
         compile project(':ambry-commons')
         compile "mysql:mysql-connector-java:$mysqlConnectorVersion"
-        compile ("org.apache.helix:helix-core:$helixVersion") {
-            exclude group: "log4j", module: "log4j"
-        }
+        compile "org.apache.helix:helix-core:$helixVersion"
         compile "com.zaxxer:HikariCP:$hikariVersion"
         testCompile project(':ambry-test-utils')
         testCompile project(path: ':ambry-clustermap', configuration: 'testArchives')

--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -9,9 +9,9 @@
 // CONDITIONS OF ANY KIND, either express or implied.
 ext {
     junitVersion = "4.8.1"
-    slf4jVersion = "1.7.5"
+    slf4jVersion = "1.7.35"
     joptSimpleVersion = "4.9"
-    log4jVersion = "1.2.17"
+    log4jVersion = "2.17.1"
     jsonVersion = "20170516"
     metricsVersion = "4.1.2"
     commonsVersion = "1.9"


### PR DESCRIPTION
Before this pr, the dependency on log4j looks like this 
https://gradle.com/s/sve4qwxonav2m

After this PR, there is no dependency on log4j:log4j:1.2
