### PR TITLE
Introduce AzureStorageClient interface

### DIFF
--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureStorageClient.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureStorageClient.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright 2019 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.cloud.azure;
+
+import com.azure.core.exception.UnexpectedLengthException;
+import com.azure.core.http.rest.Response;
+import com.azure.core.util.Context;
+import com.azure.core.util.FluxUtil;
+import com.azure.storage.blob.BlobServiceAsyncClient;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.batch.BlobBatch;
+import com.azure.storage.blob.batch.BlobBatchStorageException;
+import com.azure.storage.blob.models.AccessTier;
+import com.azure.storage.blob.models.BlobHttpHeaders;
+import com.azure.storage.blob.models.BlobProperties;
+import com.azure.storage.blob.models.BlobRange;
+import com.azure.storage.blob.models.BlobRequestConditions;
+import com.azure.storage.blob.models.BlobStorageException;
+import com.azure.storage.blob.models.BlockBlobItem;
+import com.azure.storage.blob.models.DownloadRetryOptions;
+import com.azure.storage.blob.specialized.BlockBlobAsyncClient;
+import com.github.ambry.cloud.CloudBlobMetadata;
+import com.github.ambry.commons.BlobId;
+import com.github.ambry.commons.FutureUtils;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+
+public interface AzureStorageClient {
+  /**
+   * Visible for testing.
+   * @return the underlying {@link BlobServiceClient}.
+   */
+  public BlobServiceAsyncClient getStorageClient();
+
+  /**
+   * Creates a new block blob, or updates the content of an existing block blob asynchronously.
+   * @param blobId {@link BlobId} of the blob to upload.
+   * @param data The data to write to the blob.
+   * @param length The exact length of the data. It is important that this value match precisely the length of the
+   * data provided in the {@link InputStream}.
+   * @param headers {@link BlobHttpHeaders}
+   * @param metadata Metadata to associate with the blob.
+   * @param tier {@link AccessTier} for the destination blob.
+   * @param contentMd5 An MD5 hash of the block content.
+   * @param requestConditions {@link BlobRequestConditions}
+   * @return a {@link CompletableFuture} of type {@link Void} that will eventually complete when block blob is uploaded
+   *         or will contain an exception if an error occurred.
+   */
+  public CompletableFuture<Void> uploadWithResponse(BlobId blobId, InputStream data, long length,
+      BlobHttpHeaders headers, Map<String, String> metadata, AccessTier tier, byte[] contentMd5,
+      BlobRequestConditions requestConditions);
+
+  /**
+   * Creates a new block blob, or updates the content of an existing block blob asynchronously.
+   * @param containerName name of the Azure container where the blob lives.
+   * @param blobName name of the blob.
+   * @param autoCreateContainer flag indicating whether to create the container if it does not exist.
+   * @param data The data to write to the blob.
+   * @param length The exact length of the data. It is important that this value match precisely the length of the
+   * data provided in the {@link InputStream}.
+   * @param headers {@link BlobHttpHeaders}
+   * @param metadata Metadata to associate with the blob.
+   * @param tier {@link AccessTier} for the destination blob.
+   * @param contentMd5 An MD5 hash of the block content.
+   * @param requestConditions {@link BlobRequestConditions}
+   * @return a {@link CompletableFuture} of type {@link Void} that will eventually complete when block blob is uploaded
+   *         or an exception if an error occurred.
+   */
+  public CompletableFuture<Void> uploadWithResponse(String containerName, String blobName, boolean autoCreateContainer,
+      InputStream data, long length, BlobHttpHeaders headers, Map<String, String> metadata, AccessTier tier,
+      byte[] contentMd5, BlobRequestConditions requestConditions);
+
+  /**
+   * Downloads a range of bytes from a blob into an output stream.
+   * @param containerName name of the Azure container where the blob lives.
+   * @param blobName name of the blob.
+   * @param blobId Ambry {@link BlobId} associated with the {@code fileName}.
+   * @param autoCreateContainer flag indicating whether to create the container if it does not exist.
+   * @param stream A non-null {@link OutputStream} instance where the downloaded data will be written.
+   * @param range {@link BlobRange}
+   * @param options {@link DownloadRetryOptions}
+   * @param requestConditions {@link BlobRequestConditions}
+   * @param getRangeContentMd5 Whether the contentMD5 for the specified blob range should be returned.
+   * @throws UncheckedIOException If an I/O error occurs.
+   * @throws NullPointerException if {@code stream} is null
+   */
+  public CompletableFuture<Void> downloadWithResponse(String containerName, String blobName, BlobId blobId,
+      boolean autoCreateContainer, OutputStream stream, BlobRange range, DownloadRetryOptions options,
+      BlobRequestConditions requestConditions, boolean getRangeContentMd5);
+
+  /**
+   * Returns the blob's metadata and properties.
+   * @param blobId {@link BlobId}
+   * @param requestConditions {@link BlobRequestConditions}
+   * @return a {@link CompletableFuture} that will eventually contain blob properties and metadata or an exception
+   *         if an error occurred.
+   */
+  public CompletableFuture<BlobProperties> getPropertiesWithResponse(BlobId blobId,
+      BlobRequestConditions requestConditions);
+
+  /**
+   * Changes a blob's metadata. The specified metadata in this method will replace existing metadata. If old values
+   * must be preserved, they must be downloaded and included in the call to this method.
+   * @param blobId {@link BlobId} object.
+   * @param metadata Metadata to associate with the blob.
+   * @param requestConditions {@link BlobRequestConditions}
+   * @param context Additional context that is passed through the Http pipeline during the service call.
+   * @return a {@link CompletableFuture} of type {@link Void} that will eventually complete successfully when blob
+   *         metadata is changed or completes exceptionally if an error occurred.
+   */
+  public CompletableFuture<Void> setMetadataWithResponse(BlobId blobId, Map<String, String> metadata,
+      BlobRequestConditions requestConditions, Context context);
+
+  /**
+   * Deletes a list of blobs asynchronously.
+   * @param batchOfBlobs {@link List} of {@link CloudBlobMetadata} objects.
+   * @return {@link List} of {@link Response}s for the blobs in the batch.
+   * @return a {@link CompletableFuture} that will eventually contain {@link List} of {@link Response}s for the blobs
+   *         in the batch or an exception if an error occurred.
+   */
+  public CompletableFuture<List<Response<Void>>>  deleteBatch(List<CloudBlobMetadata> batchOfBlobs);
+
+  /**
+   * Delete a file from blob storage asynchronously, if it exists.
+   * @param containerName name of the container containing file to delete.
+   * @param fileName name of the file to delete.
+   * @return a {@link CompletableFuture} of type {@link Boolean} that will eventually complete successfully when the file
+   *         is deleted or will complete exceptionally if an error occurs.
+   */
+  public CompletableFuture<Boolean> deleteFile(String containerName, String fileName) throws BlobStorageException;
+
+  /**
+   * Perform basic connectivity test.
+   */
+  public void testConnectivity();
+}

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/ClientSecretCredentialStorageClient.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/ClientSecretCredentialStorageClient.java
@@ -40,8 +40,9 @@ public class ClientSecretCredentialStorageClient extends StorageClient {
    * @param blobLayoutStrategy {@link AzureBlobLayoutStrategy} object.
    */
   public ClientSecretCredentialStorageClient(CloudConfig cloudConfig, AzureCloudConfig azureCloudConfig,
-      AzureMetrics azureMetrics, AzureBlobLayoutStrategy blobLayoutStrategy) {
-    super(cloudConfig, azureCloudConfig, azureMetrics, blobLayoutStrategy);
+      AzureMetrics azureMetrics, AzureBlobLayoutStrategy blobLayoutStrategy,
+      AzureCloudConfig.StorageAccountInfo storageAccountInfo) {
+    super(cloudConfig, azureCloudConfig, azureMetrics, blobLayoutStrategy, storageAccountInfo);
   }
 
   /**
@@ -54,8 +55,8 @@ public class ClientSecretCredentialStorageClient extends StorageClient {
    */
   public ClientSecretCredentialStorageClient(BlobServiceAsyncClient blobServiceAsyncClient,
       BlobBatchAsyncClient blobBatchAsyncClient, AzureMetrics azureMetrics, AzureBlobLayoutStrategy blobLayoutStrategy,
-      AzureCloudConfig azureCloudConfig) {
-    super(blobServiceAsyncClient, blobBatchAsyncClient, azureMetrics, blobLayoutStrategy, azureCloudConfig);
+      AzureCloudConfig azureCloudConfig, AzureCloudConfig.StorageAccountInfo storageAccountInfo) {
+    super(blobServiceAsyncClient, blobBatchAsyncClient, azureMetrics, blobLayoutStrategy, azureCloudConfig, storageAccountInfo);
   }
 
   /**
@@ -70,7 +71,7 @@ public class ClientSecretCredentialStorageClient extends StorageClient {
   protected BlobServiceAsyncClient buildBlobServiceAsyncClient(HttpClient httpClient, Configuration configuration,
       RequestRetryOptions retryOptions, AzureCloudConfig azureCloudConfig) {
     return new BlobServiceClientBuilder().credential(AzureUtils.getClientSecretCredential(azureCloudConfig))
-        .endpoint(azureCloudConfig.azureStorageEndpoint)
+        .endpoint(storageAccountInfo() != null ? storageAccountInfo().getStorageEndpoint() : azureCloudConfig.azureStorageEndpoint)
         .httpClient(httpClient)
         .retryOptions(retryOptions)
         .configuration(configuration)

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/ConnectionStringBasedStorageClient.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/ConnectionStringBasedStorageClient.java
@@ -38,8 +38,9 @@ public class ConnectionStringBasedStorageClient extends StorageClient {
    * @param blobLayoutStrategy {@link AzureBlobLayoutStrategy} object.
    */
   public ConnectionStringBasedStorageClient(CloudConfig cloudConfig, AzureCloudConfig azureCloudConfig,
-      AzureMetrics azureMetrics, AzureBlobLayoutStrategy blobLayoutStrategy) {
-    super(cloudConfig, azureCloudConfig, azureMetrics, blobLayoutStrategy);
+      AzureMetrics azureMetrics, AzureBlobLayoutStrategy blobLayoutStrategy,
+      AzureCloudConfig.StorageAccountInfo storageAccountInfo) {
+    super(cloudConfig, azureCloudConfig, azureMetrics, blobLayoutStrategy, storageAccountInfo);
   }
 
   /**
@@ -52,14 +53,14 @@ public class ConnectionStringBasedStorageClient extends StorageClient {
    */
   public ConnectionStringBasedStorageClient(BlobServiceAsyncClient blobServiceAsyncClient,
       BlobBatchAsyncClient blobBatchAsyncClient, AzureMetrics azureMetrics, AzureBlobLayoutStrategy blobLayoutStrategy,
-      AzureCloudConfig azureCloudConfig) {
-    super(blobServiceAsyncClient, blobBatchAsyncClient, azureMetrics, blobLayoutStrategy, azureCloudConfig);
+      AzureCloudConfig azureCloudConfig, AzureCloudConfig.StorageAccountInfo storageAccountInfo) {
+    super(blobServiceAsyncClient, blobBatchAsyncClient, azureMetrics, blobLayoutStrategy, azureCloudConfig, storageAccountInfo);
   }
 
   @Override
   protected BlobServiceAsyncClient buildBlobServiceAsyncClient(HttpClient httpClient, Configuration configuration,
       RequestRetryOptions retryOptions, AzureCloudConfig azureCloudConfig) {
-    return new BlobServiceClientBuilder().connectionString(azureCloudConfig.azureStorageConnectionString)
+    return new BlobServiceClientBuilder().connectionString(storageAccountInfo() != null ? storageAccountInfo().getStorageConnectionString() : azureCloudConfig.azureStorageConnectionString)
         .httpClient(httpClient)
         .retryOptions(retryOptions)
         .configuration(configuration)
@@ -71,7 +72,13 @@ public class ConnectionStringBasedStorageClient extends StorageClient {
    * @param azureCloudConfig {@link AzureCloudConfig} object.
    */
   protected void validateABSAuthConfigs(AzureCloudConfig azureCloudConfig) {
-    if (azureCloudConfig.azureStorageConnectionString.isEmpty()) {
+    if (storageAccountInfo() != null) {
+      if (storageAccountInfo().getStorageConnectionString().isEmpty()) {
+        throw new IllegalArgumentException(
+            String.format("Missing connection string config %s for the storage account %s ",
+                AzureCloudConfig.AZURE_STORAGE_ACCOUNT_INFO_STORAGE_CONNECTION_STRING, storageAccountInfo().getName()));
+      }
+    } else if (azureCloudConfig.azureStorageConnectionString.isEmpty()) {
       throw new IllegalArgumentException(
           "Missing connection string config " + AzureCloudConfig.AZURE_STORAGE_CONNECTION_STRING);
     }

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/ShardedStorageClient.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/ShardedStorageClient.java
@@ -1,0 +1,255 @@
+/**
+ * Copyright 2019 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.cloud.azure;
+
+import com.azure.core.http.HttpClient;
+import com.azure.core.http.rest.Response;
+import com.azure.core.util.Configuration;
+import com.azure.core.util.Context;
+import com.azure.storage.blob.BlobServiceAsyncClient;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.batch.BlobBatchAsyncClient;
+import com.azure.storage.blob.models.AccessTier;
+import com.azure.storage.blob.models.BlobHttpHeaders;
+import com.azure.storage.blob.models.BlobProperties;
+import com.azure.storage.blob.models.BlobRange;
+import com.azure.storage.blob.models.BlobRequestConditions;
+import com.azure.storage.blob.models.BlobStorageException;
+import com.azure.storage.blob.models.BlockBlobItem;
+import com.azure.storage.blob.models.DownloadRetryOptions;
+import com.azure.storage.common.policy.RequestRetryOptions;
+import com.github.ambry.cloud.CloudBlobMetadata;
+import com.github.ambry.commons.BlobId;
+import com.github.ambry.config.CloudConfig;
+import com.github.ambry.utils.Utils;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.MalformedURLException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+
+public class ShardedStorageClient implements AzureStorageClient {
+  public final List<StorageClient> storageClientList;
+  public final List<Integer> storageClientPartitionBoundaries;
+
+  /**
+   * Constructor for {@link ShardedStorageClient}.
+   * @param cloudConfig {@link CloudConfig} object.
+   * @param azureCloudConfig {@link AzureCloudConfig} object.
+   * @param azureMetrics {@link AzureMetrics} object.
+   * @param blobLayoutStrategy {@link AzureBlobLayoutStrategy} object.
+   */
+  public ShardedStorageClient(CloudConfig cloudConfig, AzureCloudConfig azureCloudConfig, AzureMetrics azureMetrics,
+      AzureBlobLayoutStrategy blobLayoutStrategy) throws ReflectiveOperationException {
+    List<AzureCloudConfig.StorageAccountInfo> storageAccountInfoList = azureCloudConfig.azureStorageAccountInfo;
+
+    storageClientList = new ArrayList<>();
+    storageClientPartitionBoundaries = new ArrayList<>();
+    for (AzureCloudConfig.StorageAccountInfo storageAccountInfo : storageAccountInfoList) {
+      storageClientList.add(Utils.getObj(azureCloudConfig.azureStorageClientClass, cloudConfig, azureCloudConfig,
+          azureMetrics, blobLayoutStrategy, storageAccountInfo));
+      storageClientPartitionBoundaries.add(storageAccountInfo.getPartitionRangeStart());
+    }
+    storageClientPartitionBoundaries.add(Integer.MAX_VALUE);
+  }
+  /**
+   * Constructor for {@link ShardedStorageClient}.
+   * @param blobStorageAsyncClient {@link BlobServiceAsyncClient} object.
+   * @param blobBatchAsyncClient {@link BlobBatchAsyncClient} object.
+   * @param azureMetrics {@link AzureMetrics} object.
+   * @param blobLayoutStrategy {@link AzureBlobLayoutStrategy} object.
+   * @param azureCloudConfig {@link AzureCloudConfig} object.
+   */
+  public ShardedStorageClient(BlobServiceAsyncClient blobStorageAsyncClient, BlobBatchAsyncClient blobBatchAsyncClient,
+      AzureMetrics azureMetrics, AzureBlobLayoutStrategy blobLayoutStrategy, AzureCloudConfig azureCloudConfig) throws ReflectiveOperationException {
+    List<AzureCloudConfig.StorageAccountInfo> storageAccountInfoList = azureCloudConfig.azureStorageAccountInfo;
+    if (storageAccountInfoList.isEmpty()) {
+      throw new IllegalArgumentException("No storage account provided to ShardedStorageClient");
+    }
+    storageClientList = new ArrayList<>();
+    storageClientPartitionBoundaries = new ArrayList<>();
+    for (AzureCloudConfig.StorageAccountInfo storageAccountInfo : storageAccountInfoList) {
+      storageClientList.add(Utils.getObj(azureCloudConfig.azureStorageClientClass, blobStorageAsyncClient, blobBatchAsyncClient,
+          azureMetrics, blobLayoutStrategy, azureCloudConfig, storageAccountInfo));
+      storageClientPartitionBoundaries.add(storageAccountInfo.getPartitionRangeStart());
+    }
+    storageClientPartitionBoundaries.add(Integer.MAX_VALUE);
+  }
+
+  /**
+   * Finds the StorageClient that corresponds to Azure storage account holding Ambry metadata blobs.
+   * @return {@link StorageClient} that corresponds to Azure storage account holding Ambry metadata blobs.
+   */
+  private StorageClient getMetadataAzureStorageClient() {
+    return storageClientList.get(0);
+  }
+
+  /**
+   * Finds the StorageClient corresponds to given blob id.
+   * @param blobId {@link BlobId} of the blob to find its mapping {@link StorageClient}.
+   * @return {@link StorageClient} corresponds to Azure storage account holding Ambry metadata blobs.
+   */
+  private StorageClient getAzureStorageClient(BlobId blobId) {
+    return storageClientList.get(0);
+  }
+
+  /**
+   * Visible for testing.
+   * @return the underlying {@link BlobServiceAsyncClient}.
+   */
+  @Override
+  public BlobServiceAsyncClient getStorageClient() {
+    return getMetadataAzureStorageClient().getStorageClient();
+  }
+
+  /**
+   * Creates a new block blob, or updates the content of an existing block blob asynchronously.
+   * @param blobId {@link BlobId} of the blob to upload.
+   * @param data The data to write to the blob.
+   * @param length The exact length of the data. It is important that this value match precisely the length of the
+   * data provided in the {@link InputStream}.
+   * @param headers {@link BlobHttpHeaders}
+   * @param metadata Metadata to associate with the blob.
+   * @param tier {@link AccessTier} for the destination blob.
+   * @param contentMd5 An MD5 hash of the block content.
+   * @param requestConditions {@link BlobRequestConditions}
+   * @return a {@link CompletableFuture} of type {@link Void} that will eventually complete when block blob is uploaded
+   *         or will contain an exception if an error occurred.
+   */
+  public CompletableFuture<Void> uploadWithResponse(BlobId blobId, InputStream data, long length,
+      BlobHttpHeaders headers, Map<String, String> metadata, AccessTier tier, byte[] contentMd5,
+      BlobRequestConditions requestConditions) {
+    return getAzureStorageClient(blobId).uploadWithResponse(blobId, data, length, headers, metadata, tier, contentMd5, requestConditions);
+  }
+
+  /**
+   * Creates a new block blob, or updates the content of an existing block blob asynchronously.
+   * @param containerName name of the Azure container where the blob lives.
+   * @param blobName name of the blob.
+   * @param autoCreateContainer flag indicating whether to create the container if it does not exist.
+   * @param data The data to write to the blob.
+   * @param length The exact length of the data. It is important that this value match precisely the length of the
+   * data provided in the {@link InputStream}.
+   * @param headers {@link BlobHttpHeaders}
+   * @param metadata Metadata to associate with the blob.
+   * @param tier {@link AccessTier} for the destination blob.
+   * @param contentMd5 An MD5 hash of the block content.
+   * @param requestConditions {@link BlobRequestConditions}
+   * @return a {@link CompletableFuture} of type {@link Void} that will eventually complete when block blob is uploaded
+   *         or an exception if an error occurred.
+   */
+  public CompletableFuture<Void> uploadWithResponse(String containerName, String blobName, boolean autoCreateContainer,
+      InputStream data, long length, BlobHttpHeaders headers, Map<String, String> metadata, AccessTier tier,
+      byte[] contentMd5, BlobRequestConditions requestConditions) {
+    return getMetadataAzureStorageClient().uploadWithResponse(containerName, blobName, autoCreateContainer, data,
+        length, headers, metadata, tier, contentMd5, requestConditions);
+  }
+
+  /**
+   * Downloads a range of bytes from a blob asynchronously into an output stream.
+   * @param containerName name of the Azure container where the blob lives.
+   * @param blobName name of the blob.
+   * @param blobId Ambry {@link BlobId} associated with the {@code fileName}. Null value indicates blobName refers
+   *               to a metadata blob owned by Ambry.
+   * @param autoCreateContainer flag indicating whether to create the container if it does not exist.
+   * @param stream A non-null {@link OutputStream} instance where the downloaded data will be written.
+   * @param range {@link BlobRange}
+   * @param options {@link DownloadRetryOptions}
+   * @param requestConditions {@link BlobRequestConditions}
+   * @param getRangeContentMd5 Whether the contentMD5 for the specified blob range should be returned.
+   * @return a {@link CompletableFuture} of type {@link Void} that will eventually complete when blob is downloaded
+   *         or an exception if an error occurred.
+   */
+  @Override
+  public CompletableFuture<Void> downloadWithResponse(String containerName, String blobName, BlobId blobId,
+      boolean autoCreateContainer, OutputStream stream, BlobRange range, DownloadRetryOptions options,
+      BlobRequestConditions requestConditions, boolean getRangeContentMd5) {
+    if (blobId != null) {
+      return getAzureStorageClient(blobId).downloadWithResponse(containerName, blobName, blobId, autoCreateContainer, stream,
+          range, options, requestConditions, getRangeContentMd5);
+    }
+    return getMetadataAzureStorageClient().downloadWithResponse(containerName, blobName, blobId, autoCreateContainer,
+        stream, range, options, requestConditions, getRangeContentMd5);
+  }
+
+  /**
+   * Returns the blob's metadata and properties.
+   * @param blobId {@link BlobId}
+   * @param requestConditions {@link BlobRequestConditions}
+   * @return a {@link CompletableFuture} that will eventually contain blob properties and metadata or an exception
+   *         if an error occurred.
+   */
+  @Override
+  public CompletableFuture<BlobProperties> getPropertiesWithResponse(BlobId blobId,
+      BlobRequestConditions requestConditions) {
+    return getAzureStorageClient(blobId).getPropertiesWithResponse(blobId, requestConditions);
+  }
+
+  /**
+   * Changes a blob's metadata. The specified metadata in this method will replace existing metadata. If old values
+   * must be preserved, they must be downloaded and included in the call to this method.
+   * @param blobId {@link BlobId} object.
+   * @param metadata Metadata to associate with the blob.
+   * @param requestConditions {@link BlobRequestConditions}
+   * @param context Additional context that is passed through the Http pipeline during the service call.
+   * @return a {@link CompletableFuture} of type {@link Void} that will eventually complete successfully when blob
+   *         metadata is changed or completes exceptionally if an error occurred.
+   */
+  @Override
+  public CompletableFuture<Void> setMetadataWithResponse(BlobId blobId, Map<String, String> metadata,
+      BlobRequestConditions requestConditions, Context context) {
+    return getAzureStorageClient(blobId).setMetadataWithResponse(blobId, metadata, requestConditions, context);
+  }
+
+  /**
+   * Deletes a list of blobs asynchronously.
+   * @param batchOfBlobs {@link List} of {@link CloudBlobMetadata} objects.
+   * @return {@link List} of {@link Response}s for the blobs in the batch.
+   * @return a {@link CompletableFuture} that will eventually contain {@link List} of {@link Response}s for the blobs
+   *         in the batch or an exception if an error occurred.
+   */
+  @Override
+  public CompletableFuture<List<Response<Void>>> deleteBatch(List<CloudBlobMetadata> batchOfBlobs) {
+    // TODO call getAzureStorageClient() once blobId is passed down to this routine.
+    return getMetadataAzureStorageClient().deleteBatch(batchOfBlobs);
+  }
+
+  /**
+   * Delete a file from blob storage asynchronously, if it exists.
+   * @param containerName name of the container containing file to delete.
+   * @param fileName name of the file to delete.
+   * @return a {@link CompletableFuture} of type {@link Boolean} that will eventually complete successfully when the file
+   *         is deleted or will complete exceptionally if an error occurs.
+   */
+  @Override
+  public CompletableFuture<Boolean> deleteFile(String containerName, String fileName) throws BlobStorageException {
+    // TODO call getAzureStorageClient() once blobId is passed down to this routine.
+    return getMetadataAzureStorageClient().deleteFile(containerName, fileName);
+  }
+
+  /**
+   * Perform basic connectivity test.
+   */
+  @Override
+  public void testConnectivity() {
+    for (StorageClient storageClient : storageClientList) {
+      storageClient.testConnectivity();
+    }
+  };
+}

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/StorageClient.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/StorageClient.java
@@ -65,12 +65,13 @@ import org.slf4j.LoggerFactory;
 /**
  * Abstract class to encapsulate ABS client operations. Please note that all its operations are asynchronous.
  */
-public abstract class StorageClient {
+public abstract class StorageClient implements AzureStorageClient {
   Logger logger = LoggerFactory.getLogger(StorageClient.class);
   private final AtomicReference<BlobServiceAsyncClient> storageAsyncClientRef;
   private final AtomicReference<BlobBatchAsyncClient> blobBatchAsyncClientRef;
   private final CloudConfig cloudConfig;
   protected final AzureCloudConfig azureCloudConfig;
+  private final AzureCloudConfig.StorageAccountInfo storageAccountInfo;
   private final AzureBlobLayoutStrategy blobLayoutStrategy;
   protected final AzureMetrics azureMetrics;
   // Containers known to exist in the storage account
@@ -89,7 +90,8 @@ public abstract class StorageClient {
    * @param blobLayoutStrategy {@link AzureBlobLayoutStrategy} object.
    */
   public StorageClient(CloudConfig cloudConfig, AzureCloudConfig azureCloudConfig, AzureMetrics azureMetrics,
-      AzureBlobLayoutStrategy blobLayoutStrategy) {
+      AzureBlobLayoutStrategy blobLayoutStrategy, AzureCloudConfig.StorageAccountInfo storageAccountInfo) {
+    this.storageAccountInfo = storageAccountInfo;
     this.azureCloudConfig = azureCloudConfig;
     this.cloudConfig = cloudConfig;
     this.blobLayoutStrategy = blobLayoutStrategy;
@@ -108,13 +110,19 @@ public abstract class StorageClient {
    * @param azureCloudConfig {@link AzureCloudConfig} object.
    */
   public StorageClient(BlobServiceAsyncClient storageAsyncClient, BlobBatchAsyncClient blobBatchAsyncClient,
-      AzureMetrics azureMetrics, AzureBlobLayoutStrategy blobLayoutStrategy, AzureCloudConfig azureCloudConfig) {
+      AzureMetrics azureMetrics, AzureBlobLayoutStrategy blobLayoutStrategy, AzureCloudConfig azureCloudConfig,
+      AzureCloudConfig.StorageAccountInfo storageAccountInfo) {
+    this.storageAccountInfo = storageAccountInfo;
     this.blobLayoutStrategy = blobLayoutStrategy;
     this.azureMetrics = azureMetrics;
     this.cloudConfig = null;
     this.azureCloudConfig = azureCloudConfig;
     this.storageAsyncClientRef = new AtomicReference<>(storageAsyncClient);
     this.blobBatchAsyncClientRef = new AtomicReference<>(blobBatchAsyncClient);
+  }
+
+  AzureCloudConfig.StorageAccountInfo storageAccountInfo() {
+    return storageAccountInfo;
   }
 
   /**

--- a/ambry-cloud/src/test/java/com/github/ambry/cloud/azure/AzureBlobLayoutStrategyTest.java
+++ b/ambry-cloud/src/test/java/com/github/ambry/cloud/azure/AzureBlobLayoutStrategyTest.java
@@ -17,17 +17,19 @@ import com.github.ambry.cloud.CloudBlobMetadata;
 import com.github.ambry.cloud.azure.AzureBlobLayoutStrategy.BlobLayout;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.config.VerifiableProperties;
+import com.google.common.collect.Lists;
+import java.util.Collection;
 import java.util.Properties;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.runners.Parameterized;
 
 import static org.junit.Assert.*;
 
 
 /** Test cases for {@link AzureBlobLayoutStrategy} */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(Parameterized.class)
 public class AzureBlobLayoutStrategyTest {
 
   private Properties configProps = new Properties();
@@ -35,11 +37,15 @@ public class AzureBlobLayoutStrategyTest {
   private final String clusterName = "main";
   private final String tokenFileName = "replicaTokens";
   private final String partitionPath = String.valueOf(AzureTestUtils.partition);
+  private final Integer numStorageAccountParameter;
 
+  public AzureBlobLayoutStrategyTest(final Integer numStorageAccountParameter) {
+    this.numStorageAccountParameter = numStorageAccountParameter;
+  }
   @Before
   public void setup() {
     blobId = AzureTestUtils.generateBlobId();
-    AzureTestUtils.setConfigProperties(configProps);
+    AzureTestUtils.setConfigProperties(configProps, numStorageAccountParameter);
   }
 
   /** Test default strategy and make sure it is partition-based */
@@ -116,5 +122,15 @@ public class AzureBlobLayoutStrategyTest {
   private static void checkLayout(BlobLayout layout, String expectedContainerName, String expectedBlobPath) {
     assertEquals("Unexpected container name", expectedContainerName, layout.containerName);
     assertEquals("Unexpected blob path", expectedBlobPath, layout.blobFilePath);
+  }
+
+  /**
+   * Parameters determine the number of storage accounts to use during the sharded storage account testing.
+   * The value of zero refers to no storage account sharding.
+   * @return The number of storage accounts to use.
+   */
+  @Parameterized.Parameters
+  public static Collection<Integer[]> getParameters() {
+    return Lists.newArrayList(new Integer[] { 0 }, new Integer[] { 1 });
   }
 }

--- a/ambry-cloud/src/test/java/com/github/ambry/cloud/azure/AzureCloudConfigTest.java
+++ b/ambry-cloud/src/test/java/com/github/ambry/cloud/azure/AzureCloudConfigTest.java
@@ -29,7 +29,7 @@ public class AzureCloudConfigTest {
 
   @Before
   public void setup() throws Exception {
-    AzureTestUtils.setConfigProperties(configProps);
+    AzureTestUtils.setConfigProperties(configProps, 0);
   }
 
   /** Test Azure cloud config for a single storage account */

--- a/ambry-cloud/src/test/java/com/github/ambry/cloud/azure/AzureTestUtils.java
+++ b/ambry-cloud/src/test/java/com/github/ambry/cloud/azure/AzureTestUtils.java
@@ -58,8 +58,7 @@ class AzureTestUtils {
   static final long partition = 666;
   static final ObjectMapper objectMapper = new ObjectMapper();
 
-  static void setConfigProperties(Properties configProps) {
-    configProps.setProperty(AzureCloudConfig.AZURE_STORAGE_CONNECTION_STRING, storageConnection);
+  static void setConfigProperties(Properties configProps, int numberStorageAccounts) {
     configProps.setProperty(AzureCloudConfig.COSMOS_ENDPOINT, "http://ambry.beyond-the-cosmos.com");
     configProps.setProperty(AzureCloudConfig.COSMOS_DATABASE, "ambry");
     configProps.setProperty(AzureCloudConfig.COSMOS_COLLECTION, "metadata");
@@ -69,7 +68,20 @@ class AzureTestUtils {
         "https://login.microsoftonline.com/test-account/");
     configProps.setProperty(AzureCloudConfig.AZURE_STORAGE_CLIENTID, "client-id");
     configProps.setProperty(AzureCloudConfig.AZURE_STORAGE_SECRET, "client-secret");
-    configProps.setProperty(AzureCloudConfig.AZURE_STORAGE_ENDPOINT, "https://azure_storage.blob.core.windows.net");
+
+    if (numberStorageAccounts == 0) {
+      configProps.setProperty(AzureCloudConfig.AZURE_STORAGE_CONNECTION_STRING, storageConnection);
+      configProps.setProperty(AzureCloudConfig.AZURE_STORAGE_ENDPOINT, "https://azure_storage.blob.core.windows.net");
+    } else if (numberStorageAccounts == 1) {
+      configProps.setProperty(AzureCloudConfig.AZURE_STORAGE_ACCOUNT_INFO, String.format(
+          "{\n" + "    \"storageAccountInfo\":[\n" + "      {\n" + "        \"name\":\"ambry\",\n"
+              + "        \"partitionRange\":\"0-1000000\",\n"
+              + "        \"storageConnectionString\":\"%s\",\n"
+              + "        \"storageEndpoint\":\"https://azure_storage.blob.core.windows.net\",\n" + "      }\n"
+              + "    ]\n" + "    }", storageConnection));
+    } else {
+      throw new IllegalArgumentException("Illegal numberStorageAccounts parameter. Current value:" + numberStorageAccounts);
+    }
     configProps.setProperty(AzureCloudConfig.AZURE_STORAGE_CLIENT_CLASS,
         "com.github.ambry.cloud.azure.ConnectionStringBasedStorageClient");
     configProps.setProperty("clustermap.cluster.name", "main");


### PR DESCRIPTION
Introduce AzureStorageClient interface, implement ShardedStorageClient for sharded storage accounts and turn StorageClient to its single-account implementation.

                   AzureStorageClient
                      /                    \
         StorageClient      ShardedStorageClient

AzureStorageClient exposes the same interface that StorageClient does earlier. Interaction with a particular storage account is contained in StorageClient whereas ShardedStorageClient picks the StorageClient instance corresponding to a blob. This is a temporary scheme to be backward compatible, i.e. we can go back and forth between the sharded and unsharded implementation until we can fully switch to the sharded strategy. Once that happens, we will dismantle the AzureStorageClient interface and StorageClient will be private to ShardedStorageClient.

ShardedStorageClient by default returns the only storage account we have today. Succeeding PRs will:
 - Enforce the ShardedStorageClient path via config changes
 - Implement blobId->storage account mappings in ShardedStorageClient
 - Add a new storage account
