### PR TITLE
Make VCR tool ignore patterns case insensitive

### DIFF
--- a/ambry-commons/src/main/java/com/github/ambry/clustermap/HelixVcrUtil.java
+++ b/ambry-commons/src/main/java/com/github/ambry/clustermap/HelixVcrUtil.java
@@ -63,8 +63,8 @@ public class HelixVcrUtil {
     clusterSetup.addCluster(destClusterName, true);
 
     // set ALLOW_PARTICIPANT_AUTO_JOIN
-    HelixConfigScope configScope = new HelixConfigScopeBuilder(HelixConfigScope.ConfigScopeProperty.CLUSTER).
-        forCluster(destClusterName).build();
+    HelixConfigScope configScope =
+        new HelixConfigScopeBuilder(HelixConfigScope.ConfigScopeProperty.CLUSTER).forCluster(destClusterName).build();
     Map<String, String> helixClusterProperties = new HashMap<>();
     helixClusterProperties.put(ZKHelixManager.ALLOW_PARTICIPANT_AUTO_JOIN,
         String.valueOf(config.getClusterConfigFields().isAllowAutoJoin()));
@@ -178,7 +178,8 @@ public class HelixVcrUtil {
       }
     }
     for (String resource : srcResources) {
-      if (ignoreResourceKeyWords.stream().anyMatch(resource::contains)) {
+      String resourceLowercase = resource.toLowerCase();
+      if (ignoreResourceKeyWords.stream().anyMatch(resourceLowercase::contains)) {
         logger.info("Resource {} from src cluster is ignored", resource);
         continue;
       }
@@ -283,7 +284,8 @@ public class HelixVcrUtil {
   /**
    * A method to verify resources and partitions in src cluster and dest cluster are same.
    */
-  public static boolean isSrcDestSync(String srcZkString, String srcClusterName, String destZkString, String destClusterName) {
+  public static boolean isSrcDestSync(String srcZkString, String srcClusterName, String destZkString,
+      String destClusterName) {
 
     HelixAdmin srcAdmin = new ZKHelixAdmin(srcZkString);
     Set<String> srcResources = new HashSet<>(srcAdmin.getResourcesInCluster(srcClusterName));
@@ -291,7 +293,8 @@ public class HelixVcrUtil {
     Set<String> destResources = new HashSet<>(destAdmin.getResourcesInCluster(destClusterName));
 
     for (String resource : srcResources) {
-      if (HelixVcrUtil.ignoreResourceKeyWords.stream().anyMatch(resource::contains)) {
+      String resourceLowercase = resource.toLowerCase();
+      if (HelixVcrUtil.ignoreResourceKeyWords.stream().anyMatch(resourceLowercase::contains)) {
         System.out.println("Resource " + resource + " from src cluster is ignored");
         continue;
       }

--- a/ambry-tools/src/integration-test/java/com/github/ambry/clustermap/HelixVcrPopulateToolTest.java
+++ b/ambry-tools/src/integration-test/java/com/github/ambry/clustermap/HelixVcrPopulateToolTest.java
@@ -14,6 +14,7 @@
 
 package com.github.ambry.clustermap;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.ambry.utils.TestUtils;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -23,13 +24,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.apache.helix.HelixAdmin;
-import org.apache.helix.manager.zk.ZKHelixAdmin;
 import org.apache.helix.manager.zk.ZNRecordSerializer;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.tools.ClusterSetup;
 import org.apache.helix.zookeeper.api.client.HelixZkClient;
 import org.apache.helix.zookeeper.impl.factory.SharedZkClientFactory;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -146,7 +145,7 @@ public class HelixVcrPopulateToolTest {
 
     // add one more partition to src cluster resource 1 and add one more resource to src cluster
     srcHelixAdmin.dropResource(SRC_CLUSTER_NAME, "1");
-    String[] resourceNames = {"1", "2"};
+    String[] resourceNames = {"1", "2", "mysqlTriggerRecurrent"};
     Set<String> partitionSet = new HashSet<>();
     for (int i = 0; i < 101; i++) {
       partitionSet.add(Integer.toString(i));
@@ -169,5 +168,4 @@ public class HelixVcrPopulateToolTest {
 
     destZkInfo.shutdown();
   }
-
 }


### PR DESCRIPTION
These ignore patterns should also match camel case resource names.