### PR TITLE
Split string on spaces when using 'commandLine' option in Gradle Executable tasks

### DIFF
--- a/gradle/ci-release.gradle
+++ b/gradle/ci-release.gradle
@@ -33,7 +33,7 @@ task gitPush {
 
     doLast {
       println "Pushing tag v$version"
-      exec { commandLine "git" "push" "--tags" }
+      exec { commandLine "git", "push", "--tags" }
       println "Pushed tag v$version"
     }
 }


### PR DESCRIPTION
Fixing typo in PR https://github.com/linkedin/ambry/pull/2088 to split string on spaces in the gradle Exec task.

For example, exec { commandLine "git" "push" "--tags" } seem to be executed as as 'gitpush --tags' instead of 'git push --tags' (https://github.com/linkedin/ambry/runs/5843222047?check_suite_focus=true#step:6:444). 