### PR TITLE
Fix mysql storage usage fetcher bug that fetches monthly base multiple times

### DIFF
--- a/ambry-quota/src/main/java/com/github/ambry/quota/storage/MySqlStorageUsageRefresher.java
+++ b/ambry-quota/src/main/java/com/github/ambry/quota/storage/MySqlStorageUsageRefresher.java
@@ -215,7 +215,20 @@ public class MySqlStorageUsageRefresher implements StorageUsageRefresher {
     } else {
       retries = 0;
       tryPersistMonthlyUsage();
+      // sleep for one second so we can move on to next tick
+      sleepFor(2000);
       scheduleStorageUsageMonthlyBaseFetcher();
+    }
+  }
+
+  /**
+   * Sleep for the given duration
+   * @param durationInMs
+   */
+  private void sleepFor(long durationInMs) {
+    try {
+      Thread.sleep(durationInMs);
+    } catch (Exception e) {
     }
   }
 

--- a/ambry-quota/src/main/java/com/github/ambry/quota/storage/MySqlStorageUsageRefresher.java
+++ b/ambry-quota/src/main/java/com/github/ambry/quota/storage/MySqlStorageUsageRefresher.java
@@ -215,7 +215,7 @@ public class MySqlStorageUsageRefresher implements StorageUsageRefresher {
     } else {
       retries = 0;
       tryPersistMonthlyUsage();
-      // sleep for one second so we can move on to next tick
+      // sleep for two seconds so we can move on to next tick
       sleepFor(2000);
       scheduleStorageUsageMonthlyBaseFetcher();
     }


### PR DESCRIPTION
Before this PR, fetcher would keep fetching storage monthly base
```
2022/06/01 00:10:00.956 INFO [MySqlStorageUsageRefresher] [storage-quota-enforcer0] [ambry-frontend] [] Schedule to fetch container storage monthly base after 0 seconds
2022/06/01 00:10:00.957 INFO [MySqlStorageUsageRefresher] [storage-quota-enforcer0] [ambry-frontend] [] Fetching monthly base from mysql database in periodical thread for this month: 2022-06
2022/06/01 00:10:00.958 INFO [MySqlStorageUsageRefresher] [storage-quota-enforcer0] [ambry-frontend] [] Persisted monthly container usage for 2022-06
2022/06/01 00:10:00.958 INFO [MySqlStorageUsageRefresher] [storage-quota-enforcer0] [ambry-frontend] [] Schedule to fetch container storage monthly base after 0 seconds
2022/06/01 00:10:00.959 INFO [MySqlStorageUsageRefresher] [storage-quota-enforcer0] [ambry-frontend] [] Fetching monthly base from mysql database in periodical thread for this month: 2022-06
2022/06/01 00:10:00.961 INFO [MySqlStorageUsageRefresher] [storage-quota-enforcer0] [ambry-frontend] [] Persisted monthly container usage for 2022-06
2022/06/01 00:10:00.961 INFO [MySqlStorageUsageRefresher] [storage-quota-enforcer0] [ambry-frontend] [] Schedule to fetch container storage monthly base after 0 seconds
2022/06/01 00:10:00.962 INFO [MySqlStorageUsageRefresher] [storage-quota-enforcer0] [ambry-frontend] [] Fetching monthly base from mysql database in periodical thread for this month: 2022-06
2022/06/01 00:10:00.963 INFO [MySqlStorageUsageRefresher] [storage-quota-enforcer0] [ambry-frontend] [] Persisted monthly container usage for 2022-06
2022/06/01 00:10:00.963 INFO [MySqlStorageUsageRefresher] [storage-quota-enforcer0] [ambry-frontend] [] Schedule to fetch container storage monthly base after 0 seconds
```

This PR fixes that.