### PR TITLE
Add support for float configs in VerifiableProperties.

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/VerifiableProperties.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/VerifiableProperties.java
@@ -147,6 +147,24 @@ public class VerifiableProperties {
   }
 
   /**
+   * Read a float from the properties instance. Throw an exception if the value is not in the given range (inclusive).
+   * @param name The property name
+   * @param defaultVal The default value to use if the property is not found
+   * @param start The start of the range in which the value must fall (inclusive)
+   * @param end The end of the range in which the value must fall
+   * @return the {@link Float} value
+   */
+  public Float getFloatInRange(String name, Float defaultVal, Float start, Float end) {
+    Float v = containsKey(name) ? Float.valueOf(Float.parseFloat(getProperty(name))) : defaultVal;
+    if (v >= start && v <= end) {
+      return v;
+    } else {
+      throw new IllegalArgumentException(
+          name + " has value " + v + " which is not in range " + start + "-" + end + ".");
+    }
+  }
+
+  /**
    * Read a required long property value or throw an exception if no such property is found
    */
   public long getLong(String name) {

--- a/ambry-api/src/test/java/com/github/ambry/config/VerifiablePropertiesTest.java
+++ b/ambry-api/src/test/java/com/github/ambry/config/VerifiablePropertiesTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.config;
+
+import java.util.Properties;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+/**
+ * Test for methods on {@link VerifiableProperties} class.
+ */
+public class VerifiablePropertiesTest {
+
+  @Test
+  public void testGetFloatInRange() {
+    Properties properties = new Properties();
+    VerifiableProperties verifiableProperties = new VerifiableProperties(properties);
+    String propertyName = "TEST";
+    float defaultVal = 5.0f;
+    // test for default value.
+    Float result = verifiableProperties.getFloatInRange(propertyName, defaultVal, 0.0f, 10.0f);
+    Assert.assertEquals(result, defaultVal, 0.001);
+
+    // test outside range value.
+    properties.setProperty(propertyName, "11.0");
+    try {
+      verifiableProperties.getFloatInRange(propertyName, defaultVal, 0.0f, 10.0f);
+      Assert.fail("Value outside range should fail.");
+    } catch (IllegalArgumentException ignored) {
+    }
+
+    // test invalid float value.
+    properties.setProperty(propertyName, "string");
+    try {
+      verifiableProperties.getFloatInRange(propertyName, defaultVal, 0.0f, 10.0f);
+      Assert.fail("Value outside range should fail.");
+    } catch (NumberFormatException ignored) {
+    }
+
+    // test valid float value.
+    properties.setProperty(propertyName, "9.0");
+    result = verifiableProperties.getFloatInRange(propertyName, defaultVal, 0.0f, 10.0f);
+    Assert.assertEquals(result, 9.0f, 0.001);
+  }
+}


### PR DESCRIPTION
This PR add support for method `getGloatInRange` in VerifiableProperties. This will be used in future PRs (specially by QuotaConfig).