### PR TITLE
This PR creates a way to enable throttling for storage and bandwidth quotas separately.

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/QuotaConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/QuotaConfig.java
@@ -28,7 +28,6 @@ public class QuotaConfig {
   public static final String QUOTA_CONFIG_PREFIX = "quota.";
   public static final String REQUEST_THROTTLING_ENABLED = QUOTA_CONFIG_PREFIX + "request.throttling.enabled";
   public static final String THROTTLING_MODE = QUOTA_CONFIG_PREFIX + "throttling.mode";
-  public static final String THROTTLE_IN_PROGRESS_REQUESTS = QUOTA_CONFIG_PREFIX + "throttle.in.progress.requests";
   public static final String REQUEST_QUOTA_ENFORCER_SOURCE_PAIR_INFO_JSON =
       QUOTA_CONFIG_PREFIX + "request.enforcer.source.pair.info.json";
   public static final String QUOTA_MANAGER_FACTORY = QUOTA_CONFIG_PREFIX + "manager.factory";
@@ -46,7 +45,6 @@ public class QuotaConfig {
 
   public static final String DEFAULT_QUOTA_MANAGER_FACTORY = "com.github.ambry.quota.AmbryQuotaManagerFactory";
   public static final String DEFAULT_QUOTA_THROTTLING_MODE = QuotaMode.TRACKING.name();
-  public static final boolean DEFAULT_THROTTLE_IN_PROGRESS_REQUESTS = false;
   public static final long DEFAULT_QUOTA_ACCOUNTING_UNIT = 1024; //1kb
   public static final float DEFAULT_MAX_FRONTEND_CU_USAGE_TO_ALLOW_EXCEED = 80.0f;
   public static final String DEFAULT_CU_QUOTA_IN_JSON = "{}";
@@ -97,12 +95,6 @@ public class QuotaConfig {
   @Config(REQUEST_THROTTLING_ENABLED)
   @Default("true")
   public boolean requestThrottlingEnabled;
-
-  /**
-   * Should requests in progress be throttled if they exceed their quota.
-   */
-  @Config(THROTTLE_IN_PROGRESS_REQUESTS)
-  public boolean throttleInProgressRequests;
 
   /**
    * Size of chunk that is considered for one unit of quota.
@@ -190,8 +182,6 @@ public class QuotaConfig {
             buildDefaultQuotaEnforcerSourceInfoPairJson().toString());
     quotaManagerFactory = verifiableProperties.getString(QUOTA_MANAGER_FACTORY, DEFAULT_QUOTA_MANAGER_FACTORY);
     throttlingMode = QuotaMode.valueOf(verifiableProperties.getString(THROTTLING_MODE, DEFAULT_QUOTA_THROTTLING_MODE));
-    throttleInProgressRequests =
-        verifiableProperties.getBoolean(THROTTLE_IN_PROGRESS_REQUESTS, DEFAULT_THROTTLE_IN_PROGRESS_REQUESTS);
     quotaAccountingUnit = verifiableProperties.getLong(QUOTA_ACCOUNTING_UNIT, DEFAULT_QUOTA_ACCOUNTING_UNIT);
     resourceCUQuotaInJson = verifiableProperties.getString(RESOURCE_CU_QUOTA_IN_JSON, DEFAULT_CU_QUOTA_IN_JSON);
     frontendCUCapacityInJson =

--- a/ambry-quota/src/main/java/com/github/ambry/quota/PostProcessQuotaChargeCallback.java
+++ b/ambry-quota/src/main/java/com/github/ambry/quota/PostProcessQuotaChargeCallback.java
@@ -64,8 +64,7 @@ public class PostProcessQuotaChargeCallback implements QuotaChargeCallback {
       quotaAction =
           quotaManager.chargeAndRecommend(restRequest, requestCost, shouldCheckQuotaExceedAllowed, forceCharge);
       if (isQuotaEnforcedOnRequest && QuotaUtils.shouldThrottle(quotaAction)) {
-        if (quotaManager.getQuotaMode() == QuotaMode.THROTTLING
-            && quotaManager.getQuotaConfig().throttleInProgressRequests) {
+        if (quotaManager.getQuotaMode() == QuotaMode.THROTTLING) {
           throw new QuotaException("Exception while charging quota",
               new RouterException("RequestQuotaExceeded", RouterErrorCode.TooManyRequests), false);
         } else {

--- a/ambry-quota/src/main/java/com/github/ambry/quota/storage/StorageQuotaEnforcer.java
+++ b/ambry-quota/src/main/java/com/github/ambry/quota/storage/StorageQuotaEnforcer.java
@@ -151,7 +151,10 @@ public class StorageQuotaEnforcer implements QuotaEnforcer {
       // There is no quota set for the given account/container
       return NO_QUOTA_VALUE_RECOMMENDATION;
     }
-    QuotaAction quotaAction = (currentUsage >= quotaValue) ? QuotaAction.REJECT : QuotaAction.ALLOW;
+    QuotaAction quotaAction = QuotaAction.ALLOW;
+    if (config.shouldThrottle && currentUsage >= quotaValue) {
+      quotaAction = QuotaAction.REJECT;
+    }
     float usagePercentage = currentUsage >= quotaValue ? 100f : ((float) currentUsage) / quotaValue * 100f;
     return new QuotaRecommendation(quotaAction, usagePercentage, QuotaName.STORAGE_IN_GB, NO_RETRY);
   }


### PR DESCRIPTION
This PR creates a way to enable throttling for storage and bandwidth quotas separately.

1. QuotaConfig.throttingMode determines if request will be throttled for any quota. If it is set to TRACKING, then no requests will be throttled for any quota.

2. QuotaConfig.requestThrottlingEnabled determines if request will throttled for bandwidth quotas. So, bandwidth quota throttling will be enabled only if QuotaConfig.throttlingMode is set to THROTTLING, and QuotaConfig.requestThrottlingEnabled is set to true.

3. QuotaConfig.StorageQuotaConfig.shouldThrottle already determines if requests will be throttled for storage quotas (it is always set to true by default).