### PR TITLE
Add partition key during change feed query. Also update cosmos sdk version to 4.29.1.

### DIFF
--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/CosmosDataAccessor.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/CosmosDataAccessor.java
@@ -626,14 +626,15 @@ public class CosmosDataAccessor {
       String partitionPath, Timer timer) throws CosmosException {
     CosmosChangeFeedRequestOptions cosmosChangeFeedRequestOptions;
     if (Utils.isNullOrEmpty(requestContinuationToken)) {
-      cosmosChangeFeedRequestOptions =
-          CosmosChangeFeedRequestOptions.createForProcessingFromBeginning(FeedRange.forFullRange());
+      cosmosChangeFeedRequestOptions = CosmosChangeFeedRequestOptions.createForProcessingFromBeginning(
+          FeedRange.forLogicalPartition(new PartitionKey(partitionPath)));
     } else {
       cosmosChangeFeedRequestOptions =
           CosmosChangeFeedRequestOptions.createForProcessingFromContinuation(requestContinuationToken);
     }
     // Set the maximum number of items to be returned in this change feed request.
     cosmosChangeFeedRequestOptions.setMaxItemCount(maxFeedSize);
+
     return queryChangeFeed(cosmosChangeFeedRequestOptions, changeFeed, timer);
   }
 

--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -24,7 +24,7 @@ ext {
     jaydioVersion = "0.1"
     azureStorageBlobVersion = "12.15.0"
     azureStorageBlobBatchVersion = "12.12.0"
-    azureCosmosDbAsyncVersion = "4.25.0"
+    azureCosmosDbAsyncVersion = "4.29.1"
     azureMsal4jVersion="1.7.1"
     azureMsalClientCredentialVersion="1.0.0"
     azureIdentityVersion= "1.3.6"


### PR DESCRIPTION
This commit makes sure to provide partition key while querying cosmos change feed. It also updates cosmos java SDK version to 4.29.1. With the earlier version (4.25.0), we were hitting the OOM issue since there seems to be an issue with initialization of cache maintained internally by cosmos library for storing query execution plans. Due to that and some of our queries containing IN clause not being parameterized (due to limitation on cosmos side as described [here](https://github.com/Azure/azure-cosmosdb-java/issues/60#issuecomment-477376945)), the cache was growing unbounded. This seems to have been fixed in SDK versions > 4.26.0 with this [PR](https://github.com/Azure/azure-sdk-for-java/pull/26825). 