### PR TITLE
Fixed Cloud VCR sync Helix cluster failure.

### DIFF
--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
@@ -597,6 +597,17 @@ public class HelixClusterManager implements ClusterMap {
   }
 
   /**
+   * @return all the zk connect strings.
+   */
+  public ArrayList<String> getAllDcZkConnectionString() {
+    ArrayList<String> zkStrings = new ArrayList<>();
+    for (DcInfo dcInfo : dcToDcInfo.values()) {
+      zkStrings.add(dcInfo.dcZkInfo.getZkConnectStrs().get(0));
+    }
+    return zkStrings;
+  }
+
+  /**
    * A callback class for {@link HelixClusterChangeHandler} in each dc to update cluster-wide info (i.e partition-to-replica
    * mapping, cluster-wide capacity)
    */


### PR DESCRIPTION
The VCR replication failure is due to Helix update didn't work.
We picked the wrong source Helix Zk connection string. For Azure VCR, we couldn't use local DC Zk String to find the Helix resource. It didn't exist.


1. Patched on Azure VCR node and tested the fix. It replication works now.
2. ./gradlew build locally failed with 24 unit test case. But the existing code has the same issue. Shouldn't be related to the code change. PR test run passed.