### PR TITLE
[BANDWIDTH_THROTTLING] Create per quota resource metrics to capture if requests would have been throttled.

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/quota/QuotaMetrics.java
+++ b/ambry-api/src/main/java/com/github/ambry/quota/QuotaMetrics.java
@@ -45,6 +45,7 @@ public class QuotaMetrics {
   public final Meter chargeAndRecommendRate;
   public final Counter accountUpdateNotificationCount;
   public Map<String, Counter> perQuotaResourceOutOfQuotaMap = new HashMap<>();
+  public Map<String, Counter> perQuotaResourceWouldBeThrottledMap = new HashMap<>();
   public Map<String, Counter> perQuotaResourceDelayedRequestMap = new HashMap<>();
 
   /**
@@ -90,6 +91,9 @@ public class QuotaMetrics {
       perQuotaResourceOutOfQuotaMap.putIfAbsent(quotaResourceId, metricRegistry.counter(
           MetricRegistry.name(QuotaEnforcer.class,
               String.format("QuotaResource-%s-OutOfQuotaRequestCount", quotaResourceId))));
+      perQuotaResourceWouldBeThrottledMap.putIfAbsent(quotaResourceId, metricRegistry.counter(
+          MetricRegistry.name(QuotaEnforcer.class,
+              String.format("QuotaResource-%s-WouldBeThrottledCount", quotaResourceId))));
     }
   }
 }

--- a/ambry-router/src/test/java/com/github/ambry/router/NonBlockingQuotaTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/NonBlockingQuotaTest.java
@@ -323,6 +323,7 @@ public class NonBlockingQuotaTest extends NonBlockingRouterTestBase {
     try {
       Properties properties = getNonBlockingRouterProperties("DC1");
       properties.setProperty(QuotaConfig.BANDWIDTH_THROTTLING_FEATURE_ENABLED, "true");
+      properties.setProperty(QuotaConfig.REQUEST_THROTTLING_ENABLED, "true");
       properties.setProperty(QuotaConfig.REQUEST_QUOTA_ENFORCER_SOURCE_PAIR_INFO_JSON,
           buildQuotaEnforcerSourceInfoPair());
       properties.setProperty(QuotaConfig.THROTTLING_MODE, quotaMode.name());
@@ -379,12 +380,16 @@ public class NonBlockingQuotaTest extends NonBlockingRouterTestBase {
         }
       } catch (ExecutionException ex) {
         if (quotaMode == QuotaMode.TRACKING) {
-          fail("getBlob should not throw exception if request is be rejected by an enforcer and quota mode is tracking.");
+          fail(
+              "getBlob should not throw exception if request is be rejected by an enforcer and quota mode is tracking.");
         } else {
           Assert.assertEquals(RouterErrorCode.TooManyRequests, ((RouterException) ex.getCause()).getErrorCode());
         }
       }
-      Assert.assertTrue(quotaMetrics.perQuotaResourceOutOfQuotaMap.get(Integer.toString(account.getId())).getCount() > 0);
+      Assert.assertTrue(
+          quotaMetrics.perQuotaResourceOutOfQuotaMap.get(Integer.toString(account.getId())).getCount() > 0);
+      Assert.assertTrue(
+          quotaMetrics.perQuotaResourceWouldBeThrottledMap.get(Integer.toString(account.getId())).getCount() > 0);
       retainingAsyncWritableChannel.consumeContentAsInputStream().close();
     } finally {
       if (router != null) {


### PR DESCRIPTION
These metrics will help when running in TRACKING mode to validate if quota limits in QuotaResources can potentially lead to throttling.

These metrics can be retired when bandwidth quotas are running in THROTTLING mode.