### PR TITLE
Fixed the StaticClusterManagerTest.validateSimpleConfig test failure

### DIFF
--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/StaticClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/StaticClusterManagerTest.java
@@ -390,7 +390,7 @@ public class StaticClusterManagerTest {
             partitionLayoutSer)).getClusterMap();
     assertEquals(clusterMapManager.getWritablePartitionIds(null).size(), 1);
     assertEquals(clusterMapManager.getUnallocatedRawCapacityInBytes(), 10737418240L);
-    assertNotNull(clusterMapManager.getDataNodeId("localhost", 6661));
+    assertNotNull(clusterMapManager.getDataNodeId("localhost", 6667));
   }
 
   /**


### PR DESCRIPTION
Fixed the StaticClusterManagerTest.validateSimpleConfig test failure 
due to port change in commit 9922ef8
