### PR TITLE
Log a warning when rejecting request due to reject recommendation.

### DIFF
--- a/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterMetrics.java
@@ -248,8 +248,8 @@ public class NonBlockingRouterMetrics {
   public Gauge<Integer> operationControllerQueueSize;
   public Gauge<Integer> readQueuedQuotaResourceCount;
   public Gauge<Integer> writeQueuedQuotaResourceCount;
-  public Gauge<Integer> delayedRequestsInQueue;
-  public Gauge<Integer> outOfQuotaRequestsInQueue;
+  public Gauge<Integer> delayedQuotaResourcesInQueue;
+  public Gauge<Integer> outOfQuotaResourcesInQueue;
 
   // Resource to latency histogram map. Here resource can be DataNode, Partition, Disk, Replica etc.
   Map<Resource, CachedHistogram> getBlobLocalDcResourceToLatency = new HashMap<>();
@@ -795,12 +795,12 @@ public class NonBlockingRouterMetrics {
         .filter(oc -> (oc instanceof QuotaAwareOperationController))
         .map(oc -> (QuotaAwareOperationController) oc)
         .collect(Collectors.toList());
-    outOfQuotaRequestsInQueue =
-        metricRegistry.register(MetricRegistry.name(NonBlockingRouter.class, "OutOfQuotaRequestInQueue"),
-            () -> quotaAwareOperationControllers.stream().mapToInt(oc -> oc.getOutOfQuotaRequestsInQueue()).sum());
-    delayedRequestsInQueue =
-        metricRegistry.register(MetricRegistry.name(NonBlockingRouter.class, "DelayedRequestInQueue"),
-            () -> quotaAwareOperationControllers.stream().mapToInt(oc -> oc.getDelayedRequestsInQueue()).sum());
+    outOfQuotaResourcesInQueue =
+        metricRegistry.register(MetricRegistry.name(NonBlockingRouter.class, "OutOfQuotaResourcesInQueue"),
+            () -> quotaAwareOperationControllers.stream().mapToInt(oc -> oc.getOutOfQuotaResourcesInQueue()).sum());
+    delayedQuotaResourcesInQueue =
+        metricRegistry.register(MetricRegistry.name(NonBlockingRouter.class, "DelayedQuotaResourcesInQueue"),
+            () -> quotaAwareOperationControllers.stream().mapToInt(oc -> oc.getDelayedQuotaResourcesInQueue()).sum());
   }
 
   /**

--- a/ambry-router/src/main/java/com/github/ambry/router/QuotaAwareOperationController.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/QuotaAwareOperationController.java
@@ -52,8 +52,8 @@ public class QuotaAwareOperationController extends OperationController {
   private final Map<QuotaResource, LinkedList<RequestInfo>> readRequestQueue = new HashMap<>();
   private final Map<QuotaResource, LinkedList<RequestInfo>> writeRequestQueue = new HashMap<>();
   private final List<RequestInfo> nonCompliantRequests = new ArrayList<>();
-  private volatile int outOfQuotaRequestsInQueue = 0;
-  private volatile int delayedRequestsInQueue = 0;
+  private volatile int outOfQuotaResourcesInQueue = 0;
+  private volatile int delayedQuotaResourcesInQueue = 0;
 
   /**
    * Constructor for {@link QuotaAwareOperationController} class.
@@ -158,8 +158,8 @@ public class QuotaAwareOperationController extends OperationController {
       pollQuotaExceedAllowedRequestsIfAny(requestsToSend, queue);
       delayedRequests += queue.size();
     }
-    outOfQuotaRequestsInQueue = outOfQuotaRequests;
-    delayedRequestsInQueue = delayedRequests;
+    outOfQuotaResourcesInQueue = outOfQuotaRequests;
+    delayedQuotaResourcesInQueue = delayedRequests;
     timer.stop();
   }
 
@@ -196,6 +196,8 @@ public class QuotaAwareOperationController extends OperationController {
             break;
           case REJECT:
             quotaAvailable = false;
+            logger.warn(
+                "Rejecting request for quota resource {} because of reject recommendation.", quotaResource.toString());
             routerMetrics.rejectedRequestRate.mark();
             nonCompliantRequests.add(requestInfo);
             requestQueue.get(quotaResource).removeFirst();
@@ -261,16 +263,18 @@ public class QuotaAwareOperationController extends OperationController {
   }
 
   /**
-   * @return the value of {@code outOfQuotaRequestsInQueue} representing the count of out of quota requests in the queue.
+   * @return the value of {@code outOfQuotaResourcesInQueue} representing the count of out of {@link QuotaResource}s with
+   * requests in the queue.
    */
-  int getOutOfQuotaRequestsInQueue() {
-    return outOfQuotaRequestsInQueue;
+  int getOutOfQuotaResourcesInQueue() {
+    return outOfQuotaResourcesInQueue;
   }
 
   /**
-   * @return the value of {@code delayedRequestsInQueue} representing the count of delayed requests in the queue.
+   * @return the value of {@code delayedResourcesInQueue} representing the count of {@link QuotaResource}s with delayed
+   * requests in the queue.
    */
-  int getDelayedRequestsInQueue() {
-    return delayedRequestsInQueue;
+  int getDelayedQuotaResourcesInQueue() {
+    return delayedQuotaResourcesInQueue;
   }
 }

--- a/ambry-router/src/test/java/com/github/ambry/router/NonBlockingQuotaTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/NonBlockingQuotaTest.java
@@ -365,8 +365,8 @@ public class NonBlockingQuotaTest extends NonBlockingRouterTestBase {
           .getBlobDataChannel()
           .readInto(retainingAsyncWritableChannel, null)
           .get();
-      Assert.assertEquals(0, (int) routerMetrics.outOfQuotaRequestsInQueue.getValue());
-      Assert.assertEquals(0, (int) routerMetrics.delayedRequestsInQueue.getValue());
+      Assert.assertEquals(0, (int) routerMetrics.outOfQuotaResourcesInQueue.getValue());
+      Assert.assertEquals(0, (int) routerMetrics.delayedQuotaResourcesInQueue.getValue());
       // read out all the chunks.
       retainingAsyncWritableChannel.consumeContentAsInputStream().close();
       quotaUsage = quotaSource.getCuUsage().get(String.valueOf(account.getId()));

--- a/ambry-router/src/test/java/com/github/ambry/router/QuotaAwareOperationControllerTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/QuotaAwareOperationControllerTest.java
@@ -137,8 +137,8 @@ public class QuotaAwareOperationControllerTest {
     }).when(putManager).poll(requestsToSend, requestsToDrop);
     quotaAwareOperationController.pollForRequests(requestsToSend, requestsToDrop);
     assertEquals(0, quotaAwareOperationController.getRequestQueue(quotaMethod).size());
-    assertEquals(0, quotaAwareOperationController.getDelayedRequestsInQueue());
-    assertEquals(0, quotaAwareOperationController.getOutOfQuotaRequestsInQueue());
+    assertEquals(0, quotaAwareOperationController.getDelayedQuotaResourcesInQueue());
+    assertEquals(0, quotaAwareOperationController.getOutOfQuotaResourcesInQueue());
 
     assertTrue(quotaAwareOperationController.routerMetrics.totalQuotaQueueingDelay.getMeanRate() > 0);
     assertTrue(quotaAwareOperationController.routerMetrics.addToQueueTime.getMeanRate() > 0);
@@ -161,21 +161,21 @@ public class QuotaAwareOperationControllerTest {
     quotaAwareOperationController.pollForRequests(requestsToSend, requestsToDrop);
     assertEquals(1, quotaAwareOperationController.getRequestQueue(quotaMethod).size());
     assertEquals(1, quotaAwareOperationController.getRequestQueue(quotaMethod).get(TEST_QUOTA_RESOURCE1).size());
-    assertEquals(1, quotaAwareOperationController.getOutOfQuotaRequestsInQueue());
-    assertEquals(1, quotaAwareOperationController.getDelayedRequestsInQueue());
+    assertEquals(1, quotaAwareOperationController.getOutOfQuotaResourcesInQueue());
+    assertEquals(1, quotaAwareOperationController.getDelayedQuotaResourcesInQueue());
     testChargeable1.verifyCalls(2, 1);
 
     quotaAwareOperationController.pollForRequests(requestsToSend, requestsToDrop);
     assertEquals(1, quotaAwareOperationController.getRequestQueue(quotaMethod).size());
     assertEquals(1, quotaAwareOperationController.getRequestQueue(quotaMethod).get(TEST_QUOTA_RESOURCE1).size());
-    assertEquals(1, quotaAwareOperationController.getOutOfQuotaRequestsInQueue());
-    assertEquals(1, quotaAwareOperationController.getDelayedRequestsInQueue());
+    assertEquals(1, quotaAwareOperationController.getOutOfQuotaResourcesInQueue());
+    assertEquals(1, quotaAwareOperationController.getDelayedQuotaResourcesInQueue());
     testChargeable1.verifyCalls(5, 2);
 
     quotaAwareOperationController.pollForRequests(requestsToSend, requestsToDrop);
     assertEquals(0, quotaAwareOperationController.getRequestQueue(quotaMethod).size());
-    assertEquals(0, quotaAwareOperationController.getOutOfQuotaRequestsInQueue());
-    assertEquals(0, quotaAwareOperationController.getDelayedRequestsInQueue());
+    assertEquals(0, quotaAwareOperationController.getOutOfQuotaResourcesInQueue());
+    assertEquals(0, quotaAwareOperationController.getDelayedQuotaResourcesInQueue());
     testChargeable1.verifyCalls(6, 2);
   }
 


### PR DESCRIPTION
Rename some quota metrics to a more accurate representation of their usage.