### PR TITLE
Improve logic for termination of blob operations when they are not found in originating DC

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
@@ -32,6 +32,7 @@ public class RouterConfig {
   public static final String DEFAULT_CRYPTO_SERVICE_FACTORY = "com.github.ambry.router.GCMCryptoServiceFactory";
   public static final double DEFAULT_LATENCY_TOLERANCE_QUANTILE = 0.9;
   public static final long DEFAULT_OPERATION_TRACKER_HISTOGRAM_CACHE_TIMEOUT_MS = 1000L;
+  public static final long ROUTER_NOT_FOUND_CACHE_MAX_TTL_IN_MS = 24 * 60 * 1000L;
 
   // config keys
   public static final String ROUTER_SCALING_UNIT_COUNT = "router.scaling.unit.count";
@@ -112,6 +113,7 @@ public class RouterConfig {
   public static final String ROUTER_REQUEST_HANDLER_NUM_OF_THREADS = "router.request.handler.num.of.threads";
   public static final String ROUTER_STORE_KEY_CONVERTER_FACTORY = "router.store.key.converter.factory";
   public static final String ROUTER_UNAVAILABLE_DUE_TO_OFFLINE_REPLICAS = "router.unavailable.due.to.offline.replicas";
+  public static final String ROUTER_NOT_FOUND_CACHE_TTL_IN_MS = "router.not.found.cache.ttl.in.ms";
 
   /**
    * Number of independent scaling units for the router.
@@ -562,6 +564,14 @@ public class RouterConfig {
   public final boolean routerUnavailableDueToOfflineReplicas;
 
   /**
+   * Expiration time for Blob IDs stored in not-found cache. Default value is 15 seconds.
+   * Setting it to 0 would disable the cache and avoid storing any blob IDs.
+   */
+  @Config(ROUTER_NOT_FOUND_CACHE_TTL_IN_MS)
+  @Default("15*1000")
+  public final long routerNotFoundCacheTtlInMs;
+
+  /**
    * Create a RouterConfig instance.
    * @param verifiableProperties the properties map to refer to.
    */
@@ -682,5 +692,7 @@ public class RouterConfig {
         "com.github.ambry.store.StoreKeyConverterFactoryImpl");
     routerUnavailableDueToOfflineReplicas =
         verifiableProperties.getBoolean(ROUTER_UNAVAILABLE_DUE_TO_OFFLINE_REPLICAS, false);
+    routerNotFoundCacheTtlInMs = verifiableProperties.getLongInRange(ROUTER_NOT_FOUND_CACHE_TTL_IN_MS, 15 * 1000L, 0,
+        ROUTER_NOT_FOUND_CACHE_MAX_TTL_IN_MS);
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
@@ -566,6 +566,13 @@ public class RouterConfig {
   /**
    * Expiration time for Blob IDs stored in not-found cache. Default value is 15 seconds.
    * Setting it to 0 would disable the cache and avoid storing any blob IDs.
+   * TODO: With PR https://github.com/linkedin/ambry/pull/2072, when operation tracker fails due to blob-not-found and
+   *  some of eligible replicas are offline during the time of operation, we differentiate it with unavailable error and
+   *  and return 503 to client instead of 404. But we seem to do it only for 'ttl_update' & 'delete' but not for 'Get'.
+   *  When this cache is introduced, it is possible that blobs are cached for not-found on 'Get' and that could interfere
+   *  with above logic for 'TTL_Update' and 'Delete' as we would return 404 instead of 503. We might need to keep this
+   *  cache disabled (by setting it to 0 in configs) until we fix to return 503 for 'Get' calls as well when replicas are
+   *  offline.
    */
   @Config(ROUTER_NOT_FOUND_CACHE_TTL_IN_MS)
   @Default("15*1000")

--- a/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouter.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouter.java
@@ -29,12 +29,15 @@ import com.github.ambry.quota.QuotaChargeCallback;
 import com.github.ambry.store.StoreKey;
 import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.slf4j.Logger;
@@ -60,6 +63,9 @@ class NonBlockingRouter implements Router {
   // Resources that need to be shut down when the router does.
   private final List<Closeable> resourcesToClose;
   private final AtomicInteger currentBackgroundOperationsCount = new AtomicInteger(0);
+  private static final int cacheMaxLimit = 1000;
+  // Cache to store blob IDs which were not found in servers recently.
+  private final Cache<String, Boolean> notFoundCache;
 
   /**
    * Constructs a NonBlockingRouter.
@@ -105,6 +111,21 @@ class NonBlockingRouter implements Router {
     routerMetrics.initializeNumActiveOperationsMetrics(currentOperationsCount, currentBackgroundOperationsCount,
         backgroundDeleter.getConcurrentBackgroundDeleteOperationCount());
     resourcesToClose = new ArrayList<>();
+    // Store the blob IDs which were not found in server nodes. This would avoid querying servers again and help in reducing the load.
+    // Set the expiration time (routerConfig.routerNotFoundCacheTtlInMs) to 0 to disable the notFoundCache.
+    notFoundCache = CacheBuilder.newBuilder()
+        .maximumSize(cacheMaxLimit)
+        .expireAfterWrite(routerConfig.routerNotFoundCacheTtlInMs, TimeUnit.MILLISECONDS)
+        .recordStats()
+        .build();
+    routerMetrics.initializeNotFoundCacheMetrics(notFoundCache);
+  }
+
+  /**
+   * @return cache used to store IDs of blobs recently not found in server. Used only in tests.
+   */
+  Cache<String, Boolean> getNotFoundCache() {
+    return notFoundCache;
   }
 
   /**
@@ -202,13 +223,28 @@ class NonBlockingRouter implements Router {
     routerMetrics.operationQueuingRate.mark();
     try {
       if (isOpen.get()) {
-        getOperationController().getBlob(blobIdStr, internalOptions, (internalResult, exception) -> {
-          GetBlobResult getBlobResult = internalResult == null ? null : internalResult.getBlobResult;
-          futureResult.done(getBlobResult, exception);
-          if (callback != null) {
-            callback.onCompletion(getBlobResult, exception);
+        if (notFoundCache.getIfPresent(blobIdStr) != null) {
+          // If we know that blob doesn't exist, complete the operation.
+          logger.info("Blob {} is known to be missing in servers", blobIdStr);
+          RouterException routerException;
+          if (options.getOperationType() == GetBlobOptions.OperationType.BlobInfo) {
+            routerException = new RouterException("GetBlobInfoOperation failed because of BlobNotFound",
+                RouterErrorCode.BlobDoesNotExist);
+          } else {
+            routerException = new RouterException("GetBlobOperation failed because of BlobNotFound",
+                RouterErrorCode.BlobDoesNotExist);
           }
-        }, quotaChargeCallback);
+          completeOperation(futureResult, callback, null, routerException);
+        } else {
+          getOperationController().getBlob(blobIdStr, internalOptions,
+              new BlobOperationCallbackWrapper<>(blobIdStr, (internalResult, exception) -> {
+                GetBlobResult getBlobResult = internalResult == null ? null : internalResult.getBlobResult;
+                futureResult.done(getBlobResult, exception);
+                if (callback != null) {
+                  callback.onCompletion(getBlobResult, exception);
+                }
+              }), quotaChargeCallback);
+        }
       } else {
         boolean isEncrypted = false;
         try {
@@ -314,12 +350,20 @@ class NonBlockingRouter implements Router {
     routerMetrics.operationQueuingRate.mark();
     FutureResult<Void> futureResult = new FutureResult<>();
     if (isOpen.get()) {
-      // Can skip attemptChunkDeletes if we can determine this is not a metadata blob
-      boolean attemptChunkDeletes = isMaybeMetadataBlob(blobId);
-      getOperationController().deleteBlob(blobId, serviceId, futureResult, callback, attemptChunkDeletes,
-          quotaChargeCallback);
-      if (!attemptChunkDeletes) {
-        routerMetrics.skippedGetBlobCount.inc();
+      if (notFoundCache.getIfPresent(blobId) != null) {
+        // If we know that blob doesn't exist, complete the operation
+        logger.info("Blob {} is known to be missing in servers", blobId);
+        RouterException routerException =
+            new RouterException("DeleteOperation failed because of BlobNotFound", RouterErrorCode.BlobDoesNotExist);
+        completeOperation(futureResult, callback, null, routerException);
+      } else {
+        // Can skip attemptChunkDeletes if we can determine this is not a metadata blob
+        boolean attemptChunkDeletes = isMaybeMetadataBlob(blobId);
+        getOperationController().deleteBlob(blobId, serviceId, futureResult,
+            new BlobOperationCallbackWrapper<>(blobId, callback), attemptChunkDeletes, quotaChargeCallback);
+        if (!attemptChunkDeletes) {
+          routerMetrics.skippedGetBlobCount.inc();
+        }
       }
     } else {
       RouterException routerException =
@@ -349,7 +393,16 @@ class NonBlockingRouter implements Router {
     routerMetrics.operationQueuingRate.mark();
     FutureResult<Void> futureResult = new FutureResult<>();
     if (isOpen.get()) {
-      getOperationController().undeleteBlob(blobId, serviceId, futureResult, callback, quotaChargeCallback);
+      if (notFoundCache.getIfPresent(blobId) != null) {
+        // If we know that blob doesn't exist, complete the operation.
+        logger.info("Blob {} is known to be missing in servers", blobId);
+        RouterException routerException =
+            new RouterException("UndeleteOperation failed because of BlobNotFound", RouterErrorCode.BlobDoesNotExist);
+        completeOperation(futureResult, callback, null, routerException);
+      } else {
+        getOperationController().undeleteBlob(blobId, serviceId, futureResult,
+            new BlobOperationCallbackWrapper<>(blobId, callback), quotaChargeCallback);
+      }
     } else {
       RouterException routerException =
           new RouterException("Cannot accept operation because Router is closed", RouterErrorCode.RouterClosed);
@@ -381,8 +434,16 @@ class NonBlockingRouter implements Router {
     routerMetrics.operationQueuingRate.mark();
     FutureResult<Void> futureResult = new FutureResult<>();
     if (isOpen.get()) {
-      getOperationController().updateBlobTtl(blobId, serviceId, expiresAtMs, futureResult, callback,
-          quotaChargeCallback);
+      if (notFoundCache.getIfPresent(blobId) != null) {
+        // If we know that blob doesn't exist, complete the operation.
+        logger.info("Blob {} is known to be missing in servers", blobId);
+        RouterException routerException =
+            new RouterException("TtlUpdateOperation failed because of BlobNotFound", RouterErrorCode.BlobDoesNotExist);
+        completeOperation(futureResult, callback, null, routerException);
+      } else {
+        getOperationController().updateBlobTtl(blobId, serviceId, expiresAtMs, futureResult,
+            new BlobOperationCallbackWrapper<>(blobId, callback), quotaChargeCallback);
+      }
     } else {
       RouterException routerException =
           new RouterException("Cannot accept operation because Router is closed", RouterErrorCode.RouterClosed);
@@ -580,6 +641,39 @@ class NonBlockingRouter implements Router {
    */
   int getBackgroundOperationsCount() {
     return currentBackgroundOperationsCount.get();
+  }
+
+  /**
+   * Wrapper for callbacks provided to router operations to intercept the responses and do operations such as keeping
+   * track of errors, etc. Currently, it caches the blob IDs which were not found in the servers to avoid querying them
+   * again for a configurable duration.
+   */
+  protected class BlobOperationCallbackWrapper<T> implements Callback<T> {
+
+    private final String blobId;
+    private final Callback<T> callback;
+
+    /**
+     * Creates an instance of BlobOperationCallbackWrapper with the given {@code callback}.
+     * @param blobId Blob Id on which operation is requested.
+     * @param callback the {@link Callback} to invoke on operation completion.
+     */
+    public BlobOperationCallbackWrapper(String blobId, Callback<T> callback) {
+      this.blobId = blobId;
+      this.callback = callback;
+    }
+
+    @Override
+    public void onCompletion(T result, Exception exception) {
+      // If blob doesn't exist, add it to notFoundCache to avoid querying server nodes again.
+      if (exception instanceof RouterException && ((RouterException) exception).getErrorCode()
+          .equals(RouterErrorCode.BlobDoesNotExist)) {
+        notFoundCache.put(blobId, true);
+      }
+      if (callback != null) {
+        callback.onCompletion(result, exception);
+      }
+    }
   }
 }
 

--- a/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterMetrics.java
@@ -33,6 +33,7 @@ import com.github.ambry.quota.QuotaResource;
 import com.github.ambry.utils.CachedHistogram;
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.Utils;
+import com.google.common.cache.Cache;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -729,9 +730,18 @@ public class NonBlockingRouterMetrics {
         (Gauge<Integer>) currentOperationsCount::get);
     metricRegistry.register(MetricRegistry.name(NonBlockingRouter.class, "NumActiveBackgroundOperations"),
         (Gauge<Integer>) currentBackgroundOperationsCount::get);
-    metricRegistry.register(
-        MetricRegistry.name(BackgroundDeleter.class, "NumberConcurrentBackgroundDeleteOperations"),
+    metricRegistry.register(MetricRegistry.name(BackgroundDeleter.class, "NumberConcurrentBackgroundDeleteOperations"),
         (Gauge<Integer>) concurrentBackgroundDeleteOperationCount::get);
+  }
+
+  /**
+   * Initializes a {@link Gauge} metric to monitor the cache hit rate for {@link Cache} keeping track of blobs
+   * which known not to be present in Ambry.
+   * @param cache which keeps track of blobs not found recently.
+   */
+  public void initializeNotFoundCacheMetrics(Cache cache) {
+    metricRegistry.register(MetricRegistry.name(NonBlockingRouter.class, "BlobsNotFoundCacheHitRate"),
+        (Gauge<Double>) () -> cache.stats().hitRate());
   }
 
   /**

--- a/ambry-router/src/test/java/com/github/ambry/router/CloudRouterTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/CloudRouterTest.java
@@ -286,4 +286,10 @@ public class CloudRouterTest extends NonBlockingRouterTest {
   @Ignore
   public void testResponseHandling() throws Exception {
   }
+
+  @Override
+  @Ignore
+  public void testBlobNotFoundCache() throws Exception {
+
+  }
 }

--- a/ambry-router/src/test/java/com/github/ambry/router/DeleteManagerTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/DeleteManagerTest.java
@@ -298,6 +298,8 @@ public class DeleteManagerTest {
       }
     }
     for (Map.Entry<ServerErrorCode, RouterErrorCode> entity : map.entrySet()) {
+      // Reset not-found cache after each test since we are using same blob ID for all error codes
+      router.getNotFoundCache().invalidateAll();
       testWithErrorCodes(Collections.singletonMap(entity.getKey(), 9), serverLayout, entity.getValue(),
           deleteErrorCodeChecker);
     }
@@ -416,8 +418,8 @@ public class DeleteManagerTest {
           @Override
           public void testAndAssert(RouterErrorCode expectedError) throws Exception {
             CountDownLatch operationCompleteLatch = new CountDownLatch(1);
-            future = router.deleteBlob(blobIdString, null, new ClientCallback(operationCompleteLatch),
-                quotaChargeCallback);
+            future =
+                router.deleteBlob(blobIdString, null, new ClientCallback(operationCompleteLatch), quotaChargeCallback);
             do {
               // increment mock time
               mockTime.sleep(1000);
@@ -595,6 +597,8 @@ public class DeleteManagerTest {
         serverErrorCodes.set(i * 2, ServerErrorCode.Blob_Not_Found);
         serverErrorCodes.set(i * 2 + 1, ServerErrorCode.Blob_Not_Found);
       }
+      // Reset not-found cache after each test since we are using same blob ID for all error codes
+      router.getNotFoundCache().invalidateAll();
     }
     serverLayout.getMockServers().forEach(MockServer::resetServerErrors);
   }

--- a/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTestBase.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTestBase.java
@@ -85,6 +85,7 @@ public class NonBlockingRouterTestBase {
   protected static final int DELETE_SUCCESS_TARGET = 2;
   protected static final int PUT_CONTENT_SIZE = 1000;
   protected static final int USER_METADATA_SIZE = 10;
+  protected static final int NOT_FOUND_CACHE_TTL_MS = 1000;
   protected final AtomicReference<MockSelectorState> mockSelectorState = new AtomicReference<>(MockSelectorState.Good);
   protected final MockTime mockTime;
   protected final MockKeyManagementService kms;
@@ -186,6 +187,7 @@ public class NonBlockingRouterTestBase {
     properties.setProperty("clustermap.host.name", "localhost");
     properties.setProperty("kms.default.container.key", TestUtils.getRandomKey(128));
     properties.setProperty("router.metadata.content.version", String.valueOf(metadataContentVersion));
+    properties.setProperty("router.not.found.cache.ttl.in.ms", String.valueOf(NOT_FOUND_CACHE_TTL_MS));
     return properties;
   }
 


### PR DESCRIPTION
Make sure there are at least 'PutSuccessTarget' replicas in leader or standby state in originating data center before terminating the operation with blob-not-found error.

Also, have a negative cache to store recently not-found blob IDs to avoid querying the servers again.