### PR TITLE
Fix dropped request in http2 network client

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/network/SendWithCorrelationId.java
+++ b/ambry-api/src/main/java/com/github/ambry/network/SendWithCorrelationId.java
@@ -23,4 +23,9 @@ public interface SendWithCorrelationId extends Send {
    * @return the correlation id for the {@link Send} (a process-unique identifier for a request).
    */
   int getCorrelationId();
+
+  /**
+   * @return The type of the request or response.
+   */
+  String getRequestOrResponseType();
 }

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ClientResponseHandler.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ClientResponseHandler.java
@@ -47,15 +47,13 @@ class Http2ClientResponseHandler extends SimpleChannelInboundHandler<FullHttpRes
     ByteBuf dup = msg.content().retainedDuplicate();
     // Consume length
     dup.readLong();
-    RequestInfo requestInfo = ctx.channel().attr(Http2NetworkClient.REQUEST_INFO).get();
+    RequestInfo requestInfo = releaseAndCloseStreamChannel(ctx.channel());
     if (requestInfo != null) {
       // A request maybe just dropped by Http2NetworkClient.
       http2ClientMetrics.http2StreamFirstToAllFrameReadyTime.update(
           System.currentTimeMillis() - requestInfo.getStreamHeaderFrameReceiveTime());
       ResponseInfo responseInfo = new ResponseInfo(requestInfo, null, dup);
       responseInfoQueue.put(responseInfo);
-      // release the stream anyway
-      releaseAndCloseStreamChannel(ctx.channel());
     } else {
       logger.info("Failed to get request from attribute map on channel {}, request maybe dropped", ctx.channel());
       dup.release();

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ClientResponseHandler.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ClientResponseHandler.java
@@ -57,7 +57,7 @@ class Http2ClientResponseHandler extends SimpleChannelInboundHandler<FullHttpRes
       // release the stream anyway
       releaseAndCloseStreamChannel(ctx.channel());
     } else {
-      logger.info("Failed to get request from attribute map, request maybe dropped");
+      logger.info("Failed to get request from attribute map on channel {}, request maybe dropped", ctx.channel());
       dup.release();
     }
   }

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ClientResponseHandler.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ClientResponseHandler.java
@@ -54,9 +54,12 @@ class Http2ClientResponseHandler extends SimpleChannelInboundHandler<FullHttpRes
           System.currentTimeMillis() - requestInfo.getStreamHeaderFrameReceiveTime());
       ResponseInfo responseInfo = new ResponseInfo(requestInfo, null, dup);
       responseInfoQueue.put(responseInfo);
+      // release the stream anyway
+      releaseAndCloseStreamChannel(ctx.channel());
+    } else {
+      logger.info("Failed to get request from attribute map, request maybe dropped");
+      dup.release();
     }
-    // release the stream anyway
-    releaseAndCloseStreamChannel(ctx.channel());
   }
 
   /**

--- a/ambry-network/src/test/java/com/github/ambry/network/SocketNetworkClientTest.java
+++ b/ambry-network/src/test/java/com/github/ambry/network/SocketNetworkClientTest.java
@@ -716,6 +716,11 @@ class MockSend extends AbstractByteBufHolder<MockSend> implements SendWithCorrel
     size = SEND_SIZE;
   }
 
+  @Override
+  public String getRequestOrResponseType() {
+    return "mock";
+  }
+
   /**
    * @return the correlation id of this MockSend.
    */

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/AdminRequest.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/AdminRequest.java
@@ -18,8 +18,6 @@ import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.utils.Utils;
 import java.io.DataInputStream;
 import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.channels.WritableByteChannel;
 
 
 /**

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/RequestOrResponse.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/RequestOrResponse.java
@@ -91,6 +91,11 @@ public abstract class RequestOrResponse extends AbstractByteBufHolder<RequestOrR
   }
 
   @Override
+  public String getRequestOrResponseType() {
+    return type.name();
+  }
+
+  @Override
   public long writeTo(WritableByteChannel channel) throws IOException {
     if (byteBufferToSend == null) {
       prepareBuffer();

--- a/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateManager.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateManager.java
@@ -185,6 +185,7 @@ class TtlUpdateManager {
       }
       routerMetrics.ttlUpdateManagerHandleResponseTimeMs.update(time.milliseconds() - startTime);
     } else {
+      LOGGER.warn("No TtlUpdateOperation found in the set for correlation id: {}", correlationId);
       routerMetrics.ignoredResponseCount.inc();
     }
   }

--- a/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateManager.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateManager.java
@@ -25,7 +25,6 @@ import com.github.ambry.config.RouterConfig;
 import com.github.ambry.network.RequestInfo;
 import com.github.ambry.network.ResponseInfo;
 import com.github.ambry.notification.NotificationSystem;
-import com.github.ambry.protocol.TtlUpdateRequest;
 import com.github.ambry.protocol.TtlUpdateResponse;
 import com.github.ambry.quota.QuotaChargeCallback;
 import com.github.ambry.utils.Pair;
@@ -46,7 +45,7 @@ import org.slf4j.LoggerFactory;
  * operations that are assigned to it, and manages their states and life cycles.
  */
 class TtlUpdateManager {
-  private static final Logger LOGGER = LoggerFactory.getLogger(TtlUpdateOperation.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(TtlUpdateManager.class);
   private final ClusterMap clusterMap;
   private final NotificationSystem notificationSystem;
   private final Time time;
@@ -91,7 +90,8 @@ class TtlUpdateManager {
    * @throws RouterException if the blobIdStr is invalid.
    */
   void submitTtlUpdateOperation(Collection<String> blobIdStrs, String serviceId, long expiresAtMs,
-      FutureResult<Void> futureResult, Callback<Void> callback, QuotaChargeCallback quotaChargeCallback) throws RouterException {
+      FutureResult<Void> futureResult, Callback<Void> callback, QuotaChargeCallback quotaChargeCallback)
+      throws RouterException {
     List<BlobId> blobIds = new ArrayList<>();
     for (String blobIdStr : blobIdStrs) {
       BlobId blobId = RouterUtils.getBlobIdFromString(blobIdStr, clusterMap);
@@ -107,8 +107,8 @@ class TtlUpdateManager {
               time.milliseconds(), callback, time, futureResult, quotaChargeCallback);
       ttlUpdateOperations.add(ttlUpdateOperation);
     } else {
-      BatchOperationCallbackTracker tracker = new BatchOperationCallbackTracker(blobIds, futureResult, callback,
-          quotaChargeCallback);
+      BatchOperationCallbackTracker tracker =
+          new BatchOperationCallbackTracker(blobIds, futureResult, callback, quotaChargeCallback);
       long operationTimeMs = time.milliseconds();
       for (BlobId blobId : blobIds) {
         TtlUpdateOperation ttlUpdateOperation =
@@ -160,8 +160,13 @@ class TtlUpdateManager {
         RouterUtils.extractResponseAndNotifyResponseHandler(responseHandler, routerMetrics, responseInfo,
             TtlUpdateResponse::readFrom, TtlUpdateResponse::getError);
     RequestInfo routerRequestInfo = responseInfo.getRequestInfo();
-    int correlationId = ((TtlUpdateRequest) routerRequestInfo.getRequest()).getCorrelationId();
+    int correlationId = routerRequestInfo.getRequest().getCorrelationId();
     TtlUpdateOperation ttlUpdateOperation = correlationIdToTtlUpdateOperation.remove(correlationId);
+    if (ttlUpdateOperation == null) {
+      LOGGER.warn("No TtlUpdateOperation found for correlation id: {}", correlationId);
+      routerMetrics.ignoredResponseCount.inc();
+      return;
+    }
     // If it is still an active operation, hand over the response. Otherwise, ignore.
     if (ttlUpdateOperations.contains(ttlUpdateOperation)) {
       boolean exceptionEncountered = false;


### PR DESCRIPTION
We are getting NPE in TtlUpdateManager, where a correlation id would point to a null TtlUpdateOperation. The only possible explanation is that we received two responses with the same request. This could only happen when we dropped a request and return the response  and later the real response comes back. 

This PR would close the channel right away after we drop requests.