### PR TITLE
Handle regular http requests in http2 server in ambry-server

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/network/NetworkRequest.java
+++ b/ambry-api/src/main/java/com/github/ambry/network/NetworkRequest.java
@@ -14,6 +14,7 @@
 package com.github.ambry.network;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.http.FullHttpRequest;
 import java.io.InputStream;
 
 
@@ -40,5 +41,13 @@ public interface NetworkRequest {
    */
   default boolean release() {
     return false;
+  }
+
+  default boolean isRegularHttp() {
+    return false;
+  }
+
+  default FullHttpRequest getHttpRequest() {
+    return null;
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/protocol/RequestAPI.java
+++ b/ambry-api/src/main/java/com/github/ambry/protocol/RequestAPI.java
@@ -14,6 +14,7 @@
 package com.github.ambry.protocol;
 
 import com.github.ambry.network.NetworkRequest;
+import io.netty.handler.codec.http.FullHttpRequest;
 import java.io.IOException;
 
 
@@ -28,6 +29,10 @@ public interface RequestAPI {
    * @throws InterruptedException if request processing is interrupted.
    */
   void handleRequests(NetworkRequest request) throws InterruptedException;
+
+  default void handleRegularHttpRequests(FullHttpRequest request) throws IOException, InterruptedException {
+    throw new UnsupportedOperationException("Http request not supported on this node");
+  }
 
   /**
    * Puts a blob into the store. It accepts a blob property, user metadata and the blob

--- a/ambry-api/src/main/java/com/github/ambry/protocol/RequestAPI.java
+++ b/ambry-api/src/main/java/com/github/ambry/protocol/RequestAPI.java
@@ -14,7 +14,6 @@
 package com.github.ambry.protocol;
 
 import com.github.ambry.network.NetworkRequest;
-import io.netty.handler.codec.http.FullHttpRequest;
 import java.io.IOException;
 
 
@@ -30,7 +29,13 @@ public interface RequestAPI {
    */
   void handleRequests(NetworkRequest request) throws InterruptedException;
 
-  default void handleRegularHttpRequests(FullHttpRequest request) throws IOException, InterruptedException {
+  /**
+   * Handle regular http request. This is used when the server is an http server.
+   * @param request The request to handle.
+   * @throws IOException
+   * @throws InterruptedException
+   */
+  default void handleRegularHttpRequests(NetworkRequest request) throws IOException, InterruptedException {
     throw new UnsupportedOperationException("Http request not supported on this node");
   }
 

--- a/ambry-commons/src/main/java/com/github/ambry/commons/ServerMetrics.java
+++ b/ambry-commons/src/main/java/com/github/ambry/commons/ServerMetrics.java
@@ -151,6 +151,12 @@ public class ServerMetrics {
   public final Histogram blobStoreControlResponseSendTimeInMs;
   public final Histogram blobStoreControlRequestTotalTimeInMs;
 
+  public final Histogram regularHttpRequestQueueTimeInMs;
+  public final Histogram regularHttpRequestProcessingTimeInMs;
+  public final Histogram regularHttpResponseQueueTimeInMs;
+  public final Histogram regularHttpResponseSendTimeInMs;
+  public final Histogram regularHttpRequestTotalTimeInMs;
+
   public final Histogram blobSizeInBytes;
   public final Histogram blobUserMetadataSizeInBytes;
 
@@ -422,6 +428,17 @@ public class ServerMetrics {
     blobStoreControlRequestTotalTimeInMs =
         registry.histogram(MetricRegistry.name(requestClass, "BlobStoreControlRequestTotalTimeInMs"));
 
+    regularHttpRequestQueueTimeInMs =
+        registry.histogram(MetricRegistry.name(requestClass, "RegularHttpRequestQueueTimeInMs"));
+    regularHttpRequestProcessingTimeInMs =
+        registry.histogram(MetricRegistry.name(requestClass, "RegularHttpRequestProcessingTimeInMs"));
+    regularHttpResponseQueueTimeInMs =
+        registry.histogram(MetricRegistry.name(requestClass, "RegularHttpResponseQueueTimeInMs"));
+    regularHttpResponseSendTimeInMs =
+        registry.histogram(MetricRegistry.name(requestClass, "RegularHttpResponseSendTimeInMs"));
+    regularHttpRequestTotalTimeInMs =
+        registry.histogram(MetricRegistry.name(requestClass, "RegularHttpRequestTotalTimeInMs"));
+
     blobSizeInBytes = registry.histogram(MetricRegistry.name(requestClass, "BlobSize"));
     blobUserMetadataSizeInBytes = registry.histogram(MetricRegistry.name(requestClass, "BlobUserMetadataSize"));
 
@@ -526,7 +543,7 @@ public class ServerMetrics {
 
   public void updateCrossColoMetadataExchangeBytesRate(String dcName, long bytes) {
     crossColoMetadataExchangeBytesRate.computeIfAbsent(dcName,
-        dc -> registry.meter(MetricRegistry.name(requestClass, dcName + "-CrossColoMetadataExchangeBytesRate")))
+            dc -> registry.meter(MetricRegistry.name(requestClass, dcName + "-CrossColoMetadataExchangeBytesRate")))
         .mark(bytes);
   }
 

--- a/ambry-network/src/main/java/com/github/ambry/network/NettyServerRequest.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/NettyServerRequest.java
@@ -17,6 +17,7 @@ import com.github.ambry.utils.AbstractByteBufHolder;
 import com.github.ambry.utils.NettyByteBufDataInputStream;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.FullHttpRequest;
 import java.io.InputStream;
 
 
@@ -28,11 +29,21 @@ public class NettyServerRequest extends AbstractByteBufHolder<NettyServerRequest
   private final InputStream inputStream;
   private final long startTimeInMs;
   private final ByteBuf content;
+  private final FullHttpRequest request;
 
   public NettyServerRequest(ChannelHandlerContext ctx, ByteBuf content) {
     this.ctx = ctx;
     this.content = content;
     this.inputStream = new NettyByteBufDataInputStream(content);
+    this.request = null;
+    this.startTimeInMs = System.currentTimeMillis();
+  }
+
+  public NettyServerRequest(ChannelHandlerContext ctx, FullHttpRequest request) {
+    this.ctx = ctx;
+    this.content = request.content();
+    this.inputStream = null;
+    this.request = request;
     this.startTimeInMs = System.currentTimeMillis();
   }
 
@@ -48,6 +59,16 @@ public class NettyServerRequest extends AbstractByteBufHolder<NettyServerRequest
   @Override
   public long getStartTimeInMs() {
     return startTimeInMs;
+  }
+
+  @Override
+  public FullHttpRequest getHttpRequest() {
+    return request;
+  }
+
+  @Override
+  public boolean isRegularHttp() {
+    return request != null;
   }
 
   @Override

--- a/ambry-network/src/main/java/com/github/ambry/network/NettyServerRequestResponseChannel.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/NettyServerRequestResponseChannel.java
@@ -91,15 +91,20 @@ public class NettyServerRequestResponseChannel implements RequestResponseChannel
       if (request.equals(EmptyRequest.getInstance())) {
         logger.debug("Request handler {} received shut down command ", request);
       } else {
-        DataInputStream stream = new DataInputStream(request.getInputStream());
-        try {
-          // The first 8 bytes is size of the request. TCP implementation uses this size to allocate buffer. See {@link BoundedReceive}
-          // Here we just need to consume it.
-          stream.readLong();
-        } catch (IOException e) {
-          logger.error("Encountered an error while reading length out, close the connection", e);
-          closeConnection(request);
-          request = null;
+        if (request.isRegularHttp()) {
+          // This is a regular http request
+          break;
+        } else {
+          DataInputStream stream = new DataInputStream(request.getInputStream());
+          try {
+            // The first 8 bytes is size of the request. TCP implementation uses this size to allocate buffer. See {@link BoundedReceive}
+            // Here we just need to consume it.
+            stream.readLong();
+          } catch (IOException e) {
+            logger.error("Encountered an error while reading length out, close the connection", e);
+            closeConnection(request);
+            request = null;
+          }
         }
       }
     }

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/AmbryNetworkRequestHandler.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/AmbryNetworkRequestHandler.java
@@ -44,7 +44,11 @@ public class AmbryNetworkRequestHandler extends SimpleChannelInboundHandler<Full
 
     ByteBuf dup = msg.content().retainedDuplicate();
     try {
-      requestResponseChannel.sendRequest(new NettyServerRequest(ctx, dup));
+      if (msg.uri().equals("/")) {
+        requestResponseChannel.sendRequest(new NettyServerRequest(ctx, dup));
+      } else {
+        requestResponseChannel.sendRequest(new NettyServerRequest(ctx, msg));
+      }
     } catch (InterruptedException e) {
       dup.release();
       http2ServerMetrics.requestResponseChannelErrorCount.inc();

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/HttpResponseSendAdapter.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/HttpResponseSendAdapter.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2022 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.network.http2;
+
+import com.github.ambry.commons.Callback;
+import com.github.ambry.network.Send;
+import com.github.ambry.router.AsyncWritableChannel;
+import com.github.ambry.utils.AbstractByteBufHolder;
+import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import java.io.IOException;
+import java.nio.channels.WritableByteChannel;
+
+
+public class HttpResponseSendAdapter extends AbstractByteBufHolder<HttpResponseSendAdapter> implements Send {
+
+  private final FullHttpResponse response;
+
+  public HttpResponseSendAdapter(FullHttpResponse response) {
+    this.response = response;
+  }
+
+  HttpHeaders getHeaders() {
+    return response.headers();
+  }
+
+  HttpResponseStatus getStatus() {
+    return response.status();
+  }
+
+  @Override
+  public long writeTo(WritableByteChannel channel) throws IOException {
+    return 0;
+  }
+
+  @Override
+  public void writeTo(AsyncWritableChannel channel, Callback<Long> callback) {
+    Send.super.writeTo(channel, callback);
+  }
+
+  @Override
+  public boolean isSendComplete() {
+    return false;
+  }
+
+  @Override
+  public long sizeInBytes() {
+    return 0;
+  }
+
+  @Override
+  public ByteBuf content() {
+    return response.content();
+  }
+
+  @Override
+  public HttpResponseSendAdapter replace(ByteBuf content) {
+    return null;
+  }
+}

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/AmbryRequests.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/AmbryRequests.java
@@ -115,7 +115,7 @@ public class AmbryRequests implements RequestAPI {
   public void handleRequests(NetworkRequest networkRequest) throws InterruptedException {
     try {
       if (networkRequest.isRegularHttp()) {
-        handleRegularHttpRequests(networkRequest.getHttpRequest());
+        handleRegularHttpRequests(networkRequest);
         return;
       }
       RequestOrResponseType type;

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/AmbryRequests.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/AmbryRequests.java
@@ -114,6 +114,10 @@ public class AmbryRequests implements RequestAPI {
   @Override
   public void handleRequests(NetworkRequest networkRequest) throws InterruptedException {
     try {
+      if (networkRequest.isRegularHttp()) {
+        handleRegularHttpRequests(networkRequest.getHttpRequest());
+        return;
+      }
       RequestOrResponseType type;
       if (networkRequest instanceof LocalChannelRequest) {
         RequestOrResponse request =

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryServerRequests.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryServerRequests.java
@@ -49,6 +49,7 @@ import com.github.ambry.store.StoreException;
 import com.github.ambry.store.StoreKeyConverterFactory;
 import com.github.ambry.store.StoreKeyFactory;
 import com.github.ambry.utils.SystemTime;
+import io.netty.handler.codec.http.FullHttpRequest;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.util.Collection;
@@ -234,6 +235,11 @@ public class AmbryServerRequests extends AmbryRequests {
     requestResponseChannel.sendResponse(response, request,
         new ServerNetworkResponseMetrics(responseQueueTimeHistogram, responseSendTimeHistogram,
             requestTotalTimeHistogram, null, null, totalTimeSpent));
+  }
+
+  @Override
+  public void handleRegularHttpRequests(FullHttpRequest request) throws IOException, InterruptedException {
+
   }
 
   /**

--- a/ambry-server/src/main/java/com/github/ambry/server/httphandler/ApiGetHandler.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/httphandler/ApiGetHandler.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2022 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.server.httphandler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Http Handler to return all the supported endpoints.
+ */
+public class ApiGetHandler implements Handler {
+  private static final Logger logger = LoggerFactory.getLogger(ApiGetHandler.class);
+  private final Map<String, String> descriptions = new HashMap<>();
+  private final ByteBuffer jsonSerializedDescriptions;
+
+  public ApiGetHandler() {
+    descriptions.put("POST:/", "handle frontend and replication requests");
+    descriptions.put("GET:/api", "return all supported endpoints");
+
+    ByteBuffer serialized = null;
+    try {
+      String content = new ObjectMapper().writeValueAsString(descriptions);
+      byte[] contentBytes = content.getBytes(StandardCharsets.UTF_8);
+      serialized = ByteBuffer.allocate(contentBytes.length);
+      serialized.put(contentBytes);
+      serialized.flip();
+    } catch (Exception e) {
+      logger.error("Failed to serialize description map to json", e);
+    }
+    jsonSerializedDescriptions = serialized;
+  }
+
+  @Override
+  public FullHttpResponse handle(FullHttpRequest request, FullHttpResponse defaultResponse) {
+    String acceptedEncoding = request.headers().get(HttpHeaderNames.ACCEPT_ENCODING);
+    if (acceptedEncoding != null && !acceptedEncoding.isEmpty() && !acceptedEncoding.toLowerCase()
+        .contains("application/json")) {
+      defaultResponse.setStatus(HttpResponseStatus.BAD_REQUEST);
+      return defaultResponse;
+    }
+    defaultResponse.headers().set(HttpHeaderNames.CONTENT_ENCODING, "application/json");
+    defaultResponse.headers()
+        .set(HttpHeaderNames.CONTENT_LENGTH, String.valueOf(jsonSerializedDescriptions.remaining()));
+    return defaultResponse.replace(Unpooled.wrappedBuffer(jsonSerializedDescriptions.duplicate()));
+  }
+
+  @Override
+  public HttpMethod supportedMethod() {
+    return HttpMethod.GET;
+  }
+
+  @Override
+  public boolean match(FullHttpRequest request) {
+    return request.uri().equals("/api");
+  }
+}

--- a/ambry-server/src/main/java/com/github/ambry/server/httphandler/Handler.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/httphandler/Handler.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2022 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.server.httphandler;
+
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpMethod;
+
+
+/**
+ * Http handler interface. Any http handler has to implement this interface and register
+ * itself in AmbryServerRequests in order to handle the incoming http requests.
+ *
+ * {@link #supportedMethod()} returns the HttpMethod this handler supports. This handler
+ * would be registered to only handle http requests at this {@link HttpMethod}. If this
+ * method returns {@link HttpMethod#GET}, then this handler would only handle Get requests.
+ *
+ * {@link #match} returns true if handler wants to handle the given {@link FullHttpRequest}.
+ * The simplest way is to check the {@link FullHttpRequest#uri()}.
+ *
+ * {@link #handle} method handles the given http request. This method also has a default
+ * response passed into. If you don't have any content to return, then just se the status
+ * and headers in the default response and return the default response back. If you have
+ * content to return, then use {@link FullHttpResponse#replace} to get a new response from
+ * default response.
+ */
+public interface Handler {
+  /**
+   * handle given http request and return a http response.
+   * @param request The given http request.
+   * @param defaultResponse The default http response.
+   * @return A {@link FullHttpResponse}.
+   */
+  FullHttpResponse handle(FullHttpRequest request, FullHttpResponse defaultResponse);
+
+  /**
+   * The {@link HttpMethod} this handler supports
+   * @return The {@link HttpMethod}.
+   */
+  HttpMethod supportedMethod();
+
+  /**
+   * {@code true} if handler wants to handle this request.
+   * @param request The given request
+   * @return True if handler want to handle this request.
+   */
+  boolean match(FullHttpRequest request);
+}

--- a/ambry-server/src/main/java/com/github/ambry/server/httphandler/NotFoundHandler.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/httphandler/NotFoundHandler.java
@@ -1,0 +1,31 @@
+package com.github.ambry.server.httphandler;
+
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
+
+
+/**
+ * NotFoundHandler will be used when there is no handler registered to handle an incoming request,
+ * regardless the HttpMethod.
+ */
+public class NotFoundHandler implements Handler {
+  public static final NotFoundHandler HANDLER = new NotFoundHandler();
+
+  @Override
+  public FullHttpResponse handle(FullHttpRequest request, FullHttpResponse response) {
+    response.setStatus(HttpResponseStatus.NOT_FOUND);
+    return response;
+  }
+
+  @Override
+  public HttpMethod supportedMethod() {
+    return null;
+  }
+
+  @Override
+  public boolean match(FullHttpRequest request) {
+    return true;
+  }
+}


### PR DESCRIPTION
We are adding regular http handlers in ambry-server to handle regular http request.
In order to do that, we have to change a couple interfaces.
1. NetworkRequest
2. RequestAPI


In NetworkRequest, we return an FullHttpRequest from netty when this is a regular http request.
In RequestAPI, we have a method to handle this http request.

NetworkRequest goes through a pipeline from AmbryNetworkRequestHandler to NettyServerRequestResponseChannel, and to RequestHandler and RequestHandlerPool and finally ends up in AmbryServerRequests. 

Once the regular http request reaches the AmbryServerRequests, we need to multiplexing it with different http handlers. Http Handler is created to handle different http requests. To handle new http requests, we have to add new http handlers that handle this request.


Some tests will be added later.
