### PR TITLE
[Frontend] Increase MAX_JSON_REQUEST_SIZE_BYTES_KEY

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/FrontendConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/FrontendConfig.java
@@ -218,7 +218,7 @@ public class FrontendConfig {
    * The maximum size in bytes for the JSON body of a "POST /stitch" request.
    */
   @Config(MAX_JSON_REQUEST_SIZE_BYTES_KEY)
-  @Default("20 * 1024 * 1024")
+  @Default("128 * 1024 * 1024")
   public final int maxJsonRequestSizeBytes;
 
   /**
@@ -314,7 +314,7 @@ public class FrontendConfig {
     maxAcceptableTtlSecsIfTtlRequired = verifiableProperties.getIntInRange(MAX_ACCEPTABLE_TTL_SECS_IF_TTL_REQUIRED_KEY,
         (int) TimeUnit.DAYS.toSeconds(30), 0, Integer.MAX_VALUE);
     maxJsonRequestSizeBytes =
-        verifiableProperties.getIntInRange(MAX_JSON_REQUEST_SIZE_BYTES_KEY, 20 * 1024 * 1024, 0, Integer.MAX_VALUE);
+        verifiableProperties.getIntInRange(MAX_JSON_REQUEST_SIZE_BYTES_KEY, 128 * 1024 * 1024, 0, Integer.MAX_VALUE);
     enableUndelete = verifiableProperties.getBoolean(ENABLE_UNDELETE, false);
     accountStatsStoreFactory =
         verifiableProperties.getString(ACCOUNT_STATS_STORE_FACTORY, DEFAULT_ACCOUNT_STATS_STORE_FACTORY);


### PR DESCRIPTION
This patch increases the MAX_JSON_REQUEST_SIZE_BYTES_KEY from 20mb to
128Mb. This is the maximum size of json sent as part of a stitch
request. The stitch request for 1tb blob is 64mb. Setting it to 128mb
allows 2tb stitch requests.

Tested on localhost mac by uploading a 64mb stitch request.