### PR TITLE
[BANDWIDTH_THROTTLING] Add a boolean flag to ResponseInfo, so that OperationTrackers can react to quota related rejections, and ultimately non quota compliant requests can be rejected.

### DIFF
--- a/ambry-network/src/main/java/com/github/ambry/network/SocketNetworkClient.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/SocketNetworkClient.java
@@ -351,7 +351,7 @@ public class SocketNetworkClient implements NetworkClient {
               connId, dataNodeId);
           // Explicitly set requestInfo = null in ResponseInfo, the OperationController should detect this and directly
           // notify ResponseHandler without handing it over to PutManager/GetManager/DeleteManager/TtlUpdateManager.
-          responseInfoList.add(new ResponseInfo(null, NetworkClientErrorCode.NetworkError, null, dataNodeId));
+          responseInfoList.add(new ResponseInfo(null, NetworkClientErrorCode.NetworkError, null, dataNodeId, false));
           // No need to call pendingRequests.remove() because it has been removed due to connection unavailability in prepareSends()
         }
       }

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2NetworkClient.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2NetworkClient.java
@@ -197,7 +197,7 @@ public class Http2NetworkClient implements NetworkClient {
                 successCount.incrementAndGet();
               } else {
                 failCount.incrementAndGet();
-                responseInfoList.add(new ResponseInfo(null, NetworkClientErrorCode.NetworkError, null, dataNodeId));
+                responseInfoList.add(new ResponseInfo(null, NetworkClientErrorCode.NetworkError, null, dataNodeId, false));
                 logger.error("Couldn't acquire stream channel to {}:{} . Cause: {}.", dataNodeId.getHostname(),
                     dataNodeId.getHttp2Port(), future.cause());
               }

--- a/ambry-router/src/main/java/com/github/ambry/router/AdaptiveOperationTracker.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/AdaptiveOperationTracker.java
@@ -96,6 +96,9 @@ class AdaptiveOperationTracker extends SimpleOperationTracker {
   @Override
   public void onResponse(ReplicaId replicaId, TrackedRequestFinalState trackedRequestFinalState) {
     super.onResponse(replicaId, trackedRequestFinalState);
+    if (trackedRequestFinalState == TrackedRequestFinalState.QUOTA_REJECTED) {
+      return;
+    }
     long elapsedTime;
     if (unexpiredRequestSendTimes.containsKey(replicaId)) {
       elapsedTime = time.milliseconds() - unexpiredRequestSendTimes.remove(replicaId).getSecond();
@@ -107,8 +110,8 @@ class AdaptiveOperationTracker extends SimpleOperationTracker {
       getLatencyHistogram(replicaId).update(elapsedTime);
       if (routerConfig.routerOperationTrackerMetricScope != OperationTrackerScope.Datacenter) {
         // This is only used to report whole datacenter histogram for monitoring purpose
-        Histogram histogram =
-            replicaId.getDataNodeId().getDatacenterName().equals(datacenterName) ? localDcHistogram : crossDcHistogram;
+        Histogram histogram = replicaId.getDataNodeId().getDatacenterName().equals(datacenterName) ? localDcHistogram
+            : crossDcHistogram;
         histogram.update(elapsedTime);
       }
     }

--- a/ambry-router/src/main/java/com/github/ambry/router/RouterUtils.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/RouterUtils.java
@@ -205,6 +205,9 @@ public class RouterUtils {
       NonBlockingRouterMetrics routerMetrics, ResponseInfo responseInfo, Deserializer<R> deserializer,
       Function<R, ServerErrorCode> errorExtractor) {
     R response = null;
+    if (responseInfo.isQuotaRejected()) {
+      return response;
+    }
     ReplicaId replicaId = responseInfo.getRequestInfo().getReplicaId();
     NetworkClientErrorCode networkClientErrorCode = responseInfo.getError();
     if (networkClientErrorCode == null) {

--- a/ambry-router/src/main/java/com/github/ambry/router/SimpleOperationTracker.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/SimpleOperationTracker.java
@@ -92,6 +92,7 @@ class SimpleOperationTracker implements OperationTracker {
   protected int diskReplicaInPoolOrFlightCount = 0;
   protected int cloudReplicaInPoolOrFlightCount = 0;
   protected int failedCount = 0;
+  protected boolean quotaRejected = false;
   protected int disabledCount = 0;
   protected int originatingDcNotFoundCount = 0;
   protected int totalNotFoundCount = 0;
@@ -410,6 +411,9 @@ class SimpleOperationTracker implements OperationTracker {
       case REQUEST_DISABLED:
         disabledCount++;
         break;
+      case QUOTA_REJECTED:
+        quotaRejected = true;
+        break;
       default:
         failedCount++;
         // NOT_FOUND is a special error. When tracker sees >= numReplicasInOriginatingDc - 1 "NOT_FOUND" from the
@@ -485,6 +489,9 @@ class SimpleOperationTracker implements OperationTracker {
   }
 
   public boolean hasFailed() {
+    if (quotaRejected) {
+      return true;
+    }
     if (routerOperation == RouterOperation.PutOperation && routerConfig.routerPutUseDynamicSuccessTarget
         && diskReplicasPresent) {
       return totalReplicaCount - failedCount < Math.max(totalReplicaCount - 1,

--- a/ambry-router/src/main/java/com/github/ambry/router/TrackedRequestFinalState.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/TrackedRequestFinalState.java
@@ -19,7 +19,7 @@ package com.github.ambry.router;
  * consumed by operation tracker to change success/failure counter and determine whether to update Histograms.
  */
 public enum TrackedRequestFinalState {
-  SUCCESS, FAILURE, TIMED_OUT, NOT_FOUND, REQUEST_DISABLED, DISK_DOWN;
+  SUCCESS, FAILURE, TIMED_OUT, NOT_FOUND, REQUEST_DISABLED, DISK_DOWN, QUOTA_REJECTED;
 
   /**
    *  Return the corresponding {@link TrackedRequestFinalState}  for the given {@link RouterErrorCode}.
@@ -32,6 +32,8 @@ public enum TrackedRequestFinalState {
         return TIMED_OUT;
       case BlobDoesNotExist:
         return NOT_FOUND;
+      case TooManyRequests:
+        return QUOTA_REJECTED;
       default:
         return FAILURE;
     }

--- a/ambry-router/src/main/java/com/github/ambry/router/UndeleteOperationTracker.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/UndeleteOperationTracker.java
@@ -86,6 +86,9 @@ public class UndeleteOperationTracker extends SimpleOperationTracker {
 
   @Override
   public boolean hasFailed() {
+    if (quotaRejected) {
+      return true;
+    }
     return hasReachedAnyLocalQuorum(numReplicasInDcs, numFailureInDcs);
   }
 

--- a/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTest.java
@@ -1236,7 +1236,7 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
       doNothing().when(mockNetworkClient).close();
       List<ResponseInfo> responseInfoList = new ArrayList<>();
       MockDataNodeId testDataNode = (MockDataNodeId) mockClusterMap.getDataNodeIds().get(0);
-      responseInfoList.add(new ResponseInfo(null, NetworkClientErrorCode.NetworkError, null, testDataNode));
+      responseInfoList.add(new ResponseInfo(null, NetworkClientErrorCode.NetworkError, null, testDataNode, false));
       // By default, there are 1 operation controller and 1 background deleter thread. We set CountDownLatch to 3 so that
       // at least one thread has completed calling onResponse() and test node's state has been updated in ResponseHandler
       CountDownLatch invocationLatch = new CountDownLatch(3);

--- a/ambry-router/src/test/java/com/github/ambry/router/RouterUtilsTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/RouterUtilsTest.java
@@ -25,6 +25,7 @@ import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.CommonTestUtils;
+import com.github.ambry.network.ResponseInfo;
 import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.Utils;
 import java.util.Arrays;
@@ -151,5 +152,11 @@ public class RouterUtilsTest {
     accountContainer = RouterUtils.getAccountContainer(accountService, accountId, containerId);
     Assert.assertEquals("Account doesn't match", account, accountContainer.getFirst());
     Assert.assertEquals("Container doesn't match", container, accountContainer.getSecond());
+  }
+
+  @Test
+  public void testExtractResponseAndNotifyResponseHandler() {
+    ResponseInfo responseInfo = new ResponseInfo(null, true);
+    assertNull(RouterUtils.extractResponseAndNotifyResponseHandler(null, null, responseInfo, null, null));
   }
 }

--- a/ambry-router/src/test/java/com/github/ambry/router/TrackedRequestFinalStateTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/TrackedRequestFinalStateTest.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.router;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+/**
+ * Tests for {@link TrackedRequestFinalState}.
+ */
+public class TrackedRequestFinalStateTest {
+
+  /**
+   * Tests for {@link TrackedRequestFinalState#fromRouterErrorCodeToFinalState}.
+   */
+  @Test
+  public void testFromRouterErrorCodeToFinalState() {
+    Assert.assertEquals(TrackedRequestFinalState.TIMED_OUT,
+        TrackedRequestFinalState.fromRouterErrorCodeToFinalState(RouterErrorCode.OperationTimedOut));
+    Assert.assertEquals(TrackedRequestFinalState.NOT_FOUND,
+        TrackedRequestFinalState.fromRouterErrorCodeToFinalState(RouterErrorCode.BlobDoesNotExist));
+    Assert.assertEquals(TrackedRequestFinalState.QUOTA_REJECTED,
+        TrackedRequestFinalState.fromRouterErrorCodeToFinalState(RouterErrorCode.TooManyRequests));
+
+    Set<RouterErrorCode> checkedErrorCodes = new HashSet<>(
+        Arrays.asList(RouterErrorCode.OperationTimedOut, RouterErrorCode.BlobDoesNotExist,
+            RouterErrorCode.TooManyRequests));
+    for (RouterErrorCode routerErrorCode : RouterErrorCode.values()) {
+      if (!checkedErrorCodes.contains(routerErrorCode)) {
+        Assert.assertEquals(TrackedRequestFinalState.FAILURE,
+            TrackedRequestFinalState.fromRouterErrorCodeToFinalState(routerErrorCode));
+      }
+    }
+  }
+}


### PR DESCRIPTION
OperationControllers need to reject certain non quota compliant requests. This PR adds a boolean flag to ResponseInfo, so that OperationTrackers can react to quota related rejections, and ultimately non quota compliant requests can be rejected.

Note that each operation still needs to handle the exception in its `handleResponse` method and needs to throw appropriate exception back to user. That PR will come later.

OperationController doesn't throw exception to reject requests currently. That PR will come later.