### PR TITLE
[Http2] Add a configuration to treat timeout as network error in http2 network client

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/Http2ClientConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/Http2ClientConfig.java
@@ -37,6 +37,7 @@ public class Http2ClientConfig {
   public static final String HTTP2_BLOCKING_CHANNEL_POOL_SHUTDOWN_TIMEOUT_MS =
       "http2.blocking.channel.pool.shutdown.timeout.ms";
   public static final String HTTP2_PEER_CERTIFICATE_SAN_REGEX = "http2.peer.certificate.san.regex";
+  public static final String HTTP2_TIMEOUT_AS_NETWORK_ERROR = "http.timeout.as.network.error";
 
   /**
    * HTTP/2 connection idle time before we close it. -1 means no idle close.
@@ -158,6 +159,14 @@ public class Http2ClientConfig {
   @Default("")
   public final String http2PeerCertificateSanRegex;
 
+  /**
+   * If true, treat timeout in http2 network client as network error. This would make servers that
+   * can't respond to frontend in time be marked as down by frontend.
+   */
+  @Config(HTTP2_TIMEOUT_AS_NETWORK_ERROR)
+  @Default("false")
+  public final boolean http2TimeoutAsNetworkError;
+
   public Http2ClientConfig(VerifiableProperties verifiableProperties) {
     idleConnectionTimeoutMs = verifiableProperties.getLong(HTTP2_IDLE_CONNECTION_TIMEOUT_MS, -1);
     http2MinConnectionPerPort =
@@ -180,7 +189,7 @@ public class Http2ClientConfig {
     http2BlockingChannelReceiveTimeoutMs = verifiableProperties.getInt(HTTP2_BLOCKING_CHANNEL_RECEIVE_TIMEOUT_MS, 5000);
     http2BlockingChannelPoolShutdownTimeoutMs =
         verifiableProperties.getInt(HTTP2_BLOCKING_CHANNEL_POOL_SHUTDOWN_TIMEOUT_MS, 3000);
-    http2PeerCertificateSanRegex =
-        verifiableProperties.getString(HTTP2_PEER_CERTIFICATE_SAN_REGEX, "");
+    http2PeerCertificateSanRegex = verifiableProperties.getString(HTTP2_PEER_CERTIFICATE_SAN_REGEX, "");
+    http2TimeoutAsNetworkError = verifiableProperties.getBoolean(HTTP2_TIMEOUT_AS_NETWORK_ERROR, false);
   }
 }


### PR DESCRIPTION
when ambry server has disk failures, it would not respond to any of the frontend requests. Frontend nodes would sees lots of timeout error from this pariticular ambry server node. But since timeout is not treated as the network error, frontend nodes would still consider this ambry server live and keep sending requests to this ambry server node. 

This PR adds a configuration that would make http2 network client return network error instead of timeout when seeing a timeout. This would force frontend nodes stop sending requests to the non-responding ambry server nodes. 