### PR TITLE
Adds asynchronous methods to CloudBlobStore

### DIFF
--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudDestination.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudDestination.java
@@ -15,6 +15,7 @@ package com.github.ambry.cloud;
 
 import com.github.ambry.account.Container;
 import com.github.ambry.commons.BlobId;
+import com.github.ambry.commons.FutureUtils;
 import com.github.ambry.replication.FindToken;
 import java.io.Closeable;
 import java.io.InputStream;

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudMessageFormatWriteSet.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudMessageFormatWriteSet.java
@@ -16,12 +16,14 @@ package com.github.ambry.cloud;
 import com.github.ambry.cloud.CloudBlobStore.CloudWriteChannel;
 import com.github.ambry.messageformat.MessageFormatWriteSet;
 import com.github.ambry.store.MessageInfo;
-import com.github.ambry.store.StoreException;
-import com.github.ambry.utils.Utils;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicLong;
 
 
 /**
@@ -37,9 +39,17 @@ public class CloudMessageFormatWriteSet extends MessageFormatWriteSet {
    * Write the messages in this set to the given write channel asynchronously
    * @param writeChannel The write interface to write the messages to
    * @return a {@link CompletableFuture} that will eventually contain the size in bytes that was written to the
-   *         write interface or the {@link StoreException} if an error occurred
+   *         write interface or the {@link CloudStorageException} if an error occurred
    */
-  public CompletableFuture<Long> writeAsyncTo(CloudWriteChannel writeChannel) {
-    return Utils.completedExceptionally(new UnsupportedOperationException("Async write operation not supported"));
+  CompletableFuture<Long> writeAsyncTo(CloudWriteChannel writeChannel) {
+    ReadableByteChannel readableByteChannel = Channels.newChannel(streamToWrite);
+    AtomicLong sizeWritten = new AtomicLong();
+    List<CompletableFuture<Void>> operationFutures = new ArrayList<>();
+    for (MessageInfo info : streamInfo) {
+      operationFutures.add(writeChannel.appendAsyncFrom(readableByteChannel, info.getSize())
+          .thenRun(() -> sizeWritten.addAndGet(info.getSize())));
+    }
+    return CompletableFuture.allOf(operationFutures.toArray(new CompletableFuture<?>[0]))
+        .thenApply(unused -> sizeWritten.get());
   }
 }

--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageFormatWriteSet.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageFormatWriteSet.java
@@ -30,8 +30,8 @@ import java.util.List;
  */
 public class MessageFormatWriteSet implements MessageWriteSet {
 
-  private final InputStream streamToWrite;
-  private List<MessageInfo> streamInfo;
+  protected final InputStream streamToWrite;
+  protected List<MessageInfo> streamInfo;
 
   public MessageFormatWriteSet(InputStream streamToWrite, List<MessageInfo> streamInfo, boolean materializeStream)
       throws IOException {


### PR DESCRIPTION
This change adds asynchronous methods for PUT/GET/DELETE/UNDELETE/UPDATE_TTL operations to CloudBlobStore. Currently code is duplicated for these operations in sync and async methods. Will remove the duplicated code in next PR by having sync methods as wrappers over async methods. 

Also re-copied the `CloudDestination` interface changes from open PR [2108](https://github.com/linkedin/ambry/pull/2108/files#diff-7ec7cd8c84b5225b37debb0b611d8283700c6c15b653b77d71463cabd2fb0f60) to help with compilation. Will rebase and remove this file once the other PR is merged.