### PR TITLE
Check for null responses during cosmos updates to avoid NPE

### DIFF
--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureBlobDataAccessor.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureBlobDataAccessor.java
@@ -335,7 +335,7 @@ public class AzureBlobDataAccessor {
    * @throws IllegalStateException on request timeout.
    */
   public AzureCloudDestination.UpdateResponse updateBlobMetadata(BlobId blobId, Map<String, Object> updateFields,
-      CloudUpdateValidator cloudUpdateValidator) throws BlobStorageException {
+      CloudUpdateValidator cloudUpdateValidator) throws Exception {
     Objects.requireNonNull(blobId, "BlobId cannot be null");
     updateFields.keySet()
         .forEach(field -> Objects.requireNonNull(updateFields.get(field), String.format("%s cannot be null", field)));
@@ -349,6 +349,8 @@ public class AzureBlobDataAccessor {
         String etag = blobProperties.getETag();
         Map<String, String> metadata = blobProperties.getMetadata();
 
+        // Validate the sanity of update operation by comparing the fields we want to update against existing metadata
+        // fields in Azure. This can throw StoreExceptions which are propagated to caller.
         if (!cloudUpdateValidator.validateUpdate(CloudBlobMetadata.fromMap(metadata), blobId, updateFields)) {
           return new AzureCloudDestination.UpdateResponse(false, metadata);
         }
@@ -378,7 +380,8 @@ public class AzureBlobDataAccessor {
       } finally {
         storageTimer.stop();
       }
-    } catch (Exception e) {
+    } catch (ExecutionException | InterruptedException | TimeoutException e) {
+      // Catch exceptions thrown during the Azure operation.
       Exception ex = Utils.extractFutureExceptionCause(e);
       if (ex instanceof BlobStorageException) {
         BlobStorageException bse = (BlobStorageException) ex;

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureBlobDataAccessor.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureBlobDataAccessor.java
@@ -29,6 +29,7 @@ import com.github.ambry.cloud.CloudUpdateValidator;
 import com.github.ambry.cloud.azure.AzureBlobLayoutStrategy.BlobLayout;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.config.CloudConfig;
+import com.github.ambry.store.StoreException;
 import com.github.ambry.utils.Utils;
 import java.io.IOException;
 import java.io.InputStream;
@@ -335,7 +336,7 @@ public class AzureBlobDataAccessor {
    * @throws IllegalStateException on request timeout.
    */
   public AzureCloudDestination.UpdateResponse updateBlobMetadata(BlobId blobId, Map<String, Object> updateFields,
-      CloudUpdateValidator cloudUpdateValidator) throws Exception {
+      CloudUpdateValidator cloudUpdateValidator) throws BlobStorageException, StoreException {
     Objects.requireNonNull(blobId, "BlobId cannot be null");
     updateFields.keySet()
         .forEach(field -> Objects.requireNonNull(updateFields.get(field), String.format("%s cannot be null", field)));

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestination.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestination.java
@@ -401,7 +401,7 @@ class AzureCloudDestination implements CloudDestination {
         CosmosItemResponse<CloudBlobMetadata> response = cosmosDataAccessor.updateMetadata(blobId, metadataMap);
         // cosmosDataAccessor.updateMetadata() can return null response if there is nothing to update, i.e. fields
         // already have specified value. Check for null response to see if metadata was updated.
-        updatedCosmos = response != null;
+        updatedCosmos = response != null && response.getItem() != null;
       } catch (CosmosException cex) {
         if (cex.getStatusCode() == HttpConstants.StatusCodes.NOTFOUND) {
           // blob exists in ABS but not Cosmos - inconsistent state

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestination.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestination.java
@@ -399,7 +399,9 @@ class AzureCloudDestination implements CloudDestination {
       boolean updatedCosmos;
       try {
         CosmosItemResponse<CloudBlobMetadata> response = cosmosDataAccessor.updateMetadata(blobId, metadataMap);
-        updatedCosmos = response.getItem() != null;
+        // cosmosDataAccessor.updateMetadata() can return null response if there is nothing to update, i.e. fields
+        // already have specified value. Check for null response to see if metadata was updated.
+        updatedCosmos = response != null;
       } catch (CosmosException cex) {
         if (cex.getStatusCode() == HttpConstants.StatusCodes.NOTFOUND) {
           // blob exists in ABS but not Cosmos - inconsistent state


### PR DESCRIPTION
cosmosDataAccessor.updateMetadata() can return null response if there is nothing to update, i.e. fields already have specified value. Check for null response during metadata updates to avoid NPE.