### PR TITLE
Fix NPE due to referencing null partition key in CosmosQueryRequestOptions

### DIFF
--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobMetadata.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobMetadata.java
@@ -13,7 +13,6 @@
  */
 package com.github.ambry.cloud;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -75,10 +74,10 @@ public class CloudBlobMetadata {
   private String cryptoAgentFactory;
   private long encryptedSize;
   private short lifeVersion;
-  // this field is derived from the system generated last Update Time in the cloud db
-  // and hence shouldn't be serializable.
+  // this field is derived from the system generated last modified Time in the cosmos db which is present as "_ts" in
+  // the incoming JSON. Since we are using custom serializer, this field won't be included in the outgoing JSON when
+  // writing to cosmos.
   @JsonProperty(SYSTEM_GENERATED_FIELD_LAST_UPDATED_TIME)
-  @JsonIgnore
   private long lastUpdateTime;
 
   /**

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureContainerCompactor.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureContainerCompactor.java
@@ -265,7 +265,7 @@ public class AzureContainerCompactor implements CloudContainerCompactor {
         (cosmosContainerDeletionEntry, fieldsChanged) -> {
           fieldsChanged.set(cosmosContainerDeletionEntry.removePartition(partitionPath));
           if (cosmosContainerDeletionEntry.getDeletePendingPartitions().isEmpty()) {
-            cosmosContainerDeletionEntry.markDeleted();
+            cosmosContainerDeletionEntry.setDeleted(true);
             fieldsChanged.set(true);
           }
         }), "UpdateContainerDeletionProgress", partitionPath);

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/CosmosContainerDeletionEntry.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/CosmosContainerDeletionEntry.java
@@ -13,7 +13,6 @@
  */
 package com.github.ambry.cloud.azure;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.github.ambry.account.Container;
 import com.github.ambry.clustermap.ClusterMap;
 import java.util.Collection;
@@ -26,7 +25,6 @@ import org.json.JSONObject;
 /**
  * Class representing container deletion status in cloud.
  */
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class CosmosContainerDeletionEntry {
   static final String VERSION_KEY = "version";
   static final String CONTAINER_ID_KEY = "containerId";

--- a/ambry-cloud/src/test/java/com/github/ambry/cloud/azure/AzureIntegrationTest.java
+++ b/ambry-cloud/src/test/java/com/github/ambry/cloud/azure/AzureIntegrationTest.java
@@ -156,6 +156,7 @@ public class AzureIntegrationTest {
    */
   @Test
   public void testNormalFlow() throws Exception {
+    cleanup();
     PartitionId partitionId = new MockPartitionId(testPartition, MockClusterMap.DEFAULT_PARTITION_CLASS);
     BlobId blobId = new BlobId(BLOB_ID_V6, BlobIdType.NATIVE, dataCenterId, accountId, containerId, partitionId, false,
         BlobDataType.DATACHUNK);
@@ -225,8 +226,8 @@ public class AzureIntegrationTest {
     assertEquals(metadata.getDeletionTime(), Utils.Infinite_Time);
     assertEquals(metadata.getLifeVersion(), 2);
 
-    // delete after undelete.
-    long newDeletionTime = now + 20000;
+    // delete after undelete. Set the deletion time to some value which is before the retentionPeriodDays time period.
+    long newDeletionTime = now - TimeUnit.DAYS.toMillis(retentionPeriodDays + 1);
     //TODO add a test case here to verify life version after delete.
     assertTrue("Expected deletion to return true", cloudRequestAgent.doWithRetries(
         () -> azureDest.deleteBlob(blobId, newDeletionTime, (short) 3, dummyCloudUpdateValidator), "DeleteBlob",


### PR DESCRIPTION
This commit fixes NPE seen while accessing partition key in CosmosQueryRequestOptions. Also, it makes sure that field names are defined properly in classes (Ex: CosmosContainerDeletionEntry) used to represent records in Cosmos DB. Since latest Cosmos SDK APIs use Jackson's ObjectMapper internally to serialize and deserialize POJOs to/from JSON, we might need to make sure the field names and getter/setter methods for them are valid in the classes.

Ran integration tests manually using AzureIntegrationTest.java, AzureContainerCompactorIntegrationTest.java, CloudBlobStoreIntegrationTest.java.