### PR TITLE
[Frontend] Ambry blob metadata cache - 1

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
@@ -578,11 +578,30 @@ public class RouterConfig {
   @Default("15*1000")
   public final long routerNotFoundCacheTtlInMs;
 
+  public static final String ROUTER_BLOB_METADATA_CACHE_ID = "router.blob.metadata.cache.id";
+  @Config(ROUTER_BLOB_METADATA_CACHE_ID)
+  public final String routerBlobMetadataCacheId;
+
+  public static final String ROUTER_BLOB_METADATA_CACHE_ENABLED = "router.blob.metadata.cache.enabled";
+  @Config(ROUTER_BLOB_METADATA_CACHE_ENABLED)
+  public final boolean routerBlobMetadataCacheEnabled;
+
+  public static final String ROUTER_BLOB_METADATA_CACHE_MAX_SIZE_BYTES = "router.blob.metadata.cache.max.size.bytes";
+  @Config(ROUTER_BLOB_METADATA_CACHE_MAX_SIZE_BYTES)
+  public final long routerBlobMetadataCacheMaxSizeBytes;
+  long numBytesInOneMb = (long) Math.pow(1024, 2);
+
   /**
    * Create a RouterConfig instance.
    * @param verifiableProperties the properties map to refer to.
    */
   public RouterConfig(VerifiableProperties verifiableProperties) {
+    routerBlobMetadataCacheId =
+        verifiableProperties.getString(ROUTER_BLOB_METADATA_CACHE_ID, "routerBlobMetadataCache");
+    routerBlobMetadataCacheEnabled =
+        verifiableProperties.getBoolean(ROUTER_BLOB_METADATA_CACHE_ENABLED, false);
+    routerBlobMetadataCacheMaxSizeBytes =
+        verifiableProperties.getLong(ROUTER_BLOB_METADATA_CACHE_MAX_SIZE_BYTES, 64 * numBytesInOneMb);
     routerScalingUnitCount = verifiableProperties.getIntInRange(ROUTER_SCALING_UNIT_COUNT, 1, 1, Integer.MAX_VALUE);
     routerHostname = verifiableProperties.getString(ROUTER_HOSTNAME);
     routerDatacenterName = verifiableProperties.getString(ROUTER_DATACENTER_NAME);

--- a/ambry-commons/src/main/java/com/github/ambry/commons/AmbryCache.java
+++ b/ambry-commons/src/main/java/com/github/ambry/commons/AmbryCache.java
@@ -1,0 +1,175 @@
+/**
+ * Copyright 2022 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package com.github.ambry.commons;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Implements a cache that maps a String to AmbryCacheEntry
+ */
+public class AmbryCache {
+
+  private final Cache<String, AmbryCacheEntry> ambryCache;
+  private final MetricRegistry metricRegistry;
+  private static final Logger logger = LoggerFactory.getLogger(AmbryCache.class);
+  private final String cacheId;
+  private boolean cacheEnabled;
+  private long cacheMaxSizeBytes;
+
+  // Cache metrics
+  public Meter getRequestRate;
+  public Meter putRequestRate;
+  public Meter deleteRequestRate;
+  public Histogram getLatencyMs;
+  public Histogram putLatencyMs;
+  public Histogram deleteLatencyMs;
+  public Counter getErrorCount;
+  public Counter putErrorCount;
+  public Counter deleteErrorCount;
+
+  /**
+   * Constructs an instance of AmbryCache
+   * @param cacheId String identifier for this cache
+   * @param cacheEnabled Toggles cache. If true, cache is enabled. Else, cache is disabled.
+   * @param cacheMaxSizeBytes Maximum memory footprint of the cache
+   * @param metricRegistry Instance of metrics registry to record stats
+   */
+  public AmbryCache(String cacheId, boolean cacheEnabled, long cacheMaxSizeBytes, MetricRegistry metricRegistry) {
+    this.cacheId = cacheId;
+    this.cacheEnabled = cacheEnabled;
+    this.cacheMaxSizeBytes = cacheMaxSizeBytes;
+    this.metricRegistry = metricRegistry;
+    this.ambryCache = Caffeine.newBuilder()
+        .maximumWeight(cacheMaxSizeBytes)
+        .weigher((String key, AmbryCacheEntry value) -> key.length() + value.sizeBytes())
+        .recordStats()
+        .build();
+    initializeAmbryCacheMetrics();
+    logger.info("Initialized cache " + this);
+  }
+
+  /**
+   * @return String representation of this cache
+   */
+  public String toString() {
+    String result = "";
+    result += "cacheId=" + cacheId;
+    result += ", cacheEnabled=" + cacheEnabled;
+    result += ", cacheMaxSizeBytes=" + cacheMaxSizeBytes;
+    return result;
+  }
+
+  /**
+   * Puts a key-value pair in the cache
+   * @param key Object for indexing the cache
+   * @param value Payload associated with key
+   * @return True if successful. Else false.
+   */
+  public boolean putObject(String key, AmbryCacheEntry value) {
+
+    if (!cacheEnabled) { return false; }
+
+    putRequestRate.mark();
+    long putStartTime = System.currentTimeMillis();
+    boolean result = false;
+    try {
+      ambryCache.put(key, value);
+      result = true;
+    } catch (Exception exc) {
+      putErrorCount.inc();
+      logger.error("Failed to put cache entry with key " + key + " due to " + exc);
+    } finally {
+      putLatencyMs.update(System.currentTimeMillis() - putStartTime);
+    }
+    return result;
+  }
+
+  /**
+   * Gets a value associated with a key
+   * @param key Object for indexing the cache
+   * @return Value associated with key, if present. Else, return null.
+   */
+  public AmbryCacheEntry getObject(String key) {
+
+    if (!cacheEnabled) { return null; }
+
+    getRequestRate.mark();
+    long getStartTime = System.currentTimeMillis();
+    AmbryCacheEntry result = null;
+    try {
+      result = ambryCache.getIfPresent(key);
+    } catch (Exception exc) {
+      getErrorCount.inc();
+      logger.error("Failed to get cache entry with key " + key + " due to " + exc);
+    } finally {
+      getLatencyMs.update(System.currentTimeMillis() - getStartTime);
+    }
+    return result;
+  }
+
+  /**
+   * Deletes a value associated with a key
+   * @param key Object for indexing the cache
+   * @return True, if delete succeeded. Else, false.
+   */
+  public boolean deleteObject(String key) {
+
+    if (!cacheEnabled) { return false; }
+
+    deleteRequestRate.mark();
+    long deleteStartTime = System.currentTimeMillis();
+    boolean result = false;
+    try {
+      ambryCache.invalidate(key);
+      result = true;
+    } catch (Exception exc) {
+      deleteErrorCount.inc();
+      logger.error("Failed to delete cache entry with key " + key + " due to " + exc);
+    } finally {
+      deleteLatencyMs.update(System.currentTimeMillis() - deleteStartTime);
+    }
+    return result;
+  }
+
+  /**
+   * Initialize metrics for this instance of AmbryCache
+   */
+  private void initializeAmbryCacheMetrics() {
+
+    if (!cacheEnabled) { return; }
+
+    getErrorCount = metricRegistry.counter(MetricRegistry.name(AmbryCache.class, cacheId + "GetErrorCount"));
+    putErrorCount = metricRegistry.counter(MetricRegistry.name(AmbryCache.class, cacheId + "PutErrorCount"));
+    deleteErrorCount = metricRegistry.counter(MetricRegistry.name(AmbryCache.class, cacheId + "DeleteErrorCount"));
+    getLatencyMs = metricRegistry.histogram(MetricRegistry.name(AmbryCache.class, cacheId + "GetLatencyMs"));
+    putLatencyMs = metricRegistry.histogram(MetricRegistry.name(AmbryCache.class, cacheId + "PutLatencyMs"));
+    deleteLatencyMs = metricRegistry.histogram(MetricRegistry.name(AmbryCache.class, cacheId + "DeleteLatencyMs"));
+    getRequestRate = metricRegistry.meter(MetricRegistry.name(AmbryCache.class, cacheId + "GetRequestRate"));
+    putRequestRate = metricRegistry.meter(MetricRegistry.name(AmbryCache.class, cacheId + "PutRequestRate"));
+    deleteRequestRate = metricRegistry.meter(MetricRegistry.name(AmbryCache.class, cacheId + "DeleteRequestRate"));
+    metricRegistry.register(MetricRegistry.name(AmbryCache.class, cacheId + "HitRate"), (Gauge<Double>) () -> ambryCache.stats().hitRate());
+    metricRegistry.register(MetricRegistry.name(AmbryCache.class, cacheId + "MissRate"), (Gauge<Double>) () -> ambryCache.stats().missRate());
+    metricRegistry.register(MetricRegistry.name(AmbryCache.class, cacheId + "NumEntries"), (Gauge<Long>) () -> ambryCache.estimatedSize());
+  }
+}

--- a/ambry-commons/src/main/java/com/github/ambry/commons/AmbryCacheEntry.java
+++ b/ambry-commons/src/main/java/com/github/ambry/commons/AmbryCacheEntry.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2022 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package com.github.ambry.commons;
+
+/**
+ * Implements a generic cache entry for the AmbryCache
+ */
+public interface AmbryCacheEntry {
+
+  /**
+   * @return size of AmbryCacheEntry in bytes
+   */
+  default int sizeBytes() { return 0; }
+}

--- a/ambry-router/src/main/java/com/github/ambry/router/BlobMetadata.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/BlobMetadata.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2022 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package com.github.ambry.router;
+
+import com.github.ambry.commons.AmbryCacheEntry;
+import com.github.ambry.messageformat.BlobInfo;
+import com.github.ambry.messageformat.CompositeBlobInfo;
+
+
+/**
+ * A container for metadata of a composite blob
+ */
+public class BlobMetadata implements AmbryCacheEntry {
+
+  private final String blobId;
+  private final BlobInfo blobInfo;
+  private final CompositeBlobInfo compositeBlobInfo;
+
+  /**
+   * Constructs an instance of blob metadata
+   * @param blobId Unique BlobID for Ambry blob
+   * @param blobInfo Contains blob properties, user metadata, lifeVersion of the blob.
+   * @param compositeBlobInfo Contains list of dataChunk Ids
+   */
+  public BlobMetadata(String blobId, BlobInfo blobInfo, CompositeBlobInfo compositeBlobInfo) {
+    this.blobId = blobId;
+    this.blobInfo = blobInfo;
+    this.compositeBlobInfo = compositeBlobInfo;
+  }
+
+  /**
+   * @return Ambry blobID associated with this blob metadata
+   */
+  public String getBlobId() {
+    return blobId;
+  }
+
+  /**
+   * @return Instance of compositeBlobInfo
+   */
+  public CompositeBlobInfo getCompositeBlobInfo() {
+    return compositeBlobInfo;
+  }
+
+  /**
+   * @return Instance of BlobInfo
+   */
+  public BlobInfo getBlobInfo() {
+    return blobInfo;
+  }
+
+  /**
+   * @return Size of this metadata object in bytes
+   */
+  @Override
+  public int sizeBytes() {
+    // TODO: Implement sizeBytes() for class members
+    return 0;
+  }
+}

--- a/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouter.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouter.java
@@ -15,6 +15,7 @@ package com.github.ambry.router;
 
 import com.github.ambry.account.AccountService;
 import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.commons.AmbryCache;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.Callback;
 import com.github.ambry.commons.ResponseHandler;
@@ -66,6 +67,7 @@ class NonBlockingRouter implements Router {
   private static final int cacheMaxLimit = 1000;
   // Cache to store blob IDs which were not found in servers recently.
   private final Cache<String, Boolean> notFoundCache;
+  private final AmbryCache blobMetadataCache;
 
   /**
    * Constructs a NonBlockingRouter.
@@ -120,6 +122,10 @@ class NonBlockingRouter implements Router {
         .build();
     routerMetrics.initializeNotFoundCacheMetrics(notFoundCache);
     routerMetrics.initializeQuotaOCMetrics(ocList);
+    blobMetadataCache = new AmbryCache(routerConfig.routerBlobMetadataCacheId,
+        routerConfig.routerBlobMetadataCacheEnabled,
+        routerConfig.routerBlobMetadataCacheMaxSizeBytes,
+        routerMetrics.getMetricRegistry());
   }
 
   /**

--- a/build.gradle
+++ b/build.gradle
@@ -252,6 +252,7 @@ project(':ambry-commons') {
         compile "io.netty:netty-all:$nettyVersion"
         compile "io.netty:netty-tcnative-boringssl-static:$nettyTcnativeVersion"
         compile "org.apache.helix:helix-core:$helixVersion"
+        compile "com.github.ben-manes.caffeine:caffeine:3.1.1"
         testCompile project(':ambry-test-utils')
         testCompile project(path: ':ambry-clustermap', configuration: 'testArchives')
     }


### PR DESCRIPTION
This patch adds a cache to the non-blocking router. The cache saves
metadata of composite blobs.