### PR TITLE
[BANDWIDTH_THROTTLING] Add missing quotaChargeCallback for batch operations and for background deletes.

### DIFF
--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/TtlUpdateHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/TtlUpdateHandlerTest.java
@@ -24,6 +24,7 @@ import com.github.ambry.commons.ByteBufferReadableStreamChannel;
 import com.github.ambry.config.FrontendConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.messageformat.BlobProperties;
+import com.github.ambry.quota.QuotaMethod;
 import com.github.ambry.quota.QuotaTestUtils;
 import com.github.ambry.rest.MockRestRequest;
 import com.github.ambry.rest.MockRestResponseChannel;
@@ -91,8 +92,8 @@ public class TtlUpdateHandlerTest {
         new TtlUpdateHandler(router, securityServiceFactory.getSecurityService(), idConverterFactory.getIdConverter(),
             accountAndContainerInjector, metrics, CLUSTER_MAP, QuotaTestUtils.createDummyQuotaManager());
     ReadableStreamChannel channel = new ByteBufferReadableStreamChannel(ByteBuffer.wrap(BLOB_DATA));
-    blobId = router.putBlob(BLOB_PROPERTIES, new byte[0], channel, new PutBlobOptionsBuilder().build())
-        .get(1, TimeUnit.SECONDS);
+    blobId = router.putBlob(BLOB_PROPERTIES, new byte[0], channel, new PutBlobOptionsBuilder().build(), null,
+        QuotaTestUtils.createTestQuotaChargeCallback(QuotaMethod.WRITE)).get(1, TimeUnit.SECONDS);
     idConverterFactory.translation = blobId;
   }
 
@@ -148,7 +149,8 @@ public class TtlUpdateHandlerTest {
    * @throws Exception
    */
   private void assertTtl(long expectedTtlSecs) throws Exception {
-    GetBlobResult result = router.getBlob(blobId, new GetBlobOptionsBuilder().build()).get(1, TimeUnit.SECONDS);
+    GetBlobResult result = router.getBlob(blobId, new GetBlobOptionsBuilder().build(), null,
+        QuotaTestUtils.createTestQuotaChargeCallback(QuotaMethod.WRITE)).get(1, TimeUnit.SECONDS);
     assertEquals("TTL not as expected", expectedTtlSecs,
         result.getBlobInfo().getBlobProperties().getTimeToLiveInSeconds());
   }

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/UndeleteHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/UndeleteHandlerTest.java
@@ -24,6 +24,7 @@ import com.github.ambry.commons.ByteBufferReadableStreamChannel;
 import com.github.ambry.config.FrontendConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.messageformat.BlobProperties;
+import com.github.ambry.quota.QuotaMethod;
 import com.github.ambry.quota.QuotaTestUtils;
 import com.github.ambry.rest.MockRestRequest;
 import com.github.ambry.rest.MockRestResponseChannel;
@@ -102,7 +103,8 @@ public class UndeleteHandlerTest {
     blobId = router.putBlob(BLOB_PROPERTIES, new byte[0], channel, new PutBlobOptionsBuilder().build())
         .get(1, TimeUnit.SECONDS);
     idConverterFactory.translation = blobId;
-    router.deleteBlob(blobId, SERVICE_ID).get(1, TimeUnit.SECONDS);
+    router.deleteBlob(blobId, SERVICE_ID, null, QuotaTestUtils.createTestQuotaChargeCallback(QuotaMethod.WRITE))
+        .get(1, TimeUnit.SECONDS);
   }
 
   /**

--- a/ambry-router/src/main/java/com/github/ambry/router/BackgroundDeleteRequest.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/BackgroundDeleteRequest.java
@@ -14,6 +14,7 @@
 
 package com.github.ambry.router;
 
+import com.github.ambry.quota.QuotaChargeCallback;
 import com.github.ambry.store.StoreKey;
 
 
@@ -24,15 +25,18 @@ class BackgroundDeleteRequest {
   static final String SERVICE_ID_PREFIX = "ambry-background-delete-";
   private final StoreKey storeKey;
   private final String serviceId;
+  private final QuotaChargeCallback quotaChargeCallback;
 
   /**
    * @param storeKey The {@link StoreKey} to delete.
    * @param serviceIdSuffix The suffix to attach to the delete service ID. This can be used to convey information about
    *                        the the delete requester.
+   * @param quotaChargeCallback {@link QuotaChargeCallback} object for quota compliance checks.
    */
-  BackgroundDeleteRequest(StoreKey storeKey, String serviceIdSuffix) {
+  BackgroundDeleteRequest(StoreKey storeKey, String serviceIdSuffix, QuotaChargeCallback quotaChargeCallback) {
     this.serviceId = SERVICE_ID_PREFIX + serviceIdSuffix;
     this.storeKey = storeKey;
+    this.quotaChargeCallback = quotaChargeCallback;
   }
 
   /**
@@ -47,5 +51,12 @@ class BackgroundDeleteRequest {
    */
   public String getServiceId() {
     return serviceId;
+  }
+
+  /**
+   * @return QuotaChargeCallback object.
+   */
+  public QuotaChargeCallback getQuotaChargeCallback() {
+    return quotaChargeCallback;
   }
 }

--- a/ambry-router/src/main/java/com/github/ambry/router/PutManager.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/PutManager.java
@@ -271,7 +271,8 @@ class PutManager {
       op.cleanupChunks();
       blobId = null;
       routerMetrics.onPutBlobError(e, op.isEncryptionEnabled(), op.isStitchOperation());
-      routerCallback.scheduleDeletes(op.getSuccessfullyPutChunkIdsIfCompositeDirectUpload(), op.getServiceId());
+      routerCallback.scheduleDeletes(op.getSuccessfullyPutChunkIdsIfCompositeDirectUpload(), op.getServiceId(),
+          op.getQuotaChargeCallback());
     } else {
       updateChunkingAndSizeMetricsOnSuccessfulPut(op);
     }
@@ -291,7 +292,8 @@ class PutManager {
     }
     // Regardless of the result of the operation, clean up the blobs that may have been put as the result of slipped
     // puts.
-    routerCallback.scheduleDeletes(Lists.newArrayList(op.getSlippedPutBlobIds()), op.getServiceId());
+    routerCallback.scheduleDeletes(Lists.newArrayList(op.getSlippedPutBlobIds()), op.getServiceId(),
+        op.getQuotaChargeCallback());
     NonBlockingRouter.completeOperation(op.getFuture(), op.getCallback(), blobId, e);
   }
 

--- a/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
@@ -697,6 +697,13 @@ class PutOperation {
   }
 
   /**
+   * @return QuotaChargeCallback associated with this request.
+   */
+  public QuotaChargeCallback getQuotaChargeCallback() {
+    return quotaChargeCallback;
+  }
+
+  /**
    * Called whenever the channel has data but no free or building chunk is available to be filled.
    */
   private void maybeStartTrackingWaitForChunkTime() {

--- a/ambry-router/src/main/java/com/github/ambry/router/RouterCallback.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/RouterCallback.java
@@ -14,6 +14,7 @@
 package com.github.ambry.router;
 
 import com.github.ambry.network.NetworkClient;
+import com.github.ambry.quota.QuotaChargeCallback;
 import com.github.ambry.store.StoreKey;
 import java.util.List;
 
@@ -54,10 +55,11 @@ class RouterCallback {
    * Schedule the deletes of ids in the given list.
    * @param idsToDelete the list of ids that need to be deleted.
    * @param serviceIdSuffix the suffix to append to the service ID when deleting these blobs.
+   * @param quotaChargeCallback {@link QuotaChargeCallback} object to perform quota compliance checks.
    */
-  void scheduleDeletes(List<StoreKey> idsToDelete, String serviceIdSuffix) {
+  void scheduleDeletes(List<StoreKey> idsToDelete, String serviceIdSuffix, QuotaChargeCallback quotaChargeCallback) {
     for (StoreKey storeKey : idsToDelete) {
-      backgroundDeleteRequests.add(new BackgroundDeleteRequest(storeKey, serviceIdSuffix));
+      backgroundDeleteRequests.add(new BackgroundDeleteRequest(storeKey, serviceIdSuffix, quotaChargeCallback));
     }
   }
 

--- a/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateManager.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateManager.java
@@ -113,7 +113,8 @@ class TtlUpdateManager {
       for (BlobId blobId : blobIds) {
         TtlUpdateOperation ttlUpdateOperation =
             new TtlUpdateOperation(clusterMap, routerConfig, routerMetrics, blobId, serviceId, expiresAtMs,
-                operationTimeMs, tracker.getCallback(blobId), time, BatchOperationCallbackTracker.DUMMY_FUTURE);
+                operationTimeMs, tracker.getCallback(blobId), time, BatchOperationCallbackTracker.DUMMY_FUTURE,
+                quotaChargeCallback);
         ttlUpdateOperations.add(ttlUpdateOperation);
       }
     }

--- a/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateOperation.java
@@ -80,26 +80,6 @@ class TtlUpdateOperation {
    * @param callback The {@link Callback} that is supplied by the caller.
    * @param time A {@link Time} reference.
    * @param futureResult The {@link FutureResult} that is returned to the caller.
-   */
-  TtlUpdateOperation(ClusterMap clusterMap, RouterConfig routerConfig, NonBlockingRouterMetrics routerMetrics,
-      BlobId blobId, String serviceId, long expiresAtMs, long operationTimeMs, Callback<Void> callback, Time time,
-      FutureResult<Void> futureResult) {
-    this(clusterMap, routerConfig, routerMetrics, blobId, serviceId, expiresAtMs, operationTimeMs, callback, time,
-        futureResult, null);
-  }
-
-  /**
-   * Instantiates a {@link TtlUpdateOperation}.
-   * @param clusterMap the {@link ClusterMap} to use.
-   * @param routerConfig The {@link RouterConfig} that contains router-level configurations.
-   * @param routerMetrics The {@link NonBlockingRouterMetrics} to record all router-related metrics.
-   * @param blobId The {@link BlobId} whose TTL needs to be updated by this {@link TtlUpdateOperation}.
-   * @param serviceId The service ID of the service deleting the blob. This can be null if unknown.
-   * @param expiresAtMs the new time at which the blob should expire.
-   * @param operationTimeMs the time at which the operation occurred.
-   * @param callback The {@link Callback} that is supplied by the caller.
-   * @param time A {@link Time} reference.
-   * @param futureResult The {@link FutureResult} that is returned to the caller.
    * @param quotaChargeCallback The {@link QuotaChargeCallback} object.
    */
   TtlUpdateOperation(ClusterMap clusterMap, RouterConfig routerConfig, NonBlockingRouterMetrics routerMetrics,

--- a/ambry-router/src/main/java/com/github/ambry/router/UndeleteManager.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/UndeleteManager.java
@@ -116,7 +116,7 @@ public class UndeleteManager {
       for (BlobId blobId : blobIds) {
         UndeleteOperation undeleteOperation =
             new UndeleteOperation(clusterMap, routerConfig, routerMetrics, blobId, serviceId, operationTimeMs,
-                tracker.getCallback(blobId), time, BatchOperationCallbackTracker.DUMMY_FUTURE);
+                tracker.getCallback(blobId), time, BatchOperationCallbackTracker.DUMMY_FUTURE, quotaChargeCallback);
         undeleteOperations.add(undeleteOperation);
       }
     }

--- a/ambry-router/src/main/java/com/github/ambry/router/UndeleteOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/UndeleteOperation.java
@@ -82,24 +82,6 @@ public class UndeleteOperation {
    * @param callback The {@link Callback} that is supplied by the caller.
    * @param time A {@link Time} reference.
    * @param futureResult The {@link FutureResult} that is returned to the caller.
-   */
-  UndeleteOperation(ClusterMap clusterMap, RouterConfig routerConfig, NonBlockingRouterMetrics routerMetrics,
-      BlobId blobId, String serviceId, long operationTimeMs, Callback<Void> callback, Time time,
-      FutureResult<Void> futureResult) {
-    this(clusterMap, routerConfig, routerMetrics, blobId, serviceId, operationTimeMs, callback, time, futureResult, null);
-  }
-
-  /**
-   * Instantiates a {@link UndeleteOperation}.
-   * @param clusterMap the {@link ClusterMap} to use.
-   * @param routerConfig The {@link RouterConfig} that contains router-level configurations.
-   * @param routerMetrics The {@link NonBlockingRouterMetrics} to record all router-related metrics.
-   * @param blobId The {@link BlobId} needs to be undeleted by this {@link UndeleteOperation}.
-   * @param serviceId The service ID of the service deleting the blob. This can be null if unknown.
-   * @param operationTimeMs the time at which the operation occurred.
-   * @param callback The {@link Callback} that is supplied by the caller.
-   * @param time A {@link Time} reference.
-   * @param futureResult The {@link FutureResult} that is returned to the caller.
    * @param quotaChargeCallback The {@link QuotaChargeCallback} object.
    */
   UndeleteOperation(ClusterMap clusterMap, RouterConfig routerConfig, NonBlockingRouterMetrics routerMetrics,

--- a/ambry-test-utils/src/main/java/com/github/ambry/quota/QuotaTestUtils.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/quota/QuotaTestUtils.java
@@ -116,6 +116,15 @@ public class QuotaTestUtils {
   }
 
   /**
+   * Create an implementation of {@link QuotaChargeCallback} object for test.
+   * @param quotaMethod {@link QuotaMethod} object.
+   * @return TestQuotaChargeCallback object.
+   */
+  public static TestQuotaChargeCallback createTestQuotaChargeCallback(QuotaMethod quotaMethod) {
+    return new TestQuotaChargeCallback(quotaMethod);
+  }
+
+  /**
    * Create {@link MockRestRequest} object using the specified {@link Account}, {@link Container} and {@link RestMethod}.
    * @param account {@link Account} object.
    * @param container {@link Container} object.
@@ -141,12 +150,14 @@ public class QuotaTestUtils {
   public static class TestQuotaChargeCallback implements QuotaChargeCallback {
     public int numCheckAndChargeCalls = 0;
     private final QuotaConfig quotaConfig;
+    private final QuotaMethod quotaMethod;
 
     /**
      * Default constructor for {@link TestQuotaChargeCallback}.
      */
     public TestQuotaChargeCallback() {
       this.quotaConfig = new QuotaConfig(new VerifiableProperties(new Properties()));
+      this.quotaMethod = QuotaMethod.READ;
     }
 
     /**
@@ -155,6 +166,16 @@ public class QuotaTestUtils {
      */
     public TestQuotaChargeCallback(QuotaConfig quotaConfig) {
       this.quotaConfig = quotaConfig;
+      this.quotaMethod = QuotaMethod.READ;
+    }
+
+    /**
+     * Constructor for {@link TestQuotaChargeCallback} with the specified {@link QuotaConfig}.
+     * @param quotaMethod {@link QuotaMethod} object.
+     */
+    public TestQuotaChargeCallback(QuotaMethod quotaMethod) {
+      this.quotaConfig = new QuotaConfig(new VerifiableProperties(new Properties()));
+      this.quotaMethod = quotaMethod;
     }
 
 


### PR DESCRIPTION
There are few places in batch operations (ttl update and delete of a composite blob), and in background deletes, where QuotaChargeCallback is null. It leads to inaccurate quota charging for these operations. This PR fixes that issue.