### PR TITLE
Increase network timeout for router requests during heavy load 

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/Http2ClientConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/Http2ClientConfig.java
@@ -38,6 +38,8 @@ public class Http2ClientConfig {
       "http2.blocking.channel.pool.shutdown.timeout.ms";
   public static final String HTTP2_PEER_CERTIFICATE_SAN_REGEX = "http2.peer.certificate.san.regex";
   public static final String HTTP2_TIMEOUT_AS_NETWORK_ERROR = "http.timeout.as.network.error";
+  public static final String HTTP2_REQUEST_ADDITIONAL_TIMEOUT_MS = "http2.request.additional.timeout.ms";
+  public static final String HTTP2_REQUEST_COUNT_FOR_SCALING_TIMEOUT = "http2.request.count.for.scaling.timeout";
 
   /**
    * HTTP/2 connection idle time before we close it. -1 means no idle close.
@@ -167,6 +169,22 @@ public class Http2ClientConfig {
   @Default("false")
   public final boolean http2TimeoutAsNetworkError;
 
+  /**
+   * Denotes how much extra time should be given for requests to receive response under heavy load.
+   */
+  @Config(HTTP2_REQUEST_ADDITIONAL_TIMEOUT_MS)
+  @Default("2500")
+  public final int http2RequestAdditionalTimeoutMs;
+
+  /**
+   * Denotes the number of requests to consider when increasing the network time out. For example, if
+   * {@link this#http2RequestAdditionalTimeoutMs} is 2500 and this value is 100000, it means that we will
+   * increment network timeout by 2.5 seconds for every 100K requests.
+   */
+  @Config(HTTP2_REQUEST_COUNT_FOR_SCALING_TIMEOUT)
+  @Default("100000")
+  public final int http2RequestCountForScalingTimeout;
+
   public Http2ClientConfig(VerifiableProperties verifiableProperties) {
     idleConnectionTimeoutMs = verifiableProperties.getLong(HTTP2_IDLE_CONNECTION_TIMEOUT_MS, -1);
     http2MinConnectionPerPort =
@@ -191,5 +209,7 @@ public class Http2ClientConfig {
         verifiableProperties.getInt(HTTP2_BLOCKING_CHANNEL_POOL_SHUTDOWN_TIMEOUT_MS, 3000);
     http2PeerCertificateSanRegex = verifiableProperties.getString(HTTP2_PEER_CERTIFICATE_SAN_REGEX, "");
     http2TimeoutAsNetworkError = verifiableProperties.getBoolean(HTTP2_TIMEOUT_AS_NETWORK_ERROR, false);
+    http2RequestAdditionalTimeoutMs = verifiableProperties.getInt(HTTP2_REQUEST_ADDITIONAL_TIMEOUT_MS, 2500);
+    http2RequestCountForScalingTimeout = verifiableProperties.getInt(HTTP2_REQUEST_COUNT_FOR_SCALING_TIMEOUT, 100000);
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
@@ -53,11 +53,7 @@ public class RouterConfig {
   public static final String ROUTER_CONNECTIONS_WARM_UP_TIMEOUT_MS = "router.connections.warm.up.timeout.ms";
   public static final String ROUTER_CONNECTION_CHECKOUT_TIMEOUT_MS = "router.connection.checkout.timeout.ms";
   public static final String ROUTER_REQUEST_TIMEOUT_MS = "router.request.timeout.ms";
-  public static final String ROUTER_REQUEST_NETWORK_TIMEOUT_MS = "router.request.network.default.timeout.ms";
-  public static final String ROUTER_REQUEST_NETWORK_TIMEOUT_INCREMENT_MS =
-      "router.request.network.timeout.increment.ms";
-  public static final String ROUTER_REQUEST_NETWORK_TIMEOUT_SCALING_REQUEST_NUM =
-      "router.request.network.timeout.scaling.request.num";
+  public static final String ROUTER_REQUEST_NETWORK_TIMEOUT_MS = "router.request.network.timeout.ms";
   public static final String ROUTER_DROP_REQUEST_ON_TIMEOUT = "router.drop.request.on.timeout";
   public static final String ROUTER_MAX_PUT_CHUNK_SIZE_BYTES = "router.max.put.chunk.size.bytes";
   public static final String ROUTER_PUT_REQUEST_PARALLELISM = "router.put.request.parallelism";
@@ -203,22 +199,6 @@ public class RouterConfig {
   @Config(ROUTER_REQUEST_NETWORK_TIMEOUT_MS)
   @Default("10000")
   public final int routerRequestNetworkTimeoutMs;
-
-  /**
-   * Denotes how much extra time should be given for requests waiting at the network layer under heavy load.
-   */
-  @Config(ROUTER_REQUEST_NETWORK_TIMEOUT_INCREMENT_MS)
-  @Default("2500")
-  public final int routerRequestNetworkTimeoutIncrementMs;
-
-  /**
-   * Denotes the number of requests to consider when increasing the network time out. For example, if
-   * {@link this#routerRequestNetworkTimeoutIncrementMs} is 2500 and this value is 100000, it means that we will
-   * increment network timeout by 2.5 seconds for every 100K requests.
-   */
-  @Config(ROUTER_REQUEST_NETWORK_TIMEOUT_SCALING_REQUEST_NUM)
-  @Default("100000")
-  public final int routerRequestNetworkTimeoutScalingRequestNum;
 
   /**
    * {@code true} if the router should tell the network layer about requests that have timed out. The network client
@@ -768,11 +748,5 @@ public class RouterConfig {
         verifiableProperties.getBoolean(ROUTER_UNAVAILABLE_DUE_TO_OFFLINE_REPLICAS, false);
     routerNotFoundCacheTtlInMs = verifiableProperties.getLongInRange(ROUTER_NOT_FOUND_CACHE_TTL_IN_MS, 15 * 1000L, 0,
         ROUTER_NOT_FOUND_CACHE_MAX_TTL_IN_MS);
-    routerRequestNetworkTimeoutIncrementMs =
-        verifiableProperties.getIntInRange(ROUTER_REQUEST_NETWORK_TIMEOUT_INCREMENT_MS, 2500, 1,
-            MAX_NETWORK_TIMEOUT_VALUE_FOR_A_REQUEST_IN_MS);
-    routerRequestNetworkTimeoutScalingRequestNum =
-        verifiableProperties.getIntInRange(ROUTER_REQUEST_NETWORK_TIMEOUT_SCALING_REQUEST_NUM, 100000, 1,
-            Integer.MAX_VALUE);
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
@@ -53,7 +53,11 @@ public class RouterConfig {
   public static final String ROUTER_CONNECTIONS_WARM_UP_TIMEOUT_MS = "router.connections.warm.up.timeout.ms";
   public static final String ROUTER_CONNECTION_CHECKOUT_TIMEOUT_MS = "router.connection.checkout.timeout.ms";
   public static final String ROUTER_REQUEST_TIMEOUT_MS = "router.request.timeout.ms";
-  public static final String ROUTER_REQUEST_NETWORK_TIMEOUT_MS = "router.request.network.timeout.ms";
+  public static final String ROUTER_REQUEST_NETWORK_TIMEOUT_MS = "router.request.network.default.timeout.ms";
+  public static final String ROUTER_REQUEST_NETWORK_TIMEOUT_INCREMENT_MS =
+      "router.request.network.timeout.increment.ms";
+  public static final String ROUTER_REQUEST_NETWORK_TIMEOUT_SCALING_REQUEST_NUM =
+      "router.request.network.timeout.scaling.request.num";
   public static final String ROUTER_DROP_REQUEST_ON_TIMEOUT = "router.drop.request.on.timeout";
   public static final String ROUTER_MAX_PUT_CHUNK_SIZE_BYTES = "router.max.put.chunk.size.bytes";
   public static final String ROUTER_PUT_REQUEST_PARALLELISM = "router.put.request.parallelism";
@@ -190,15 +194,31 @@ public class RouterConfig {
    * Timeout for requests waiting at the router layer.
    */
   @Config(ROUTER_REQUEST_TIMEOUT_MS)
-  @Default("4000")
+  @Default("20000")
   public final int routerRequestTimeoutMs;
 
   /**
    * Timeout for requests waiting at the network layer.
    */
   @Config(ROUTER_REQUEST_NETWORK_TIMEOUT_MS)
-  @Default("2000")
+  @Default("10000")
   public final int routerRequestNetworkTimeoutMs;
+
+  /**
+   * Denotes how much extra time should be given for requests waiting at the network layer under heavy load.
+   */
+  @Config(ROUTER_REQUEST_NETWORK_TIMEOUT_INCREMENT_MS)
+  @Default("2500")
+  public final int routerRequestNetworkTimeoutIncrementMs;
+
+  /**
+   * Denotes the number of requests to consider when increasing the network time out. For example, if
+   * {@link this#routerRequestNetworkTimeoutIncrementMs} is 2500 and this value is 100000, it means that we will
+   * increment network timeout by 2.5 seconds for every 100K requests.
+   */
+  @Config(ROUTER_REQUEST_NETWORK_TIMEOUT_SCALING_REQUEST_NUM)
+  @Default("100000")
+  public final int routerRequestNetworkTimeoutScalingRequestNum;
 
   /**
    * {@code true} if the router should tell the network layer about requests that have timed out. The network client
@@ -748,5 +768,11 @@ public class RouterConfig {
         verifiableProperties.getBoolean(ROUTER_UNAVAILABLE_DUE_TO_OFFLINE_REPLICAS, false);
     routerNotFoundCacheTtlInMs = verifiableProperties.getLongInRange(ROUTER_NOT_FOUND_CACHE_TTL_IN_MS, 15 * 1000L, 0,
         ROUTER_NOT_FOUND_CACHE_MAX_TTL_IN_MS);
+    routerRequestNetworkTimeoutIncrementMs =
+        verifiableProperties.getIntInRange(ROUTER_REQUEST_NETWORK_TIMEOUT_INCREMENT_MS, 2500, 1,
+            MAX_NETWORK_TIMEOUT_VALUE_FOR_A_REQUEST_IN_MS);
+    routerRequestNetworkTimeoutScalingRequestNum =
+        verifiableProperties.getIntInRange(ROUTER_REQUEST_NETWORK_TIMEOUT_SCALING_REQUEST_NUM, 100000, 1,
+            Integer.MAX_VALUE);
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/network/RequestInfo.java
+++ b/ambry-api/src/main/java/com/github/ambry/network/RequestInfo.java
@@ -45,7 +45,7 @@ public class RequestInfo {
    * @param chargeable the {@link Chargeable} associated with this request.
    * @param creationTime the creation time of this request in msec.
    * @param networkTimeOutMs the time in msec to wait for response from server.
-   * @param finalTimeOutMs
+   * @param finalTimeOutMs the overall wait time for a request in router.
    */
   public RequestInfo(String host, Port port, SendWithCorrelationId request, ReplicaId replicaId, Chargeable chargeable,
       long creationTime, long networkTimeOutMs, long finalTimeOutMs) {
@@ -181,14 +181,6 @@ public class RequestInfo {
    */
   public long getNetworkTimeOutMs() {
     return networkTimeOutMs.get();
-  }
-
-  /**
-   * Set the time to wait for response from server.
-   * @param networkTimeOutMs time out in milliseconds.
-   */
-  public void setNetworkTimeOutMs(long networkTimeOutMs) {
-    this.networkTimeOutMs.set(networkTimeOutMs);
   }
 
   /**

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ClientMetrics.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ClientMetrics.java
@@ -21,6 +21,7 @@ import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.utils.Utils;
 import io.netty.channel.EventLoopGroup;
+import java.util.concurrent.atomic.AtomicLong;
 
 
 /**
@@ -52,6 +53,7 @@ public class Http2ClientMetrics {
   public final Counter http2NetworkErrorCount;
   public final Counter http2RequestsToDropCount;
   public final Counter http2StreamNotWritableCount;
+  public final Counter http2InFlightRequestsCount;
 
   public final Meter http2ClientSendRate;
   public final Meter http2ClientReceiveRate;
@@ -114,10 +116,17 @@ public class Http2ClientMetrics {
 
     http2ServerCertificateValidationFailureCount =
         registry.counter(MetricRegistry.name(Http2NetworkClient.class, "http2ServerCertificateValidationFailureCount"));
+    http2InFlightRequestsCount =
+        registry.counter(MetricRegistry.name(Http2NetworkClient.class, "Http2InFlightRequestsCount"));
   }
 
   void registerNettyPendingTasksGauge(EventLoopGroup eventLoopGroup) {
-    Gauge<Long> pendingTasksGetter =  () -> Utils.getNumberOfPendingTasks(eventLoopGroup);
+    Gauge<Long> pendingTasksGetter = () -> Utils.getNumberOfPendingTasks(eventLoopGroup);
     registry.register(MetricRegistry.name(Http2NetworkClient.class, "NettyPendingTasks"), pendingTasksGetter);
+  }
+
+  public void registerInFlightRequestCount(AtomicLong inFlightRequests) {
+    Gauge<Long> inFlightRequestsCount = inFlightRequests::get;
+    registry.register(MetricRegistry.name(Http2NetworkClient.class, "InFlightRequests"), inFlightRequestsCount);
   }
 }

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ClientMetrics.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ClientMetrics.java
@@ -124,6 +124,6 @@ public class Http2ClientMetrics {
 
   public void registerInFlightRequestCount(AtomicLong inFlightRequests) {
     Gauge<Long> inFlightRequestsCount = inFlightRequests::get;
-    registry.register(MetricRegistry.name(Http2NetworkClient.class, "InFlightRequestsCount"), inFlightRequestsCount);
+    registry.gauge(MetricRegistry.name(Http2NetworkClient.class, "InFlightRequestsCount"), () -> inFlightRequestsCount);
   }
 }

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ClientMetrics.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ClientMetrics.java
@@ -53,7 +53,6 @@ public class Http2ClientMetrics {
   public final Counter http2NetworkErrorCount;
   public final Counter http2RequestsToDropCount;
   public final Counter http2StreamNotWritableCount;
-  public final Counter http2InFlightRequestsCount;
 
   public final Meter http2ClientSendRate;
   public final Meter http2ClientReceiveRate;
@@ -116,8 +115,6 @@ public class Http2ClientMetrics {
 
     http2ServerCertificateValidationFailureCount =
         registry.counter(MetricRegistry.name(Http2NetworkClient.class, "http2ServerCertificateValidationFailureCount"));
-    http2InFlightRequestsCount =
-        registry.counter(MetricRegistry.name(Http2NetworkClient.class, "Http2InFlightRequestsCount"));
   }
 
   void registerNettyPendingTasksGauge(EventLoopGroup eventLoopGroup) {
@@ -127,6 +124,6 @@ public class Http2ClientMetrics {
 
   public void registerInFlightRequestCount(AtomicLong inFlightRequests) {
     Gauge<Long> inFlightRequestsCount = inFlightRequests::get;
-    registry.register(MetricRegistry.name(Http2NetworkClient.class, "InFlightRequests"), inFlightRequestsCount);
+    registry.register(MetricRegistry.name(Http2NetworkClient.class, "InFlightRequestsCount"), inFlightRequestsCount);
   }
 }

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2NetworkClient.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2NetworkClient.java
@@ -57,6 +57,7 @@ public class Http2NetworkClient implements NetworkClient {
   private final Http2ClientConfig http2ClientConfig;
   private final Http2StreamFrameToHttpObjectCodec http2StreamFrameToHttpObjectCodec;
   private final AmbrySendToHttp2Adaptor ambrySendToHttp2Adaptor;
+  private final RequestsStatsHandler requestsStatsHandler;
   private final Map<Integer, Channel> correlationIdInFlightToChannelMap;
   static final AttributeKey<RequestInfo> REQUEST_INFO = AttributeKey.newInstance("RequestInfo");
 
@@ -67,6 +68,7 @@ public class Http2NetworkClient implements NetworkClient {
     this.http2ClientStreamStatsHandler = new Http2ClientStreamStatsHandler(http2ClientMetrics);
     this.http2StreamFrameToHttpObjectCodec = new Http2StreamFrameToHttpObjectCodec(false);
     this.ambrySendToHttp2Adaptor = new AmbrySendToHttp2Adaptor(false, http2ClientConfig.http2FrameMaxSize);
+    this.requestsStatsHandler = new RequestsStatsHandler(http2ClientMetrics);
     this.pools = new Http2ChannelPoolMap(sslFactory, eventLoopGroup, http2ClientConfig, http2ClientMetrics,
         new StreamChannelInitializer());
     this.http2ClientMetrics = http2ClientMetrics;
@@ -127,6 +129,10 @@ public class Http2NetworkClient implements NetworkClient {
                 logger.debug("Stream {} {} not writable. BytesBeforeWritable {} {}", streamChannel.hashCode(),
                     streamChannel, streamChannel.bytesBeforeWritable(), streamChannel.parent().bytesBeforeWritable());
               }
+
+              // Set approximate additional time that may be needed for the response when under heavy load.
+              increaseTimeoutForRequestIfNeeded(requestInfo, streamInitiateTime, streamAcquiredTime);
+
               streamChannel.writeAndFlush(requestInfo.getRequest()).addListener(new ChannelFutureListener() {
                 @Override
                 public void operationComplete(ChannelFuture future) throws Exception {
@@ -241,6 +247,15 @@ public class Http2NetworkClient implements NetworkClient {
 
   }
 
+  private void increaseTimeoutForRequestIfNeeded(RequestInfo requestInfo, long streamInitiateTime,
+      long streamAcquiredTime) {
+    long inFlightRequestCount = requestsStatsHandler.getInFlightRequestCount();
+    long additionalRequestTimeOutMs = (streamAcquiredTime - streamInitiateTime) + (
+        (inFlightRequestCount / http2ClientConfig.http2RequestCountForScalingTimeout)
+            * http2ClientConfig.http2RequestAdditionalTimeoutMs);
+    requestInfo.incrementNetworkTimeOutMs(additionalRequestTimeOutMs);
+  }
+
   private class StreamChannelInitializer extends ChannelInitializer {
 
     public void initChannel(Channel channel) {
@@ -248,8 +263,10 @@ public class Http2NetworkClient implements NetworkClient {
       // TODO: implement ourselves' aggregator. Http2Streams to Response Object
       channel.pipeline().addLast(http2StreamFrameToHttpObjectCodec);
       channel.pipeline().addLast(new HttpObjectAggregator(http2ClientConfig.http2MaxContentLength));
-      channel.pipeline().addLast(http2ClientResponseHandler);
       channel.pipeline().addLast(ambrySendToHttp2Adaptor);
+      // Add requests stats handler before response handler since the latter closes the channel after processing the message.
+      channel.pipeline().addLast(requestsStatsHandler);
+      channel.pipeline().addLast(http2ClientResponseHandler);
       // We log hashCode because frame id is -1 at this time.
       logger.trace("Handlers added to channel: {} {} ", channel.hashCode(), channel);
     }

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/RequestsStatsHandler.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/RequestsStatsHandler.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2020 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.network.http2;
+
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import java.util.concurrent.atomic.AtomicLong;
+
+
+/**
+ * A handler to track requests stats. For now, it only tracks in-flight request count.
+ */
+
+@ChannelHandler.Sharable
+class RequestsStatsHandler extends ChannelDuplexHandler {
+  private final AtomicLong inFlightRequests = new AtomicLong(0);
+
+  public RequestsStatsHandler(Http2ClientMetrics http2Metrics) {
+    http2Metrics.registerInFlightRequestCount(inFlightRequests);
+  }
+
+  @Override
+  public void channelRead(ChannelHandlerContext ctx, Object obj) throws Exception {
+    inFlightRequests.decrementAndGet();
+    super.channelRead(ctx, obj);
+  }
+
+  @Override
+  public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+    inFlightRequests.incrementAndGet();
+    super.write(ctx, msg, promise);
+  }
+
+  @Override
+  public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+    inFlightRequests.decrementAndGet();
+    super.exceptionCaught(ctx, cause);
+  }
+
+  /**
+   * @return the number of in-flight requests.
+   */
+  public long getInFlightRequestCount() {
+    return inFlightRequests.get();
+  }
+}
+

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/RequestsStatsHandler.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/RequestsStatsHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 LinkedIn Corp. All rights reserved.
+ * Copyright 2022 LinkedIn Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ambry-network/src/test/java/com/github/ambry/network/http2/RequestsStatsHandlerTest.java
+++ b/ambry-network/src/test/java/com/github/ambry/network/http2/RequestsStatsHandlerTest.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2022 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.network.http2;
+
+import com.codahale.metrics.MetricRegistry;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.*;
+
+
+public class RequestsStatsHandlerTest {
+
+  RequestsStatsHandler requestsStatsHandler;
+
+  public RequestsStatsHandlerTest() {
+    setup();
+  }
+
+  @Before
+  public void setup() {
+    requestsStatsHandler = new RequestsStatsHandler(new Http2ClientMetrics(new MetricRegistry()));
+  }
+
+  @Test
+  public void inFlightRequestCountTest() {
+
+    EmbeddedChannel channel = new EmbeddedChannel(requestsStatsHandler);
+    int inFlightRequestCount = 0;
+
+    channel.writeOutbound(new Object());
+    Assert.assertEquals("Mismatch in in flight request count", ++inFlightRequestCount,
+        requestsStatsHandler.getInFlightRequestCount());
+
+    channel.writeInbound(new Object());
+    Assert.assertEquals("Mismatch in in flight request count", --inFlightRequestCount,
+        requestsStatsHandler.getInFlightRequestCount());
+  }
+
+  @Test
+  public void inFlightRequestCountTestDuringException() {
+    EmbeddedChannel channel = new EmbeddedChannel(new TestHandler(), requestsStatsHandler);
+    int inFlightRequestCount = 0;
+
+    channel.writeOutbound(new Object());
+    Assert.assertEquals("Mismatch in in flight request count", ++inFlightRequestCount,
+        requestsStatsHandler.getInFlightRequestCount());
+
+    try {
+      channel.writeInbound(new Object());
+      Assert.assertEquals("Mismatch in in flight request count", --inFlightRequestCount,
+          requestsStatsHandler.getInFlightRequestCount());
+      verify(requestsStatsHandler, times(1)).exceptionCaught(any(), any());
+    } catch (Exception ex) {
+
+    }
+  }
+
+  static class TestHandler extends ChannelInboundHandlerAdapter {
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+      throw new RuntimeException("Network error");
+    }
+  }
+}

--- a/ambry-network/src/test/java/com/github/ambry/network/http2/RequestsStatsHandlerTest.java
+++ b/ambry-network/src/test/java/com/github/ambry/network/http2/RequestsStatsHandlerTest.java
@@ -66,14 +66,14 @@ public class RequestsStatsHandlerTest {
       Assert.assertEquals("Mismatch in in flight request count", --inFlightRequestCount,
           requestsStatsHandler.getInFlightRequestCount());
       verify(requestsStatsHandler, times(1)).exceptionCaught(any(), any());
-    } catch (Exception ex) {
+    } catch (Exception ignored) {
 
     }
   }
 
   static class TestHandler extends ChannelInboundHandlerAdapter {
     @Override
-    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+    public void channelRead(ChannelHandlerContext ctx, Object msg) {
       throw new RuntimeException("Network error");
     }
   }

--- a/ambry-router/src/main/java/com/github/ambry/router/DeleteOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/DeleteOperation.java
@@ -134,7 +134,8 @@ class DeleteOperation {
       Port port = RouterUtils.getPortToConnectTo(replica, routerConfig.routerEnableHttp2NetworkClient);
       DeleteRequest deleteRequest = createDeleteRequest();
       RequestInfo requestInfo =
-          new RequestInfo(hostname, port, deleteRequest, replica, operationQuotaCharger, time.milliseconds());
+          new RequestInfo(hostname, port, deleteRequest, replica, operationQuotaCharger, time.milliseconds(),
+              routerConfig.routerRequestNetworkTimeoutMs, routerConfig.routerRequestTimeoutMs);
       deleteRequestInfos.put(deleteRequest.getCorrelationId(), requestInfo);
       requestRegistrationCallback.registerRequestToSend(this, requestInfo);
       replicaIterator.remove();
@@ -273,7 +274,7 @@ class DeleteOperation {
       // throttling, etc) for long time, drop the request.
       long currentTimeInMs = time.milliseconds();
       RouterUtils.RouterRequestExpiryReason routerRequestExpiryReason =
-          RouterUtils.isRequestExpired(requestInfo, currentTimeInMs, routerConfig);
+          RouterUtils.isRequestExpired(requestInfo, currentTimeInMs);
       if (routerRequestExpiryReason != RouterUtils.RouterRequestExpiryReason.NO_TIMEOUT) {
         itr.remove();
         logger.trace("Delete Request with correlationId {} in flight has expired for replica {} due to {}",

--- a/ambry-router/src/main/java/com/github/ambry/router/DeleteOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/DeleteOperation.java
@@ -285,10 +285,11 @@ class DeleteOperation {
         onErrorResponse(requestInfo.getReplicaId(),
             RouterUtils.buildTimeoutException(correlationId, requestInfo.getReplicaId().getDataNodeId(), blobId));
         requestRegistrationCallback.registerRequestToDrop(correlationId);
-      } else {
-        // the entries are ordered by correlation id and time. Break on the first request that has not timed out.
-        break;
       }
+      // Note: Even though the entries are ordered by correlation id and their creation time, we cannot break out of
+      // the while loop when we find an unexpired entry. This is because time outs for all requests may not be equal
+      // now. For example, we assign higher time outs when we find that there are lot of outstanding requests by
+      // letting Network client dynamically update the timeout via RequestInfo#incrementNetworkTimeOutMs.
     }
   }
 

--- a/ambry-router/src/main/java/com/github/ambry/router/GetBlobInfoOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/GetBlobInfoOperation.java
@@ -41,8 +41,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -71,7 +71,7 @@ class GetBlobInfoOperation extends GetOperation {
   private final CryptoJobMetricsTracker decryptJobMetricsTracker =
       new CryptoJobMetricsTracker(routerMetrics.decryptJobMetrics);
   // map of correlation id to the request metadata for every request issued for this operation.
-  private final Map<Integer, RequestInfo> correlationIdToGetRequestInfo = new TreeMap<>();
+  private final Map<Integer, RequestInfo> correlationIdToGetRequestInfo = new LinkedHashMap<>();
 
   private static final Logger logger = LoggerFactory.getLogger(GetBlobInfoOperation.class);
 
@@ -165,11 +165,19 @@ class GetBlobInfoOperation extends GetOperation {
             RouterUtils.buildTimeoutException(correlationId, requestInfo.getReplicaId().getDataNodeId(), blobId));
         requestRegistrationCallback.registerRequestToDrop(correlationId);
         inFlightRequestsIterator.remove();
+      } else {
+        // Note: Even though the requests are ordered by correlation id and their creation time, we cannot break out of
+        // the while loop here. This is because time outs for all requests may not be equal now.
+
+        // For example, request 1 in the map may have been assigned high time out since it might be sent at a
+        // time when the load is high and request 2 may have been assigned lower time out value since the load might have
+        // decreased by the time it is sent out. In this case, we should continue iterating the loop and clean up
+        // request 2 in the map.
+
+        // The cost of iterating all entries should be okay since the map contains outstanding requests whose number
+        // should be small. The maximum outstanding requests possible would be equal to the operation parallelism value
+        // and may be few more if adaptive operation tracker is used.
       }
-      // Note: Even though the entries are ordered by correlation id and their creation time, we cannot break out of
-      // the while loop when we find an unexpired entry. This is because time outs for all requests may not be equal
-      // now. For example, we assign higher time outs when we find that there are lot of outstanding requests by
-      // letting Network client dynamically update the timeout via RequestInfo#incrementNetworkTimeOutMs.
     }
   }
 

--- a/ambry-router/src/main/java/com/github/ambry/router/GetBlobInfoOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/GetBlobInfoOperation.java
@@ -165,10 +165,11 @@ class GetBlobInfoOperation extends GetOperation {
             RouterUtils.buildTimeoutException(correlationId, requestInfo.getReplicaId().getDataNodeId(), blobId));
         requestRegistrationCallback.registerRequestToDrop(correlationId);
         inFlightRequestsIterator.remove();
-      } else {
-        // the entries are ordered by correlation id and time. Break on the first request that has not timed out.
-        break;
       }
+      // Note: Even though the entries are ordered by correlation id and their creation time, we cannot break out of
+      // the while loop when we find an unexpired entry. This is because time outs for all requests may not be equal
+      // now. For example, we assign higher time outs when we find that there are lot of outstanding requests by
+      // letting Network client dynamically update the timeout via RequestInfo#incrementNetworkTimeOutMs.
     }
   }
 

--- a/ambry-router/src/main/java/com/github/ambry/router/GetBlobInfoOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/GetBlobInfoOperation.java
@@ -154,7 +154,7 @@ class GetBlobInfoOperation extends GetOperation {
       // throttling, etc) for long time, drop the request.
       long currentTimeInMs = time.milliseconds();
       RouterUtils.RouterRequestExpiryReason routerRequestExpiryReason =
-          RouterUtils.isRequestExpired(requestInfo, currentTimeInMs, routerConfig);
+          RouterUtils.isRequestExpired(requestInfo, currentTimeInMs);
       if (routerRequestExpiryReason != RouterUtils.RouterRequestExpiryReason.NO_TIMEOUT) {
         logger.trace("GetBlobInfoRequest with correlationId {} in flight has expired for replica {} due to {}",
             correlationId, requestInfo.getReplicaId().getDataNodeId(), routerRequestExpiryReason.name());
@@ -183,7 +183,8 @@ class GetBlobInfoOperation extends GetOperation {
       Port port = RouterUtils.getPortToConnectTo(replicaId, routerConfig.routerEnableHttp2NetworkClient);
       GetRequest getRequest = createGetRequest(blobId, getOperationFlag(), options.getBlobOptions.getGetOption());
       RequestInfo requestInfo =
-          new RequestInfo(hostname, port, getRequest, replicaId, operationQuotaCharger, time.milliseconds());
+          new RequestInfo(hostname, port, getRequest, replicaId, operationQuotaCharger, time.milliseconds(),
+              routerConfig.routerRequestNetworkTimeoutMs, routerConfig.routerRequestTimeoutMs);
       int correlationId = getRequest.getCorrelationId();
       correlationIdToGetRequestInfo.put(correlationId, requestInfo);
       requestRegistrationCallback.registerRequestToSend(this, requestInfo);

--- a/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
@@ -213,8 +213,8 @@ class GetBlobOperation extends GetOperation {
     if (firstChunk.shouldSaveMetadata()) {
       BlobMetadata blobMetadata = new BlobMetadata(blobId.toString(), blobInfo, compositeBlobInfo);
       putResult = blobMetadataCache.putObject(blobMetadata.getBlobId(), blobMetadata);
-      logger.debug("[{}] Issued save-metadata for blobId = {}, result = {}", blobMetadata.getBlobId(),
-          blobId, putResult);
+      logger.debug("[{}] Issued save-metadata for blobId = {}, result = {}", blobMetadata.getBlobId(), blobId,
+          putResult);
     }
     return putResult;
   }
@@ -229,8 +229,8 @@ class GetBlobOperation extends GetOperation {
       return false;
     }
     boolean deleteResult = blobMetadataCache.deleteObject(blobId.toString());
-    logger.debug("[{}] Issued delete-metadata for blobId = {}, reason = {}, result = {}", blobMetadataCache.getCacheId(),
-        blobId, reason, deleteResult);
+    logger.debug("[{}] Issued delete-metadata for blobId = {}, reason = {}, result = {}",
+        blobMetadataCache.getCacheId(), blobId, reason, deleteResult);
     return deleteResult;
   }
 
@@ -898,7 +898,7 @@ class GetBlobOperation extends GetOperation {
         // throttling, etc) for long time, drop the request.
         long currentTimeInMs = time.milliseconds();
         RouterUtils.RouterRequestExpiryReason routerRequestExpiryReason =
-            RouterUtils.isRequestExpired(requestInfo, currentTimeInMs, routerConfig);
+            RouterUtils.isRequestExpired(requestInfo, currentTimeInMs);
         if (routerRequestExpiryReason != RouterUtils.RouterRequestExpiryReason.NO_TIMEOUT) {
           logger.trace("GetBlobRequest with correlationId {} in flight has expired for replica {} due to {} ",
               correlationId, requestInfo.getReplicaId().getDataNodeId(), routerRequestExpiryReason.name());
@@ -929,7 +929,8 @@ class GetBlobOperation extends GetOperation {
         Port port = RouterUtils.getPortToConnectTo(replicaId, routerConfig.routerEnableHttp2NetworkClient);
         GetRequest getRequest = createGetRequest(chunkBlobId, getOperationFlag(), getGetOption());
         RequestInfo requestInfo =
-            new RequestInfo(hostname, port, getRequest, replicaId, prepareQuotaCharger(), time.milliseconds());
+            new RequestInfo(hostname, port, getRequest, replicaId, prepareQuotaCharger(), time.milliseconds(),
+                routerConfig.routerRequestNetworkTimeoutMs, routerConfig.routerRequestTimeoutMs);
         int correlationId = getRequest.getCorrelationId();
         correlationIdToGetRequestInfo.put(correlationId, requestInfo);
         correlationIdToGetChunk.put(correlationId, this);

--- a/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
@@ -58,10 +58,10 @@ import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
-import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -676,7 +676,7 @@ class GetBlobOperation extends GetOperation {
    */
   private class GetChunk {
     // map of correlation id to the request metadata for every request issued for this operation.
-    protected final Map<Integer, RequestInfo> correlationIdToGetRequestInfo = new TreeMap<>();
+    protected final Map<Integer, RequestInfo> correlationIdToGetRequestInfo = new LinkedHashMap<>();
     // progress tracker used to track whether the operation is completed or not and whether it succeeded or failed on complete
     protected ProgressTracker progressTracker;
     // DecryptCallBackResultInfo that holds all info about decrypt job callback
@@ -910,11 +910,19 @@ class GetBlobOperation extends GetOperation {
                   chunkBlobId));
           requestRegistrationCallback.registerRequestToDrop(correlationId);
           inFlightRequestsIterator.remove();
+        } else {
+          // Note: Even though the requests are ordered by correlation id and their creation time, we cannot break out of
+          // the while loop here. This is because time outs for all requests may not be equal now.
+
+          // For example, request 1 in the map may have been assigned high time out since it might be sent at a
+          // time when the load is high and request 2 may have been assigned lower time out value since the load might have
+          // decreased by the time it is sent out. In this case, we should continue iterating the loop and clean up
+          // request 2 in the map.
+
+          // The cost of iterating all entries should be okay since the map contains outstanding requests whose number
+          // should be small. The maximum outstanding requests possible would be equal to the operation parallelism value
+          // and may be few more if adaptive operation tracker is used.
         }
-        // Note: Even though the entries are ordered by correlation id and their creation time, we cannot break out of
-        // the while loop when we find an unexpired entry. This is because time outs for all requests may not be equal
-        // now. For example, we assign higher time outs when we find that there are lot of outstanding requests by
-        // letting Network client dynamically update the timeout via RequestInfo#incrementNetworkTimeOutMs.
       }
     }
 

--- a/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
@@ -910,10 +910,11 @@ class GetBlobOperation extends GetOperation {
                   chunkBlobId));
           requestRegistrationCallback.registerRequestToDrop(correlationId);
           inFlightRequestsIterator.remove();
-        } else {
-          // the entries are ordered by correlation id and time. Break on the first request that has not timed out.
-          break;
         }
+        // Note: Even though the entries are ordered by correlation id and their creation time, we cannot break out of
+        // the while loop when we find an unexpired entry. This is because time outs for all requests may not be equal
+        // now. For example, we assign higher time outs when we find that there are lot of outstanding requests by
+        // letting Network client dynamically update the timeout via RequestInfo#incrementNetworkTimeOutMs.
       }
     }
 

--- a/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
@@ -1468,10 +1468,11 @@ class PutOperation {
               chunkBlobId));
           requestRegistrationCallback.registerRequestToDrop(correlationId);
           inFlightRequestsIterator.remove();
-        } else {
-          // the entries are ordered by correlation id and time. Break on the first request that has not timed out.
-          break;
         }
+        // Note: Even though the entries are ordered by correlation id and their creation time, we cannot break out of
+        // the while loop when we find an unexpired entry. This is because time outs for all requests may not be equal
+        // now. For example, we assign higher time outs when we find that there are lot of outstanding requests by
+        // letting Network client dynamically update the timeout via RequestInfo#incrementNetworkTimeOutMs.
       }
     }
 

--- a/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
@@ -1455,7 +1455,7 @@ class PutOperation {
         // throttling, etc) for long time, drop the request.
         long currentTimeInMs = time.milliseconds();
         RouterUtils.RouterRequestExpiryReason routerRequestExpiryReason =
-            RouterUtils.isRequestExpired(requestInfo, currentTimeInMs, routerConfig);
+            RouterUtils.isRequestExpired(requestInfo, currentTimeInMs);
         if (routerRequestExpiryReason != RouterUtils.RouterRequestExpiryReason.NO_TIMEOUT) {
           onErrorResponse(requestInfo.getReplicaId(), TrackedRequestFinalState.FAILURE);
           logger.warn("{}: PutRequest with correlationId {} in flight has expired for replica {} {} due to {} ",
@@ -1486,7 +1486,8 @@ class PutOperation {
         Port port = RouterUtils.getPortToConnectTo(replicaId, routerConfig.routerEnableHttp2NetworkClient);
         PutRequest putRequest = createPutRequest();
         RequestInfo requestInfo =
-            new RequestInfo(hostname, port, putRequest, replicaId, prepareQuotaCharger(), time.milliseconds());
+            new RequestInfo(hostname, port, putRequest, replicaId, prepareQuotaCharger(), time.milliseconds(),
+                routerConfig.routerRequestNetworkTimeoutMs, routerConfig.routerRequestTimeoutMs);
         int correlationId = putRequest.getCorrelationId();
         correlationIdToChunkPutRequestInfo.put(correlationId, requestInfo);
         correlationIdToPutChunk.put(correlationId, this);

--- a/ambry-router/src/main/java/com/github/ambry/router/RouterUtils.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/RouterUtils.java
@@ -295,15 +295,13 @@ public class RouterUtils {
    * (unavailable quota, etc.) for a long time.
    * @param requestInfo of the request.
    * @param currentTimeInMs current time in msec.
-   * @param routerConfig router config.
    * @return RouterRequestExpiryReason representing the reason for request expiry.
    */
-  public static RouterRequestExpiryReason isRequestExpired(RequestInfo requestInfo, long currentTimeInMs,
-      RouterConfig routerConfig) {
+  public static RouterRequestExpiryReason isRequestExpired(RequestInfo requestInfo, long currentTimeInMs) {
     if ((requestInfo.isRequestReceivedByNetworkLayer()
-        && currentTimeInMs - requestInfo.getRequestEnqueueTime() > routerConfig.routerRequestNetworkTimeoutMs)) {
+        && currentTimeInMs - requestInfo.getRequestEnqueueTime() > requestInfo.getNetworkTimeOutMs())) {
       return RouterRequestExpiryReason.ROUTER_SERVER_NETWORK_CLIENT_TIMEOUT;
-    } else if (currentTimeInMs - requestInfo.getRequestCreateTime() > routerConfig.routerRequestTimeoutMs) {
+    } else if (currentTimeInMs - requestInfo.getRequestCreateTime() > requestInfo.getFinalTimeOutMs()) {
       return RouterRequestExpiryReason.ROUTER_REQUEST_TIMEOUT;
     }
     return RouterRequestExpiryReason.NO_TIMEOUT;

--- a/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateOperation.java
@@ -267,10 +267,11 @@ class TtlUpdateOperation {
         onErrorResponse(requestInfo.getReplicaId(),
             RouterUtils.buildTimeoutException(correlationId, requestInfo.getReplicaId().getDataNodeId(), blobId));
         requestRegistrationCallback.registerRequestToDrop(correlationId);
-      } else {
-        // the entries are ordered by correlation id and time. Break on the first request that has not timed out.
-        break;
       }
+      // Note: Even though the entries are ordered by correlation id and their creation time, we cannot break out of
+      // the while loop when we find an unexpired entry. This is because time outs for all requests may not be equal
+      // now. For example, we assign higher time outs when we find that there are lot of outstanding requests by
+      // letting Network client dynamically update the timeout via RequestInfo#incrementNetworkTimeOutMs.
     }
   }
 

--- a/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateOperation.java
@@ -130,7 +130,8 @@ class TtlUpdateOperation {
       Port port = RouterUtils.getPortToConnectTo(replica, routerConfig.routerEnableHttp2NetworkClient);
       TtlUpdateRequest ttlUpdateRequest = createTtlUpdateRequest();
       RequestInfo requestInfo =
-          new RequestInfo(hostname, port, ttlUpdateRequest, replica, operationQuotaCharger, time.milliseconds());
+          new RequestInfo(hostname, port, ttlUpdateRequest, replica, operationQuotaCharger, time.milliseconds(),
+              routerConfig.routerRequestNetworkTimeoutMs, routerConfig.routerRequestTimeoutMs);
       ttlUpdateRequestInfos.put(ttlUpdateRequest.getCorrelationId(), requestInfo);
       requestRegistrationCallback.registerRequestToSend(this, requestInfo);
       replicaIterator.remove();
@@ -255,7 +256,7 @@ class TtlUpdateOperation {
       // throttling, etc) for long time, drop the request.
       long currentTimeInMs = time.milliseconds();
       RouterUtils.RouterRequestExpiryReason routerRequestExpiryReason =
-          RouterUtils.isRequestExpired(requestInfo, currentTimeInMs, routerConfig);
+          RouterUtils.isRequestExpired(requestInfo, currentTimeInMs);
       if (routerRequestExpiryReason != RouterUtils.RouterRequestExpiryReason.NO_TIMEOUT) {
         itr.remove();
         LOGGER.trace("TTL Request with correlationid {} in flight has expired for replica {} due to {}", correlationId,

--- a/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateOperation.java
@@ -30,8 +30,8 @@ import com.github.ambry.quota.QuotaUtils;
 import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.utils.Time;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,7 +57,7 @@ class TtlUpdateOperation {
   // The operation tracker that tracks the state of this operation.
   private final OperationTracker operationTracker;
   // A map used to find inflight requests using a correlation id.
-  private final Map<Integer, RequestInfo> ttlUpdateRequestInfos = new TreeMap<>();
+  private final Map<Integer, RequestInfo> ttlUpdateRequestInfos = new LinkedHashMap<>();
   // The result of this operation to be set into FutureResult.
   private final Void operationResult = null;
   // the cause for failure of this operation. This will be set if and when the operation encounters an irrecoverable
@@ -267,11 +267,19 @@ class TtlUpdateOperation {
         onErrorResponse(requestInfo.getReplicaId(),
             RouterUtils.buildTimeoutException(correlationId, requestInfo.getReplicaId().getDataNodeId(), blobId));
         requestRegistrationCallback.registerRequestToDrop(correlationId);
+      } else {
+        // Note: Even though the requests are ordered by correlation id and their creation time, we cannot break out of
+        // the while loop here. This is because time outs for all requests may not be equal now.
+
+        // For example, request 1 in the map may have been assigned high time out since it might be sent at a
+        // time when the load is high and request 2 may have been assigned lower time out value since the load might have
+        // decreased by the time it is sent out. In this case, we should continue iterating the loop and clean up
+        // request 2 in the map.
+
+        // The cost of iterating all entries should be okay since the map contains outstanding requests whose number
+        // should be small. The maximum outstanding requests possible would be equal to the operation parallelism value
+        // and may be few more if adaptive operation tracker is used.
       }
-      // Note: Even though the entries are ordered by correlation id and their creation time, we cannot break out of
-      // the while loop when we find an unexpired entry. This is because time outs for all requests may not be equal
-      // now. For example, we assign higher time outs when we find that there are lot of outstanding requests by
-      // letting Network client dynamically update the timeout via RequestInfo#incrementNetworkTimeOutMs.
     }
   }
 

--- a/ambry-router/src/main/java/com/github/ambry/router/UndeleteOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/UndeleteOperation.java
@@ -30,8 +30,8 @@ import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.store.MessageInfo;
 import com.github.ambry.utils.Time;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,7 +55,7 @@ public class UndeleteOperation {
   // The operation tracker that tracks the state of this operation.
   private final OperationTracker operationTracker;
   // A map used to find inflight requests using a correlation id.
-  private final Map<Integer, RequestInfo> undeleteRequestInfos = new TreeMap<>();
+  private final Map<Integer, RequestInfo> undeleteRequestInfos = new LinkedHashMap<>();
   // The result of this operation to be set into FutureResult.
   private final Void operationResult = null;
   // the cause for failure of this operation. This will be set if and when the operation encounters an irrecoverable
@@ -296,11 +296,19 @@ public class UndeleteOperation {
         onErrorResponse(requestInfo.getReplicaId(),
             RouterUtils.buildTimeoutException(correlationId, requestInfo.getReplicaId().getDataNodeId(), blobId));
         requestRegistrationCallback.registerRequestToDrop(correlationId);
+      } else {
+        // Note: Even though the requests are ordered by correlation id and their creation time, we cannot break out of
+        // the while loop here. This is because time outs for all requests may not be equal now.
+
+        // For example, request 1 in the map may have been assigned high time out since it might be sent at a
+        // time when the load is high and request 2 may have been assigned lower time out value since the load might have
+        // decreased by the time it is sent out. In this case, we should continue iterating the loop and clean up
+        // request 2 in the map.
+
+        // The cost of iterating all entries should be okay since the map contains outstanding requests whose number
+        // should be small. The maximum outstanding requests possible would be equal to the operation parallelism value
+        // and may be few more if adaptive operation tracker is used.
       }
-      // Note: Even though the entries are ordered by correlation id and their creation time, we cannot break out of
-      // the while loop when we find an unexpired entry. This is because time outs for all requests may not be equal
-      // now. For example, we assign higher time outs when we find that there are lot of outstanding requests by
-      // letting Network client dynamically update the timeout via RequestInfo#incrementNetworkTimeOutMs.
     }
   }
 

--- a/ambry-router/src/main/java/com/github/ambry/router/UndeleteOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/UndeleteOperation.java
@@ -60,7 +60,7 @@ public class UndeleteOperation {
   private final Void operationResult = null;
   // the cause for failure of this operation. This will be set if and when the operation encounters an irrecoverable
   // failure.
-  private final AtomicReference<Exception> operationException = new AtomicReference<Exception>();
+  private final AtomicReference<Exception> operationException = new AtomicReference<>();
   // Quota charger for this operation.
   private final OperationQuotaCharger operationQuotaCharger;
   // Denotes whether the operation is complete.
@@ -296,10 +296,11 @@ public class UndeleteOperation {
         onErrorResponse(requestInfo.getReplicaId(),
             RouterUtils.buildTimeoutException(correlationId, requestInfo.getReplicaId().getDataNodeId(), blobId));
         requestRegistrationCallback.registerRequestToDrop(correlationId);
-      } else {
-        // the entries are ordered by correlation id and time. Break on the first request that has not timed out.
-        break;
       }
+      // Note: Even though the entries are ordered by correlation id and their creation time, we cannot break out of
+      // the while loop when we find an unexpired entry. This is because time outs for all requests may not be equal
+      // now. For example, we assign higher time outs when we find that there are lot of outstanding requests by
+      // letting Network client dynamically update the timeout via RequestInfo#incrementNetworkTimeOutMs.
     }
   }
 

--- a/ambry-router/src/main/java/com/github/ambry/router/UndeleteOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/UndeleteOperation.java
@@ -128,7 +128,8 @@ public class UndeleteOperation {
       Port port = RouterUtils.getPortToConnectTo(replica, routerConfig.routerEnableHttp2NetworkClient);
       UndeleteRequest undeleteRequest = createUndeleteRequest();
       RequestInfo requestInfo =
-          new RequestInfo(hostname, port, undeleteRequest, replica, operationQuotaCharger, time.milliseconds());
+          new RequestInfo(hostname, port, undeleteRequest, replica, operationQuotaCharger, time.milliseconds(),
+              routerConfig.routerRequestNetworkTimeoutMs, routerConfig.routerRequestTimeoutMs);
       undeleteRequestInfos.put(undeleteRequest.getCorrelationId(), requestInfo);
       requestRegistrationCallback.registerRequestToSend(this, requestInfo);
       replicaIterator.remove();
@@ -284,7 +285,7 @@ public class UndeleteOperation {
       // throttling, etc) for long time, drop the request.
       long currentTimeInMs = time.milliseconds();
       RouterUtils.RouterRequestExpiryReason routerRequestExpiryReason =
-          RouterUtils.isRequestExpired(requestInfo, currentTimeInMs, routerConfig);
+          RouterUtils.isRequestExpired(requestInfo, currentTimeInMs);
       if (routerRequestExpiryReason != RouterUtils.RouterRequestExpiryReason.NO_TIMEOUT) {
         iter.remove();
         LOGGER.warn("Undelete request with correlationid {} in flight has expired for replica {} due to {}",

--- a/ambry-router/src/test/java/com/github/ambry/router/RouterUtilsTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/RouterUtilsTest.java
@@ -167,29 +167,24 @@ public class RouterUtilsTest {
 
   @Test
   public void testIsRequestExpired() {
-    Properties properties = new Properties();
-    properties.setProperty(RouterConfig.ROUTER_HOSTNAME, "test");
-    properties.setProperty(RouterConfig.ROUTER_DATACENTER_NAME, "dc");
-    properties.setProperty(RouterConfig.ROUTER_REQUEST_NETWORK_TIMEOUT_MS, "10");
-    properties.setProperty(RouterConfig.ROUTER_REQUEST_TIMEOUT_MS, "10");
-
     RequestInfo requestInfo = Mockito.mock(RequestInfo.class);
-    RouterConfig routerConfig = new RouterConfig(new VerifiableProperties(properties));
     Mockito.when(requestInfo.isRequestReceivedByNetworkLayer()).thenReturn(true);
     Mockito.when(requestInfo.getRequestEnqueueTime()).thenReturn(1L);
+    Mockito.when(requestInfo.getNetworkTimeOutMs()).thenReturn(10L);
     assertEquals(RouterUtils.RouterRequestExpiryReason.ROUTER_SERVER_NETWORK_CLIENT_TIMEOUT,
         RouterUtils.isRequestExpired(requestInfo, 12L));
 
     Mockito.when(requestInfo.isRequestReceivedByNetworkLayer()).thenReturn(false);
     Mockito.when(requestInfo.getRequestEnqueueTime()).thenReturn(1L);
     Mockito.when(requestInfo.getRequestCreateTime()).thenReturn(1L);
+    Mockito.when(requestInfo.getFinalTimeOutMs()).thenReturn(10L);
     assertEquals(RouterUtils.RouterRequestExpiryReason.ROUTER_REQUEST_TIMEOUT,
         RouterUtils.isRequestExpired(requestInfo, 12L));
 
     Mockito.when(requestInfo.isRequestReceivedByNetworkLayer()).thenReturn(false);
     Mockito.when(requestInfo.getRequestEnqueueTime()).thenReturn(1L);
     Mockito.when(requestInfo.getRequestCreateTime()).thenReturn(5L);
-    assertEquals(RouterUtils.RouterRequestExpiryReason.NO_TIMEOUT,
-        RouterUtils.isRequestExpired(requestInfo, 12L));
+    Mockito.when(requestInfo.getFinalTimeOutMs()).thenReturn(10L);
+    assertEquals(RouterUtils.RouterRequestExpiryReason.NO_TIMEOUT, RouterUtils.isRequestExpired(requestInfo, 12L));
   }
 }

--- a/ambry-router/src/test/java/com/github/ambry/router/RouterUtilsTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/RouterUtilsTest.java
@@ -178,18 +178,18 @@ public class RouterUtilsTest {
     Mockito.when(requestInfo.isRequestReceivedByNetworkLayer()).thenReturn(true);
     Mockito.when(requestInfo.getRequestEnqueueTime()).thenReturn(1L);
     assertEquals(RouterUtils.RouterRequestExpiryReason.ROUTER_SERVER_NETWORK_CLIENT_TIMEOUT,
-        RouterUtils.isRequestExpired(requestInfo, 12L, routerConfig));
+        RouterUtils.isRequestExpired(requestInfo, 12L));
 
     Mockito.when(requestInfo.isRequestReceivedByNetworkLayer()).thenReturn(false);
     Mockito.when(requestInfo.getRequestEnqueueTime()).thenReturn(1L);
     Mockito.when(requestInfo.getRequestCreateTime()).thenReturn(1L);
     assertEquals(RouterUtils.RouterRequestExpiryReason.ROUTER_REQUEST_TIMEOUT,
-        RouterUtils.isRequestExpired(requestInfo, 12L, routerConfig));
+        RouterUtils.isRequestExpired(requestInfo, 12L));
 
     Mockito.when(requestInfo.isRequestReceivedByNetworkLayer()).thenReturn(false);
     Mockito.when(requestInfo.getRequestEnqueueTime()).thenReturn(1L);
     Mockito.when(requestInfo.getRequestCreateTime()).thenReturn(5L);
     assertEquals(RouterUtils.RouterRequestExpiryReason.NO_TIMEOUT,
-        RouterUtils.isRequestExpired(requestInfo, 12L, routerConfig));
+        RouterUtils.isRequestExpired(requestInfo, 12L));
   }
 }


### PR DESCRIPTION
Since it is possible that the response times for requests sent from ambry-frontend to ambry-server may increase under heavy load (For example, we could have lot of simultaneous TTLUpdate operations on chunks of a large composite blob), we might need to set higher time outs for requests going out so that they don't expire. 

This change uses the number of in-flight requests between frontend router and server to calculate approximate time needed for the response and accordingly increases the time out of the request. 