### PR TITLE
[BANDWIDTH_THROTTLING] Rename QuotaTestUtils::createDummyQuotaChargeCallback to QuotaTestUtils::createTestQuotaChargeCallback

### DIFF
--- a/ambry-router/src/test/java/com/github/ambry/router/ChunkFillTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/ChunkFillTest.java
@@ -71,7 +71,7 @@ public class ChunkFillTest {
   private MockCryptoService cryptoService = null;
   private CryptoJobHandler cryptoJobHandler = null;
   private final QuotaChargeCallback quotaChargeCallback =
-      QuotaTestUtils.createDummyQuotaChargeCallback();
+      QuotaTestUtils.createTestQuotaChargeCallback();
 
   /**
    * Running for both regular and encrypted blobs

--- a/ambry-router/src/test/java/com/github/ambry/router/DeleteManagerTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/DeleteManagerTest.java
@@ -69,7 +69,7 @@ public class DeleteManagerTest {
   private String blobIdString;
   private PartitionId partition;
   private Future<Void> future;
-  private final QuotaChargeCallback quotaChargeCallback = QuotaTestUtils.createDummyQuotaChargeCallback();
+  private final QuotaChargeCallback quotaChargeCallback = QuotaTestUtils.createTestQuotaChargeCallback();
 
   /**
    * A checker that either asserts that a delete operation succeeds or returns the specified error code.

--- a/ambry-router/src/test/java/com/github/ambry/router/GetBlobInfoOperationTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/GetBlobInfoOperationTest.java
@@ -100,7 +100,7 @@ public class GetBlobInfoOperationTest {
   private final byte[] putContent;
   private final boolean testEncryption;
   private final String operationTrackerType;
-  private final QuotaChargeCallback quotaChargeCallback = QuotaTestUtils.createDummyQuotaChargeCallback();
+  private final QuotaChargeCallback quotaChargeCallback = QuotaTestUtils.createTestQuotaChargeCallback();
   private final RequestRegistrationCallback<GetOperation> requestRegistrationCallback =
       new RequestRegistrationCallback<>(correlationIdToGetOperation);
   private final GetBlobOptionsInternal options;

--- a/ambry-router/src/test/java/com/github/ambry/router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/GetBlobOperationTest.java
@@ -156,7 +156,7 @@ public class GetBlobOperationTest {
 
   private final RequestRegistrationCallback<GetOperation> requestRegistrationCallback =
       new RequestRegistrationCallback<>(correlationIdToGetOperation);
-  private final QuotaChargeCallback quotaChargeCallback = QuotaTestUtils.createDummyQuotaChargeCallback();
+  private final QuotaChargeCallback quotaChargeCallback = QuotaTestUtils.createTestQuotaChargeCallback();
 
   /**
    * A checker that either asserts that a get operation succeeds or returns the specified error code.

--- a/ambry-router/src/test/java/com/github/ambry/router/GetManagerTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/GetManagerTest.java
@@ -84,7 +84,7 @@ public class GetManagerTest {
   private GetBlobOptions options = new GetBlobOptionsBuilder().build();
   private List<ChunkInfo> chunkInfos;
   private final QuotaChargeCallback quotaChargeCallback =
-      QuotaTestUtils.createDummyQuotaChargeCallback();
+      QuotaTestUtils.createTestQuotaChargeCallback();
 
   /**
    * Pre-initialization common to all tests.

--- a/ambry-router/src/test/java/com/github/ambry/router/PutManagerTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/PutManagerTest.java
@@ -397,7 +397,7 @@ public class PutManagerTest {
         router.putBlob(req.putBlobProperties, req.putUserMetadata, putChannel, req.options, (result, exception) -> {
           callbackCalled.countDown();
           throw new RuntimeException("Throwing an exception in the user callback");
-        }, QuotaTestUtils.createDummyQuotaChargeCallback());
+        }, QuotaTestUtils.createTestQuotaChargeCallback());
     submitPutsAndAssertSuccess(false);
     //future.get() for operation with bad callback should still succeed
     future.get();

--- a/ambry-router/src/test/java/com/github/ambry/router/PutOperationTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/PutOperationTest.java
@@ -61,7 +61,7 @@ public class PutOperationTest {
   private final MockServer mockServer = new MockServer(mockClusterMap, "");
   private final RequestRegistrationCallback<PutOperation> requestRegistrationCallback =
       new RequestRegistrationCallback<>(correlationIdToPutOperation);
-  private final QuotaChargeCallback quotaChargeCallback = QuotaTestUtils.createDummyQuotaChargeCallback();
+  private final QuotaChargeCallback quotaChargeCallback = QuotaTestUtils.createTestQuotaChargeCallback();
   private final int chunkSize = 10;
   private final int requestParallelism = 3;
   private final int successTarget = 1;

--- a/ambry-router/src/test/java/com/github/ambry/router/TtlUpdateManagerTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/TtlUpdateManagerTest.java
@@ -86,7 +86,7 @@ public class TtlUpdateManagerTest {
   private final TtlUpdateNotificationSystem notificationSystem = new TtlUpdateNotificationSystem();
   private final int serverCount = serverLayout.getMockServers().size();
   private final AccountService accountService = new InMemAccountService(true, false);
-  private final QuotaChargeCallback quotaChargeCallback = QuotaTestUtils.createDummyQuotaChargeCallback();
+  private final QuotaChargeCallback quotaChargeCallback = QuotaTestUtils.createTestQuotaChargeCallback();
   private NettyByteBufLeakHelper nettyByteBufLeakHelper = new NettyByteBufLeakHelper();
 
   /**

--- a/ambry-router/src/test/java/com/github/ambry/router/UndeleteManagerTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/UndeleteManagerTest.java
@@ -76,7 +76,7 @@ public class UndeleteManagerTest {
   private static final String LOCAL_DC = "DC1";
   private final NonBlockingRouter router;
   private final RouterConfig routerConfig;
-  private final QuotaChargeCallback quotaChargeCallback = QuotaTestUtils.createDummyQuotaChargeCallback();
+  private final QuotaChargeCallback quotaChargeCallback = QuotaTestUtils.createTestQuotaChargeCallback();
   private final AtomicReference<MockSelectorState> mockSelectorState = new AtomicReference<>(MockSelectorState.Good);
   private final MockClusterMap clusterMap = new MockClusterMap();
   private final MockServerLayout serverLayout = new MockServerLayout(clusterMap);

--- a/ambry-server/src/integration-test/java/com/github/ambry/server/RouterServerTestFramework.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/RouterServerTestFramework.java
@@ -73,7 +73,7 @@ class RouterServerTestFramework {
   private final MockNotificationSystem notificationSystem;
   private final Router router;
   private boolean testEncryption = false;
-  private final QuotaChargeCallback quotaChargeCallback = QuotaTestUtils.createDummyQuotaChargeCallback();
+  private final QuotaChargeCallback quotaChargeCallback = QuotaTestUtils.createTestQuotaChargeCallback();
 
   final InMemAccountService accountService = new InMemAccountService(false, true);
 

--- a/ambry-server/src/integration-test/java/com/github/ambry/server/ServerTestUtil.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/ServerTestUtil.java
@@ -145,7 +145,7 @@ import static org.junit.Assert.*;
 
 final class ServerTestUtil {
   private static final QuotaChargeCallback QUOTA_CHARGE_EVENT_LISTENER =
-      QuotaTestUtils.createDummyQuotaChargeCallback();
+      QuotaTestUtils.createTestQuotaChargeCallback();
 
   static byte[] getBlobDataAndRelease(BlobData blobData) {
     byte[] actualBlobData = new byte[(int) blobData.getSize()];

--- a/ambry-test-utils/src/main/java/com/github/ambry/quota/QuotaTestUtils.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/quota/QuotaTestUtils.java
@@ -99,44 +99,11 @@ public class QuotaTestUtils {
   }
 
   /**
-   * Create a dummy {@link QuotaChargeCallback} object, that does nothing, for test.
-   * @return QuotaChargeCallback object.
+   * Create an implementation of {@link QuotaChargeCallback} object for test.
+   * @return TestQuotaChargeCallback object.
    */
-  public static QuotaChargeCallback createDummyQuotaChargeCallback() {
-    return new QuotaChargeCallback() {
-      @Override
-      public void charge(long chunkSize) {
-      }
-
-      @Override
-      public void charge() {
-      }
-
-      @Override
-      public boolean check() {
-        return false;
-      }
-
-      @Override
-      public boolean quotaExceedAllowed() {
-        return false;
-      }
-
-      @Override
-      public QuotaResource getQuotaResource() {
-        return new QuotaResource("test", QuotaResourceType.ACCOUNT);
-      }
-
-      @Override
-      public QuotaMethod getQuotaMethod() {
-        return null;
-      }
-
-      @Override
-      public QuotaConfig getQuotaConfig() {
-        return new QuotaConfig(new VerifiableProperties(new Properties()));
-      }
-    };
+  public static TestQuotaChargeCallback createTestQuotaChargeCallback() {
+    return new TestQuotaChargeCallback();
   }
 
   /**
@@ -157,5 +124,43 @@ public class QuotaTestUtils {
     headers.put(RestUtils.InternalKeys.TARGET_CONTAINER_KEY, container);
     data.put(MockRestRequest.HEADERS_KEY, headers);
     return new MockRestRequest(data, null);
+  }
+
+  /**
+   * An implementation of {@link QuotaChargeCallback} for tests.
+   */
+  public static class TestQuotaChargeCallback implements QuotaChargeCallback {
+    @Override
+    public void charge(long chunkSize) {
+    }
+
+    @Override
+    public void charge() {
+    }
+
+    @Override
+    public boolean check() {
+      return false;
+    }
+
+    @Override
+    public boolean quotaExceedAllowed() {
+      return false;
+    }
+
+    @Override
+    public QuotaResource getQuotaResource() {
+      return new QuotaResource("test", QuotaResourceType.ACCOUNT);
+    }
+
+    @Override
+    public QuotaMethod getQuotaMethod() {
+      return null;
+    }
+
+    @Override
+    public QuotaConfig getQuotaConfig() {
+      return new QuotaConfig(new VerifiableProperties(new Properties()));
+    }
   }
 }


### PR DESCRIPTION
This is done to prepare for writing future tests that will build on the implementation of TestQuotaChargeCallback class.