### PR TITLE
Add pinned memory usage for netty metrics

### DIFF
--- a/ambry-commons/src/main/java/com/github/ambry/commons/NettyInternalMetrics.java
+++ b/ambry-commons/src/main/java/com/github/ambry/commons/NettyInternalMetrics.java
@@ -69,6 +69,8 @@ public class NettyInternalMetrics {
   private volatile int numThreadLocalCaches;
   private volatile long usedHeapMemory;
   private volatile long usedDirectMemory;
+  private volatile long pinnedHeapMemory;
+  private volatile long pinnedDirectMemory;
   private volatile long numHeapTotalAllocations;
   private volatile long numHeapTotalDeallocations;
   private volatile long numHeapTotalActiveAllocations;
@@ -94,6 +96,14 @@ public class NettyInternalMetrics {
 
   private long getUsedDirectMemory() {
     return usedDirectMemory;
+  }
+
+  private long getPinnedHeapMemory() {
+    return pinnedHeapMemory;
+  }
+
+  private long getPinnedDirectMemory() {
+    return pinnedDirectMemory;
   }
 
   private long getNumHeapTotalAllocations() {
@@ -131,6 +141,10 @@ public class NettyInternalMetrics {
         (Gauge<Long>) this::getUsedHeapMemory);
     registry.register(MetricRegistry.name(NettyInternalMetrics.class, "UsedDirectMemory"),
         (Gauge<Long>) this::getUsedDirectMemory);
+    registry.register(MetricRegistry.name(NettyInternalMetrics.class, "PinnedHeapMemory"),
+        (Gauge<Long>) this::getPinnedHeapMemory);
+    registry.register(MetricRegistry.name(NettyInternalMetrics.class, "PinnedDirectMemory"),
+        (Gauge<Long>) this::getPinnedDirectMemory);
     registry.register(MetricRegistry.name(NettyInternalMetrics.class, "NumberHeapTotalAllocations"),
         (Gauge<Long>) this::getNumHeapTotalAllocations);
     registry.register(MetricRegistry.name(NettyInternalMetrics.class, "NumberHeapTotalDeallocations"),
@@ -181,6 +195,8 @@ public class NettyInternalMetrics {
       numThreadLocalCaches = metric.numThreadLocalCaches();
       usedHeapMemory = metric.usedHeapMemory();
       usedDirectMemory = metric.usedDirectMemory();
+      pinnedHeapMemory = PooledByteBufAllocator.DEFAULT.pinnedHeapMemory();
+      pinnedDirectMemory = PooledByteBufAllocator.DEFAULT.pinnedDirectMemory();
       List<PoolArenaMetric> heapArenaMetrics = metric.heapArenas();
       List<PoolArenaMetric> directArenaMetrics = metric.directArenas();
       numHeapTotalAllocations = heapArenaMetrics.stream().mapToLong(PoolArenaMetric::numAllocations).sum();


### PR DESCRIPTION
We have used direct memory for netty metric, but used direct memory includes all the direct memory that netty is managing. So it doesn't reflect the amount of direct memory the application is currently using. 

Adding pinned direct memory would show us that.

The difference between used direct memory and pinned direct memory might be huge.
When application tries allocate 1MB from netty, and netty would create a new pooled chunk, which is 16mb. In this case, the pinned direct memory is 1MB, but the used direct memory is 16MB.