### PR TITLE
Check for time outs correctly before dropping a request at Router

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
@@ -33,6 +33,10 @@ public class RouterConfig {
   public static final double DEFAULT_LATENCY_TOLERANCE_QUANTILE = 0.9;
   public static final long DEFAULT_OPERATION_TRACKER_HISTOGRAM_CACHE_TIMEOUT_MS = 1000L;
   public static final long ROUTER_NOT_FOUND_CACHE_MAX_TTL_IN_MS = 24 * 60 * 1000L;
+  public static final int MAX_NETWORK_TIMEOUT_VALUE_FOR_A_REQUEST_IN_MS = 60 * 1000;
+  // This is a theoretical maximum value. Configured value may be much smaller since we might need to respond back to
+  // client with either success or failure much sooner.
+  public static final int MAX_OVERALL_TIMEOUT_VALUE_FOR_A_REQUEST_IN_MS = 60 * 60 * 1000;
 
   // config keys
   public static final String ROUTER_SCALING_UNIT_COUNT = "router.scaling.unit.count";
@@ -631,9 +635,10 @@ public class RouterConfig {
         verifiableProperties.getIntInRange(ROUTER_CONNECTIONS_WARM_UP_TIMEOUT_MS, 5000, 0, Integer.MAX_VALUE);
     routerConnectionCheckoutTimeoutMs =
         verifiableProperties.getIntInRange(ROUTER_CONNECTION_CHECKOUT_TIMEOUT_MS, 1000, 1, 5000);
-    routerRequestTimeoutMs = verifiableProperties.getIntInRange(ROUTER_REQUEST_TIMEOUT_MS, 4000, 1, 60000);
-    routerRequestNetworkTimeoutMs =
-        verifiableProperties.getIntInRange(ROUTER_REQUEST_NETWORK_TIMEOUT_MS, 2000, 1, 30000);
+    routerRequestTimeoutMs = verifiableProperties.getIntInRange(ROUTER_REQUEST_TIMEOUT_MS, 4000, 1,
+        MAX_OVERALL_TIMEOUT_VALUE_FOR_A_REQUEST_IN_MS);
+    routerRequestNetworkTimeoutMs = verifiableProperties.getIntInRange(ROUTER_REQUEST_NETWORK_TIMEOUT_MS, 2000, 1,
+        MAX_NETWORK_TIMEOUT_VALUE_FOR_A_REQUEST_IN_MS);
     routerDropRequestOnTimeout = verifiableProperties.getBoolean(ROUTER_DROP_REQUEST_ON_TIMEOUT, false);
     routerMaxPutChunkSizeBytes =
         verifiableProperties.getIntInRange(ROUTER_MAX_PUT_CHUNK_SIZE_BYTES, 4 * 1024 * 1024, 1, Integer.MAX_VALUE);

--- a/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
@@ -49,6 +49,7 @@ public class RouterConfig {
   public static final String ROUTER_CONNECTIONS_WARM_UP_TIMEOUT_MS = "router.connections.warm.up.timeout.ms";
   public static final String ROUTER_CONNECTION_CHECKOUT_TIMEOUT_MS = "router.connection.checkout.timeout.ms";
   public static final String ROUTER_REQUEST_TIMEOUT_MS = "router.request.timeout.ms";
+  public static final String ROUTER_REQUEST_NETWORK_TIMEOUT_MS = "router.request.network.timeout.ms";
   public static final String ROUTER_DROP_REQUEST_ON_TIMEOUT = "router.drop.request.on.timeout";
   public static final String ROUTER_MAX_PUT_CHUNK_SIZE_BYTES = "router.max.put.chunk.size.bytes";
   public static final String ROUTER_PUT_REQUEST_PARALLELISM = "router.put.request.parallelism";
@@ -182,11 +183,18 @@ public class RouterConfig {
   public final int routerConnectionCheckoutTimeoutMs;
 
   /**
-   * Timeout for requests issued by the router to the network layer.
+   * Timeout for requests waiting at the router layer.
    */
   @Config(ROUTER_REQUEST_TIMEOUT_MS)
-  @Default("2000")
+  @Default("4000")
   public final int routerRequestTimeoutMs;
+
+  /**
+   * Timeout for requests waiting at the network layer.
+   */
+  @Config(ROUTER_REQUEST_NETWORK_TIMEOUT_MS)
+  @Default("2000")
+  public final int routerRequestNetworkTimeoutMs;
 
   /**
    * {@code true} if the router should tell the network layer about requests that have timed out. The network client
@@ -603,8 +611,7 @@ public class RouterConfig {
   public RouterConfig(VerifiableProperties verifiableProperties) {
     routerBlobMetadataCacheId =
         verifiableProperties.getString(ROUTER_BLOB_METADATA_CACHE_ID, "routerBlobMetadataCache");
-    routerBlobMetadataCacheEnabled =
-        verifiableProperties.getBoolean(ROUTER_BLOB_METADATA_CACHE_ENABLED, false);
+    routerBlobMetadataCacheEnabled = verifiableProperties.getBoolean(ROUTER_BLOB_METADATA_CACHE_ENABLED, false);
     routerBlobMetadataCacheMaxSizeBytes =
         verifiableProperties.getLong(ROUTER_BLOB_METADATA_CACHE_MAX_SIZE_BYTES, 64 * NUM_BYTES_IN_ONE_MB);
     routerSmallestBlobForMetadataCache =
@@ -624,7 +631,9 @@ public class RouterConfig {
         verifiableProperties.getIntInRange(ROUTER_CONNECTIONS_WARM_UP_TIMEOUT_MS, 5000, 0, Integer.MAX_VALUE);
     routerConnectionCheckoutTimeoutMs =
         verifiableProperties.getIntInRange(ROUTER_CONNECTION_CHECKOUT_TIMEOUT_MS, 1000, 1, 5000);
-    routerRequestTimeoutMs = verifiableProperties.getIntInRange(ROUTER_REQUEST_TIMEOUT_MS, 2000, 1, 10000);
+    routerRequestTimeoutMs = verifiableProperties.getIntInRange(ROUTER_REQUEST_TIMEOUT_MS, 4000, 1, 60000);
+    routerRequestNetworkTimeoutMs =
+        verifiableProperties.getIntInRange(ROUTER_REQUEST_NETWORK_TIMEOUT_MS, 2000, 1, 30000);
     routerDropRequestOnTimeout = verifiableProperties.getBoolean(ROUTER_DROP_REQUEST_ON_TIMEOUT, false);
     routerMaxPutChunkSizeBytes =
         verifiableProperties.getIntInRange(ROUTER_MAX_PUT_CHUNK_SIZE_BYTES, 4 * 1024 * 1024, 1, Integer.MAX_VALUE);

--- a/ambry-api/src/main/java/com/github/ambry/network/RequestInfo.java
+++ b/ambry-api/src/main/java/com/github/ambry/network/RequestInfo.java
@@ -165,7 +165,7 @@ public class RequestInfo {
    * @return {@code True} if request has been received by network layer.
    */
   public boolean isRequestReceivedByNetworkLayer() {
-    return requestEnqueueTime != 1;
+    return requestEnqueueTime != -1;
   }
 
   @Override

--- a/ambry-api/src/main/java/com/github/ambry/network/RequestInfo.java
+++ b/ambry-api/src/main/java/com/github/ambry/network/RequestInfo.java
@@ -28,6 +28,7 @@ public class RequestInfo {
   private final ReplicaId replicaId;
   private final Chargeable chargeable;
   private final long requestCreateTime;
+  private long requestSendTime = -1;
   private long streamSendTime = -1;
   private long streamHeaderFrameReceiveTime = -1;
   public int responseFramesCount = 0;
@@ -112,5 +113,21 @@ public class RequestInfo {
   public String toString() {
     return "RequestInfo{" + "host='" + host + '\'' + ", port=" + port + ", request=" + request + ", replicaId="
         + replicaId + '}';
+  }
+
+  /**
+   * Get the time at which network client received this request and initiated to send this request.
+   * @return the time in milliseconds.
+   */
+  public long getRequestSendTime() {
+    return requestSendTime;
+  }
+
+  /**
+   * Set the time at which network client received this request and initiated to send this request.
+   * @param requestSendTime time in milliseconds at which request was received by network client.
+   */
+  public void setRequestSendTime(long requestSendTime) {
+    this.requestSendTime = requestSendTime;
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/network/RequestInfo.java
+++ b/ambry-api/src/main/java/com/github/ambry/network/RequestInfo.java
@@ -28,9 +28,9 @@ public class RequestInfo {
   private final ReplicaId replicaId;
   private final Chargeable chargeable;
   private final long requestCreateTime;
+  private long requestEnqueueTime = -1;
   private long requestSendTime = -1;
-  private long streamSendTime = -1;
-  private long streamHeaderFrameReceiveTime = -1;
+  private long responseHeaderReceiveTime = -1;
   public int responseFramesCount = 0;
 
   /**
@@ -49,6 +49,25 @@ public class RequestInfo {
     this.replicaId = replicaId;
     this.chargeable = chargeable;
     requestCreateTime = System.currentTimeMillis();
+  }
+
+  /**
+   * Construct a RequestInfo with the given parameters
+   * @param host the host to which the data is meant for
+   * @param port the port on the host to which the data is meant for
+   * @param request the data to be sent.
+   * @param replicaId the {@link ReplicaId} associated with this request.
+   * @param chargeable the {@link Chargeable} associated with this request.
+   * @param creationTime the creation time of this request in msec.
+   */
+  public RequestInfo(String host, Port port, SendWithCorrelationId request, ReplicaId replicaId, Chargeable chargeable,
+      long creationTime) {
+    this.host = host;
+    this.port = port;
+    this.request = request;
+    this.replicaId = replicaId;
+    this.chargeable = chargeable;
+    requestCreateTime = creationTime;
   }
 
   /**
@@ -86,48 +105,72 @@ public class RequestInfo {
     return replicaId;
   }
 
-  public long getStreamHeaderFrameReceiveTime() {
-    return streamHeaderFrameReceiveTime;
-  }
-
-  public void setStreamHeaderFrameReceiveTime(long streamHeaderFrameReceiveTime) {
-    this.streamHeaderFrameReceiveTime = streamHeaderFrameReceiveTime;
-  }
-
-  public long getStreamSendTime() {
-    return streamSendTime;
-  }
-
-  public void setStreamSendTime(long streamSendTime) {
-    this.streamSendTime = streamSendTime;
-  }
-
   /**
-   * @return creation time of this request in msec.
+   * @return time in msec at which this request was created.
    */
   public long getRequestCreateTime() {
     return requestCreateTime;
   }
 
-  @Override
-  public String toString() {
-    return "RequestInfo{" + "host='" + host + '\'' + ", port=" + port + ", request=" + request + ", replicaId="
-        + replicaId + '}';
+  /**
+   * Set the time at which request was received and enqueued at network layer.
+   * @param requestEnqueueTime time in msec.
+   */
+  public void setRequestEnqueueTime(long requestEnqueueTime) {
+    this.requestEnqueueTime = requestEnqueueTime;
   }
 
   /**
-   * Get the time at which network client received this request and initiated to send this request.
-   * @return the time in milliseconds.
+   * @return the time in msec at which request was received and enqueued at network layer. If it is -1, it means that
+   * network layer didn't receive this request yet from router.
+   */
+  public long getRequestEnqueueTime() {
+    return requestEnqueueTime;
+  }
+
+  /**
+   * Set the time in msec at which request was sent out.
+   * @param requestSendTime in msec.
+   */
+  public void setRequestSendTime(long requestSendTime) {
+    this.requestSendTime = requestSendTime;
+  }
+
+  /**
+   * @return the time in msec at which request was sent out. If it is -1, it means that request is not yet sent out of
+   * network layer.
    */
   public long getRequestSendTime() {
     return requestSendTime;
   }
 
   /**
-   * Set the time at which network client received this request and initiated to send this request.
-   * @param requestSendTime time in milliseconds at which request was received by network client.
+   * Set the time in msec at which response header is received. For HTTP2, this is the time at which first response
+   * header frame is received.
+   * @param responseHeaderReceiveTime in msec.
    */
-  public void setRequestSendTime(long requestSendTime) {
-    this.requestSendTime = requestSendTime;
+  public void setResponseHeaderReceiveTime(long responseHeaderReceiveTime) {
+    this.responseHeaderReceiveTime = responseHeaderReceiveTime;
+  }
+
+  /**
+   * @return the time in msec at which response header is received. For HTTP2, this is the time at which first response
+   * header frame is received. If it is -1, it means that response is not yet received.
+   */
+  public long getResponseHeaderReceiveTime() {
+    return responseHeaderReceiveTime;
+  }
+
+  /**
+   * @return {@code True} if request has been received by network layer.
+   */
+  public boolean isRequestReceivedByNetworkLayer() {
+    return requestEnqueueTime != 1;
+  }
+
+  @Override
+  public String toString() {
+    return "RequestInfo{" + "host='" + host + '\'' + ", port=" + port + ", request=" + request + ", replicaId="
+        + replicaId + '}';
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/network/RequestInfo.java
+++ b/ambry-api/src/main/java/com/github/ambry/network/RequestInfo.java
@@ -40,24 +40,6 @@ public class RequestInfo {
    * @param request the data to be sent.
    * @param replicaId the {@link ReplicaId} associated with this request.
    * @param chargeable the {@link Chargeable} associated with this request.
-   */
-  public RequestInfo(String host, Port port, SendWithCorrelationId request, ReplicaId replicaId,
-      Chargeable chargeable) {
-    this.host = host;
-    this.port = port;
-    this.request = request;
-    this.replicaId = replicaId;
-    this.chargeable = chargeable;
-    requestCreateTime = System.currentTimeMillis();
-  }
-
-  /**
-   * Construct a RequestInfo with the given parameters
-   * @param host the host to which the data is meant for
-   * @param port the port on the host to which the data is meant for
-   * @param request the data to be sent.
-   * @param replicaId the {@link ReplicaId} associated with this request.
-   * @param chargeable the {@link Chargeable} associated with this request.
    * @param creationTime the creation time of this request in msec.
    */
   public RequestInfo(String host, Port port, SendWithCorrelationId request, ReplicaId replicaId, Chargeable chargeable,
@@ -68,6 +50,19 @@ public class RequestInfo {
     this.replicaId = replicaId;
     this.chargeable = chargeable;
     requestCreateTime = creationTime;
+  }
+
+  /**
+   * Construct a RequestInfo with the given parameters
+   * @param host the host to which the data is meant for
+   * @param port the port on the host to which the data is meant for
+   * @param request the data to be sent.
+   * @param replicaId the {@link ReplicaId} associated with this request.
+   * @param chargeable the {@link Chargeable} associated with this request.
+   */
+  public RequestInfo(String host, Port port, SendWithCorrelationId request, ReplicaId replicaId,
+      Chargeable chargeable) {
+    this(host, port, request, replicaId, chargeable, System.currentTimeMillis());
   }
 
   /**

--- a/ambry-network/src/main/java/com/github/ambry/network/LocalNetworkClient.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/LocalNetworkClient.java
@@ -78,6 +78,7 @@ public class LocalNetworkClient implements NetworkClient {
       // Request is sent and received as it is without serializing to stream since they are handled in same process via
       // local queues.
       try {
+        requestInfo.setRequestSendTime(System.currentTimeMillis());
         channel.sendRequest(new LocalChannelRequest(requestInfo, processorId));
       } catch (Exception e) {
         logger.error("Received an unexpected error during sendAndPoll(): ", e);

--- a/ambry-network/src/main/java/com/github/ambry/network/LocalNetworkClient.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/LocalNetworkClient.java
@@ -78,7 +78,7 @@ public class LocalNetworkClient implements NetworkClient {
       // Request is sent and received as it is without serializing to stream since they are handled in same process via
       // local queues.
       try {
-        requestInfo.setRequestSendTime(System.currentTimeMillis());
+        requestInfo.setRequestEnqueueTime(System.currentTimeMillis());
         channel.sendRequest(new LocalChannelRequest(requestInfo, processorId));
       } catch (Exception e) {
         logger.error("Received an unexpected error during sendAndPoll(): ", e);

--- a/ambry-network/src/main/java/com/github/ambry/network/SocketNetworkClient.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/SocketNetworkClient.java
@@ -112,6 +112,7 @@ public class SocketNetworkClient implements NetworkClient {
     List<NetworkSend> sends = null;
     try {
       for (RequestInfo requestInfo : requestsToSend) {
+        requestInfo.setRequestSendTime(System.currentTimeMillis());
         pendingRequests.add(new RequestMetadata(requestInfo));
       }
       sends = prepareSends(requestsToDrop, responseInfoList);

--- a/ambry-network/src/main/java/com/github/ambry/network/SocketNetworkClient.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/SocketNetworkClient.java
@@ -112,7 +112,7 @@ public class SocketNetworkClient implements NetworkClient {
     List<NetworkSend> sends = null;
     try {
       for (RequestInfo requestInfo : requestsToSend) {
-        requestInfo.setRequestSendTime(System.currentTimeMillis());
+        requestInfo.setRequestEnqueueTime(System.currentTimeMillis());
         pendingRequests.add(new RequestMetadata(requestInfo));
       }
       sends = prepareSends(requestsToDrop, responseInfoList);

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ClientResponseHandler.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ClientResponseHandler.java
@@ -51,7 +51,7 @@ class Http2ClientResponseHandler extends SimpleChannelInboundHandler<FullHttpRes
     if (requestInfo != null) {
       // A request maybe just dropped by Http2NetworkClient.
       http2ClientMetrics.http2StreamFirstToAllFrameReadyTime.update(
-          System.currentTimeMillis() - requestInfo.getStreamHeaderFrameReceiveTime());
+          System.currentTimeMillis() - requestInfo.getResponseHeaderReceiveTime());
       ResponseInfo responseInfo = new ResponseInfo(requestInfo, null, dup);
       responseInfoQueue.put(responseInfo);
     } else {

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ClientStreamStatsHandler.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ClientStreamStatsHandler.java
@@ -44,10 +44,10 @@ class Http2ClientStreamStatsHandler extends SimpleChannelInboundHandler<Http2Fra
     RequestInfo requestInfo = ctx.channel().attr(Http2NetworkClient.REQUEST_INFO).get();
     if (requestInfo != null) {
       requestInfo.responseFramesCount++;
-      long time = System.currentTimeMillis() - requestInfo.getStreamSendTime();
+      long time = System.currentTimeMillis() - requestInfo.getRequestSendTime();
       if (frame instanceof Http2HeadersFrame) {
         http2ClientMetrics.http2StreamRoundTripTime.update(time);
-        requestInfo.setStreamHeaderFrameReceiveTime(System.currentTimeMillis());
+        requestInfo.setResponseHeaderReceiveTime(System.currentTimeMillis());
         logger.debug("Header Frame received. Time from send: {}ms. Request: {}", time, requestInfo);
       } else if (frame instanceof Http2DataFrame) {
         logger.debug("Data Frame size: {}. Time from send: {}ms. Request: {}",

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2NetworkClient.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2NetworkClient.java
@@ -110,10 +110,9 @@ public class Http2NetworkClient implements NetworkClient {
     http2ClientMetrics.http2ClientSendRate.mark(requestsToSend.size());
     for (RequestInfo requestInfo : requestsToSend) {
       long streamInitiateTime = System.currentTimeMillis();
-
       long waitingTime = streamInitiateTime - requestInfo.getRequestCreateTime();
       http2ClientMetrics.requestToNetworkClientLatencyMs.update(waitingTime);
-
+      requestInfo.setRequestSendTime(streamInitiateTime);
       this.pools.get(InetSocketAddress.createUnresolved(requestInfo.getHost(), requestInfo.getPort().getPort()))
           .acquire()
           .addListener((GenericFutureListener<Future<Channel>>) future -> {

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2NetworkClient.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2NetworkClient.java
@@ -112,7 +112,7 @@ public class Http2NetworkClient implements NetworkClient {
       long streamInitiateTime = System.currentTimeMillis();
       long waitingTime = streamInitiateTime - requestInfo.getRequestCreateTime();
       http2ClientMetrics.requestToNetworkClientLatencyMs.update(waitingTime);
-      requestInfo.setRequestSendTime(streamInitiateTime);
+      requestInfo.setRequestEnqueueTime(streamInitiateTime);
       this.pools.get(InetSocketAddress.createUnresolved(requestInfo.getHost(), requestInfo.getPort().getPort()))
           .acquire()
           .addListener((GenericFutureListener<Future<Channel>>) future -> {
@@ -135,7 +135,7 @@ public class Http2NetworkClient implements NetworkClient {
                   if (future.isSuccess()) {
                     long writeAndFlushUsedTime = System.currentTimeMillis() - streamAcquiredTime;
                     http2ClientMetrics.http2StreamWriteAndFlushTime.update(writeAndFlushUsedTime);
-                    requestInfo.setStreamSendTime(System.currentTimeMillis());
+                    requestInfo.setRequestSendTime(System.currentTimeMillis());
                     if (writeAndFlushUsedTime > http2ClientConfig.http2WriteAndFlushTimeoutMs) {
                       // This usually happens if remote can't accept data in time.
                       logger.debug(

--- a/ambry-protocol/src/test/java/com/github/ambry/protocol/RequestResponseTest.java
+++ b/ambry-protocol/src/test/java/com/github/ambry/protocol/RequestResponseTest.java
@@ -13,7 +13,6 @@
  */
 package com.github.ambry.protocol;
 
-import com.codahale.metrics.Timer;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.ambry.clustermap.ClusterMap;
@@ -27,7 +26,6 @@ import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.messageformat.BlobType;
 import com.github.ambry.messageformat.MessageFormatFlags;
 import com.github.ambry.messageformat.MessageMetadata;
-import com.github.ambry.network.RequestInfo;
 import com.github.ambry.network.Send;
 import com.github.ambry.replication.FindToken;
 import com.github.ambry.replication.FindTokenFactory;
@@ -57,10 +55,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Queue;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -170,7 +166,6 @@ public class RequestResponseTest {
   private static short versionSaved;
   private final boolean useByteBufContent;
   private final NettyByteBufLeakHelper nettyByteBufLeakHelper = new NettyByteBufLeakHelper();
-  private static final Logger LOGGER = LoggerFactory.getLogger(RequestResponseTest.class);
 
   @Parameterized.Parameters
   public static List<Object[]> data() {
@@ -319,37 +314,6 @@ public class RequestResponseTest {
         }
       }
     }
-  }
-
-  @Test
-  public void logTimeTest() {
-    Queue<RequestInfo> requestInfoQueue = new LinkedList<>();
-    long startTime = SystemTime.getInstance().milliseconds();
-    Timer timer = new Timer();
-    for (int i = 0; i < 260000; i++) {
-      requestInfoQueue.add(new RequestInfo(Integer.toString(i), null, null, null, null));
-    }
-    Timer.Context t = timer.time();
-    long enqueTime = SystemTime.getInstance().milliseconds() - startTime;
-    System.out.println(enqueTime);
-    Map<String, List<RequestInfo>> map = new HashMap<>();
-    for (int i = 0; i < 260000; i++) {
-      RequestInfo requestInfo = requestInfoQueue.remove();
-      if(!map.containsKey("1")) {
-        map.put("1", new LinkedList<>());
-      }
-      map.get("1").add(requestInfo);
-    }
-
-    for (int i = 0; i < 260000; i++) {
-      List<RequestInfo> l = map.get("1");
-      l.remove(0);
-    }
-
-    long dequeueTime = SystemTime.getInstance().milliseconds() - enqueTime;
-    //System.out.println(dequeueTime);
-    System.out.println(SystemTime.getInstance().milliseconds() - startTime);
-    System.out.println(t.stop() * 1000000);
   }
 
   @Test

--- a/ambry-router/src/main/java/com/github/ambry/router/DeleteOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/DeleteOperation.java
@@ -269,12 +269,10 @@ class DeleteOperation {
       Map.Entry<Integer, RequestInfo> entry = itr.next();
       int correlationId = entry.getKey();
       RequestInfo requestInfo = entry.getValue();
-      // If request times out due to no response from server or due to being stuck in router itself for long time,
-      // drop the request.
+      // If request times out due to no response from server or due to being stuck in router itself (due to bandwidth
+      // throttling, etc) for long time, drop the request.
       long currentTimeInMs = time.milliseconds();
-      if ((requestInfo.isRequestReceivedByNetworkLayer()
-          && currentTimeInMs - requestInfo.getRequestEnqueueTime() > routerConfig.routerRequestNetworkTimeoutMs)
-          || currentTimeInMs - requestInfo.getRequestCreateTime() > routerConfig.routerRequestTimeoutMs) {
+      if (RouterUtils.isRequestExpired(requestInfo, currentTimeInMs, routerConfig)) {
         itr.remove();
         logger.trace("Delete Request with correlationId {} in flight has expired for replica {} ", correlationId,
             requestInfo.getReplicaId().getDataNodeId());

--- a/ambry-router/src/main/java/com/github/ambry/router/DeleteOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/DeleteOperation.java
@@ -63,7 +63,7 @@ class DeleteOperation {
   // The operation tracker that tracks the state of this operation.
   private final OperationTracker operationTracker;
   // A map used to find inflight requests using a correlation id.
-  private final Map<Integer, DeleteRequestInfo> deleteRequestInfos;
+  private final Map<Integer, RequestInfo> deleteRequestInfos;
   // The result of this operation to be set into FutureResult.
   private final Void operationResult = null;
   private final QuotaChargeCallback quotaChargeCallback;
@@ -100,7 +100,7 @@ class DeleteOperation {
     this.time = time;
     this.quotaChargeCallback = quotaChargeCallback;
     this.deletionTimeMs = time.milliseconds();
-    this.deleteRequestInfos = new TreeMap<Integer, DeleteRequestInfo>();
+    this.deleteRequestInfos = new TreeMap<>();
     byte blobDcId = blobId.getDatacenterId();
     String originatingDcName = clusterMap.getDatacenterName(blobDcId);
     this.operationTracker =
@@ -133,8 +133,8 @@ class DeleteOperation {
       String hostname = replica.getDataNodeId().getHostname();
       Port port = RouterUtils.getPortToConnectTo(replica, routerConfig.routerEnableHttp2NetworkClient);
       DeleteRequest deleteRequest = createDeleteRequest();
-      deleteRequestInfos.put(deleteRequest.getCorrelationId(), new DeleteRequestInfo(time.milliseconds(), replica));
       RequestInfo requestInfo = new RequestInfo(hostname, port, deleteRequest, replica, operationQuotaCharger);
+      deleteRequestInfos.put(deleteRequest.getCorrelationId(), requestInfo);
       requestRegistrationCallback.registerRequestToSend(this, requestInfo);
       replicaIterator.remove();
       if (RouterUtils.isRemoteReplica(routerConfig, replica)) {
@@ -169,18 +169,19 @@ class DeleteOperation {
    */
   void handleResponse(ResponseInfo responseInfo, DeleteResponse deleteResponse) {
     DeleteRequest deleteRequest = (DeleteRequest) responseInfo.getRequestInfo().getRequest();
-    DeleteRequestInfo deleteRequestInfo = deleteRequestInfos.remove(deleteRequest.getCorrelationId());
+    RequestInfo deleteRequestInfo = deleteRequestInfos.remove(deleteRequest.getCorrelationId());
     // deleteRequestInfo can be null if this request was timed out before this response is received. No
     // metric is updated here, as corresponding metrics have been updated when the request was timed out.
     if (deleteRequestInfo == null) {
       return;
     }
-    ReplicaId replica = deleteRequestInfo.replica;
+    ReplicaId replica = deleteRequestInfo.getReplicaId();
     if (responseInfo.isQuotaRejected()) {
       processQuotaRejectedResponse(deleteRequest.getCorrelationId(), replica);
       return;
     }
-    long requestLatencyMs = time.milliseconds() - deleteRequestInfo.startTimeMs;
+    // Track the over all time taken for the response since the creation of the request.
+    long requestLatencyMs = time.milliseconds() - deleteRequestInfo.getRequestCreateTime();
     routerMetrics.routerRequestLatencyMs.update(requestLatencyMs);
     routerMetrics.getDataNodeBasedMetrics(replica.getDataNodeId()).deleteRequestLatencyMs.update(requestLatencyMs);
     // Check the error code from NetworkClient.
@@ -249,8 +250,8 @@ class DeleteOperation {
    * @param replicaId {@link ReplicaId} of the request.
    */
   private void processQuotaRejectedResponse(int correlationId, ReplicaId replicaId) {
-    logger.trace(
-        "DeleteRequest with response correlationId {} was rejected because quota was exceeded.", correlationId);
+    logger.trace("DeleteRequest with response correlationId {} was rejected because quota was exceeded.",
+        correlationId);
     onErrorResponse(replicaId, new RouterException("QuotaExceeded", RouterErrorCode.TooManyRequests), false);
     checkAndMaybeComplete();
   }
@@ -262,20 +263,25 @@ class DeleteOperation {
    */
   private void cleanupExpiredInflightRequests(
       RequestRegistrationCallback<DeleteOperation> requestRegistrationCallback) {
-    Iterator<Map.Entry<Integer, DeleteRequestInfo>> itr = deleteRequestInfos.entrySet().iterator();
+    Iterator<Map.Entry<Integer, RequestInfo>> itr = deleteRequestInfos.entrySet().iterator();
     while (itr.hasNext()) {
-      Map.Entry<Integer, DeleteRequestInfo> entry = itr.next();
+      Map.Entry<Integer, RequestInfo> entry = itr.next();
       int correlationId = entry.getKey();
-      DeleteRequestInfo deleteRequestInfo = entry.getValue();
-      if (time.milliseconds() - deleteRequestInfo.startTimeMs > routerConfig.routerRequestTimeoutMs) {
+      RequestInfo requestInfo = entry.getValue();
+      // If there is no response from network layer or if request itself didn't get chance to reach chance to reach
+      // network layer (due to some throttling in router, etc), drop the request after some time.
+      long currentTimeInMs = time.milliseconds();
+      if ((requestInfo.getRequestSendTime() != -1
+          && currentTimeInMs - requestInfo.getRequestSendTime() > routerConfig.routerRequestNetworkTimeoutMs)
+          || currentTimeInMs - requestInfo.getRequestCreateTime() > routerConfig.routerRequestTimeoutMs) {
         itr.remove();
         logger.trace("Delete Request with correlationId {} in flight has expired for replica {} ", correlationId,
-            deleteRequestInfo.replica.getDataNodeId());
+            requestInfo.getReplicaId().getDataNodeId());
         // Do not notify this as a failure to the response handler, as this timeout could simply be due to
         // connection unavailability. If there is indeed a network error, the NetworkClient will provide an error
         // response and the response handler will be notified accordingly.
-        onErrorResponse(deleteRequestInfo.replica,
-            RouterUtils.buildTimeoutException(correlationId, deleteRequestInfo.replica.getDataNodeId(), blobId));
+        onErrorResponse(requestInfo.getReplicaId(),
+            RouterUtils.buildTimeoutException(correlationId, requestInfo.getReplicaId().getDataNodeId(), blobId));
         requestRegistrationCallback.registerRequestToDrop(correlationId);
       } else {
         // the entries are ordered by correlation id and time. Break on the first request that has not timed out.
@@ -457,18 +463,5 @@ class DeleteOperation {
 
   long getSubmissionTimeMs() {
     return submissionTimeMs;
-  }
-
-  /**
-   * A wrapper class that is used to check if a request has been expired.
-   */
-  private class DeleteRequestInfo {
-    final long startTimeMs;
-    final ReplicaId replica;
-
-    DeleteRequestInfo(long submissionTime, ReplicaId replica) {
-      this.startTimeMs = submissionTime;
-      this.replica = replica;
-    }
   }
 }

--- a/ambry-router/src/main/java/com/github/ambry/router/GetBlobInfoOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/GetBlobInfoOperation.java
@@ -149,12 +149,10 @@ class GetBlobInfoOperation extends GetOperation {
       Map.Entry<Integer, RequestInfo> entry = inFlightRequestsIterator.next();
       int correlationId = entry.getKey();
       RequestInfo requestInfo = entry.getValue();
-      // If there is no response from network layer or if request itself didn't get chance to reach chance to reach
-      // network layer (due to some throttling in router, etc), drop the request after some time.
+      // If request times out due to no response from server or due to being stuck in router itself (due to bandwidth
+      // throttling, etc) for long time, drop the request.
       long currentTimeInMs = time.milliseconds();
-      if ((requestInfo.isRequestReceivedByNetworkLayer()
-          && currentTimeInMs - requestInfo.getRequestEnqueueTime() > routerConfig.routerRequestNetworkTimeoutMs)
-          || currentTimeInMs - requestInfo.getRequestCreateTime() > routerConfig.routerRequestTimeoutMs) {
+      if (RouterUtils.isRequestExpired(requestInfo, currentTimeInMs, routerConfig)) {
         logger.trace("GetBlobInfoRequest with correlationId {} in flight has expired for replica {} ", correlationId,
             requestInfo.getReplicaId().getDataNodeId());
         // Do not notify this as a failure to the response handler, as this timeout could simply be due to

--- a/ambry-router/src/main/java/com/github/ambry/router/GetBlobInfoOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/GetBlobInfoOperation.java
@@ -71,7 +71,7 @@ class GetBlobInfoOperation extends GetOperation {
   private final CryptoJobMetricsTracker decryptJobMetricsTracker =
       new CryptoJobMetricsTracker(routerMetrics.decryptJobMetrics);
   // map of correlation id to the request metadata for every request issued for this operation.
-  private final Map<Integer, GetRequestInfo> correlationIdToGetRequestInfo = new TreeMap<Integer, GetRequestInfo>();
+  private final Map<Integer, RequestInfo> correlationIdToGetRequestInfo = new TreeMap<>();
 
   private static final Logger logger = LoggerFactory.getLogger(GetBlobInfoOperation.class);
 
@@ -94,7 +94,8 @@ class GetBlobInfoOperation extends GetOperation {
   GetBlobInfoOperation(RouterConfig routerConfig, NonBlockingRouterMetrics routerMetrics, ClusterMap clusterMap,
       ResponseHandler responseHandler, BlobId blobId, GetBlobOptionsInternal options,
       Callback<GetBlobResultInternal> callback, RouterCallback routerCallback, KeyManagementService kms,
-      CryptoService cryptoService, CryptoJobHandler cryptoJobHandler, Time time, boolean isEncrypted, QuotaChargeCallback quotaChargeCallback) {
+      CryptoService cryptoService, CryptoJobHandler cryptoJobHandler, Time time, boolean isEncrypted,
+      QuotaChargeCallback quotaChargeCallback) {
     super(routerConfig, routerMetrics, clusterMap, responseHandler, blobId, options, callback, kms, cryptoService,
         cryptoJobHandler, time, isEncrypted);
     this.routerCallback = routerCallback;
@@ -142,20 +143,25 @@ class GetBlobInfoOperation extends GetOperation {
    * @param requestRegistrationCallback The callback to use to notify the networking layer of dropped requests.
    */
   private void cleanupExpiredInFlightRequests(RequestRegistrationCallback<GetOperation> requestRegistrationCallback) {
-    Iterator<Map.Entry<Integer, GetRequestInfo>> inFlightRequestsIterator =
+    Iterator<Map.Entry<Integer, RequestInfo>> inFlightRequestsIterator =
         correlationIdToGetRequestInfo.entrySet().iterator();
     while (inFlightRequestsIterator.hasNext()) {
-      Map.Entry<Integer, GetRequestInfo> entry = inFlightRequestsIterator.next();
+      Map.Entry<Integer, RequestInfo> entry = inFlightRequestsIterator.next();
       int correlationId = entry.getKey();
-      GetRequestInfo info = entry.getValue();
-      if (time.milliseconds() - info.startTimeMs > routerConfig.routerRequestTimeoutMs) {
+      RequestInfo requestInfo = entry.getValue();
+      // If there is no response from network layer or if request itself didn't get chance to reach chance to reach
+      // network layer (due to some throttling in router, etc), drop the request after some time.
+      long currentTimeInMs = time.milliseconds();
+      if ((requestInfo.getRequestSendTime() != -1
+          && currentTimeInMs - requestInfo.getRequestSendTime() > routerConfig.routerRequestNetworkTimeoutMs)
+          || currentTimeInMs - requestInfo.getRequestCreateTime() > routerConfig.routerRequestTimeoutMs) {
         logger.trace("GetBlobInfoRequest with correlationId {} in flight has expired for replica {} ", correlationId,
-            info.replicaId.getDataNodeId());
+            requestInfo.getReplicaId().getDataNodeId());
         // Do not notify this as a failure to the response handler, as this timeout could simply be due to
         // connection unavailability. If there is indeed a network error, the NetworkClient will provide an error
         // response and the response handler will be notified accordingly.
-        onErrorResponse(entry.getValue().replicaId,
-            RouterUtils.buildTimeoutException(correlationId, info.replicaId.getDataNodeId(), blobId));
+        onErrorResponse(entry.getValue().getReplicaId(),
+            RouterUtils.buildTimeoutException(correlationId, requestInfo.getReplicaId().getDataNodeId(), blobId));
         requestRegistrationCallback.registerRequestToDrop(correlationId);
         inFlightRequestsIterator.remove();
       } else {
@@ -175,10 +181,10 @@ class GetBlobInfoOperation extends GetOperation {
       String hostname = replicaId.getDataNodeId().getHostname();
       Port port = RouterUtils.getPortToConnectTo(replicaId, routerConfig.routerEnableHttp2NetworkClient);
       GetRequest getRequest = createGetRequest(blobId, getOperationFlag(), options.getBlobOptions.getGetOption());
-      RequestInfo request = new RequestInfo(hostname, port, getRequest, replicaId, operationQuotaCharger);
+      RequestInfo requestInfo = new RequestInfo(hostname, port, getRequest, replicaId, operationQuotaCharger);
       int correlationId = getRequest.getCorrelationId();
-      correlationIdToGetRequestInfo.put(correlationId, new GetRequestInfo(replicaId, time.milliseconds()));
-      requestRegistrationCallback.registerRequestToSend(this, request);
+      correlationIdToGetRequestInfo.put(correlationId, requestInfo);
+      requestRegistrationCallback.registerRequestToSend(this, requestInfo);
       replicaIterator.remove();
       if (RouterUtils.isRemoteReplica(routerConfig, replicaId)) {
         logger.trace("Making request with correlationId {} to a remote replica {} in {} ", correlationId,
@@ -208,32 +214,31 @@ class GetBlobInfoOperation extends GetOperation {
     }
     int correlationId = responseInfo.getRequestInfo().getRequest().getCorrelationId();
     // Get the GetOperation that generated the request.
-    GetRequestInfo getRequestInfo = correlationIdToGetRequestInfo.remove(correlationId);
+    RequestInfo getRequestInfo = correlationIdToGetRequestInfo.remove(correlationId);
     if (getRequestInfo == null) {
       // Ignore. The request must have timed out.
       return;
     }
     if (responseInfo.isQuotaRejected()) {
-      processQuotaRejectedResponse(correlationId, getRequestInfo.replicaId);
+      processQuotaRejectedResponse(correlationId, getRequestInfo.getReplicaId());
       return;
     }
-    long requestLatencyMs = time.milliseconds() - getRequestInfo.startTimeMs;
+    // Track the over all time taken for the response since the creation of the request.
+    long requestLatencyMs = time.milliseconds() - getRequestInfo.getRequestCreateTime();
     routerMetrics.routerRequestLatencyMs.update(requestLatencyMs);
-    routerMetrics.getDataNodeBasedMetrics(getRequestInfo.replicaId.getDataNodeId())
-        .getBlobInfoRequestLatencyMs.update(requestLatencyMs);
+    routerMetrics.getDataNodeBasedMetrics(
+        getRequestInfo.getReplicaId().getDataNodeId()).getBlobInfoRequestLatencyMs.update(requestLatencyMs);
     if (responseInfo.getError() != null) {
       logger.trace("GetBlobInfoRequest with response correlationId {} timed out for replica {} ", correlationId,
-          getRequestInfo.replicaId.getDataNodeId());
-      onErrorResponse(getRequestInfo.replicaId, new RouterException(
+          getRequestInfo.getReplicaId().getDataNodeId());
+      onErrorResponse(getRequestInfo.getReplicaId(), new RouterException(
           "Operation timed out because of " + responseInfo.getError() + " at DataNode " + responseInfo.getDataNode(),
           RouterErrorCode.OperationTimedOut));
     } else {
       if (getResponse == null) {
-        logger.trace(
-            "GetBlobInfoRequest with response correlationId {} received an unexpected error on response"
-                + "deserialization from replica {} ",
-            correlationId, getRequestInfo.replicaId.getDataNodeId());
-        onErrorResponse(getRequestInfo.replicaId,
+        logger.trace("GetBlobInfoRequest with response correlationId {} received an unexpected error on response"
+            + "deserialization from replica {} ", correlationId, getRequestInfo.getReplicaId().getDataNodeId());
+        onErrorResponse(getRequestInfo.getReplicaId(),
             new RouterException("Response deserialization received an unexpected error",
                 RouterErrorCode.UnexpectedInternalError));
       } else {
@@ -244,8 +249,8 @@ class GetBlobInfoOperation extends GetOperation {
           // There is no other way to handle it.
           routerMetrics.unknownReplicaResponseError.inc();
           logger.trace("GetBlobInfoRequest with response correlationId {} mismatch from response {} for replica {} ",
-              correlationId, getResponse.getCorrelationId(), getRequestInfo.replicaId.getDataNodeId());
-          onErrorResponse(getRequestInfo.replicaId, new RouterException(
+              correlationId, getResponse.getCorrelationId(), getRequestInfo.getReplicaId().getDataNodeId());
+          onErrorResponse(getRequestInfo.getReplicaId(), new RouterException(
               "The correlation id in the GetResponse " + getResponse.getCorrelationId()
                   + "is not the same as the correlation id in the associated GetRequest: " + correlationId,
               RouterErrorCode.UnexpectedInternalError));
@@ -258,9 +263,9 @@ class GetBlobInfoOperation extends GetOperation {
             // detection.
             logger.trace(
                 "GetBlobInfoRequest with response correlationId {} response deserialization failed for replica {} ",
-                correlationId, getRequestInfo.replicaId.getDataNodeId());
+                correlationId, getRequestInfo.getReplicaId().getDataNodeId());
             routerMetrics.responseDeserializationErrorCount.inc();
-            onErrorResponse(getRequestInfo.replicaId,
+            onErrorResponse(getRequestInfo.getReplicaId(),
                 new RouterException("Response deserialization received an unexpected error", e,
                     RouterErrorCode.UnexpectedInternalError));
           }
@@ -272,19 +277,19 @@ class GetBlobInfoOperation extends GetOperation {
 
   /**
    * Process the {@link GetResponse} extracted from a {@link ResponseInfo}
-   * @param getRequestInfo the associated {@link GetRequestInfo} for which this response was received.
+   * @param getRequestInfo the associated {@link RequestInfo} for which this response was received.
    * @param getResponse the {@link GetResponse} extracted from the {@link ResponseInfo}
    * @throws IOException if there is an error during deserialization of the GetResponse.
    * @throws MessageFormatException if there is an error during deserialization of the GetResponse.
    */
-  private void processGetBlobInfoResponse(GetRequestInfo getRequestInfo, GetResponse getResponse)
+  private void processGetBlobInfoResponse(RequestInfo getRequestInfo, GetResponse getResponse)
       throws IOException, MessageFormatException {
     ServerErrorCode getError = getResponse.getError();
     if (getError == ServerErrorCode.No_Error) {
       int partitionsInResponse = getResponse.getPartitionResponseInfoList().size();
       // Each get request issued by the router is for a single blob.
       if (partitionsInResponse != 1) {
-        onErrorResponse(getRequestInfo.replicaId, new RouterException(
+        onErrorResponse(getRequestInfo.getReplicaId(), new RouterException(
             "Unexpected number of partition responses, expected: 1, " + "received: " + partitionsInResponse,
             RouterErrorCode.UnexpectedInternalError));
         // Again, no need to notify the responseHandler.
@@ -294,31 +299,31 @@ class GetBlobInfoOperation extends GetOperation {
           PartitionResponseInfo partitionResponseInfo = getResponse.getPartitionResponseInfoList().get(0);
           int msgsInResponse = partitionResponseInfo.getMessageInfoList().size();
           if (msgsInResponse != 1) {
-            onErrorResponse(getRequestInfo.replicaId, new RouterException(
+            onErrorResponse(getRequestInfo.getReplicaId(), new RouterException(
                 "Unexpected number of messages in a partition response, expected: 1, " + "received: " + msgsInResponse,
                 RouterErrorCode.UnexpectedInternalError));
           } else {
             MessageMetadata messageMetadata = partitionResponseInfo.getMessageMetadataList().get(0);
             MessageInfo messageInfo = partitionResponseInfo.getMessageInfoList().get(0);
             handleBody(getResponse.getInputStream(), messageMetadata, messageInfo);
-            operationTracker.onResponse(getRequestInfo.replicaId, TrackedRequestFinalState.SUCCESS);
-            if (RouterUtils.isRemoteReplica(routerConfig, getRequestInfo.replicaId)) {
+            operationTracker.onResponse(getRequestInfo.getReplicaId(), TrackedRequestFinalState.SUCCESS);
+            if (RouterUtils.isRemoteReplica(routerConfig, getRequestInfo.getReplicaId())) {
               logger.trace("Cross colo request successful for remote replica in {} ",
-                  getRequestInfo.replicaId.getDataNodeId().getDatacenterName());
+                  getRequestInfo.getReplicaId().getDataNodeId().getDatacenterName());
               routerMetrics.crossColoSuccessCount.inc();
             }
           }
         } else {
           // process and set the most relevant exception.
           logger.trace("Replica  {} returned error {} with response correlationId {} ",
-              getRequestInfo.replicaId.getDataNodeId(), getError, getResponse.getCorrelationId());
+              getRequestInfo.getReplicaId().getDataNodeId(), getError, getResponse.getCorrelationId());
           RouterErrorCode routerErrorCode = processServerError(getError);
           if (getError == ServerErrorCode.Disk_Unavailable) {
-            operationTracker.onResponse(getRequestInfo.replicaId, TrackedRequestFinalState.DISK_DOWN);
+            operationTracker.onResponse(getRequestInfo.getReplicaId(), TrackedRequestFinalState.DISK_DOWN);
             setOperationException(new RouterException("Server returned: " + getError, routerErrorCode));
             routerMetrics.routerRequestErrorCount.inc();
-            routerMetrics.getDataNodeBasedMetrics(getRequestInfo.replicaId.getDataNodeId()).getBlobInfoRequestErrorCount
-                .inc();
+            routerMetrics.getDataNodeBasedMetrics(
+                getRequestInfo.getReplicaId().getDataNodeId()).getBlobInfoRequestErrorCount.inc();
           } else {
             if (getError == ServerErrorCode.Blob_Deleted || getError == ServerErrorCode.Blob_Expired
                 || getError == ServerErrorCode.Blob_Authorization_Failure) {
@@ -328,15 +333,16 @@ class GetBlobInfoOperation extends GetOperation {
             }
             // any server error code that is not equal to ServerErrorCode.No_Error, the onErrorResponse should be invoked
             // because the operation itself doesn't succeed although the response in some cases is successful (i.e. Blob_Deleted)
-            onErrorResponse(getRequestInfo.replicaId,
+            onErrorResponse(getRequestInfo.getReplicaId(),
                 new RouterException("Server returned: " + getError, routerErrorCode));
           }
         }
       }
     } else {
       logger.trace("Replica {} returned an error {} for a GetBlobInfoRequest with response correlationId : {} ",
-          getRequestInfo.replicaId.getDataNodeId(), getError, getResponse.getCorrelationId());
-      onErrorResponse(getRequestInfo.replicaId, new RouterException("Server returned", processServerError(getError)));
+          getRequestInfo.getReplicaId().getDataNodeId(), getError, getResponse.getCorrelationId());
+      onErrorResponse(getRequestInfo.getReplicaId(),
+          new RouterException("Server returned", processServerError(getError)));
     }
   }
 
@@ -403,28 +409,29 @@ class GetBlobInfoOperation extends GetOperation {
       decryptJobMetricsTracker.onJobSubmission();
       long startTimeMs = System.currentTimeMillis();
       cryptoJobHandler.submitJob(
-          new DecryptJob(blobId, encryptionKey.duplicate(), null, userMetadata, cryptoService, kms, options.getBlobOptions,
-              decryptJobMetricsTracker, (DecryptJob.DecryptJobResult result, Exception exception) -> {
-            decryptJobMetricsTracker.onJobResultProcessingStart();
-            logger.trace("Handling decrypt job callback results for {}", blobId);
-            routerMetrics.decryptTimeMs.update(System.currentTimeMillis() - startTimeMs);
-            if (exception == null) {
-              logger.trace("Successfully updating decrypt job callback results for {}", blobId);
-              BlobInfo blobInfo = new BlobInfo(serverBlobProperties, result.getDecryptedUserMetadata().array(),
-                  messageInfo.getLifeVersion());
-              operationResult = new GetBlobResultInternal(new GetBlobResult(blobInfo, null), null);
-              progressTracker.setCryptoJobSuccess();
-            } else {
-              decryptJobMetricsTracker.incrementOperationError();
-              logger.trace("Exception {} thrown on decryption for {}", exception, blobId);
-              setOperationException(
-                  new RouterException("Exception thrown on decrypting the content for " + blobId, exception,
-                      RouterErrorCode.UnexpectedInternalError));
-              progressTracker.setCryptoJobFailed();
-            }
-            decryptJobMetricsTracker.onJobResultProcessingComplete();
-            routerCallback.onPollReady();
-          }));
+          new DecryptJob(blobId, encryptionKey.duplicate(), null, userMetadata, cryptoService, kms,
+              options.getBlobOptions, decryptJobMetricsTracker,
+              (DecryptJob.DecryptJobResult result, Exception exception) -> {
+                decryptJobMetricsTracker.onJobResultProcessingStart();
+                logger.trace("Handling decrypt job callback results for {}", blobId);
+                routerMetrics.decryptTimeMs.update(System.currentTimeMillis() - startTimeMs);
+                if (exception == null) {
+                  logger.trace("Successfully updating decrypt job callback results for {}", blobId);
+                  BlobInfo blobInfo = new BlobInfo(serverBlobProperties, result.getDecryptedUserMetadata().array(),
+                      messageInfo.getLifeVersion());
+                  operationResult = new GetBlobResultInternal(new GetBlobResult(blobInfo, null), null);
+                  progressTracker.setCryptoJobSuccess();
+                } else {
+                  decryptJobMetricsTracker.incrementOperationError();
+                  logger.trace("Exception {} thrown on decryption for {}", exception, blobId);
+                  setOperationException(
+                      new RouterException("Exception thrown on decrypting the content for " + blobId, exception,
+                          RouterErrorCode.UnexpectedInternalError));
+                  progressTracker.setCryptoJobFailed();
+                }
+                decryptJobMetricsTracker.onJobResultProcessingComplete();
+                routerCallback.onPollReady();
+              }));
     }
   }
 

--- a/ambry-router/src/main/java/com/github/ambry/router/GetBlobInfoOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/GetBlobInfoOperation.java
@@ -152,8 +152,8 @@ class GetBlobInfoOperation extends GetOperation {
       // If there is no response from network layer or if request itself didn't get chance to reach chance to reach
       // network layer (due to some throttling in router, etc), drop the request after some time.
       long currentTimeInMs = time.milliseconds();
-      if ((requestInfo.getRequestSendTime() != -1
-          && currentTimeInMs - requestInfo.getRequestSendTime() > routerConfig.routerRequestNetworkTimeoutMs)
+      if ((requestInfo.isRequestReceivedByNetworkLayer()
+          && currentTimeInMs - requestInfo.getRequestEnqueueTime() > routerConfig.routerRequestNetworkTimeoutMs)
           || currentTimeInMs - requestInfo.getRequestCreateTime() > routerConfig.routerRequestTimeoutMs) {
         logger.trace("GetBlobInfoRequest with correlationId {} in flight has expired for replica {} ", correlationId,
             requestInfo.getReplicaId().getDataNodeId());
@@ -181,7 +181,8 @@ class GetBlobInfoOperation extends GetOperation {
       String hostname = replicaId.getDataNodeId().getHostname();
       Port port = RouterUtils.getPortToConnectTo(replicaId, routerConfig.routerEnableHttp2NetworkClient);
       GetRequest getRequest = createGetRequest(blobId, getOperationFlag(), options.getBlobOptions.getGetOption());
-      RequestInfo requestInfo = new RequestInfo(hostname, port, getRequest, replicaId, operationQuotaCharger);
+      RequestInfo requestInfo =
+          new RequestInfo(hostname, port, getRequest, replicaId, operationQuotaCharger, time.milliseconds());
       int correlationId = getRequest.getCorrelationId();
       correlationIdToGetRequestInfo.put(correlationId, requestInfo);
       requestRegistrationCallback.registerRequestToSend(this, requestInfo);

--- a/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
@@ -877,8 +877,8 @@ class GetBlobOperation extends GetOperation {
         // If there is no response from network layer or if request itself didn't get chance to reach chance to reach
         // network layer (due to some throttling in router, etc), drop the request after some time.
         long currentTimeInMs = time.milliseconds();
-        if ((requestInfo.getRequestSendTime() != -1
-            && currentTimeInMs - requestInfo.getRequestSendTime() > routerConfig.routerRequestNetworkTimeoutMs)
+        if ((requestInfo.isRequestReceivedByNetworkLayer()
+            && currentTimeInMs - requestInfo.getRequestEnqueueTime() > routerConfig.routerRequestNetworkTimeoutMs)
             || currentTimeInMs - requestInfo.getRequestCreateTime() > routerConfig.routerRequestTimeoutMs) {
           logger.trace("GetBlobRequest with correlationId {} in flight has expired for replica {} ", correlationId,
               requestInfo.getReplicaId().getDataNodeId());
@@ -908,7 +908,8 @@ class GetBlobOperation extends GetOperation {
         String hostname = replicaId.getDataNodeId().getHostname();
         Port port = RouterUtils.getPortToConnectTo(replicaId, routerConfig.routerEnableHttp2NetworkClient);
         GetRequest getRequest = createGetRequest(chunkBlobId, getOperationFlag(), getGetOption());
-        RequestInfo requestInfo = new RequestInfo(hostname, port, getRequest, replicaId, prepareQuotaCharger());
+        RequestInfo requestInfo =
+            new RequestInfo(hostname, port, getRequest, replicaId, prepareQuotaCharger(), time.milliseconds());
         int correlationId = getRequest.getCorrelationId();
         correlationIdToGetRequestInfo.put(correlationId, requestInfo);
         correlationIdToGetChunk.put(correlationId, this);

--- a/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
@@ -874,12 +874,10 @@ class GetBlobOperation extends GetOperation {
         Map.Entry<Integer, RequestInfo> entry = inFlightRequestsIterator.next();
         int correlationId = entry.getKey();
         RequestInfo requestInfo = entry.getValue();
-        // If there is no response from network layer or if request itself didn't get chance to reach chance to reach
-        // network layer (due to some throttling in router, etc), drop the request after some time.
+        // If request times out due to no response from server or due to being stuck in router itself (due to bandwidth
+        // throttling, etc) for long time, drop the request.
         long currentTimeInMs = time.milliseconds();
-        if ((requestInfo.isRequestReceivedByNetworkLayer()
-            && currentTimeInMs - requestInfo.getRequestEnqueueTime() > routerConfig.routerRequestNetworkTimeoutMs)
-            || currentTimeInMs - requestInfo.getRequestCreateTime() > routerConfig.routerRequestTimeoutMs) {
+        if (RouterUtils.isRequestExpired(requestInfo, currentTimeInMs, routerConfig)) {
           logger.trace("GetBlobRequest with correlationId {} in flight has expired for replica {} ", correlationId,
               requestInfo.getReplicaId().getDataNodeId());
           // Do not notify this as a failure to the response handler, as this timeout could simply be due to

--- a/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
@@ -156,7 +156,8 @@ class GetBlobOperation extends GetOperation {
     this.blobIdFactory = blobIdFactory;
     this.quotaChargeCallback = quotaChargeCallback;
     this.blobMetadataCache = blobMetadataCache;
-    BlobMetadata blobMetadata = shouldLookupMetadataCache() ? (BlobMetadata) blobMetadataCache.getObject(blobId.toString()) : null;
+    BlobMetadata blobMetadata =
+        shouldLookupMetadataCache() ? (BlobMetadata) blobMetadataCache.getObject(blobId.toString()) : null;
     firstChunk = (blobMetadata == null) ? new FirstGetChunk() : new CachedFirstChunk(blobMetadata);
   }
 
@@ -179,11 +180,8 @@ class GetBlobOperation extends GetOperation {
    *  False, otherwise.
    */
   boolean shouldLookupMetadataCache() {
-    return (blobMetadataCache != null &&
-        isRangeRequest() &&
-        options.getBlobOptions.hasBlobSegmentIdx() == false &&
-        options.getBlobOptions.isRawMode() == false &&
-        blobId.getBlobDataType() == BlobId.BlobDataType.METADATA);
+    return (blobMetadataCache != null && isRangeRequest() && options.getBlobOptions.hasBlobSegmentIdx() == false
+        && options.getBlobOptions.isRawMode() == false && blobId.getBlobDataType() == BlobId.BlobDataType.METADATA);
   }
 
   /**
@@ -262,7 +260,7 @@ class GetBlobOperation extends GetOperation {
       }
     }
     if (abortCause != null && abortCause instanceof RouterException) {
-      switch(((RouterException) abortCause).getErrorCode()) {
+      switch (((RouterException) abortCause).getErrorCode()) {
         /* If the blob is not found, then delete its metadata from frontend cache. */
         case BlobDoesNotExist:
         case BlobDeleted:
@@ -658,7 +656,7 @@ class GetBlobOperation extends GetOperation {
    */
   private class GetChunk {
     // map of correlation id to the request metadata for every request issued for this operation.
-    protected final Map<Integer, GetRequestInfo> correlationIdToGetRequestInfo = new TreeMap<>();
+    protected final Map<Integer, RequestInfo> correlationIdToGetRequestInfo = new TreeMap<>();
     // progress tracker used to track whether the operation is completed or not and whether it succeeded or failed on complete
     protected ProgressTracker progressTracker;
     // DecryptCallBackResultInfo that holds all info about decrypt job callback
@@ -870,20 +868,26 @@ class GetBlobOperation extends GetOperation {
      */
     private void cleanupExpiredInFlightRequests(RequestRegistrationCallback<GetOperation> requestRegistrationCallback) {
       //First, check if any of the existing requests have timed out.
-      Iterator<Map.Entry<Integer, GetRequestInfo>> inFlightRequestsIterator =
+      Iterator<Map.Entry<Integer, RequestInfo>> inFlightRequestsIterator =
           correlationIdToGetRequestInfo.entrySet().iterator();
       while (inFlightRequestsIterator.hasNext()) {
-        Map.Entry<Integer, GetRequestInfo> entry = inFlightRequestsIterator.next();
+        Map.Entry<Integer, RequestInfo> entry = inFlightRequestsIterator.next();
         int correlationId = entry.getKey();
-        GetRequestInfo info = entry.getValue();
-        if (time.milliseconds() - info.startTimeMs > routerConfig.routerRequestTimeoutMs) {
+        RequestInfo requestInfo = entry.getValue();
+        // If there is no response from network layer or if request itself didn't get chance to reach chance to reach
+        // network layer (due to some throttling in router, etc), drop the request after some time.
+        long currentTimeInMs = time.milliseconds();
+        if ((requestInfo.getRequestSendTime() != -1
+            && currentTimeInMs - requestInfo.getRequestSendTime() > routerConfig.routerRequestNetworkTimeoutMs)
+            || currentTimeInMs - requestInfo.getRequestCreateTime() > routerConfig.routerRequestTimeoutMs) {
           logger.trace("GetBlobRequest with correlationId {} in flight has expired for replica {} ", correlationId,
-              info.replicaId.getDataNodeId());
+              requestInfo.getReplicaId().getDataNodeId());
           // Do not notify this as a failure to the response handler, as this timeout could simply be due to
           // connection unavailability. If there is indeed a network error, the NetworkClient will provide an error
           // response and the response handler will be notified accordingly.
-          onErrorResponse(info.replicaId,
-              RouterUtils.buildTimeoutException(correlationId, info.replicaId.getDataNodeId(), chunkBlobId));
+          onErrorResponse(requestInfo.getReplicaId(),
+              RouterUtils.buildTimeoutException(correlationId, requestInfo.getReplicaId().getDataNodeId(),
+                  chunkBlobId));
           requestRegistrationCallback.registerRequestToDrop(correlationId);
           inFlightRequestsIterator.remove();
         } else {
@@ -904,11 +908,11 @@ class GetBlobOperation extends GetOperation {
         String hostname = replicaId.getDataNodeId().getHostname();
         Port port = RouterUtils.getPortToConnectTo(replicaId, routerConfig.routerEnableHttp2NetworkClient);
         GetRequest getRequest = createGetRequest(chunkBlobId, getOperationFlag(), getGetOption());
-        RequestInfo request = new RequestInfo(hostname, port, getRequest, replicaId, prepareQuotaCharger());
+        RequestInfo requestInfo = new RequestInfo(hostname, port, getRequest, replicaId, prepareQuotaCharger());
         int correlationId = getRequest.getCorrelationId();
-        correlationIdToGetRequestInfo.put(correlationId, new GetRequestInfo(replicaId, time.milliseconds()));
+        correlationIdToGetRequestInfo.put(correlationId, requestInfo);
         correlationIdToGetChunk.put(correlationId, this);
-        requestRegistrationCallback.registerRequestToSend(GetBlobOperation.this, request);
+        requestRegistrationCallback.registerRequestToSend(GetBlobOperation.this, requestInfo);
         if (RouterUtils.isRemoteReplica(routerConfig, replicaId)) {
           logger.trace("Making request with correlationId {} to a remote replica {} in {} ", correlationId,
               replicaId.getDataNodeId(), replicaId.getDataNodeId().getDatacenterName());
@@ -1008,34 +1012,35 @@ class GetBlobOperation extends GetOperation {
     void handleResponse(ResponseInfo responseInfo, GetResponse getResponse) {
       int correlationId = responseInfo.getRequestInfo().getRequest().getCorrelationId();
       // Get the GetOperation that generated the request.
-      GetRequestInfo getRequestInfo = correlationIdToGetRequestInfo.remove(correlationId);
+      RequestInfo getRequestInfo = correlationIdToGetRequestInfo.remove(correlationId);
       if (getRequestInfo == null) {
         // Ignore right away. This associated operation has completed.
         return;
       }
       if (responseInfo.isQuotaRejected()) {
-        processQuotaRejectedResponse(correlationId, getRequestInfo.replicaId);
+        processQuotaRejectedResponse(correlationId, getRequestInfo.getReplicaId());
         return;
       }
-      long requestLatencyMs = time.milliseconds() - getRequestInfo.startTimeMs;
+      // Track the over all time taken for the response since the creation of the request.
+      long requestLatencyMs = time.milliseconds() - getRequestInfo.getRequestCreateTime();
       routerMetrics.routerRequestLatencyMs.update(requestLatencyMs);
-      routerMetrics.getDataNodeBasedMetrics(getRequestInfo.replicaId.getDataNodeId()).getRequestLatencyMs.update(
+      routerMetrics.getDataNodeBasedMetrics(getRequestInfo.getReplicaId().getDataNodeId()).getRequestLatencyMs.update(
           requestLatencyMs);
       if (responseInfo.getError() != null) {
         // responseInfo.getError() returns NetworkClientErrorCode. If error is not null, it probably means (1) connection
         // checkout timed out; (2) pending connection timed out; (3) established connection timed out. In all these cases,
         // the latency histogram in adaptive operation tracker should not be updated.
         logger.trace("GetBlobRequest with response correlationId {} timed out for replica {} ", correlationId,
-            getRequestInfo.replicaId.getDataNodeId());
-        onErrorResponse(getRequestInfo.replicaId, buildChunkException(
+            getRequestInfo.getReplicaId().getDataNodeId());
+        onErrorResponse(getRequestInfo.getReplicaId(), buildChunkException(
             "Operation timed out because of " + responseInfo.getError() + " at DataNode " + responseInfo.getDataNode(),
             RouterErrorCode.OperationTimedOut));
       } else {
         if (getResponse == null) {
           logger.trace(
               "GetBlobRequest with response correlationId {} received an unexpected error on response deserialization from replica {} ",
-              correlationId, getRequestInfo.replicaId.getDataNodeId());
-          onErrorResponse(getRequestInfo.replicaId,
+              correlationId, getRequestInfo.getReplicaId().getDataNodeId());
+          onErrorResponse(getRequestInfo.getReplicaId(),
               buildChunkException("Response deserialization received an unexpected error",
                   RouterErrorCode.UnexpectedInternalError));
         } else {
@@ -1045,9 +1050,9 @@ class GetBlobOperation extends GetOperation {
             // sent over it. The check here ensures that is indeed the case. If not, log an error and fail this request.
             // There is no other way to handle it.
             logger.trace("GetBlobRequest with response correlationId {} mismatch from response {} for replica {} ",
-                correlationId, getResponse.getCorrelationId(), getRequestInfo.replicaId.getDataNodeId());
+                correlationId, getResponse.getCorrelationId(), getRequestInfo.getReplicaId().getDataNodeId());
             routerMetrics.unknownReplicaResponseError.inc();
-            onErrorResponse(getRequestInfo.replicaId, buildChunkException(
+            onErrorResponse(getRequestInfo.getReplicaId(), buildChunkException(
                 "The correlation id in the GetResponse " + getResponse.getCorrelationId()
                     + " is not the same as the correlation id in the associated GetRequest: " + correlationId,
                 RouterErrorCode.UnexpectedInternalError));
@@ -1060,9 +1065,9 @@ class GetBlobOperation extends GetOperation {
               // detection.
               logger.trace(
                   "GetBlobRequest with response correlationId {} response deserialization failed for replica {} ",
-                  correlationId, getRequestInfo.replicaId.getDataNodeId());
+                  correlationId, getRequestInfo.getReplicaId().getDataNodeId());
               routerMetrics.responseDeserializationErrorCount.inc();
-              onErrorResponse(getRequestInfo.replicaId,
+              onErrorResponse(getRequestInfo.getReplicaId(),
                   buildChunkException("Response deserialization received an unexpected error", e,
                       RouterErrorCode.UnexpectedInternalError));
             }
@@ -1130,14 +1135,14 @@ class GetBlobOperation extends GetOperation {
      * @throws IOException if there is an error during deserialization of the GetResponse.
      * @throws MessageFormatException if there is an error during deserialization of the GetResponse.
      */
-    private void processGetBlobResponse(GetRequestInfo getRequestInfo, GetResponse getResponse)
+    private void processGetBlobResponse(RequestInfo getRequestInfo, GetResponse getResponse)
         throws IOException, MessageFormatException {
       ServerErrorCode getError = getResponse.getError();
       if (getError == ServerErrorCode.No_Error) {
         int partitionsInResponse = getResponse.getPartitionResponseInfoList().size();
         // Each get request issued by the router is for a single blob.
         if (partitionsInResponse != 1) {
-          onErrorResponse(getRequestInfo.replicaId, buildChunkException(
+          onErrorResponse(getRequestInfo.getReplicaId(), buildChunkException(
               "Unexpected number of partition responses, expected: 1, " + "received: " + partitionsInResponse,
               RouterErrorCode.UnexpectedInternalError));
         } else {
@@ -1146,17 +1151,17 @@ class GetBlobOperation extends GetOperation {
             PartitionResponseInfo partitionResponseInfo = getResponse.getPartitionResponseInfoList().get(0);
             int objectsInPartitionResponse = partitionResponseInfo.getMessageInfoList().size();
             if (objectsInPartitionResponse != 1) {
-              onErrorResponse(getRequestInfo.replicaId, buildChunkException(
+              onErrorResponse(getRequestInfo.getReplicaId(), buildChunkException(
                   "Unexpected number of messages in a partition response, expected: 1, " + "received: "
                       + objectsInPartitionResponse, RouterErrorCode.UnexpectedInternalError));
             } else {
               MessageMetadata messageMetadata = partitionResponseInfo.getMessageMetadataList().get(0);
               MessageInfo messageInfo = partitionResponseInfo.getMessageInfoList().get(0);
               handleBody(getResponse.getInputStream(), messageMetadata, messageInfo);
-              chunkOperationTracker.onResponse(getRequestInfo.replicaId, TrackedRequestFinalState.SUCCESS);
-              if (RouterUtils.isRemoteReplica(routerConfig, getRequestInfo.replicaId)) {
+              chunkOperationTracker.onResponse(getRequestInfo.getReplicaId(), TrackedRequestFinalState.SUCCESS);
+              if (RouterUtils.isRemoteReplica(routerConfig, getRequestInfo.getReplicaId())) {
                 logger.trace("Cross colo request successful for remote replica in {} ",
-                    getRequestInfo.replicaId.getDataNodeId().getDatacenterName());
+                    getRequestInfo.getReplicaId().getDataNodeId().getDatacenterName());
                 routerMetrics.crossColoSuccessCount.inc();
               }
             }
@@ -1169,11 +1174,11 @@ class GetBlobOperation extends GetOperation {
             // process and set the most relevant exception.
             RouterErrorCode routerErrorCode = processServerError(getError);
             if (getError == ServerErrorCode.Disk_Unavailable) {
-              chunkOperationTracker.onResponse(getRequestInfo.replicaId, TrackedRequestFinalState.DISK_DOWN);
+              chunkOperationTracker.onResponse(getRequestInfo.getReplicaId(), TrackedRequestFinalState.DISK_DOWN);
               setChunkException(buildChunkException("Server returned: " + getError, routerErrorCode));
               routerMetrics.routerRequestErrorCount.inc();
               routerMetrics.getDataNodeBasedMetrics(
-                  getRequestInfo.replicaId.getDataNodeId()).getRequestErrorCount.inc();
+                  getRequestInfo.getReplicaId().getDataNodeId()).getRequestErrorCount.inc();
             } else {
               if (getError == ServerErrorCode.Blob_Deleted || getError == ServerErrorCode.Blob_Expired
                   || getError == ServerErrorCode.Blob_Authorization_Failure) {
@@ -1184,16 +1189,17 @@ class GetBlobOperation extends GetOperation {
               }
               // any server error code that is not equal to ServerErrorCode.No_Error, the onErrorResponse should be invoked
               // because the operation itself doesn't succeed although the response in some cases is successful (i.e. Blob_Deleted)
-              onErrorResponse(getRequestInfo.replicaId,
+              onErrorResponse(getRequestInfo.getReplicaId(),
                   buildChunkException("Server returned: " + getError, routerErrorCode));
             }
           }
         }
       } else {
         logger.trace("Replica {} returned an error {} for a GetBlobRequest with response correlationId : {} ",
-            getRequestInfo.replicaId.getDataNodeId(), getError, getResponse.getCorrelationId());
+            getRequestInfo.getReplicaId().getDataNodeId(), getError, getResponse.getCorrelationId());
         // process and set the most relevant exception.
-        onErrorResponse(getRequestInfo.replicaId, buildChunkException("Server returned", processServerError(getError)));
+        onErrorResponse(getRequestInfo.getReplicaId(),
+            buildChunkException("Server returned", processServerError(getError)));
       }
     }
 
@@ -1371,14 +1377,10 @@ class GetBlobOperation extends GetOperation {
      *  False, otherwise.
      */
     protected boolean shouldSaveMetadata() {
-      return (blobMetadataCache != null &&
-          isRangeRequest() &&
-          options.getBlobOptions.hasBlobSegmentIdx() == false &&
-          options.getBlobOptions.isRawMode() == false &&
-          blobId.getBlobDataType() == BlobId.BlobDataType.METADATA &&
-          blobType == BlobType.MetadataBlob &&
-          totalSize >= routerConfig.routerSmallestBlobForMetadataCache &&
-          isComplete() && getChunkException() == null && getOperationException() == null);
+      return (blobMetadataCache != null && isRangeRequest() && options.getBlobOptions.hasBlobSegmentIdx() == false
+          && options.getBlobOptions.isRawMode() == false && blobId.getBlobDataType() == BlobId.BlobDataType.METADATA
+          && blobType == BlobType.MetadataBlob && totalSize >= routerConfig.routerSmallestBlobForMetadataCache
+          && isComplete() && getChunkException() == null && getOperationException() == null);
     }
 
     /**
@@ -1808,7 +1810,9 @@ class GetBlobOperation extends GetOperation {
      * @return False for cached first chunk. There is nothing to cache.
      */
     @Override
-    protected boolean shouldSaveMetadata() { return false; }
+    protected boolean shouldSaveMetadata() {
+      return false;
+    }
 
     /**
      * On an invalid cache entry, set a {@link RouterErrorCode} exception for first chunk, mark the chunk

--- a/ambry-router/src/main/java/com/github/ambry/router/GetOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/GetOperation.java
@@ -275,21 +275,3 @@ abstract class GetOperation {
   }
 }
 
-/**
- * A class that holds information about the get requests sent out.
- */
-class GetRequestInfo {
-  final ReplicaId replicaId;
-  final long startTimeMs;
-
-  /**
-   * Construct a GetRequestInfo
-   * @param replicaId the replica to which this request is being sent.
-   * @param startTimeMs the time at which this request was created.
-   */
-  GetRequestInfo(ReplicaId replicaId, long startTimeMs) {
-    this.replicaId = replicaId;
-    this.startTimeMs = startTimeMs;
-  }
-}
-

--- a/ambry-router/src/main/java/com/github/ambry/router/OperationController.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/OperationController.java
@@ -518,7 +518,7 @@ public class OperationController implements Runnable {
     // as the poll timeout should not cause the request to not time out for a lot longer than the configured request
     // timeout. In the worst case, the request will time out in (request_timeout_ms + poll_timeout_ms), so the poll
     // timeout should be at least an order of magnitude smaller.
-    final int NETWORK_CLIENT_POLL_TIMEOUT = routerConfig.routerRequestTimeoutMs / 10;
+    final int NETWORK_CLIENT_POLL_TIMEOUT = routerConfig.routerRequestNetworkTimeoutMs / 10;
     try {
       while (nonBlockingRouter.isOpen.get()) {
         List<RequestInfo> requestsToSend = new ArrayList<>();

--- a/ambry-router/src/main/java/com/github/ambry/router/OperationController.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/OperationController.java
@@ -467,7 +467,7 @@ public class OperationController implements Runnable {
           responseHandler.onConnectionTimeout(dataNodeId);
         } else {
           if (!responseInfo.isQuotaRejected()) {
-            long responseReceiveTime = requestInfo.getStreamHeaderFrameReceiveTime();
+            long responseReceiveTime = requestInfo.getResponseHeaderReceiveTime();
             if (responseReceiveTime != -1) {
               routerMetrics.responseReceiveToHandleLatencyMs.update(System.currentTimeMillis() - responseReceiveTime);
             }

--- a/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
@@ -1454,8 +1454,8 @@ class PutOperation {
         // If there is no response from network layer or if request itself didn't get chance to reach chance to reach
         // network layer (due to some throttling in router, etc), drop the request after some time.
         long currentTimeInMs = time.milliseconds();
-        if ((requestInfo.getRequestSendTime() != -1
-            && currentTimeInMs - requestInfo.getRequestSendTime() > routerConfig.routerRequestNetworkTimeoutMs)
+        if ((requestInfo.isRequestReceivedByNetworkLayer()
+            && currentTimeInMs - requestInfo.getRequestEnqueueTime() > routerConfig.routerRequestNetworkTimeoutMs)
             || currentTimeInMs - requestInfo.getRequestCreateTime() > routerConfig.routerRequestTimeoutMs) {
           onErrorResponse(requestInfo.getReplicaId(), TrackedRequestFinalState.FAILURE);
           logger.warn("{}: PutRequest with correlationId {} in flight has expired for replica {} {}", loggingContext,
@@ -1484,7 +1484,8 @@ class PutOperation {
         String hostname = replicaId.getDataNodeId().getHostname();
         Port port = RouterUtils.getPortToConnectTo(replicaId, routerConfig.routerEnableHttp2NetworkClient);
         PutRequest putRequest = createPutRequest();
-        RequestInfo requestInfo = new RequestInfo(hostname, port, putRequest, replicaId, prepareQuotaCharger());
+        RequestInfo requestInfo =
+            new RequestInfo(hostname, port, putRequest, replicaId, prepareQuotaCharger(), time.milliseconds());
         int correlationId = putRequest.getCorrelationId();
         correlationIdToChunkPutRequestInfo.put(correlationId, requestInfo);
         correlationIdToPutChunk.put(correlationId, this);

--- a/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
@@ -1042,7 +1042,7 @@ class PutOperation {
     // the list of partitions already attempted for this chunk.
     private List<PartitionId> attemptedPartitionIds = new ArrayList<PartitionId>();
     // map of correlation id to the request metadata for every request issued for the current chunk.
-    private final Map<Integer, ChunkPutRequestInfo> correlationIdToChunkPutRequestInfo = new TreeMap<>();
+    private final Map<Integer, RequestInfo> correlationIdToChunkPutRequestInfo = new TreeMap<>();
     // list of buffers that were once associated with this chunk and are not yet freed.
     private final Logger logger = LoggerFactory.getLogger(PutChunk.class);
     // Tracks quota charging for this chunk.
@@ -1414,7 +1414,8 @@ class PutOperation {
             quotaChargeCallback.checkAndCharge(false, true, chunkBlobProperties.getBlobSize());
           } catch (QuotaException quotaException) {
             // For now we only log for quota charge exceptions for in progress requests.
-            logger.info("{}: Exception {} while handling quota charge event", loggingContext, quotaException.toString());
+            logger.info("{}: Exception {} while handling quota charge event", loggingContext,
+                quotaException.toString());
           }
         }
         state = ChunkState.Complete;
@@ -1444,21 +1445,26 @@ class PutOperation {
      * @param requestRegistrationCallback The callback to use to notify the networking layer of dropped requests.
      */
     private void cleanupExpiredInFlightRequests(RequestRegistrationCallback<PutOperation> requestRegistrationCallback) {
-      Iterator<Map.Entry<Integer, ChunkPutRequestInfo>> inFlightRequestsIterator =
+      Iterator<Map.Entry<Integer, RequestInfo>> inFlightRequestsIterator =
           correlationIdToChunkPutRequestInfo.entrySet().iterator();
       while (inFlightRequestsIterator.hasNext()) {
-        Map.Entry<Integer, ChunkPutRequestInfo> entry = inFlightRequestsIterator.next();
+        Map.Entry<Integer, RequestInfo> entry = inFlightRequestsIterator.next();
         int correlationId = entry.getKey();
-        ChunkPutRequestInfo info = entry.getValue();
-        if (time.milliseconds() - info.startTimeMs > routerConfig.routerRequestTimeoutMs) {
-          onErrorResponse(info.replicaId, TrackedRequestFinalState.FAILURE);
+        RequestInfo requestInfo = entry.getValue();
+        // If there is no response from network layer or if request itself didn't get chance to reach chance to reach
+        // network layer (due to some throttling in router, etc), drop the request after some time.
+        long currentTimeInMs = time.milliseconds();
+        if ((requestInfo.getRequestSendTime() != -1
+            && currentTimeInMs - requestInfo.getRequestSendTime() > routerConfig.routerRequestNetworkTimeoutMs)
+            || currentTimeInMs - requestInfo.getRequestCreateTime() > routerConfig.routerRequestTimeoutMs) {
+          onErrorResponse(requestInfo.getReplicaId(), TrackedRequestFinalState.FAILURE);
           logger.warn("{}: PutRequest with correlationId {} in flight has expired for replica {} {}", loggingContext,
-              correlationId, info.replicaId.getDataNodeId(), info);
+              correlationId, requestInfo.getReplicaId().getDataNodeId(), requestInfo);
           // Do not notify this as a failure to the response handler, as this timeout could simply be due to
           // connection unavailability. If there is indeed a network error, the NetworkClient will provide an error
           // response and the response handler will be notified accordingly.
-          setChunkException(
-              RouterUtils.buildTimeoutException(correlationId, info.replicaId.getDataNodeId(), chunkBlobId));
+          setChunkException(RouterUtils.buildTimeoutException(correlationId, requestInfo.getReplicaId().getDataNodeId(),
+              chunkBlobId));
           requestRegistrationCallback.registerRequestToDrop(correlationId);
           inFlightRequestsIterator.remove();
         } else {
@@ -1478,12 +1484,11 @@ class PutOperation {
         String hostname = replicaId.getDataNodeId().getHostname();
         Port port = RouterUtils.getPortToConnectTo(replicaId, routerConfig.routerEnableHttp2NetworkClient);
         PutRequest putRequest = createPutRequest();
-        RequestInfo request = new RequestInfo(hostname, port, putRequest, replicaId, prepareQuotaCharger());
+        RequestInfo requestInfo = new RequestInfo(hostname, port, putRequest, replicaId, prepareQuotaCharger());
         int correlationId = putRequest.getCorrelationId();
-        correlationIdToChunkPutRequestInfo.put(correlationId,
-            new ChunkPutRequestInfo(replicaId, putRequest, time.milliseconds()));
+        correlationIdToChunkPutRequestInfo.put(correlationId, requestInfo);
         correlationIdToPutChunk.put(correlationId, this);
-        requestRegistrationCallback.registerRequestToSend(PutOperation.this, request);
+        requestRegistrationCallback.registerRequestToSend(PutOperation.this, requestInfo);
         replicaIterator.remove();
         if (RouterUtils.isRemoteReplica(routerConfig, replicaId)) {
           logger.debug("{}: Making request with correlationId {} to a remote replica {} in {}", loggingContext,
@@ -1545,8 +1550,8 @@ class PutOperation {
      */
     void handleResponse(ResponseInfo responseInfo, PutResponse putResponse) {
       int correlationId = responseInfo.getRequestInfo().getRequest().getCorrelationId();
-      ChunkPutRequestInfo chunkPutRequestInfo = correlationIdToChunkPutRequestInfo.remove(correlationId);
-      if (chunkPutRequestInfo == null) {
+      RequestInfo requestInfo = correlationIdToChunkPutRequestInfo.remove(correlationId);
+      if (requestInfo == null) {
         // Ignore right away. This could mean:
         // - the response is valid for this chunk, but was timed out and removed from the map.
         // - the response is for an earlier attempt of this chunk (slipped put scenario). And the map was cleared
@@ -1556,18 +1561,19 @@ class PutOperation {
         return;
       }
       if (responseInfo.isQuotaRejected()) {
-        processQuotaRejectedResponse(correlationId, chunkPutRequestInfo.replicaId);
+        processQuotaRejectedResponse(correlationId, requestInfo.getReplicaId());
         return;
       }
-      long requestLatencyMs = time.milliseconds() - chunkPutRequestInfo.startTimeMs;
+      // Track the over all time taken for the response since the creation of the request.
+      long requestLatencyMs = time.milliseconds() - requestInfo.getRequestCreateTime();
       routerMetrics.routerRequestLatencyMs.update(requestLatencyMs);
-      routerMetrics.getDataNodeBasedMetrics(chunkPutRequestInfo.replicaId.getDataNodeId()).putRequestLatencyMs.update(
+      routerMetrics.getDataNodeBasedMetrics(requestInfo.getReplicaId().getDataNodeId()).putRequestLatencyMs.update(
           requestLatencyMs);
       boolean isSuccessful;
       TrackedRequestFinalState putRequestFinalState = null;
       if (responseInfo.getError() != null) {
         logger.debug("{}: PutRequest with response correlationId {} timed out for replica {} ", loggingContext,
-            correlationId, chunkPutRequestInfo.replicaId.getDataNodeId());
+            correlationId, requestInfo.getReplicaId().getDataNodeId());
         setChunkException(new RouterException(
             "Operation timed out because of " + responseInfo.getError() + " at DataNode " + responseInfo.getDataNode(),
             RouterErrorCode.OperationTimedOut));
@@ -1577,7 +1583,7 @@ class PutOperation {
         if (putResponse == null) {
           logger.debug(
               "{}: PutRequest with response correlationId {} received an unexpected error on response deserialization from replica {} ",
-              loggingContext, correlationId, chunkPutRequestInfo.replicaId.getDataNodeId());
+              loggingContext, correlationId, requestInfo.getReplicaId().getDataNodeId());
           setChunkException(new RouterException("Response deserialization received an unexpected error",
               RouterErrorCode.UnexpectedInternalError));
           isSuccessful = false;
@@ -1606,7 +1612,7 @@ class PutOperation {
               // chunkException will be set within processServerError.
               logger.trace(
                   "{}: Replica {} returned an error {} for a PutRequest with response correlationId : {} and blobId {}",
-                  loggingContext, chunkPutRequestInfo.replicaId, putResponse.getError(), putResponse.getCorrelationId(),
+                  loggingContext, requestInfo.getReplicaId(), putResponse.getError(), putResponse.getCorrelationId(),
                   blobId);
               processServerError(putResponse.getError());
               isSuccessful = false;
@@ -1618,14 +1624,14 @@ class PutOperation {
         }
       }
       if (isSuccessful) {
-        operationTracker.onResponse(chunkPutRequestInfo.replicaId, TrackedRequestFinalState.SUCCESS);
-        if (RouterUtils.isRemoteReplica(routerConfig, chunkPutRequestInfo.replicaId)) {
+        operationTracker.onResponse(requestInfo.getReplicaId(), TrackedRequestFinalState.SUCCESS);
+        if (RouterUtils.isRemoteReplica(routerConfig, requestInfo.getReplicaId())) {
           logger.trace("{}: Cross colo request successful for remote replica in {} ", loggingContext,
-              chunkPutRequestInfo.replicaId.getDataNodeId().getDatacenterName());
+              requestInfo.getReplicaId().getDataNodeId().getDatacenterName());
           routerMetrics.crossColoSuccessCount.inc();
         }
       } else {
-        onErrorResponse(chunkPutRequestInfo.replicaId, putRequestFinalState);
+        onErrorResponse(requestInfo.getReplicaId(), putRequestFinalState);
       }
       checkAndMaybeComplete();
     }
@@ -1690,26 +1696,6 @@ class PutOperation {
       // However, for metrics, we will need to distinguish them here.
       setChunkException(new RouterException("Could not complete operation, server returned: " + error,
           RouterErrorCode.AmbryUnavailable));
-    }
-
-    /**
-     * A class that holds information about requests sent out by this PutChunk.
-     */
-    private class ChunkPutRequestInfo {
-      final ReplicaId replicaId;
-      final PutRequest putRequest;
-      final long startTimeMs;
-
-      /**
-       * Construct a ChunkPutRequestInfo
-       * @param replicaId the replica to which this request is being sent.
-       * @param startTimeMs the time at which this request was created.
-       */
-      ChunkPutRequestInfo(ReplicaId replicaId, PutRequest putRequest, long startTimeMs) {
-        this.replicaId = replicaId;
-        this.putRequest = putRequest;
-        this.startTimeMs = startTimeMs;
-      }
     }
 
     /**

--- a/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
@@ -1451,12 +1451,10 @@ class PutOperation {
         Map.Entry<Integer, RequestInfo> entry = inFlightRequestsIterator.next();
         int correlationId = entry.getKey();
         RequestInfo requestInfo = entry.getValue();
-        // If there is no response from network layer or if request itself didn't get chance to reach chance to reach
-        // network layer (due to some throttling in router, etc), drop the request after some time.
+        // If request times out due to no response from server or due to being stuck in router itself (due to bandwidth
+        // throttling, etc) for long time, drop the request.
         long currentTimeInMs = time.milliseconds();
-        if ((requestInfo.isRequestReceivedByNetworkLayer()
-            && currentTimeInMs - requestInfo.getRequestEnqueueTime() > routerConfig.routerRequestNetworkTimeoutMs)
-            || currentTimeInMs - requestInfo.getRequestCreateTime() > routerConfig.routerRequestTimeoutMs) {
+        if (RouterUtils.isRequestExpired(requestInfo, currentTimeInMs, routerConfig)) {
           onErrorResponse(requestInfo.getReplicaId(), TrackedRequestFinalState.FAILURE);
           logger.warn("{}: PutRequest with correlationId {} in flight has expired for replica {} {}", loggingContext,
               correlationId, requestInfo.getReplicaId().getDataNodeId(), requestInfo);

--- a/ambry-router/src/main/java/com/github/ambry/router/RouterUtils.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/RouterUtils.java
@@ -26,6 +26,7 @@ import com.github.ambry.network.LocalNetworkClient;
 import com.github.ambry.network.NetworkClientErrorCode;
 import com.github.ambry.network.Port;
 import com.github.ambry.network.PortType;
+import com.github.ambry.network.RequestInfo;
 import com.github.ambry.network.ResponseInfo;
 import com.github.ambry.protocol.DeleteResponse;
 import com.github.ambry.protocol.GetResponse;
@@ -287,5 +288,19 @@ public class RouterUtils {
       receivedResponse = sentResponse;
     }
     return receivedResponse;
+  }
+
+  /**
+   * Checks if the request has expired due to either no response from server or it being stuck in router itself
+   * (unavailable quota, etc.) for a long time.
+   * @param requestInfo of the request.
+   * @param currentTimeInMs current time in msec.
+   * @param routerConfig router config.
+   * @return {@code True} if the request has expired waiting for the response.
+   */
+  public static boolean isRequestExpired(RequestInfo requestInfo, long currentTimeInMs, RouterConfig routerConfig) {
+    return ((requestInfo.isRequestReceivedByNetworkLayer()
+        && currentTimeInMs - requestInfo.getRequestEnqueueTime() > routerConfig.routerRequestNetworkTimeoutMs)
+        || currentTimeInMs - requestInfo.getRequestCreateTime() > routerConfig.routerRequestTimeoutMs);
   }
 }

--- a/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateOperation.java
@@ -251,12 +251,10 @@ class TtlUpdateOperation {
       Map.Entry<Integer, RequestInfo> ttlUpdateRequestInfoEntry = itr.next();
       int correlationId = ttlUpdateRequestInfoEntry.getKey();
       RequestInfo requestInfo = ttlUpdateRequestInfoEntry.getValue();
-      // If there is no response from network layer or if request itself didn't get chance to reach chance to reach
-      // network layer (due to some throttling in router, etc), drop the request after some time.
+      // If request times out due to no response from server or due to being stuck in router itself (due to bandwidth
+      // throttling, etc) for long time, drop the request.
       long currentTimeInMs = time.milliseconds();
-      if ((requestInfo.isRequestReceivedByNetworkLayer()
-          && currentTimeInMs - requestInfo.getRequestEnqueueTime() > routerConfig.routerRequestNetworkTimeoutMs)
-          || currentTimeInMs - requestInfo.getRequestCreateTime() > routerConfig.routerRequestTimeoutMs) {
+      if (RouterUtils.isRequestExpired(requestInfo, currentTimeInMs, routerConfig)) {
         itr.remove();
         LOGGER.trace("TTL Request with correlationid {} in flight has expired for replica {} ", correlationId,
             requestInfo.getReplicaId().getDataNodeId());

--- a/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateOperation.java
@@ -57,7 +57,7 @@ class TtlUpdateOperation {
   // The operation tracker that tracks the state of this operation.
   private final OperationTracker operationTracker;
   // A map used to find inflight requests using a correlation id.
-  private final Map<Integer, TtlUpdateRequestInfo> ttlUpdateRequestInfos = new TreeMap<>();
+  private final Map<Integer, RequestInfo> ttlUpdateRequestInfos = new TreeMap<>();
   // The result of this operation to be set into FutureResult.
   private final Void operationResult = null;
   // the cause for failure of this operation. This will be set if and when the operation encounters an irrecoverable
@@ -129,9 +129,8 @@ class TtlUpdateOperation {
       String hostname = replica.getDataNodeId().getHostname();
       Port port = RouterUtils.getPortToConnectTo(replica, routerConfig.routerEnableHttp2NetworkClient);
       TtlUpdateRequest ttlUpdateRequest = createTtlUpdateRequest();
-      ttlUpdateRequestInfos.put(ttlUpdateRequest.getCorrelationId(),
-          new TtlUpdateRequestInfo(time.milliseconds(), replica));
       RequestInfo requestInfo = new RequestInfo(hostname, port, ttlUpdateRequest, replica, operationQuotaCharger);
+      ttlUpdateRequestInfos.put(ttlUpdateRequest.getCorrelationId(), requestInfo);
       requestRegistrationCallback.registerRequestToSend(this, requestInfo);
       replicaIterator.remove();
       if (RouterUtils.isRemoteReplica(routerConfig, replica)) {
@@ -163,18 +162,19 @@ class TtlUpdateOperation {
    */
   void handleResponse(ResponseInfo responseInfo, TtlUpdateResponse ttlUpdateResponse) {
     TtlUpdateRequest ttlUpdateRequest = (TtlUpdateRequest) responseInfo.getRequestInfo().getRequest();
-    TtlUpdateRequestInfo ttlUpdateRequestInfo = ttlUpdateRequestInfos.remove(ttlUpdateRequest.getCorrelationId());
+    RequestInfo ttlUpdateRequestInfo = ttlUpdateRequestInfos.remove(ttlUpdateRequest.getCorrelationId());
     // ttlUpdateRequestInfo can be null if this request was timed out before this response is received. No
     // metric is updated here, as corresponding metrics have been updated when the request was timed out.
     if (ttlUpdateRequestInfo == null) {
       return;
     }
-    ReplicaId replica = ttlUpdateRequestInfo.replica;
+    ReplicaId replica = ttlUpdateRequestInfo.getReplicaId();
     if (responseInfo.isQuotaRejected()) {
       processQuotaRejectedResponse(ttlUpdateRequest.getCorrelationId(), replica);
       return;
     }
-    long requestLatencyMs = time.milliseconds() - ttlUpdateRequestInfo.startTimeMs;
+    // Track the over all time taken for the response since the creation of the request.
+    long requestLatencyMs = time.milliseconds() - ttlUpdateRequestInfo.getRequestCreateTime();
     routerMetrics.routerRequestLatencyMs.update(requestLatencyMs);
     routerMetrics.getDataNodeBasedMetrics(replica.getDataNodeId()).ttlUpdateRequestLatencyMs.update(requestLatencyMs);
     // Check the error code from NetworkClient.
@@ -245,20 +245,25 @@ class TtlUpdateOperation {
    */
   private void cleanupExpiredInflightRequests(
       RequestRegistrationCallback<TtlUpdateOperation> requestRegistrationCallback) {
-    Iterator<Map.Entry<Integer, TtlUpdateRequestInfo>> itr = ttlUpdateRequestInfos.entrySet().iterator();
+    Iterator<Map.Entry<Integer, RequestInfo>> itr = ttlUpdateRequestInfos.entrySet().iterator();
     while (itr.hasNext()) {
-      Map.Entry<Integer, TtlUpdateRequestInfo> ttlUpdateRequestInfoEntry = itr.next();
+      Map.Entry<Integer, RequestInfo> ttlUpdateRequestInfoEntry = itr.next();
       int correlationId = ttlUpdateRequestInfoEntry.getKey();
-      TtlUpdateRequestInfo ttlUpdateRequestInfo = ttlUpdateRequestInfoEntry.getValue();
-      if (time.milliseconds() - ttlUpdateRequestInfo.startTimeMs > routerConfig.routerRequestTimeoutMs) {
+      RequestInfo requestInfo = ttlUpdateRequestInfoEntry.getValue();
+      // If there is no response from network layer or if request itself didn't get chance to reach chance to reach
+      // network layer (due to some throttling in router, etc), drop the request after some time.
+      long currentTimeInMs = time.milliseconds();
+      if ((requestInfo.getRequestSendTime() != -1
+          && currentTimeInMs - requestInfo.getRequestSendTime() > routerConfig.routerRequestNetworkTimeoutMs)
+          || currentTimeInMs - requestInfo.getRequestCreateTime() > routerConfig.routerRequestTimeoutMs) {
         itr.remove();
         LOGGER.trace("TTL Request with correlationid {} in flight has expired for replica {} ", correlationId,
-            ttlUpdateRequestInfo.replica.getDataNodeId());
+            requestInfo.getReplicaId().getDataNodeId());
         // Do not notify this as a failure to the response handler, as this timeout could simply be due to
         // connection unavailability. If there is indeed a network error, the NetworkClient will provide an error
         // response and the response handler will be notified accordingly.
-        onErrorResponse(ttlUpdateRequestInfo.replica,
-            RouterUtils.buildTimeoutException(correlationId, ttlUpdateRequestInfo.replica.getDataNodeId(), blobId));
+        onErrorResponse(requestInfo.getReplicaId(),
+            RouterUtils.buildTimeoutException(correlationId, requestInfo.getReplicaId().getDataNodeId(), blobId));
         requestRegistrationCallback.registerRequestToDrop(correlationId);
       } else {
         // the entries are ordered by correlation id and time. Break on the first request that has not timed out.
@@ -342,9 +347,8 @@ class TtlUpdateOperation {
       if (operationTracker.hasSucceeded()) {
         operationException.set(null);
       } else if (operationTracker.maybeFailedDueToOfflineReplicas()) {
-        operationException.set(
-            new RouterException("TtlUpdateOperation failed possibly because of offline replicas",
-                RouterErrorCode.AmbryUnavailable));
+        operationException.set(new RouterException("TtlUpdateOperation failed possibly because of offline replicas",
+            RouterErrorCode.AmbryUnavailable));
       } else if (operationTracker.hasFailedOnNotFound()) {
         operationException.set(
             new RouterException("TtlUpdateOperation failed because of BlobNotFound", RouterErrorCode.BlobDoesNotExist));
@@ -472,18 +476,5 @@ class TtlUpdateOperation {
    */
   long getExpiresAtMs() {
     return expiresAtMs;
-  }
-
-  /**
-   * A wrapper class that is used to check if a request has been expired.
-   */
-  private class TtlUpdateRequestInfo {
-    final long startTimeMs;
-    final ReplicaId replica;
-
-    TtlUpdateRequestInfo(long submissionTime, ReplicaId replica) {
-      this.startTimeMs = submissionTime;
-      this.replica = replica;
-    }
   }
 }

--- a/ambry-router/src/main/java/com/github/ambry/router/UndeleteOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/UndeleteOperation.java
@@ -280,12 +280,10 @@ public class UndeleteOperation {
       Map.Entry<Integer, RequestInfo> undeleteRequestInfoEntry = iter.next();
       int correlationId = undeleteRequestInfoEntry.getKey();
       RequestInfo requestInfo = undeleteRequestInfoEntry.getValue();
-      // If there is no response from network layer or if request itself didn't get chance to reach chance to reach
-      // network layer (due to some throttling in router, etc), drop the request after some time.
+      // If request times out due to no response from server or due to being stuck in router itself (due to bandwidth
+      // throttling, etc) for long time, drop the request.
       long currentTimeInMs = time.milliseconds();
-      if ((requestInfo.isRequestReceivedByNetworkLayer()
-          && currentTimeInMs - requestInfo.getRequestEnqueueTime() > routerConfig.routerRequestNetworkTimeoutMs)
-          || currentTimeInMs - requestInfo.getRequestCreateTime() > routerConfig.routerRequestTimeoutMs) {
+      if (RouterUtils.isRequestExpired(requestInfo, currentTimeInMs, routerConfig)) {
         iter.remove();
         LOGGER.warn("Undelete request with correlationid {} in flight has expired for replica {} ", correlationId,
             requestInfo.getReplicaId().getDataNodeId());

--- a/ambry-router/src/main/java/com/github/ambry/router/UndeleteOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/UndeleteOperation.java
@@ -55,7 +55,7 @@ public class UndeleteOperation {
   // The operation tracker that tracks the state of this operation.
   private final OperationTracker operationTracker;
   // A map used to find inflight requests using a correlation id.
-  private final Map<Integer, UndeleteRequestInfo> undeleteRequestInfos = new TreeMap<>();
+  private final Map<Integer, RequestInfo> undeleteRequestInfos = new TreeMap<>();
   // The result of this operation to be set into FutureResult.
   private final Void operationResult = null;
   // the cause for failure of this operation. This will be set if and when the operation encounters an irrecoverable
@@ -127,9 +127,8 @@ public class UndeleteOperation {
       String hostname = replica.getDataNodeId().getHostname();
       Port port = RouterUtils.getPortToConnectTo(replica, routerConfig.routerEnableHttp2NetworkClient);
       UndeleteRequest undeleteRequest = createUndeleteRequest();
-      undeleteRequestInfos.put(undeleteRequest.getCorrelationId(),
-          new UndeleteRequestInfo(time.milliseconds(), replica));
       RequestInfo requestInfo = new RequestInfo(hostname, port, undeleteRequest, replica, operationQuotaCharger);
+      undeleteRequestInfos.put(undeleteRequest.getCorrelationId(), requestInfo);
       requestRegistrationCallback.registerRequestToSend(this, requestInfo);
       replicaIterator.remove();
       if (RouterUtils.isRemoteReplica(routerConfig, replica)) {
@@ -161,18 +160,19 @@ public class UndeleteOperation {
    */
   void handleResponse(ResponseInfo responseInfo, UndeleteResponse undeleteResponse) {
     UndeleteRequest undeleteRequest = (UndeleteRequest) responseInfo.getRequestInfo().getRequest();
-    UndeleteRequestInfo undeleteRequestInfo = undeleteRequestInfos.remove(undeleteRequest.getCorrelationId());
+    RequestInfo undeleteRequestInfo = undeleteRequestInfos.remove(undeleteRequest.getCorrelationId());
     // undeleteRequestInfo can be null if this request was timed out before this response is received. No
     // metric is updated here, as corresponding metrics have been updated when the request was timed out.
     if (undeleteRequestInfo == null) {
       return;
     }
-    ReplicaId replica = undeleteRequestInfo.replica;
+    ReplicaId replica = undeleteRequestInfo.getReplicaId();
     if (responseInfo.isQuotaRejected()) {
       processQuotaRejectedResponse(undeleteRequest.getCorrelationId(), replica);
       return;
     }
-    long requestLatencyMs = time.milliseconds() - undeleteRequestInfo.startTimeMs;
+    // Track the over all time taken for the response since the creation of the request.
+    long requestLatencyMs = time.milliseconds() - undeleteRequestInfo.getRequestCreateTime();
     routerMetrics.routerRequestLatencyMs.update(requestLatencyMs);
     routerMetrics.getDataNodeBasedMetrics(replica.getDataNodeId()).undeleteRequestLatencyMs.update(requestLatencyMs);
     // Check the error code from NetworkClient.
@@ -261,23 +261,10 @@ public class UndeleteOperation {
    * @param replicaId {@link ReplicaId} of the request.
    */
   private void processQuotaRejectedResponse(int correlationId, ReplicaId replicaId) {
-    LOGGER.trace(
-        "UndeleteRequest with response correlationId {} was rejected because quota was exceeded.", correlationId);
+    LOGGER.trace("UndeleteRequest with response correlationId {} was rejected because quota was exceeded.",
+        correlationId);
     onErrorResponse(replicaId, new RouterException("QuotaExceeded", RouterErrorCode.TooManyRequests), false);
     checkAndMaybeComplete();
-  }
-
-  /**
-   * A wrapper class that is used to check if a request has been expired.
-   */
-  private class UndeleteRequestInfo {
-    final long startTimeMs;
-    final ReplicaId replica;
-
-    UndeleteRequestInfo(long submissionTime, ReplicaId replica) {
-      this.startTimeMs = submissionTime;
-      this.replica = replica;
-    }
   }
 
   /**
@@ -287,20 +274,25 @@ public class UndeleteOperation {
    */
   private void cleanupExpiredInflightRequests(
       RequestRegistrationCallback<UndeleteOperation> requestRegistrationCallback) {
-    Iterator<Map.Entry<Integer, UndeleteRequestInfo>> iter = undeleteRequestInfos.entrySet().iterator();
+    Iterator<Map.Entry<Integer, RequestInfo>> iter = undeleteRequestInfos.entrySet().iterator();
     while (iter.hasNext()) {
-      Map.Entry<Integer, UndeleteRequestInfo> undeleteRequestInfoEntry = iter.next();
+      Map.Entry<Integer, RequestInfo> undeleteRequestInfoEntry = iter.next();
       int correlationId = undeleteRequestInfoEntry.getKey();
-      UndeleteRequestInfo undeleteRequestInfo = undeleteRequestInfoEntry.getValue();
-      if (time.milliseconds() - undeleteRequestInfo.startTimeMs > routerConfig.routerRequestTimeoutMs) {
+      RequestInfo requestInfo = undeleteRequestInfoEntry.getValue();
+      // If there is no response from network layer or if request itself didn't get chance to reach chance to reach
+      // network layer (due to some throttling in router, etc), drop the request after some time.
+      long currentTimeInMs = time.milliseconds();
+      if ((requestInfo.getRequestSendTime() != -1
+          && currentTimeInMs - requestInfo.getRequestSendTime() > routerConfig.routerRequestNetworkTimeoutMs)
+          || currentTimeInMs - requestInfo.getRequestCreateTime() > routerConfig.routerRequestTimeoutMs) {
         iter.remove();
         LOGGER.warn("Undelete request with correlationid {} in flight has expired for replica {} ", correlationId,
-            undeleteRequestInfo.replica.getDataNodeId());
+            requestInfo.getReplicaId().getDataNodeId());
         // Do not notify this as a failure to the response handler, as this timeout could simply be due to
         // connection unavailability. If there is indeed a network error, the NetworkClient will provide an error
         // response and the response handler will be notified accordingly.
-        onErrorResponse(undeleteRequestInfo.replica,
-            RouterUtils.buildTimeoutException(correlationId, undeleteRequestInfo.replica.getDataNodeId(), blobId));
+        onErrorResponse(requestInfo.getReplicaId(),
+            RouterUtils.buildTimeoutException(correlationId, requestInfo.getReplicaId().getDataNodeId(), blobId));
         requestRegistrationCallback.registerRequestToDrop(correlationId);
       } else {
         // the entries are ordered by correlation id and time. Break on the first request that has not timed out.

--- a/ambry-router/src/test/java/com/github/ambry/router/DeleteManagerTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/DeleteManagerTest.java
@@ -211,7 +211,8 @@ public class DeleteManagerTest {
     // Create a router with QuotaRejectionOperationController for this test.
     router.close();
     Properties properties = getNonBlockingRouterProperties();
-    properties.setProperty(RouterConfig.OPERATION_CONTROLLER, QuotaRejectingOperationController.class.getCanonicalName());
+    properties.setProperty(RouterConfig.OPERATION_CONTROLLER,
+        QuotaRejectingOperationController.class.getCanonicalName());
     VerifiableProperties vProps = new VerifiableProperties(properties);
     RouterConfig routerConfig = new RouterConfig(vProps);
     router = new NonBlockingRouter(routerConfig, new NonBlockingRouterMetrics(clusterMap, routerConfig),
@@ -262,7 +263,7 @@ public class DeleteManagerTest {
    * @throws Exception
    */
   @Test
-  public void routerErrorCodeResolutionTest() throws Exception {
+  public void routerErrorCodeResolutionFirstSetTest() throws Exception {
     LinkedHashMap<ServerErrorCode, RouterErrorCode> codesToSetAndTest = new LinkedHashMap<>();
     // test 4 codes
     codesToSetAndTest.put(ServerErrorCode.Blob_Authorization_Failure, RouterErrorCode.BlobAuthorizationFailure);
@@ -270,9 +271,15 @@ public class DeleteManagerTest {
     codesToSetAndTest.put(ServerErrorCode.Disk_Unavailable, RouterErrorCode.AmbryUnavailable);
     codesToSetAndTest.put(ServerErrorCode.IO_Error, RouterErrorCode.UnexpectedInternalError);
     doRouterErrorCodeResolutionTest(codesToSetAndTest);
+  }
 
-    // test another 4 codes
-    codesToSetAndTest.clear();
+  /**
+   * Tests to ensure that {@link RouterErrorCode}s are properly resolved based on precedence
+   * @throws Exception
+   */
+  @Test
+  public void routerErrorCodeResolutionSecondSetTest() throws Exception {
+    LinkedHashMap<ServerErrorCode, RouterErrorCode> codesToSetAndTest = new LinkedHashMap<>();
     codesToSetAndTest.put(ServerErrorCode.Blob_Authorization_Failure, RouterErrorCode.BlobAuthorizationFailure);
     codesToSetAndTest.put(ServerErrorCode.Disk_Unavailable, RouterErrorCode.AmbryUnavailable);
     codesToSetAndTest.put(ServerErrorCode.Replica_Unavailable, RouterErrorCode.AmbryUnavailable);
@@ -596,8 +603,6 @@ public class DeleteManagerTest {
         serverErrorCodes.set(i * 2, ServerErrorCode.Blob_Not_Found);
         serverErrorCodes.set(i * 2 + 1, ServerErrorCode.Blob_Not_Found);
       }
-      // Reset not-found cache after each test since we are using same blob ID for all error codes
-      router.getNotFoundCache().invalidateAll();
     }
     serverLayout.getMockServers().forEach(MockServer::resetServerErrors);
   }

--- a/ambry-router/src/test/java/com/github/ambry/router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/GetBlobOperationTest.java
@@ -559,7 +559,7 @@ public class GetBlobOperationTest {
   }
 
   /**
-   * Test the case where all requests time out within the GetOperation.
+   * Test the case where all requests time out at router layer within the GetOperation.
    * @throws Exception
    */
   @Test
@@ -571,6 +571,46 @@ public class GetBlobOperationTest {
       time.sleep(routerConfig.routerRequestTimeoutMs + 1);
       op.poll(requestRegistrationCallback);
     }
+    // At this time requests would have been created for all replicas, as none of them were delivered,
+    // and cross-colo proxying is enabled by default.
+    Assert.assertEquals("Must have attempted sending requests to all replicas", replicasCount,
+        correlationIdToGetOperation.size());
+    assertFailureAndCheckErrorCode(op, RouterErrorCode.OperationTimedOut);
+
+    // test that timed out response won't update latency histogram if exclude timeout is enabled.
+    assumeTrue(operationTrackerType.equals(AdaptiveOperationTracker.class.getSimpleName()));
+    AdaptiveOperationTracker tracker = (AdaptiveOperationTracker) op.getFirstChunkOperationTrackerInUse();
+    Histogram localColoTracker =
+        tracker.getLatencyHistogram(RouterTestHelpers.getAnyReplica(blobId, true, localDcName));
+    Histogram crossColoTracker =
+        tracker.getLatencyHistogram(RouterTestHelpers.getAnyReplica(blobId, false, localDcName));
+    Assert.assertEquals("Timed-out response shouldn't be counted into local colo latency histogram", 0,
+        localColoTracker.getCount());
+    Assert.assertEquals("Timed-out response shouldn't be counted into cross colo latency histogram", 0,
+        crossColoTracker.getCount());
+  }
+
+  /**
+   * Test the case where all requests time out at network layer within the GetOperation.
+   * @throws Exception
+   */
+  @Test
+  public void testNetworkRequestTimeoutAllFailure() throws Exception {
+    doPut();
+    GetBlobOperation op = createOperation(routerConfig, null);
+    op.poll(requestRegistrationCallback);
+    int count = 0;
+    while (!op.isOperationComplete()) {
+      for (RequestInfo requestInfo : requestRegistrationCallback.getRequestsToSend()) {
+        requestInfo.setRequestEnqueueTime(time.milliseconds());
+      }
+      time.sleep(routerConfig.routerRequestNetworkTimeoutMs + 1);
+      op.poll(requestRegistrationCallback);
+      count++;
+    }
+
+    Assert.assertEquals("Mismatch in expected number of polls",
+        (int) Math.ceil((double) replicasCount / routerConfig.routerGetRequestParallelism), count);
     // At this time requests would have been created for all replicas, as none of them were delivered,
     // and cross-colo proxying is enabled by default.
     Assert.assertEquals("Must have attempted sending requests to all replicas", replicasCount,
@@ -1846,7 +1886,8 @@ public class GetBlobOperationTest {
     properties.setProperty("router.get.request.parallelism", Integer.toString(2));
     properties.setProperty("router.get.success.target", Integer.toString(1));
     properties.setProperty("router.get.operation.tracker.type", operationTrackerType);
-    properties.setProperty("router.request.timeout.ms", Integer.toString(20));
+    properties.setProperty("router.request.timeout.ms", Integer.toString(40));
+    properties.setProperty("router.request.network.timeout.ms", Integer.toString(20));
     properties.setProperty("router.operation.tracker.exclude.timeout.enabled", Boolean.toString(excludeTimeout));
     properties.setProperty("router.operation.tracker.terminate.on.not.found.enabled", "true");
     properties.setProperty("router.get.blob.operation.share.memory", "true");

--- a/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTestBase.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTestBase.java
@@ -77,6 +77,7 @@ public class NonBlockingRouterTestBase {
   protected static final int MAX_PORTS_SSL = 3;
   protected static final int CHECKOUT_TIMEOUT_MS = 1000;
   protected static final int REQUEST_TIMEOUT_MS = 1000;
+  protected static final int NETWORK_TIMEOUT_MS = 500;
   protected static final int PUT_REQUEST_PARALLELISM = 3;
   protected static final int PUT_SUCCESS_TARGET = 2;
   protected static final int GET_REQUEST_PARALLELISM = 2;
@@ -180,6 +181,7 @@ public class NonBlockingRouterTestBase {
     properties.setProperty("router.delete.success.target", Integer.toString(DELETE_SUCCESS_TARGET));
     properties.setProperty("router.connection.checkout.timeout.ms", Integer.toString(CHECKOUT_TIMEOUT_MS));
     properties.setProperty("router.request.timeout.ms", Integer.toString(REQUEST_TIMEOUT_MS));
+    properties.setProperty("router.request.network.timeout.ms", Integer.toString(NETWORK_TIMEOUT_MS));
     properties.setProperty("router.connections.local.dc.warm.up.percentage", Integer.toString(67));
     properties.setProperty("router.connections.remote.dc.warm.up.percentage", Integer.toString(34));
     properties.setProperty("clustermap.cluster.name", "test");
@@ -227,7 +229,8 @@ public class NonBlockingRouterTestBase {
    * Setup test suite to perform a {@link Router#putBlob} call using random account and container ids.
    */
   protected void setOperationParams(int putContentSize, long ttlSecs) {
-    setOperationParams(putContentSize, ttlSecs, Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM));
+    setOperationParams(putContentSize, ttlSecs, Utils.getRandomShort(TestUtils.RANDOM),
+        Utils.getRandomShort(TestUtils.RANDOM));
   }
 
   /**
@@ -238,8 +241,9 @@ public class NonBlockingRouterTestBase {
    * @param containerId container id for the blob.
    */
   protected void setOperationParams(int putContentSize, long ttlSecs, short accountId, short containerId) {
-    putBlobProperties = new BlobProperties(-1, "serviceId", "memberId", "contentType", false, ttlSecs,
-        accountId, containerId, testEncryption, null, null, null);
+    putBlobProperties =
+        new BlobProperties(-1, "serviceId", "memberId", "contentType", false, ttlSecs, accountId, containerId,
+            testEncryption, null, null, null);
     putUserMetadata = new byte[USER_METADATA_SIZE];
     random.nextBytes(putUserMetadata);
     putContent = new byte[putContentSize];


### PR DESCRIPTION
Currently when we drop a request at router due to no response from network, we check for the time elapsed since its creation at Router. But it could be possible that some of the requests spent majority of time at router layer (due to bandwidth throttling, etc) before reaching Network layer. Such requests would expire even before they are sent to network or wouldn't be given sufficient time to receive response from network. To handle such cases, this change tries to check for time elapsed since a request was received at network layer. In addition, it also checks over all time elapsed at router layer to avoid negative cases where requests get stuck at router layer itself. 

Also removed wrapper classes like `ChunkPutRequestInfo`, `ChunkGetRequestInfo`, etc and used `RequestInfo` itself for book keeping at router.