### PR TITLE
[Frontend] Cap number of metadata cache entries

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
@@ -608,6 +608,11 @@ public class RouterConfig {
   public final long routerSmallestBlobForMetadataCache;
   public static final long NUM_BYTES_IN_ONE_TB = (long) Math.pow(1024, 4);
 
+  public static final String ROUTER_MAX_NUM_METADATA_CACHE_ENTRIES = "router.max.num.metadata.cache.entries";
+  @Config(ROUTER_MAX_NUM_METADATA_CACHE_ENTRIES)
+  public final int routerMaxNumMetadataCacheEntries;
+  public static final int MAX_NUM_METADATA_CACHE_ENTRIES_DEFAULT = 10;
+
   /**
    * Create a RouterConfig instance.
    * @param verifiableProperties the properties map to refer to.
@@ -615,6 +620,8 @@ public class RouterConfig {
   public RouterConfig(VerifiableProperties verifiableProperties) {
     routerBlobMetadataCacheId =
         verifiableProperties.getString(ROUTER_BLOB_METADATA_CACHE_ID, "routerBlobMetadataCache");
+    routerMaxNumMetadataCacheEntries =
+        verifiableProperties.getInt(ROUTER_MAX_NUM_METADATA_CACHE_ENTRIES, MAX_NUM_METADATA_CACHE_ENTRIES_DEFAULT);
     routerBlobMetadataCacheEnabled = verifiableProperties.getBoolean(ROUTER_BLOB_METADATA_CACHE_ENABLED, false);
     routerBlobMetadataCacheMaxSizeBytes =
         verifiableProperties.getLong(ROUTER_BLOB_METADATA_CACHE_MAX_SIZE_BYTES, 64 * NUM_BYTES_IN_ONE_MB);

--- a/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterFactory.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterFactory.java
@@ -125,7 +125,7 @@ public class NonBlockingRouterFactory implements RouterFactory {
     try {
       AmbryCache blobMetadataCache = new AmbryCache(routerConfig.routerBlobMetadataCacheId,
           routerConfig.routerBlobMetadataCacheEnabled,
-          routerConfig.routerBlobMetadataCacheMaxSizeBytes,
+          routerConfig.routerMaxNumMetadataCacheEntries,
           routerMetrics.getMetricRegistry());
       logger.info("[{}] Smallest blob to qualify for metadata caching = {} bytes",
           blobMetadataCache.getCacheId(),

--- a/ambry-router/src/test/java/com/github/ambry/router/AmbryCacheWithStats.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/AmbryCacheWithStats.java
@@ -31,12 +31,12 @@ public class AmbryCacheWithStats extends AmbryCache {
    * Constructs an instance of AmbryCache
    * @param cacheId String identifier for this cache
    * @param cacheEnabled Toggles cache. If true, cache is enabled. Else, cache is disabled.
-   * @param cacheMaxSizeBytes Maximum memory footprint of the cache
+   * @param maxNumCacheEntries Maximum number of cache entries
    * @param metricRegistry Instance of metrics registry to record stats
    */
-  public AmbryCacheWithStats(String cacheId, boolean cacheEnabled, long cacheMaxSizeBytes,
+  public AmbryCacheWithStats(String cacheId, boolean cacheEnabled, int maxNumCacheEntries,
       MetricRegistry metricRegistry, AmbryCacheStats ambryCacheStats) {
-    super(cacheId, cacheEnabled, cacheMaxSizeBytes, metricRegistry);
+    super(cacheId, cacheEnabled, maxNumCacheEntries, metricRegistry);
     cacheHitCountDown = new CountDownLatch(ambryCacheStats.getNumCacheHit());
     cacheMissCountDown = new CountDownLatch(ambryCacheStats.getNumCacheMiss());
     putObjectCountDown = new CountDownLatch(ambryCacheStats.getNumPut());

--- a/ambry-router/src/test/java/com/github/ambry/router/CloudRouterTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/CloudRouterTest.java
@@ -323,4 +323,10 @@ public class CloudRouterTest extends NonBlockingRouterTest {
   @Override
   @Ignore
   public void testRouterMetadataCacheUpdateTTLCompositeBlob() throws Exception {}
+  @Override
+  @Ignore
+  public void testRouterMetadataCacheEviction() throws Exception {}
+  @Override
+  @Ignore
+  public void testRouterMetadataCacheNoEviction() throws Exception {}
 }

--- a/ambry-router/src/test/java/com/github/ambry/router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/GetBlobOperationTest.java
@@ -235,6 +235,7 @@ public class GetBlobOperationTest {
     Properties routerProperties = getDefaultNonBlockingRouterProperties(true);
     routerProperties.setProperty(RouterConfig.ROUTER_BLOB_METADATA_CACHE_ENABLED, String.valueOf(enableMetadataCache));
     routerProperties.setProperty(RouterConfig.ROUTER_SMALLEST_BLOB_FOR_METADATA_CACHE, Long.toString(0));
+    routerProperties.setProperty(RouterConfig.ROUTER_MAX_NUM_METADATA_CACHE_ENTRIES, Integer.toString(RouterConfig.MAX_NUM_METADATA_CACHE_ENTRIES_DEFAULT));
     this.enableMetadataCache = enableMetadataCache;
     VerifiableProperties vprops = new VerifiableProperties(routerProperties);
     routerConfig = new RouterConfig(vprops);
@@ -258,7 +259,7 @@ public class GetBlobOperationTest {
     }
     this.blobMetadataCache = new AmbryCache("GetBlobOperationTestRouterMetadataCache",
         routerConfig.routerBlobMetadataCacheEnabled,
-        routerConfig.routerBlobMetadataCacheMaxSizeBytes,
+        routerConfig.routerMaxNumMetadataCacheEntries,
         routerMetrics.getMetricRegistry());
     router = new NonBlockingRouter(routerConfig, new NonBlockingRouterMetrics(mockClusterMap, routerConfig),
         networkClientFactory, new LoggingNotificationSystem(), mockClusterMap, kms, cryptoService, cryptoJobHandler,

--- a/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTestBase.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTestBase.java
@@ -224,7 +224,7 @@ public class NonBlockingRouterTestBase {
     routerConfig = new RouterConfig(verifiableProperties);
     routerMetrics = new NonBlockingRouterMetrics(mockClusterMap, routerConfig);
     AmbryCacheWithStats ambryCacheWithStats = new AmbryCacheWithStats("AmbryCacheWithStats",
-        true, routerConfig.routerBlobMetadataCacheMaxSizeBytes, routerMetrics.getMetricRegistry(), ambryCacheStats);
+        true, routerConfig.routerMaxNumMetadataCacheEntries, routerMetrics.getMetricRegistry(), ambryCacheStats);
     router = new NonBlockingRouter(routerConfig, routerMetrics,
         new MockNetworkClientFactory(verifiableProperties, mockSelectorState, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
             CHECKOUT_TIMEOUT_MS, mockServerLayout, mockTime), new LoggingNotificationSystem(), mockClusterMap, kms, cryptoService,


### PR DESCRIPTION
This PR adds an ability to restrict the maximum number of entries
in the metadata cache. This allows us to control the amount of memory
consumed by the metadata cache.