### PR TITLE
[BANDWIDTH_THROTTLING] Implement QuotaResourceMutexFactory to synchronize based on QuotaResource value.

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/quota/QuotaResource.java
+++ b/ambry-api/src/main/java/com/github/ambry/quota/QuotaResource.java
@@ -133,4 +133,9 @@ public class QuotaResource {
   public int hashCode() {
     return 89 * quotaResourceType.hashCode() + resourceId.hashCode();
   }
+
+  @Override
+  public String toString() {
+    return String.format("QuotaResource: [resourceId: %s, resourceType: %s]", resourceId, quotaResourceType);
+  }
 }

--- a/ambry-quota/src/main/java/com/github/ambry/quota/QuotaMetrics.java
+++ b/ambry-quota/src/main/java/com/github/ambry/quota/QuotaMetrics.java
@@ -27,6 +27,7 @@ public class QuotaMetrics {
   public final Counter quotaNotEnforcedCount;
   public final Timer quotaManagerInitTime;
   public final Timer quotaChargeTime;
+  public final Counter quotaResourceInvalidUnlockAttemptCount;
 
   /**
    * {@link QuotaMetrics} constructor.
@@ -38,5 +39,7 @@ public class QuotaMetrics {
     quotaNotEnforcedCount = metricRegistry.counter(MetricRegistry.name(QuotaMetrics.class, "QuotaNotEnforcedCount"));
     quotaManagerInitTime = metricRegistry.timer(MetricRegistry.name(QuotaMetrics.class, "QuotaManagerInitTime"));
     quotaChargeTime = metricRegistry.timer(MetricRegistry.name(QuotaMetrics.class, "QuotaChargeTime"));
+    quotaResourceInvalidUnlockAttemptCount =
+        metricRegistry.counter(MetricRegistry.name(QuotaMetrics.class, "QuotaResourceInvalidUnlockAttemptCount"));
   }
 }

--- a/ambry-quota/src/main/java/com/github/ambry/quota/QuotaResourceSynchronizer.java
+++ b/ambry-quota/src/main/java/com/github/ambry/quota/QuotaResourceSynchronizer.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2022 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.quota;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Class to provide synchronization constructs (lock and unlock) for all {@link QuotaResource} objects based on their value.
+ * This class can be used to enforce mutual exclusion between multiple {@link QuotaResource} objects that represent the
+ * same quota resource (as determined by {@link QuotaResource#equals}) method.
+ *
+ * To ensure the synchronization, this class internally creates a unique {@link ReentrantLock} for each quota resource,
+ * and maintains a {@link ConcurrentHashMap} to cache the mapping and reuse same {@link ReentrantLock} across multiple
+ * {@link QuotaResource} instances that represent the same quota resource.
+ *
+ * In order to prevent {@link ReentrantLock}s from being inadvertently reused outside this scope, this class doesn't
+ * leak the {@link ReentrantLock}s outside. It provides only lock and unlock constructs to the callers.
+ */
+public class QuotaResourceSynchronizer {
+  private static final Logger LOGGER = LoggerFactory.getLogger(QuotaResourceMutexCache.class);
+  protected final QuotaResourceMutexCache quotaResourceMutexCache = new QuotaResourceMutexCache();
+  private final QuotaMetrics quotaMetrics;
+
+  /**
+   * Constructor for {@link QuotaResourceSynchronizer}.
+   * @param quotaMetrics {@link QuotaMetrics} object.
+   */
+  public QuotaResourceSynchronizer(QuotaMetrics quotaMetrics) {
+    this.quotaMetrics = quotaMetrics;
+  }
+
+  /**
+   * Acquires the lock for the quota resource represented by the specified {@link QuotaResource}.
+   * @param quotaResource {@link QuotaResource} object representing the quota resource for which lock needs to be
+   *                      acquired.
+   */
+  public void lock(QuotaResource quotaResource) {
+    quotaResourceMutexCache.get(quotaResource).lock();
+  }
+
+  /**
+   * Releases the lock for the quota resource represented by the specified {@link QuotaResource}.
+   * @param quotaResource {@link QuotaResource} object representing the quota resource for which lock needs to be
+   *                      released.
+   */
+  public void unlock(QuotaResource quotaResource) {
+    ReentrantLock lock = quotaResourceMutexCache.mutexCache.getOrDefault(quotaResource, null);
+    if (lock != null) {
+      lock.unlock();
+    } else {
+      LOGGER.warn("Attempted unlock for {} when lock wasn't held.", quotaResource);
+      quotaMetrics.quotaResourceInvalidUnlockAttemptCount.inc();
+    }
+  }
+
+  /**
+   * A cache of unique mutexes for all {@link QuotaResource} objects that represent the same quota resource.
+   */
+  static class QuotaResourceMutexCache {
+    /*
+     * There are multiple optimization opportunities here.
+     * 1. If we never clean the cache, we don't really need all the complexity, and hence latency, of a ConcurrentHashMap.
+     *    We could just use an array of mutexes to synchronize. But doing that will add extra complexity (extra code,
+     *    extra tests etc). So unless there is a performance issue, using ConcurrentHashMap should be just fine.
+     * 2. This cache never removes entries until the service (Ambry frontend) is restarted. In the worst case the size
+     *    of the cache might grow upto the total number of QuotaResources (accounts + containers + services) for which quota
+     *    is being enforced. Periodically cleaning up cache is one way to reduce the memory pressure, but will add more
+     *    complexity to maintain thread safety (and maybe more latency to access the cache too). Ambry's frontend keeps
+     *    the accounts and containers in memory at multiple places currently (e.g, AccountService implementation), with the
+     *    assumption that the total number of accounts and containers are small enough to keep in memory. As long as that
+     *    assumption holds, not cleaning up this cache is fine. If that assumption doesn't hold, a lot of code might need
+     *    restructuring, and this cache cleanup should be taken up as part of that effort.
+     */
+    protected final ConcurrentHashMap<QuotaResource, ReentrantLock> mutexCache = new ConcurrentHashMap<>();
+
+    /**
+     * Returns the mutex in the form of {@link ReentrantLock} object for the specified {@link QuotaResource}.
+     * If the mutex is not already present in the cache, it creates a new mapping.
+     * @param quotaResource {@link QuotaResource} object.
+     * @return ReentrantLock object as mutex for the specified quotaResource.
+     */
+    ReentrantLock get(QuotaResource quotaResource) {
+      return mutexCache.computeIfAbsent(quotaResource, k -> new ReentrantLock());
+    }
+  }
+}

--- a/ambry-quota/src/test/java/com/github/ambry/quota/QuotaResourceSynchronizerTest.java
+++ b/ambry-quota/src/test/java/com/github/ambry/quota/QuotaResourceSynchronizerTest.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2022 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.quota;
+
+import com.codahale.metrics.MetricRegistry;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+
+/**
+ * Test for {@link QuotaResourceSynchronizer}.
+ */
+public class QuotaResourceSynchronizerTest {
+  private TestQuotaResourceSynchronizer quotaResourceSychronizer;
+  private QuotaResourceSynchronizer.QuotaResourceMutexCache quotaResourceMutexCache;
+
+  @Before
+  public void setup() {
+    quotaResourceSychronizer = new TestQuotaResourceSynchronizer(new QuotaMetrics(new MetricRegistry()));
+    quotaResourceMutexCache = quotaResourceSychronizer.quotaResourceMutexCache;
+  }
+
+  @Test
+  public void testQuotaResourceMutexes() {
+    // test that same quotaresource objects get the same mutex
+    QuotaResource quotaResource1 = new QuotaResource(Integer.toString(1), QuotaResourceType.ACCOUNT);
+    QuotaResource quotaResource2 = new QuotaResource(Integer.toString(1), QuotaResourceType.ACCOUNT);
+    Assert.assertNotSame(quotaResource1, quotaResource2);
+    Assert.assertEquals(quotaResource1, quotaResource2);
+    ReentrantLock mutex1 = quotaResourceMutexCache.get(quotaResource1);
+    ReentrantLock mutex2 = quotaResourceMutexCache.get(quotaResource2);
+    ReentrantLock mutex = mutex2;
+    Assert.assertSame(mutex1, mutex2);
+    Assert.assertEquals(1, quotaResourceSychronizer.getMutexMap().size());
+
+    // test that different quota resource objects get different mutex
+    quotaResource1 = new QuotaResource(Integer.toString(1), QuotaResourceType.ACCOUNT);
+    quotaResource2 = new QuotaResource(Integer.toString(2), QuotaResourceType.ACCOUNT);
+    Assert.assertFalse(quotaResource1.equals(quotaResource2));
+    mutex1 = quotaResourceMutexCache.get(quotaResource1);
+    mutex2 = quotaResourceMutexCache.get(quotaResource2);
+    Assert.assertNotSame(mutex1, mutex2);
+    Assert.assertSame(mutex, mutex1);
+    Assert.assertEquals(2, quotaResourceSychronizer.getMutexMap().size());
+
+    // test that different quota resource objects get different mutex
+    quotaResource1 = new QuotaResource(Integer.toString(1), QuotaResourceType.ACCOUNT);
+    quotaResource2 = new QuotaResource(Integer.toString(2), QuotaResourceType.CONTAINER);
+    Assert.assertFalse(quotaResource1.equals(quotaResource2));
+    mutex1 = quotaResourceMutexCache.get(quotaResource1);
+    mutex2 = quotaResourceMutexCache.get(quotaResource2);
+    Assert.assertNotSame(mutex1, mutex2);
+    Assert.assertSame(mutex, mutex1);
+    Assert.assertEquals(3, quotaResourceSychronizer.getMutexMap().size());
+  }
+
+  @Test
+  public void testLockUnlock() throws InterruptedException {
+    // 1. acquire lock for a quota resource (quotaResource1)
+    QuotaResource quotaResource1 = new QuotaResource(Integer.toString(1), QuotaResourceType.ACCOUNT);
+    quotaResourceSychronizer.lock(quotaResource1);
+    Assert.assertEquals(1,
+        quotaResourceSychronizer.lockAttemptCountMap.getOrDefault(quotaResource1, new AtomicInteger(0)).get());
+    Assert.assertEquals(0,
+        quotaResourceSychronizer.unlockAttemptCountMap.getOrDefault(quotaResource1, new AtomicInteger(0)).get());
+
+    // 2. acquire lock for a different quota resource (quotaResource2). This should just work.
+    QuotaResource quotaResource2 = new QuotaResource(Integer.toString(2), QuotaResourceType.ACCOUNT);
+    quotaResourceSychronizer.lock(quotaResource2);
+    quotaResourceSychronizer.unlock(quotaResource2);
+    Assert.assertEquals(1,
+        quotaResourceSychronizer.lockAttemptCountMap.getOrDefault(quotaResource2, new AtomicInteger(0)).get());
+    Assert.assertEquals(1,
+        quotaResourceSychronizer.unlockAttemptCountMap.getOrDefault(quotaResource2, new AtomicInteger(0)).get());
+
+    // 3. acquire lock for quotaResource1 in a different thread. the thread should block until current thread releases the lock.
+    ReentrantLock lockForSignalling = new ReentrantLock();
+    Condition acquired = lockForSignalling.newCondition();
+    Condition released = lockForSignalling.newCondition();
+    LockUnlockSignalHelper lockUnlockSignalHelper =
+        new LockUnlockSignalHelper(quotaResourceSychronizer, lockForSignalling, quotaResource1, acquired, released);
+    Thread thread = new Thread(lockUnlockSignalHelper);
+    thread.start();
+    // sleeping below allow the new thread to execute.
+    // Note that there is still no guarantee that the thread would have executed in 5 seconds, it only highly likely.
+    Thread.sleep(5000);
+    quotaResource1 = new QuotaResource(Integer.toString(1), QuotaResourceType.ACCOUNT);
+
+    // ensure that the other thread was not able to lock
+    Assert.assertEquals(1,
+        quotaResourceSychronizer.lockAttemptCountMap.getOrDefault(quotaResource1, new AtomicInteger(0)).get());
+    Assert.assertEquals(0,
+        quotaResourceSychronizer.unlockAttemptCountMap.getOrDefault(quotaResource1, new AtomicInteger(0)).get());
+
+    quotaResourceSychronizer.unlock(quotaResource1);
+    // ensure that the other thread was able to lock.
+    try {
+      lockForSignalling.lock();
+      while (quotaResourceSychronizer.lockAttemptCountMap.getOrDefault(quotaResource1, new AtomicInteger(0)).get()
+          != 2) {
+        acquired.await();
+      }
+    } finally {
+      lockForSignalling.unlock();
+    }
+
+    // ensure that the other thread was able to unlock.
+    try {
+      lockForSignalling.lock();
+      while (quotaResourceSychronizer.unlockAttemptCountMap.getOrDefault(quotaResource1, new AtomicInteger(0)).get()
+          != 2) {
+        released.await();
+      }
+    } finally {
+      lockForSignalling.unlock();
+    }
+
+    Assert.assertEquals(2,
+        quotaResourceSychronizer.lockAttemptCountMap.getOrDefault(quotaResource1, new AtomicInteger(0)).get());
+    Assert.assertEquals(2,
+        quotaResourceSychronizer.unlockAttemptCountMap.getOrDefault(quotaResource1, new AtomicInteger(0)).get());
+
+    // ensure thread exited
+    thread.join();
+  }
+
+  /**
+   * Helper {@link Runnable} implementation that attempts to lock and unlock for a {@link QuotaResource} and signal for
+   * every such successful attempt.
+   */
+  private static class LockUnlockSignalHelper implements Runnable {
+    private final QuotaResourceSynchronizer quotaResourceSynchronizer;
+    private final ReentrantLock lock;
+    private final QuotaResource quotaResource;
+    private final Condition acquired;
+    private final Condition released;
+
+    /**
+     * Constructor for {@link LockUnlockSignalHelper}.
+     * @param quotaResourceSynchronizer {@link QuotaResourceSynchronizer} object.
+     * @param lock {@link ReentrantLock} object for signalling.
+     * @param quotaResource {@link QuotaResource} object.
+     * @param acquired {@link Condition} to signal when quota resource lock is acquired.
+     * @param released {@link Condition} to signal when quota resource lock is released.
+     */
+    LockUnlockSignalHelper(QuotaResourceSynchronizer quotaResourceSynchronizer, ReentrantLock lock,
+        QuotaResource quotaResource, Condition acquired, Condition released) {
+      this.lock = lock;
+      this.quotaResourceSynchronizer = quotaResourceSynchronizer;
+      this.quotaResource = quotaResource;
+      this.acquired = acquired;
+      this.released = released;
+    }
+
+    @Override
+    public void run() {
+      try {
+        lock.lock();
+        quotaResourceSynchronizer.lock(quotaResource);
+        acquired.signalAll();
+      } finally {
+        lock.unlock();
+      }
+
+      try {
+        lock.lock();
+        quotaResourceSynchronizer.unlock(quotaResource);
+        released.signalAll();
+      } finally {
+        lock.unlock();
+      }
+    }
+  }
+
+  /**
+   * Test class that extends {@link QuotaResourceSynchronizer} to expose some of its protected members for tests.
+   */
+  private static class TestQuotaResourceSynchronizer extends QuotaResourceSynchronizer {
+    ConcurrentHashMap<QuotaResource, AtomicInteger> lockAttemptCountMap = new ConcurrentHashMap<>();
+    ConcurrentHashMap<QuotaResource, AtomicInteger> unlockAttemptCountMap = new ConcurrentHashMap<>();
+
+    /**
+     * Constructor for {@link TestQuotaResourceSynchronizer}.
+     * @param quotaMetrics {@link QuotaMetrics} object.
+     */
+    public TestQuotaResourceSynchronizer(QuotaMetrics quotaMetrics) {
+      super(quotaMetrics);
+    }
+
+    @Override
+    public void lock(QuotaResource quotaResource) {
+      super.lock(quotaResource);
+      lockAttemptCountMap.putIfAbsent(quotaResource, new AtomicInteger(0));
+      lockAttemptCountMap.get(quotaResource).incrementAndGet();
+    }
+
+    @Override
+    public void unlock(QuotaResource quotaResource) {
+      super.unlock(quotaResource);
+      unlockAttemptCountMap.putIfAbsent(quotaResource, new AtomicInteger(0));
+      unlockAttemptCountMap.get(quotaResource).incrementAndGet();
+    }
+
+    /**
+     * Method to return {@link QuotaResourceSynchronizer}'s mutex cache for tests.
+     * @return ConcurrentMap of {@link QuotaResource} id and its mutex {@link ReentrantLock}.
+     */
+    public ConcurrentMap<QuotaResource, ReentrantLock> getMutexMap() {
+      return quotaResourceMutexCache.mutexCache;
+    }
+  }
+}


### PR DESCRIPTION
QuotaManager implementation might need to synchronize quota usage accounting for the same QuotaResource. This synchronization needs to happen based on the QuotaResource object's value rather than on QuotaResource object instances (which is how java's monitor works by default). This PR creates a synchronization construct to synchronize based on the QuotaResource value. 