### PR TITLE
Remove unnecessary request log

### DIFF
--- a/ambry-quota/src/main/java/com/github/ambry/quota/capacityunit/AmbryCUQuotaEnforcer.java
+++ b/ambry-quota/src/main/java/com/github/ambry/quota/capacityunit/AmbryCUQuotaEnforcer.java
@@ -86,7 +86,7 @@ public class AmbryCUQuotaEnforcer implements QuotaEnforcer {
     float usage = doAndHandleException(() -> {
       final QuotaResource quotaResource = QuotaResource.fromRestRequest(restRequest);
       return quotaSource.getUsage(quotaResource, quotaName);
-    }, String.format("Could not recommend for request %s due to", restRequest));
+    }, String.format("Could not recommend for request %s due to", restRequest.getPath()));
     return buildQuotaRecommendation(usage, quotaName);
   }
 


### PR DESCRIPTION
We are seeing the entire request being logged to the file, including all the headers, which is totally unnecessary since this is a quota related log message.