### PR TITLE
[BANDWIDTH_THROTTLING] Handle quota rejected response in all operations.

### DIFF
--- a/ambry-router/src/test/java/com/github/ambry/router/DeleteManagerTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/DeleteManagerTest.java
@@ -204,6 +204,24 @@ public class DeleteManagerTest {
   }
 
   /**
+   * Test for the case when delete operation fails due to quota compliance.
+   */
+  @Test
+  public void testQuotaRejected() throws Exception {
+    // Create a router with QuotaRejectionOperationController for this test.
+    router.close();
+    Properties properties = getNonBlockingRouterProperties();
+    properties.setProperty(RouterConfig.OPERATION_CONTROLLER, QuotaRejectingOperationController.class.getCanonicalName());
+    VerifiableProperties vProps = new VerifiableProperties(properties);
+    RouterConfig routerConfig = new RouterConfig(vProps);
+    router = new NonBlockingRouter(routerConfig, new NonBlockingRouterMetrics(clusterMap, routerConfig),
+        new MockNetworkClientFactory(vProps, mockSelectorState, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
+            CHECKOUT_TIMEOUT_MS, serverLayout, mockTime), new LoggingNotificationSystem(), clusterMap, null, null, null,
+        new InMemAccountService(false, true), mockTime, MockClusterMap.DEFAULT_PARTITION_CLASS);
+    testWithQuotaRejection(deleteErrorCodeChecker);
+  }
+
+  /**
    * Test the case when one server store responds with {@code Blob_Authorization_Failure}, and other servers
    * respond with {@code Blob_Not_Found}. The delete operation should be able to resolve the
    * router error code as {@code Blob_Authorization_Failure}. The order of received responses is the same as

--- a/ambry-router/src/test/java/com/github/ambry/router/QuotaRejectingOperationController.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/QuotaRejectingOperationController.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2022 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.router;
+
+import com.github.ambry.account.AccountService;
+import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.commons.ResponseHandler;
+import com.github.ambry.config.RouterConfig;
+import com.github.ambry.network.NetworkClientFactory;
+import com.github.ambry.network.RequestInfo;
+import com.github.ambry.network.ResponseInfo;
+import com.github.ambry.notification.NotificationSystem;
+import com.github.ambry.utils.Time;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * An {@link OperationController} implementation, that rejects all requests for quota compliance.
+ */
+public class QuotaRejectingOperationController extends OperationController {
+  private static final Logger logger = LoggerFactory.getLogger(QuotaRejectingOperationController.class);
+  public QuotaRejectingOperationController(String suffix, String defaultPartitionClass, AccountService accountService,
+      NetworkClientFactory networkClientFactory, ClusterMap clusterMap, RouterConfig routerConfig,
+      ResponseHandler responseHandler, NotificationSystem notificationSystem, NonBlockingRouterMetrics routerMetrics,
+      KeyManagementService kms, CryptoService cryptoService, CryptoJobHandler cryptoJobHandler, Time time,
+      NonBlockingRouter nonBlockingRouter) throws IOException {
+    super(suffix, defaultPartitionClass, accountService, networkClientFactory, clusterMap, routerConfig,
+        responseHandler, notificationSystem, routerMetrics, kms, cryptoService, cryptoJobHandler, time,
+        nonBlockingRouter);
+  }
+
+  @Override
+  public void run() {
+    try {
+      while (nonBlockingRouter.isOpen.get()) {
+        List<RequestInfo> requestsToSend = new ArrayList<>();
+        Set<Integer> requestsToDrop = new HashSet<>();
+        pollForRequests(requestsToSend, requestsToDrop);
+
+        List<ResponseInfo> responseInfoList = new ArrayList<>();
+        for(RequestInfo requestInfo : requestsToSend) {
+          responseInfoList.add(new ResponseInfo(requestInfo, true));
+        }
+        onResponse(responseInfoList);
+        responseInfoList.forEach(ResponseInfo::release);
+      }
+    } catch (Throwable e) {
+      logger.error("Aborting, as requestResponseHandlerThread received an unexpected error: ", e);
+      routerMetrics.requestResponseHandlerUnexpectedErrorCount.inc();
+    } finally {
+      // Close the router.
+      nonBlockingRouter.shutDownOperationControllers();
+    }
+  }
+}

--- a/ambry-router/src/test/java/com/github/ambry/router/RouterTestHelpers.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/RouterTestHelpers.java
@@ -128,6 +128,16 @@ class RouterTestHelpers {
   }
 
   /**
+   * Test operation that gets rejected due to quota checks.
+   * @param errorCodeChecker Performs the checks that ensure that {@link RouterErrorCode#TooManyRequests} is returned .
+   * @throws Exception
+   */
+  static void testWithQuotaRejection(ErrorCodeChecker errorCodeChecker)
+      throws Exception {
+    errorCodeChecker.testAndAssert(RouterErrorCode.TooManyRequests);
+  }
+
+  /**
    * Set the servers in the specified layout to respond with the designated error codes.
    * @param serverErrorCodesInOrder The error codes to set in the order of the servers in {@code serverLayout}.
    *                                If there are fewer error codes in this array than there are servers,


### PR DESCRIPTION
This PR handles quota rejected response in all operations -- Get, GetInfo, Put, Delete, Undelete and TtlUpdate.
The main changes are in the handleResponse() of each operation. In handleResponse() if the response info indicates that the response has been rejected due to quota compliance, then the operation/chunk should be marked as failed due to RouterErrorCode.TooManyRequests.

This PR also updates the precedence of errors for each of the operations, by updating the getPrecendenceLevel() method in each of the operations. In case multiple errors are present, the final error thrown is based on the precedence order.