### PR TITLE
[BANDWIDTH_THROTTLING] If bandwidth throttling is enabled, quota charge shouldn't happen after chunk requests are processed.

### DIFF
--- a/ambry-quota/src/main/java/com/github/ambry/quota/QuotaUtils.java
+++ b/ambry-quota/src/main/java/com/github/ambry/quota/QuotaUtils.java
@@ -90,6 +90,16 @@ public class QuotaUtils {
     }
   }
 
+  /**
+   * @param quotaChargeCallback {@link QuotaChargeCallback} object.
+   * @return {@code true} if the charge needs to happen AFTER a request is processed. {@code false} otherwise.
+   */
+  public static boolean postProcessCharge(QuotaChargeCallback quotaChargeCallback) {
+    // Bandwidth throttling based implementation of quota enforcement will need ensure quota compliance BEFORE sending
+    // the chunk request to server. Hence return false if bandwidth throttling feature is enabled.
+    return quotaChargeCallback != null && !quotaChargeCallback.getQuotaConfig().bandwidthThrottlingFeatureEnabled;
+  }
+
   /*
    * @return QuotaName of the CU quota associated with {@link RestRequest}.
    */

--- a/ambry-router/src/main/java/com/github/ambry/router/BatchOperationCallbackTracker.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/BatchOperationCallbackTracker.java
@@ -17,6 +17,7 @@ import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.Callback;
 import com.github.ambry.quota.QuotaChargeCallback;
 import com.github.ambry.quota.QuotaException;
+import com.github.ambry.quota.QuotaUtils;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -87,7 +88,7 @@ class BatchOperationCallbackTracker {
    */
   private void complete(Exception e) {
     if (completed.compareAndSet(false, true)) {
-      if (quotaChargeCallback != null) {
+      if (QuotaUtils.postProcessCharge(quotaChargeCallback)) {
         try {
           quotaChargeCallback.charge();
         } catch (QuotaException quotaException) {

--- a/ambry-router/src/main/java/com/github/ambry/router/DeleteOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/DeleteOperation.java
@@ -26,6 +26,7 @@ import com.github.ambry.protocol.DeleteRequest;
 import com.github.ambry.protocol.DeleteResponse;
 import com.github.ambry.quota.QuotaChargeCallback;
 import com.github.ambry.quota.QuotaException;
+import com.github.ambry.quota.QuotaUtils;
 import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.utils.Time;
 import java.util.Iterator;
@@ -317,7 +318,7 @@ class DeleteOperation {
         operationException.set(
             new RouterException("DeleteOperation failed because of BlobNotFound", RouterErrorCode.BlobDoesNotExist));
       }
-      if (quotaChargeCallback != null) {
+      if (QuotaUtils.postProcessCharge(quotaChargeCallback)) {
         try {
           quotaChargeCallback.charge();
         } catch (QuotaException quotaException) {

--- a/ambry-router/src/main/java/com/github/ambry/router/GetBlobInfoOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/GetBlobInfoOperation.java
@@ -33,6 +33,7 @@ import com.github.ambry.protocol.GetResponse;
 import com.github.ambry.protocol.PartitionResponseInfo;
 import com.github.ambry.quota.QuotaChargeCallback;
 import com.github.ambry.quota.QuotaException;
+import com.github.ambry.quota.QuotaUtils;
 import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.store.MessageInfo;
 import com.github.ambry.utils.Time;
@@ -447,7 +448,7 @@ class GetBlobInfoOperation extends GetOperation {
     }
 
     if (operationCompleted && operationCallbackInvoked.compareAndSet(false, true)) {
-      if (quotaChargeCallback != null) {
+      if (QuotaUtils.postProcessCharge(quotaChargeCallback)) {
         try {
           quotaChargeCallback.charge();
         } catch (QuotaException quotaException) {

--- a/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
@@ -43,6 +43,7 @@ import com.github.ambry.quota.QuotaChargeCallback;
 import com.github.ambry.quota.QuotaException;
 import com.github.ambry.quota.QuotaMethod;
 import com.github.ambry.quota.QuotaResource;
+import com.github.ambry.quota.QuotaUtils;
 import com.github.ambry.rest.RestServiceErrorCode;
 import com.github.ambry.rest.RestServiceException;
 import com.github.ambry.server.ServerErrorCode;
@@ -909,14 +910,14 @@ class GetBlobOperation extends GetOperation {
         chunkCompleted = true;
       }
       if (chunkCompleted) {
-        if (state != ChunkState.Complete && quotaChargeCallback != null && chunkException == null) {
+        if (state != ChunkState.Complete && QuotaUtils.postProcessCharge(quotaChargeCallback)
+            && chunkException == null) {
           try {
             if (chunkSize != -1) {
               quotaChargeCallback.charge(chunkSize);
             } else {
-              if (this instanceof FirstGetChunk && ((FirstGetChunk) this).blobType == BlobType.DataBlob
-                  && blobInfo != null) {
-                quotaChargeCallback.charge(blobInfo.getBlobProperties().getBlobSize());
+              if (this instanceof FirstGetChunk && ((FirstGetChunk) this).blobType == BlobType.DataBlob) {
+                quotaChargeCallback.charge(totalSize);
               }
               // other cases mean that either this was a metadata blob, or there was an error.
             }

--- a/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
@@ -42,6 +42,7 @@ import com.github.ambry.quota.QuotaChargeCallback;
 import com.github.ambry.quota.QuotaException;
 import com.github.ambry.quota.QuotaMethod;
 import com.github.ambry.quota.QuotaResource;
+import com.github.ambry.quota.QuotaUtils;
 import com.github.ambry.rest.NettyRequest;
 import com.github.ambry.rest.RestRequest;
 import com.github.ambry.server.ServerErrorCode;
@@ -1453,7 +1454,8 @@ class PutOperation {
       }
       if (done) {
         // the chunk is complete now. We can charge against quota for the chunk if its not a metadata chunk.
-        if (quotaChargeCallback != null && !(this instanceof MetadataPutChunk) && chunkException == null) {
+        if (QuotaUtils.postProcessCharge(quotaChargeCallback) && !(this instanceof MetadataPutChunk)
+            && chunkException == null) {
           try {
             quotaChargeCallback.charge(chunkBlobProperties.getBlobSize());
           } catch (QuotaException quotaException) {

--- a/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateOperation.java
@@ -26,6 +26,7 @@ import com.github.ambry.protocol.TtlUpdateRequest;
 import com.github.ambry.protocol.TtlUpdateResponse;
 import com.github.ambry.quota.QuotaChargeCallback;
 import com.github.ambry.quota.QuotaException;
+import com.github.ambry.quota.QuotaUtils;
 import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.utils.Time;
 import java.util.Iterator;
@@ -339,7 +340,7 @@ class TtlUpdateOperation {
         operationException.set(
             new RouterException("TtlUpdateOperation failed because of BlobNotFound", RouterErrorCode.BlobDoesNotExist));
       }
-      if (quotaChargeCallback != null) {
+      if (QuotaUtils.postProcessCharge(quotaChargeCallback)) {
         try {
           quotaChargeCallback.charge();
         } catch (QuotaException quotaException) {

--- a/ambry-router/src/main/java/com/github/ambry/router/UndeleteOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/UndeleteOperation.java
@@ -25,6 +25,7 @@ import com.github.ambry.protocol.UndeleteRequest;
 import com.github.ambry.protocol.UndeleteResponse;
 import com.github.ambry.quota.QuotaChargeCallback;
 import com.github.ambry.quota.QuotaException;
+import com.github.ambry.quota.QuotaUtils;
 import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.store.MessageInfo;
 import com.github.ambry.utils.Time;
@@ -366,7 +367,7 @@ public class UndeleteOperation {
         operationException.set(
             new RouterException("UndeleteOperation failed because of BlobNotFound", RouterErrorCode.BlobDoesNotExist));
       }
-      if (quotaChargeCallback != null) {
+      if (QuotaUtils.postProcessCharge(quotaChargeCallback)) {
         try {
           quotaChargeCallback.charge();
         } catch (QuotaException quotaException) {

--- a/ambry-router/src/test/java/com/github/ambry/router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/GetBlobOperationTest.java
@@ -31,6 +31,7 @@ import com.github.ambry.commons.LoggingNotificationSystem;
 import com.github.ambry.commons.ResponseHandler;
 import com.github.ambry.config.CryptoServiceConfig;
 import com.github.ambry.config.KMSConfig;
+import com.github.ambry.config.QuotaConfig;
 import com.github.ambry.config.RouterConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.messageformat.BlobAll;
@@ -156,7 +157,7 @@ public class GetBlobOperationTest {
 
   private final RequestRegistrationCallback<GetOperation> requestRegistrationCallback =
       new RequestRegistrationCallback<>(correlationIdToGetOperation);
-  private final QuotaChargeCallback quotaChargeCallback = QuotaTestUtils.createTestQuotaChargeCallback();
+  private final QuotaTestUtils.TestQuotaChargeCallback quotaChargeCallback;
 
   /**
    * A checker that either asserts that a get operation succeeds or returns the specified error code.
@@ -192,9 +193,11 @@ public class GetBlobOperationTest {
    */
   @Parameterized.Parameters
   public static List<Object[]> data() {
-    return Arrays.asList(new Object[][]{{SimpleOperationTracker.class.getSimpleName(), false},
-        {AdaptiveOperationTracker.class.getSimpleName(), false},
-        {AdaptiveOperationTracker.class.getSimpleName(), true}});
+    return Arrays.asList(new Object[][]{{SimpleOperationTracker.class.getSimpleName(), false, false},
+        {SimpleOperationTracker.class.getSimpleName(), false, true},
+        {AdaptiveOperationTracker.class.getSimpleName(), false, false},
+        {AdaptiveOperationTracker.class.getSimpleName(), false, true},
+        {AdaptiveOperationTracker.class.getSimpleName(), true, false}});
   }
 
   /**
@@ -202,8 +205,16 @@ public class GetBlobOperationTest {
    * and can be queried by the getBlob operations in the test.
    * @param operationTrackerType the type of {@link OperationTracker} to use.
    * @param testEncryption {@code true} if blobs need to be tested w/ encryption. {@code false} otherwise
+   * @param isBandwidthThrottlingEnabled value for
+   * {@link com.github.ambry.config.QuotaConfig#bandwidthThrottlingFeatureEnabled}.
    */
-  public GetBlobOperationTest(String operationTrackerType, boolean testEncryption) throws Exception {
+  public GetBlobOperationTest(String operationTrackerType, boolean testEncryption, boolean isBandwidthThrottlingEnabled)
+      throws Exception {
+    Properties properties = new Properties();
+    properties.setProperty(QuotaConfig.BANDWIDTH_THROTTLING_FEATURE_ENABLED,
+        String.valueOf(isBandwidthThrottlingEnabled));
+    QuotaConfig quotaConfig = new QuotaConfig(new VerifiableProperties(properties));
+    quotaChargeCallback = QuotaTestUtils.createTestQuotaChargeCallback(quotaConfig);
     this.operationTrackerType = operationTrackerType;
     this.testEncryption = testEncryption;
     // Defaults. Tests may override these and do new puts as appropriate.
@@ -375,6 +386,9 @@ public class GetBlobOperationTest {
       options = new GetBlobOptionsInternal(new GetBlobOptionsBuilder().operationType(operationType).build(), false,
           routerMetrics.ageAtGet);
       getAndAssertSuccess(false, false, expectedLifeVersion);
+      if (!quotaChargeCallback.getQuotaConfig().bandwidthThrottlingFeatureEnabled) {
+        Assert.assertEquals(i + 1, quotaChargeCallback.numChargeCalls);
+      }
     }
   }
 

--- a/ambry-test-utils/src/main/java/com/github/ambry/quota/QuotaTestUtils.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/quota/QuotaTestUtils.java
@@ -107,6 +107,15 @@ public class QuotaTestUtils {
   }
 
   /**
+   * Create an implementation of {@link QuotaChargeCallback} object for test.
+   * @param quotaConfig for the {@link QuotaChargeCallback} implementation.
+   * @return TestQuotaChargeCallback object.
+   */
+  public static TestQuotaChargeCallback createTestQuotaChargeCallback(QuotaConfig quotaConfig) {
+    return new TestQuotaChargeCallback(quotaConfig);
+  }
+
+  /**
    * Create {@link MockRestRequest} object using the specified {@link Account}, {@link Container} and {@link RestMethod}.
    * @param account {@link Account} object.
    * @param container {@link Container} object.
@@ -130,12 +139,33 @@ public class QuotaTestUtils {
    * An implementation of {@link QuotaChargeCallback} for tests.
    */
   public static class TestQuotaChargeCallback implements QuotaChargeCallback {
+    public int numChargeCalls = 0;
+    private final QuotaConfig quotaConfig;
+
+    /**
+     * Default constructor for {@link TestQuotaChargeCallback}.
+     */
+    public TestQuotaChargeCallback() {
+      this.quotaConfig = new QuotaConfig(new VerifiableProperties(new Properties()));
+    }
+
+    /**
+     * Constructor for {@link TestQuotaChargeCallback} with the specified {@link QuotaConfig}.
+     * @param quotaConfig {@link QuotaConfig} object.
+     */
+    public TestQuotaChargeCallback(QuotaConfig quotaConfig) {
+      this.quotaConfig = quotaConfig;
+    }
+
+
     @Override
     public void charge(long chunkSize) {
+      numChargeCalls++;
     }
 
     @Override
     public void charge() {
+      charge(quotaConfig.quotaAccountingUnit);
     }
 
     @Override
@@ -160,7 +190,7 @@ public class QuotaTestUtils {
 
     @Override
     public QuotaConfig getQuotaConfig() {
-      return new QuotaConfig(new VerifiableProperties(new Properties()));
+      return quotaConfig;
     }
   }
 }


### PR DESCRIPTION
With bandwidth throttling enabled, QuotaAwareOperationController will do the quota charges before chunk requests are sent over network.

Also introduces get QuotaConfig method in QuotaChargeCallback to access QuotaConfig in Operation classes.