### PR TITLE
Add GetMode in NamedBlobDb to get deleted and expired named blob record

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/named/NamedBlobDb.java
+++ b/ambry-api/src/main/java/com/github/ambry/named/NamedBlobDb.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2020 LinkedIn Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
  */
-
 package com.github.ambry.named;
 
 import com.github.ambry.frontend.Page;
@@ -25,6 +24,39 @@ import java.util.concurrent.CompletableFuture;
 public interface NamedBlobDb {
 
   /**
+   * The mode for get method.
+   */
+  enum GetMode {
+    /**
+     * Return NamedBlobRecord in get method when it's not expired or deleted.
+     */
+    Include_None,
+    /**
+     * Return NamedBlobRecord in get method even if it's deleted.
+     */
+    Include_Deleted,
+    /**
+     * Return NamedBlobRecord in get method even if it's expired.
+     */
+    Include_Expired,
+    /**
+     * Return NamedBlobRecord in get method even if it's deleted or expired.
+     */
+    Include_All
+  }
+
+  /**
+   * Look up a {@link NamedBlobRecord} by name.
+   * @param accountName the name of the account.
+   * @param containerName the name of the container.
+   * @param blobName the name of the blob.
+   * @param mode The {@link GetMode} for this get method.
+   * @return a {@link CompletableFuture} that will eventually contain either the {@link NamedBlobRecord} for the named
+   *         blob or an exception if an error occurred.
+   */
+  CompletableFuture<NamedBlobRecord> get(String accountName, String containerName, String blobName, GetMode mode);
+
+  /**
    * Look up a {@link NamedBlobRecord} by name.
    * @param accountName the name of the account.
    * @param containerName the name of the container.
@@ -32,7 +64,9 @@ public interface NamedBlobDb {
    * @return a {@link CompletableFuture} that will eventually contain either the {@link NamedBlobRecord} for the named
    *         blob or an exception if an error occurred.
    */
-  CompletableFuture<NamedBlobRecord> get(String accountName, String containerName, String blobName);
+  default CompletableFuture<NamedBlobRecord> get(String accountName, String containerName, String blobName) {
+    return get(accountName, containerName, blobName, GetMode.Include_None);
+  }
 
   /**
    * List blobs that start with a provided prefix in a container. This returns paginated results. If there are

--- a/ambry-api/src/main/java/com/github/ambry/named/NamedBlobDb.java
+++ b/ambry-api/src/main/java/com/github/ambry/named/NamedBlobDb.java
@@ -15,6 +15,7 @@
 package com.github.ambry.named;
 
 import com.github.ambry.frontend.Page;
+import com.github.ambry.protocol.GetOption;
 import java.util.concurrent.CompletableFuture;
 
 
@@ -24,37 +25,15 @@ import java.util.concurrent.CompletableFuture;
 public interface NamedBlobDb {
 
   /**
-   * The mode for get method.
-   */
-  enum GetMode {
-    /**
-     * Return NamedBlobRecord in get method when it's not expired or deleted.
-     */
-    Include_None,
-    /**
-     * Return NamedBlobRecord in get method even if it's deleted.
-     */
-    Include_Deleted,
-    /**
-     * Return NamedBlobRecord in get method even if it's expired.
-     */
-    Include_Expired,
-    /**
-     * Return NamedBlobRecord in get method even if it's deleted or expired.
-     */
-    Include_All
-  }
-
-  /**
    * Look up a {@link NamedBlobRecord} by name.
    * @param accountName the name of the account.
    * @param containerName the name of the container.
    * @param blobName the name of the blob.
-   * @param mode The {@link GetMode} for this get method.
+   * @param option The {@link GetOption} for this get method.
    * @return a {@link CompletableFuture} that will eventually contain either the {@link NamedBlobRecord} for the named
    *         blob or an exception if an error occurred.
    */
-  CompletableFuture<NamedBlobRecord> get(String accountName, String containerName, String blobName, GetMode mode);
+  CompletableFuture<NamedBlobRecord> get(String accountName, String containerName, String blobName, GetOption option);
 
   /**
    * Look up a {@link NamedBlobRecord} by name.
@@ -65,7 +44,7 @@ public interface NamedBlobDb {
    *         blob or an exception if an error occurred.
    */
   default CompletableFuture<NamedBlobRecord> get(String accountName, String containerName, String blobName) {
-    return get(accountName, containerName, blobName, GetMode.Include_None);
+    return get(accountName, containerName, blobName, GetOption.None);
   }
 
   /**

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbryIdConverterFactory.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbryIdConverterFactory.java
@@ -33,7 +33,6 @@ import com.github.ambry.rest.RestUtils;
 import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.Utils;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
@@ -66,14 +65,6 @@ public class AmbryIdConverterFactory implements IdConverterFactory {
     private final IdSigningService idSigningService;
     private final NamedBlobDb namedBlobDb;
     private final FrontendMetrics frontendMetrics;
-    private static final Map<GetOption, NamedBlobDb.GetMode> getOptionToGetModeMapping = new HashMap<>();
-
-    static {
-      getOptionToGetModeMapping.put(GetOption.Include_All, NamedBlobDb.GetMode.Include_All);
-      getOptionToGetModeMapping.put(GetOption.Include_Deleted_Blobs, NamedBlobDb.GetMode.Include_Deleted);
-      getOptionToGetModeMapping.put(GetOption.Include_Expired_Blobs, NamedBlobDb.GetMode.Include_Expired);
-      getOptionToGetModeMapping.put(GetOption.None, NamedBlobDb.GetMode.Include_None);
-    }
 
     AmbryIdConverter(IdSigningService idSigningService, NamedBlobDb namedBlobDb, FrontendMetrics frontendMetrics) {
       this.idSigningService = idSigningService;
@@ -172,8 +163,7 @@ public class AmbryIdConverterFactory implements IdConverterFactory {
               namedBlobPath.getBlobName()).thenApply(DeleteResult::getBlobId);
         } else {
           conversionFuture = getNamedBlobDb().get(namedBlobPath.getAccountName(), namedBlobPath.getContainerName(),
-                  namedBlobPath.getBlobName(),
-                  getOptionToGetModeMapping.getOrDefault(getOption, NamedBlobDb.GetMode.Include_None))
+                  namedBlobPath.getBlobName(), , getOption)
               .thenApply(NamedBlobRecord::getBlobId);
         }
       } else if (restRequest.getRestMethod() == RestMethod.PUT && RestUtils.getRequestPath(restRequest)

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbryIdConverterFactory.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbryIdConverterFactory.java
@@ -163,8 +163,7 @@ public class AmbryIdConverterFactory implements IdConverterFactory {
               namedBlobPath.getBlobName()).thenApply(DeleteResult::getBlobId);
         } else {
           conversionFuture = getNamedBlobDb().get(namedBlobPath.getAccountName(), namedBlobPath.getContainerName(),
-                  namedBlobPath.getBlobName(), , getOption)
-              .thenApply(NamedBlobRecord::getBlobId);
+              namedBlobPath.getBlobName(), getOption).thenApply(NamedBlobRecord::getBlobId);
         }
       } else if (restRequest.getRestMethod() == RestMethod.PUT && RestUtils.getRequestPath(restRequest)
           .matchesOperation(Operations.NAMED_BLOB)) {

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/AmbryIdConverterFactoryTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/AmbryIdConverterFactoryTest.java
@@ -26,6 +26,7 @@ import com.github.ambry.named.DeleteResult;
 import com.github.ambry.named.NamedBlobDb;
 import com.github.ambry.named.NamedBlobRecord;
 import com.github.ambry.named.PutResult;
+import com.github.ambry.protocol.GetOption;
 import com.github.ambry.rest.MockRestRequest;
 import com.github.ambry.rest.RequestPath;
 import com.github.ambry.rest.RestMethod;
@@ -117,10 +118,10 @@ public class AmbryIdConverterFactoryTest {
     String outputId = "dummy-id";
     reset(idSigningService);
     reset(namedBlobDb);
-    when(namedBlobDb.get(any(), any(), any())).thenReturn(
+    when(namedBlobDb.get(any(), any(), any(), any())).thenReturn(
         CompletableFuture.completedFuture(new NamedBlobRecord("", "", "", outputId, Utils.Infinite_Time)));
     testConversion(idConverter, RestMethod.GET, null, outputId, NAMED_BLOB_PATH);
-    verify(namedBlobDb).get(ACCOUNT_NAME, CONTAINER_NAME, BLOB_NAME);
+    verify(namedBlobDb).get(ACCOUNT_NAME, CONTAINER_NAME, BLOB_NAME, GetOption.None);
 
     reset(idSigningService);
     reset(namedBlobDb);

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/AmbryIdConverterFactoryTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/AmbryIdConverterFactoryTest.java
@@ -117,7 +117,7 @@ public class AmbryIdConverterFactoryTest {
     String outputId = "dummy-id";
     reset(idSigningService);
     reset(namedBlobDb);
-    when(namedBlobDb.get(any(), any(), any(), any())).thenReturn(
+    when(namedBlobDb.get(any(), any(), any())).thenReturn(
         CompletableFuture.completedFuture(new NamedBlobRecord("", "", "", outputId, Utils.Infinite_Time)));
     testConversion(idConverter, RestMethod.GET, null, outputId, NAMED_BLOB_PATH);
     verify(namedBlobDb).get(ACCOUNT_NAME, CONTAINER_NAME, BLOB_NAME);

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/AmbryIdConverterFactoryTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/AmbryIdConverterFactoryTest.java
@@ -117,10 +117,10 @@ public class AmbryIdConverterFactoryTest {
     String outputId = "dummy-id";
     reset(idSigningService);
     reset(namedBlobDb);
-    when(namedBlobDb.get(any(), any(), any(), any())).thenReturn(
+    when(namedBlobDb.get(any(), any(), any(), , any())).thenReturn(
         CompletableFuture.completedFuture(new NamedBlobRecord("", "", "", outputId, Utils.Infinite_Time)));
     testConversion(idConverter, RestMethod.GET, null, outputId, NAMED_BLOB_PATH);
-    verify(namedBlobDb).get(ACCOUNT_NAME, CONTAINER_NAME, BLOB_NAME, NamedBlobDb.GetMode.Include_None);
+    verify(namedBlobDb).get(ACCOUNT_NAME, CONTAINER_NAME, BLOB_NAME, , NamedBlobDb.GetMode.Include_None);
 
     reset(idSigningService);
     reset(namedBlobDb);

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/AmbryIdConverterFactoryTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/AmbryIdConverterFactoryTest.java
@@ -117,10 +117,10 @@ public class AmbryIdConverterFactoryTest {
     String outputId = "dummy-id";
     reset(idSigningService);
     reset(namedBlobDb);
-    when(namedBlobDb.get(any(), any(), any())).thenReturn(
+    when(namedBlobDb.get(any(), any(), any(), any())).thenReturn(
         CompletableFuture.completedFuture(new NamedBlobRecord("", "", "", outputId, Utils.Infinite_Time)));
     testConversion(idConverter, RestMethod.GET, null, outputId, NAMED_BLOB_PATH);
-    verify(namedBlobDb).get(ACCOUNT_NAME, CONTAINER_NAME, BLOB_NAME);
+    verify(namedBlobDb).get(ACCOUNT_NAME, CONTAINER_NAME, BLOB_NAME, NamedBlobDb.GetMode.Include_None);
 
     reset(idSigningService);
     reset(namedBlobDb);

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/AmbryIdConverterFactoryTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/AmbryIdConverterFactoryTest.java
@@ -117,10 +117,10 @@ public class AmbryIdConverterFactoryTest {
     String outputId = "dummy-id";
     reset(idSigningService);
     reset(namedBlobDb);
-    when(namedBlobDb.get(any(), any(), any(), , any())).thenReturn(
+    when(namedBlobDb.get(any(), any(), any(), any())).thenReturn(
         CompletableFuture.completedFuture(new NamedBlobRecord("", "", "", outputId, Utils.Infinite_Time)));
     testConversion(idConverter, RestMethod.GET, null, outputId, NAMED_BLOB_PATH);
-    verify(namedBlobDb).get(ACCOUNT_NAME, CONTAINER_NAME, BLOB_NAME, , NamedBlobDb.GetMode.Include_None);
+    verify(namedBlobDb).get(ACCOUNT_NAME, CONTAINER_NAME, BLOB_NAME);
 
     reset(idSigningService);
     reset(namedBlobDb);

--- a/ambry-named-mysql/src/main/java/com/github/ambry/named/MySqlNamedBlobDb.java
+++ b/ambry-named-mysql/src/main/java/com/github/ambry/named/MySqlNamedBlobDb.java
@@ -25,6 +25,7 @@ import com.github.ambry.config.MySqlNamedBlobDbConfig;
 import com.github.ambry.frontend.Page;
 import com.github.ambry.mysql.MySqlUtils;
 import com.github.ambry.mysql.MySqlUtils.DbEndpoint;
+import com.github.ambry.protocol.GetOption;
 import com.github.ambry.rest.RestServiceErrorCode;
 import com.github.ambry.rest.RestServiceException;
 import com.github.ambry.utils.Utils;
@@ -76,10 +77,10 @@ class MySqlNamedBlobDb implements NamedBlobDb {
   private static final String IS_DELETED_OR_EXPIRED = "(" + IS_DELETED + " OR " + IS_EXPIRED + ")";
   private static final String PK_MATCH = String.format("(%s, %s, %s) = (?, ?, ?)", ACCOUNT_ID, CONTAINER_ID, BLOB_NAME);
 
-  private static final Set<GetMode> includeDeletedModes =
-      new HashSet<>(Arrays.asList(GetMode.Include_All, GetMode.Include_Deleted));
-  private static final Set<GetMode> includeExpiredModes =
-      new HashSet<>(Arrays.asList(GetMode.Include_All, GetMode.Include_Expired));
+  private static final Set<GetOption> includeDeletedModes =
+      new HashSet<>(Arrays.asList(GetOption.Include_All, GetOption.Include_Deleted_Blobs));
+  private static final Set<GetOption> includeExpiredModes =
+      new HashSet<>(Arrays.asList(GetOption.Include_All, GetOption.Include_Expired_Blobs));
 
   /**
    * Select a record that matches a blob name (lookup by primary key).
@@ -151,7 +152,7 @@ class MySqlNamedBlobDb implements NamedBlobDb {
 
   @Override
   public CompletableFuture<NamedBlobRecord> get(String accountName, String containerName, String blobName,
-      GetMode mode) {
+      GetOption option) {
     TransactionStateTracker transactionStateTracker =
         new GetTransactionStateTracker(remoteDatacenters, localDatacenter);
     return executeTransactionAsync(accountName, containerName, true, (accountId, containerId, connection) -> {
@@ -168,10 +169,10 @@ class MySqlNamedBlobDb implements NamedBlobDb {
           Timestamp expirationTime = resultSet.getTimestamp(2);
           Timestamp deletionTime = resultSet.getTimestamp(3);
           long currentTime = System.currentTimeMillis();
-          if (compareTimestamp(expirationTime, currentTime) <= 0 && !includeExpiredModes.contains(mode)) {
+          if (compareTimestamp(expirationTime, currentTime) <= 0 && !includeExpiredModes.contains(option)) {
             throw buildException("GET: Blob expired", RestServiceErrorCode.Deleted, accountName, containerName,
                 blobName);
-          } else if (compareTimestamp(deletionTime, currentTime) <= 0 && !includeDeletedModes.contains(mode)) {
+          } else if (compareTimestamp(deletionTime, currentTime) <= 0 && !includeDeletedModes.contains(option)) {
             throw buildException("GET: Blob deleted", RestServiceErrorCode.Deleted, accountName, containerName,
                 blobName);
           } else {

--- a/ambry-named-mysql/src/main/java/com/github/ambry/named/MySqlNamedBlobDb.java
+++ b/ambry-named-mysql/src/main/java/com/github/ambry/named/MySqlNamedBlobDb.java
@@ -35,8 +35,11 @@ import java.sql.ResultSet;
 import java.sql.SQLIntegrityConstraintViolationException;
 import java.sql.Timestamp;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -72,6 +75,11 @@ class MySqlNamedBlobDb implements NamedBlobDb {
   private static final String IS_EXPIRED = String.format(CURRENT_TIME_COMPARISON, EXPIRES_TS);
   private static final String IS_DELETED_OR_EXPIRED = "(" + IS_DELETED + " OR " + IS_EXPIRED + ")";
   private static final String PK_MATCH = String.format("(%s, %s, %s) = (?, ?, ?)", ACCOUNT_ID, CONTAINER_ID, BLOB_NAME);
+
+  private static final Set<GetMode> includeDeletedModes =
+      new HashSet<>(Arrays.asList(GetMode.Include_All, GetMode.Include_Deleted));
+  private static final Set<GetMode> includeExpiredModes =
+      new HashSet<>(Arrays.asList(GetMode.Include_All, GetMode.Include_Expired));
 
   /**
    * Select a record that matches a blob name (lookup by primary key).
@@ -142,7 +150,8 @@ class MySqlNamedBlobDb implements NamedBlobDb {
   }
 
   @Override
-  public CompletableFuture<NamedBlobRecord> get(String accountName, String containerName, String blobName) {
+  public CompletableFuture<NamedBlobRecord> get(String accountName, String containerName, String blobName,
+      GetMode mode) {
     TransactionStateTracker transactionStateTracker =
         new GetTransactionStateTracker(remoteDatacenters, localDatacenter);
     return executeTransactionAsync(accountName, containerName, true, (accountId, containerId, connection) -> {
@@ -159,10 +168,10 @@ class MySqlNamedBlobDb implements NamedBlobDb {
           Timestamp expirationTime = resultSet.getTimestamp(2);
           Timestamp deletionTime = resultSet.getTimestamp(3);
           long currentTime = System.currentTimeMillis();
-          if (compareTimestamp(expirationTime, currentTime) <= 0) {
+          if (compareTimestamp(expirationTime, currentTime) <= 0 && !includeExpiredModes.contains(mode)) {
             throw buildException("GET: Blob expired", RestServiceErrorCode.Deleted, accountName, containerName,
                 blobName);
-          } else if (compareTimestamp(deletionTime, currentTime) <= 0) {
+          } else if (compareTimestamp(deletionTime, currentTime) <= 0 && !includeDeletedModes.contains(mode)) {
             throw buildException("GET: Blob deleted", RestServiceErrorCode.Deleted, accountName, containerName,
                 blobName);
           } else {

--- a/ambry-named-mysql/src/test/resources/mysql.properties
+++ b/ambry-named-mysql/src/test/resources/mysql.properties
@@ -9,4 +9,4 @@
 # under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 # CONDITIONS OF ANY KIND, either express or implied.
 #
-mysql.named.blob.db.info=[{"url":"jdbc:mysql://localhost/AmbryNamedBlobs","datacenter":"dc1","isWriteable":"true","username":"travis","password":""}]
+mysql.named.blob.db.info=[{"url":"jdbc:mysql://localhost/AmbryNamedBlobs?serverTimezone=UTC","datacenter":"dc1","isWriteable":"true","username":"travis","password":""}]


### PR DESCRIPTION
In get requests, we can add get-options in the header to fetch deleted and expired regular blob. But we can't do this in the named blob due to NamedBlobDb's lack of support of retrieving deleted and expired named blob record. 

This PR adds that support to NamedBlobDb.