### PR TITLE
Revert "Bump up Helix core from 1.0.1 to 1.0.3."

### DIFF
--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixParticipantTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixParticipantTest.java
@@ -78,8 +78,8 @@ public class HelixParticipantTest {
 
   @BeforeClass
   public static void initialize() throws IOException {
+    zkInfoList.add(new ZkInfo(null, dcName, (byte) 0, 2199, true));
     String tempDirPath = getTempDir("HelixParticipantTest-");
-    zkInfoList.add(new ZkInfo(tempDirPath, dcName, (byte) 0, 2199, true));
     System.out.println(tempDirPath);
     hardwareLayoutPath = tempDirPath + "/hardwareLayoutTest.json";
     partitionLayoutPath = tempDirPath + "/partitionLayoutTest.json";

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixAdmin.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixAdmin.java
@@ -34,12 +34,6 @@ import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.MaintenanceSignal;
 import org.apache.helix.model.ResourceConfig;
 import org.apache.helix.model.StateModelDefinition;
-import org.apache.helix.model.CustomizedView;
-import org.apache.helix.api.topology.ClusterTopology;
-import org.apache.helix.api.status.ClusterManagementModeRequest;
-import org.apache.helix.constants.InstanceConstants;
-
-import org.apache.helix.api.status.ClusterManagementMode;
 
 import static com.github.ambry.clustermap.ClusterMapUtils.*;
 
@@ -159,42 +153,6 @@ public class MockHelixAdmin implements HelixAdmin {
     removeDisabledReplicasIfNeeded(instanceConfig);
     instanceNameToInstanceConfigs.put(instanceName, instanceConfig);
     return true;
-  }
-
-  @Override
-  public CustomizedView getResourceCustomizedView(String clusterName, String resourceName, String customizedStateType) {
-    return null;
-  }
-
-  @Override
-  public ClusterTopology getClusterTopology(String clusterName) {
-    return null;
-  }
-
-  @Override
-  public void purgeOfflineInstances(String clusterName, long offlineDuration) {
-    return;
-  }
-
-  @Override
-  public void setClusterManagementMode(ClusterManagementModeRequest request) {
-    return;
-  }
-
-  @Override
-  public ClusterManagementMode getClusterManagementMode(String clusterName) {
-    return null;
-  }
-
-  @Override
-  public void enableInstance(String clusterName, List<String> instances, boolean enabled,
-      InstanceConstants.InstanceDisabledType disabledType, String reason) {
-    return;
-  }
-  @Override
-  public void enableInstance(String clusterName, String instanceName, boolean enabled,
-      InstanceConstants.InstanceDisabledType disabledType, String reason) {
-    return;
   }
 
   /**

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixManager.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixManager.java
@@ -196,15 +196,8 @@ class MockHelixManager implements HelixManager {
    */
   void triggerLiveInstanceNotification(boolean init) {
     List<LiveInstance> liveInstances = new ArrayList<>();
-    for (int i = 0; i < mockAdmin.getUpInstances().size(); i++) {
-      // Need set LiveInstance.ZNRecord.setEphemeralOwner to non-zero unique value.
-      // Otherwise new RoutingTableProvider(manager, PropertyType.CURRENTSTATES) will throw null pointer exception.
-      // The exception is due to ZNRecord.getSimpleField is null in the below code.
-      // https://jarvis.corp.linkedin.com/codesearch/result/?name=LiveInstance.java&path=helix-lib%2Fhelix%2Fhelix-core%2Fsrc%2Fmain%2Fjava%2Forg%2Fapache%2Fhelix%2Fmodel&reponame=multiproducts%2Fhelix-lib#115
-      String instance = mockAdmin.getUpInstances().get(i);
-      ZNRecord znRecord = new ZNRecord(instance);
-      znRecord.setEphemeralOwner(i+1);
-      liveInstances.add(new LiveInstance(znRecord));
+    for (String instance : mockAdmin.getUpInstances()) {
+      liveInstances.add(new LiveInstance(instance));
     }
     NotificationContext notificationContext = new NotificationContext(this);
     if (init) {

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/StaticClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/StaticClusterManagerTest.java
@@ -390,7 +390,7 @@ public class StaticClusterManagerTest {
             partitionLayoutSer)).getClusterMap();
     assertEquals(clusterMapManager.getWritablePartitionIds(null).size(), 1);
     assertEquals(clusterMapManager.getUnallocatedRawCapacityInBytes(), 10737418240L);
-    assertNotNull(clusterMapManager.getDataNodeId("localhost", 6667));
+    assertNotNull(clusterMapManager.getDataNodeId("localhost", 6661));
   }
 
   /**

--- a/ambry-quota/src/main/java/com/github/ambry/quota/capacityunit/CapacityUnit.java
+++ b/ambry-quota/src/main/java/com/github/ambry/quota/capacityunit/CapacityUnit.java
@@ -16,7 +16,7 @@ package com.github.ambry.quota.capacityunit;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.ambry.quota.QuotaName;
 import java.util.concurrent.atomic.AtomicLong;
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.codehaus.jackson.annotate.JsonIgnore;
 
 
 /**

--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -19,7 +19,7 @@ ext {
     javaxVersion = "3.0.1"
     nettyVersion = "4.1.74.Final"
     nettyTcnativeVersion = "2.0.49.Final"
-    helixVersion = "1.0.3"
+    helixVersion = "1.0.1"
     jacksonVersion = "2.10.2"
     jaydioVersion = "0.1"
     azureStorageBlobVersion = "12.15.0"


### PR DESCRIPTION
Reverts linkedin/ambry#2113
Helix 1.0.3 has a backward compatibility issue. Revert it back until the problem is fixed.