### PR TITLE
[Frontend] Rename AmbryCacheMetrics to AmbryCacheStats

### DIFF
--- a/ambry-router/src/test/java/com/github/ambry/router/AmbryCacheStats.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/AmbryCacheStats.java
@@ -14,14 +14,14 @@
 
 package com.github.ambry.router;
 
-public class AmbryCacheMetrics {
+public class AmbryCacheStats {
 
   final int numCacheHit;
   final int numCacheMiss;
   final int numPut;
   final int numDelete;
 
-  public AmbryCacheMetrics(int numCacheHit, int numCacheMiss, int numPut, int numDelete) {
+  public AmbryCacheStats(int numCacheHit, int numCacheMiss, int numPut, int numDelete) {
     this.numCacheHit = numCacheHit;
     this.numCacheMiss = numCacheMiss;
     this.numPut = numPut;

--- a/ambry-router/src/test/java/com/github/ambry/router/AmbryCacheWithStats.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/AmbryCacheWithStats.java
@@ -20,7 +20,7 @@ import com.github.ambry.commons.AmbryCacheEntry;
 import java.util.concurrent.CountDownLatch;
 
 
-public class AmbryCacheWithMetrics extends AmbryCache {
+public class AmbryCacheWithStats extends AmbryCache {
 
   final CountDownLatch cacheHitCountDown;
   final CountDownLatch cacheMissCountDown;
@@ -34,13 +34,13 @@ public class AmbryCacheWithMetrics extends AmbryCache {
    * @param cacheMaxSizeBytes Maximum memory footprint of the cache
    * @param metricRegistry Instance of metrics registry to record stats
    */
-  public AmbryCacheWithMetrics(String cacheId, boolean cacheEnabled, long cacheMaxSizeBytes,
-      MetricRegistry metricRegistry, AmbryCacheMetrics ambryCacheMetrics) {
+  public AmbryCacheWithStats(String cacheId, boolean cacheEnabled, long cacheMaxSizeBytes,
+      MetricRegistry metricRegistry, AmbryCacheStats ambryCacheStats) {
     super(cacheId, cacheEnabled, cacheMaxSizeBytes, metricRegistry);
-    cacheHitCountDown = new CountDownLatch(ambryCacheMetrics.getNumCacheHit());
-    cacheMissCountDown = new CountDownLatch(ambryCacheMetrics.getNumCacheMiss());
-    putObjectCountDown = new CountDownLatch(ambryCacheMetrics.getNumPut());
-    deleteObjectCountDown = new CountDownLatch(ambryCacheMetrics.getNumDelete());
+    cacheHitCountDown = new CountDownLatch(ambryCacheStats.getNumCacheHit());
+    cacheMissCountDown = new CountDownLatch(ambryCacheStats.getNumCacheMiss());
+    putObjectCountDown = new CountDownLatch(ambryCacheStats.getNumPut());
+    deleteObjectCountDown = new CountDownLatch(ambryCacheStats.getNumDelete());
   }
 
   @Override

--- a/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTest.java
@@ -1370,9 +1370,9 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
       Properties properties = getNonBlockingRouterProperties("DC1");
       properties.setProperty("router.blob.metadata.cache.enabled", Boolean.toString(true));
       properties.setProperty("router.smallest.blob.for.metadata.cache", Long.toString(0));
-      setRouterWithMetadataCache(properties, new AmbryCacheMetrics(1,1,1,0));
-      AmbryCacheWithMetrics ambryCacheWithMetrics = (AmbryCacheWithMetrics) router.getBlobMetadataCache();
-      assertNotNull("Metadata cache must be created", ambryCacheWithMetrics);
+      setRouterWithMetadataCache(properties, new AmbryCacheStats(1,1,1,0));
+      AmbryCacheWithStats ambryCacheWithStats = (AmbryCacheWithStats) router.getBlobMetadataCache();
+      assertNotNull("Metadata cache must be created", ambryCacheWithStats);
 
       // put a simple blob and test it is absent in the metadata cache
       setOperationParams(PUT_CONTENT_SIZE, TTL_SECS);
@@ -1417,9 +1417,9 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
       Properties properties = getNonBlockingRouterProperties("DC1");
       properties.setProperty("router.blob.metadata.cache.enabled", Boolean.toString(true));
       properties.setProperty("router.smallest.blob.for.metadata.cache", Long.toString(0));
-      setRouterWithMetadataCache(properties, new AmbryCacheMetrics(1,1,1,0));
-      AmbryCacheWithMetrics ambryCacheWithMetrics = (AmbryCacheWithMetrics) router.getBlobMetadataCache();
-      assertNotNull("Metadata cache must be created", ambryCacheWithMetrics);
+      setRouterWithMetadataCache(properties, new AmbryCacheStats(1,1,1,0));
+      AmbryCacheWithStats ambryCacheWithStats = (AmbryCacheWithStats) router.getBlobMetadataCache();
+      assertNotNull("Metadata cache must be created", ambryCacheWithStats);
 
       // put a composite blob and test it is absent in the metadata cache
       setOperationParams(2 * PUT_CONTENT_SIZE, TTL_SECS);
@@ -1445,14 +1445,14 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
       // get the one byte from composite blob, and it's metadata must be present in cache
       ByteRange range = ByteRanges.fromOffsetRange(1, 2);
       router.getBlob(blobId, new GetBlobOptionsBuilder().range(range).build()).get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-      assertTrue("Must encounter a cache miss", ambryCacheWithMetrics.getCacheMissCountDown().await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-      assertTrue("Must put metadata in cache", ambryCacheWithMetrics.getPutObjectCountDown().await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+      assertTrue("Must encounter a cache miss", ambryCacheWithStats.getCacheMissCountDown().await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+      assertTrue("Must put metadata in cache", ambryCacheWithStats.getPutObjectCountDown().await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
       assertNotNull("Blob metadata must be present in metadata cache", router.getBlobMetadataCache().getObject(blobId));
 
       // cache hit
       // get one byte from composite blob, and it's metadata must be present in cache
       router.getBlob(blobId, new GetBlobOptionsBuilder().range(range).build()).get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-      assertTrue("Must encounter a cache hit", ambryCacheWithMetrics.getCacheHitCountDown().await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+      assertTrue("Must encounter a cache hit", ambryCacheWithStats.getCacheHitCountDown().await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
       assertNotNull("Blob metadata must be present in metadata cache", router.getBlobMetadataCache().getObject(blobId));
     } finally {
       router.close();
@@ -1465,9 +1465,9 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
       Properties properties = getNonBlockingRouterProperties("DC1");
       properties.setProperty("router.blob.metadata.cache.enabled", Boolean.toString(true));
       properties.setProperty("router.smallest.blob.for.metadata.cache", Long.toString(0));
-      setRouterWithMetadataCache(properties, new AmbryCacheMetrics(1,1,1,1));
-      AmbryCacheWithMetrics ambryCacheWithMetrics = (AmbryCacheWithMetrics) router.getBlobMetadataCache();
-      assertNotNull("Metadata cache must be created", ambryCacheWithMetrics);
+      setRouterWithMetadataCache(properties, new AmbryCacheStats(1,1,1,1));
+      AmbryCacheWithStats ambryCacheWithStats = (AmbryCacheWithStats) router.getBlobMetadataCache();
+      assertNotNull("Metadata cache must be created", ambryCacheWithStats);
 
       // put a composite blob and test it is absent in the metadata cache
       setOperationParams(2 * PUT_CONTENT_SIZE, TTL_SECS);
@@ -1478,14 +1478,14 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
       // get the one byte from composite blob, and it's metadata must be present in cache
       ByteRange range = ByteRanges.fromOffsetRange(1, 2);
       router.getBlob(blobId, new GetBlobOptionsBuilder().range(range).build()).get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-      assertTrue("Must encounter a cache miss", ambryCacheWithMetrics.getCacheMissCountDown().await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-      assertTrue("Must put metadata in cache", ambryCacheWithMetrics.getPutObjectCountDown().await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+      assertTrue("Must encounter a cache miss", ambryCacheWithStats.getCacheMissCountDown().await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+      assertTrue("Must put metadata in cache", ambryCacheWithStats.getPutObjectCountDown().await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
       assertNotNull("Blob metadata must be present in metadata cache", router.getBlobMetadataCache().getObject(blobId));
 
       // delete composite blob
       router.deleteBlob(blobId, null).get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-      assertTrue("Must encounter a cache hit", ambryCacheWithMetrics.getCacheHitCountDown().await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-      assertTrue("Must delete metadata in cache", ambryCacheWithMetrics.getDeleteObjectCountDown().await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+      assertTrue("Must encounter a cache hit", ambryCacheWithStats.getCacheHitCountDown().await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+      assertTrue("Must delete metadata in cache", ambryCacheWithStats.getDeleteObjectCountDown().await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
       assertNull("Blob metadata must be absent in metadata cache", router.getBlobMetadataCache().getObject(blobId));
     } finally {
       router.close();
@@ -1497,9 +1497,9 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
       Properties properties = getNonBlockingRouterProperties("DC1");
       properties.setProperty("router.blob.metadata.cache.enabled", Boolean.toString(true));
       properties.setProperty("router.smallest.blob.for.metadata.cache", Long.toString(0));
-      setRouterWithMetadataCache(properties, new AmbryCacheMetrics(1,1,1,1));
-      AmbryCacheWithMetrics ambryCacheWithMetrics = (AmbryCacheWithMetrics) router.getBlobMetadataCache();
-      assertNotNull("Metadata cache must be created", ambryCacheWithMetrics);
+      setRouterWithMetadataCache(properties, new AmbryCacheStats(1,1,1,1));
+      AmbryCacheWithStats ambryCacheWithStats = (AmbryCacheWithStats) router.getBlobMetadataCache();
+      assertNotNull("Metadata cache must be created", ambryCacheWithStats);
 
       // put a composite blob and test it is absent in the metadata cache
       setOperationParams(2 * PUT_CONTENT_SIZE, TTL_SECS);
@@ -1510,8 +1510,8 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
       // successful get
       ByteRange range = ByteRanges.fromOffsetRange(1, 2);
       router.getBlob(blobId, new GetBlobOptionsBuilder().range(range).build()).get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-      assertTrue("Must encounter a cache miss", ambryCacheWithMetrics.getCacheMissCountDown().await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-      assertTrue("Must put metadata in cache", ambryCacheWithMetrics.getPutObjectCountDown().await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+      assertTrue("Must encounter a cache miss", ambryCacheWithStats.getCacheMissCountDown().await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+      assertTrue("Must put metadata in cache", ambryCacheWithStats.getPutObjectCountDown().await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
       assertNotNull("Blob metadata must be present in metadata cache", router.getBlobMetadataCache().getObject(blobId));
 
       // failed get
@@ -1519,9 +1519,9 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
       TestCallback<GetBlobResult> testCallback = new TestCallback<>();
       Future<GetBlobResult> future = router.getBlob(blobId, new GetBlobOptionsBuilder().range(range).build(), testCallback, null);
       assertFailureAndCheckErrorCode(future, testCallback, routerErrorCode);
-      assertTrue("Must encounter a cache hit", ambryCacheWithMetrics.getCacheHitCountDown().await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+      assertTrue("Must encounter a cache hit", ambryCacheWithStats.getCacheHitCountDown().await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
       if (deleteCacheEntryOnFail) {
-        assertTrue("Must delete metadata in cache", ambryCacheWithMetrics.getDeleteObjectCountDown().await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        assertTrue("Must delete metadata in cache", ambryCacheWithStats.getDeleteObjectCountDown().await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
         assertNull("Blob metadata must be absent in metadata cache", router.getBlobMetadataCache().getObject(blobId));
       } else {
         assertNotNull("Blob metadata must be present in metadata cache", router.getBlobMetadataCache().getObject(blobId));
@@ -1560,9 +1560,9 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
       Properties properties = getNonBlockingRouterProperties("DC1");
       properties.setProperty("router.blob.metadata.cache.enabled", Boolean.toString(true));
       properties.setProperty("router.smallest.blob.for.metadata.cache", Long.toString(0));
-      setRouterWithMetadataCache(properties, new AmbryCacheMetrics(1,1,1,1));
-      AmbryCacheWithMetrics ambryCacheWithMetrics = (AmbryCacheWithMetrics) router.getBlobMetadataCache();
-      assertNotNull("Metadata cache must be created", ambryCacheWithMetrics);
+      setRouterWithMetadataCache(properties, new AmbryCacheStats(1,1,1,1));
+      AmbryCacheWithStats ambryCacheWithStats = (AmbryCacheWithStats) router.getBlobMetadataCache();
+      assertNotNull("Metadata cache must be created", ambryCacheWithStats);
 
       // put a composite blob and test it is absent in the metadata cache
       setOperationParams(2 * PUT_CONTENT_SIZE, TTL_SECS);
@@ -1573,8 +1573,8 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
       // successful get
       ByteRange range = ByteRanges.fromOffsetRange(1, 2);
       router.getBlob(blobId, new GetBlobOptionsBuilder().range(range).build()).get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-      assertTrue("Must encounter a cache miss", ambryCacheWithMetrics.getCacheMissCountDown().await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-      assertTrue("Must put metadata in cache", ambryCacheWithMetrics.getPutObjectCountDown().await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+      assertTrue("Must encounter a cache miss", ambryCacheWithStats.getCacheMissCountDown().await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+      assertTrue("Must put metadata in cache", ambryCacheWithStats.getPutObjectCountDown().await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
       assertNotNull("Blob metadata must be present in metadata cache", router.getBlobMetadataCache().getObject(blobId));
 
       // failed delete
@@ -1589,7 +1589,7 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
 
       // successful get, cache must be intact
       router.getBlob(blobId, new GetBlobOptionsBuilder().range(range).build()).get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-      assertTrue("Must encounter a cache hit", ambryCacheWithMetrics.getCacheHitCountDown().await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+      assertTrue("Must encounter a cache hit", ambryCacheWithStats.getCacheHitCountDown().await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     } finally {
       router.close();
     }

--- a/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTestBase.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTestBase.java
@@ -218,17 +218,17 @@ public class NonBlockingRouterTestBase {
         cryptoJobHandler, accountService, mockTime, MockClusterMap.DEFAULT_PARTITION_CLASS, null);
   }
 
-  protected void setRouterWithMetadataCache(Properties props, AmbryCacheMetrics ambryCacheMetrics)
+  protected void setRouterWithMetadataCache(Properties props, AmbryCacheStats ambryCacheStats)
       throws Exception {
     VerifiableProperties verifiableProperties = new VerifiableProperties((props));
     routerConfig = new RouterConfig(verifiableProperties);
     routerMetrics = new NonBlockingRouterMetrics(mockClusterMap, routerConfig);
-    AmbryCacheWithMetrics ambryCacheWithMetrics = new AmbryCacheWithMetrics("AmbryCacheWithMetrics",
-        true, routerConfig.routerBlobMetadataCacheMaxSizeBytes, routerMetrics.getMetricRegistry(), ambryCacheMetrics);
+    AmbryCacheWithStats ambryCacheWithStats = new AmbryCacheWithStats("AmbryCacheWithStats",
+        true, routerConfig.routerBlobMetadataCacheMaxSizeBytes, routerMetrics.getMetricRegistry(), ambryCacheStats);
     router = new NonBlockingRouter(routerConfig, routerMetrics,
         new MockNetworkClientFactory(verifiableProperties, mockSelectorState, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
             CHECKOUT_TIMEOUT_MS, mockServerLayout, mockTime), new LoggingNotificationSystem(), mockClusterMap, kms, cryptoService,
-        cryptoJobHandler, accountService, mockTime, MockClusterMap.DEFAULT_PARTITION_CLASS, ambryCacheWithMetrics);
+        cryptoJobHandler, accountService, mockTime, MockClusterMap.DEFAULT_PARTITION_CLASS, ambryCacheWithStats);
   }
 
   /**


### PR DESCRIPTION
Renaming AmbryCacheMetrics to AmbryCacheStats as it is less confusing.
Renaming associated usages as well.