### PR TITLE
[BANDWIDTH_THROTTLING] Pass QuotaMetrics instead of MetricRegistry to AmbryQuotaManager.

### DIFF
--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/AmbrySecurityServiceTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/AmbrySecurityServiceTest.java
@@ -28,6 +28,7 @@ import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.messageformat.BlobInfo;
 import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.quota.AmbryQuotaManager;
+import com.github.ambry.quota.QuotaMetrics;
 import com.github.ambry.quota.SimpleQuotaRecommendationMergePolicy;
 import com.github.ambry.quota.QuotaManager;
 import com.github.ambry.quota.QuotaMode;
@@ -131,7 +132,7 @@ public class AmbrySecurityServiceTest {
       QuotaConfig quotaConfig = QuotaTestUtils.createQuotaConfig(Collections.emptyMap(), false, QuotaMode.TRACKING);
       QUOTA_MANAGER =
           new AmbryQuotaManager(quotaConfig, new SimpleQuotaRecommendationMergePolicy(quotaConfig), mock(AccountService.class), null,
-              new MetricRegistry());
+              new QuotaMetrics(new MetricRegistry()));
     } catch (Exception e) {
       throw new IllegalStateException(e);
     }

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceFactoryTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceFactoryTest.java
@@ -23,6 +23,7 @@ import com.github.ambry.config.FrontendConfig;
 import com.github.ambry.config.QuotaConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.quota.AmbryQuotaManager;
+import com.github.ambry.quota.QuotaMetrics;
 import com.github.ambry.quota.SimpleQuotaRecommendationMergePolicy;
 import com.github.ambry.quota.QuotaManager;
 import com.github.ambry.quota.QuotaMode;
@@ -50,7 +51,7 @@ public class FrontendRestRequestServiceFactoryTest {
       QuotaConfig quotaConfig = QuotaTestUtils.createQuotaConfig(Collections.emptyMap(), false, QuotaMode.TRACKING);
       QUOTA_MANAGER =
           new AmbryQuotaManager(quotaConfig, new SimpleQuotaRecommendationMergePolicy(quotaConfig), Mockito.mock(AccountService.class),
-              null, new MetricRegistry());
+              null, new QuotaMetrics(new MetricRegistry()));
     } catch (Exception e) {
       throw new IllegalStateException(e);
     }

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
@@ -42,6 +42,7 @@ import com.github.ambry.named.NamedBlobDb;
 import com.github.ambry.named.NamedBlobRecord;
 import com.github.ambry.protocol.GetOption;
 import com.github.ambry.quota.AmbryQuotaManager;
+import com.github.ambry.quota.QuotaMetrics;
 import com.github.ambry.quota.SimpleQuotaRecommendationMergePolicy;
 import com.github.ambry.quota.QuotaChargeCallback;
 import com.github.ambry.quota.QuotaManager;
@@ -138,7 +139,7 @@ public class FrontendRestRequestServiceTest {
       QuotaConfig quotaConfig = QuotaTestUtils.createQuotaConfig(Collections.emptyMap(), false, QuotaMode.TRACKING);
       QUOTA_MANAGER =
           new AmbryQuotaManager(quotaConfig, new SimpleQuotaRecommendationMergePolicy(quotaConfig),
-              Mockito.mock(AccountService.class), null, new MetricRegistry());
+              Mockito.mock(AccountService.class), null, new QuotaMetrics(new MetricRegistry()));
     } catch (Exception e) {
       throw new IllegalStateException(e);
     }

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/PostBlobHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/PostBlobHandlerTest.java
@@ -30,6 +30,7 @@ import com.github.ambry.config.QuotaConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.quota.AmbryQuotaManager;
+import com.github.ambry.quota.QuotaMetrics;
 import com.github.ambry.quota.SimpleQuotaRecommendationMergePolicy;
 import com.github.ambry.quota.QuotaManager;
 import com.github.ambry.quota.QuotaMode;
@@ -113,7 +114,7 @@ public class PostBlobHandlerTest {
         QuotaConfig quotaConfig = QuotaTestUtils.createQuotaConfig(Collections.emptyMap(), false, QuotaMode.TRACKING);
         QUOTA_MANAGER =
             new AmbryQuotaManager(quotaConfig, new SimpleQuotaRecommendationMergePolicy(quotaConfig),
-                Mockito.mock(AccountService.class), null, new MetricRegistry());
+                Mockito.mock(AccountService.class), null, new QuotaMetrics(new MetricRegistry()));
       } catch (Exception e) {
         throw new IllegalStateException(e);
       }

--- a/ambry-quota/src/main/java/com/github/ambry/quota/AmbryQuotaManager.java
+++ b/ambry-quota/src/main/java/com/github/ambry/quota/AmbryQuotaManager.java
@@ -13,7 +13,6 @@
  */
 package com.github.ambry.quota;
 
-import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.github.ambry.account.Account;
 import com.github.ambry.account.AccountService;
@@ -54,11 +53,11 @@ public class AmbryQuotaManager implements QuotaManager {
    * @param quotaRecommendationMergePolicy {@link QuotaRecommendationMergePolicy} object that makes the overall recommendation.
    * @param accountService {@link AccountService} object to get all the accounts and container information.
    * @param accountStatsStore {@link AccountStatsStore} object to get all the account stats related information.
-   * @param metricRegistry {@link MetricRegistry} object for creating quota metrics.
+   * @param quotaMetrics {@link QuotaMetrics} object.
    * @throws ReflectiveOperationException in case of any exception.
    */
   public AmbryQuotaManager(QuotaConfig quotaConfig, QuotaRecommendationMergePolicy quotaRecommendationMergePolicy,
-      AccountService accountService, AccountStatsStore accountStatsStore, MetricRegistry metricRegistry)
+      AccountService accountService, AccountStatsStore accountStatsStore, QuotaMetrics quotaMetrics)
       throws ReflectiveOperationException {
     Map<String, String> quotaEnforcerSourceMap =
         parseQuotaEnforcerAndSourceInfo(quotaConfig.requestQuotaEnforcerSourcePairInfoJson);
@@ -72,7 +71,7 @@ public class AmbryQuotaManager implements QuotaManager {
     }
     this.quotaRecommendationMergePolicy = quotaRecommendationMergePolicy;
     this.quotaConfig = quotaConfig;
-    this.quotaMetrics = new QuotaMetrics(metricRegistry);
+    this.quotaMetrics = quotaMetrics;
     this.quotaMode = quotaConfig.throttlingMode;
     accountService.addAccountUpdateConsumer(this::onAccountUpdateNotification);
   }

--- a/ambry-quota/src/main/java/com/github/ambry/quota/AmbryQuotaManagerFactory.java
+++ b/ambry-quota/src/main/java/com/github/ambry/quota/AmbryQuotaManagerFactory.java
@@ -37,7 +37,7 @@ public class AmbryQuotaManagerFactory implements QuotaManagerFactory {
       QuotaRecommendationMergePolicy quotaRecommendationMergePolicy, AccountService accountService,
       AccountStatsStore accountStatsStore, MetricRegistry metricRegistry) throws ReflectiveOperationException {
     quotaManager = new AmbryQuotaManager(quotaConfig, quotaRecommendationMergePolicy, accountService, accountStatsStore,
-        metricRegistry);
+        new QuotaMetrics(metricRegistry));
   }
 
   @Override

--- a/ambry-quota/src/test/java/com/github/ambry/quota/AmbryQuotaManagerUpdateNotificationTest.java
+++ b/ambry-quota/src/test/java/com/github/ambry/quota/AmbryQuotaManagerUpdateNotificationTest.java
@@ -53,7 +53,8 @@ public class AmbryQuotaManagerUpdateNotificationTest {
         new AccountServiceForConsumerTest(new AccountServiceConfig(verifiableProperties),
             new AccountServiceMetrics(metricRegistry), null);
     AmbryQuotaManager ambryQuotaManager =
-        new AmbryQuotaManager(quotaConfig, quotaRecommendationMergePolicy, accountService, null, metricRegistry);
+        new AmbryQuotaManager(quotaConfig, quotaRecommendationMergePolicy, accountService, null,
+            new QuotaMetrics(metricRegistry));
     UnlimitedQuotaSource quotaSource = (UnlimitedQuotaSource) getQuotaSourceMember(ambryQuotaManager);
     assertTrue("updated accounts should be empty", quotaSource.getQuotaResourceList().isEmpty());
 

--- a/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterQuotaCallbackTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterQuotaCallbackTest.java
@@ -27,6 +27,7 @@ import com.github.ambry.quota.QuotaChargeCallback;
 import com.github.ambry.quota.QuotaException;
 import com.github.ambry.quota.QuotaManager;
 import com.github.ambry.quota.QuotaMethod;
+import com.github.ambry.quota.QuotaMetrics;
 import com.github.ambry.quota.QuotaMode;
 import com.github.ambry.quota.QuotaName;
 import com.github.ambry.quota.QuotaRecommendationMergePolicy;
@@ -313,7 +314,8 @@ public class NonBlockingRouterQuotaCallbackTest extends NonBlockingRouterTestBas
         QuotaRecommendationMergePolicy quotaRecommendationMergePolicy, AccountService accountService,
         AccountStatsStore accountStatsStore, MetricRegistry metricRegistry, AtomicInteger chargeCalledCount)
         throws ReflectiveOperationException {
-      super(quotaConfig, quotaRecommendationMergePolicy, accountService, accountStatsStore, metricRegistry);
+      super(quotaConfig, quotaRecommendationMergePolicy, accountService, accountStatsStore,
+          new QuotaMetrics(metricRegistry));
       this.chargeCalledCount = chargeCalledCount;
     }
 


### PR DESCRIPTION
This PR changes the AmbryQuotaManager constructor to get QuotaMetrics object, instead of MetricRegistry object. The main reason for this change is that in upcoming PRs, AmbryQuotaManager will be inherited. Its cleaner to pass the QuotaMetrics object to the inherited class, than to make quotaMetrics object in base class protected.