### PR TITLE
Changing SecurityService, IdConverter, Router interface to add CompletableFuture

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/commons/CallbackUtils.java
+++ b/ambry-api/src/main/java/com/github/ambry/commons/CallbackUtils.java
@@ -18,6 +18,7 @@ package com.github.ambry.commons;
 import com.github.ambry.utils.AsyncOperationTracker;
 import com.github.ambry.utils.ThrowingConsumer;
 import com.github.ambry.utils.Utils;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 
@@ -70,5 +71,22 @@ public class CallbackUtils {
   public static <T> void callCallbackAfter(CompletionStage<T> completionStage, Callback<T> callback) {
     completionStage.whenComplete(
         (result, throwable) -> callback.onCompletion(result, Utils.extractFutureExceptionCause(throwable)));
+  }
+
+  /**
+   * Create a callback that would complete the given {@link CompletableFuture} when the corresponding result
+   * comes to callback.
+   * @param future The given {@link CompletableFuture} to complete.
+   * @param <T> The result's type.
+   * @return
+   */
+  public static <T> Callback<T> fromCompletableFuture(CompletableFuture<T> future) {
+    return (result, exception) -> {
+      if (exception != null) {
+        future.completeExceptionally(exception);
+      } else {
+        future.complete(result);
+      }
+    };
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/frontend/IdConverter.java
+++ b/ambry-api/src/main/java/com/github/ambry/frontend/IdConverter.java
@@ -13,10 +13,12 @@
  */
 package com.github.ambry.frontend;
 
+import com.github.ambry.commons.CallbackUtils;
 import com.github.ambry.messageformat.BlobInfo;
 import com.github.ambry.rest.RestRequest;
 import com.github.ambry.commons.Callback;
 import java.io.Closeable;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 
 
@@ -41,11 +43,34 @@ public interface IdConverter extends Closeable {
    * Converts an ID.
    * @param restRequest {@link RestRequest} representing the request.
    * @param input the ID that needs to be converted.
+   * @return a {@link CompletableFuture} that will eventually contain the converted ID.
+   */
+  default CompletableFuture<String> convert(RestRequest restRequest, String input) {
+    CompletableFuture<String> future = new CompletableFuture<>();
+    convert(restRequest, input, CallbackUtils.fromCompletableFuture(future));
+    return future;
+  }
+
+  /**
+   * Converts an ID.
+   * @param restRequest {@link RestRequest} representing the request.
+   * @param input the ID that needs to be converted.
    * @param blobInfo the {@link BlobInfo} for an uploaded blob. Can be null for non-upload use cases.
    * @param callback the {@link Callback} to invoke once the converted ID is available. Can be null.
    * @return a {@link Future} that will eventually contain the converted ID.
    */
   default Future<String> convert(RestRequest restRequest, String input, BlobInfo blobInfo, Callback<String> callback) {
     return convert(restRequest, input, callback);
+  }
+
+  /**
+   * Converts an ID.
+   * @param restRequest {@link RestRequest} representing the request.
+   * @param input the ID that needs to be converted.
+   * @param blobInfo the {@link BlobInfo} for an uploaded blob. Can be null for non-upload use cases.
+   * @return a {@link CompletableFuture} that will eventually contain the converted ID.
+   */
+  default CompletableFuture<String> convert(RestRequest restRequest, String input, BlobInfo blobInfo) {
+    return convert(restRequest, input);
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/frontend/SecurityService.java
+++ b/ambry-api/src/main/java/com/github/ambry/frontend/SecurityService.java
@@ -14,11 +14,12 @@
 package com.github.ambry.frontend;
 
 import com.github.ambry.commons.Callback;
+import com.github.ambry.commons.CallbackUtils;
 import com.github.ambry.messageformat.BlobInfo;
 import com.github.ambry.rest.RestRequest;
 import com.github.ambry.rest.RestResponseChannel;
-import com.github.ambry.router.FutureResult;
 import java.io.Closeable;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 
 
@@ -81,36 +82,36 @@ public interface SecurityService extends Closeable {
    * Similar to {@link #preProcessRequest(RestRequest, Callback)} but returns a {@link Future} instead of requiring
    * a callback.
    * @param restRequest {@link RestRequest} upon which validations has to be performed
-   * @return a {@link Future} that is completed when the pre-processing is done.
+   * @return a {@link CompletableFuture} that is completed when the pre-processing is done.
    */
-  default Future<Void> preProcessRequest(RestRequest restRequest) {
-    FutureResult<Void> futureResult = new FutureResult<>();
-    preProcessRequest(restRequest, futureResult::done);
-    return futureResult;
+  default CompletableFuture<Void> preProcessRequest(RestRequest restRequest) {
+    CompletableFuture<Void> future = new CompletableFuture<>();
+    preProcessRequest(restRequest, CallbackUtils.fromCompletableFuture(future));
+    return future;
   }
 
   /**
    * Similar to {@link #processRequest(RestRequest, Callback)} but returns a {@link Future} instead of requiring
    * a callback.
    * @param restRequest {@link RestRequest} upon which validations has to be performed
-   * @return a {@link Future} that is completed when the processing is done.
+   * @return a {@link CompletableFuture} that is completed when the processing is done.
    */
-  default Future<Void> processRequest(RestRequest restRequest) {
-    FutureResult<Void> futureResult = new FutureResult<>();
-    processRequest(restRequest, futureResult::done);
-    return futureResult;
+  default CompletableFuture<Void> processRequest(RestRequest restRequest) {
+    CompletableFuture<Void> future = new CompletableFuture<>();
+    processRequest(restRequest, CallbackUtils.fromCompletableFuture(future));
+    return future;
   }
 
   /**
    * Similar to {@link #postProcessRequest(RestRequest, Callback)} but returns a {@link Future} instead of requiring
    * a callback.
    * @param restRequest {@link RestRequest} upon which validations has to be performed
-   * @return a {@link Future} that is completed when the post-processing is done.
+   * @return a {@link CompletableFuture} that is completed when the post-processing is done.
    */
-  default Future<Void> postProcessRequest(RestRequest restRequest) {
-    FutureResult<Void> futureResult = new FutureResult<>();
-    postProcessRequest(restRequest, futureResult::done);
-    return futureResult;
+  default CompletableFuture<Void> postProcessRequest(RestRequest restRequest) {
+    CompletableFuture<Void> future = new CompletableFuture<>();
+    postProcessRequest(restRequest, CallbackUtils.fromCompletableFuture(future));
+    return future;
   }
 
   /**
@@ -119,12 +120,12 @@ public interface SecurityService extends Closeable {
    * @param restRequest {@link RestRequest} whose response have to be validated
    * @param responseChannel the {@link RestResponseChannel} over which the response is sent
    * @param blobInfo the {@link BlobInfo} pertaining to the rest request made
-   * @return a {@link Future} that is completed when the processing is done.
+   * @return a {@link CompletableFuture} that is completed when the processing is done.
    */
-  default Future<Void> processResponse(RestRequest restRequest, RestResponseChannel responseChannel,
+  default CompletableFuture<Void> processResponse(RestRequest restRequest, RestResponseChannel responseChannel,
       BlobInfo blobInfo) {
-    FutureResult<Void> futureResult = new FutureResult<>();
-    processResponse(restRequest, responseChannel, blobInfo, futureResult::done);
-    return futureResult;
+    CompletableFuture<Void> future = new CompletableFuture<>();
+    processResponse(restRequest, responseChannel, blobInfo, CallbackUtils.fromCompletableFuture(future));
+    return future;
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/frontend/SecurityService.java
+++ b/ambry-api/src/main/java/com/github/ambry/frontend/SecurityService.java
@@ -79,7 +79,7 @@ public interface SecurityService extends Closeable {
       Callback<Void> callback);
 
   /**
-   * Similar to {@link #preProcessRequest(RestRequest, Callback)} but returns a {@link Future} instead of requiring
+   * Similar to {@link #preProcessRequest(RestRequest, Callback)} but returns a {@link CompletableFuture} instead of requiring
    * a callback.
    * @param restRequest {@link RestRequest} upon which validations has to be performed
    * @return a {@link CompletableFuture} that is completed when the pre-processing is done.
@@ -91,7 +91,7 @@ public interface SecurityService extends Closeable {
   }
 
   /**
-   * Similar to {@link #processRequest(RestRequest, Callback)} but returns a {@link Future} instead of requiring
+   * Similar to {@link #processRequest(RestRequest, Callback)} but returns a {@link CompletableFuture} instead of requiring
    * a callback.
    * @param restRequest {@link RestRequest} upon which validations has to be performed
    * @return a {@link CompletableFuture} that is completed when the processing is done.
@@ -103,7 +103,7 @@ public interface SecurityService extends Closeable {
   }
 
   /**
-   * Similar to {@link #postProcessRequest(RestRequest, Callback)} but returns a {@link Future} instead of requiring
+   * Similar to {@link #postProcessRequest(RestRequest, Callback)} but returns a {@link CompletableFuture} instead of requiring
    * a callback.
    * @param restRequest {@link RestRequest} upon which validations has to be performed
    * @return a {@link CompletableFuture} that is completed when the post-processing is done.
@@ -116,7 +116,7 @@ public interface SecurityService extends Closeable {
 
   /**
    * Similar to {@link #processResponse(RestRequest, RestResponseChannel, BlobInfo, Callback)} but returns a
-   * {@link Future} instead of requiring a callback.
+   * {@link CompletableFuture} instead of requiring a callback.
    * @param restRequest {@link RestRequest} whose response have to be validated
    * @param responseChannel the {@link RestResponseChannel} over which the response is sent
    * @param blobInfo the {@link BlobInfo} pertaining to the rest request made

--- a/ambry-api/src/main/java/com/github/ambry/router/Router.java
+++ b/ambry-api/src/main/java/com/github/ambry/router/Router.java
@@ -14,6 +14,7 @@
 package com.github.ambry.router;
 
 import com.github.ambry.commons.Callback;
+import com.github.ambry.commons.CallbackUtils;
 import com.github.ambry.messageformat.BlobInfo;
 import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.quota.QuotaChargeCallback;
@@ -21,6 +22,7 @@ import com.github.ambry.utils.Utils;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 
 
@@ -129,8 +131,10 @@ public interface Router extends Closeable {
    * @return A future that would eventually contain a {@link GetBlobResult} that can contain either
    *         the {@link BlobInfo}, the {@link ReadableStreamChannel} containing the blob data, or both.
    */
-  default Future<GetBlobResult> getBlob(String blobId, GetBlobOptions options) {
-    return getBlob(blobId, options, null, null);
+  default CompletableFuture<GetBlobResult> getBlob(String blobId, GetBlobOptions options) {
+    CompletableFuture<GetBlobResult> future = new CompletableFuture<>();
+    getBlob(blobId, options, CallbackUtils.fromCompletableFuture(future), null);
+    return future;
   }
 
   /**
@@ -145,8 +149,11 @@ public interface Router extends Closeable {
    *                       fields are set accurately.
    * @return A future that would contain the BlobId eventually.
    */
-  default Future<String> stitchBlob(BlobProperties blobProperties, byte[] userMetadata, List<ChunkInfo> chunksToStitch) {
-    return stitchBlob(blobProperties, userMetadata, chunksToStitch, null, null);
+  default CompletableFuture<String> stitchBlob(BlobProperties blobProperties, byte[] userMetadata,
+      List<ChunkInfo> chunksToStitch) {
+    CompletableFuture<String> future = new CompletableFuture<>();
+    stitchBlob(blobProperties, userMetadata, chunksToStitch, CallbackUtils.fromCompletableFuture(future), null);
+    return future;
   }
 
   /**
@@ -159,9 +166,11 @@ public interface Router extends Closeable {
    * @param options The {@link PutBlobOptions} associated with the request. This cannot be null.
    * @return A future that would contain the BlobId eventually.
    */
-  default Future<String> putBlob(BlobProperties blobProperties, byte[] userMetadata, ReadableStreamChannel channel,
-      PutBlobOptions options) {
-    return putBlob(blobProperties, userMetadata, channel, options, null, null);
+  default CompletableFuture<String> putBlob(BlobProperties blobProperties, byte[] userMetadata,
+      ReadableStreamChannel channel, PutBlobOptions options) {
+    CompletableFuture<String> future = new CompletableFuture<>();
+    putBlob(blobProperties, userMetadata, channel, options, CallbackUtils.fromCompletableFuture(future), null);
+    return future;
   }
 
   /**
@@ -171,8 +180,10 @@ public interface Router extends Closeable {
    * @param serviceId The service ID of the service deleting the blob. This can be null if unknown.
    * @return A future that would contain information about whether the deletion succeeded or not, eventually.
    */
-  default Future<Void> deleteBlob(String blobId, String serviceId) {
-    return deleteBlob(blobId, serviceId, null, null);
+  default CompletableFuture<Void> deleteBlob(String blobId, String serviceId) {
+    CompletableFuture<Void> future = new CompletableFuture<>();
+    deleteBlob(blobId, serviceId, CallbackUtils.fromCompletableFuture(future), null);
+    return future;
   }
 
   /**
@@ -184,8 +195,10 @@ public interface Router extends Closeable {
    *                    permanent
    * @return A future that would contain information about whether the update succeeded or not, eventually.
    */
-  default Future<Void> updateBlobTtl(String blobId, String serviceId, long expiresAtMs) {
-    return updateBlobTtl(blobId, serviceId, expiresAtMs, null, null);
+  default CompletableFuture<Void> updateBlobTtl(String blobId, String serviceId, long expiresAtMs) {
+    CompletableFuture<Void> future = new CompletableFuture<>();
+    updateBlobTtl(blobId, serviceId, expiresAtMs, CallbackUtils.fromCompletableFuture(future), null);
+    return future;
   }
 
   /**
@@ -195,7 +208,9 @@ public interface Router extends Closeable {
    * @param serviceId The service ID of the service undeleting the blob. This can be null if unknown.
    * @return A future that would contain information about whether the undelete succeeded or not, eventually.
    */
-  default Future<Void> undeleteBlob(String blobId, String serviceId) {
-    return undeleteBlob(blobId, serviceId, null, null);
+  default CompletableFuture<Void> undeleteBlob(String blobId, String serviceId) {
+    CompletableFuture<Void> future = new CompletableFuture<>();
+    undeleteBlob(blobId, serviceId, CallbackUtils.fromCompletableFuture(future), null);
+    return future;
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -214,6 +214,32 @@ project(':ambry-api') {
     }
 }
 
+project(':ambry-messageformat') {
+    dependencies {
+        compile project(':ambry-api'),
+                project(':ambry-utils')
+        compile "io.dropwizard.metrics:metrics-core:$metricsVersion"
+        testCompile project(':ambry-test-utils')
+        testCompile project(path: ':ambry-api', configuration: 'testArchives')
+    }
+}
+
+project(':ambry-commons') {
+    dependencies {
+        compile project(':ambry-api'),
+                project(':ambry-messageformat'),
+                project(':ambry-utils')
+        compile "org.conscrypt:conscrypt-openjdk-uber:$conscryptVersion"
+        compile "io.netty:netty-all:$nettyVersion"
+        compile "io.netty:netty-tcnative-boringssl-static:$nettyTcnativeVersion"
+        compile "org.apache.helix:helix-core:$helixVersion"
+        compile "com.github.ben-manes.caffeine:caffeine:3.1.1"
+        testCompile project(':ambry-test-utils')
+        testCompile project(path: ':ambry-clustermap', configuration: 'testArchives')
+    }
+}
+
+
 project(':ambry-account') {
     dependencies {
         compile project(':ambry-api'),
@@ -241,21 +267,6 @@ project(':ambry-clustermap') {
         testCompile project(':ambry-test-utils')
         testCompile project(path: ':ambry-api', configuration: 'testArchives')
 
-    }
-}
-
-project(':ambry-commons') {
-    dependencies {
-        compile project(':ambry-api'),
-                project(':ambry-messageformat'),
-                project(':ambry-utils')
-        compile "org.conscrypt:conscrypt-openjdk-uber:$conscryptVersion"
-        compile "io.netty:netty-all:$nettyVersion"
-        compile "io.netty:netty-tcnative-boringssl-static:$nettyTcnativeVersion"
-        compile "org.apache.helix:helix-core:$helixVersion"
-        compile "com.github.ben-manes.caffeine:caffeine:3.1.1"
-        testCompile project(':ambry-test-utils')
-        testCompile project(path: ':ambry-clustermap', configuration: 'testArchives')
     }
 }
 
@@ -324,15 +335,6 @@ project(':ambry-store') {
     }
 }
 
-project(':ambry-messageformat') {
-    dependencies {
-        compile project(':ambry-api'),
-                project(':ambry-utils')
-        compile "io.dropwizard.metrics:metrics-core:$metricsVersion"
-        testCompile project(':ambry-test-utils')
-        testCompile project(path: ':ambry-api', configuration: 'testArchives')
-    }
-}
 
 project(':ambry-replication') {
     dependencies {


### PR DESCRIPTION
Adding CompletableFuture to SecurityService, Router and IdConverter interface.

With these interface supporting CompletableFuture, we can move FrontRestRequestService's HttpHandlers away from Callback hell and into CompletableFuture.