### PR TITLE
[Frontend] Add metadata cache in router

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
@@ -114,6 +114,8 @@ public class RouterConfig {
   public static final String ROUTER_STORE_KEY_CONVERTER_FACTORY = "router.store.key.converter.factory";
   public static final String ROUTER_UNAVAILABLE_DUE_TO_OFFLINE_REPLICAS = "router.unavailable.due.to.offline.replicas";
   public static final String ROUTER_NOT_FOUND_CACHE_TTL_IN_MS = "router.not.found.cache.ttl.in.ms";
+  private static final String ROUTER_METADATA_CACHE = "router.metadata.cache" ;
+  private static final String ROUTER_METADATA_CACHE_MAX_ITEM_COUNT = "router.metadata.cache.max.item.count";
 
   /**
    * Number of independent scaling units for the router.
@@ -578,6 +580,11 @@ public class RouterConfig {
   @Default("15*1000")
   public final long routerNotFoundCacheTtlInMs;
 
+  @Config(ROUTER_METADATA_CACHE)
+  public final boolean routerMetadataCache;
+
+  @Config(ROUTER_METADATA_CACHE_MAX_ITEM_COUNT)
+  public final int routerMetadataCacheMaxItemCount;
   /**
    * Create a RouterConfig instance.
    * @param verifiableProperties the properties map to refer to.
@@ -643,6 +650,8 @@ public class RouterConfig {
         verifiableProperties.getIntInRange(ROUTER_UNDELETE_REQUEST_PARALLELISM, 3, 1, Integer.MAX_VALUE);
     routerUseGetBlobOperationForBlobInfo =
         verifiableProperties.getBoolean(ROUTER_USE_GET_BLOB_OPERATION_FOR_BLOB_INFO, false);
+    routerMetadataCache = verifiableProperties.getBoolean(ROUTER_METADATA_CACHE, false);
+    routerMetadataCacheMaxItemCount = verifiableProperties.getInt(ROUTER_METADATA_CACHE_MAX_ITEM_COUNT, 100);
     List<String> customPercentiles =
         Utils.splitString(verifiableProperties.getString(ROUTER_OPERATION_TRACKER_CUSTOM_PERCENTILES, ""), ",");
     routerOperationTrackerCustomPercentiles =

--- a/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
@@ -114,7 +114,7 @@ public class RouterConfig {
   public static final String ROUTER_STORE_KEY_CONVERTER_FACTORY = "router.store.key.converter.factory";
   public static final String ROUTER_UNAVAILABLE_DUE_TO_OFFLINE_REPLICAS = "router.unavailable.due.to.offline.replicas";
   public static final String ROUTER_NOT_FOUND_CACHE_TTL_IN_MS = "router.not.found.cache.ttl.in.ms";
-  private static final String ROUTER_METADATA_CACHE = "router.metadata.cache" ;
+  private static final String ROUTER_METADATA_CACHE_ENABLED = "router.metadata.cache.enabled" ;
   private static final String ROUTER_METADATA_CACHE_MAX_ITEM_COUNT = "router.metadata.cache.max.item.count";
 
   /**
@@ -580,11 +580,20 @@ public class RouterConfig {
   @Default("15*1000")
   public final long routerNotFoundCacheTtlInMs;
 
-  @Config(ROUTER_METADATA_CACHE)
-  public final boolean routerMetadataCache;
+  /**
+   * Toggles metadata cache improvement in NonBlockingRouter.
+   * If true, metadata chunk of a composite blob is cached.
+   * If false, there is no caching of metadata chunks.
+   */
+  @Config(ROUTER_METADATA_CACHE_ENABLED)
+  public final boolean routerMetadataCacheEnabled;
 
+  /**
+   * Maximum number of entries in metadata cache in NonBlockingRouter
+   */
   @Config(ROUTER_METADATA_CACHE_MAX_ITEM_COUNT)
   public final int routerMetadataCacheMaxItemCount;
+
   /**
    * Create a RouterConfig instance.
    * @param verifiableProperties the properties map to refer to.
@@ -650,7 +659,7 @@ public class RouterConfig {
         verifiableProperties.getIntInRange(ROUTER_UNDELETE_REQUEST_PARALLELISM, 3, 1, Integer.MAX_VALUE);
     routerUseGetBlobOperationForBlobInfo =
         verifiableProperties.getBoolean(ROUTER_USE_GET_BLOB_OPERATION_FOR_BLOB_INFO, false);
-    routerMetadataCache = verifiableProperties.getBoolean(ROUTER_METADATA_CACHE, false);
+    routerMetadataCacheEnabled = verifiableProperties.getBoolean(ROUTER_METADATA_CACHE_ENABLED, false);
     routerMetadataCacheMaxItemCount = verifiableProperties.getInt(ROUTER_METADATA_CACHE_MAX_ITEM_COUNT, 100);
     List<String> customPercentiles =
         Utils.splitString(verifiableProperties.getString(ROUTER_OPERATION_TRACKER_CUSTOM_PERCENTILES, ""), ",");

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PartitionLayout.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PartitionLayout.java
@@ -269,15 +269,7 @@ public class PartitionLayout {
    */
   public Partition getPartition(InputStream stream) throws IOException {
     byte[] partitionBytes = Partition.readPartitionBytesFromStream(stream);
-    logger.info("Partition bytes from stream: " + deserializePartitionBytes(partitionBytes));
-    logger.info("Partition map state: " + toString());
-    logger.info("Partition map keys: " + partitionMap.keySet().stream().map(key -> deserializePartitionBytes(key.array())).collect(Collectors.joining()));
     return partitionMap.get(ByteBuffer.wrap(partitionBytes));
-  }
-
-  private String deserializePartitionBytes(byte[] bytes) {
-    ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
-    return "Partition version: " + byteBuffer.getShort() + " id: " + byteBuffer.getLong();
   }
 
   public JSONObject toJSONObject() throws JSONException {

--- a/ambry-commons/src/main/java/com/github/ambry/commons/MetadataChunk.java
+++ b/ambry-commons/src/main/java/com/github/ambry/commons/MetadataChunk.java
@@ -1,0 +1,29 @@
+package com.github.ambry.commons;
+
+import com.github.ambry.messageformat.BlobInfo;
+import com.github.ambry.messageformat.CompositeBlobInfo;
+
+public class MetadataChunk {
+
+  private BlobInfo blobInfo;
+  private CompositeBlobInfo compositeBlobInfo;
+
+  public MetadataChunk(CompositeBlobInfo compositeBlobInfo) {
+    this.blobInfo = null;
+    this.compositeBlobInfo = compositeBlobInfo;
+  }
+
+  public MetadataChunk(BlobInfo blobInfo, CompositeBlobInfo compositeBlobInfo) {
+    this.blobInfo = blobInfo;
+    this.compositeBlobInfo = compositeBlobInfo;
+  }
+  
+  public BlobInfo getBlobInfo() {
+    return blobInfo;
+  }
+
+  public CompositeBlobInfo getCompositeBlobInfo() {
+    return compositeBlobInfo;
+  }
+
+}

--- a/ambry-commons/src/main/java/com/github/ambry/commons/MetadataChunk.java
+++ b/ambry-commons/src/main/java/com/github/ambry/commons/MetadataChunk.java
@@ -1,3 +1,17 @@
+/**
+ * Copyright 2022 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 package com.github.ambry.commons;
 
 import com.github.ambry.messageformat.BlobInfo;
@@ -5,25 +19,17 @@ import com.github.ambry.messageformat.CompositeBlobInfo;
 
 public class MetadataChunk {
 
-  private BlobInfo blobInfo;
-  private CompositeBlobInfo compositeBlobInfo;
-
-  public MetadataChunk(CompositeBlobInfo compositeBlobInfo) {
-    this.blobInfo = null;
-    this.compositeBlobInfo = compositeBlobInfo;
-  }
+  private final BlobInfo blobInfo;
+  private final CompositeBlobInfo compositeBlobInfo;
 
   public MetadataChunk(BlobInfo blobInfo, CompositeBlobInfo compositeBlobInfo) {
     this.blobInfo = blobInfo;
     this.compositeBlobInfo = compositeBlobInfo;
   }
-  
-  public BlobInfo getBlobInfo() {
-    return blobInfo;
-  }
 
   public CompositeBlobInfo getCompositeBlobInfo() {
     return compositeBlobInfo;
   }
+  public BlobInfo getBlobInfo() { return blobInfo; }
 
 }

--- a/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouter.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouter.java
@@ -122,7 +122,7 @@ class NonBlockingRouter implements Router {
         .recordStats()
         .build();
     routerMetrics.initializeNotFoundCacheMetrics(notFoundCache);
-    enableMetadataCache = routerConfig.routerMetadataCache;
+    enableMetadataCache = routerConfig.routerMetadataCacheEnabled;
     logger.info("enableMetadataCache = " + enableMetadataCache);
     metadataChunkCache = CacheBuilder.newBuilder()
         .maximumSize(routerConfig.routerMetadataCacheMaxItemCount)

--- a/ambry-router/src/main/java/com/github/ambry/router/OperationController.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/OperationController.java
@@ -16,10 +16,13 @@ package com.github.ambry.router;
 import com.github.ambry.account.AccountService;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.DataNodeId;
+import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.Callback;
+import com.github.ambry.commons.MetadataChunk;
 import com.github.ambry.commons.ResponseHandler;
 import com.github.ambry.config.RouterConfig;
 import com.github.ambry.messageformat.BlobProperties;
+import com.github.ambry.messageformat.CompositeBlobInfo;
 import com.github.ambry.network.NetworkClient;
 import com.github.ambry.network.NetworkClientFactory;
 import com.github.ambry.network.RequestInfo;
@@ -135,7 +138,7 @@ public class OperationController implements Runnable {
             suffix, kms, cryptoService, cryptoJobHandler, accountService, time, defaultPartitionClass);
     getManager =
         new GetManager(clusterMap, responseHandler, routerConfig, routerMetrics, routerCallback, kms, cryptoService,
-            cryptoJobHandler, time);
+            cryptoJobHandler, time, this);
     deleteManager =
         new DeleteManager(clusterMap, responseHandler, accountService, notificationSystem, routerConfig, routerMetrics,
             routerCallback, time);
@@ -545,6 +548,27 @@ public class OperationController implements Runnable {
 
   public Thread getRequestResponseHandlerThread() {
     return requestResponseHandlerThread;
+  }
+
+  public void cacheMetadataChunk(String id, MetadataChunk metadataChunk) {
+    if (this.nonBlockingRouter == null) {
+      return;
+    }
+    this.nonBlockingRouter.cacheMetadataChunk(id, metadataChunk);
+  }
+
+  public MetadataChunk lookupCachedMetadataChunk(String blobIdStr) {
+    if (this.nonBlockingRouter == null) {
+      return null;
+    }
+    return this.nonBlockingRouter.lookupCachedMetadataChunk(blobIdStr);
+  }
+
+  public void eraseCachedMetadataChunk(String blobIdStr) {
+    if (this.nonBlockingRouter == null) {
+      return;
+    }
+    this.nonBlockingRouter.eraseCachedMetadataChunk(blobIdStr);
   }
 }
 

--- a/ambry-router/src/test/java/com/github/ambry/router/CloudOperationTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/CloudOperationTest.java
@@ -53,11 +53,9 @@ import com.github.ambry.store.StoreErrorCodes;
 import com.github.ambry.utils.MockTime;
 import com.github.ambry.utils.NettyByteBufLeakHelper;
 import com.github.ambry.utils.Utils;
-import com.github.ambry.utils.NettyByteBufDataInputStream;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
 import java.nio.ByteBuffer;
-import java.io.DataInputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -366,7 +364,7 @@ public class CloudOperationTest {
     NonBlockingRouter.currentOperationsCount.incrementAndGet();
     GetBlobOperation op =
         new GetBlobOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobId, options, callback,
-            routerCallback, blobIdFactory, null, null, null, time, false, null);
+            routerCallback, blobIdFactory, null, null, null, time, false, null, null);
     requestRegistrationCallback.setRequestsToSend(new ArrayList<>());
 
     // Wait operation to complete

--- a/ambry-router/src/test/java/com/github/ambry/router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/GetBlobOperationTest.java
@@ -54,7 +54,6 @@ import com.github.ambry.protocol.PutRequest;
 import com.github.ambry.quota.QuotaTestUtils;
 import com.github.ambry.rest.RestServiceErrorCode;
 import com.github.ambry.rest.RestServiceException;
-import com.github.ambry.router.RouterTestHelpers.*;
 import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.store.StoreKey;
 import com.github.ambry.utils.ByteBufferChannel;
@@ -339,7 +338,7 @@ public class GetBlobOperationTest {
     GetBlobOperation op = new GetBlobOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobId,
         new GetBlobOptionsInternal(new GetBlobOptionsBuilder().build(), false, routerMetrics.ageAtGet),
         getRouterCallback, routerCallback, blobIdFactory, kms, cryptoService, cryptoJobHandler, time, false,
-        quotaChargeCallback);
+        quotaChargeCallback, null);
     Assert.assertEquals("Callbacks must match", getRouterCallback, op.getCallback());
     Assert.assertEquals("Blob ids must match", blobIdStr, op.getBlobIdStr());
 
@@ -351,7 +350,7 @@ public class GetBlobOperationTest {
       new GetBlobOperation(badConfig, routerMetrics, mockClusterMap, responseHandler, blobId,
           new GetBlobOptionsInternal(new GetBlobOptionsBuilder().build(), false, routerMetrics.ageAtGet),
           getRouterCallback, routerCallback, blobIdFactory, kms, cryptoService, cryptoJobHandler, time, false,
-          quotaChargeCallback);
+          quotaChargeCallback, null);
       Assert.fail("Instantiation of GetBlobOperation with an invalid tracker type must fail");
     } catch (IllegalArgumentException e) {
       // expected. Nothing to do.
@@ -1678,7 +1677,7 @@ public class GetBlobOperationTest {
     NonBlockingRouter.currentOperationsCount.incrementAndGet();
     GetBlobOperation op =
         new GetBlobOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobId, options, callback,
-            routerCallback, blobIdFactory, kms, cryptoService, cryptoJobHandler, time, false, quotaChargeCallback);
+            routerCallback, blobIdFactory, kms, cryptoService, cryptoJobHandler, time, false, quotaChargeCallback, null);
     requestRegistrationCallback.setRequestsToSend(new ArrayList<>());
     return op;
   }

--- a/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTest.java
@@ -1328,7 +1328,7 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
       opHelper = new OperationHelper(OperationType.GET);
       getManager = new GetManager(mockClusterMap, mockResponseHandler, new RouterConfig(verifiableProperties), new NonBlockingRouterMetrics(mockClusterMap, null),
           new RouterCallback(networkClient, new ArrayList<BackgroundDeleteRequest>()), localKMS, cryptoService,
-          cryptoJobHandler, mockTime);
+          cryptoJobHandler, mockTime, null);
       testFailureDetectorNotification(opHelper, networkClient, failedReplicaIds, blobId, successfulResponseCount,
           invalidResponse, -1);
       // Test that if a failed response comes before the operation is completed, failure detector is notified.


### PR DESCRIPTION
This patch adds a cache to save metadata chunks of composite blobs.
The NonBlockingRouter instantiates a volatile MetadataCache. The cache
maps a String blobID to a MetadataChunk object. We use Guava Cache and
configure it to hold a maximum of routerMetadataCacheMaxItemCount items.
Localhost experiments show we save 110-125ms on RANGE requests on
a 1TB blob with range sizes varying from 1MB to 1024MB.