### PR TITLE
[BANDWIDTH_THROTTLING] Refactor QuotaChargeCallback and its implementations.

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/network/ResponseInfo.java
+++ b/ambry-api/src/main/java/com/github/ambry/network/ResponseInfo.java
@@ -25,7 +25,7 @@ import io.netty.util.ReferenceCountUtil;
  * Request associated with this response.
  * Either a non-null exception if there was an error sending the request or a non-null ByteBuffer containing the
  * successful response received for this request.
- * A flag to indicate if this request was rejected due quota non-compliance.
+ * A flag to indicate if this request was rejected due to quota non-compliance.
  * The {@link DataNodeId} to which the request is issued.
  */
 public class ResponseInfo extends AbstractByteBufHolder<ResponseInfo> {
@@ -46,7 +46,7 @@ public class ResponseInfo extends AbstractByteBufHolder<ResponseInfo> {
   /**
    * Constructs a ResponseInfo with the given parameters.
    * @param requestInfo the {@link RequestInfo} associated with this response.
-   * @param quotaRejected {@code true} if this request was rejected due quota non-compliance. {@code false} otherwise.
+   * @param quotaRejected {@code true} if this request was rejected due to quota non-compliance. {@code false} otherwise.
    */
   public ResponseInfo(RequestInfo requestInfo, boolean quotaRejected) {
     this(requestInfo, null, null, requestInfo == null ? null : requestInfo.getReplicaId().getDataNodeId(), quotaRejected);

--- a/ambry-api/src/main/java/com/github/ambry/quota/QuotaChargeCallback.java
+++ b/ambry-api/src/main/java/com/github/ambry/quota/QuotaChargeCallback.java
@@ -17,15 +17,58 @@ import com.github.ambry.config.QuotaConfig;
 
 
 /**
- * Callback for charging request cost against quota. Used by {@link QuotaEnforcer}s to charge quota for a request.
+ * Callback for performing quota compliance operations, as each chunk of a user request is processed. The main job of
+ * this callback is to translate quota compliance operations done for each chunk, into quota compliance operations
+ * against the {@link QuotaResource} of the corresponding user request. Used by {@link Chargeable} implementations.
+ *
+ * Uses {@link QuotaManager} implementation for performing the quota operations. Hence the thread safety and atomicity
+ * guarantees are same as that of the {@link QuotaManager} implementation used.
+ * Uses {@link RequestQuotaCostPolicy} implementation to calculate the cost of the chunk request.
  */
 public interface QuotaChargeCallback {
+
+  /**
+   * Charges the cost of chunk request against quota, if checks to allow a chunk request are successful. The cost to
+   * charge is determined by the specified chunkSize, with help from {@link RequestQuotaCostPolicy} implementations.
+   *
+   * Checks to allow a request are:
+   * 1. If usage is within quota, OR
+   * 2. If shouldCheckExceedAllowed is set as {@code true}, and the implementation determines that quota is allowed to
+   * exceed usage. For examples about when usage could be allowed to exceed quota, check {@link QuotaEnforcer}.
+   *
+   * If forceCharge is specified as {@code true}, then the charge must happen. In that case the implementations can skip
+   * any checks for allowing the request, as those checks are inconsequential.
+   *
+   * @param shouldCheckExceedAllowed if set to {@code true}, check if usage is allowed to exceed quota.
+   * @param forceCharge if set to {@code true}, then charge must happen. Implementation may decide to skip any checks as
+   *                    they are inconsequential.
+   * @param chunkSize of the chunk.
+   * @throws QuotaException In case of any exception.
+   * @return QuotaAction representing the recommended action to take for quota compliance.
+   */
+  QuotaAction checkAndCharge(boolean shouldCheckExceedAllowed, boolean forceCharge, long chunkSize) throws QuotaException;
+
+  /**
+   * Charges the cost of chunk request against quota, if checks to allow a chunk request are successful. The cost to
+   * charge is one unit of quota cost, as determined by {@link QuotaConfig#quotaAccountingUnit}.
+   * For more details check {@link QuotaChargeCallback#checkAndCharge(boolean, boolean, long)}.
+   *
+   * @param shouldCheckExceedAllowed if set to {@code true}, check if usage is allowed to exceed quota.
+   * @param forceCharge if set to {@code true}, then charge must happen. Implementation may decide to skip any checks as
+   *                    they are inconsequential.
+   * @throws QuotaException In case of any exception.
+   * @return QuotaAction representing the recommended action to take for quota compliance.
+   */
+  default QuotaAction checkAndCharge(boolean shouldCheckExceedAllowed, boolean forceCharge) throws QuotaException {
+    return checkAndCharge(shouldCheckExceedAllowed, forceCharge, getQuotaConfig().quotaAccountingUnit);
+  }
 
   /**
    * Callback method that can be used to charge quota usage for a request or part of a request.
    * @param chunkSize of the chunk.
    * @throws QuotaException In case request needs to be throttled.
    */
+  @Deprecated
   void charge(long chunkSize) throws QuotaException;
 
   /**
@@ -33,18 +76,21 @@ public interface QuotaChargeCallback {
    * when the quota charge doesn't depend on the chunk size.
    * @throws QuotaException In case request needs to be throttled.
    */
+  @Deprecated
   void charge() throws QuotaException;
 
   /**
    * Check if request should be throttled based on quota usage.
    * @return {@code true} if request usage exceeds limit and request should be throttled. {@code false} otherwise.
    */
+  @Deprecated
   boolean check();
 
   /**
    * Check if usage is allowed to exceed the quota limit.
    * @return {@code true} if usage is allowed to exceed the quota limit. {@code false} otherwise.
    */
+  @Deprecated
   boolean quotaExceedAllowed();
 
   /**

--- a/ambry-quota/src/main/java/com/github/ambry/quota/PostProcessQuotaChargeCallback.java
+++ b/ambry-quota/src/main/java/com/github/ambry/quota/PostProcessQuotaChargeCallback.java
@@ -24,9 +24,14 @@ import org.slf4j.LoggerFactory;
 
 
 /**
- * A {@link QuotaChargeCallback} implementation that will reject requests that exceed their quota.
+ * A {@link QuotaChargeCallback} implementation to be called when quota accounting needs to be done after chunk for a
+ * user request has been processed. Since the accounting is done after the chunk is already processed (uploaded or
+ * downloaded from storage nodes), usage is charged irrespective of the recommendation.
+ *
+ * If {@link QuotaManager} recommends that request be throttled, this implementation will reject the user request with
+ * {@link RouterErrorCode#TooManyRequests} if {@link QuotaMode} is set to THROTTLING.
  */
-public class RejectingQuotaChargeCallback implements QuotaChargeCallback {
+public class PostProcessQuotaChargeCallback implements QuotaChargeCallback {
   private static final Logger LOGGER = LoggerFactory.getLogger(QuotaChargeCallback.class);
   private final QuotaManager quotaManager;
   private final RestRequest restRequest;
@@ -34,18 +39,47 @@ public class RejectingQuotaChargeCallback implements QuotaChargeCallback {
   private final boolean isQuotaEnforcedOnRequest;
 
   /**
-   * Constructor for {@link RejectingQuotaChargeCallback}.
+   * Constructor for {@link PostProcessQuotaChargeCallback}.
    * @param quotaManager {@link QuotaManager} object responsible for charging the quota.
    * @param restRequest {@link RestRequest} for which quota is being charged.
    * @param isQuotaEnforcedOnRequest flag indicating if request quota should be enforced after charging. Requests like
    *                                 update ttl, delete etc are charged, but quota is not enforced on them.
    */
-  public RejectingQuotaChargeCallback(QuotaManager quotaManager, RestRequest restRequest,
+  public PostProcessQuotaChargeCallback(QuotaManager quotaManager, RestRequest restRequest,
       boolean isQuotaEnforcedOnRequest) {
     this.quotaManager = quotaManager;
     requestCostPolicy = new SimpleRequestQuotaCostPolicy(quotaManager.getQuotaConfig());
     this.restRequest = restRequest;
     this.isQuotaEnforcedOnRequest = isQuotaEnforcedOnRequest;
+  }
+
+  @Override
+  public QuotaAction checkAndCharge(boolean shouldCheckQuotaExceedAllowed, boolean forceCharge, long chunkSize) throws QuotaException {
+    QuotaAction quotaAction = QuotaAction.ALLOW;
+    try {
+      Map<QuotaName, Double> requestCost = requestCostPolicy.calculateRequestQuotaCharge(restRequest, chunkSize)
+          .entrySet()
+          .stream()
+          .collect(Collectors.toMap(entry -> QuotaName.valueOf(entry.getKey()), Map.Entry::getValue));
+      quotaAction =
+          quotaManager.chargeAndRecommend(restRequest, requestCost, shouldCheckQuotaExceedAllowed, forceCharge);
+      if (isQuotaEnforcedOnRequest && QuotaUtils.shouldThrottle(quotaAction)) {
+        if (quotaManager.getQuotaMode() == QuotaMode.THROTTLING
+            && quotaManager.getQuotaConfig().throttleInProgressRequests) {
+          throw new QuotaException("Exception while charging quota",
+              new RouterException("RequestQuotaExceeded", RouterErrorCode.TooManyRequests), false);
+        } else {
+          LOGGER.debug("Quota exceeded for an in progress request.");
+        }
+      }
+    } catch (Exception ex) {
+      if (ex.getCause() instanceof RouterException && ((RouterException) ex.getCause()).getErrorCode()
+          .equals(RouterErrorCode.TooManyRequests)) {
+        throw ex;
+      }
+      LOGGER.error("Unexpected exception while charging quota.", ex);
+    }
+    return quotaAction;
   }
 
   @Override

--- a/ambry-quota/src/main/java/com/github/ambry/quota/QuotaUtils.java
+++ b/ambry-quota/src/main/java/com/github/ambry/quota/QuotaUtils.java
@@ -15,15 +15,12 @@ package com.github.ambry.quota;
 
 import com.github.ambry.account.Account;
 import com.github.ambry.frontend.Operations;
-import com.github.ambry.messageformat.BlobInfo;
 import com.github.ambry.rest.RequestPath;
 import com.github.ambry.rest.RestMethod;
 import com.github.ambry.rest.RestRequest;
 import com.github.ambry.rest.RestUtils;
-import io.netty.handler.codec.http.HttpResponseStatus;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
 
 import static com.github.ambry.rest.RestUtils.InternalKeys.*;
@@ -84,7 +81,7 @@ public class QuotaUtils {
   public static QuotaChargeCallback buildQuotaChargeCallback(RestRequest restRequest, QuotaManager quotaManager,
       boolean isQuotaEnforcedOnRequest) {
     if (!quotaManager.getQuotaConfig().bandwidthThrottlingFeatureEnabled) {
-      return new RejectingQuotaChargeCallback(quotaManager, restRequest, isQuotaEnforcedOnRequest);
+      return new PostProcessQuotaChargeCallback(quotaManager, restRequest, isQuotaEnforcedOnRequest);
     } else {
       throw new UnsupportedOperationException("Not implemented yet.");
     }

--- a/ambry-test-utils/src/main/java/com/github/ambry/quota/QuotaTestUtils.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/quota/QuotaTestUtils.java
@@ -131,6 +131,16 @@ public class QuotaTestUtils {
    */
   public static class TestQuotaChargeCallback implements QuotaChargeCallback {
     @Override
+    public QuotaAction checkAndCharge(boolean shouldCheckExceedAllowed, boolean forceCharge, long chunkSize) {
+      return QuotaAction.ALLOW;
+    }
+
+    @Override
+    public QuotaAction checkAndCharge(boolean shouldCheckExceedAllowed, boolean forceCharge) {
+      return QuotaAction.ALLOW;
+    }
+
+    @Override
     public void charge(long chunkSize) {
     }
 

--- a/ambry-tools/src/main/java/com/github/ambry/tools/admin/ConcurrencyTestTool.java
+++ b/ambry-tools/src/main/java/com/github/ambry/tools/admin/ConcurrencyTestTool.java
@@ -25,6 +25,7 @@ import com.github.ambry.config.QuotaConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.commons.Callback;
+import com.github.ambry.quota.QuotaAction;
 import com.github.ambry.quota.QuotaChargeCallback;
 import com.github.ambry.quota.QuotaMethod;
 import com.github.ambry.quota.QuotaResource;
@@ -105,6 +106,16 @@ public class ConcurrencyTestTool {
   private static final AtomicBoolean putComplete = new AtomicBoolean(false);
   private static final Random random = new Random();
   private static final QuotaChargeCallback QUOTA_CHARGE_EVENT_LISTENER = new QuotaChargeCallback() {
+    @Override
+    public QuotaAction checkAndCharge(boolean shouldCheckExceedAllowed, boolean forceCharge, long chunkSize) {
+      return QuotaAction.ALLOW;
+    }
+
+    @Override
+    public QuotaAction checkAndCharge(boolean shouldCheckExceedAllowed, boolean forceCharge) {
+      return QuotaAction.ALLOW;
+    }
+
     @Override
     public void charge(long chunkSize) {
 


### PR DESCRIPTION
Refactor QuotaChargeCallback and its implementations.
1. Deprecate QuotaChargeCallback methods charge(), check() and quotaExceedAllowed().
2. Add new methods for checkAndCharge(). The new methods will check if specified conditions are met, and charge the quota accordingly.
3. Rename RejectingQuotaChargeCallback to PostProcessQuotaChargeCallback. In essence, this implementation of QuotaChargeCallback is used for enforcing quota after a chunk has been processed.

Note that
1. An implementation of PreProcessQuotaChargeCallback will follow. That implementation will be used for enforcing quota for bandwidth throttling case, which will happen before chunks are processed.
2. charge(), check() and quotaExceedAllowed() methods are marked as deprecated (instead of being removed) as the current `Chargeable` implementations use them. Once `Chargeable` implementations are refactored too, these methods will be removed.