### PR TITLE
[BANDWIDTH_THROTTLING] Ensure that PreProcessQuotaChargeCallback doesn't return DELAY or REJECT recommendation, when QuotaMode is TRACKING.

### DIFF
--- a/ambry-quota/src/main/java/com/github/ambry/quota/PreProcessQuotaChargeCallback.java
+++ b/ambry-quota/src/main/java/com/github/ambry/quota/PreProcessQuotaChargeCallback.java
@@ -18,8 +18,6 @@ import com.github.ambry.rest.RestRequest;
 import com.github.ambry.router.RouterErrorCode;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
@@ -54,7 +52,11 @@ public class PreProcessQuotaChargeCallback implements QuotaChargeCallback {
         .entrySet()
         .stream()
         .collect(Collectors.toMap(entry -> QuotaName.valueOf(entry.getKey()), Map.Entry::getValue));
-    return quotaManager.chargeAndRecommend(restRequest, requestCost, shouldCheckQuotaExceedAllowed, forceCharge);
+    QuotaAction quotaAction =
+        quotaManager.chargeAndRecommend(restRequest, requestCost, shouldCheckQuotaExceedAllowed, forceCharge);
+    // Note that we track quota usages even if QuotaMode is TRACKING, so although we return ALLOW, checkAndCharge still
+    // needs to happen
+    return quotaManager.getQuotaMode() == QuotaMode.TRACKING ? QuotaAction.ALLOW : quotaAction;
   }
 
   @Override


### PR DESCRIPTION
Returning DELAY or REJECT from PreProcessQuotaChargeCallback will lead to enforcement of quotas in QuotaAwareOperationController. This PR ensure that when QuotaMode is Tracking, the usage is tracked, but PreProcessQuotaChargeCallback returns ALLOW recommendation in all cases.