### PR TITLE
Add missing quota charge callback for background delete operations. Add logs if QuotaChargeCallback is null in OperationQuotaCharger.

### DIFF
--- a/ambry-router/src/main/java/com/github/ambry/router/OperationController.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/OperationController.java
@@ -645,7 +645,7 @@ class BackgroundDeleter extends OperationController {
       super.deleteBlob(blobIdStr, serviceId, futureResult, (Void result, Exception e) -> {
         callback.onCompletion(result, e);
         concurrentBackgroundDeleteOperationCount.decrementAndGet();
-      }, attemptChunkDeletes, null);
+      }, attemptChunkDeletes, quotaChargeCallback);
       return null;
     };
     if (routerConfig.routerBackgroundDeleterMaxConcurrentOperations > 0) {

--- a/ambry-router/src/main/java/com/github/ambry/router/OperationQuotaCharger.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/OperationQuotaCharger.java
@@ -98,6 +98,7 @@ public class OperationQuotaCharger implements Chargeable {
   @Override
   public QuotaResource getQuotaResource() {
     if (Objects.isNull(quotaChargeCallback)) {
+      LOGGER.warn("quota charge callback is null for operation: {}", operationName);
       return null;
     }
     try {
@@ -116,6 +117,10 @@ public class OperationQuotaCharger implements Chargeable {
 
   @Override
   public QuotaMethod getQuotaMethod() {
+    if (Objects.isNull(quotaChargeCallback)) {
+      LOGGER.warn("quota charge callback is null for operation: {}", operationName);
+      return null;
+    }
     return quotaChargeCallback.getQuotaMethod();
   }
 

--- a/ambry-router/src/test/java/com/github/ambry/router/OperationQuotaChargerTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/OperationQuotaChargerTest.java
@@ -23,6 +23,7 @@ import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.quota.QuotaAction;
 import com.github.ambry.quota.QuotaChargeCallback;
 import com.github.ambry.quota.QuotaException;
+import com.github.ambry.quota.QuotaMethod;
 import com.github.ambry.quota.QuotaResource;
 import com.github.ambry.quota.QuotaResourceType;
 import com.github.ambry.rest.RestServiceErrorCode;
@@ -85,6 +86,28 @@ public class OperationQuotaChargerTest {
     Assert.assertNull("getQuotaResource should return null if quotaChargeCallback is null.",
         operationQuotaCharger.getQuotaResource());
     Assert.assertEquals(1, routerMetrics.unknownExceptionInChargeableRate.getCount());
+  }
+
+  @Test
+  public void testGetQuotaMethod() throws Exception {
+    ClusterMap clusterMap = new MockClusterMap();
+    NonBlockingRouterMetrics routerMetrics = new NonBlockingRouterMetrics(clusterMap, routerConfig);
+    // getQuotaResource should return null if quotaChargeCallback is null.
+    OperationQuotaCharger operationQuotaCharger =
+        new OperationQuotaCharger(null, BLOBID, GetOperation.class.getSimpleName(), routerMetrics);
+    Assert.assertNull("getQuotaResource should return null if quotaChargeCallback is null.",
+        operationQuotaCharger.getQuotaMethod());
+
+    QuotaChargeCallback quotaChargeCallback = Mockito.mock(QuotaChargeCallback.class);
+    Mockito.when(quotaChargeCallback.getQuotaMethod()).thenReturn(QuotaMethod.READ);
+    operationQuotaCharger =
+        new OperationQuotaCharger(quotaChargeCallback, BLOBID, GetOperation.class.getSimpleName(), routerMetrics);
+    Assert.assertEquals(QuotaMethod.READ, operationQuotaCharger.getQuotaMethod());
+
+    Mockito.when(quotaChargeCallback.getQuotaMethod()).thenReturn(QuotaMethod.WRITE);
+    operationQuotaCharger =
+        new OperationQuotaCharger(quotaChargeCallback, BLOBID, GetOperation.class.getSimpleName(), routerMetrics);
+    Assert.assertEquals(QuotaMethod.WRITE, operationQuotaCharger.getQuotaMethod());
   }
 
   private void testCheckAndCharge(boolean shouldCheckExceedAllowed) throws Exception {


### PR DESCRIPTION
This PR adds the quota charge callback that was missing from background deletes. It also adds logging to highlight cases where quota method was null.