### PR TITLE
Support max ttl for chunk upload

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/FrontendConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/FrontendConfig.java
@@ -32,6 +32,7 @@ public class FrontendConfig {
   // Property keys
   public static final String URL_SIGNER_ENDPOINTS = PREFIX + "url.signer.endpoints";
   public static final String CHUNK_UPLOAD_INITIAL_CHUNK_TTL_SECS_KEY = PREFIX + "chunk.upload.initial.chunk.ttl.secs";
+  public static final String CHUNK_UPLOAD_MAX_CHUNK_TTL_SECS_KEY = PREFIX + "chunk.upload.max.chunk.ttl.secs";
   public static final String FAIL_IF_TTL_REQUIRED_BUT_NOT_PROVIDED_KEY =
       PREFIX + "fail.if.ttl.required.but.not.provided";
   public static final String MAX_ACCEPTABLE_TTL_SECS_IF_TTL_REQUIRED_KEY =
@@ -192,11 +193,18 @@ public class FrontendConfig {
   public final GetOption defaultRouterGetOption;
 
   /**
-   * The blob TTL in seconds to use for data chunks uploaded in a stitched upload session.
+   * The default blob TTL in seconds to use for data chunks uploaded in a stitched upload session.
    */
   @Config(CHUNK_UPLOAD_INITIAL_CHUNK_TTL_SECS_KEY)
   @Default("28 * 24 * 60 * 60")
   public final long chunkUploadInitialChunkTtlSecs;
+
+  /**
+   * Maximum value of the blob TTL in seconds to use for data chunks uploaded in a stitched upload session.
+   */
+  @Config(CHUNK_UPLOAD_MAX_CHUNK_TTL_SECS_KEY)
+  @Default("90 * 24 * 60 * 60")
+  public final long chunkUploadMaxChunkTtlSecs;
 
   @Config(FAIL_IF_TTL_REQUIRED_BUT_NOT_PROVIDED_KEY)
   @Default("false")
@@ -301,6 +309,7 @@ public class FrontendConfig {
         GetOption.valueOf(verifiableProperties.getString("frontend.default.router.get.option", GetOption.None.name()));
     chunkUploadInitialChunkTtlSecs =
         verifiableProperties.getLong(CHUNK_UPLOAD_INITIAL_CHUNK_TTL_SECS_KEY, TimeUnit.DAYS.toSeconds(28));
+    chunkUploadMaxChunkTtlSecs = verifiableProperties.getLong(CHUNK_UPLOAD_MAX_CHUNK_TTL_SECS_KEY, TimeUnit.DAYS.toSeconds(90));
     failIfTtlRequiredButNotProvided = verifiableProperties.getBoolean(FAIL_IF_TTL_REQUIRED_BUT_NOT_PROVIDED_KEY, false);
     maxAcceptableTtlSecsIfTtlRequired = verifiableProperties.getIntInRange(MAX_ACCEPTABLE_TTL_SECS_IF_TTL_REQUIRED_KEY,
         (int) TimeUnit.DAYS.toSeconds(30), 0, Integer.MAX_VALUE);

--- a/ambry-api/src/main/java/com/github/ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com/github/ambry/rest/RestUtils.java
@@ -460,7 +460,7 @@ public class RestUtils {
   }
 
   /**
-   * An util method to get ttl from arguments associated with a request.
+   * An util method to get ttl from arguments associated with a request. CHUNK_UPLOAD_TTL takes precedence over TTL.
    * @param args the arguments associated with the request. Cannot be {@code null}.
    * @return the ttl extracted from the arguments.
    * @throws RestServiceException if required arguments aren't present or if they aren't in the format expected.
@@ -470,6 +470,10 @@ public class RestUtils {
     Long ttlFromHeader = getLongHeader(args, Headers.TTL, false);
     Long chunkUploadTtlFromHeader = getLongHeader(args, Headers.CHUNK_UPLOAD_TTL, false);
     if (chunkUploadTtlFromHeader != null) {
+      if (chunkUploadTtlFromHeader < -1) {
+        throw new RestServiceException(Headers.CHUNK_UPLOAD_TTL + "[" + chunkUploadTtlFromHeader + "] is not valid (has to be >= -1)",
+            RestServiceErrorCode.InvalidArgs);
+      }
       ttl = chunkUploadTtlFromHeader;
     } else {
       if (ttlFromHeader != null) {

--- a/ambry-api/src/main/java/com/github/ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com/github/ambry/rest/RestUtils.java
@@ -202,10 +202,6 @@ public class RestUtils {
      */
     public static final String URL_TTL = "x-ambry-url-ttl-secs";
     /**
-     * The TTL (in secs) of the chunk upload.
-     */
-    public static final String CHUNK_UPLOAD_TTL = "x-ambry-chunk-upload-ttl";
-    /**
      * The maximum size of the blob that can be uploaded using the URL.
      */
     public static final String MAX_UPLOAD_SIZE = "x-ambry-max-upload-size";
@@ -460,7 +456,7 @@ public class RestUtils {
   }
 
   /**
-   * An util method to get ttl from arguments associated with a request. CHUNK_UPLOAD_TTL takes precedence over TTL.
+   * An util method to get ttl from arguments associated with a request.
    * @param args the arguments associated with the request. Cannot be {@code null}.
    * @return the ttl extracted from the arguments.
    * @throws RestServiceException if required arguments aren't present or if they aren't in the format expected.
@@ -468,21 +464,12 @@ public class RestUtils {
   public static long getTtlFromRequestHeader(Map<String, Object> args) throws RestServiceException {
     long ttl = Utils.Infinite_Time;
     Long ttlFromHeader = getLongHeader(args, Headers.TTL, false);
-    Long chunkUploadTtlFromHeader = getLongHeader(args, Headers.CHUNK_UPLOAD_TTL, false);
-    if (chunkUploadTtlFromHeader != null) {
-      if (chunkUploadTtlFromHeader < -1) {
-        throw new RestServiceException(Headers.CHUNK_UPLOAD_TTL + "[" + chunkUploadTtlFromHeader + "] is not valid (has to be >= -1)",
+    if (ttlFromHeader != null) {
+      if (ttlFromHeader < -1) {
+        throw new RestServiceException(Headers.TTL + "[" + ttlFromHeader + "] is not valid (has to be >= -1)",
             RestServiceErrorCode.InvalidArgs);
       }
-      ttl = chunkUploadTtlFromHeader;
-    } else {
-      if (ttlFromHeader != null) {
-        if (ttlFromHeader < -1) {
-          throw new RestServiceException(Headers.TTL + "[" + ttlFromHeader + "] is not valid (has to be >= -1)",
-              RestServiceErrorCode.InvalidArgs);
-        }
-        ttl = ttlFromHeader;
-      }
+      ttl = ttlFromHeader;
     }
     return ttl;
   }

--- a/ambry-api/src/main/java/com/github/ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com/github/ambry/rest/RestUtils.java
@@ -18,7 +18,6 @@ import com.github.ambry.account.Container;
 import com.github.ambry.frontend.Operations;
 import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.protocol.GetOption;
-import com.github.ambry.quota.QuotaName;
 import com.github.ambry.quota.ThrottlingRecommendation;
 import com.github.ambry.router.ByteRange;
 import com.github.ambry.router.ByteRanges;
@@ -202,6 +201,10 @@ public class RestUtils {
      * The TTL (in secs) of the signed URL.
      */
     public static final String URL_TTL = "x-ambry-url-ttl-secs";
+    /**
+     * The TTL (in secs) of the chunk upload.
+     */
+    public static final String CHUNK_UPLOAD_TTL = "x-ambry-chunk-upload-ttl";
     /**
      * The maximum size of the blob that can be uploaded using the URL.
      */
@@ -465,12 +468,17 @@ public class RestUtils {
   public static long getTtlFromRequestHeader(Map<String, Object> args) throws RestServiceException {
     long ttl = Utils.Infinite_Time;
     Long ttlFromHeader = getLongHeader(args, Headers.TTL, false);
-    if (ttlFromHeader != null) {
-      if (ttlFromHeader < -1) {
-        throw new RestServiceException(Headers.TTL + "[" + ttlFromHeader + "] is not valid (has to be >= -1)",
-            RestServiceErrorCode.InvalidArgs);
+    Long chunkUploadTtlFromHeader = getLongHeader(args, Headers.CHUNK_UPLOAD_TTL, false);
+    if (chunkUploadTtlFromHeader != null) {
+      ttl = chunkUploadTtlFromHeader;
+    } else {
+      if (ttlFromHeader != null) {
+        if (ttlFromHeader < -1) {
+          throw new RestServiceException(Headers.TTL + "[" + ttlFromHeader + "] is not valid (has to be >= -1)",
+              RestServiceErrorCode.InvalidArgs);
+        }
+        ttl = ttlFromHeader;
       }
-      ttl = ttlFromHeader;
     }
     return ttl;
   }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbryUrlSigningService.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbryUrlSigningService.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.UUID;
 
 
+
 /**
  * Default implementation of {@link UrlSigningService} that currently only converts all headers that start with
  * "x-ambry-" into query parameters and does not actually sign the URL.
@@ -139,7 +140,9 @@ public class AmbryUrlSigningService implements UrlSigningService {
         maxUploadSize = chunkUploadMaxChunkSize;
         // They also have a non-optional blob TTL to ensure that chunks that were not stitched within a reasonable time
         // span are cleaned up.
-        argsForUrl.put(RestUtils.Headers.TTL, chunkUploadInitialChunkTtlSecs);
+        if (RestUtils.getLongHeader(args, RestUtils.Headers.TTL, false) == null) {
+          argsForUrl.put(RestUtils.Headers.TTL, chunkUploadInitialChunkTtlSecs);
+        }
         argsForUrl.put(RestUtils.Headers.CHUNK_UPLOAD, true);
         argsForUrl.put(RestUtils.Headers.SESSION, UUID.randomUUID().toString());
       }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/PostBlobHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/PostBlobHandler.java
@@ -265,16 +265,12 @@ class PostBlobHandler {
           frontendMetrics.postBlobMetricsGroup);
       BlobProperties blobProperties = RestUtils.buildBlobProperties(restRequest.getArgs());
       Container container = RestUtils.getContainerFromArgs(restRequest.getArgs());
-      Long chunkUploadTtl =
-          RestUtils.getLongHeader(restRequest.getArgs(), RestUtils.Headers.CHUNK_UPLOAD_TTL, false);
       if (blobProperties.getTimeToLiveInSeconds() + TimeUnit.MILLISECONDS.toSeconds(
           blobProperties.getCreationTimeInMs()) > Integer.MAX_VALUE) {
         LOGGER.debug("TTL set to very large value in POST request with BlobProperties {}", blobProperties);
         frontendMetrics.ttlTooLargeError.inc();
-      } else if (container.isTtlRequired() && (
-          blobProperties.getTimeToLiveInSeconds() == Utils.Infinite_Time || (chunkUploadTtl == null ?
-              blobProperties.getTimeToLiveInSeconds() > frontendConfig.maxAcceptableTtlSecsIfTtlRequired
-              : blobProperties.getTimeToLiveInSeconds() > frontendConfig.chunkUploadMaxChunkTtlSecs))) {
+      } else if (container.isTtlRequired() && (blobProperties.getTimeToLiveInSeconds() == Utils.Infinite_Time
+          || blobProperties.getTimeToLiveInSeconds() > frontendConfig.maxAcceptableTtlSecsIfTtlRequired)) {
         String descriptor = RestUtils.getAccountFromArgs(restRequest.getArgs()).getName() + ":" + container.getName();
         if (frontendConfig.failIfTtlRequiredButNotProvided) {
           throw new RestServiceException(
@@ -343,12 +339,9 @@ class PostBlobHandler {
         RestUtils.getHeader(restRequest.getArgs(), RestUtils.Headers.SESSION, true);
         // validate that a max chunk size is set.
         RestUtils.getLongHeader(restRequest.getArgs(), RestUtils.Headers.MAX_UPLOAD_SIZE, true);
-        Long chunkUploadTtl =
-            RestUtils.getLongHeader(restRequest.getArgs(), RestUtils.Headers.CHUNK_UPLOAD_TTL, false);
         // validate that the TTL for the chunk is set correctly.
         long chunkTtl = blobProperties.getTimeToLiveInSeconds();
-        if (chunkTtl <= 0 || (chunkUploadTtl == null ? chunkTtl > frontendConfig.chunkUploadInitialChunkTtlSecs
-            : chunkUploadTtl > frontendConfig.chunkUploadMaxChunkTtlSecs)) {
+        if (chunkTtl <= 0 || chunkTtl > frontendConfig.chunkUploadMaxChunkTtlSecs) {
           throw new RestServiceException("Invalid chunk upload TTL: " + chunkTtl, RestServiceErrorCode.InvalidArgs);
         }
       }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/PostBlobHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/PostBlobHandler.java
@@ -271,11 +271,10 @@ class PostBlobHandler {
           blobProperties.getCreationTimeInMs()) > Integer.MAX_VALUE) {
         LOGGER.debug("TTL set to very large value in POST request with BlobProperties {}", blobProperties);
         frontendMetrics.ttlTooLargeError.inc();
-      } else if (container.isTtlRequired() && (blobProperties.getTimeToLiveInSeconds() == Utils.Infinite_Time
-          || chunkUploadTtl == null
-          && blobProperties.getTimeToLiveInSeconds() > frontendConfig.maxAcceptableTtlSecsIfTtlRequired
-          || chunkUploadTtl != null
-          && blobProperties.getTimeToLiveInSeconds() > frontendConfig.chunkUploadMaxChunkTtlSecs)) {
+      } else if (container.isTtlRequired() && (
+          blobProperties.getTimeToLiveInSeconds() == Utils.Infinite_Time || (chunkUploadTtl == null ?
+              blobProperties.getTimeToLiveInSeconds() > frontendConfig.maxAcceptableTtlSecsIfTtlRequired
+              : blobProperties.getTimeToLiveInSeconds() > frontendConfig.chunkUploadMaxChunkTtlSecs))) {
         String descriptor = RestUtils.getAccountFromArgs(restRequest.getArgs()).getName() + ":" + container.getName();
         if (frontendConfig.failIfTtlRequiredButNotProvided) {
           throw new RestServiceException(
@@ -348,8 +347,8 @@ class PostBlobHandler {
             RestUtils.getLongHeader(restRequest.getArgs(), RestUtils.Headers.CHUNK_UPLOAD_TTL, false);
         // validate that the TTL for the chunk is set correctly.
         long chunkTtl = blobProperties.getTimeToLiveInSeconds();
-        if (chunkTtl <= 0 || chunkUploadTtl == null && chunkTtl > frontendConfig.chunkUploadInitialChunkTtlSecs
-            || chunkUploadTtl != null && chunkUploadTtl > frontendConfig.chunkUploadMaxChunkTtlSecs) {
+        if (chunkTtl <= 0 || (chunkUploadTtl == null ? chunkTtl > frontendConfig.chunkUploadInitialChunkTtlSecs
+            : chunkUploadTtl > frontendConfig.chunkUploadMaxChunkTtlSecs)) {
           throw new RestServiceException("Invalid chunk upload TTL: " + chunkTtl, RestServiceErrorCode.InvalidArgs);
         }
       }

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendIntegrationTestBase.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendIntegrationTestBase.java
@@ -246,10 +246,10 @@ public class FrontendIntegrationTestBase {
    * @throws IllegalArgumentException if any of {@code headers}, {@code serviceId}, {@code contentType} is null or if
    *                                  {@code contentLength} < 0 or if {@code ttlInSecs} < -1.
    */
-  void setAmbryHeadersForPut(HttpHeaders httpHeaders, long ttlInSecs, boolean isPrivate, String serviceId,
+  void setAmbryHeadersForPut(HttpHeaders httpHeaders, Long ttlInSecs, boolean isPrivate, String serviceId,
       String contentType, String ownerId, String targetAccountName, String targetContainerName) {
     if (httpHeaders != null && serviceId != null && contentType != null) {
-      if (ttlInSecs > -1) {
+      if (ttlInSecs != null && ttlInSecs > -1) {
         httpHeaders.add(RestUtils.Headers.TTL, ttlInSecs);
       }
       httpHeaders.add(RestUtils.Headers.SERVICE_ID, serviceId);


### PR DESCRIPTION
This PR support:
1. Treat chunkUploadInitialChunkTtlSecs as the default if the customer did not specify ttl
2. If the customer did specify x-ambry-ttl header, check that it is less than chunkUploadMaxChunkTtlSecs instead of chunkUploadInitialChunkTtlSecs