### PR TITLE
Pass blobId to Azure StorageClient downloadWithResponse function

### DIFF
--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureBlobDataAccessor.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureBlobDataAccessor.java
@@ -212,16 +212,17 @@ public class AzureBlobDataAccessor {
    * Download a file from blob storage.
    * @param containerName name of the container containing blob to download.
    * @param fileName name of the blob.
+   * @param blobId Ambry {@link BlobId} associated with the {@code fileName}.
    * @param outputStream the output stream to use for download.
    * @param errorOnNotFound If {@code true}, throw BlobStorageException on blob not found, otherwise return false.
    * @return {@code true} if the download was successful, {@code false} if the blob was not found.
    * @throws BlobStorageException for any error on ABS side.
    * @throws UncheckedIOException for any error with supplied data stream.
    */
-  public boolean downloadFile(String containerName, String fileName, OutputStream outputStream, boolean errorOnNotFound)
-      throws BlobStorageException, IOException {
+  public boolean downloadFile(String containerName, String fileName, BlobId blobId, OutputStream outputStream,
+      boolean errorOnNotFound) throws BlobStorageException, IOException {
     try {
-      storageClient.downloadWithResponse(containerName, fileName, false, outputStream, null, null,
+      storageClient.downloadWithResponse(containerName, fileName, blobId, false, outputStream, null, null,
           defaultRequestConditions, false).get(uploadTimeout.toMillis(), TimeUnit.MILLISECONDS);
       return true;
     } catch (ExecutionException | InterruptedException | TimeoutException e) {
@@ -284,7 +285,7 @@ public class AzureBlobDataAccessor {
     Timer.Context storageTimer = azureMetrics.blobDownloadTime.time();
     try {
       BlobLayout blobLayout = blobLayoutStrategy.getDataBlobLayout(blobId);
-      downloadFile(blobLayout.containerName, blobLayout.blobFilePath, outputStream, true);
+      downloadFile(blobLayout.containerName, blobLayout.blobFilePath, blobId, outputStream, true);
       azureMetrics.blobDownloadSuccessCount.inc();
     } catch (Exception e) {
       azureMetrics.blobDownloadErrorCount.inc();

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestination.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestination.java
@@ -452,7 +452,7 @@ class AzureCloudDestination implements CloudDestination {
       throws CloudStorageException {
     try {
       BlobLayout tokenLayout = blobLayoutStrategy.getTokenBlobLayout(partitionPath, tokenFileName);
-      return azureBlobDataAccessor.downloadFile(tokenLayout.containerName, tokenLayout.blobFilePath, outputStream,
+      return azureBlobDataAccessor.downloadFile(tokenLayout.containerName, tokenLayout.blobFilePath, null, outputStream,
           false);
     } catch (Exception e) {
       throw toCloudStorageException("Could not retrieve token: " + partitionPath, e);

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureContainerCompactor.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureContainerCompactor.java
@@ -177,7 +177,7 @@ public class AzureContainerCompactor implements CloudContainerCompactor {
       ByteArrayOutputStream baos = new ByteArrayOutputStream(Long.BYTES);
       requestAgent.doWithRetries(() -> {
         azureBlobDataAccessor.downloadFile(AzureCloudDestination.CHECKPOINT_CONTAINER,
-            CONTAINER_DELETION_CHECKPOINT_FILE, baos, false);
+            CONTAINER_DELETION_CHECKPOINT_FILE, null, baos, false);
         return null;
       }, "read-container-deletion-checkpoint", null);
       ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureStorageCompactor.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureStorageCompactor.java
@@ -276,7 +276,7 @@ public class AzureStorageCompactor {
     String payload = requestAgent.doWithRetries(() -> {
       ByteArrayOutputStream baos = new ByteArrayOutputStream(CHECKPOINT_BUFFER_SIZE);
       boolean hasCheckpoint =
-          azureBlobDataAccessor.downloadFile(AzureCloudDestination.CHECKPOINT_CONTAINER, partitionPath, baos, false);
+          azureBlobDataAccessor.downloadFile(AzureCloudDestination.CHECKPOINT_CONTAINER, partitionPath, null, baos, false);
       return hasCheckpoint ? baos.toString() : null;
     }, "Download compaction checkpoint", partitionPath);
     if (payload == null) {

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/StorageClient.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/StorageClient.java
@@ -179,6 +179,8 @@ public abstract class StorageClient {
    * Downloads a range of bytes from a blob asynchronously into an output stream.
    * @param containerName name of the Azure container where the blob lives.
    * @param blobName name of the blob.
+   * @param blobId Ambry {@link BlobId} associated with the {@code fileName}. Null value indicates blobName refers
+   *               to a metadata blob owned by Ambry.
    * @param autoCreateContainer flag indicating whether to create the container if it does not exist.
    * @param stream A non-null {@link OutputStream} instance where the downloaded data will be written.
    * @param range {@link BlobRange}
@@ -188,7 +190,7 @@ public abstract class StorageClient {
    * @return a {@link CompletableFuture} of type {@link Void} that will eventually complete when blob is downloaded
    *         or an exception if an error occurred.
    */
-  public CompletableFuture<Void> downloadWithResponse(String containerName, String blobName,
+  public CompletableFuture<Void> downloadWithResponse(String containerName, String blobName, BlobId blobId,
       boolean autoCreateContainer, OutputStream stream, BlobRange range, DownloadRetryOptions options,
       BlobRequestConditions requestConditions, boolean getRangeContentMd5) {
     // Might as well use same timeout for upload and download
@@ -215,7 +217,7 @@ public abstract class StorageClient {
    * @return a {@link CompletableFuture} of type {@link Boolean} that will eventually complete successfully when the file
    *         is deleted or will complete exceptionally if an error occurs.
    */
-  CompletableFuture<Boolean> deleteFile(String containerName, String fileName) throws BlobStorageException {
+ public CompletableFuture<Boolean> deleteFile(String containerName, String fileName) throws BlobStorageException {
     return FutureUtils.retry(() -> {
       CompletableFuture<Boolean> completableFuture = new CompletableFuture<>();
       BlockBlobAsyncClient blobAsyncClient = getBlockBlobAsyncClient(containerName, fileName, false);
@@ -233,7 +235,7 @@ public abstract class StorageClient {
   /**
    * Perform basic connectivity test.
    */
-  void testConnectivity() {
+ public void testConnectivity() {
     CompletableFuture<Response<Boolean>> completableFuture = FutureUtils.retry(
         () -> storageAsyncClientRef.get().getBlobContainerAsyncClient("partition-0").existsWithResponse().toFuture(),
         retries, retryPredicate, this::onRetriableError, this::onError);

--- a/ambry-cloud/src/test/java/com/github/ambry/cloud/azure/AzureBlobDataAccessorTest.java
+++ b/ambry-cloud/src/test/java/com/github/ambry/cloud/azure/AzureBlobDataAccessorTest.java
@@ -308,14 +308,14 @@ public class AzureBlobDataAccessorTest {
     when(mockBlockBlobAsyncClient.downloadWithResponse(any(), any(), any(), anyBoolean())).thenReturn(
         Mono.error(mockBlobStorageException), Mono.just(response));
 
-    adAuthBasedStorageClient.downloadWithResponse("containerName", "blobName", false,
+    adAuthBasedStorageClient.downloadWithResponse("containerName", "blobName", null,false,
         new ByteArrayOutputStream(blobSize), null, null, null, false).join();
     verify(mockBlockBlobAsyncClient, times(2)).downloadWithResponse(any(), any(), any(), anyBoolean());
 
     // verify that BlockBlobAsyncClient.downloadWithResponse is called only once when not throwing any exception.
     when(mockBlockBlobAsyncClient.downloadWithResponse(any(), any(), any(), anyBoolean())).thenReturn(
         Mono.just(response));
-    adAuthBasedStorageClient.downloadWithResponse("containerName", "blobName", false,
+    adAuthBasedStorageClient.downloadWithResponse("containerName", "blobName", null, false,
         new ByteArrayOutputStream(blobSize), null, null, null, false).join();
     verify(mockBlockBlobAsyncClient, times(3)).downloadWithResponse(any(), any(), any(), anyBoolean());
 
@@ -324,7 +324,7 @@ public class AzureBlobDataAccessorTest {
     when(mockBlockBlobAsyncClient.downloadWithResponse(any(), any(), any(), anyBoolean())).thenReturn(
         Mono.error(mockBlobStorageException)).thenReturn(Mono.just(response));
     expectBlobStorageException(
-        () -> adAuthBasedStorageClient.downloadWithResponse("containerName", "blobName", false,
+        () -> adAuthBasedStorageClient.downloadWithResponse("containerName", "blobName", null, false,
             new ByteArrayOutputStream(blobSize), null, null, null, false).join());
     verify(mockBlockBlobAsyncClient, times(4)).downloadWithResponse(any(), any(), any(), anyBoolean());
   }

--- a/ambry-cloud/src/test/java/com/github/ambry/cloud/azure/AzurePerformanceTest.java
+++ b/ambry-cloud/src/test/java/com/github/ambry/cloud/azure/AzurePerformanceTest.java
@@ -121,7 +121,7 @@ public class AzurePerformanceTest {
         String blobName = String.format("Test-%s-%d", label, j);
         OutputStream outputStream = new ByteArrayOutputStream(blobSizes[sizeIndex]);
         long startTime = System.currentTimeMillis();
-        blobDataAccessor.downloadFile(containerName, blobName, outputStream, true);
+        blobDataAccessor.downloadFile(containerName, blobName, null, outputStream, true);
         long downloadTime = System.currentTimeMillis() - startTime;
         totalTime += downloadTime;
         maxTime = Math.max(maxTime, downloadTime);


### PR DESCRIPTION
In the big picture, StorageClient will be an implementation of an interface called AzureStorageClient.

                       AzureStorageClient
                          /                    \
             StorageClient      ShardedStorageClient

AzureStorageClient will expose the same interface that StorageClient does today. Interaction with a particular storage account will be contained in StorageClient whereas ShardedStorageClient will pick the StorageClient instance corresponding to a blob. This is a temporary scheme to be backward compatible, i.e. we can go back and forth between the sharded and unsharded implementation until we can fully switch to the sharded strategy. Once that happens, we will dismantle the AzureStorageClient interface and StorageClient will be private to ShardedStorageClient.

This is in preparation to pick the storage account corresponding to a blob upon sharding the blobs across multiple storage accounts by the ShardedStorageClient. PR passes the blobId to the Azure StorageClient downloadWithResponse function when applicable (this function is also called to fetch metadata files regarding compaction and replication) so that future PRs can extract the partitionId from the blobId and map the request to the correct storage account.

PR also makes the testConnectivity and deleteFile routines public since these routines will be called through the AzureStorageClient interface.