### PR TITLE
Adding Host State logic to HealthCheck in AdminRequest w/ Tests

### DIFF
--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryServerRequests.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryServerRequests.java
@@ -423,34 +423,26 @@ public class AmbryServerRequests extends AmbryRequests {
    */
   private AdminResponse handleHealthCheckRequest(DataInputStream requestStream, AdminRequest adminRequest)
       throws StoreException, IOException {
-    boolean hostHealthy = true; //used to determine if the host is ever unhealthy
+    boolean hostHealthy = false; //used to determine if the host is ever unhealthy
 
-    //Confirms that the storeManager is instance of StorageManager
-    StorageManager storageManager = null;
+    if (this.storeManager instanceof StorageManager) {
+      StorageManager storageManager = (StorageManager) this.storeManager;
+      hostHealthy = true;
 
-    if(this.storeManager instanceof StorageManager){
-      storageManager = (StorageManager)this.storeManager;
-    }else{
-      hostHealthy = false;
-    }
+      //Finds all replicas of every partition that have this server's hostName
+      List<PartitionId> partitionsInThisHost =Collections.list(storageManager.getPartitionToDiskManager().keys());
 
-    //Finds all replicas of every partition that have this server's hostName
-    List<PartitionId> partitionsInThisHost = hostHealthy ?
-        Collections.list(storageManager.getPartitionToDiskManager().keys()) : null;
-
-    /*
-     * Checks if the Host's BlobStore exists,started and is Leader/Standby ReplicaState for all Partitions
-     * this Host is apart of
-     */
-    if(hostHealthy) {
-
+      /*
+       * Checks if the Host's BlobStore exists,started and is Leader/Standby ReplicaState for all Partitions
+       * this Host is apart of
+       */
       for (PartitionId partitionId : partitionsInThisHost) {
         BlobStore hostBlobStore = (BlobStore) storageManager.getStore(partitionId);
 
         //if any fail, this host isn't healthy
         if (hostBlobStore == null || !hostBlobStore.isStarted() ||
-            ((hostBlobStore.getCurrentState() != ReplicaState.STANDBY) && (
-            hostBlobStore.getCurrentState() != ReplicaState.LEADER))) {
+            ((hostBlobStore.getCurrentState() != ReplicaState.STANDBY) &&
+                (hostBlobStore.getCurrentState() != ReplicaState.LEADER))) {
           hostHealthy = false;
           break;
         }

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryServerRequests.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryServerRequests.java
@@ -464,7 +464,6 @@ public class AmbryServerRequests extends AmbryRequests {
     return new AdminResponseWithContent(adminRequest.getCorrelationId(), adminRequest.getClientId(), error, content);
   }
 
-
   /**
    * Handles admin request that starts BlobStore
    * @param partitionId the {@link PartitionId} associated with BlobStore

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryServerRequests.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryServerRequests.java
@@ -44,23 +44,19 @@ import com.github.ambry.replication.FindTokenHelper;
 import com.github.ambry.replication.ReplicationAPI;
 import com.github.ambry.replication.ReplicationManager;
 import com.github.ambry.store.BlobStore;
-import com.github.ambry.store.DiskManager;
 import com.github.ambry.store.StorageManager;
 import com.github.ambry.store.Store;
 import com.github.ambry.store.StoreException;
 import com.github.ambry.store.StoreKeyConverterFactory;
 import com.github.ambry.store.StoreKeyFactory;
 import com.github.ambry.utils.SystemTime;
-import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
@@ -429,7 +425,7 @@ public class AmbryServerRequests extends AmbryRequests {
       StorageManager storageManager = (StorageManager) this.storeManager;
       hostHealthy = true;
 
-      //Finds all replicas of every partition that have this server's hostName
+      //Finds all partitions on this host
       List<PartitionId> partitionsInThisHost =Collections.list(storageManager.getPartitionToDiskManager().keys());
 
       /*

--- a/ambry-server/src/test/java/com/github/ambry/server/AmbryServerRequestsTest.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/AmbryServerRequestsTest.java
@@ -972,26 +972,21 @@ public class AmbryServerRequestsTest {
           (AdminResponseWithContent) sendRequestGetResponse(adminRequest, ServerErrorCode.No_Error);
 
       assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
-
       assertEquals("Payload was expected to be {\"health\":\"GOOD\"}","{\"health\":\"GOOD\"}",
-          new String(Arrays.copyOfRange(response.getContent(), 0, response.getContent().length),
-              StandardCharsets.UTF_8));
+          new String(response.getContent(),StandardCharsets.UTF_8));
 
       //Test 2: "BAD" response expected where change replicas to error State on this partition
-
       //change all replica states in partition to ERROR
       for(ReplicaId replica : id.getReplicaIds()) {
         storageManager.getStore(replica.getPartitionId()).setCurrentState(ReplicaState.ERROR);
       }
 
       adminRequest = new AdminRequest(AdminRequestOrResponseType.HealthCheck, id, correlationId, clientId);
-      response =
-          (AdminResponseWithContent) sendRequestGetResponse(adminRequest, ServerErrorCode.No_Error);
+      response = (AdminResponseWithContent) sendRequestGetResponse(adminRequest, ServerErrorCode.No_Error);
 
       assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
       assertEquals("Payload was expected to be {\"health\":\"BAD\"}","{\"health\":\"BAD\"}",
-          new String(Arrays.copyOfRange(response.getContent(), 0, response.getContent().length),
-              StandardCharsets.UTF_8));
+          new String(response.getContent(),StandardCharsets.UTF_8));
 
       //restore the state of the Replicas
       for(ReplicaId replica : id.getReplicaIds()) {

--- a/ambry-server/src/test/java/com/github/ambry/server/MockStorageManager.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/MockStorageManager.java
@@ -591,4 +591,17 @@ class MockStorageManager extends StorageManager {
     tokenReceived = null;
     maxTotalSizeOfEntriesReceived = null;
   }
+
+  /**
+   * Starts all test BlobStores
+   * @throws InterruptedException
+   * @throws StoreException
+   */
+  @Override
+  public void start() throws InterruptedException, StoreException {
+    super.start();
+    for(Store store: storeMap.values()){
+      ((TestStore) store).start();
+    }
+  }
 }

--- a/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
@@ -49,7 +49,7 @@ import static com.github.ambry.store.StorageManager.*;
 /**
  * Manages all the stores on a disk.
  */
-class DiskManager {
+public class DiskManager {
 
   private final ConcurrentHashMap<PartitionId, BlobStore> stores = new ConcurrentHashMap<>();
   private final ConcurrentHashMap<PartitionId, ReplicaId> partitionToReplicaMap = new ConcurrentHashMap<>();

--- a/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
@@ -451,6 +451,23 @@ public class StorageManager implements StoreManager {
   }
 
   /**
+   * Getter utility for protected diskToDiskManager
+   * @return diskToDiskManager
+   */
+  public ConcurrentHashMap<DiskId, DiskManager> getDiskToDiskManager(){
+    return diskToDiskManager;
+  }
+
+  /**
+   * Getter utility for protected parititontoDiskManager
+   * @return parititontoDiskManager
+   */
+  public ConcurrentHashMap<PartitionId, DiskManager> getPartitionToDiskManager(){
+    return partitionToDiskManager;
+  }
+
+
+  /**
    * Implementation of {@link PartitionStateChangeListener} to capture state changes and take actions accordingly.
    */
   private class PartitionStateChangeListenerImpl implements PartitionStateChangeListener {

--- a/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
@@ -466,7 +466,6 @@ public class StorageManager implements StoreManager {
     return partitionToDiskManager;
   }
 
-
   /**
    * Implementation of {@link PartitionStateChangeListener} to capture state changes and take actions accordingly.
    */

--- a/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
@@ -180,7 +180,7 @@ public class StorageManager implements StoreManager {
    * Start the {@link DiskManager}s for all disks on this node.
    * @throws InterruptedException
    */
-  public void start() throws InterruptedException {
+  public void start() throws InterruptedException, StoreException {
     long startTimeMs = time.milliseconds();
     try {
       logger.info("Starting storage manager");


### PR DESCRIPTION
Added Host State Logic to account for BlobStore being initialized and Standby/Leader state in order for the host to be considered healthy.
Implemented tests to assess the Host State Logic.
DiskManager and getStore needed to be public in order to reference the class/functions.