### PR TITLE
Move the handler logic out of FrontendRestRequestService

### DIFF
--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbrySecurityService.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbrySecurityService.java
@@ -195,7 +195,8 @@ class AmbrySecurityService implements SecurityService {
       }
       RequestPath requestPath = RestUtils.getRequestPath(restRequest);
       RestMethod restMethod = restRequest.getRestMethod();
-      if (blobInfo == null && !restMethod.equals(RestMethod.OPTIONS) && !restMethod.equals(RestMethod.PUT)) {
+      if (blobInfo == null && !restMethod.equals(RestMethod.OPTIONS) && !restMethod.equals(RestMethod.PUT)
+          && !restMethod.equals(RestMethod.DELETE)) {
         if (!requestPath.matchesOperation(Operations.GET_SIGNED_URL)) {
           throw new IllegalArgumentException("BlobInfo is null");
         }
@@ -268,6 +269,9 @@ class AmbrySecurityService implements SecurityService {
               responseChannel.setHeader(RestUtils.Headers.CREATION_TIME,
                   new Date(blobInfo.getBlobProperties().getCreationTimeInMs()));
             }
+            break;
+          case DELETE:
+            // There is nothing to do with delete
             break;
           default:
             exception = new RestServiceException("Cannot process response for request with method " + restMethod,

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/DeleteBlobHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/DeleteBlobHandler.java
@@ -152,7 +152,12 @@ public class DeleteBlobHandler {
         restResponseChannel.setHeader(RestUtils.Headers.DATE, new GregorianCalendar().getTime());
         restResponseChannel.setHeader(RestUtils.Headers.CONTENT_LENGTH, 0);
         securityService.processResponse(restRequest, restResponseChannel, null, securityProcessResponseCallback());
-      }, restRequest.getUri(), LOGGER, finalCallback);
+      }, restRequest.getUri(), LOGGER, (r, e) -> {
+        // Even we failed in router operations, we already used some of the resources in router,
+        // so let's record the charges for this request.
+        securityService.processRequestCharges(restRequest, restResponseChannel, null);
+        finalCallback.onCompletion(null, e);
+      });
     }
 
     /**

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/DeleteBlobHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/DeleteBlobHandler.java
@@ -32,11 +32,11 @@ import static com.github.ambry.rest.RestUtils.*;
 
 
 /**
- * Handler for all delete requests.
+ * Handler for all delete blob requests.
  */
-public class DeleteHandler {
+public class DeleteBlobHandler {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(DeleteHandler.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(DeleteBlobHandler.class);
 
   private final Router router;
   private final SecurityService securityService;
@@ -46,7 +46,7 @@ public class DeleteHandler {
   private final ClusterMap clusterMap;
   private final QuotaManager quotaManager;
 
-  DeleteHandler(Router router, SecurityService securityService, IdConverter idConverter,
+  DeleteBlobHandler(Router router, SecurityService securityService, IdConverter idConverter,
       AccountAndContainerInjector accountAndContainerInjector, FrontendMetrics metrics, ClusterMap clusterMap,
       QuotaManager quotaManager) {
     this.router = router;

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/DeleteHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/DeleteHandler.java
@@ -1,16 +1,3 @@
-/*
- * Copyright 2020 LinkedIn Corp. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- */
 package com.github.ambry.frontend;
 
 import com.github.ambry.clustermap.ClusterMap;
@@ -18,8 +5,8 @@ import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.Callback;
 import com.github.ambry.quota.QuotaManager;
 import com.github.ambry.quota.QuotaUtils;
+import com.github.ambry.rest.ResponseStatus;
 import com.github.ambry.rest.RestRequest;
-import com.github.ambry.rest.RestRequestMetrics;
 import com.github.ambry.rest.RestResponseChannel;
 import com.github.ambry.rest.RestUtils;
 import com.github.ambry.router.Router;
@@ -28,14 +15,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static com.github.ambry.frontend.FrontendUtils.*;
-import static com.github.ambry.rest.RestUtils.InternalKeys.*;
 
 
 /**
- * Handler for all Undelete requests.
+ * Handler for all delete requests.
  */
-public class UndeleteHandler {
-  private static final Logger LOGGER = LoggerFactory.getLogger(UndeleteHandler.class);
+public class DeleteHandler {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(DeleteHandler.class);
 
   private final Router router;
   private final SecurityService securityService;
@@ -45,17 +32,7 @@ public class UndeleteHandler {
   private final ClusterMap clusterMap;
   private final QuotaManager quotaManager;
 
-  /**
-   * Constructs a handler for handling requests for undelete the blobs
-   * @param router the {@link Router} to use.
-   * @param securityService the {@link SecurityService} to use.
-   * @param idConverter the {@link IdConverter} to use.
-   * @param accountAndContainerInjector helper to resolve account and container for a given request.
-   * @param metrics {@link FrontendMetrics} instance where metrics should be recorded.
-   * @param clusterMap the {@link ClusterMap} in use.
-   * @param quotaManager the {@link QuotaManager} object.
-   */
-  UndeleteHandler(Router router, SecurityService securityService, IdConverter idConverter,
+  DeleteHandler(Router router, SecurityService securityService, IdConverter idConverter,
       AccountAndContainerInjector accountAndContainerInjector, FrontendMetrics metrics, ClusterMap clusterMap,
       QuotaManager quotaManager) {
     this.router = router;
@@ -67,21 +44,10 @@ public class UndeleteHandler {
     this.quotaManager = quotaManager;
   }
 
-  /**
-   * Handles a request for undeleting a blob
-   * @param restRequest the {@link RestRequest} that contains the request parameters.
-   * @param restResponseChannel the {@link RestResponseChannel} where headers should be set.
-   * @param callback the {@link Callback} to invoke when the response is ready (or if there is an exception).
-   */
   void handle(RestRequest restRequest, RestResponseChannel restResponseChannel, Callback<Void> callback) {
-    // And always send failure reason back to client for undelete
-    restRequest.setArg(SEND_FAILURE_REASON, Boolean.TRUE);
     new CallbackChain(restRequest, restResponseChannel, callback).start();
   }
 
-  /**
-   * Represents the chain of actions to take. Keeps request context that is relevant to all callback stages.
-   */
   private class CallbackChain {
     private final RestRequest restRequest;
     private final RestResponseChannel restResponseChannel;
@@ -103,9 +69,6 @@ public class UndeleteHandler {
      * Start the chain by calling {@link SecurityService#processRequest}.
      */
     private void start() {
-      RestRequestMetrics requestMetrics =
-          metrics.undeleteBlobMetricsGroup.getRestRequestMetrics(restRequest.isSslUsed(), false);
-      restRequest.getMetricsTracker().injectMetrics(requestMetrics);
       restRequest.setArg(RestUtils.InternalKeys.KEEP_ALIVE_ON_ERROR_HINT, true);
       securityService.processRequest(restRequest, securityProcessRequestCallback());
     }
@@ -116,7 +79,7 @@ public class UndeleteHandler {
      * @return a {@link Callback} to be used with {@link SecurityService#processRequest}.
      */
     private Callback<Void> securityProcessRequestCallback() {
-      return buildCallback(metrics.undeleteBlobSecurityProcessRequestMetrics, result -> {
+      return buildCallback(metrics.deleteBlobSecurityProcessRequestMetrics, result -> {
         String blobIdStr = RestUtils.getHeader(restRequest.getArgs(), RestUtils.Headers.BLOB_ID, true);
         idConverter.convert(restRequest, blobIdStr, idConverterCallback());
       }, restRequest.getUri(), LOGGER, finalCallback);
@@ -128,37 +91,39 @@ public class UndeleteHandler {
      * @return a {@link Callback} to be used with {@link IdConverter#convert}.
      */
     private Callback<String> idConverterCallback() {
-      return buildCallback(metrics.undeleteBlobIdConversionMetrics, convertedBlobId -> {
+      return buildCallback(metrics.deleteBlobIdConversionMetrics, convertedBlobId -> {
         BlobId blobId = FrontendUtils.getBlobIdFromString(convertedBlobId, clusterMap);
         accountAndContainerInjector.injectTargetAccountAndContainerFromBlobId(blobId, restRequest,
-            metrics.undeleteBlobMetricsGroup);
+            metrics.deleteBlobMetricsGroup);
         securityService.postProcessRequest(restRequest, securityPostProcessRequestCallback(blobId));
       }, restRequest.getUri(), LOGGER, finalCallback);
     }
 
     /**
-     * After {@link SecurityService#postProcessRequest} finishes, call {@link Router#undeleteBlob} to undelete
+     * After {@link SecurityService#postProcessRequest} finishes, call {@link Router#deleteBlob} to delete
      * the blob in the storage layer.
      * @param blobId the {@link BlobId} to undelete
      * @return a {@link Callback} to be used with {@link SecurityService#postProcessRequest}.
      */
     private Callback<Void> securityPostProcessRequestCallback(BlobId blobId) {
-      return buildCallback(metrics.undeleteBlobSecurityPostProcessRequestMetrics, result -> {
-        String serviceId = RestUtils.getHeader(restRequest.getArgs(), RestUtils.Headers.SERVICE_ID, true);
-        router.undeleteBlob(blobId.getID(), serviceId, routerCallback(),
+      return buildCallback(metrics.deleteBlobSecurityPostProcessRequestMetrics, result -> {
+        String serviceId = RestUtils.getHeader(restRequest.getArgs(), RestUtils.Headers.SERVICE_ID, false);
+        router.deleteBlob(blobId.getID(), serviceId, routerCallback(),
             QuotaUtils.buildQuotaChargeCallback(restRequest, quotaManager, false));
       }, restRequest.getUri(), LOGGER, finalCallback);
     }
 
     /**
-     * After {@link Router#undeleteBlob} finishes, call {@link SecurityService#processResponse}.
-     * @return a {@link Callback} to be used with {@link Router#undeleteBlob}.
+     * After {@link Router#deleteBlob} finishes, call {@link SecurityService#processResponse}.
+     * @return a {@link Callback} to be used with {@link Router#deleteBlob}.
      */
     private Callback<Void> routerCallback() {
-      return buildCallback(metrics.undeleteBlobRouterMetrics, result -> {
-        LOGGER.debug("Undeleted {}", RestUtils.getHeader(restRequest.getArgs(), RestUtils.Headers.BLOB_ID, true));
+      return buildCallback(metrics.deleteBlobRouterMetrics, result -> {
+        LOGGER.debug("Deleted {}", RestUtils.getHeader(restRequest.getArgs(), RestUtils.Headers.BLOB_ID, true));
+        restResponseChannel.setStatus(ResponseStatus.Accepted);
         restResponseChannel.setHeader(RestUtils.Headers.DATE, new GregorianCalendar().getTime());
         restResponseChannel.setHeader(RestUtils.Headers.CONTENT_LENGTH, 0);
+        securityService.processRequestCharges(restRequest, restResponseChannel, null);
         securityService.processResponse(restRequest, restResponseChannel, null, securityProcessResponseCallback());
       }, restRequest.getUri(), LOGGER, finalCallback);
     }
@@ -168,7 +133,7 @@ public class UndeleteHandler {
      * @return a {@link Callback} to be used with {@link SecurityService#processResponse}.
      */
     private Callback<Void> securityProcessResponseCallback() {
-      return buildCallback(metrics.undeleteBlobSecurityProcessResponseMetrics,
+      return buildCallback(metrics.deleteBlobSecurityProcessResponseMetrics,
           securityCheckResult -> finalCallback.onCompletion(null, null), restRequest.getUri(), LOGGER, finalCallback);
     }
   }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/DeleteHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/DeleteHandler.java
@@ -28,6 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static com.github.ambry.frontend.FrontendUtils.*;
+import static com.github.ambry.rest.RestUtils.*;
 
 
 /**
@@ -93,7 +94,7 @@ public class DeleteHandler {
      */
     private Callback<Void> securityProcessRequestCallback() {
       return buildCallback(metrics.deleteBlobSecurityProcessRequestMetrics, result -> {
-        String blobIdStr = RestUtils.getHeader(restRequest.getArgs(), RestUtils.Headers.BLOB_ID, true);
+        String blobIdStr = getRequestPath(restRequest).getOperationOrBlobId(false);
         idConverter.convert(restRequest, blobIdStr, idConverterCallback());
       }, restRequest.getUri(), LOGGER, finalCallback);
     }
@@ -132,11 +133,10 @@ public class DeleteHandler {
      */
     private Callback<Void> routerCallback() {
       return buildCallback(metrics.deleteBlobRouterMetrics, result -> {
-        LOGGER.debug("Deleted {}", RestUtils.getHeader(restRequest.getArgs(), RestUtils.Headers.BLOB_ID, true));
+        LOGGER.debug("Deleted {}", getRequestPath(restRequest).getOperationOrBlobId(false));
         restResponseChannel.setStatus(ResponseStatus.Accepted);
         restResponseChannel.setHeader(RestUtils.Headers.DATE, new GregorianCalendar().getTime());
         restResponseChannel.setHeader(RestUtils.Headers.CONTENT_LENGTH, 0);
-        securityService.processRequestCharges(restRequest, restResponseChannel, null);
         securityService.processResponse(restRequest, restResponseChannel, null, securityProcessResponseCallback());
       }, restRequest.getUri(), LOGGER, finalCallback);
     }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/DeleteHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/DeleteHandler.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2022 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
 package com.github.ambry.frontend;
 
 import com.github.ambry.clustermap.ClusterMap;

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendMetrics.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendMetrics.java
@@ -68,11 +68,24 @@ public class FrontendMetrics {
   public final AsyncOperationTracker.Metrics updateBlobTtlIdConversionMetrics;
   public final AsyncOperationTracker.Metrics updateBlobTtlSecurityProcessResponseMetrics;
 
+  public final AsyncOperationTracker.Metrics deleteBlobSecurityProcessRequestMetrics;
+  public final AsyncOperationTracker.Metrics deleteBlobSecurityPostProcessRequestMetrics;
+  public final AsyncOperationTracker.Metrics deleteBlobRouterMetrics;
+  public final AsyncOperationTracker.Metrics deleteBlobIdConversionMetrics;
+  public final AsyncOperationTracker.Metrics deleteBlobSecurityProcessResponseMetrics;
+
   public final AsyncOperationTracker.Metrics undeleteBlobSecurityProcessRequestMetrics;
   public final AsyncOperationTracker.Metrics undeleteBlobSecurityPostProcessRequestMetrics;
   public final AsyncOperationTracker.Metrics undeleteBlobRouterMetrics;
   public final AsyncOperationTracker.Metrics undeleteBlobIdConversionMetrics;
   public final AsyncOperationTracker.Metrics undeleteBlobSecurityProcessResponseMetrics;
+
+  public final AsyncOperationTracker.Metrics headBlobSecurityProcessRequestMetrics;
+  public final AsyncOperationTracker.Metrics headBlobSecurityPostProcessRequestMetrics;
+  public final AsyncOperationTracker.Metrics headBlobRouterMetrics;
+  public final AsyncOperationTracker.Metrics headBlobIdConversionMetrics;
+  public final AsyncOperationTracker.Metrics headBlobSecurityProcessResponseMetrics;
+
 
   public final AsyncOperationTracker.Metrics putSecurityProcessRequestMetrics;
   public final AsyncOperationTracker.Metrics putSecurityPostProcessRequestMetrics;
@@ -294,6 +307,16 @@ public class FrontendMetrics {
     updateBlobTtlSecurityProcessResponseMetrics =
         new AsyncOperationTracker.Metrics(TtlUpdateHandler.class, "securityProcessResponse", metricRegistry);
 
+    deleteBlobSecurityProcessRequestMetrics =
+        new AsyncOperationTracker.Metrics(DeleteHandler.class, "securityProcessRequest", metricRegistry);
+    deleteBlobSecurityPostProcessRequestMetrics =
+        new AsyncOperationTracker.Metrics(DeleteHandler.class, "securityPostProcessRequest", metricRegistry);
+    deleteBlobRouterMetrics = new AsyncOperationTracker.Metrics(DeleteHandler.class, "router", metricRegistry);
+    deleteBlobIdConversionMetrics =
+        new AsyncOperationTracker.Metrics(DeleteHandler.class, "idConversion", metricRegistry);
+    deleteBlobSecurityProcessResponseMetrics =
+        new AsyncOperationTracker.Metrics(DeleteHandler.class, "securityProcessResponse", metricRegistry);
+
     undeleteBlobSecurityProcessRequestMetrics =
         new AsyncOperationTracker.Metrics(UndeleteHandler.class, "securityProcessRequest", metricRegistry);
     undeleteBlobSecurityPostProcessRequestMetrics =
@@ -303,6 +326,16 @@ public class FrontendMetrics {
         new AsyncOperationTracker.Metrics(UndeleteHandler.class, "idConversion", metricRegistry);
     undeleteBlobSecurityProcessResponseMetrics =
         new AsyncOperationTracker.Metrics(UndeleteHandler.class, "securityProcessResponse", metricRegistry);
+
+    headBlobSecurityProcessRequestMetrics =
+        new AsyncOperationTracker.Metrics(HeadHandler.class, "securityProcessRequest", metricRegistry);
+    headBlobSecurityPostProcessRequestMetrics =
+        new AsyncOperationTracker.Metrics(HeadHandler.class, "securityPostProcessRequest", metricRegistry);
+    headBlobRouterMetrics = new AsyncOperationTracker.Metrics(HeadHandler.class, "router", metricRegistry);
+    headBlobIdConversionMetrics =
+        new AsyncOperationTracker.Metrics(HeadHandler.class, "idConversion", metricRegistry);
+    headBlobSecurityProcessResponseMetrics =
+        new AsyncOperationTracker.Metrics(HeadHandler.class, "securityProcessResponse", metricRegistry);
 
     putSecurityProcessRequestMetrics =
         new AsyncOperationTracker.Metrics(NamedBlobPutHandler.class, "putSecurityProcessRequest", metricRegistry);

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendMetrics.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendMetrics.java
@@ -86,6 +86,11 @@ public class FrontendMetrics {
   public final AsyncOperationTracker.Metrics headBlobIdConversionMetrics;
   public final AsyncOperationTracker.Metrics headBlobSecurityProcessResponseMetrics;
 
+  public final AsyncOperationTracker.Metrics getBlobSecurityProcessRequestMetrics;
+  public final AsyncOperationTracker.Metrics getBlobSecurityPostProcessRequestMetrics;
+  public final AsyncOperationTracker.Metrics getBlobRouterMetrics;
+  public final AsyncOperationTracker.Metrics getBlobIdConversionMetrics;
+  public final AsyncOperationTracker.Metrics getBlobSecurityProcessResponseMetrics;
 
   public final AsyncOperationTracker.Metrics putSecurityProcessRequestMetrics;
   public final AsyncOperationTracker.Metrics putSecurityPostProcessRequestMetrics;
@@ -255,8 +260,8 @@ public class FrontendMetrics {
     getSignedUrlMetricsGroup =
         new RestRequestMetricsGroup(GetSignedUrlHandler.class, "GetSignedUrl", false, metricRegistry, frontendConfig);
     getClusterMapSnapshotMetricsGroup =
-        new RestRequestMetricsGroup(GetClusterMapSnapshotHandler.class, "GetClusterMapSnapshot",
-            false, metricRegistry, frontendConfig);
+        new RestRequestMetricsGroup(GetClusterMapSnapshotHandler.class, "GetClusterMapSnapshot", false, metricRegistry,
+            frontendConfig);
     getAccountsMetricsGroup =
         new RestRequestMetricsGroup(GetAccountsHandler.class, "GetAccounts", false, metricRegistry, frontendConfig);
     getStatsReportMetricsGroup =
@@ -332,10 +337,19 @@ public class FrontendMetrics {
     headBlobSecurityPostProcessRequestMetrics =
         new AsyncOperationTracker.Metrics(HeadHandler.class, "securityPostProcessRequest", metricRegistry);
     headBlobRouterMetrics = new AsyncOperationTracker.Metrics(HeadHandler.class, "router", metricRegistry);
-    headBlobIdConversionMetrics =
-        new AsyncOperationTracker.Metrics(HeadHandler.class, "idConversion", metricRegistry);
+    headBlobIdConversionMetrics = new AsyncOperationTracker.Metrics(HeadHandler.class, "idConversion", metricRegistry);
     headBlobSecurityProcessResponseMetrics =
         new AsyncOperationTracker.Metrics(HeadHandler.class, "securityProcessResponse", metricRegistry);
+
+    getBlobSecurityProcessRequestMetrics =
+        new AsyncOperationTracker.Metrics(GetBlobHandler.class, "securityProcessRequest", metricRegistry);
+    getBlobSecurityPostProcessRequestMetrics =
+        new AsyncOperationTracker.Metrics(GetBlobHandler.class, "securityPostProcessRequest", metricRegistry);
+    getBlobRouterMetrics = new AsyncOperationTracker.Metrics(GetBlobHandler.class, "router", metricRegistry);
+    getBlobIdConversionMetrics =
+        new AsyncOperationTracker.Metrics(GetBlobHandler.class, "idConversion", metricRegistry);
+    getBlobSecurityProcessResponseMetrics =
+        new AsyncOperationTracker.Metrics(GetBlobHandler.class, "securityProcessResponse", metricRegistry);
 
     putSecurityProcessRequestMetrics =
         new AsyncOperationTracker.Metrics(NamedBlobPutHandler.class, "putSecurityProcessRequest", metricRegistry);

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendMetrics.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendMetrics.java
@@ -313,14 +313,14 @@ public class FrontendMetrics {
         new AsyncOperationTracker.Metrics(TtlUpdateHandler.class, "securityProcessResponse", metricRegistry);
 
     deleteBlobSecurityProcessRequestMetrics =
-        new AsyncOperationTracker.Metrics(DeleteHandler.class, "securityProcessRequest", metricRegistry);
+        new AsyncOperationTracker.Metrics(DeleteBlobHandler.class, "securityProcessRequest", metricRegistry);
     deleteBlobSecurityPostProcessRequestMetrics =
-        new AsyncOperationTracker.Metrics(DeleteHandler.class, "securityPostProcessRequest", metricRegistry);
-    deleteBlobRouterMetrics = new AsyncOperationTracker.Metrics(DeleteHandler.class, "router", metricRegistry);
+        new AsyncOperationTracker.Metrics(DeleteBlobHandler.class, "securityPostProcessRequest", metricRegistry);
+    deleteBlobRouterMetrics = new AsyncOperationTracker.Metrics(DeleteBlobHandler.class, "router", metricRegistry);
     deleteBlobIdConversionMetrics =
-        new AsyncOperationTracker.Metrics(DeleteHandler.class, "idConversion", metricRegistry);
+        new AsyncOperationTracker.Metrics(DeleteBlobHandler.class, "idConversion", metricRegistry);
     deleteBlobSecurityProcessResponseMetrics =
-        new AsyncOperationTracker.Metrics(DeleteHandler.class, "securityProcessResponse", metricRegistry);
+        new AsyncOperationTracker.Metrics(DeleteBlobHandler.class, "securityProcessResponse", metricRegistry);
 
     undeleteBlobSecurityProcessRequestMetrics =
         new AsyncOperationTracker.Metrics(UndeleteHandler.class, "securityProcessRequest", metricRegistry);
@@ -333,13 +333,13 @@ public class FrontendMetrics {
         new AsyncOperationTracker.Metrics(UndeleteHandler.class, "securityProcessResponse", metricRegistry);
 
     headBlobSecurityProcessRequestMetrics =
-        new AsyncOperationTracker.Metrics(HeadHandler.class, "securityProcessRequest", metricRegistry);
+        new AsyncOperationTracker.Metrics(HeadBlobHandler.class, "securityProcessRequest", metricRegistry);
     headBlobSecurityPostProcessRequestMetrics =
-        new AsyncOperationTracker.Metrics(HeadHandler.class, "securityPostProcessRequest", metricRegistry);
-    headBlobRouterMetrics = new AsyncOperationTracker.Metrics(HeadHandler.class, "router", metricRegistry);
-    headBlobIdConversionMetrics = new AsyncOperationTracker.Metrics(HeadHandler.class, "idConversion", metricRegistry);
+        new AsyncOperationTracker.Metrics(HeadBlobHandler.class, "securityPostProcessRequest", metricRegistry);
+    headBlobRouterMetrics = new AsyncOperationTracker.Metrics(HeadBlobHandler.class, "router", metricRegistry);
+    headBlobIdConversionMetrics = new AsyncOperationTracker.Metrics(HeadBlobHandler.class, "idConversion", metricRegistry);
     headBlobSecurityProcessResponseMetrics =
-        new AsyncOperationTracker.Metrics(HeadHandler.class, "securityProcessResponse", metricRegistry);
+        new AsyncOperationTracker.Metrics(HeadBlobHandler.class, "securityProcessResponse", metricRegistry);
 
     getBlobSecurityProcessRequestMetrics =
         new AsyncOperationTracker.Metrics(GetBlobHandler.class, "securityProcessRequest", metricRegistry);

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestService.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestService.java
@@ -79,8 +79,8 @@ class FrontendRestRequestService implements RestRequestService {
   private PostBlobHandler postBlobHandler;
   private NamedBlobPutHandler namedBlobPutHandler;
   private TtlUpdateHandler ttlUpdateHandler;
-  private DeleteHandler deleteHandler;
-  private HeadHandler headHandler;
+  private DeleteBlobHandler deleteBlobHandler;
+  private HeadBlobHandler headBlobHandler;
   private UndeleteHandler undeleteHandler;
   private GetClusterMapSnapshotHandler getClusterMapSnapshotHandler;
   private GetAccountsHandler getAccountsHandler;
@@ -171,10 +171,10 @@ class FrontendRestRequestService implements RestRequestService {
     ttlUpdateHandler =
         new TtlUpdateHandler(router, securityService, idConverter, accountAndContainerInjector, frontendMetrics,
             clusterMap, quotaManager);
-    deleteHandler =
-        new DeleteHandler(router, securityService, idConverter, accountAndContainerInjector, frontendMetrics,
+    deleteBlobHandler =
+        new DeleteBlobHandler(router, securityService, idConverter, accountAndContainerInjector, frontendMetrics,
             clusterMap, quotaManager);
-    headHandler = new HeadHandler(frontendConfig, router, securityService, idConverter, accountAndContainerInjector,
+    headBlobHandler = new HeadBlobHandler(frontendConfig, router, securityService, idConverter, accountAndContainerInjector,
         frontendMetrics, clusterMap, quotaManager);
     undeleteHandler =
         new UndeleteHandler(router, securityService, idConverter, accountAndContainerInjector, frontendMetrics,
@@ -300,7 +300,7 @@ class FrontendRestRequestService implements RestRequestService {
         accountAndContainerInjector.injectAccountAndContainerForNamedBlob(restRequest,
             frontendMetrics.deleteBlobMetricsGroup);
       }
-      deleteHandler.handle(restRequest, restResponseChannel, (r, e) -> {
+      deleteBlobHandler.handle(restRequest, restResponseChannel, (r, e) -> {
         submitResponse(restRequest, restResponseChannel, null, e);
       });
     };
@@ -315,7 +315,7 @@ class FrontendRestRequestService implements RestRequestService {
           frontendMetrics.headBlobMetricsGroup.getRestRequestMetrics(restRequest.isSslUsed(), false);
       restRequest.getMetricsTracker().injectMetrics(requestMetrics);
 
-      headHandler.handle(restRequest, restResponseChannel, (r, e) -> {
+      headBlobHandler.handle(restRequest, restResponseChannel, (r, e) -> {
         submitResponse(restRequest, restResponseChannel, null, e);
       });
     };

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestService.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestService.java
@@ -174,8 +174,9 @@ class FrontendRestRequestService implements RestRequestService {
     deleteBlobHandler =
         new DeleteBlobHandler(router, securityService, idConverter, accountAndContainerInjector, frontendMetrics,
             clusterMap, quotaManager);
-    headBlobHandler = new HeadBlobHandler(frontendConfig, router, securityService, idConverter, accountAndContainerInjector,
-        frontendMetrics, clusterMap, quotaManager);
+    headBlobHandler =
+        new HeadBlobHandler(frontendConfig, router, securityService, idConverter, accountAndContainerInjector,
+            frontendMetrics, clusterMap, quotaManager);
     undeleteHandler =
         new UndeleteHandler(router, securityService, idConverter, accountAndContainerInjector, frontendMetrics,
             clusterMap, quotaManager);
@@ -292,15 +293,7 @@ class FrontendRestRequestService implements RestRequestService {
   @Override
   public void handleDelete(RestRequest restRequest, RestResponseChannel restResponseChannel) {
     ThrowingConsumer<RequestPath> routingAction = requestPath -> {
-      RestRequestMetrics requestMetrics =
-          frontendMetrics.deleteBlobMetricsGroup.getRestRequestMetrics(restRequest.isSslUsed(), false);
-      restRequest.getMetricsTracker().injectMetrics(requestMetrics);
-      // named blob requests have their account/container in the URI, so checks can be done prior to ID conversion.
-      if (requestPath.matchesOperation(Operations.NAMED_BLOB)) {
-        accountAndContainerInjector.injectAccountAndContainerForNamedBlob(restRequest,
-            frontendMetrics.deleteBlobMetricsGroup);
-      }
-      deleteBlobHandler.handle(restRequest, restResponseChannel, (r, e) -> {
+      deleteBlobHandler.handle(restRequest, restResponseChannel, requestPath, (r, e) -> {
         submitResponse(restRequest, restResponseChannel, null, e);
       });
     };

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestService.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestService.java
@@ -13,21 +13,15 @@
  */
 package com.github.ambry.frontend;
 
-import com.codahale.metrics.Histogram;
 import com.github.ambry.account.AccountService;
+import com.github.ambry.accountstats.AccountStatsStore;
 import com.github.ambry.clustermap.ClusterMap;
-import com.github.ambry.commons.BlobId;
-import com.github.ambry.commons.ByteBufferReadableStreamChannel;
 import com.github.ambry.commons.Callback;
 import com.github.ambry.config.FrontendConfig;
-import com.github.ambry.messageformat.BlobInfo;
 import com.github.ambry.named.NamedBlobDb;
-import com.github.ambry.protocol.GetOption;
 import com.github.ambry.quota.QuotaManager;
-import com.github.ambry.quota.QuotaUtils;
 import com.github.ambry.rest.RequestPath;
 import com.github.ambry.rest.ResponseStatus;
-import com.github.ambry.rest.RestMethod;
 import com.github.ambry.rest.RestRequest;
 import com.github.ambry.rest.RestRequestMetrics;
 import com.github.ambry.rest.RestRequestService;
@@ -35,21 +29,15 @@ import com.github.ambry.rest.RestResponseChannel;
 import com.github.ambry.rest.RestResponseHandler;
 import com.github.ambry.rest.RestServiceErrorCode;
 import com.github.ambry.rest.RestServiceException;
-import com.github.ambry.rest.RestUtils;
-import com.github.ambry.router.GetBlobOptions;
-import com.github.ambry.router.GetBlobOptionsBuilder;
-import com.github.ambry.router.GetBlobResult;
 import com.github.ambry.router.ReadableStreamChannel;
 import com.github.ambry.router.Router;
 import com.github.ambry.router.RouterErrorCode;
 import com.github.ambry.router.RouterException;
-import com.github.ambry.accountstats.AccountStatsStore;
 import com.github.ambry.utils.AsyncOperationTracker;
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.ThrowingConsumer;
 import com.github.ambry.utils.Utils;
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.GregorianCalendar;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -65,21 +53,12 @@ import static com.github.ambry.rest.RestUtils.InternalKeys.*;
 class FrontendRestRequestService implements RestRequestService {
   static final String TTL_UPDATE_REJECTED_ALLOW_HEADER_VALUE = "GET,HEAD,DELETE";
 
-  private static final ByteBuffer EMPTY_BUFFER = ByteBuffer.allocate(0);
-
-  private static final String OPERATION_TYPE_INBOUND_ID_CONVERSION = "Inbound Id Conversion";
-  private static final String OPERATION_TYPE_GET_RESPONSE_SECURITY = "GET Response Security";
-  private static final String OPERATION_TYPE_HEAD_RESPONSE_SECURITY = "HEAD Response Security";
-  private static final String OPERATION_TYPE_GET = "GET";
-  private static final String OPERATION_TYPE_HEAD = "HEAD";
-  private static final String OPERATION_TYPE_DELETE = "DELETE";
   private final Router router;
   private final IdConverterFactory idConverterFactory;
   private final SecurityServiceFactory securityServiceFactory;
   private final ClusterMap clusterMap;
   private final FrontendConfig frontendConfig;
   private final FrontendMetrics frontendMetrics;
-  private final GetReplicasHandler getReplicasHandler;
   private final UrlSigningService urlSigningService;
   private final IdSigningService idSigningService;
   private final NamedBlobDb namedBlobDb;
@@ -96,9 +75,12 @@ class FrontendRestRequestService implements RestRequestService {
   private GetPeersHandler getPeersHandler;
   private GetSignedUrlHandler getSignedUrlHandler;
   private NamedBlobListHandler listNamedBlobsHandler;
+  private GetBlobHandler getBlobHandler;
   private PostBlobHandler postBlobHandler;
   private NamedBlobPutHandler namedBlobPutHandler;
   private TtlUpdateHandler ttlUpdateHandler;
+  private DeleteHandler deleteHandler;
+  private HeadHandler headHandler;
   private UndeleteHandler undeleteHandler;
   private GetClusterMapSnapshotHandler getClusterMapSnapshotHandler;
   private GetAccountsHandler getAccountsHandler;
@@ -147,7 +129,6 @@ class FrontendRestRequestService implements RestRequestService {
     this.hostname = hostname;
     this.quotaManager = quotaManager;
     this.clusterName = clusterName.toLowerCase();
-    getReplicasHandler = new GetReplicasHandler(frontendMetrics, clusterMap);
     logger.trace("Instantiated FrontendRestRequestService");
   }
 
@@ -178,6 +159,9 @@ class FrontendRestRequestService implements RestRequestService {
             frontendMetrics, clusterMap);
     listNamedBlobsHandler =
         new NamedBlobListHandler(securityService, namedBlobDb, accountAndContainerInjector, frontendMetrics);
+    getBlobHandler =
+        new GetBlobHandler(frontendConfig, router, securityService, idConverter, accountAndContainerInjector,
+            frontendMetrics, clusterMap, quotaManager);
     postBlobHandler =
         new PostBlobHandler(securityService, idConverter, idSigningService, router, accountAndContainerInjector,
             SystemTime.getInstance(), frontendConfig, frontendMetrics, clusterName, quotaManager);
@@ -187,6 +171,11 @@ class FrontendRestRequestService implements RestRequestService {
     ttlUpdateHandler =
         new TtlUpdateHandler(router, securityService, idConverter, accountAndContainerInjector, frontendMetrics,
             clusterMap, quotaManager);
+    deleteHandler =
+        new DeleteHandler(router, securityService, idConverter, accountAndContainerInjector, frontendMetrics,
+            clusterMap, quotaManager);
+    headHandler = new HeadHandler(frontendConfig, router, securityService, idConverter, accountAndContainerInjector,
+        frontendMetrics, clusterMap, quotaManager);
     undeleteHandler =
         new UndeleteHandler(router, securityService, idConverter, accountAndContainerInjector, frontendMetrics,
             clusterMap, quotaManager);
@@ -250,24 +239,10 @@ class FrontendRestRequestService implements RestRequestService {
         listNamedBlobsHandler.handle(restRequest, restResponseChannel,
             ((result, exception) -> submitResponse(restRequest, restResponseChannel, result, exception)));
       } else {
-        SubResource subResource = requestPath.getSubResource();
-        GetBlobOptions options = buildGetBlobOptions(restRequest.getArgs(), subResource,
-            getGetOption(restRequest, frontendConfig.defaultRouterGetOption), restRequest,
-            requestPath.getBlobSegmentIdx());
-        GetCallback routerCallback = new GetCallback(restRequest, restResponseChannel, subResource, options);
-        SecurityProcessRequestCallback securityCallback =
-            new SecurityProcessRequestCallback(restRequest, restResponseChannel, routerCallback);
-        if (subResource == SubResource.Replicas) {
-          securityCallback = new SecurityProcessRequestCallback(restRequest, restResponseChannel);
-        }
-        RestRequestMetricsGroup metricsGroup = getMetricsGroupForGet(frontendMetrics, subResource);
-        RestRequestMetrics restRequestMetrics = metricsGroup.getRestRequestMetrics(restRequest.isSslUsed(), false);
-        restRequest.getMetricsTracker().injectMetrics(restRequestMetrics);
-        // named blob requests have their account/container in the URI, so checks can be done prior to ID conversion.
-        if (requestPath.matchesOperation(Operations.NAMED_BLOB)) {
-          accountAndContainerInjector.injectAccountAndContainerForNamedBlob(restRequest, metricsGroup);
-        }
-        securityService.processRequest(restRequest, securityCallback);
+
+        getBlobHandler.handle(requestPath, restRequest, restResponseChannel, (r, e) -> {
+          submitResponse(restRequest, restResponseChannel, r, e);
+        });
       }
     };
     preProcessAndRouteRequest(restRequest, restResponseChannel, frontendMetrics.getPreProcessingMetrics, routingAction);
@@ -301,14 +276,10 @@ class FrontendRestRequestService implements RestRequestService {
         });
       } else if (requestPath.matchesOperation(Operations.UNDELETE) && frontendConfig.enableUndelete) {
         // If the undelete is not enabled, then treat it as unrecognized operation.
-
-        // And always send failure reason back to client for undelete
-        restRequest.setArg(SEND_FAILURE_REASON, Boolean.TRUE);
         undeleteHandler.handle(restRequest, restResponseChannel, (r, e) -> {
           submitResponse(restRequest, restResponseChannel, null, e);
         });
       } else if (requestPath.matchesOperation(Operations.NAMED_BLOB)) {
-        restRequest.setArg(SEND_FAILURE_REASON, Boolean.TRUE);
         namedBlobPutHandler.handle(restRequest, restResponseChannel,
             (r, e) -> submitResponse(restRequest, restResponseChannel, null, e));
       } else {
@@ -330,10 +301,9 @@ class FrontendRestRequestService implements RestRequestService {
         accountAndContainerInjector.injectAccountAndContainerForNamedBlob(restRequest,
             frontendMetrics.deleteBlobMetricsGroup);
       }
-      DeleteCallback routerCallback = new DeleteCallback(restRequest, restResponseChannel);
-      SecurityProcessRequestCallback securityCallback =
-          new SecurityProcessRequestCallback(restRequest, restResponseChannel, routerCallback);
-      securityService.processRequest(restRequest, securityCallback);
+      deleteHandler.handle(restRequest, restResponseChannel, (r, e) -> {
+        submitResponse(restRequest, restResponseChannel, null, e);
+      });
     };
     preProcessAndRouteRequest(restRequest, restResponseChannel, frontendMetrics.deletePreProcessingMetrics,
         routingAction);
@@ -350,10 +320,9 @@ class FrontendRestRequestService implements RestRequestService {
         accountAndContainerInjector.injectAccountAndContainerForNamedBlob(restRequest,
             frontendMetrics.headBlobMetricsGroup);
       }
-      HeadCallback routerCallback = new HeadCallback(restRequest, restResponseChannel);
-      SecurityProcessRequestCallback securityCallback =
-          new SecurityProcessRequestCallback(restRequest, restResponseChannel, routerCallback);
-      securityService.processRequest(restRequest, securityCallback);
+      headHandler.handle(restRequest, restResponseChannel, (r, e) -> {
+        submitResponse(restRequest, restResponseChannel, null, e);
+      });
     };
     preProcessAndRouteRequest(restRequest, restResponseChannel, frontendMetrics.headPreProcessingMetrics,
         routingAction);
@@ -518,572 +487,6 @@ class FrontendRestRequestService implements RestRequestService {
   private void checkAvailable() throws RestServiceException {
     if (!isUp) {
       throw new RestServiceException("FrontendRestRequestService unavailable", RestServiceErrorCode.ServiceUnavailable);
-    }
-  }
-
-  /**
-   * Callback for {@link IdConverter} that is used when inbound IDs are converted.
-   */
-  private class InboundIdConverterCallback implements Callback<String> {
-    private final RestRequest restRequest;
-    private final RestResponseChannel restResponseChannel;
-    private final GetCallback getCallback;
-    private final HeadCallback headCallback;
-    private final DeleteCallback deleteCallback;
-    private final CallbackTracker callbackTracker;
-
-    InboundIdConverterCallback(RestRequest restRequest, RestResponseChannel restResponseChannel, GetCallback callback) {
-      this(restRequest, restResponseChannel, callback, null, null);
-    }
-
-    InboundIdConverterCallback(RestRequest restRequest, RestResponseChannel restResponseChannel,
-        HeadCallback callback) {
-      this(restRequest, restResponseChannel, null, callback, null);
-    }
-
-    InboundIdConverterCallback(RestRequest restRequest, RestResponseChannel restResponseChannel,
-        DeleteCallback callback) {
-      this(restRequest, restResponseChannel, null, null, callback);
-    }
-
-    private InboundIdConverterCallback(RestRequest restRequest, RestResponseChannel restResponseChannel,
-        GetCallback getCallback, HeadCallback headCallback, DeleteCallback deleteCallback) {
-      this.restRequest = restRequest;
-      this.restResponseChannel = restResponseChannel;
-      this.getCallback = getCallback;
-      this.headCallback = headCallback;
-      this.deleteCallback = deleteCallback;
-      callbackTracker = new CallbackTracker(restRequest, OPERATION_TYPE_INBOUND_ID_CONVERSION,
-          frontendMetrics.inboundIdConversionTimeInMs, frontendMetrics.inboundIdConversionCallbackProcessingTimeInMs);
-      callbackTracker.markOperationStart();
-    }
-
-    /**
-     * Calls {@link SecurityService#postProcessRequest} once ID conversion is completed.
-     * @param result The converted ID. This would be non null when the request executed successfully
-     * @param exception The exception that was reported on execution of the request
-     * @throws IllegalStateException if both {@code result} and {@code exception} are null.
-     */
-    @Override
-    public void onCompletion(String result, Exception exception) {
-      callbackTracker.markOperationEnd();
-      if (result == null && exception == null) {
-        throw new IllegalStateException("Both result and exception cannot be null");
-      } else if (exception == null) {
-        try {
-          RestMethod restMethod = restRequest.getRestMethod();
-          logger.trace("Handling {} of {}", restMethod, result);
-          BlobId blobId = FrontendUtils.getBlobIdFromString(result, clusterMap);
-          RestRequestMetricsGroup metricsGroup = null;
-          if (getCallback != null) {
-            metricsGroup = getMetricsGroupForGet(frontendMetrics, getRequestPath(restRequest).getSubResource());
-          } else if (headCallback != null) {
-            metricsGroup = frontendMetrics.headBlobMetricsGroup;
-          } else if (deleteCallback != null) {
-            metricsGroup = frontendMetrics.deleteBlobMetricsGroup;
-          }
-          // named blobs already have their account/container arguments set by handleGet/handleHead/handleDelete
-          if (!RestUtils.getRequestPath(restRequest).matchesOperation(Operations.NAMED_BLOB)) {
-            accountAndContainerInjector.injectTargetAccountAndContainerFromBlobId(blobId, restRequest, metricsGroup);
-          }
-          securityService.postProcessRequest(restRequest,
-              securityPostProcessRequestCallback(result, restRequest, restResponseChannel, getCallback, headCallback,
-                  deleteCallback));
-        } catch (Exception e) {
-          exception = e;
-        }
-      }
-
-      if (exception != null) {
-        submitResponse(restRequest, restResponseChannel, null, exception);
-      }
-      callbackTracker.markCallbackProcessingEnd();
-    }
-  }
-
-  /**
-   * Callback for {@link SecurityService#processRequest(RestRequest, Callback)}.
-   */
-  private class SecurityProcessRequestCallback implements Callback<Void> {
-    private static final String PROCESS_GET = "GET Request Security";
-    private static final String PROCESS_HEAD = "HEAD Request Security";
-    private static final String PROCESS_DELETE = "DELETE Request Security";
-
-    private final RestRequest restRequest;
-    private final RestResponseChannel restResponseChannel;
-    private final CallbackTracker callbackTracker;
-
-    private GetCallback getCallback;
-    private HeadCallback headCallback;
-    private DeleteCallback deleteCallback;
-
-    /**
-     * Constructor for GETs that will eventually reach the {@link Router}.
-     */
-    SecurityProcessRequestCallback(RestRequest restRequest, RestResponseChannel restResponseChannel,
-        GetCallback callback) {
-      this(restRequest, restResponseChannel, PROCESS_GET, frontendMetrics.getSecurityRequestTimeInMs,
-          frontendMetrics.getSecurityRequestCallbackProcessingTimeInMs);
-      this.getCallback = callback;
-    }
-
-    /**
-     * Constructor for GETs that will not be sent to the {@link Router}.
-     */
-    SecurityProcessRequestCallback(RestRequest restRequest, RestResponseChannel restResponseChannel) {
-      this(restRequest, restResponseChannel, PROCESS_GET, frontendMetrics.getSecurityRequestTimeInMs,
-          frontendMetrics.getSecurityRequestCallbackProcessingTimeInMs);
-    }
-
-    /**
-     * Constructor for HEAD that will eventually reach the {@link Router}.
-     */
-    SecurityProcessRequestCallback(RestRequest restRequest, RestResponseChannel restResponseChannel,
-        HeadCallback callback) {
-      this(restRequest, restResponseChannel, PROCESS_HEAD, frontendMetrics.headSecurityRequestTimeInMs,
-          frontendMetrics.headSecurityRequestCallbackProcessingTimeInMs);
-      this.headCallback = callback;
-    }
-
-    /**
-     * Constructor for DELETE that will eventually reach the {@link Router}.
-     */
-    SecurityProcessRequestCallback(RestRequest restRequest, RestResponseChannel restResponseChannel,
-        DeleteCallback callback) {
-      this(restRequest, restResponseChannel, PROCESS_DELETE, frontendMetrics.deleteSecurityRequestTimeInMs,
-          frontendMetrics.deleteSecurityRequestCallbackProcessingTimeInMs);
-      this.deleteCallback = callback;
-    }
-
-    private SecurityProcessRequestCallback(RestRequest restRequest, RestResponseChannel restResponseChannel,
-        String operationType, Histogram operationTimeTracker, Histogram callbackProcessingTimeTracker) {
-      this.restRequest = restRequest;
-      this.restResponseChannel = restResponseChannel;
-      callbackTracker =
-          new CallbackTracker(restRequest, operationType, operationTimeTracker, callbackProcessingTimeTracker);
-      callbackTracker.markOperationStart();
-    }
-
-    /**
-     * Handles request once it has been vetted by the {@link SecurityService}.
-     * In case of exception, response is immediately submitted to the {@link RestResponseHandler}.
-     * In case of GET, HEAD and DELETE, ID conversion is triggered.
-     * @param result The result of the request. This would be non null when the request executed successfully
-     * @param exception The exception that was reported on execution of the request
-     */
-    @Override
-    public void onCompletion(Void result, Exception exception) {
-      callbackTracker.markOperationEnd();
-      if (exception == null) {
-        try {
-          RestMethod restMethod = restRequest.getRestMethod();
-          logger.trace("Forwarding {} to the IdConverter/Router", restMethod);
-          String receivedId = getRequestPath(restRequest).getOperationOrBlobId(false);
-          switch (restMethod) {
-            case GET:
-              InboundIdConverterCallback idConverterCallback =
-                  new InboundIdConverterCallback(restRequest, restResponseChannel, getCallback);
-              idConverter.convert(restRequest, receivedId, idConverterCallback);
-              break;
-            case HEAD:
-              idConverterCallback = new InboundIdConverterCallback(restRequest, restResponseChannel, headCallback);
-              idConverter.convert(restRequest, receivedId, idConverterCallback);
-              break;
-            case DELETE:
-              idConverterCallback = new InboundIdConverterCallback(restRequest, restResponseChannel, deleteCallback);
-              idConverter.convert(restRequest, receivedId, idConverterCallback);
-              break;
-            default:
-              exception = new IllegalStateException("Unrecognized RestMethod: " + restMethod);
-          }
-        } catch (Exception e) {
-          exception = Utils.extractFutureExceptionCause(e);
-        }
-      }
-
-      if (exception != null) {
-        submitResponse(restRequest, restResponseChannel, null, exception);
-      }
-      callbackTracker.markCallbackProcessingEnd();
-    }
-  }
-
-  /**
-   * Build a callback to use for {@link SecurityService#postProcessRequest}. This callback forwards request to the
-   * {@link Router} once ID conversion is completed. In the case of some sub-resources
-   * (e.g., {@link SubResource#Replicas}), the request is completed and not forwarded to the {@link Router}.
-   * @param convertedId the converted blob ID to use in router requests.
-   * @param restRequest the {@link RestRequest}.
-   * @param restResponseChannel the {@link RestResponseChannel}.
-   * @param getCallback the {@link GetCallback} to use if this is a {@link RestMethod#GET} request, or null for other
-   *                    request types.
-   * @param headCallback the {@link HeadCallback} to use if this is a {@link RestMethod#HEAD} request, or null for other
-   *                    request types.
-   * @param deleteCallback the {@link DeleteCallback} to use if this is a {@link RestMethod#DELETE} request, or null for
-   *                       other request types.
-   * @return the {@link Callback} to use.
-   */
-  private Callback<Void> securityPostProcessRequestCallback(String convertedId, RestRequest restRequest,
-      RestResponseChannel restResponseChannel, GetCallback getCallback, HeadCallback headCallback,
-      DeleteCallback deleteCallback) {
-    Callback<ReadableStreamChannel> completionCallback =
-        (result, exception) -> submitResponse(restRequest, restResponseChannel, result, exception);
-    RestMethod restMethod = restRequest.getRestMethod();
-    AsyncOperationTracker.Metrics metrics;
-    switch (restMethod) {
-      case GET:
-        metrics = frontendMetrics.getSecurityPostProcessRequestMetrics;
-        break;
-      case HEAD:
-        metrics = frontendMetrics.headSecurityPostProcessRequestMetrics;
-        break;
-      case DELETE:
-        metrics = frontendMetrics.deleteSecurityPostProcessRequestMetrics;
-        break;
-      default:
-        throw new IllegalStateException("Unrecognized RestMethod: " + restMethod);
-    }
-    return FrontendUtils.buildCallback(metrics, result -> {
-      ReadableStreamChannel response = null;
-      switch (restMethod) {
-        case GET:
-          SubResource subResource = getRequestPath(restRequest).getSubResource();
-          // inject encryption metrics if need be
-          if (BlobId.isEncrypted(convertedId)) {
-            RestRequestMetrics restRequestMetrics =
-                getMetricsGroupForGet(frontendMetrics, subResource).getRestRequestMetrics(restRequest.isSslUsed(),
-                    true);
-            restRequest.getMetricsTracker().injectMetrics(restRequestMetrics);
-          }
-          if (subResource == null) {
-            getCallback.markStartTime();
-            router.getBlob(convertedId, getCallback.options, getCallback,
-                QuotaUtils.buildQuotaChargeCallback(restRequest, quotaManager, true));
-          } else {
-            switch (subResource) {
-              case BlobInfo:
-              case UserMetadata:
-              case Segment:
-                getCallback.markStartTime();
-                router.getBlob(convertedId, getCallback.options, getCallback,
-                    QuotaUtils.buildQuotaChargeCallback(restRequest, quotaManager, true));
-                break;
-              case Replicas:
-                response = getReplicasHandler.getReplicas(convertedId, restResponseChannel);
-                break;
-            }
-          }
-          break;
-        case HEAD:
-          GetOption getOption = getGetOption(restRequest, frontendConfig.defaultRouterGetOption);
-          // inject encryption metrics if need be
-          if (BlobId.isEncrypted(convertedId)) {
-            RestRequestMetrics requestMetrics =
-                frontendMetrics.headBlobMetricsGroup.getRestRequestMetrics(restRequest.isSslUsed(), true);
-            restRequest.getMetricsTracker().injectMetrics(requestMetrics);
-          }
-          headCallback.markStartTime();
-          router.getBlob(convertedId, new GetBlobOptionsBuilder().operationType(GetBlobOptions.OperationType.BlobInfo)
-              .getOption(getOption)
-              .restRequest(restRequest)
-              .build(), headCallback, QuotaUtils.buildQuotaChargeCallback(restRequest, quotaManager, false));
-          break;
-        case DELETE:
-          deleteCallback.markStartTime();
-          router.deleteBlob(convertedId, getHeader(restRequest.getArgs(), Headers.SERVICE_ID, false), deleteCallback,
-              QuotaUtils.buildQuotaChargeCallback(restRequest, quotaManager, false));
-          break;
-        default:
-          throw new IllegalStateException("Unrecognized RestMethod: " + restMethod);
-      }
-      if (response != null) {
-        completionCallback.onCompletion(response, null);
-      }
-    }, restRequest.getUri(), logger, completionCallback);
-  }
-
-  /**
-   * Tracks metrics and logs progress of operations that accept callbacks.
-   */
-  private class CallbackTracker {
-    private long operationStartTime = 0;
-    private long processingStartTime = 0;
-
-    private final String operationType;
-    private final Histogram operationTimeTracker;
-    private final Histogram callbackProcessingTimeTracker;
-    private final String blobId;
-
-    /**
-     * Create a CallbackTracker that tracks a particular operation.
-     * @param restRequest the {@link RestRequest} for the operation.
-     * @param operationType the type of operation.
-     * @param operationTimeTracker the {@link Histogram} of the time taken by the operation.
-     * @param callbackProcessingTimeTracker the {@link Histogram} of the time taken by the callback of the operation.
-     */
-    CallbackTracker(RestRequest restRequest, String operationType, Histogram operationTimeTracker,
-        Histogram callbackProcessingTimeTracker) {
-      this.operationType = operationType;
-      this.operationTimeTracker = operationTimeTracker;
-      this.callbackProcessingTimeTracker = callbackProcessingTimeTracker;
-      blobId = getRequestPath(restRequest).getOperationOrBlobId(false);
-    }
-
-    /**
-     * Marks that the operation being tracked has started.
-     */
-    void markOperationStart() {
-      logger.trace("{} started for {}", operationType, blobId);
-      operationStartTime = System.currentTimeMillis();
-    }
-
-    /**
-     * Marks that the operation being tracked has ended and callback processing has started.
-     */
-    void markOperationEnd() {
-      logger.trace("{} finished for {}", operationType, blobId);
-      processingStartTime = System.currentTimeMillis();
-      long operationTime = processingStartTime - operationStartTime;
-      operationTimeTracker.update(operationTime);
-    }
-
-    /**
-     * Marks that the  callback processing has ended.
-     */
-    void markCallbackProcessingEnd() {
-      logger.trace("Callback for {} of {} finished", operationType, blobId);
-      long processingTime = System.currentTimeMillis() - processingStartTime;
-      callbackProcessingTimeTracker.update(processingTime);
-    }
-  }
-
-  /**
-   * Callback for GET operations. Updates headers and submits the response body if there is no security exception.
-   */
-  private class GetCallback implements Callback<GetBlobResult> {
-    private final RestRequest restRequest;
-    private final RestResponseChannel restResponseChannel;
-    private final SubResource subResource;
-    private final GetBlobOptions options;
-    private final CallbackTracker callbackTracker;
-
-    /**
-     * Create a GET callback.
-     * @param restRequest the {@link RestRequest} for whose response this is a callback.
-     * @param restResponseChannel the {@link RestResponseChannel} to set headers on.
-     * @param subResource the sub-resource requested.
-     * @param options the {@link GetBlobOptions} associated with the {@link Router#getBlob(String, GetBlobOptions, Callback)} call.
-     */
-    GetCallback(RestRequest restRequest, RestResponseChannel restResponseChannel, SubResource subResource,
-        GetBlobOptions options) {
-      this.restRequest = restRequest;
-      this.restResponseChannel = restResponseChannel;
-      this.subResource = subResource;
-      this.options = options;
-      callbackTracker = new CallbackTracker(restRequest, OPERATION_TYPE_GET, frontendMetrics.getTimeInMs,
-          frontendMetrics.getCallbackProcessingTimeInMs);
-    }
-
-    /**
-     * If the request is not for a sub resource, makes a GET call to the router. If the request is for a sub resource,
-     * responds immediately. If there was no {@code routerResult} or if there was an exception, bails out.
-     * Submits the GET response to {@link RestResponseHandler} so that it can be sent (or the exception handled).
-     * @param routerResult The result of the request i.e a {@link GetBlobResult} object with the properties of the blob
-     *                     (and a channel for blob data, if the request did not have a subresource) that is going to be
-     *                     returned if no exception occured. This is non null if the request executed successfully.
-     * @param routerException The exception that was reported on execution of the request (if any).
-     */
-    @Override
-    public void onCompletion(final GetBlobResult routerResult, Exception routerException) {
-      callbackTracker.markOperationEnd();
-      if (routerResult == null && routerException == null) {
-        throw new IllegalStateException("Both response and exception are null");
-      }
-      try {
-        if (routerException == null) {
-          final CallbackTracker securityCallbackTracker =
-              new CallbackTracker(restRequest, OPERATION_TYPE_GET_RESPONSE_SECURITY,
-                  frontendMetrics.getSecurityResponseTimeInMs,
-                  frontendMetrics.getSecurityResponseCallbackProcessingTimeInMs);
-          accountAndContainerInjector.ensureAccountAndContainerInjected(restRequest,
-              routerResult.getBlobInfo().getBlobProperties(), getMetricsGroupForGet(frontendMetrics, subResource));
-          securityCallbackTracker.markOperationStart();
-          securityService.processResponse(restRequest, restResponseChannel, routerResult.getBlobInfo(),
-              (securityResult, securityException) -> {
-                securityCallbackTracker.markOperationEnd();
-                ReadableStreamChannel response = routerResult.getBlobDataChannel();
-                try {
-                  if (securityException == null) {
-                    if (subResource != null && !subResource.equals(SubResource.Segment)) {
-                      BlobInfo blobInfo = routerResult.getBlobInfo();
-                      if (restRequest.getArgs().containsKey(SEND_USER_METADATA_AS_RESPONSE_BODY)
-                          && (boolean) restRequest.getArgs().get(SEND_USER_METADATA_AS_RESPONSE_BODY)) {
-                        restResponseChannel.setHeader(Headers.CONTENT_TYPE, "application/octet-stream");
-                        restResponseChannel.setHeader(Headers.CONTENT_LENGTH, blobInfo.getUserMetadata().length);
-                        response = new ByteBufferReadableStreamChannel(ByteBuffer.wrap(blobInfo.getUserMetadata()));
-                      } else {
-                        restResponseChannel.setHeader(Headers.CONTENT_LENGTH, 0);
-                        response = new ByteBufferReadableStreamChannel(EMPTY_BUFFER);
-                      }
-                    } else if (restResponseChannel.getStatus() == ResponseStatus.NotModified) {
-                      response = null;
-                      // If the blob was not modified, we need to close the channel, as it will not be submitted to
-                      // the RestResponseHandler
-                      routerResult.getBlobDataChannel().close();
-                    }
-                  }
-                } catch (Exception e) {
-                  frontendMetrics.getSecurityResponseCallbackProcessingError.inc();
-                  securityException = e;
-                } finally {
-                  submitResponse(restRequest, restResponseChannel, response, securityException);
-                  securityCallbackTracker.markCallbackProcessingEnd();
-                }
-              });
-        }
-      } catch (Exception e) {
-        frontendMetrics.getCallbackProcessingError.inc();
-        routerException = e;
-      } finally {
-        if (routerException != null) {
-          securityService.processRequestCharges(restRequest, restResponseChannel, null);
-          submitResponse(restRequest, restResponseChannel,
-              routerResult != null ? routerResult.getBlobDataChannel() : null, routerException);
-        }
-        callbackTracker.markCallbackProcessingEnd();
-      }
-    }
-
-    /**
-     * Marks the start time of the operation.
-     */
-    void markStartTime() {
-      callbackTracker.markOperationStart();
-    }
-  }
-
-  /**
-   * Callback for DELETE operations. Sends an ACCEPTED response to the client if operation is successful. Submits
-   * response either to handle exceptions or to clean up after a response.
-   */
-  private class DeleteCallback implements Callback<Void> {
-    private final RestRequest restRequest;
-    private final RestResponseChannel restResponseChannel;
-    private final CallbackTracker callbackTracker;
-
-    /**
-     * Create a DELETE callback.
-     * @param restRequest the {@link RestRequest} for whose response this is a callback.
-     * @param restResponseChannel the {@link RestResponseChannel} over which response to {@code restRequest} can be
-     *                            sent.
-     */
-    DeleteCallback(RestRequest restRequest, RestResponseChannel restResponseChannel) {
-      this.restRequest = restRequest;
-      this.restResponseChannel = restResponseChannel;
-      callbackTracker = new CallbackTracker(restRequest, OPERATION_TYPE_DELETE, frontendMetrics.deleteTimeInMs,
-          frontendMetrics.deleteCallbackProcessingTimeInMs);
-    }
-
-    /**
-     * If there was no exception, updates the header with the acceptance of the request. Submits the response either for
-     * exception handling or for cleanup.
-     * @param routerResult The result of the request. This is always null.
-     * @param routerException The exception that was reported on execution of the request (if any).
-     */
-    @Override
-    public void onCompletion(Void routerResult, Exception routerException) {
-      callbackTracker.markOperationEnd();
-      try {
-        if (routerException == null) {
-          restResponseChannel.setHeader(Headers.DATE, new GregorianCalendar().getTime());
-          restResponseChannel.setStatus(ResponseStatus.Accepted);
-          restResponseChannel.setHeader(Headers.CONTENT_LENGTH, 0);
-        }
-      } catch (Exception e) {
-        frontendMetrics.deleteCallbackProcessingError.inc();
-        routerException = e;
-      } finally {
-        securityService.processRequestCharges(restRequest, restResponseChannel, null);
-        submitResponse(restRequest, restResponseChannel, null, routerException);
-        callbackTracker.markCallbackProcessingEnd();
-      }
-    }
-
-    /**
-     * Marks the start time of the operation.
-     */
-    void markStartTime() {
-      callbackTracker.markOperationStart();
-    }
-  }
-
-  /**
-   * Callback for HEAD operations. Sends the headers to the client if operation is successful. Submits response either
-   * to handle exceptions or to clean up after a response.
-   */
-  private class HeadCallback implements Callback<GetBlobResult> {
-    private final RestRequest restRequest;
-    private final RestResponseChannel restResponseChannel;
-    private final CallbackTracker callbackTracker;
-
-    /**
-     * Create a HEAD callback.
-     * @param restRequest the {@link RestRequest} for whose response this is a callback.
-     * @param restResponseChannel the {@link RestResponseChannel} over which response to {@code restRequest} can be
-     *                            sent.
-     */
-    HeadCallback(RestRequest restRequest, RestResponseChannel restResponseChannel) {
-      this.restRequest = restRequest;
-      this.restResponseChannel = restResponseChannel;
-      callbackTracker = new CallbackTracker(restRequest, OPERATION_TYPE_HEAD, frontendMetrics.headTimeInMs,
-          frontendMetrics.headCallbackProcessingTimeInMs);
-    }
-
-    /**
-     * If there was no exception, updates the header with the properties. Exceptions, if any, will be handled upon
-     * submission.
-     * @param routerResult The result of the request, which includes a {@link BlobInfo} object with the properties of
-     *                     the blob. This is non null if the request executed successfully.
-     * @param routerException The exception that was reported on execution of the request (if any).
-     */
-    @Override
-    public void onCompletion(GetBlobResult routerResult, Exception routerException) {
-      callbackTracker.markOperationEnd();
-      if (routerResult == null && routerException == null) {
-        throw new IllegalStateException("Both response and exception are null");
-      }
-      try {
-        if (routerException == null) {
-          final CallbackTracker securityCallbackTracker =
-              new CallbackTracker(restRequest, OPERATION_TYPE_HEAD_RESPONSE_SECURITY,
-                  frontendMetrics.headSecurityResponseTimeInMs,
-                  frontendMetrics.headSecurityResponseCallbackProcessingTimeInMs);
-          accountAndContainerInjector.ensureAccountAndContainerInjected(restRequest,
-              routerResult.getBlobInfo().getBlobProperties(), frontendMetrics.headBlobMetricsGroup);
-          securityCallbackTracker.markOperationStart();
-          securityService.processResponse(restRequest, restResponseChannel, routerResult.getBlobInfo(),
-              (securityResult, securityException) -> {
-                callbackTracker.markOperationEnd();
-                submitResponse(restRequest, restResponseChannel, null, securityException);
-                callbackTracker.markCallbackProcessingEnd();
-              });
-        }
-      } catch (Exception e) {
-        frontendMetrics.headCallbackProcessingError.inc();
-        routerException = e;
-      } finally {
-        if (routerException != null) {
-          submitResponse(restRequest, restResponseChannel, null, routerException);
-        }
-        callbackTracker.markCallbackProcessingEnd();
-      }
-    }
-
-    /**
-     * Marks the start time of the operation.
-     */
-    void markStartTime() {
-      callbackTracker.markOperationStart();
     }
   }
 }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestService.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestService.java
@@ -239,7 +239,6 @@ class FrontendRestRequestService implements RestRequestService {
         listNamedBlobsHandler.handle(restRequest, restResponseChannel,
             ((result, exception) -> submitResponse(restRequest, restResponseChannel, result, exception)));
       } else {
-
         getBlobHandler.handle(requestPath, restRequest, restResponseChannel, (r, e) -> {
           submitResponse(restRequest, restResponseChannel, r, e);
         });
@@ -315,11 +314,7 @@ class FrontendRestRequestService implements RestRequestService {
       RestRequestMetrics requestMetrics =
           frontendMetrics.headBlobMetricsGroup.getRestRequestMetrics(restRequest.isSslUsed(), false);
       restRequest.getMetricsTracker().injectMetrics(requestMetrics);
-      // named blob requests have their account/container in the URI, so checks can be done prior to ID conversion.
-      if (requestPath.matchesOperation(Operations.NAMED_BLOB)) {
-        accountAndContainerInjector.injectAccountAndContainerForNamedBlob(restRequest,
-            frontendMetrics.headBlobMetricsGroup);
-      }
+
       headHandler.handle(restRequest, restResponseChannel, (r, e) -> {
         submitResponse(restRequest, restResponseChannel, null, e);
       });
@@ -433,33 +428,6 @@ class FrontendRestRequestService implements RestRequestService {
     } catch (Exception e) {
       errorCallback.onCompletion(null, e);
     }
-  }
-
-  /**
-   * Fetch {@link RestRequestMetricsGroup} for GetRequest based on the {@link SubResource}.
-   * @param frontendMetrics instance of {@link FrontendMetrics} to use
-   * @param subResource {@link SubResource} corresponding to the GetRequest
-   * @return the appropriate {@link RestRequestMetricsGroup} based on the given params
-   */
-  private static RestRequestMetricsGroup getMetricsGroupForGet(FrontendMetrics frontendMetrics,
-      SubResource subResource) {
-    RestRequestMetricsGroup group = null;
-    if (subResource == null || subResource.equals(SubResource.Segment)) {
-      group = frontendMetrics.getBlobMetricsGroup;
-    } else {
-      switch (subResource) {
-        case BlobInfo:
-          group = frontendMetrics.getBlobInfoMetricsGroup;
-          break;
-        case UserMetadata:
-          group = frontendMetrics.getUserMetadataMetricsGroup;
-          break;
-        case Replicas:
-          group = frontendMetrics.getReplicasMetricsGroup;
-          break;
-      }
-    }
-    return group;
   }
 
   /**

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/GetBlobHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/GetBlobHandler.java
@@ -1,0 +1,240 @@
+package com.github.ambry.frontend;
+
+import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.commons.BlobId;
+import com.github.ambry.commons.ByteBufferReadableStreamChannel;
+import com.github.ambry.commons.Callback;
+import com.github.ambry.config.FrontendConfig;
+import com.github.ambry.messageformat.BlobInfo;
+import com.github.ambry.quota.QuotaManager;
+import com.github.ambry.quota.QuotaUtils;
+import com.github.ambry.rest.RequestPath;
+import com.github.ambry.rest.ResponseStatus;
+import com.github.ambry.rest.RestRequest;
+import com.github.ambry.rest.RestRequestMetrics;
+import com.github.ambry.rest.RestResponseChannel;
+import com.github.ambry.rest.RestServiceException;
+import com.github.ambry.rest.RestUtils;
+import com.github.ambry.router.GetBlobOptions;
+import com.github.ambry.router.GetBlobResult;
+import com.github.ambry.router.ReadableStreamChannel;
+import com.github.ambry.router.Router;
+import java.nio.ByteBuffer;
+import java.util.GregorianCalendar;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.github.ambry.frontend.FrontendUtils.*;
+import static com.github.ambry.rest.RestUtils.*;
+import static com.github.ambry.rest.RestUtils.InternalKeys.*;
+
+
+public class GetBlobHandler {
+  private static final Logger LOGGER = LoggerFactory.getLogger(GetBlobHandler.class);
+  private static final ByteBuffer EMPTY_BUFFER = ByteBuffer.allocate(0);
+
+  private final FrontendConfig frontendConfig;
+  private final Router router;
+  private final SecurityService securityService;
+  private final IdConverter idConverter;
+  private final AccountAndContainerInjector accountAndContainerInjector;
+  private final FrontendMetrics metrics;
+  private final ClusterMap clusterMap;
+  private final QuotaManager quotaManager;
+  private final GetReplicasHandler getReplicasHandler;
+
+  GetBlobHandler(FrontendConfig frontendConfig, Router router, SecurityService securityService, IdConverter idConverter,
+      AccountAndContainerInjector accountAndContainerInjector, FrontendMetrics metrics, ClusterMap clusterMap,
+      QuotaManager quotaManager) {
+    this.frontendConfig = frontendConfig;
+    this.router = router;
+    this.securityService = securityService;
+    this.idConverter = idConverter;
+    this.accountAndContainerInjector = accountAndContainerInjector;
+    this.metrics = metrics;
+    this.clusterMap = clusterMap;
+    this.quotaManager = quotaManager;
+    getReplicasHandler = new GetReplicasHandler(metrics, clusterMap);
+  }
+
+  void handle(RequestPath requestPath, RestRequest restRequest, RestResponseChannel restResponseChannel,
+      Callback<ReadableStreamChannel> callback) throws RestServiceException {
+    SubResource subResource = requestPath.getSubResource();
+    GetBlobOptions options = buildGetBlobOptions(restRequest.getArgs(), subResource,
+        getGetOption(restRequest, frontendConfig.defaultRouterGetOption), restRequest, requestPath.getBlobSegmentIdx());
+    RestRequestMetricsGroup metricsGroup = getMetricsGroupForGet(metrics, subResource);
+    RestRequestMetrics restRequestMetrics = metricsGroup.getRestRequestMetrics(restRequest.isSslUsed(), false);
+    // named blob requests have their account/container in the URI, so checks can be done prior to ID conversion.
+    if (requestPath.matchesOperation(Operations.NAMED_BLOB)) {
+      accountAndContainerInjector.injectAccountAndContainerForNamedBlob(restRequest, metricsGroup);
+    }
+    restRequest.getMetricsTracker().injectMetrics(restRequestMetrics);
+    new CallbackChain(restRequest, restResponseChannel, metricsGroup, requestPath, subResource, options,
+        callback).start();
+  }
+
+  /**
+   * Fetch {@link RestRequestMetricsGroup} for GetRequest based on the {@link SubResource}.
+   * @param frontendMetrics instance of {@link FrontendMetrics} to use
+   * @param subResource {@link SubResource} corresponding to the GetRequest
+   * @return the appropriate {@link RestRequestMetricsGroup} based on the given params
+   */
+  private static RestRequestMetricsGroup getMetricsGroupForGet(FrontendMetrics frontendMetrics,
+      SubResource subResource) {
+    RestRequestMetricsGroup group = null;
+    if (subResource == null || subResource.equals(SubResource.Segment)) {
+      group = frontendMetrics.getBlobMetricsGroup;
+    } else {
+      switch (subResource) {
+        case BlobInfo:
+          group = frontendMetrics.getBlobInfoMetricsGroup;
+          break;
+        case UserMetadata:
+          group = frontendMetrics.getUserMetadataMetricsGroup;
+          break;
+        case Replicas:
+          group = frontendMetrics.getReplicasMetricsGroup;
+          break;
+      }
+    }
+    return group;
+  }
+
+  private class CallbackChain {
+    private final RestRequest restRequest;
+    private final RestResponseChannel restResponseChannel;
+    private final Callback<ReadableStreamChannel> finalCallback;
+    private final RestRequestMetricsGroup metricsGroup;
+    private final RequestPath requestPath;
+    private final SubResource subResource;
+    private final GetBlobOptions options;
+
+    /**
+     * @param restRequest the {@link RestRequest}.
+     * @param restResponseChannel the {@link RestResponseChannel}.
+     * @param finalCallback the {@link Callback} to call on completion.
+     */
+    private CallbackChain(RestRequest restRequest, RestResponseChannel restResponseChannel,
+        RestRequestMetricsGroup metricsGroup, RequestPath requestPath, SubResource subResource, GetBlobOptions options,
+        Callback<ReadableStreamChannel> finalCallback) {
+      this.restRequest = restRequest;
+      this.restResponseChannel = restResponseChannel;
+      this.metricsGroup = metricsGroup;
+      this.requestPath = requestPath;
+      this.subResource = subResource;
+      this.options = options;
+      this.finalCallback = finalCallback;
+    }
+
+    /**
+     * Start the chain by calling {@link SecurityService#processRequest}.
+     */
+    private void start() {
+      securityService.processRequest(restRequest, securityProcessRequestCallback());
+    }
+
+    /**
+     * After {@link SecurityService#processRequest} finishes, call {@link IdConverter#convert} to convert the incoming
+     * ID if required.
+     * @return a {@link Callback} to be used with {@link SecurityService#processRequest}.
+     */
+    private Callback<Void> securityProcessRequestCallback() {
+      return buildCallback(metrics.headBlobSecurityProcessRequestMetrics, result -> {
+        String blobIdStr = RestUtils.getHeader(restRequest.getArgs(), RestUtils.Headers.BLOB_ID, true);
+        idConverter.convert(restRequest, blobIdStr, idConverterCallback());
+      }, restRequest.getUri(), LOGGER, finalCallback);
+    }
+
+    /**
+     * After {@link IdConverter#convert} finishes, call {@link SecurityService#postProcessRequest} to perform
+     * request time security checks that rely on the request being fully parsed and any additional arguments set.
+     * @return a {@link Callback} to be used with {@link IdConverter#convert}.
+     */
+    private Callback<String> idConverterCallback() {
+      return buildCallback(metrics.headBlobIdConversionMetrics, convertedBlobId -> {
+        BlobId blobId = FrontendUtils.getBlobIdFromString(convertedBlobId, clusterMap);
+        accountAndContainerInjector.injectTargetAccountAndContainerFromBlobId(blobId, restRequest, metricsGroup);
+        securityService.postProcessRequest(restRequest, securityPostProcessRequestCallback(blobId));
+      }, restRequest.getUri(), LOGGER, finalCallback);
+    }
+
+    /**
+     * After {@link SecurityService#postProcessRequest} finishes, call {@link Router#getBlob} to dget
+     * the blob info from the storage layer.
+     * @param blobId the {@link BlobId} to get info
+     * @return a {@link Callback} to be used with {@link SecurityService#postProcessRequest}.
+     */
+    private Callback<Void> securityPostProcessRequestCallback(BlobId blobId) {
+      return buildCallback(metrics.getSecurityPostProcessRequestMetrics, result -> {
+        // inject encryption metrics if need be
+        if (BlobId.isEncrypted(blobId.getID())) {
+          RestRequestMetrics restRequestMetrics = metricsGroup.getRestRequestMetrics(restRequest.isSslUsed(), true);
+          restRequest.getMetricsTracker().injectMetrics(restRequestMetrics);
+        }
+        if (subResource == null) {
+          router.getBlob(blobId.getID(), options, routerCallback(),
+              QuotaUtils.buildQuotaChargeCallback(restRequest, quotaManager, true));
+        } else {
+          switch (subResource) {
+            case BlobInfo:
+            case UserMetadata:
+            case Segment:
+              router.getBlob(blobId.getID(), options, routerCallback(),
+                  QuotaUtils.buildQuotaChargeCallback(restRequest, quotaManager, true));
+              break;
+            case Replicas:
+              finalCallback.onCompletion(getReplicasHandler.getReplicas(blobId.getID(), restResponseChannel), null);
+              break;
+          }
+        }
+      }, restRequest.getUri(), LOGGER, finalCallback);
+    }
+
+    /**
+     * After {@link Router#getBlob} finishes, call {@link SecurityService#processResponse}.
+     * @return a {@link Callback} to be used with {@link Router#getBlob}.
+     */
+    private Callback<GetBlobResult> routerCallback() {
+      return buildCallback(metrics.headBlobRouterMetrics, result -> {
+        LOGGER.debug("Get {}", RestUtils.getHeader(restRequest.getArgs(), RestUtils.Headers.BLOB_ID, true));
+        accountAndContainerInjector.ensureAccountAndContainerInjected(restRequest,
+            result.getBlobInfo().getBlobProperties(), metricsGroup);
+
+        restResponseChannel.setHeader(RestUtils.Headers.DATE, new GregorianCalendar().getTime());
+        restResponseChannel.setHeader(RestUtils.Headers.CONTENT_LENGTH, 0);
+        accountAndContainerInjector.ensureAccountAndContainerInjected(restRequest,
+            result.getBlobInfo().getBlobProperties(), metrics.headBlobMetricsGroup);
+        securityService.processResponse(restRequest, restResponseChannel, result.getBlobInfo(),
+            securityProcessResponseCallback(result));
+      }, restRequest.getUri(), LOGGER, finalCallback);
+    }
+
+    /**
+     * After {@link SecurityService#processResponse}, call {@code finalCallback}.
+     * @return a {@link Callback} to be used with {@link SecurityService#processResponse}.
+     */
+    private Callback<Void> securityProcessResponseCallback(GetBlobResult result) {
+      return buildCallback(metrics.headBlobSecurityProcessResponseMetrics, securityCheckResult -> {
+        ReadableStreamChannel response = result.getBlobDataChannel();
+        if (subResource != null && !subResource.equals(SubResource.Segment)) {
+          BlobInfo blobInfo = result.getBlobInfo();
+          if (restRequest.getArgs().containsKey(SEND_USER_METADATA_AS_RESPONSE_BODY) && (boolean) restRequest.getArgs()
+              .get(SEND_USER_METADATA_AS_RESPONSE_BODY)) {
+            restResponseChannel.setHeader(Headers.CONTENT_TYPE, "application/octet-stream");
+            restResponseChannel.setHeader(Headers.CONTENT_LENGTH, blobInfo.getUserMetadata().length);
+            response = new ByteBufferReadableStreamChannel(ByteBuffer.wrap(blobInfo.getUserMetadata()));
+          } else {
+            restResponseChannel.setHeader(Headers.CONTENT_LENGTH, 0);
+            response = new ByteBufferReadableStreamChannel(EMPTY_BUFFER);
+          }
+        } else if (restResponseChannel.getStatus() == ResponseStatus.NotModified) {
+          response = null;
+          // If the blob was not modified, we need to close the channel, as it will not be submitted to
+          // the RestResponseHandler
+          result.getBlobDataChannel().close();
+        }
+        finalCallback.onCompletion(response, null);
+      }, restRequest.getUri(), LOGGER, finalCallback);
+    }
+  }
+}

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/GetBlobHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/GetBlobHandler.java
@@ -168,7 +168,10 @@ public class GetBlobHandler {
     private Callback<String> idConverterCallback() {
       return buildCallback(metrics.getBlobIdConversionMetrics, convertedBlobId -> {
         BlobId blobId = FrontendUtils.getBlobIdFromString(convertedBlobId, clusterMap);
-        accountAndContainerInjector.injectTargetAccountAndContainerFromBlobId(blobId, restRequest, metricsGroup);
+        if (restRequest.getArgs().get(TARGET_ACCOUNT_KEY) == null) {
+          // Inject account and container when they are missing from the rest request.
+          accountAndContainerInjector.injectTargetAccountAndContainerFromBlobId(blobId, restRequest, metricsGroup);
+        }
         securityService.postProcessRequest(restRequest, securityPostProcessRequestCallback(blobId));
       }, restRequest.getUri(), LOGGER, finalCallback);
     }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/GetBlobHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/GetBlobHandler.java
@@ -222,8 +222,12 @@ public class GetBlobHandler {
                 securityProcessResponseCallback(result));
           }, restRequest.getUri(), LOGGER,
           // Still pass result.getBlobDataChannel() to finalCallback if we already have it.
-          (r, e) -> finalCallback.onCompletion(resultRef.get() != null ? resultRef.get().getBlobDataChannel() : null,
-              e));
+          (r, e) -> {
+            // Even we failed in router operations, we already used some of the resources in router,
+            // so let's record the charges for this request.
+            securityService.processRequestCharges(restRequest, restResponseChannel, null);
+            finalCallback.onCompletion(resultRef.get() != null ? resultRef.get().getBlobDataChannel() : null, e);
+          });
     }
 
     /**

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/GetBlobHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/GetBlobHandler.java
@@ -41,6 +41,9 @@ import static com.github.ambry.rest.RestUtils.*;
 import static com.github.ambry.rest.RestUtils.InternalKeys.*;
 
 
+/**
+ * Handler to handle all the http GET requests on blobs.
+ */
 public class GetBlobHandler {
   private static final Logger LOGGER = LoggerFactory.getLogger(GetBlobHandler.class);
   private static final ByteBuffer EMPTY_BUFFER = ByteBuffer.allocate(0);

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/HeadBlobHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/HeadBlobHandler.java
@@ -161,7 +161,12 @@ public class HeadBlobHandler {
             result.getBlobInfo().getBlobProperties(), metrics.headBlobMetricsGroup);
         securityService.processResponse(restRequest, restResponseChannel, result.getBlobInfo(),
             securityProcessResponseCallback());
-      }, restRequest.getUri(), LOGGER, finalCallback);
+      }, restRequest.getUri(), LOGGER, (r, e) -> {
+        // Even we failed in router operations, we already used some of the resources in router,
+        // so let's record the charges for this request.
+        securityService.processRequestCharges(restRequest, restResponseChannel, null);
+        finalCallback.onCompletion(null, e);
+      });
     }
 
     /**

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/HeadBlobHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/HeadBlobHandler.java
@@ -36,8 +36,11 @@ import static com.github.ambry.frontend.FrontendUtils.*;
 import static com.github.ambry.rest.RestUtils.*;
 
 
-public class HeadHandler {
-  private static final Logger LOGGER = LoggerFactory.getLogger(HeadHandler.class);
+/**
+ * Handler to handle all the http HEAD requests on blobs.
+ */
+public class HeadBlobHandler {
+  private static final Logger LOGGER = LoggerFactory.getLogger(HeadBlobHandler.class);
 
   private final FrontendConfig frontendConfig;
   private final Router router;
@@ -48,9 +51,9 @@ public class HeadHandler {
   private final ClusterMap clusterMap;
   private final QuotaManager quotaManager;
 
-  HeadHandler(FrontendConfig frontendConfig, Router router, SecurityService securityService, IdConverter idConverter,
-      AccountAndContainerInjector accountAndContainerInjector, FrontendMetrics metrics, ClusterMap clusterMap,
-      QuotaManager quotaManager) {
+  HeadBlobHandler(FrontendConfig frontendConfig, Router router, SecurityService securityService,
+      IdConverter idConverter, AccountAndContainerInjector accountAndContainerInjector, FrontendMetrics metrics,
+      ClusterMap clusterMap, QuotaManager quotaManager) {
     this.frontendConfig = frontendConfig;
     this.router = router;
     this.securityService = securityService;

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/HeadBlobHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/HeadBlobHandler.java
@@ -121,7 +121,8 @@ public class HeadBlobHandler {
         BlobId blobId = FrontendUtils.getBlobIdFromString(convertedBlobId, clusterMap);
         if (restRequest.getArgs().get(TARGET_ACCOUNT_KEY) == null) {
           // Inject account and container when they are missing from the rest request.
-          accountAndContainerInjector.injectTargetAccountAndContainerFromBlobId(blobId, restRequest, metricsGroup);
+          accountAndContainerInjector.injectTargetAccountAndContainerFromBlobId(blobId, restRequest,
+              metrics.headBlobMetricsGroup);
         }
         securityService.postProcessRequest(restRequest, securityPostProcessRequestCallback(blobId));
       }, restRequest.getUri(), LOGGER, finalCallback);

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/HeadBlobHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/HeadBlobHandler.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 
 import static com.github.ambry.frontend.FrontendUtils.*;
 import static com.github.ambry.rest.RestUtils.*;
+import static com.github.ambry.rest.RestUtils.InternalKeys.*;
 
 
 /**
@@ -118,8 +119,10 @@ public class HeadBlobHandler {
     private Callback<String> idConverterCallback() {
       return buildCallback(metrics.headBlobIdConversionMetrics, convertedBlobId -> {
         BlobId blobId = FrontendUtils.getBlobIdFromString(convertedBlobId, clusterMap);
-        accountAndContainerInjector.injectTargetAccountAndContainerFromBlobId(blobId, restRequest,
-            metrics.headBlobMetricsGroup);
+        if (restRequest.getArgs().get(TARGET_ACCOUNT_KEY) == null) {
+          // Inject account and container when they are missing from the rest request.
+          accountAndContainerInjector.injectTargetAccountAndContainerFromBlobId(blobId, restRequest, metricsGroup);
+        }
         securityService.postProcessRequest(restRequest, securityPostProcessRequestCallback(blobId));
       }, restRequest.getUri(), LOGGER, finalCallback);
     }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/HeadHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/HeadHandler.java
@@ -1,42 +1,32 @@
-/*
- * Copyright 2020 LinkedIn Corp. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- */
 package com.github.ambry.frontend;
 
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.Callback;
+import com.github.ambry.config.FrontendConfig;
+import com.github.ambry.protocol.GetOption;
 import com.github.ambry.quota.QuotaManager;
 import com.github.ambry.quota.QuotaUtils;
 import com.github.ambry.rest.RestRequest;
 import com.github.ambry.rest.RestRequestMetrics;
 import com.github.ambry.rest.RestResponseChannel;
 import com.github.ambry.rest.RestUtils;
+import com.github.ambry.router.GetBlobOptions;
+import com.github.ambry.router.GetBlobOptionsBuilder;
+import com.github.ambry.router.GetBlobResult;
 import com.github.ambry.router.Router;
 import java.util.GregorianCalendar;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static com.github.ambry.frontend.FrontendUtils.*;
-import static com.github.ambry.rest.RestUtils.InternalKeys.*;
+import static com.github.ambry.rest.RestUtils.*;
 
 
-/**
- * Handler for all Undelete requests.
- */
-public class UndeleteHandler {
-  private static final Logger LOGGER = LoggerFactory.getLogger(UndeleteHandler.class);
+public class HeadHandler {
+  private static final Logger LOGGER = LoggerFactory.getLogger(HeadHandler.class);
 
+  private final FrontendConfig frontendConfig;
   private final Router router;
   private final SecurityService securityService;
   private final IdConverter idConverter;
@@ -45,19 +35,10 @@ public class UndeleteHandler {
   private final ClusterMap clusterMap;
   private final QuotaManager quotaManager;
 
-  /**
-   * Constructs a handler for handling requests for undelete the blobs
-   * @param router the {@link Router} to use.
-   * @param securityService the {@link SecurityService} to use.
-   * @param idConverter the {@link IdConverter} to use.
-   * @param accountAndContainerInjector helper to resolve account and container for a given request.
-   * @param metrics {@link FrontendMetrics} instance where metrics should be recorded.
-   * @param clusterMap the {@link ClusterMap} in use.
-   * @param quotaManager the {@link QuotaManager} object.
-   */
-  UndeleteHandler(Router router, SecurityService securityService, IdConverter idConverter,
+  HeadHandler(FrontendConfig frontendConfig, Router router, SecurityService securityService, IdConverter idConverter,
       AccountAndContainerInjector accountAndContainerInjector, FrontendMetrics metrics, ClusterMap clusterMap,
       QuotaManager quotaManager) {
+    this.frontendConfig = frontendConfig;
     this.router = router;
     this.securityService = securityService;
     this.idConverter = idConverter;
@@ -67,21 +48,10 @@ public class UndeleteHandler {
     this.quotaManager = quotaManager;
   }
 
-  /**
-   * Handles a request for undeleting a blob
-   * @param restRequest the {@link RestRequest} that contains the request parameters.
-   * @param restResponseChannel the {@link RestResponseChannel} where headers should be set.
-   * @param callback the {@link Callback} to invoke when the response is ready (or if there is an exception).
-   */
   void handle(RestRequest restRequest, RestResponseChannel restResponseChannel, Callback<Void> callback) {
-    // And always send failure reason back to client for undelete
-    restRequest.setArg(SEND_FAILURE_REASON, Boolean.TRUE);
     new CallbackChain(restRequest, restResponseChannel, callback).start();
   }
 
-  /**
-   * Represents the chain of actions to take. Keeps request context that is relevant to all callback stages.
-   */
   private class CallbackChain {
     private final RestRequest restRequest;
     private final RestResponseChannel restResponseChannel;
@@ -103,9 +73,6 @@ public class UndeleteHandler {
      * Start the chain by calling {@link SecurityService#processRequest}.
      */
     private void start() {
-      RestRequestMetrics requestMetrics =
-          metrics.undeleteBlobMetricsGroup.getRestRequestMetrics(restRequest.isSslUsed(), false);
-      restRequest.getMetricsTracker().injectMetrics(requestMetrics);
       restRequest.setArg(RestUtils.InternalKeys.KEEP_ALIVE_ON_ERROR_HINT, true);
       securityService.processRequest(restRequest, securityProcessRequestCallback());
     }
@@ -116,7 +83,7 @@ public class UndeleteHandler {
      * @return a {@link Callback} to be used with {@link SecurityService#processRequest}.
      */
     private Callback<Void> securityProcessRequestCallback() {
-      return buildCallback(metrics.undeleteBlobSecurityProcessRequestMetrics, result -> {
+      return buildCallback(metrics.headBlobSecurityProcessRequestMetrics, result -> {
         String blobIdStr = RestUtils.getHeader(restRequest.getArgs(), RestUtils.Headers.BLOB_ID, true);
         idConverter.convert(restRequest, blobIdStr, idConverterCallback());
       }, restRequest.getUri(), LOGGER, finalCallback);
@@ -128,38 +95,48 @@ public class UndeleteHandler {
      * @return a {@link Callback} to be used with {@link IdConverter#convert}.
      */
     private Callback<String> idConverterCallback() {
-      return buildCallback(metrics.undeleteBlobIdConversionMetrics, convertedBlobId -> {
+      return buildCallback(metrics.headBlobIdConversionMetrics, convertedBlobId -> {
         BlobId blobId = FrontendUtils.getBlobIdFromString(convertedBlobId, clusterMap);
         accountAndContainerInjector.injectTargetAccountAndContainerFromBlobId(blobId, restRequest,
-            metrics.undeleteBlobMetricsGroup);
+            metrics.headBlobMetricsGroup);
         securityService.postProcessRequest(restRequest, securityPostProcessRequestCallback(blobId));
       }, restRequest.getUri(), LOGGER, finalCallback);
     }
 
     /**
-     * After {@link SecurityService#postProcessRequest} finishes, call {@link Router#undeleteBlob} to undelete
-     * the blob in the storage layer.
-     * @param blobId the {@link BlobId} to undelete
+     * After {@link SecurityService#postProcessRequest} finishes, call {@link Router#getBlob} to dget
+     * the blob info from the storage layer.
+     * @param blobId the {@link BlobId} to get info
      * @return a {@link Callback} to be used with {@link SecurityService#postProcessRequest}.
      */
     private Callback<Void> securityPostProcessRequestCallback(BlobId blobId) {
-      return buildCallback(metrics.undeleteBlobSecurityPostProcessRequestMetrics, result -> {
-        String serviceId = RestUtils.getHeader(restRequest.getArgs(), RestUtils.Headers.SERVICE_ID, true);
-        router.undeleteBlob(blobId.getID(), serviceId, routerCallback(),
-            QuotaUtils.buildQuotaChargeCallback(restRequest, quotaManager, false));
+      return buildCallback(metrics.headBlobSecurityPostProcessRequestMetrics, result -> {
+        GetOption getOption = getGetOption(restRequest, frontendConfig.defaultRouterGetOption);
+        // inject encryption metrics if need be
+        if (BlobId.isEncrypted(blobId.getID())) {
+          RestRequestMetrics requestMetrics =
+              metrics.headBlobMetricsGroup.getRestRequestMetrics(restRequest.isSslUsed(), true);
+          restRequest.getMetricsTracker().injectMetrics(requestMetrics);
+        }
+        router.getBlob(blobId.getID(), new GetBlobOptionsBuilder().operationType(GetBlobOptions.OperationType.BlobInfo)
+            .getOption(getOption)
+            .restRequest(restRequest)
+            .build(), routerCallback(), QuotaUtils.buildQuotaChargeCallback(restRequest, quotaManager, false));
       }, restRequest.getUri(), LOGGER, finalCallback);
     }
 
     /**
-     * After {@link Router#undeleteBlob} finishes, call {@link SecurityService#processResponse}.
-     * @return a {@link Callback} to be used with {@link Router#undeleteBlob}.
+     * After {@link Router#getBlob} finishes, call {@link SecurityService#processResponse}.
+     * @return a {@link Callback} to be used with {@link Router#getBlob}.
      */
-    private Callback<Void> routerCallback() {
-      return buildCallback(metrics.undeleteBlobRouterMetrics, result -> {
-        LOGGER.debug("Undeleted {}", RestUtils.getHeader(restRequest.getArgs(), RestUtils.Headers.BLOB_ID, true));
+    private Callback<GetBlobResult> routerCallback() {
+      return buildCallback(metrics.headBlobRouterMetrics, result -> {
+        LOGGER.debug("Head {}", RestUtils.getHeader(restRequest.getArgs(), RestUtils.Headers.BLOB_ID, true));
         restResponseChannel.setHeader(RestUtils.Headers.DATE, new GregorianCalendar().getTime());
         restResponseChannel.setHeader(RestUtils.Headers.CONTENT_LENGTH, 0);
-        securityService.processResponse(restRequest, restResponseChannel, null, securityProcessResponseCallback());
+        accountAndContainerInjector.ensureAccountAndContainerInjected(restRequest,
+            result.getBlobInfo().getBlobProperties(), metrics.headBlobMetricsGroup);
+        securityService.processResponse(restRequest, restResponseChannel, result.getBlobInfo(), securityProcessResponseCallback());
       }, restRequest.getUri(), LOGGER, finalCallback);
     }
 
@@ -168,7 +145,7 @@ public class UndeleteHandler {
      * @return a {@link Callback} to be used with {@link SecurityService#processResponse}.
      */
     private Callback<Void> securityProcessResponseCallback() {
-      return buildCallback(metrics.undeleteBlobSecurityProcessResponseMetrics,
+      return buildCallback(metrics.headBlobSecurityProcessResponseMetrics,
           securityCheckResult -> finalCallback.onCompletion(null, null), restRequest.getUri(), LOGGER, finalCallback);
     }
   }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/HeadHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/HeadHandler.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2022 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
 package com.github.ambry.frontend;
 
 import com.github.ambry.clustermap.ClusterMap;

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
@@ -52,6 +52,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static com.github.ambry.frontend.FrontendUtils.*;
+import static com.github.ambry.rest.RestUtils.InternalKeys.*;
 import static com.github.ambry.router.RouterErrorCode.*;
 
 
@@ -122,6 +123,7 @@ public class NamedBlobPutHandler {
    * @param callback the {@link Callback} to invoke when the response is ready (or if there is an exception).
    */
   void handle(RestRequest restRequest, RestResponseChannel restResponseChannel, Callback<Void> callback) {
+    restRequest.setArg(SEND_FAILURE_REASON, Boolean.TRUE);
     new NamedBlobPutHandler.CallbackChain(restRequest, restResponseChannel, callback).start();
   }
 

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/AmbrySecurityServiceTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/AmbrySecurityServiceTest.java
@@ -130,9 +130,8 @@ public class AmbrySecurityServiceTest {
           RestUtils.buildUserMetadata(USER_METADATA), DEFAULT_LIFEVERSION);
       ACCOUNT_SERVICE.updateAccounts(Collections.singletonList(InMemAccountService.UNKNOWN_ACCOUNT));
       QuotaConfig quotaConfig = QuotaTestUtils.createQuotaConfig(Collections.emptyMap(), false, QuotaMode.TRACKING);
-      QUOTA_MANAGER =
-          new AmbryQuotaManager(quotaConfig, new SimpleQuotaRecommendationMergePolicy(quotaConfig), mock(AccountService.class), null,
-              new QuotaMetrics(new MetricRegistry()));
+      QUOTA_MANAGER = new AmbryQuotaManager(quotaConfig, new SimpleQuotaRecommendationMergePolicy(quotaConfig),
+          mock(AccountService.class), null, new QuotaMetrics(new MetricRegistry()));
     } catch (Exception e) {
       throw new IllegalStateException(e);
     }
@@ -281,13 +280,6 @@ public class AmbrySecurityServiceTest {
     TestUtils.assertException(IllegalArgumentException.class,
         () -> securityService.processResponse(restRequest, new MockRestResponseChannel(), null).get(), null);
 
-    // for unsupported methods
-    RestMethod[] methods = {RestMethod.DELETE};
-    for (RestMethod restMethod : methods) {
-      testExceptionCasesProcessResponse(restMethod, new MockRestResponseChannel(), DEFAULT_INFO,
-          RestServiceErrorCode.InternalServerError);
-    }
-
     // OPTIONS (should be no errors)
     securityService.processResponse(createRestRequest(RestMethod.OPTIONS, "/", null), new MockRestResponseChannel(),
         null).get();
@@ -402,7 +394,7 @@ public class AmbrySecurityServiceTest {
 
     // security service closed
     securityService.close();
-    methods = new RestMethod[]{RestMethod.POST, RestMethod.GET, RestMethod.DELETE, RestMethod.HEAD};
+    RestMethod[] methods = new RestMethod[]{RestMethod.POST, RestMethod.GET, RestMethod.DELETE, RestMethod.HEAD};
     for (RestMethod restMethod : methods) {
       testExceptionCasesProcessResponse(restMethod, new MockRestResponseChannel(), blobInfo,
           RestServiceErrorCode.ServiceUnavailable);


### PR DESCRIPTION
This PR would move the delete, head, and get blob logic out of FrontendRestRequestService and create a handler for each of them respectively. This way, our http handling code would be more consistent.

There are some changes made to this existing logics.
1. Some metrics are no longer used
2. processResponse would delete with delete

