### PR TITLE
Fix onSuccess call in get in blobstore

### DIFF
--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
@@ -15,7 +15,6 @@ package com.github.ambry.clustermap;
 
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.config.ClusterMapConfig;
-import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.SystemTime;
 import java.io.IOException;
 import java.io.InputStream;

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -309,7 +309,7 @@ public class BlobStore implements Store {
         }
       }
 
-      MessageReadSet readSet = new StoreMessageReadSet(readOptions, new StoreMessageReadSet.IOOperationHandler() {
+      MessageReadSet readSet = new StoreMessageReadSet(readOptions, new StoreMessageReadSet.IOPHandler() {
         @Override
         public void onSuccess() {
           BlobStore.this.onSuccess("GET");

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -259,7 +259,7 @@ public class BlobStore implements Store {
             config.storeEnableCurrentInvalidSizeMetric);
         checkCapacityAndUpdateReplicaStatusDelegate();
         logger.trace("The store {} is successfully started", storeId);
-        onSuccess();
+        onSuccess("START");
         isDisabled.set(false);
         started = true;
         resolveStoreInitialState();
@@ -309,14 +309,26 @@ public class BlobStore implements Store {
         }
       }
 
-      MessageReadSet readSet = new StoreMessageReadSet(readOptions);
+      MessageReadSet readSet = new StoreMessageReadSet(readOptions, new StoreMessageReadSet.IOOperationHandler() {
+        @Override
+        public void onSuccess() {
+          BlobStore.this.onSuccess("GET");
+        }
+
+        @Override
+        public void onError() {
+          try {
+            BlobStore.this.onError();
+          } catch (Exception e) {
+          }
+        }
+      });
       // We ensure that the metadata list is ordered with the order of the message read set view that the
       // log provides. This ensures ordering of all messages across the log and metadata from the index.
       List<MessageInfo> messageInfoList = new ArrayList<MessageInfo>(readSet.count());
       for (int i = 0; i < readSet.count(); i++) {
         messageInfoList.add(indexMessages.get(readSet.getKeyAt(i)));
       }
-      onSuccess();
       return new StoreInfo(readSet, messageInfoList);
     } catch (StoreException e) {
       if (e.getErrorCode() == StoreErrorCodes.IOError) {
@@ -520,7 +532,7 @@ public class BlobStore implements Store {
           logger.trace("All entries were absent, and were written to the store successfully");
           break;
       }
-      onSuccess();
+      onSuccess("PUT");
     } catch (StoreException e) {
       if (e.getErrorCode() == StoreErrorCodes.IOError) {
         onError();
@@ -660,7 +672,7 @@ public class BlobStore implements Store {
         }
         logger.trace("Store : {} delete has been marked in the index ", dataDir);
       }
-      onSuccess();
+      onSuccess("DELETE");
     } catch (StoreException e) {
       if (e.getErrorCode() == StoreErrorCodes.IOError) {
         onError();
@@ -776,7 +788,7 @@ public class BlobStore implements Store {
         }
         logger.trace("Store : {} ttl update has been marked in the index ", dataDir);
       }
-      onSuccess();
+      onSuccess("TTL_UPDATE");
     } catch (StoreException e) {
       if (e.getErrorCode() == StoreErrorCodes.IOError) {
         onError();
@@ -862,7 +874,7 @@ public class BlobStore implements Store {
             lifeVersionFromMessageInfo);
         blobStoreStats.handleNewUndeleteEntry(info.getStoreKey(), newUndelete, originalPut, latestValue);
       }
-      onSuccess();
+      onSuccess("UNDELETE");
       return revisedLifeVersion;
     } catch (StoreException e) {
       if (e.getErrorCode() == StoreErrorCodes.IOError) {
@@ -888,7 +900,6 @@ public class BlobStore implements Store {
         remoteTokenTracker.updateTokenFromPeerReplica(token, hostname, remoteReplicaPath);
       }
       FindInfo findInfo = index.findEntriesSince(token, maxTotalSizeOfEntries);
-      onSuccess();
       return findInfo;
     } catch (StoreException e) {
       if (e.getErrorCode() == StoreErrorCodes.IOError) {
@@ -906,7 +917,6 @@ public class BlobStore implements Store {
     final Timer.Context context = metrics.findMissingKeysResponse.time();
     try {
       Set<StoreKey> missingKeys = index.findMissingKeys(keys);
-      onSuccess();
       return missingKeys;
     } catch (StoreException e) {
       if (e.getErrorCode() == StoreErrorCodes.IOError) {
@@ -1146,8 +1156,10 @@ public class BlobStore implements Store {
   /**
    * If store restarted successfully or at least one operation succeeded, reset the error count.
    */
-  private void onSuccess() {
-    errorCount.getAndSet(0);
+  private void onSuccess(String method) {
+    if (errorCount.getAndSet(0) != 0) {
+      logger.info("Store {}: method {} set error count back to 0", storeId, method);
+    }
   }
 
   /**

--- a/ambry-store/src/main/java/com/github/ambry/store/StoreMessageReadSet.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StoreMessageReadSet.java
@@ -191,13 +191,13 @@ class StoreMessageReadSet implements MessageReadSet {
 
   private final List<BlobReadOptions> readOptions;
   private static final Logger logger = LoggerFactory.getLogger(StoreMessageReadSet.class);
-  private final IOOperationHandler handler;
+  private final IOPHandler handler;
 
   StoreMessageReadSet(List<BlobReadOptions> readOptions) {
     this(readOptions, null);
   }
 
-  StoreMessageReadSet(List<BlobReadOptions> readOptions, IOOperationHandler handler) {
+  StoreMessageReadSet(List<BlobReadOptions> readOptions, IOPHandler handler) {
     Collections.sort(readOptions);
     this.readOptions = readOptions;
     this.handler = handler;
@@ -286,9 +286,18 @@ class StoreMessageReadSet implements MessageReadSet {
     return readOptions.get(index).getPrefetchedData();
   }
 
-  public interface IOOperationHandler {
+  /**
+   * Interface to call after dealing with IO operation in the {@link StoreMessageReadSet}.
+   */
+  public interface IOPHandler {
+    /**
+     * Call this method after successfully read bytes for {@link StoreMessageReadSet}.
+     */
     void onSuccess();
 
+    /**
+     * Call this method after failing to read bytes for {@link StoreMessageReadSet}.
+     */
     void onError();
   }
 }

--- a/ambry-store/src/main/java/com/github/ambry/store/StoreMessageReadSet.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StoreMessageReadSet.java
@@ -15,8 +15,8 @@ package com.github.ambry.store;
 
 import com.github.ambry.account.Account;
 import com.github.ambry.account.Container;
-import com.github.ambry.router.AsyncWritableChannel;
 import com.github.ambry.commons.Callback;
+import com.github.ambry.router.AsyncWritableChannel;
 import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.Utils;
@@ -191,10 +191,16 @@ class StoreMessageReadSet implements MessageReadSet {
 
   private final List<BlobReadOptions> readOptions;
   private static final Logger logger = LoggerFactory.getLogger(StoreMessageReadSet.class);
+  private final IOOperationHandler handler;
 
   StoreMessageReadSet(List<BlobReadOptions> readOptions) {
+    this(readOptions, null);
+  }
+
+  StoreMessageReadSet(List<BlobReadOptions> readOptions, IOOperationHandler handler) {
     Collections.sort(readOptions);
     this.readOptions = readOptions;
+    this.handler = handler;
   }
 
   @Override
@@ -264,11 +270,25 @@ class StoreMessageReadSet implements MessageReadSet {
 
   @Override
   public void doPrefetch(int index, long relativeOffset, long size) throws IOException {
-    readOptions.get(index).doPrefetch(relativeOffset, size);
+    try {
+      readOptions.get(index).doPrefetch(relativeOffset, size);
+      handler.onSuccess();
+    } catch (IOException e) {
+      if (e.getMessage().contains("Input/output error")) {
+        handler.onError();
+      }
+      throw e;
+    }
   }
 
   @Override
   public ByteBuf getPrefetchedData(int index) {
     return readOptions.get(index).getPrefetchedData();
+  }
+
+  public interface IOOperationHandler {
+    void onSuccess();
+
+    void onError();
   }
 }

--- a/ambry-store/src/main/java/com/github/ambry/store/StoreMessageReadSet.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StoreMessageReadSet.java
@@ -194,7 +194,7 @@ class StoreMessageReadSet implements MessageReadSet {
   private final IOPHandler handler;
 
   StoreMessageReadSet(List<BlobReadOptions> readOptions) {
-    this(readOptions, null);
+    this(readOptions, IOPHandler.DEFAULT);
   }
 
   StoreMessageReadSet(List<BlobReadOptions> readOptions, IOPHandler handler) {
@@ -299,5 +299,18 @@ class StoreMessageReadSet implements MessageReadSet {
      * Call this method after failing to read bytes for {@link StoreMessageReadSet}.
      */
     void onError();
+
+    /**
+     * A nop implementation of IOPHandler.
+     */
+    IOPHandler DEFAULT = new IOPHandler() {
+      @Override
+      public void onSuccess() {
+      }
+
+      @Override
+      public void onError() {
+      }
+    };
   }
 }

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
@@ -1812,7 +1812,13 @@ public class BlobStoreTest {
     Mockito.reset(mockStoreKeyFactory);
     StoreInfo storeInfo = testStore2.get(Collections.singletonList(id2), EnumSet.noneOf(StoreGetOptions.class));
     assertNotNull(storeInfo);
-    assertEquals("Error count should be reset", 0, testStore2.getErrorCount().get());
+    assertEquals("Error count should not be reset before reading bytes", 2, testStore2.getErrorCount().get());
+    try {
+      storeInfo.getMessageReadSet().doPrefetch(0, 0, 53);
+    } catch (IOException e) {
+      fail("Fail to read bytes from message read set");
+    }
+    assertEquals("Error count should be reset after reading bytes", 0, testStore2.getErrorCount().get());
 
     doThrow(new IOException(StoreException.IO_ERROR_STR)).when(mockStoreKeyFactory)
         .getStoreKey(any(DataInputStream.class));


### PR DESCRIPTION
In BlobStore.get method, it call onSuccess after get method returns a StoreMessageReadSet back to the caller. But get method never performs any io operation to read bytes from disks, so we can't really call onSuccess or onError in get method. We have to call onSuccess and onError after reading the bytes in StoreMessageReadSet.