### PR TITLE
Ensure all Router tests exercise the bandwidth throttling logic.

### DIFF
--- a/ambry-account/src/test/java/com/github/ambry/account/RouterStoreTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/RouterStoreTest.java
@@ -18,6 +18,7 @@ import com.github.ambry.clustermap.HelixStoreOperator;
 import com.github.ambry.clustermap.MockHelixPropertyStore;
 import com.github.ambry.config.HelixAccountServiceConfig;
 import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.quota.AdminRequestQuotaChargeCallback;
 import com.github.ambry.router.GetBlobOptionsBuilder;
 import com.github.ambry.router.RouterErrorCode;
 import com.github.ambry.router.RouterException;
@@ -234,7 +235,8 @@ public class RouterStoreTest {
           blobIDAndVersionsAfterUpdate.get(i - 1));
     }
     try {
-      router.getBlob(blobIDAndVersions.get(0).getBlobID(), new GetBlobOptionsBuilder().build()).get();
+      router.getBlob(blobIDAndVersions.get(0).getBlobID(), new GetBlobOptionsBuilder().build(),
+          new AdminRequestQuotaChargeCallback(true)).get();
       fail("Expecting not found exception");
     } catch (ExecutionException e) {
       Throwable t = e.getCause();

--- a/ambry-api/src/main/java/com/github/ambry/config/QuotaConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/QuotaConfig.java
@@ -51,7 +51,7 @@ public class QuotaConfig {
   public static final float DEFAULT_MAX_FRONTEND_CU_USAGE_TO_ALLOW_EXCEED = 80.0f;
   public static final String DEFAULT_CU_QUOTA_IN_JSON = "{}";
   public static final String DEFAULT_FRONTEND_BANDWIDTH_CAPACITY_IN_JSON = "{}";
-  public static final boolean DEFAULT_BANDWIDTH_THROTTLING_FEATURE_ENABLED = false;
+  public static final boolean DEFAULT_BANDWIDTH_THROTTLING_FEATURE_ENABLED = true;
   public static final long DEFAULT_CU_QUOTA_AGGREGATION_WINDOW_IN_SECS = 10;
   public static final int DEFAULT_QUOTA_USAGE_WARNING_THRESHOLD_IN_PERCENTAGE = 80;
   public StorageQuotaConfig storageQuotaConfig;

--- a/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
@@ -676,7 +676,7 @@ public class RouterConfig {
     routerPutRequestUseJavaNativeCrc32 =
         verifiableProperties.getBoolean(ROUTER_PUT_REQUEST_USE_JAVA_NATIVE_CRC32, false);
     operationController =
-        verifiableProperties.getString(OPERATION_CONTROLLER, "com.github.ambry.router.OperationController");
+        verifiableProperties.getString(OPERATION_CONTROLLER, "com.github.ambry.router.QuotaAwareOperationController");
     routerRequestHandlerNumOfThreads = verifiableProperties.getInt(ROUTER_REQUEST_HANDLER_NUM_OF_THREADS, 7);
     routerStoreKeyConverterFactory = verifiableProperties.getString(ROUTER_STORE_KEY_CONVERTER_FACTORY,
         "com.github.ambry.store.StoreKeyConverterFactoryImpl");

--- a/ambry-api/src/main/java/com/github/ambry/router/Router.java
+++ b/ambry-api/src/main/java/com/github/ambry/router/Router.java
@@ -126,11 +126,12 @@ public interface Router extends Closeable {
    * {@link ReadableStreamChannel} containing the blob data, or both.
    * @param blobId The ID of the blob for which blob data is requested.
    * @param options The options associated with the request.
+   * @param quotaChargeCallback Callback to charge quota cost for the operation.
    * @return A future that would eventually contain a {@link GetBlobResult} that can contain either
    *         the {@link BlobInfo}, the {@link ReadableStreamChannel} containing the blob data, or both.
    */
-  default Future<GetBlobResult> getBlob(String blobId, GetBlobOptions options) {
-    return getBlob(blobId, options, null, null);
+  default Future<GetBlobResult> getBlob(String blobId, GetBlobOptions options, QuotaChargeCallback quotaChargeCallback) {
+    return getBlob(blobId, options, null, quotaChargeCallback);
   }
 
   /**
@@ -143,10 +144,12 @@ public interface Router extends Closeable {
    * @param chunksToStitch the list of data chunks to stitch together. The router will treat the metadata in the
    *                       {@link ChunkInfo} object as a source of truth, so the caller should ensure that these
    *                       fields are set accurately.
+   * @param quotaChargeCallback Callback to charge quota cost for the operation.
    * @return A future that would contain the BlobId eventually.
    */
-  default Future<String> stitchBlob(BlobProperties blobProperties, byte[] userMetadata, List<ChunkInfo> chunksToStitch) {
-    return stitchBlob(blobProperties, userMetadata, chunksToStitch, null, null);
+  default Future<String> stitchBlob(BlobProperties blobProperties, byte[] userMetadata, List<ChunkInfo> chunksToStitch,
+      QuotaChargeCallback quotaChargeCallback) {
+    return stitchBlob(blobProperties, userMetadata, chunksToStitch, null, quotaChargeCallback);
   }
 
   /**
@@ -157,11 +160,12 @@ public interface Router extends Closeable {
    * @param userMetadata Optional user metadata about the blob. This can be null.
    * @param channel The {@link ReadableStreamChannel} that contains the content of the blob.
    * @param options The {@link PutBlobOptions} associated with the request. This cannot be null.
+   * @param quotaChargeCallback Callback to charge quota cost for the operation.
    * @return A future that would contain the BlobId eventually.
    */
   default Future<String> putBlob(BlobProperties blobProperties, byte[] userMetadata, ReadableStreamChannel channel,
-      PutBlobOptions options) {
-    return putBlob(blobProperties, userMetadata, channel, options, null, null);
+      PutBlobOptions options, QuotaChargeCallback quotaChargeCallback) {
+    return putBlob(blobProperties, userMetadata, channel, options, null, quotaChargeCallback);
   }
 
   /**
@@ -169,10 +173,11 @@ public interface Router extends Closeable {
    * about whether the request succeeded or not.
    * @param blobId The ID of the blob that needs to be deleted.
    * @param serviceId The service ID of the service deleting the blob. This can be null if unknown.
+   * @param quotaChargeCallback Callback to charge quota cost for the operation.
    * @return A future that would contain information about whether the deletion succeeded or not, eventually.
    */
-  default Future<Void> deleteBlob(String blobId, String serviceId) {
-    return deleteBlob(blobId, serviceId, null, null);
+  default Future<Void> deleteBlob(String blobId, String serviceId, QuotaChargeCallback quotaChargeCallback) {
+    return deleteBlob(blobId, serviceId, null, quotaChargeCallback);
   }
 
   /**
@@ -182,10 +187,12 @@ public interface Router extends Closeable {
    * @param serviceId The service ID of the service updating the blob. This can be null if unknown.
    * @param expiresAtMs The new expiry time (in ms) of the blob. Using {@link Utils#Infinite_Time} makes the blob
    *                    permanent
+   * @param quotaChargeCallback Callback to charge quota cost for the operation.
    * @return A future that would contain information about whether the update succeeded or not, eventually.
    */
-  default Future<Void> updateBlobTtl(String blobId, String serviceId, long expiresAtMs) {
-    return updateBlobTtl(blobId, serviceId, expiresAtMs, null, null);
+  default Future<Void> updateBlobTtl(String blobId, String serviceId, long expiresAtMs,
+      QuotaChargeCallback quotaChargeCallback) {
+    return updateBlobTtl(blobId, serviceId, expiresAtMs, null, quotaChargeCallback);
   }
 
   /**
@@ -193,9 +200,10 @@ public interface Router extends Closeable {
    * about whether the request succeeded or not.
    * @param blobId The ID of the blob that needs to be undeleted.
    * @param serviceId The service ID of the service undeleting the blob. This can be null if unknown.
+   * @param quotaChargeCallback Callback to charge quota cost for the operation.
    * @return A future that would contain information about whether the undelete succeeded or not, eventually.
    */
-  default Future<Void> undeleteBlob(String blobId, String serviceId) {
-    return undeleteBlob(blobId, serviceId, null, null);
+  default Future<Void> undeleteBlob(String blobId, String serviceId, QuotaChargeCallback quotaChargeCallback) {
+    return undeleteBlob(blobId, serviceId, null, quotaChargeCallback);
   }
 }

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
@@ -43,6 +43,7 @@ import com.github.ambry.named.NamedBlobRecord;
 import com.github.ambry.protocol.GetOption;
 import com.github.ambry.quota.AmbryQuotaManager;
 import com.github.ambry.quota.QuotaMetrics;
+import com.github.ambry.quota.QuotaUtils;
 import com.github.ambry.quota.SimpleQuotaRecommendationMergePolicy;
 import com.github.ambry.quota.QuotaChargeCallback;
 import com.github.ambry.quota.QuotaManager;
@@ -722,8 +723,11 @@ public class FrontendRestRequestServiceTest {
         new BlobProperties(0, "userMetadataTestOldStyleServiceID", Account.UNKNOWN_ACCOUNT_ID,
             Container.UNKNOWN_CONTAINER_ID, false);
     byte[] usermetadata = TestUtils.getRandomBytes(25);
+    QuotaChargeCallback quotaChargeCallback = QuotaUtils.buildQuotaChargeCallback(
+        QuotaTestUtils.createRestRequest(refAccount, refContainer, RestMethod.POST),
+        QuotaTestUtils.createDummyQuotaManager(), true);
     String blobId = router.putBlob(blobProperties, usermetadata, new ByteBufferReadableStreamChannel(content),
-        new PutBlobOptionsBuilder().build()).get();
+        new PutBlobOptionsBuilder().build(), quotaChargeCallback).get();
 
     RestUtils.SubResource[] subResources = {RestUtils.SubResource.UserMetadata, RestUtils.SubResource.BlobInfo};
     for (RestUtils.SubResource subResource : subResources) {

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/NamedBlobPutHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/NamedBlobPutHandlerTest.java
@@ -27,7 +27,9 @@ import com.github.ambry.commons.ByteBufferReadableStreamChannel;
 import com.github.ambry.config.FrontendConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.messageformat.BlobProperties;
+import com.github.ambry.quota.QuotaManager;
 import com.github.ambry.quota.QuotaTestUtils;
+import com.github.ambry.quota.QuotaUtils;
 import com.github.ambry.rest.MockRestResponseChannel;
 import com.github.ambry.rest.RequestPath;
 import com.github.ambry.rest.ResponseStatus;
@@ -112,6 +114,7 @@ public class NamedBlobPutHandlerTest {
   private FrontendConfig frontendConfig;
   private NamedBlobPutHandler namedBlobPutHandler;
   private final String request_path;
+  private final QuotaManager quotaManager = QuotaTestUtils.createDummyQuotaManager();
 
   public NamedBlobPutHandlerTest() {
     idConverterFactory = new FrontendTestIdConverterFactory();
@@ -402,7 +405,9 @@ public class NamedBlobPutHandlerTest {
               null);
       String blobId =
           router.putBlob(blobProperties, null, new ByteBufferReadableStreamChannel(ByteBuffer.wrap(content)),
-              new PutBlobOptionsBuilder().chunkUpload(true).build()).get(TIMEOUT_SECS, TimeUnit.SECONDS);
+              new PutBlobOptionsBuilder().chunkUpload(true).build(), QuotaUtils.buildQuotaChargeCallback(
+                  QuotaTestUtils.createRestRequest(REF_ACCOUNT, REF_CONTAINER, RestMethod.POST), quotaManager, true))
+              .get(TIMEOUT_SECS, TimeUnit.SECONDS);
 
       chunks.add(new ChunkInfo(blobId, chunkSize, Utils.addSecondsToEpochTime(creationTimeMs, blobTtlSecs)));
     }

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/PostBlobHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/PostBlobHandlerTest.java
@@ -31,6 +31,7 @@ import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.quota.AmbryQuotaManager;
 import com.github.ambry.quota.QuotaMetrics;
+import com.github.ambry.quota.QuotaUtils;
 import com.github.ambry.quota.SimpleQuotaRecommendationMergePolicy;
 import com.github.ambry.quota.QuotaManager;
 import com.github.ambry.quota.QuotaMode;
@@ -465,7 +466,11 @@ public class PostBlobHandlerTest {
               null);
       String blobId =
           router.putBlob(blobProperties, null, new ByteBufferReadableStreamChannel(ByteBuffer.wrap(content)),
-              new PutBlobOptionsBuilder().chunkUpload(true).build()).get(TIMEOUT_SECS, TimeUnit.SECONDS);
+              new PutBlobOptionsBuilder().chunkUpload(true).build(),
+              QuotaUtils.buildQuotaChargeCallback(
+                  QuotaTestUtils.createRestRequest(REF_ACCOUNT, REF_CONTAINER, RestMethod.POST),
+                  QuotaTestUtils.createDummyQuotaManager(), true))
+              .get(TIMEOUT_SECS, TimeUnit.SECONDS);
 
       chunks.add(new ChunkInfo(blobId, chunkSize, Utils.addSecondsToEpochTime(creationTimeMs, blobTtlSecs)));
     }

--- a/ambry-quota/src/main/java/com/github/ambry/quota/AdminRequestQuotaChargeCallback.java
+++ b/ambry-quota/src/main/java/com/github/ambry/quota/AdminRequestQuotaChargeCallback.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.quota;
+
+import com.github.ambry.config.QuotaConfig;
+import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.rest.RestRequest;
+import java.util.Properties;
+
+
+/**
+ * A {@link QuotaChargeCallback} implementation for admin operations like RouterStore, that don't originate as part of
+ * user requests, and hence dont have user quotas or {@link RestRequest} associated with them.
+ */
+public class AdminRequestQuotaChargeCallback implements QuotaChargeCallback {
+  public static QuotaResource ADMIN_QUOTA_RESOURCE = new QuotaResource("ADMIN_RESOURCE", QuotaResourceType.ACCOUNT);
+  private final boolean isReadRequest;
+
+  public AdminRequestQuotaChargeCallback(boolean isReadRequest) {
+    this.isReadRequest = isReadRequest;
+  }
+
+  @Override
+  public QuotaAction checkAndCharge(boolean shouldCheckExceedAllowed, boolean forceCharge, long chunkSize) {
+    return QuotaAction.ALLOW;
+  }
+
+  @Override
+  public QuotaResource getQuotaResource() {
+    return ADMIN_QUOTA_RESOURCE;
+  }
+
+  @Override
+  public QuotaMethod getQuotaMethod() {
+    return isReadRequest ? QuotaMethod.READ : QuotaMethod.WRITE;
+  }
+
+  @Override
+  public QuotaConfig getQuotaConfig() {
+    return new QuotaConfig(new VerifiableProperties(new Properties()));
+  }
+}

--- a/ambry-router/src/main/java/com/github/ambry/router/BackgroundDeleteRequest.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/BackgroundDeleteRequest.java
@@ -14,6 +14,7 @@
 
 package com.github.ambry.router;
 
+import com.github.ambry.quota.QuotaChargeCallback;
 import com.github.ambry.store.StoreKey;
 
 
@@ -24,15 +25,18 @@ class BackgroundDeleteRequest {
   static final String SERVICE_ID_PREFIX = "ambry-background-delete-";
   private final StoreKey storeKey;
   private final String serviceId;
+  private final QuotaChargeCallback quotaChargeCallback;
 
   /**
    * @param storeKey The {@link StoreKey} to delete.
    * @param serviceIdSuffix The suffix to attach to the delete service ID. This can be used to convey information about
    *                        the the delete requester.
+   * @param quotaChargeCallback {@link QuotaChargeCallback} object for quota compliance checks.
    */
-  BackgroundDeleteRequest(StoreKey storeKey, String serviceIdSuffix) {
+  BackgroundDeleteRequest(StoreKey storeKey, String serviceIdSuffix, QuotaChargeCallback quotaChargeCallback) {
     this.serviceId = SERVICE_ID_PREFIX + serviceIdSuffix;
     this.storeKey = storeKey;
+    this.quotaChargeCallback = quotaChargeCallback;
   }
 
   /**
@@ -47,5 +51,12 @@ class BackgroundDeleteRequest {
    */
   public String getServiceId() {
     return serviceId;
+  }
+
+  /**
+   * @return QuotaChargeCallback object.
+   */
+  public QuotaChargeCallback getQuotaChargeCallback() {
+    return quotaChargeCallback;
   }
 }

--- a/ambry-router/src/main/java/com/github/ambry/router/PutManager.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/PutManager.java
@@ -271,7 +271,8 @@ class PutManager {
       op.cleanupChunks();
       blobId = null;
       routerMetrics.onPutBlobError(e, op.isEncryptionEnabled(), op.isStitchOperation());
-      routerCallback.scheduleDeletes(op.getSuccessfullyPutChunkIdsIfCompositeDirectUpload(), op.getServiceId());
+      routerCallback.scheduleDeletes(op.getSuccessfullyPutChunkIdsIfCompositeDirectUpload(), op.getServiceId(),
+          op.getQuotaChargeCallback());
     } else {
       updateChunkingAndSizeMetricsOnSuccessfulPut(op);
     }
@@ -291,7 +292,8 @@ class PutManager {
     }
     // Regardless of the result of the operation, clean up the blobs that may have been put as the result of slipped
     // puts.
-    routerCallback.scheduleDeletes(Lists.newArrayList(op.getSlippedPutBlobIds()), op.getServiceId());
+    routerCallback.scheduleDeletes(Lists.newArrayList(op.getSlippedPutBlobIds()), op.getServiceId(),
+        op.getQuotaChargeCallback());
     NonBlockingRouter.completeOperation(op.getFuture(), op.getCallback(), blobId, e);
   }
 

--- a/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
@@ -697,6 +697,13 @@ class PutOperation {
   }
 
   /**
+   * @return QuotaChargeCallback object associated with this operation.
+   */
+  QuotaChargeCallback getQuotaChargeCallback() {
+    return quotaChargeCallback;
+  }
+
+  /**
    * Called whenever the channel has data but no free or building chunk is available to be filled.
    */
   private void maybeStartTrackingWaitForChunkTime() {

--- a/ambry-router/src/main/java/com/github/ambry/router/RouterCallback.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/RouterCallback.java
@@ -14,6 +14,7 @@
 package com.github.ambry.router;
 
 import com.github.ambry.network.NetworkClient;
+import com.github.ambry.quota.QuotaChargeCallback;
 import com.github.ambry.store.StoreKey;
 import java.util.List;
 
@@ -54,10 +55,11 @@ class RouterCallback {
    * Schedule the deletes of ids in the given list.
    * @param idsToDelete the list of ids that need to be deleted.
    * @param serviceIdSuffix the suffix to append to the service ID when deleting these blobs.
+   * @param quotaChargeCallback {@link QuotaChargeCallback} object to perform quota compliance checks.
    */
-  void scheduleDeletes(List<StoreKey> idsToDelete, String serviceIdSuffix) {
+  void scheduleDeletes(List<StoreKey> idsToDelete, String serviceIdSuffix, QuotaChargeCallback quotaChargeCallback) {
     for (StoreKey storeKey : idsToDelete) {
-      backgroundDeleteRequests.add(new BackgroundDeleteRequest(storeKey, serviceIdSuffix));
+      backgroundDeleteRequests.add(new BackgroundDeleteRequest(storeKey, serviceIdSuffix, quotaChargeCallback));
     }
   }
 

--- a/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateManager.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateManager.java
@@ -113,7 +113,8 @@ class TtlUpdateManager {
       for (BlobId blobId : blobIds) {
         TtlUpdateOperation ttlUpdateOperation =
             new TtlUpdateOperation(clusterMap, routerConfig, routerMetrics, blobId, serviceId, expiresAtMs,
-                operationTimeMs, tracker.getCallback(blobId), time, BatchOperationCallbackTracker.DUMMY_FUTURE);
+                operationTimeMs, tracker.getCallback(blobId), time, BatchOperationCallbackTracker.DUMMY_FUTURE,
+                quotaChargeCallback);
         ttlUpdateOperations.add(ttlUpdateOperation);
       }
     }

--- a/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateOperation.java
@@ -80,26 +80,6 @@ class TtlUpdateOperation {
    * @param callback The {@link Callback} that is supplied by the caller.
    * @param time A {@link Time} reference.
    * @param futureResult The {@link FutureResult} that is returned to the caller.
-   */
-  TtlUpdateOperation(ClusterMap clusterMap, RouterConfig routerConfig, NonBlockingRouterMetrics routerMetrics,
-      BlobId blobId, String serviceId, long expiresAtMs, long operationTimeMs, Callback<Void> callback, Time time,
-      FutureResult<Void> futureResult) {
-    this(clusterMap, routerConfig, routerMetrics, blobId, serviceId, expiresAtMs, operationTimeMs, callback, time,
-        futureResult, null);
-  }
-
-  /**
-   * Instantiates a {@link TtlUpdateOperation}.
-   * @param clusterMap the {@link ClusterMap} to use.
-   * @param routerConfig The {@link RouterConfig} that contains router-level configurations.
-   * @param routerMetrics The {@link NonBlockingRouterMetrics} to record all router-related metrics.
-   * @param blobId The {@link BlobId} whose TTL needs to be updated by this {@link TtlUpdateOperation}.
-   * @param serviceId The service ID of the service deleting the blob. This can be null if unknown.
-   * @param expiresAtMs the new time at which the blob should expire.
-   * @param operationTimeMs the time at which the operation occurred.
-   * @param callback The {@link Callback} that is supplied by the caller.
-   * @param time A {@link Time} reference.
-   * @param futureResult The {@link FutureResult} that is returned to the caller.
    * @param quotaChargeCallback The {@link QuotaChargeCallback} object.
    */
   TtlUpdateOperation(ClusterMap clusterMap, RouterConfig routerConfig, NonBlockingRouterMetrics routerMetrics,

--- a/ambry-router/src/main/java/com/github/ambry/router/UndeleteManager.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/UndeleteManager.java
@@ -116,7 +116,7 @@ public class UndeleteManager {
       for (BlobId blobId : blobIds) {
         UndeleteOperation undeleteOperation =
             new UndeleteOperation(clusterMap, routerConfig, routerMetrics, blobId, serviceId, operationTimeMs,
-                tracker.getCallback(blobId), time, BatchOperationCallbackTracker.DUMMY_FUTURE);
+                tracker.getCallback(blobId), time, BatchOperationCallbackTracker.DUMMY_FUTURE, quotaChargeCallback);
         undeleteOperations.add(undeleteOperation);
       }
     }

--- a/ambry-router/src/main/java/com/github/ambry/router/UndeleteOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/UndeleteOperation.java
@@ -82,24 +82,6 @@ public class UndeleteOperation {
    * @param callback The {@link Callback} that is supplied by the caller.
    * @param time A {@link Time} reference.
    * @param futureResult The {@link FutureResult} that is returned to the caller.
-   */
-  UndeleteOperation(ClusterMap clusterMap, RouterConfig routerConfig, NonBlockingRouterMetrics routerMetrics,
-      BlobId blobId, String serviceId, long operationTimeMs, Callback<Void> callback, Time time,
-      FutureResult<Void> futureResult) {
-    this(clusterMap, routerConfig, routerMetrics, blobId, serviceId, operationTimeMs, callback, time, futureResult, null);
-  }
-
-  /**
-   * Instantiates a {@link UndeleteOperation}.
-   * @param clusterMap the {@link ClusterMap} to use.
-   * @param routerConfig The {@link RouterConfig} that contains router-level configurations.
-   * @param routerMetrics The {@link NonBlockingRouterMetrics} to record all router-related metrics.
-   * @param blobId The {@link BlobId} needs to be undeleted by this {@link UndeleteOperation}.
-   * @param serviceId The service ID of the service deleting the blob. This can be null if unknown.
-   * @param operationTimeMs the time at which the operation occurred.
-   * @param callback The {@link Callback} that is supplied by the caller.
-   * @param time A {@link Time} reference.
-   * @param futureResult The {@link FutureResult} that is returned to the caller.
    * @param quotaChargeCallback The {@link QuotaChargeCallback} object.
    */
   UndeleteOperation(ClusterMap clusterMap, RouterConfig routerConfig, NonBlockingRouterMetrics routerMetrics,

--- a/ambry-router/src/test/java/com/github/ambry/router/ChargeTesterQuotaManagerFactory.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/ChargeTesterQuotaManagerFactory.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2022 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ */
+package com.github.ambry.router;
+
+import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.account.AccountService;
+import com.github.ambry.accountstats.AccountStatsStore;
+import com.github.ambry.config.QuotaConfig;
+import com.github.ambry.quota.AmbryQuotaManager;
+import com.github.ambry.quota.QuotaAction;
+import com.github.ambry.quota.QuotaEnforcer;
+import com.github.ambry.quota.QuotaException;
+import com.github.ambry.quota.QuotaManager;
+import com.github.ambry.quota.QuotaManagerFactory;
+import com.github.ambry.quota.QuotaMetrics;
+import com.github.ambry.quota.QuotaName;
+import com.github.ambry.quota.QuotaRecommendationMergePolicy;
+import com.github.ambry.quota.capacityunit.AmbryCUQuotaEnforcer;
+import com.github.ambry.rest.RestRequest;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+
+public class ChargeTesterQuotaManagerFactory implements QuotaManagerFactory {
+  private final QuotaManager quotaManager;
+  private final AtomicInteger calledCountListener = new AtomicInteger(0);
+
+  /**
+   * @param quotaConfig {@link QuotaConfig} object.
+   * @param quotaRecommendationMergePolicy {@link QuotaRecommendationMergePolicy} object.
+   * @param accountService {@link AccountService} object.
+   * @param accountStatsStore {@link AccountStatsStore} object.
+   * @param metricRegistry {@link MetricRegistry} object.
+   * @throws ReflectiveOperationException
+   */
+  public ChargeTesterQuotaManagerFactory(QuotaConfig quotaConfig,
+      QuotaRecommendationMergePolicy quotaRecommendationMergePolicy, AccountService accountService,
+      AccountStatsStore accountStatsStore, MetricRegistry metricRegistry) throws ReflectiveOperationException {
+    quotaManager = new ChargeTesterQuotaManager(quotaConfig, quotaRecommendationMergePolicy, accountService, accountStatsStore,
+        new QuotaMetrics(metricRegistry), new AtomicInteger(0));
+  }
+
+  @Override
+  public QuotaManager getQuotaManager() {
+    return quotaManager;
+  }
+}
+/**
+ * {@link AmbryQuotaManager} extension to test behavior with default implementation.
+ */
+class ChargeTesterQuotaManager extends AmbryQuotaManager {
+  private final AtomicInteger chargeCalledCount;
+
+  /**
+   * Constructor for {@link ChargeTesterQuotaManagerFactory}.
+   * @param quotaConfig {@link QuotaConfig} object.
+   * @param quotaRecommendationMergePolicy {@link QuotaRecommendationMergePolicy} object that makes the overall recommendation.
+   * @param accountService {@link AccountService} object to get all the accounts and container information.
+   * @param accountStatsStore {@link AccountStatsStore} object to get all the account stats related information.
+   * @param quotaMetrics {@link QuotaMetrics} object.
+   * @throws ReflectiveOperationException in case of any exception.
+   */
+  public ChargeTesterQuotaManager(QuotaConfig quotaConfig,
+      QuotaRecommendationMergePolicy quotaRecommendationMergePolicy, AccountService accountService,
+      AccountStatsStore accountStatsStore, QuotaMetrics quotaMetrics, AtomicInteger chargeCalledCount)
+      throws ReflectiveOperationException {
+    super(quotaConfig, quotaRecommendationMergePolicy, accountService, accountStatsStore, quotaMetrics);
+    this.chargeCalledCount = chargeCalledCount;
+  }
+
+  @Override
+  public QuotaAction chargeAndRecommend(RestRequest restRequest, Map<QuotaName, Double> requestCostMap,
+      boolean shouldCheckIfQuotaExceedAllowed, boolean forceCharge) throws QuotaException {
+    chargeCalledCount.incrementAndGet();
+    return super.chargeAndRecommend(restRequest, requestCostMap, shouldCheckIfQuotaExceedAllowed, forceCharge);
+  }
+
+  /**
+   * @return TestCUQuotaSource object from the {@link QuotaEnforcer}s.
+   */
+  public TestCUQuotaSource getTestCuQuotaSource() {
+    for (QuotaEnforcer quotaEnforcer : quotaEnforcers) {
+      if (quotaEnforcer instanceof AmbryCUQuotaEnforcer && !(quotaEnforcer instanceof RejectingQuotaEnforcer)) {
+        return (TestCUQuotaSource) quotaEnforcer.getQuotaSource();
+      }
+    }
+    throw new IllegalStateException("could not find TestCUQuotaSource in QuotaManager.");
+  }
+
+  public AtomicInteger getChargeCalledCount() {
+    return chargeCalledCount;
+  }
+}

--- a/ambry-router/src/test/java/com/github/ambry/router/CloudRouterTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/CloudRouterTest.java
@@ -33,6 +33,7 @@ import com.github.ambry.network.NetworkClientFactory;
 import com.github.ambry.network.NetworkMetrics;
 import com.github.ambry.notification.NotificationSystem;
 import com.github.ambry.protocol.RequestHandlerPool;
+import com.github.ambry.quota.QuotaTestUtils;
 import com.github.ambry.utils.Utils;
 import java.util.Arrays;
 import java.util.EnumMap;
@@ -147,6 +148,7 @@ public class CloudRouterTest extends NonBlockingRouterTest {
         new NonBlockingRouter(routerConfig, routerMetrics, networkClientFactory, notificationSystem, mockClusterMap,
             kms, cryptoService, cryptoJobHandler, accountService, mockTime, MockClusterMap.DEFAULT_PARTITION_CLASS);
     router.addResourceToClose(requestHandlerPool);
+    quotaManager = QuotaTestUtils.createDummyQuotaManager();
   }
 
   /**

--- a/ambry-router/src/test/java/com/github/ambry/router/DeleteManagerTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/DeleteManagerTest.java
@@ -77,7 +77,7 @@ public class DeleteManagerTest {
   private final ErrorCodeChecker deleteErrorCodeChecker = new ErrorCodeChecker() {
     @Override
     public void testAndAssert(RouterErrorCode expectedError) throws Exception {
-      future = router.deleteBlob(blobIdString, null);
+      future = router.deleteBlob(blobIdString, null, quotaChargeCallback);
       if (expectedError == null) {
         future.get(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
       } else {
@@ -156,7 +156,7 @@ public class DeleteManagerTest {
                   }
                 }, quotaChargeCallback));
               } else {
-                futures.add(router.deleteBlob(blobIdString, null));
+                futures.add(router.deleteBlob(blobIdString, null, quotaChargeCallback));
               }
             }
             for (Future future : futures) {
@@ -172,7 +172,7 @@ public class DeleteManagerTest {
             Assert.assertTrue("Router should not be closed", router.isOpen());
 
             //Test that DeleteManager is still operational
-            router.deleteBlob(blobIdString, null).get();
+            router.deleteBlob(blobIdString, null, quotaChargeCallback).get();
           }
         });
   }
@@ -184,7 +184,7 @@ public class DeleteManagerTest {
   public void testBlobIdNotValid() throws Exception {
     String[] input = {"123", "abcd", "", "/"};
     for (String s : input) {
-      future = router.deleteBlob(s, null);
+      future = router.deleteBlob(s, null, quotaChargeCallback);
       assertFailureAndCheckErrorCode(future, RouterErrorCode.InvalidBlobId);
     }
   }
@@ -469,7 +469,7 @@ public class DeleteManagerTest {
         RouterErrorCode.RouterClosed, new ErrorCodeChecker() {
           @Override
           public void testAndAssert(RouterErrorCode expectedError) throws Exception {
-            future = router.deleteBlob(blobIdString, null);
+            future = router.deleteBlob(blobIdString, null, quotaChargeCallback);
             router.close();
             assertFailureAndCheckErrorCode(future, expectedError);
           }

--- a/ambry-router/src/test/java/com/github/ambry/router/GetBlobInfoOperationTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/GetBlobInfoOperationTest.java
@@ -34,6 +34,7 @@ import com.github.ambry.network.ResponseInfo;
 import com.github.ambry.network.SocketNetworkClient;
 import com.github.ambry.protocol.GetResponse;
 import com.github.ambry.quota.QuotaChargeCallback;
+import com.github.ambry.quota.QuotaMethod;
 import com.github.ambry.quota.QuotaTestUtils;
 import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.utils.MockTime;
@@ -164,7 +165,8 @@ public class GetBlobInfoOperationTest {
     random.nextBytes(putContent);
     ReadableStreamChannel putChannel = new ByteBufferReadableStreamChannel(ByteBuffer.wrap(putContent));
     String blobIdStr =
-        router.putBlob(blobProperties, userMetadata, putChannel, new PutBlobOptionsBuilder().build()).get();
+        router.putBlob(blobProperties, userMetadata, putChannel, new PutBlobOptionsBuilder().build(),
+            QuotaTestUtils.createTestQuotaChargeCallback(QuotaMethod.WRITE)).get();
     blobId = RouterUtils.getBlobIdFromString(blobIdStr, mockClusterMap);
     localReplica = RouterTestHelpers.getAnyReplica(blobId, true, localDcName);
     remoteReplica = RouterTestHelpers.getAnyReplica(blobId, false, localDcName);

--- a/ambry-router/src/test/java/com/github/ambry/router/OperationQuotaChargerTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/OperationQuotaChargerTest.java
@@ -26,6 +26,7 @@ import com.github.ambry.quota.QuotaException;
 import com.github.ambry.quota.QuotaMethod;
 import com.github.ambry.quota.QuotaResource;
 import com.github.ambry.quota.QuotaResourceType;
+import com.github.ambry.quota.QuotaTestUtils;
 import com.github.ambry.rest.RestServiceErrorCode;
 import com.github.ambry.rest.RestServiceException;
 import java.util.Properties;
@@ -57,6 +58,7 @@ public class OperationQuotaChargerTest {
   public void testGetQuotaResource() throws Exception {
     ClusterMap clusterMap = new MockClusterMap();
     NonBlockingRouterMetrics routerMetrics = new NonBlockingRouterMetrics(clusterMap, routerConfig);
+
     // getQuotaResource should return null if quotaChargeCallback is null.
     OperationQuotaCharger operationQuotaCharger =
         new OperationQuotaCharger(null, BLOBID, GetOperation.class.getSimpleName(), routerMetrics);
@@ -115,7 +117,8 @@ public class OperationQuotaChargerTest {
     NonBlockingRouterMetrics routerMetrics = new NonBlockingRouterMetrics(clusterMap, routerConfig);
     // checkAndCharge should return allow if quotaChargeCallback is null.
     OperationQuotaCharger operationQuotaCharger =
-        new OperationQuotaCharger(null, BLOBID, GetOperation.class.getSimpleName(), routerMetrics);
+        new OperationQuotaCharger(QuotaTestUtils.createTestQuotaChargeCallback(QuotaMethod.READ), BLOBID,
+            GetOperation.class.getSimpleName(), routerMetrics);
     Assert.assertEquals("checkAndCharge should return allow if quotaChargeCallback is null.", QuotaAction.ALLOW,
         operationQuotaCharger.checkAndCharge(shouldCheckExceedAllowed));
 

--- a/ambry-router/src/test/java/com/github/ambry/router/RouterTestHelpers.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/RouterTestHelpers.java
@@ -24,6 +24,9 @@ import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.ByteBufferAsyncWritableChannel;
 import com.github.ambry.commons.Callback;
 import com.github.ambry.commons.CommonTestUtils;
+import com.github.ambry.quota.QuotaChargeCallback;
+import com.github.ambry.quota.QuotaTestUtils;
+import com.github.ambry.quota.QuotaUtils;
 import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.utils.TestUtils;
@@ -241,9 +244,10 @@ class RouterTestHelpers {
   static void assertTtl(Router router, Collection<String> blobIds, long expectedTtlSecs) throws Exception {
     GetBlobOptions options[] = {new GetBlobOptionsBuilder().build(),
         new GetBlobOptionsBuilder().operationType(GetBlobOptions.OperationType.BlobInfo).build()};
+    QuotaChargeCallback quotaChargeCallback = QuotaTestUtils.createTestQuotaChargeCallback();
     for (String blobId : blobIds) {
       for (GetBlobOptions option : options) {
-        GetBlobResult result = router.getBlob(blobId, option).get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        GetBlobResult result = router.getBlob(blobId, option, quotaChargeCallback).get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
         Assert.assertEquals("TTL not as expected", expectedTtlSecs,
             result.getBlobInfo().getBlobProperties().getTimeToLiveInSeconds());
         if (result.getBlobDataChannel() != null) {

--- a/ambry-router/src/test/java/com/github/ambry/router/TtlUpdateManagerTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/TtlUpdateManagerTest.java
@@ -30,6 +30,7 @@ import com.github.ambry.network.SocketNetworkClient;
 import com.github.ambry.protocol.RequestOrResponse;
 import com.github.ambry.protocol.RequestOrResponseType;
 import com.github.ambry.quota.QuotaChargeCallback;
+import com.github.ambry.quota.QuotaResourceType;
 import com.github.ambry.quota.QuotaTestUtils;
 import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.utils.MockTime;
@@ -109,7 +110,8 @@ public class TtlUpdateManagerTest {
       ReadableStreamChannel putChannel = new ByteBufferReadableStreamChannel(ByteBuffer.wrap(PUT_CONTENT));
       BlobProperties putBlobProperties = new BlobProperties(-1, "serviceId", "memberId", "contentType", false, TTL_SECS,
           Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM), false, null, null, null);
-      String blobId = router.putBlob(putBlobProperties, new byte[0], putChannel, new PutBlobOptionsBuilder().build()).get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+      String blobId = router.putBlob(putBlobProperties, new byte[0], putChannel, new PutBlobOptionsBuilder().build(),
+          quotaChargeCallback).get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
       blobIds.add(blobId);
     }
     ttlUpdateManager =

--- a/ambry-server/src/integration-test/java/com/github/ambry/server/ServerTestUtil.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/ServerTestUtil.java
@@ -2139,7 +2139,7 @@ final class ServerTestUtil {
       assertEquals(ServerErrorCode.No_Error, deleteResponse.getError());
 
       // Now send the undelete operation through router, and it should fail because of not deleted error.
-      Future<Void> future = router.undeleteBlob(blobId1.toString(), "service");
+      Future<Void> future = router.undeleteBlob(blobId1.toString(), "service", QUOTA_CHARGE_EVENT_LISTENER);
       try {
         future.get();
         fail("Undelete blob " + blobId1.toString() + " should fail");
@@ -2250,7 +2250,7 @@ final class ServerTestUtil {
       assertEquals(ServerErrorCode.No_Error, deleteResponse.getError());
 
       // Now send the undelete operation through router, and it should fail because of lifeVersion conflict error.
-      future = router.undeleteBlob(blobId2.toString(), "service");
+      future = router.undeleteBlob(blobId2.toString(), "service", QUOTA_CHARGE_EVENT_LISTENER);
       try {
         future.get();
         fail("Undelete blob " + blobId2.toString() + " should fail");
@@ -2594,7 +2594,7 @@ final class ServerTestUtil {
 
   private static void checkBlobId(Router router, BlobId blobId, byte[] data) throws Exception {
     GetBlobResult result =
-        router.getBlob(blobId.getID(), new GetBlobOptionsBuilder().build())
+        router.getBlob(blobId.getID(), new GetBlobOptionsBuilder().build(), QUOTA_CHARGE_EVENT_LISTENER)
             .get(20, TimeUnit.SECONDS);
     ReadableStreamChannel blob = result.getBlobDataChannel();
     assertEquals("Size does not match that of data", data.length,

--- a/ambry-test-utils/src/main/java/com/github/ambry/quota/QuotaTestUtils.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/quota/QuotaTestUtils.java
@@ -21,6 +21,7 @@ import com.github.ambry.rest.MockRestRequest;
 import com.github.ambry.rest.RestMethod;
 import com.github.ambry.rest.RestRequest;
 import com.github.ambry.rest.RestUtils;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
 import org.json.JSONArray;
@@ -68,7 +69,8 @@ public class QuotaTestUtils {
 
       @Override
       public ThrottlingRecommendation recommend(RestRequest restRequest) {
-        return null;
+        return new ThrottlingRecommendation(QuotaAction.ALLOW,
+            Collections.singletonMap(QuotaName.READ_CAPACITY_UNIT, 10.0f), -1, QuotaUsageLevel.HEALTHY);
       }
 
       @Override
@@ -78,21 +80,22 @@ public class QuotaTestUtils {
 
       @Override
       public QuotaMode getQuotaMode() {
-        return null;
+        return QuotaMode.TRACKING;
       }
 
       @Override
-      public void setQuotaMode(QuotaMode mode) {
-
-      }
-
-      @Override
-      public QuotaAction chargeAndRecommend(RestRequest restRequest, Map<QuotaName, Double> requestCostMap, boolean checkQuotaExceedAllowed, boolean forceCharge) {
-        return null;
+      public QuotaAction chargeAndRecommend(RestRequest restRequest, Map<QuotaName, Double> requestCostMap,
+          boolean checkQuotaExceedAllowed, boolean forceCharge) {
+        return QuotaAction.ALLOW;
       }
 
       @Override
       public void shutdown() {
+
+      }
+
+      @Override
+      public void setQuotaMode(QuotaMode mode) {
 
       }
     };
@@ -113,6 +116,26 @@ public class QuotaTestUtils {
    */
   public static TestQuotaChargeCallback createTestQuotaChargeCallback(QuotaConfig quotaConfig) {
     return new TestQuotaChargeCallback(quotaConfig);
+  }
+
+  /**
+   * Create an implementation of {@link QuotaChargeCallback} object for test.
+   * @param quotaMethod {@link QuotaMethod} object.
+   * @return TestQuotaChargeCallback object.
+   */
+  public static TestQuotaChargeCallback createTestQuotaChargeCallback(QuotaMethod quotaMethod) {
+    return new TestQuotaChargeCallback(quotaMethod);
+  }
+
+  /**
+   * Create an implementation of {@link QuotaChargeCallback} object for test.
+   * @param quotaConfig for the {@link QuotaChargeCallback} implementation.
+   * @param quotaMethod {@link QuotaMethod} object.
+   * @return TestQuotaChargeCallback object.
+   */
+  public static TestQuotaChargeCallback createTestQuotaChargeCallback(QuotaConfig quotaConfig,
+      QuotaMethod quotaMethod) {
+    return new TestQuotaChargeCallback(quotaConfig, quotaMethod);
   }
 
   /**
@@ -139,14 +162,16 @@ public class QuotaTestUtils {
    * An implementation of {@link QuotaChargeCallback} for tests.
    */
   public static class TestQuotaChargeCallback implements QuotaChargeCallback {
-    public int numCheckAndChargeCalls = 0;
     private final QuotaConfig quotaConfig;
+    private final QuotaMethod quotaMethod;
+    public int numCheckAndChargeCalls = 0;
 
     /**
      * Default constructor for {@link TestQuotaChargeCallback}.
      */
     public TestQuotaChargeCallback() {
       this.quotaConfig = new QuotaConfig(new VerifiableProperties(new Properties()));
+      this.quotaMethod = QuotaMethod.READ;
     }
 
     /**
@@ -155,8 +180,27 @@ public class QuotaTestUtils {
      */
     public TestQuotaChargeCallback(QuotaConfig quotaConfig) {
       this.quotaConfig = quotaConfig;
+      this.quotaMethod = QuotaMethod.READ;
     }
 
+    /**
+     * Constructor for {@link TestQuotaChargeCallback} with the specified {@link QuotaMethod}.
+     * @param quotaMethod {@link QuotaMethod} object.
+     */
+    public TestQuotaChargeCallback(QuotaMethod quotaMethod) {
+      this.quotaConfig = new QuotaConfig(new VerifiableProperties(new Properties()));
+      this.quotaMethod = quotaMethod;
+    }
+
+    /**
+     * Constructor for {@link TestQuotaChargeCallback} with the specified {@link QuotaConfig} and {@link QuotaMethod}.
+     * @param quotaConfig {@link QuotaConfig} object.
+     * @param quotaMethod {@link QuotaMethod} object.
+     */
+    public TestQuotaChargeCallback(QuotaConfig quotaConfig, QuotaMethod quotaMethod) {
+      this.quotaConfig = quotaConfig;
+      this.quotaMethod = quotaMethod;
+    }
 
     @Override
     public QuotaAction checkAndCharge(boolean shouldCheckExceedAllowed, boolean forceCharge, long chunkSize) {
@@ -176,7 +220,7 @@ public class QuotaTestUtils {
 
     @Override
     public QuotaMethod getQuotaMethod() {
-      return null;
+      return quotaMethod;
     }
 
     @Override

--- a/build.gradle
+++ b/build.gradle
@@ -218,7 +218,8 @@ project(':ambry-account') {
         compile project(':ambry-api'),
                 project(':ambry-utils'),
                 project(':ambry-commons'),
-                project(':ambry-mysql')
+                project(':ambry-mysql'),
+                project(':ambry-quota')
         compile "org.apache.helix:helix-core:$helixVersion"
         compile "io.dropwizard.metrics:metrics-core:$metricsVersion"
         compile "org.json:json:$jsonVersion"


### PR DESCRIPTION
This PR ensures all Router tests exercise the bandwidth throttling logic enabled bandwidth throttling.
It also fixes an issue where null QuotaChargeCallback was being passed from batch operations (like delete of a composite blob).


Its a long PR, But most of the changes are due to changes in `Router.java` interface to pass `QuotaChargeCallback` for each operation. This ensures that all operations that go through `OperationController` can exercise the quota logic.

The main changes are:
1. Change in `Router.java` to ensure `QuotaChargeCallback` object is passed for each operation.
2. Changes to update all the code and tests to changes in `Router.java` interface.
3. Update `QuotaConfig` to enable bandwidth throttling and `RouterConfig` to enable `QuotaAwareOperationController` by default, so that all tests using `Router`, exercise the bandwidth throttling logic.
4. Update `OperationController.java` and `NonBlockingRouter.java` to ensure that `QuotaChargeCallback` is not passed as `null` for any operation.