### PR TITLE
[Frontend] Update TTL in metadata cache path

### DIFF
--- a/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
@@ -1847,6 +1847,7 @@ class GetBlobOperation extends GetOperation {
         throws IOException, MessageFormatException {
       /* If we find blob metadata in frontend cache, validate it and use it. */
       BlobProperties receivedBlobProperties = MessageFormatRecord.deserializeBlobProperties(payload);
+      updateTtlIfRequired(receivedBlobProperties, messageInfo);
       /*
        * Some cached variables are mutable.
        * Update them and then compare if other immutable variables are same or not.
@@ -1864,7 +1865,9 @@ class GetBlobOperation extends GetOperation {
          * We do not need to decrypt anything at this point.
          */
         String reason = "Cached blob property does not match received blob property";
-        logger.error("{} for blobId = {}, cached blob property = {}, received blob property = {}", reason, blobId,
+        logger.error("[{}] {} for blobId = {}, cached blob property = {}, received blob property = {}",
+            blobMetadataCache.getCacheId(),
+            reason, blobId,
             serverBlobProperties, receivedBlobProperties);
         deleteMetadata(reason);
         onInvalidCacheEntry(new RouterException(reason, RouterErrorCode.UnexpectedInternalError));

--- a/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
@@ -1866,9 +1866,7 @@ class GetBlobOperation extends GetOperation {
          */
         String reason = "Cached blob property does not match received blob property";
         logger.error("[{}] {} for blobId = {}, cached blob property = {}, received blob property = {}",
-            blobMetadataCache.getCacheId(),
-            reason, blobId,
-            serverBlobProperties, receivedBlobProperties);
+            blobMetadataCache.getCacheId(), reason, blobId, serverBlobProperties, receivedBlobProperties);
         deleteMetadata(reason);
         onInvalidCacheEntry(new RouterException(reason, RouterErrorCode.UnexpectedInternalError));
         return;

--- a/ambry-router/src/test/java/com/github/ambry/router/CloudRouterTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/CloudRouterTest.java
@@ -320,5 +320,7 @@ public class CloudRouterTest extends NonBlockingRouterTest {
   @Override
   @Ignore
   public void testRouterMetadataCacheBlobDoesNotExistOnDeleteCompositeBlob() throws Exception {}
-
+  @Override
+  @Ignore
+  public void testRouterMetadataCacheUpdateTTLCompositeBlob() throws Exception {}
 }

--- a/config/frontend.properties
+++ b/config/frontend.properties
@@ -24,9 +24,10 @@ router.delete.success.target=1
 # enable metadata cache for localhost testing
 router.blob.metadata.cache.enabled=true
 router.blob.metadata.cache.id=LocalhostMetadataCache
-# The smallest blob to qualify for metadata caching is 64MB.
+# The smallest blob to qualify for metadata caching is 16MB.
 # Any blobs smaller than this will not have metadata cached.
-router.smallest.blob.for.metadata.cache=67108864
+router.smallest.blob.for.metadata.cache=16777216
+router.ttl.update.success.target=1
 
 # cluster map
 clustermap.cluster.name=Ambry_Dev


### PR DESCRIPTION
This patch updates the ttl of the received metadata so that it can
be compared with the cached metadata. Apparently, the received metadata
isn't up-to-date and must be fixed upon receipt.