### PR TITLE
[BANDWIDTH_THROTTLING] Introduce QuotaAction as the recommended action to be taken in order to ensure requests are quota compliant.

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/quota/QuotaAction.java
+++ b/ambry-api/src/main/java/com/github/ambry/quota/QuotaAction.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.quota;
+
+/**
+ * Action recommended for handling quota compliance of requests.
+ * The enum is declared in the order of severity in order to make the severity comparison easy.
+ * In terms of severity {@link QuotaAction#ALLOW} < {@link QuotaAction#DELAY} < {@link QuotaAction#REJECT}.
+ */
+public enum QuotaAction {
+  /**
+   * Allow the request to go through.
+   */
+  ALLOW,
+  /**
+   * Delay the request.
+   */
+  DELAY,
+  /**
+   * Reject the request.
+   */
+  REJECT
+}

--- a/ambry-api/src/main/java/com/github/ambry/quota/QuotaRecommendation.java
+++ b/ambry-api/src/main/java/com/github/ambry/quota/QuotaRecommendation.java
@@ -15,35 +15,35 @@ package com.github.ambry.quota;
 
 /**
  * Class representing recommendation made by a {@link QuotaEnforcer} implementation. QuotaEnforcer
- * implementations can use this object to provide a boolean recommendation to throttle the
- * request or not, along with usage information like usage percentage, name of the quota for which this recommendation
- * was made and the recommended http status (indicating whether or not throttled request should be retried).
+ * implementations can use this object to specify a {@link QuotaAction}, as action recommended to ensure quota
+ * compliance, along with percentage usage and name of the quota for which this recommendation was made.
  */
 public class QuotaRecommendation {
-  private final boolean shouldThrottle;
+  private final QuotaAction quotaAction;
   private final float usagePercentage;
   private final QuotaName quotaName;
   private final long retryAfterMs;
+  public final static long NO_THROTTLE_RETRY_AFTER_MS = -1;
 
   /**
    * Constructor for {@link QuotaRecommendation}.
-   * @param shouldThrottle boolean flag indicating throttling recommendation.
+   * @param quotaAction the {@link QuotaAction} recommended.
    * @param usagePercentage percentage of resource usage.
    * @param quotaName name of the enforcement that made the recommendation.
    * @param retryAfterMs time after which request can be retried.
    */
-  public QuotaRecommendation(boolean shouldThrottle, float usagePercentage, QuotaName quotaName, long retryAfterMs) {
-    this.shouldThrottle = shouldThrottle;
+  public QuotaRecommendation(QuotaAction quotaAction, float usagePercentage, QuotaName quotaName, long retryAfterMs) {
+    this.quotaAction = quotaAction;
     this.usagePercentage = usagePercentage;
     this.quotaName = quotaName;
     this.retryAfterMs = retryAfterMs;
   }
 
   /**
-   * @return true if recommendation is to throttle. false otherwise.
+   * @return QuotaAction object representing the recommended action.
    */
-  public boolean shouldThrottle() {
-    return shouldThrottle;
+  public QuotaAction getQuotaAction() {
+    return quotaAction;
   }
 
   /**
@@ -62,7 +62,7 @@ public class QuotaRecommendation {
 
   /**
    * @return the time interval in milliseconds after the request can be retried.
-   * If request is not throttled then returns -1.
+   * If request is not throttled then returns NO_THROTTLE_RETRY_AFTER_MS.
    */
   public long getRetryAfterMs() {
     return retryAfterMs;

--- a/ambry-api/src/main/java/com/github/ambry/quota/ThrottlingRecommendation.java
+++ b/ambry-api/src/main/java/com/github/ambry/quota/ThrottlingRecommendation.java
@@ -13,7 +13,6 @@
  */
 package com.github.ambry.quota;
 
-import io.netty.handler.codec.http.HttpResponseStatus;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -24,25 +23,22 @@ import java.util.Map;
  */
 public class ThrottlingRecommendation {
   public static final long NO_RETRY_AFTER_MS = -1; // No retry needed when request is not throttled.
-  private final boolean throttle;
+  private final QuotaAction quotaAction;
   private final Map<QuotaName, Float> quotaUsagePercentage;
-  private final HttpResponseStatus recommendedHttpStatus;
   private final long retryAfterMs;
   private final QuotaUsageLevel quotaUsageLevel;
 
   /**
    * Constructor for {@link ThrottlingRecommendation}.
-   * @param throttle flag indicating if request should be throttled.
+   * @param quotaAction {@link QuotaAction} object as the recommended action to take.
    * @param quotaUsagePercentage A {@link Map} of {@link QuotaName} to usage percentage.
-   * @param recommendedHttpStatus {@link HttpResponseStatus} representing overall recommended http status.
    * @param retryAfterMs time in ms after which request should be retried. -1 if request is not throttled.
    * @param quotaUsageLevel {@link QuotaUsageLevel} object.
    */
-  public ThrottlingRecommendation(boolean throttle, Map<QuotaName, Float> quotaUsagePercentage,
-      HttpResponseStatus recommendedHttpStatus, long retryAfterMs, QuotaUsageLevel quotaUsageLevel) {
-    this.throttle = throttle;
+  public ThrottlingRecommendation(QuotaAction quotaAction, Map<QuotaName, Float> quotaUsagePercentage,
+      long retryAfterMs, QuotaUsageLevel quotaUsageLevel) {
+    this.quotaAction = quotaAction;
     this.quotaUsagePercentage = new HashMap<>(quotaUsagePercentage);
-    this.recommendedHttpStatus = recommendedHttpStatus;
     this.retryAfterMs = retryAfterMs;
     this.quotaUsageLevel = quotaUsageLevel;
   }
@@ -51,7 +47,21 @@ public class ThrottlingRecommendation {
    * @return true if recommendation is to throttle. false otherwise.
    */
   public boolean shouldThrottle() {
-    return this.throttle;
+    return this.quotaAction == QuotaAction.REJECT || this.quotaAction == QuotaAction.DELAY;
+  }
+
+  /**
+   * @return true if recommendation is to delay request. false otherwise.
+   */
+  public boolean shouldDelay() {
+    return this.quotaAction == QuotaAction.DELAY;
+  }
+
+  /**
+   * @return true if recommendation is to reject request. false otherwise.
+   */
+  public boolean shouldReject() {
+    return this.quotaAction == QuotaAction.REJECT;
   }
 
   /**
@@ -59,13 +69,6 @@ public class ThrottlingRecommendation {
    */
   public Map<QuotaName, Float> getQuotaUsagePercentage() {
     return Collections.unmodifiableMap(this.quotaUsagePercentage);
-  }
-
-  /**
-   * @return http status recommended.
-   */
-  public HttpResponseStatus getRecommendedHttpStatus() {
-    return this.recommendedHttpStatus;
   }
 
   /**
@@ -80,5 +83,12 @@ public class ThrottlingRecommendation {
    */
   public QuotaUsageLevel getQuotaUsageLevel() {
     return quotaUsageLevel;
+  }
+
+  /**
+   * @return QuotaAction object.
+   */
+  public QuotaAction getQuotaAction() {
+    return quotaAction;
   }
 }

--- a/ambry-api/src/test/java/com/github/ambry/quota/QuotaActionSeverityTest.java
+++ b/ambry-api/src/test/java/com/github/ambry/quota/QuotaActionSeverityTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.quota;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+
+/**
+ * Tests that {@link QuotaAction#compareTo} returns correct ordering.
+ */
+public class QuotaActionSeverityTest {
+  @Test
+  public void severityOrderingTest() {
+    // 1. test that Reject > Allow
+    Assert.assertTrue(QuotaAction.REJECT.compareTo(QuotaAction.ALLOW) > 0);
+
+    // 2. test that Reject > Delay
+    Assert.assertTrue(QuotaAction.REJECT.compareTo(QuotaAction.DELAY) > 0);
+
+    // 3. test that Delay > Allow
+    Assert.assertTrue(QuotaAction.DELAY.compareTo(QuotaAction.ALLOW) > 0);
+
+    // 4. test that Delay < Reject
+    Assert.assertTrue(QuotaAction.DELAY.compareTo(QuotaAction.REJECT) < 0);
+
+    // 5. test that Allow < Reject
+    Assert.assertTrue(QuotaAction.ALLOW.compareTo(QuotaAction.REJECT) < 0);
+
+    // 6. test that Allow < Delay
+    Assert.assertTrue(QuotaAction.ALLOW.compareTo(QuotaAction.DELAY) < 0);
+  }
+}

--- a/ambry-api/src/test/java/com/github/ambry/quota/ThrottlingRecommendationTest.java
+++ b/ambry-api/src/test/java/com/github/ambry/quota/ThrottlingRecommendationTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.quota;
+
+import java.util.Collections;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+/**
+ * Test of {@link ThrottlingRecommendation}.
+ */
+public class ThrottlingRecommendationTest {
+  private static final Map<QuotaName, Float> USAGE_MAP = Collections.emptyMap();
+  private static final long retryAfterMs = -1;
+  private static final QuotaUsageLevel quotaUsageLevel = QuotaUsageLevel.EXCEEDED;
+
+  @Test
+  public void testShouldThrottle() {
+    Assert.assertFalse(
+        new ThrottlingRecommendation(QuotaAction.ALLOW, USAGE_MAP, retryAfterMs, quotaUsageLevel).shouldThrottle());
+    Assert.assertTrue(
+        new ThrottlingRecommendation(QuotaAction.REJECT, USAGE_MAP, retryAfterMs, quotaUsageLevel).shouldThrottle());
+    Assert.assertTrue(
+        new ThrottlingRecommendation(QuotaAction.DELAY, USAGE_MAP, retryAfterMs, quotaUsageLevel).shouldThrottle());
+  }
+
+  @Test
+  public void testShouldDelay() {
+    Assert.assertFalse(
+        new ThrottlingRecommendation(QuotaAction.ALLOW, USAGE_MAP, retryAfterMs, quotaUsageLevel).shouldDelay());
+    Assert.assertFalse(
+        new ThrottlingRecommendation(QuotaAction.REJECT, USAGE_MAP, retryAfterMs, quotaUsageLevel).shouldDelay());
+    Assert.assertTrue(
+        new ThrottlingRecommendation(QuotaAction.DELAY, USAGE_MAP, retryAfterMs, quotaUsageLevel).shouldDelay());
+  }
+
+  @Test
+  public void testShouldReject() {
+    Assert.assertFalse(
+        new ThrottlingRecommendation(QuotaAction.ALLOW, USAGE_MAP, retryAfterMs, quotaUsageLevel).shouldReject());
+    Assert.assertTrue(
+        new ThrottlingRecommendation(QuotaAction.REJECT, USAGE_MAP, retryAfterMs, quotaUsageLevel).shouldReject());
+    Assert.assertFalse(
+        new ThrottlingRecommendation(QuotaAction.DELAY, USAGE_MAP, retryAfterMs, quotaUsageLevel).shouldReject());
+  }
+}

--- a/ambry-quota/src/main/java/com/github/ambry/quota/QuotaUtils.java
+++ b/ambry-quota/src/main/java/com/github/ambry/quota/QuotaUtils.java
@@ -87,13 +87,14 @@ public class QuotaUtils {
    * Build {@link QuotaChargeCallback} to handle quota compliance of requests.
    * @param restRequest {@link RestRequest} for which quota is being charged.
    * @param quotaManager {@link QuotaManager} object responsible for charging the quota.
-   * @param shouldThrottle flag indicating if request should be throttled after charging. Requests like updatettl, delete etc need not be throttled.
+   * @param isQuotaEnforcedOnRequest flag indicating if request quota should be enforced after charging. Requests like
+   *                                 updatettl, delete etc are charged, but quota is not enforced on them.
    * @return QuotaChargeCallback object.
    */
   public static QuotaChargeCallback buildQuotaChargeCallback(RestRequest restRequest, QuotaManager quotaManager,
-      boolean shouldThrottle) {
+      boolean isQuotaEnforcedOnRequest) {
     if (!quotaManager.getQuotaConfig().bandwidthThrottlingFeatureEnabled) {
-      return new RejectingQuotaChargeCallback(quotaManager, restRequest, shouldThrottle);
+      return new RejectingQuotaChargeCallback(quotaManager, restRequest, isQuotaEnforcedOnRequest);
     } else {
       throw new UnsupportedOperationException("Not implemented yet.");
     }

--- a/ambry-quota/src/main/java/com/github/ambry/quota/capacityunit/AmbryCapacityUnitQuotaEnforcer.java
+++ b/ambry-quota/src/main/java/com/github/ambry/quota/capacityunit/AmbryCapacityUnitQuotaEnforcer.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.quota.capacityunit;
 
+import com.github.ambry.quota.QuotaAction;
 import com.github.ambry.quota.QuotaEnforcer;
 import com.github.ambry.quota.QuotaName;
 import com.github.ambry.quota.QuotaRecommendation;
@@ -41,8 +42,8 @@ public class AmbryCapacityUnitQuotaEnforcer implements QuotaEnforcer {
    */
   public AmbryCapacityUnitQuotaEnforcer(QuotaSource quotaSource) {
     this.quotaSource = quotaSource;
-    this.allowReadRecommendation = new QuotaRecommendation(false, 0, QuotaName.READ_CAPACITY_UNIT, 0);
-    this.allowWriteRecommendation = new QuotaRecommendation(false, 0, QuotaName.WRITE_CAPACITY_UNIT, 0);
+    this.allowReadRecommendation = new QuotaRecommendation(QuotaAction.ALLOW, 0, QuotaName.READ_CAPACITY_UNIT, 0);
+    this.allowWriteRecommendation = new QuotaRecommendation(QuotaAction.ALLOW, 0, QuotaName.WRITE_CAPACITY_UNIT, 0);
   }
 
   @Override

--- a/ambry-quota/src/main/java/com/github/ambry/quota/storage/StorageQuotaEnforcer.java
+++ b/ambry-quota/src/main/java/com/github/ambry/quota/storage/StorageQuotaEnforcer.java
@@ -20,6 +20,7 @@ import com.github.ambry.account.Container;
 import com.github.ambry.accountstats.AccountStatsStore;
 import com.github.ambry.config.StorageQuotaConfig;
 import com.github.ambry.quota.Quota;
+import com.github.ambry.quota.QuotaAction;
 import com.github.ambry.quota.QuotaEnforcer;
 import com.github.ambry.quota.QuotaException;
 import com.github.ambry.quota.QuotaName;
@@ -56,7 +57,7 @@ public class StorageQuotaEnforcer implements QuotaEnforcer {
   private static final long BYTES_IN_GB = 1024 * 1024 * 1024;
   // The quota recommendation returned when there is no quota found for the given account/container.
   private static final QuotaRecommendation NO_QUOTA_VALUE_RECOMMENDATION =
-      new QuotaRecommendation(false, 0.0f, QuotaName.STORAGE_IN_GB, NO_RETRY);
+      new QuotaRecommendation(QuotaAction.ALLOW, 0.0f, QuotaName.STORAGE_IN_GB, NO_RETRY);
   protected final StorageUsageRefresher storageUsageRefresher;
   protected final QuotaSource quotaSource;
   protected final StorageQuotaConfig config;
@@ -150,9 +151,9 @@ public class StorageQuotaEnforcer implements QuotaEnforcer {
       // There is no quota set for the given account/container
       return NO_QUOTA_VALUE_RECOMMENDATION;
     }
-    boolean shouldThrottle = currentUsage >= quotaValue;
+    QuotaAction quotaAction = (currentUsage >= quotaValue) ? QuotaAction.REJECT : QuotaAction.ALLOW;
     float usagePercentage = currentUsage >= quotaValue ? 100f : ((float) currentUsage) / quotaValue * 100f;
-    return new QuotaRecommendation(shouldThrottle, usagePercentage, QuotaName.STORAGE_IN_GB, NO_RETRY);
+    return new QuotaRecommendation(quotaAction, usagePercentage, QuotaName.STORAGE_IN_GB, NO_RETRY);
   }
 
   @Override

--- a/ambry-test-utils/src/main/java/com/github/ambry/quota/RejectRequestQuotaEnforcer.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/quota/RejectRequestQuotaEnforcer.java
@@ -24,7 +24,6 @@ import java.util.Map;
  */
 public class RejectRequestQuotaEnforcer implements QuotaEnforcer {
   private static final float DUMMY_REJECTABLE_USAGE_PERCENTAGE = 101;
-  private static final boolean SHOULD_THROTTLE = true;
   private final QuotaSource quotaSource;
 
   /**
@@ -46,7 +45,7 @@ public class RejectRequestQuotaEnforcer implements QuotaEnforcer {
 
   @Override
   public QuotaRecommendation recommend(RestRequest restRequest) {
-    return new QuotaRecommendation(SHOULD_THROTTLE, DUMMY_REJECTABLE_USAGE_PERCENTAGE, QuotaName.READ_CAPACITY_UNIT, 1);
+    return new QuotaRecommendation(QuotaAction.REJECT, DUMMY_REJECTABLE_USAGE_PERCENTAGE, QuotaName.READ_CAPACITY_UNIT, 1);
   }
 
   @Override


### PR DESCRIPTION
For out of quota user/chunk requests, QuotaEnforcers can decide to either DELAY a request (in case of bandwidth/CU enforcers), or REJECT a request in case of storage request. This PR introduces QuotaAction to represent the recommended action by QuotaEnforcers and QuotaManager.