### PR TITLE
Aggregate Get and Put qps to detect live traffic before container deletion

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/FrontendConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/FrontendConfig.java
@@ -41,6 +41,8 @@ public class FrontendConfig {
   public static final String NAMED_BLOB_DB_FACTORY = PREFIX + "named.blob.db.factory";
   public static final String CONTAINER_METRICS_EXCLUDED_ACCOUNTS = PREFIX + "container.metrics.excluded.accounts";
   public static final String ACCOUNT_STATS_STORE_FACTORY = PREFIX + "account.stats.store.factory";
+  public static final String CONTAINER_METRICS_ENABLED_REQUEST_TYPES = PREFIX + "container.metrics.enabled.request.types";
+  public static final String CONTAINER_METRICS_ENABLED_GET_REQUEST_TYPES = PREFIX + "container.metrics.enabled.get.request.types";
 
   // Default values
   private static final String DEFAULT_ENDPOINT = "http://localhost:1174";
@@ -49,6 +51,12 @@ public class FrontendConfig {
 
   private static final String DEFAULT_ACCOUNT_STATS_STORE_FACTORY =
       "com.github.ambry.accountstats.InmemoryAccountStatsStoreFactory";
+
+  private static final String DEFAULT_CONTAINER_METRICS_ENABLED_REQUEST_TYPES =
+      "DeleteBlob,GetBlob,GetBlobInfo,GetSignedUrl,PostBlob,UpdateBlobTtl,UndeleteBlob,PutBlob";
+
+  private static final String DEFAULT_CONTAINER_METRICS_ENABLED_GET_REQUEST_TYPES = "GetBlob,GetBlobInfo,GetSignedUrl";
+
 
   /**
    * Cache validity in seconds for non-private blobs for GET.
@@ -220,6 +228,20 @@ public class FrontendConfig {
   public final String accountStatsStoreFactory;
 
   /**
+   * The set of container metrics enabled request type.
+   */
+  @Config(CONTAINER_METRICS_ENABLED_REQUEST_TYPES)
+  @Default(DEFAULT_CONTAINER_METRICS_ENABLED_REQUEST_TYPES)
+  public final String containerMetricsEnabledRequestTypes;
+
+  /**
+   * The set of container metrics enabled get request type.
+   */
+  @Config(CONTAINER_METRICS_ENABLED_GET_REQUEST_TYPES)
+  @Default(DEFAULT_CONTAINER_METRICS_ENABLED_GET_REQUEST_TYPES)
+  public final String containerMetricsEnabledGetRequestTypes;
+
+  /**
    * Can be set to a classname that implements {@link com.github.ambry.named.NamedBlobDbFactory} to enable named blob
    * support.
    */
@@ -262,7 +284,10 @@ public class FrontendConfig {
     allowServiceIdBasedPostRequest =
         verifiableProperties.getBoolean("frontend.allow.service.id.based.post.request", true);
     attachTrackingInfo = verifiableProperties.getBoolean("frontend.attach.tracking.info", true);
-
+    containerMetricsEnabledRequestTypes = verifiableProperties.getString(CONTAINER_METRICS_ENABLED_REQUEST_TYPES,
+        DEFAULT_CONTAINER_METRICS_ENABLED_REQUEST_TYPES);
+    containerMetricsEnabledGetRequestTypes = verifiableProperties.getString(CONTAINER_METRICS_ENABLED_GET_REQUEST_TYPES,
+        DEFAULT_CONTAINER_METRICS_ENABLED_GET_REQUEST_TYPES);
     urlSignerEndpoints = verifiableProperties.getString(URL_SIGNER_ENDPOINTS, DEFAULT_ENDPOINTS_STRING);
     urlSignerDefaultMaxUploadSizeBytes =
         verifiableProperties.getLongInRange("frontend.url.signer.default.max.upload.size.bytes", 100 * 1024 * 1024, 0,

--- a/ambry-api/src/main/java/com/github/ambry/frontend/ContainerMetrics.java
+++ b/ambry-api/src/main/java/com/github/ambry/frontend/ContainerMetrics.java
@@ -50,7 +50,7 @@ public class ContainerMetrics {
   // 410
   private final Counter goneCount;
 
-  private final Counter totalQpsCount;
+  private final Counter totalCount;
 
   /**
    * Metric names will be in the following format:
@@ -85,8 +85,8 @@ public class ContainerMetrics {
         metricRegistry.counter(MetricRegistry.name(ContainerMetrics.class, metricPrefix + "ForbiddenCount"));
     notFoundCount = metricRegistry.counter(MetricRegistry.name(ContainerMetrics.class, metricPrefix + "NotFoundCount"));
     goneCount = metricRegistry.counter(MetricRegistry.name(ContainerMetrics.class, metricPrefix + "GoneCount"));
-    String qpsMetricPrefix = accountName + SEPARATOR + containerName + SEPARATOR + (isGetRequest ? "GetRequestQps" : "PutRequestQps");
-    totalQpsCount = metricRegistry.counter(MetricRegistry.name(ContainerMetrics.class, qpsMetricPrefix + "totalQpsCount"));
+    String qpsMetricPrefix = accountName + SEPARATOR + containerName + SEPARATOR + (isGetRequest ? "GetRequest" : "PutRequest");
+    totalCount = metricRegistry.counter(MetricRegistry.name(ContainerMetrics.class, qpsMetricPrefix + "totalCount"));
   }
 
   /**
@@ -96,7 +96,7 @@ public class ContainerMetrics {
    */
   public void recordMetrics(long roundTripTimeInMs, ResponseStatus responseStatus) {
     this.roundTripTimeInMs.update(roundTripTimeInMs);
-    totalQpsCount.inc();
+    totalCount.inc();
     if (responseStatus.isSuccess()) {
       successCount.inc();
     } else if (responseStatus.isRedirection()) {

--- a/ambry-api/src/main/java/com/github/ambry/frontend/ContainerMetrics.java
+++ b/ambry-api/src/main/java/com/github/ambry/frontend/ContainerMetrics.java
@@ -50,6 +50,8 @@ public class ContainerMetrics {
   // 410
   private final Counter goneCount;
 
+  private final Counter totalQpsCount;
+
   /**
    * Metric names will be in the following format:
    * {@code com.github.ambry.frontend.ContainerMetrics.{accountName}___{containerName}___{operationType}{metric}}
@@ -59,8 +61,10 @@ public class ContainerMetrics {
    * @param containerName the container name to use for naming metrics.
    * @param operationType the operation type to use for naming metrics.
    * @param metricRegistry the {@link MetricRegistry}.
+   * @param isGetRequest the request operationType is get.
    */
-  ContainerMetrics(String accountName, String containerName, String operationType, MetricRegistry metricRegistry) {
+  ContainerMetrics(String accountName, String containerName, String operationType, MetricRegistry metricRegistry,
+      boolean isGetRequest) {
     String metricPrefix = accountName + SEPARATOR + containerName + SEPARATOR + operationType;
     roundTripTimeInMs =
         metricRegistry.histogram(MetricRegistry.name(ContainerMetrics.class, metricPrefix + "RoundTripTimeInMs"));
@@ -81,6 +85,8 @@ public class ContainerMetrics {
         metricRegistry.counter(MetricRegistry.name(ContainerMetrics.class, metricPrefix + "ForbiddenCount"));
     notFoundCount = metricRegistry.counter(MetricRegistry.name(ContainerMetrics.class, metricPrefix + "NotFoundCount"));
     goneCount = metricRegistry.counter(MetricRegistry.name(ContainerMetrics.class, metricPrefix + "GoneCount"));
+    String qpsMetricPrefix = accountName + SEPARATOR + containerName + SEPARATOR + (isGetRequest ? "GetRequestQps" : "PutRequestQps");
+    totalQpsCount = metricRegistry.counter(MetricRegistry.name(ContainerMetrics.class, qpsMetricPrefix + "totalQpsCount"));
   }
 
   /**
@@ -90,7 +96,7 @@ public class ContainerMetrics {
    */
   public void recordMetrics(long roundTripTimeInMs, ResponseStatus responseStatus) {
     this.roundTripTimeInMs.update(roundTripTimeInMs);
-
+    totalQpsCount.inc();
     if (responseStatus.isSuccess()) {
       successCount.inc();
     } else if (responseStatus.isRedirection()) {

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbryIdConverterFactory.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbryIdConverterFactory.java
@@ -16,6 +16,7 @@ package com.github.ambry.frontend;
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.commons.Callback;
 import com.github.ambry.commons.CallbackUtils;
+import com.github.ambry.config.FrontendConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.messageformat.BlobInfo;
 import com.github.ambry.messageformat.BlobProperties;
@@ -50,7 +51,7 @@ public class AmbryIdConverterFactory implements IdConverterFactory {
       IdSigningService idSigningService, NamedBlobDb namedBlobDb) {
     this.idSigningService = idSigningService;
     this.namedBlobDb = namedBlobDb;
-    frontendMetrics = new FrontendMetrics(metricRegistry);
+    frontendMetrics = new FrontendMetrics(metricRegistry, new FrontendConfig(verifiableProperties));
   }
 
   @Override

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbrySecurityServiceFactory.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbrySecurityServiceFactory.java
@@ -40,7 +40,7 @@ public class AmbrySecurityServiceFactory implements SecurityServiceFactory {
       AccountAndContainerInjector accountAndContainerInjector, QuotaManager quotaManager) {
     frontendConfig = new FrontendConfig(verifiableProperties);
     hostThrottleConfig = new HostThrottleConfig(verifiableProperties);
-    frontendMetrics = new FrontendMetrics(clusterMap.getMetricRegistry());
+    frontendMetrics = new FrontendMetrics(clusterMap.getMetricRegistry(), frontendConfig);
     this.urlSigningService = urlSigningService;
     this.quotaManager = quotaManager;
   }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendMetrics.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendMetrics.java
@@ -17,6 +17,7 @@ import com.codahale.metrics.Counter;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.config.FrontendConfig;
 import com.github.ambry.utils.AsyncOperationTracker;
 
 
@@ -216,49 +217,57 @@ public class FrontendMetrics {
   /**
    * Creates an instance of FrontendMetrics using the given {@code metricRegistry}.
    * @param metricRegistry the {@link MetricRegistry} to use for the metrics.
+   * @param frontendConfig the {@link FrontendConfig} to use for the metrics.
    */
-  public FrontendMetrics(MetricRegistry metricRegistry) {
+  public FrontendMetrics(MetricRegistry metricRegistry, FrontendConfig frontendConfig) {
     // RestRequestMetricsGroup
     // DELETE
     deleteBlobMetricsGroup =
-        new RestRequestMetricsGroup(FrontendRestRequestService.class, "DeleteBlob", false, true, metricRegistry);
+        new RestRequestMetricsGroup(FrontendRestRequestService.class, "DeleteBlob", false, metricRegistry,
+            frontendConfig);
     // GET
     getBlobMetricsGroup =
-        new RestRequestMetricsGroup(FrontendRestRequestService.class, "GetBlob", true, true, metricRegistry);
+        new RestRequestMetricsGroup(FrontendRestRequestService.class, "GetBlob", true, metricRegistry, frontendConfig);
     getBlobInfoMetricsGroup =
-        new RestRequestMetricsGroup(FrontendRestRequestService.class, "GetBlobInfo", true, true, metricRegistry);
+        new RestRequestMetricsGroup(FrontendRestRequestService.class, "GetBlobInfo", true, metricRegistry,
+            frontendConfig);
     getUserMetadataMetricsGroup =
-        new RestRequestMetricsGroup(FrontendRestRequestService.class, "GetUserMetadata", true, false, metricRegistry);
-    getPeersMetricsGroup = new RestRequestMetricsGroup(GetPeersHandler.class, "GetPeers", false, false, metricRegistry);
+        new RestRequestMetricsGroup(FrontendRestRequestService.class, "GetUserMetadata", true, metricRegistry,
+            frontendConfig);
+    getPeersMetricsGroup =
+        new RestRequestMetricsGroup(GetPeersHandler.class, "GetPeers", false, metricRegistry, frontendConfig);
     getReplicasMetricsGroup =
-        new RestRequestMetricsGroup(FrontendRestRequestService.class, "GetReplicas", false, false, metricRegistry);
+        new RestRequestMetricsGroup(FrontendRestRequestService.class, "GetReplicas", false, metricRegistry,
+            frontendConfig);
     getSignedUrlMetricsGroup =
-        new RestRequestMetricsGroup(GetSignedUrlHandler.class, "GetSignedUrl", false, true, metricRegistry);
+        new RestRequestMetricsGroup(GetSignedUrlHandler.class, "GetSignedUrl", false, metricRegistry, frontendConfig);
     getClusterMapSnapshotMetricsGroup =
-        new RestRequestMetricsGroup(GetClusterMapSnapshotHandler.class, "GetClusterMapSnapshot", false, false,
-            metricRegistry);
+        new RestRequestMetricsGroup(GetClusterMapSnapshotHandler.class, "GetClusterMapSnapshot",
+            false, metricRegistry, frontendConfig);
     getAccountsMetricsGroup =
-        new RestRequestMetricsGroup(GetAccountsHandler.class, "GetAccounts", false, false, metricRegistry);
+        new RestRequestMetricsGroup(GetAccountsHandler.class, "GetAccounts", false, metricRegistry, frontendConfig);
     getStatsReportMetricsGroup =
-        new RestRequestMetricsGroup(GetStatsReportHandler.class, "GetStatsReport", false, false, metricRegistry);
+        new RestRequestMetricsGroup(GetStatsReportHandler.class, "GetStatsReport", false, metricRegistry,
+            frontendConfig);
     // HEAD
     headBlobMetricsGroup =
-        new RestRequestMetricsGroup(FrontendRestRequestService.class, "HeadBlob", false, false, metricRegistry);
+        new RestRequestMetricsGroup(FrontendRestRequestService.class, "HeadBlob", false, metricRegistry,
+            frontendConfig);
     // OPTIONS
     optionsMetricsGroup =
-        new RestRequestMetricsGroup(FrontendRestRequestService.class, "Options", false, false, metricRegistry);
+        new RestRequestMetricsGroup(FrontendRestRequestService.class, "Options", false, metricRegistry, frontendConfig);
     // POST
     postBlobMetricsGroup =
-        new RestRequestMetricsGroup(FrontendRestRequestService.class, "PostBlob", true, true, metricRegistry);
+        new RestRequestMetricsGroup(FrontendRestRequestService.class, "PostBlob", true, metricRegistry, frontendConfig);
     postAccountsMetricsGroup =
-        new RestRequestMetricsGroup(PostAccountsHandler.class, "PostAccounts", false, false, metricRegistry);
+        new RestRequestMetricsGroup(PostAccountsHandler.class, "PostAccounts", false, metricRegistry, frontendConfig);
     // PUT
     updateBlobTtlMetricsGroup =
-        new RestRequestMetricsGroup(TtlUpdateHandler.class, "UpdateBlobTtl", false, true, metricRegistry);
+        new RestRequestMetricsGroup(TtlUpdateHandler.class, "UpdateBlobTtl", false, metricRegistry, frontendConfig);
     undeleteBlobMetricsGroup =
-        new RestRequestMetricsGroup(UndeleteHandler.class, "UndeleteBlob", false, true, metricRegistry);
+        new RestRequestMetricsGroup(UndeleteHandler.class, "UndeleteBlob", false, metricRegistry, frontendConfig);
     putBlobMetricsGroup =
-        new RestRequestMetricsGroup(NamedBlobPutHandler.class, "PutBlob", false, true, metricRegistry);
+        new RestRequestMetricsGroup(NamedBlobPutHandler.class, "PutBlob", false, metricRegistry, frontendConfig);
     // AsyncOperationTracker.Metrics instances
     postSecurityProcessRequestMetrics =
         new AsyncOperationTracker.Metrics(PostBlobHandler.class, "postSecurityProcessRequest", metricRegistry);

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestServiceFactory.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestServiceFactory.java
@@ -67,7 +67,7 @@ public class FrontendRestRequestServiceFactory implements RestRequestServiceFact
     this.accountService = Objects.requireNonNull(accountService, "Provided AccountService is null");
     clusterMapConfig = new ClusterMapConfig(verifiableProperties);
     frontendConfig = new FrontendConfig(verifiableProperties);
-    frontendMetrics = new FrontendMetrics(clusterMap.getMetricRegistry());
+    frontendMetrics = new FrontendMetrics(clusterMap.getMetricRegistry(), frontendConfig);
     logger.trace("Instantiated FrontendRestRequestServiceFactory");
   }
 

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/AmbrySecurityServiceTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/AmbrySecurityServiceTest.java
@@ -106,7 +106,7 @@ public class AmbrySecurityServiceTest {
       new FrontendTestUrlSigningServiceFactory();
 
   private final SecurityService securityService =
-      new AmbrySecurityService(FRONTEND_CONFIG, new FrontendMetrics(new MetricRegistry()),
+      new AmbrySecurityService(FRONTEND_CONFIG, new FrontendMetrics(new MetricRegistry(), FRONTEND_CONFIG),
           URL_SIGNING_SERVICE_FACTORY.getUrlSigningService(), hostLevelThrottler, QUOTA_MANAGER);
 
   static {
@@ -170,7 +170,7 @@ public class AmbrySecurityServiceTest {
     properties.setProperty("frontend.attach.tracking.info", "false");
     FrontendConfig frontendConfig = new FrontendConfig(new VerifiableProperties(properties));
     SecurityService securityServiceWithTrackingDisabled =
-        new AmbrySecurityService(frontendConfig, new FrontendMetrics(new MetricRegistry()),
+        new AmbrySecurityService(frontendConfig, new FrontendMetrics(new MetricRegistry(), frontendConfig),
             URL_SIGNING_SERVICE_FACTORY.getUrlSigningService(), hostLevelThrottler, QUOTA_MANAGER);
     restRequest = createRestRequest(RestMethod.GET, "/", null);
     securityServiceWithTrackingDisabled.preProcessRequest(restRequest);
@@ -235,10 +235,10 @@ public class AmbrySecurityServiceTest {
   @Test
   public void postProcessQuotaManagerTest() throws Exception {
     HostLevelThrottler quotaManager = Mockito.mock(HostLevelThrottler.class);
+    FrontendConfig frontendConfig = new FrontendConfig(new VerifiableProperties(new Properties()));
     AmbrySecurityService ambrySecurityService =
-        new AmbrySecurityService(new FrontendConfig(new VerifiableProperties(new Properties())),
-            new FrontendMetrics(new MetricRegistry()), URL_SIGNING_SERVICE_FACTORY.getUrlSigningService(), quotaManager,
-            QUOTA_MANAGER);
+        new AmbrySecurityService(frontendConfig, new FrontendMetrics(new MetricRegistry(), frontendConfig),
+            URL_SIGNING_SERVICE_FACTORY.getUrlSigningService(), quotaManager, QUOTA_MANAGER);
     // Everything should be good.
     Mockito.when(quotaManager.shouldThrottle(any())).thenReturn(false);
     for (int i = 0; i < 100; i++) {

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
@@ -148,7 +148,7 @@ public class FrontendRestRequestServiceTest {
   private final Account refAccount;
   private final Properties configProps = new Properties();
   private final MetricRegistry metricRegistry = new MetricRegistry();
-  private final FrontendMetrics frontendMetrics = new FrontendMetrics(metricRegistry);
+  private final FrontendMetrics frontendMetrics;
   private final IdConverterFactory idConverterFactory;
   private final SecurityServiceFactory securityServiceFactory;
   private final FrontendTestResponseHandler responseHandler;
@@ -194,6 +194,7 @@ public class FrontendRestRequestServiceTest {
     clusterMap = new MockClusterMap();
     clusterMap.setPermanentMetricRegistry(metricRegistry);
     frontendConfig = new FrontendConfig(verifiableProperties);
+    frontendMetrics = new FrontendMetrics(metricRegistry, frontendConfig);
     accountAndContainerInjector = new AccountAndContainerInjector(accountService, frontendMetrics, frontendConfig);
     String endpoint = "http://localhost:1174";
     urlSigningService = new AmbryUrlSigningService(endpoint, endpoint, frontendConfig.urlSignerDefaultUrlTtlSecs,

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/GetAccountsHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/GetAccountsHandlerTest.java
@@ -20,6 +20,8 @@ import com.github.ambry.account.AccountCollectionSerde;
 import com.github.ambry.account.Container;
 import com.github.ambry.account.InMemAccountService;
 import com.github.ambry.commons.RetainingAsyncWritableChannel;
+import com.github.ambry.config.FrontendConfig;
+import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.rest.MockRestRequest;
 import com.github.ambry.rest.MockRestResponseChannel;
 import com.github.ambry.rest.RequestPath;
@@ -37,6 +39,7 @@ import com.github.ambry.utils.ThrowingConsumer;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import org.json.JSONObject;
@@ -55,7 +58,8 @@ public class GetAccountsHandlerTest {
   private final GetAccountsHandler handler;
 
   public GetAccountsHandlerTest() {
-    FrontendMetrics metrics = new FrontendMetrics(new MetricRegistry());
+    FrontendMetrics metrics =
+        new FrontendMetrics(new MetricRegistry(), new FrontendConfig(new VerifiableProperties(new Properties())));
     securityServiceFactory = new FrontendTestSecurityServiceFactory();
     accountService = new InMemAccountService(false, true);
     handler = new GetAccountsHandler(securityServiceFactory.getSecurityService(), accountService, metrics);

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/GetClusterMapSnapshotHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/GetClusterMapSnapshotHandlerTest.java
@@ -17,6 +17,8 @@ import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.ClusterMapSnapshotConstants;
 import com.github.ambry.clustermap.MockClusterMap;
+import com.github.ambry.config.FrontendConfig;
+import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.rest.MockRestRequest;
 import com.github.ambry.rest.MockRestResponseChannel;
 import com.github.ambry.rest.RestMethod;
@@ -26,6 +28,7 @@ import com.github.ambry.rest.RestTestUtils;
 import com.github.ambry.rest.RestUtils;
 import com.github.ambry.router.ReadableStreamChannel;
 import java.io.IOException;
+import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -45,7 +48,8 @@ public class GetClusterMapSnapshotHandlerTest {
   private final GetClusterMapSnapshotHandler handler;
 
   public GetClusterMapSnapshotHandlerTest() throws IOException {
-    FrontendMetrics metrics = new FrontendMetrics(new MetricRegistry());
+    FrontendMetrics metrics =
+        new FrontendMetrics(new MetricRegistry(), new FrontendConfig(new VerifiableProperties(new Properties())));
     clusterMap = new MockClusterMap();
     securityServiceFactory = new FrontendTestSecurityServiceFactory();
     handler = new GetClusterMapSnapshotHandler(securityServiceFactory.getSecurityService(), metrics, clusterMap);

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/GetPeersHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/GetPeersHandlerTest.java
@@ -23,6 +23,8 @@ import com.github.ambry.clustermap.MockPartitionId;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.clustermap.ReplicaEventType;
 import com.github.ambry.clustermap.ReplicaId;
+import com.github.ambry.config.FrontendConfig;
+import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.network.Port;
 import com.github.ambry.network.PortType;
 import com.github.ambry.rest.MockRestRequest;
@@ -45,6 +47,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -66,7 +69,8 @@ public class GetPeersHandlerTest {
   private final GetPeersHandler getPeersHandler;
 
   public GetPeersHandlerTest() {
-    FrontendMetrics metrics = new FrontendMetrics(new MetricRegistry());
+    FrontendMetrics metrics =
+        new FrontendMetrics(new MetricRegistry(), new FrontendConfig(new VerifiableProperties(new Properties())));
     clusterMap = new TailoredPeersClusterMap();
     securityServiceFactory = new FrontendTestSecurityServiceFactory();
     getPeersHandler = new GetPeersHandler(clusterMap, securityServiceFactory.getSecurityService(), metrics);

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/GetReplicasHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/GetReplicasHandlerTest.java
@@ -21,6 +21,8 @@ import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.CommonTestUtils;
+import com.github.ambry.config.FrontendConfig;
+import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.rest.MockRestResponseChannel;
 import com.github.ambry.rest.ResponseStatus;
 import com.github.ambry.rest.RestResponseChannel;
@@ -31,6 +33,7 @@ import com.github.ambry.rest.RestUtils;
 import com.github.ambry.router.ReadableStreamChannel;
 import java.io.IOException;
 import java.util.List;
+import java.util.Properties;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -46,7 +49,9 @@ public class GetReplicasHandlerTest {
   static {
     try {
       CLUSTER_MAP = new MockClusterMap();
-      getReplicasHandler = new GetReplicasHandler(new FrontendMetrics(new MetricRegistry()), CLUSTER_MAP);
+      getReplicasHandler = new GetReplicasHandler(
+          new FrontendMetrics(new MetricRegistry(), new FrontendConfig(new VerifiableProperties(new Properties()))),
+          CLUSTER_MAP);
     } catch (IOException e) {
       throw new IllegalStateException(e);
     }

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/GetSignedUrlHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/GetSignedUrlHandlerTest.java
@@ -73,8 +73,8 @@ public class GetSignedUrlHandlerTest {
   private final GetSignedUrlHandler getSignedUrlHandler;
 
   public GetSignedUrlHandlerTest() {
-    FrontendMetrics metrics = new FrontendMetrics(new MetricRegistry());
     FrontendConfig config = new FrontendConfig(new VerifiableProperties(new Properties()));
+    FrontendMetrics metrics = new FrontendMetrics(new MetricRegistry(), config);
     AccountAndContainerInjector accountAndContainerInjector =
         new AccountAndContainerInjector(ACCOUNT_SERVICE, metrics, config);
     getSignedUrlHandler = new GetSignedUrlHandler(urlSigningServiceFactory.getUrlSigningService(),

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/GetStatsReportHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/GetStatsReportHandlerTest.java
@@ -16,6 +16,8 @@ package com.github.ambry.frontend;
 import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.ambry.accountstats.AccountStatsStore;
+import com.github.ambry.config.FrontendConfig;
+import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.rest.MockRestRequest;
 import com.github.ambry.rest.MockRestResponseChannel;
 import com.github.ambry.rest.RestMethod;
@@ -33,6 +35,7 @@ import com.github.ambry.server.storagestats.AggregatedAccountStorageStats;
 import com.github.ambry.server.storagestats.AggregatedPartitionClassStorageStats;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.ThrowingBiConsumer;
+import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import org.json.JSONObject;
 import org.junit.Test;
@@ -52,7 +55,7 @@ public class GetStatsReportHandlerTest {
   private final AccountStatsStore accountStatsStore;
 
   public GetStatsReportHandlerTest() {
-    FrontendMetrics metrics = new FrontendMetrics(new MetricRegistry());
+    FrontendMetrics metrics = new FrontendMetrics(new MetricRegistry(), new FrontendConfig(new VerifiableProperties(new Properties())));
     securityServiceFactory = new FrontendTestSecurityServiceFactory();
     accountStatsStore = mock(AccountStatsStore.class);
     handler = new GetStatsReportHandler(securityServiceFactory.getSecurityService(), metrics, accountStatsStore);

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/NamedBlobPutHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/NamedBlobPutHandlerTest.java
@@ -103,7 +103,7 @@ public class NamedBlobPutHandlerTest {
   }
 
   private final MockTime time = new MockTime();
-  private final FrontendMetrics metrics = new FrontendMetrics(new MetricRegistry());
+  private final FrontendMetrics metrics;
   private final InMemoryRouter router;
   private final FrontendTestIdConverterFactory idConverterFactory;
   private final FrontendTestSecurityServiceFactory securityServiceFactory;
@@ -119,7 +119,9 @@ public class NamedBlobPutHandlerTest {
     Properties props = new Properties();
     VerifiableProperties verifiableProperties = new VerifiableProperties(props);
     router = new InMemoryRouter(verifiableProperties, CLUSTER_MAP);
-    injector = new AccountAndContainerInjector(ACCOUNT_SERVICE, metrics, new FrontendConfig(verifiableProperties));
+    FrontendConfig frontendConfig = new FrontendConfig(verifiableProperties);
+    metrics = new FrontendMetrics(new MetricRegistry(), frontendConfig);
+    injector = new AccountAndContainerInjector(ACCOUNT_SERVICE, metrics, frontendConfig);
     idSigningService = new AmbryIdSigningService();
     request_path =
         NAMED_BLOB_PREFIX + SLASH + REF_ACCOUNT.getName() + SLASH + REF_CONTAINER.getName() + SLASH + BLOBNAME;

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/PostAccountContainersHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/PostAccountContainersHandlerTest.java
@@ -60,11 +60,12 @@ public class PostAccountContainersHandlerTest {
   private final Account theAccount;
 
   public PostAccountContainersHandlerTest() {
-    FrontendMetrics metrics = new FrontendMetrics(new MetricRegistry());
+    FrontendConfig frontendConfig = new FrontendConfig(new VerifiableProperties(new Properties()));
+    FrontendMetrics metrics = new FrontendMetrics(new MetricRegistry(), frontendConfig);
     securityServiceFactory = new FrontendTestSecurityServiceFactory();
     accountService = new InMemAccountService(false, true);
-    handler = new PostAccountsHandler(securityServiceFactory.getSecurityService(), accountService,
-        new FrontendConfig(new VerifiableProperties(new Properties())), metrics);
+    handler =
+        new PostAccountsHandler(securityServiceFactory.getSecurityService(), accountService, frontendConfig, metrics);
     theAccount = accountService.createAndAddRandomAccount();
   }
 

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/PostAccountsHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/PostAccountsHandlerTest.java
@@ -58,11 +58,12 @@ public class PostAccountsHandlerTest {
   private final PostAccountsHandler handler;
 
   public PostAccountsHandlerTest() {
-    FrontendMetrics metrics = new FrontendMetrics(new MetricRegistry());
+    FrontendConfig frontendConfig = new FrontendConfig(new VerifiableProperties(new Properties()));
+    FrontendMetrics metrics = new FrontendMetrics(new MetricRegistry(), frontendConfig);
     securityServiceFactory = new FrontendTestSecurityServiceFactory();
     accountService = new InMemAccountService(false, true);
-    handler = new PostAccountsHandler(securityServiceFactory.getSecurityService(), accountService,
-        new FrontendConfig(new VerifiableProperties(new Properties())), metrics);
+    handler =
+        new PostAccountsHandler(securityServiceFactory.getSecurityService(), accountService, frontendConfig, metrics);
   }
 
   /**

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/PostBlobHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/PostBlobHandlerTest.java
@@ -124,7 +124,7 @@ public class PostBlobHandlerTest {
   }
 
   private final MockTime time = new MockTime();
-  private final FrontendMetrics metrics = new FrontendMetrics(new MetricRegistry());
+  private final FrontendMetrics metrics;
   private final InMemoryRouter router;
   private final FrontendTestIdConverterFactory idConverterFactory;
   private final FrontendTestSecurityServiceFactory securityServiceFactory;
@@ -139,7 +139,9 @@ public class PostBlobHandlerTest {
     Properties props = new Properties();
     VerifiableProperties verifiableProperties = new VerifiableProperties(props);
     router = new InMemoryRouter(verifiableProperties, CLUSTER_MAP);
-    injector = new AccountAndContainerInjector(ACCOUNT_SERVICE, metrics, new FrontendConfig(verifiableProperties));
+    FrontendConfig frontendConfig = new FrontendConfig(verifiableProperties);
+    metrics = new FrontendMetrics(new MetricRegistry(), frontendConfig);
+    injector = new AccountAndContainerInjector(ACCOUNT_SERVICE, metrics, frontendConfig);
     idSigningService = new AmbryIdSigningService();
     initPostBlobHandler(props);
   }

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/TtlUpdateHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/TtlUpdateHandlerTest.java
@@ -83,8 +83,8 @@ public class TtlUpdateHandlerTest {
   private final FrontendTestIdConverterFactory idConverterFactory = new FrontendTestIdConverterFactory();
 
   public TtlUpdateHandlerTest() throws Exception {
-    FrontendMetrics metrics = new FrontendMetrics(new MetricRegistry());
     FrontendConfig config = new FrontendConfig(new VerifiableProperties(new Properties()));
+    FrontendMetrics metrics = new FrontendMetrics(new MetricRegistry(), config);
     AccountAndContainerInjector accountAndContainerInjector =
         new AccountAndContainerInjector(ACCOUNT_SERVICE, metrics, config);
     ttlUpdateHandler =

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/UndeleteHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/UndeleteHandlerTest.java
@@ -84,8 +84,8 @@ public class UndeleteHandlerTest {
   private String blobId;
 
   public UndeleteHandlerTest() {
-    FrontendMetrics metrics = new FrontendMetrics(new MetricRegistry());
     FrontendConfig config = new FrontendConfig(new VerifiableProperties(new Properties()));
+    FrontendMetrics metrics = new FrontendMetrics(new MetricRegistry(), config);
     AccountAndContainerInjector accountAndContainerInjector =
         new AccountAndContainerInjector(ACCOUNT_SERVICE, metrics, config);
     undeleteHandler =


### PR DESCRIPTION
We plan to automatically test live traffic before the container deletion.
In order to do that, Nuage team support a flow which can only take two metrics, one for put request and one for get request.
So this pr support 
1. Aggregate the per request QPS metric into the get and put QPS metric.
2. Code refactoring to move containerMetricsEnabledRequestTypes into open source, so we won't forget to define the request type in close source. Currently we forget to include UndeleteBlob and PutBlob into the list in close source for container metrics.