### PR TITLE
Add platform specific build for netty

### DIFF
--- a/ambry-rest/src/test/java/com/github/ambry/rest/NettyRequestTest.java
+++ b/ambry-rest/src/test/java/com/github/ambry/rest/NettyRequestTest.java
@@ -48,6 +48,7 @@ import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.codec.http.cookie.Cookie;
 import io.netty.handler.codec.http.cookie.DefaultCookie;
+import io.netty.handler.ssl.OpenSsl;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslHandler;
@@ -103,6 +104,14 @@ public class NettyRequestTest {
 
   public NettyRequestTest() {
     NettyRequest.bufferWatermark = DEFAULT_WATERMARK;
+  }
+
+  @Test
+  public void testOpenssl() throws Exception {
+    Throwable t = OpenSsl.unavailabilityCause();
+    if (t != null) {
+      throw new Exception(t);
+    }
   }
 
   /**

--- a/build.gradle
+++ b/build.gradle
@@ -178,6 +178,27 @@ subprojects {
     }
 }
 
+ext {
+    osArch = System.getProperty("os.arch")
+    osName = System.getProperty("os.name").toLowerCase()
+    osNameShort = ""
+    if (osName.contains("mac"))
+        osNameShort = "osx"
+    else if (osName.contains("Linux"))
+        osNameShort = "linux"
+    else
+        osNameShort = "windows"
+    osClass = "${osNameShort}_$osArch"
+    osArchNetty = ""
+    if (osArch.contains("aarch"))
+        osArchNetty = "aarch_64" // arm64
+    else
+        osArchNetty = "x86_64"
+    osClassNetty = "${osNameShort}-$osArchNetty"
+    print osClass
+    print osClassNetty
+}
+
 project(':ambry-utils') {
     dependencies {
         compile "io.dropwizard.metrics:metrics-core:$metricsVersion"
@@ -396,7 +417,7 @@ project(':ambry-rest') {
         compile "io.dropwizard.metrics:metrics-jmx:$metricsVersion"
         compile "net.sf.jopt-simple:jopt-simple:$joptSimpleVersion"
         compile "io.netty:netty-all:$nettyVersion"
-        compile "io.netty:netty-tcnative-boringssl-static:$nettyTcnativeVersion"
+        compile "io.netty:netty-tcnative-boringssl-static:$nettyTcnativeVersion:$osClassNetty"
         compile "io.netty:netty-transport-native-epoll:$nettyVersion"
         compile "javax.servlet:javax.servlet-api:$javaxVersion"
         runtimeOnly "org.apache.logging.log4j:log4j-core:$log4jVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -178,31 +178,6 @@ subprojects {
     }
 }
 
-ext {
-    // Get platform specific information
-    osArch = System.getProperty("os.arch")
-    osName = System.getProperty("os.name").toLowerCase()
-    osNameShort = ""
-    if (osName.contains("mac"))
-        osNameShort = "osx"
-    else if (osName.contains("linux"))
-        osNameShort = "linux"
-    else
-        osNameShort = "windows"
-    osClass = "${osNameShort}_$osArch"
-
-    // Netty tcnative has a different string for os arch
-    osArchNetty = ""
-    if (osArch.contains("aarch"))
-        osArchNetty = "aarch_64" // arm64
-    else
-        osArchNetty = "x86_64"
-    osClassNetty = "${osNameShort}-$osArchNetty"
-
-    print osClass
-    print osClassNetty
-}
-
 project(':ambry-utils') {
     dependencies {
         compile "io.dropwizard.metrics:metrics-core:$metricsVersion"
@@ -275,7 +250,11 @@ project(':ambry-commons') {
                 project(':ambry-utils')
         compile "org.conscrypt:conscrypt-openjdk-uber:$conscryptVersion"
         compile "io.netty:netty-all:$nettyVersion"
-        compile "io.netty:netty-tcnative-boringssl-static:$nettyTcnativeVersion"
+        runtime "io.netty:netty-tcnative-boringssl-static:$nettyTcnativeVersion:linux-x86_64"
+        runtime "io.netty:netty-tcnative-boringssl-static:$nettyTcnativeVersion:osx-x86_64"
+        runtime "io.netty:netty-tcnative-boringssl-static:$nettyTcnativeVersion:linux-aarch_64"
+        runtime "io.netty:netty-tcnative-boringssl-static:$nettyTcnativeVersion:osx-aarch_64"
+        runtime "io.netty:netty-tcnative-boringssl-static:$nettyTcnativeVersion:windows-x86_64"
         compile "org.apache.helix:helix-core:$helixVersion"
         compile "com.github.ben-manes.caffeine:caffeine:3.1.1"
         testCompile project(':ambry-test-utils')
@@ -290,7 +269,11 @@ project(':ambry-network') {
                 project(':ambry-commons'),
                 project(':ambry-clustermap')
         compile "io.netty:netty-all:$nettyVersion"
-        compile "io.netty:netty-tcnative-boringssl-static:$nettyTcnativeVersion"
+        runtime "io.netty:netty-tcnative-boringssl-static:$nettyTcnativeVersion:linux-x86_64"
+        runtime "io.netty:netty-tcnative-boringssl-static:$nettyTcnativeVersion:osx-x86_64"
+        runtime "io.netty:netty-tcnative-boringssl-static:$nettyTcnativeVersion:linux-aarch_64"
+        runtime "io.netty:netty-tcnative-boringssl-static:$nettyTcnativeVersion:osx-aarch_64"
+        runtime "io.netty:netty-tcnative-boringssl-static:$nettyTcnativeVersion:windows-x86_64"
         compile "io.netty:netty-transport-native-epoll:$nettyVersion"
         compile "io.dropwizard.metrics:metrics-core:$metricsVersion"
         testCompile project(':ambry-test-utils')
@@ -421,7 +404,11 @@ project(':ambry-rest') {
         compile "io.dropwizard.metrics:metrics-jmx:$metricsVersion"
         compile "net.sf.jopt-simple:jopt-simple:$joptSimpleVersion"
         compile "io.netty:netty-all:$nettyVersion"
-        compile "io.netty:netty-tcnative-boringssl-static:$nettyTcnativeVersion:$osClassNetty"
+        runtime "io.netty:netty-tcnative-boringssl-static:$nettyTcnativeVersion:linux-x86_64"
+        runtime "io.netty:netty-tcnative-boringssl-static:$nettyTcnativeVersion:osx-x86_64"
+        runtime "io.netty:netty-tcnative-boringssl-static:$nettyTcnativeVersion:linux-aarch_64"
+        runtime "io.netty:netty-tcnative-boringssl-static:$nettyTcnativeVersion:osx-aarch_64"
+        runtime "io.netty:netty-tcnative-boringssl-static:$nettyTcnativeVersion:windows-x86_64"
         compile "io.netty:netty-transport-native-epoll:$nettyVersion"
         compile "javax.servlet:javax.servlet-api:$javaxVersion"
         runtimeOnly "org.apache.logging.log4j:log4j-core:$log4jVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -179,22 +179,26 @@ subprojects {
 }
 
 ext {
+    // Get platform specific information
     osArch = System.getProperty("os.arch")
     osName = System.getProperty("os.name").toLowerCase()
     osNameShort = ""
     if (osName.contains("mac"))
         osNameShort = "osx"
-    else if (osName.contains("Linux"))
+    else if (osName.contains("linux"))
         osNameShort = "linux"
     else
         osNameShort = "windows"
     osClass = "${osNameShort}_$osArch"
+
+    // Netty tcnative has a different string for os arch
     osArchNetty = ""
     if (osArch.contains("aarch"))
         osArchNetty = "aarch_64" // arm64
     else
         osArchNetty = "x86_64"
     osClassNetty = "${osNameShort}-$osArchNetty"
+
     print osClass
     print osClassNetty
 }


### PR DESCRIPTION
A quick workaround to re-enable openssl.

Real released war should be built in a linux box so it will eventually include linux-native library.