### PR TITLE
Fixed the setEndOffsets null pointer issue 

### DIFF
--- a/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
@@ -2303,7 +2303,7 @@ class PersistentIndex {
    * @param logSegmentName the name of the log segment whose index segment files are required.
    * @return the list of {@link IndexSegment} files that refer to the log segment with name {@code logSegmentName}.
    */
-  static File[] getIndexSegmentFilesForLogSegment(String dataDir, final LogSegmentName logSegmentName) { // ERROR
+  static File[] getIndexSegmentFilesForLogSegment(String dataDir, final LogSegmentName logSegmentName) {
     return new File(dataDir).listFiles(new FilenameFilter() {
       @Override
       public boolean accept(File dir, String name) {

--- a/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
@@ -2311,7 +2311,7 @@ class PersistentIndex {
         // index name has the format of <offset>_index, for example 0_index, 265_index
         // In this case, input parameter logSegmentName == ""
         if (logSegmentName.toString().isEmpty())
-          return name.startsWith(logSegmentName.toString()) && name.endsWith(IndexSegment.INDEX_SEGMENT_FILE_NAME_SUFFIX);
+          return name.endsWith(IndexSegment.INDEX_SEGMENT_FILE_NAME_SUFFIX);
         else
           return name.startsWith(logSegmentName.toString()+BlobStore.SEPARATOR) && name.endsWith(IndexSegment.INDEX_SEGMENT_FILE_NAME_SUFFIX);
       }
@@ -2329,8 +2329,11 @@ class PersistentIndex {
     File[] filesToCleanup = new File(dataDir).listFiles(new FilenameFilter() {
       @Override
       public boolean accept(File dir, String name) {
-        return name.startsWith(logSegmentName.toString()) && (name.endsWith(IndexSegment.INDEX_SEGMENT_FILE_NAME_SUFFIX)
-            || name.endsWith(IndexSegment.BLOOM_FILE_NAME_SUFFIX));
+        if (logSegmentName.toString().isEmpty())
+          return (name.endsWith(IndexSegment.INDEX_SEGMENT_FILE_NAME_SUFFIX) || name.endsWith(IndexSegment.BLOOM_FILE_NAME_SUFFIX));
+        else
+          return name.startsWith(logSegmentName.toString()+BlobStore.SEPARATOR) && (name.endsWith(IndexSegment.INDEX_SEGMENT_FILE_NAME_SUFFIX)
+              || name.endsWith(IndexSegment.BLOOM_FILE_NAME_SUFFIX));
       }
     });
     if (filesToCleanup == null) {

--- a/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
@@ -2303,11 +2303,17 @@ class PersistentIndex {
    * @param logSegmentName the name of the log segment whose index segment files are required.
    * @return the list of {@link IndexSegment} files that refer to the log segment with name {@code logSegmentName}.
    */
-  static File[] getIndexSegmentFilesForLogSegment(String dataDir, final LogSegmentName logSegmentName) {
+  static File[] getIndexSegmentFilesForLogSegment(String dataDir, final LogSegmentName logSegmentName) { // ERROR
     return new File(dataDir).listFiles(new FilenameFilter() {
       @Override
       public boolean accept(File dir, String name) {
-        return name.startsWith(logSegmentName.toString()) && name.endsWith(IndexSegment.INDEX_SEGMENT_FILE_NAME_SUFFIX);
+        // If not segmented, log name is log_current
+        // index name has the format of <offset>_index, for example 0_index, 265_index
+        // In this case, input parameter logSegmentName == ""
+        if (logSegmentName.toString().isEmpty())
+          return name.startsWith(logSegmentName.toString()) && name.endsWith(IndexSegment.INDEX_SEGMENT_FILE_NAME_SUFFIX);
+        else
+          return name.startsWith(logSegmentName.toString()+BlobStore.SEPARATOR) && name.endsWith(IndexSegment.INDEX_SEGMENT_FILE_NAME_SUFFIX);
       }
     });
   }

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
@@ -561,14 +561,13 @@ public class BlobStoreTest {
   }
 
   @Test
-  public void storeStartupTests2() throws IOException, StoreException { // here
+  public void storeStartupTests2() throws IOException, StoreException {
     if (!isLogSegmented) {
       verifyStartupFailure(store, StoreErrorCodes.Store_Already_Started);
       return;
     }
 
-    // Test the following LogSegment == null issue
-    // https://jira01.corp.linkedin.com:8443/browse/AMBRY-9175
+    // Test the LogSegment null pointer issue caused by matching index segment file with wrong log segment file due to same prefix
     // copy and generate:
     //    0_49_18_bloom
     //    0_49_18_index


### PR DESCRIPTION
Fixed the setEndOffsets null pointer issue when there was some compaction log temp file.

To associate index segment files with log segment file, index segment file should start with name.startsWith(logSegmentName.toString()+BlobStore.SEPARATOR),
not only name.startsWith(logSegmentName.toString()) because 0_49_18_index is not a index segment of  0_4_log

