### PR TITLE
[frontend] Revert logs in PartitionLayout

### DIFF
--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PartitionLayout.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PartitionLayout.java
@@ -17,7 +17,6 @@ import com.github.ambry.config.ClusterMapConfig;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -269,15 +268,7 @@ public class PartitionLayout {
    */
   public Partition getPartition(InputStream stream) throws IOException {
     byte[] partitionBytes = Partition.readPartitionBytesFromStream(stream);
-    logger.info("Partition bytes from stream: " + deserializePartitionBytes(partitionBytes));
-    logger.info("Partition map state: " + toString());
-    logger.info("Partition map keys: " + partitionMap.keySet().stream().map(key -> deserializePartitionBytes(key.array())).collect(Collectors.joining()));
     return partitionMap.get(ByteBuffer.wrap(partitionBytes));
-  }
-
-  private String deserializePartitionBytes(byte[] bytes) {
-    ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
-    return "Partition version: " + byteBuffer.getShort() + " id: " + byteBuffer.getLong();
   }
 
   public JSONObject toJSONObject() throws JSONException {


### PR DESCRIPTION
This patch removes log messages added as part of a root-cause investigation
because the log messages print a significant amount of data and
increase the latency of a range request. This increase is substantial
for large blobs in the order of terabytes. For example, the p95 for
deserializing the metadata blob for a 1TB blob was ~4600 ms. If we
were trying to download the 1TB blob in chunks of 128MB at a time,
then it translates to over 10 hrs of time spent just deserializing metadata.