### PR TITLE
Include Disk HealthCheck in Ambry State HealthCheck w/Tests

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/DiskManagerConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/DiskManagerConfig.java
@@ -32,11 +32,35 @@ public class DiskManagerConfig {
   @Default("false")
   public final boolean diskManagerEnableSegmentPooling;
 
+  @Config("disk.manager.disk.healthcheck.enabled")
+  @Default("false")
+  public final boolean diskManagerDiskHealthCheckEnabled;
+
+  @Config("disk.manager.disk.healthcheck.interval.seconds")
+  @Default("60")
+  public final int diskManagerDiskHealthCheckIntervalSeconds;
+
+  @Config("disk.manager.disk.healthcheck.file.path")
+  @Default("/ambry-data/")
+  public final String diskManagerDiskHealthCheckFilePath;
+
+  @Config("disk.manager.disk.healthcheck.operation.timeout.seconds")
+  @Default("5")
+  public final int diskManagerDiskHealthCheckOperationTimeoutSeconds;
+
   public DiskManagerConfig(VerifiableProperties verifiableProperties) {
     diskManagerReserveFileDirName =
         verifiableProperties.getString("disk.manager.reserve.file.dir.name", "reserve-pool");
     diskManagerRequiredSwapSegmentsPerSize =
         verifiableProperties.getIntInRange("disk.manager.required.swap.segments.per.size", 1, 0, 1000);
     diskManagerEnableSegmentPooling = verifiableProperties.getBoolean("disk.manager.enable.segment.pooling", false);
+    diskManagerDiskHealthCheckEnabled =
+        verifiableProperties.getBoolean("disk.manager.disk.healthcheck.enabled", false);
+    diskManagerDiskHealthCheckIntervalSeconds =
+        verifiableProperties.getInt("disk.manager.disk.healthcheck.interval.seconds", 60);
+    diskManagerDiskHealthCheckFilePath =
+        verifiableProperties.getString("disk.manager.disk.healthcheck.file.path", "/ambry-data/");
+    diskManagerDiskHealthCheckOperationTimeoutSeconds =
+        verifiableProperties.getInt("disk.manager.disk.healthcheck.operation.timeout.seconds", 5);
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/config/DiskManagerConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/DiskManagerConfig.java
@@ -37,7 +37,7 @@ public class DiskManagerConfig {
   public final boolean diskManagerDiskHealthCheckEnabled;
 
   @Config("disk.manager.disk.healthcheck.interval.seconds")
-  @Default("60")
+  @Default("180")
   public final int diskManagerDiskHealthCheckIntervalSeconds;
 
   @Config("disk.manager.disk.healthcheck.file.path")

--- a/ambry-api/src/main/java/com/github/ambry/config/DiskManagerConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/DiskManagerConfig.java
@@ -54,8 +54,7 @@ public class DiskManagerConfig {
     diskManagerRequiredSwapSegmentsPerSize =
         verifiableProperties.getIntInRange("disk.manager.required.swap.segments.per.size", 1, 0, 1000);
     diskManagerEnableSegmentPooling = verifiableProperties.getBoolean("disk.manager.enable.segment.pooling", false);
-    diskManagerDiskHealthCheckEnabled =
-        verifiableProperties.getBoolean("disk.manager.disk.healthcheck.enabled", false);
+    diskManagerDiskHealthCheckEnabled = verifiableProperties.getBoolean("disk.manager.disk.healthcheck.enabled", false);
     diskManagerDiskHealthCheckIntervalSeconds =
         verifiableProperties.getInt("disk.manager.disk.healthcheck.interval.seconds", 60);
     diskManagerDiskHealthCheckFilePath =

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryServer.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryServer.java
@@ -284,7 +284,7 @@ public class AmbryServer {
       FindTokenHelper findTokenHelper = new FindTokenHelper(storeKeyFactory, replicationConfig);
       requests = new AmbryServerRequests(storageManager, networkServer.getRequestResponseChannel(), clusterMap, nodeId,
           registry, metrics, findTokenHelper, notificationSystem, replicationManager, storeKeyFactory, serverConfig,
-          diskManagerConfig,storeKeyConverterFactory, statsManager, clusterParticipants.get(0));
+          diskManagerConfig, storeKeyConverterFactory, statsManager, clusterParticipants.get(0));
       requestHandlerPool = new RequestHandlerPool(serverConfig.serverRequestHandlerNumOfThreads,
           networkServer.getRequestResponseChannel(), requests);
       networkServer.start();

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryServer.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryServer.java
@@ -284,7 +284,7 @@ public class AmbryServer {
       FindTokenHelper findTokenHelper = new FindTokenHelper(storeKeyFactory, replicationConfig);
       requests = new AmbryServerRequests(storageManager, networkServer.getRequestResponseChannel(), clusterMap, nodeId,
           registry, metrics, findTokenHelper, notificationSystem, replicationManager, storeKeyFactory, serverConfig,
-          storeKeyConverterFactory, statsManager, clusterParticipants.get(0));
+          diskManagerConfig,storeKeyConverterFactory, statsManager, clusterParticipants.get(0));
       requestHandlerPool = new RequestHandlerPool(serverConfig.serverRequestHandlerNumOfThreads,
           networkServer.getRequestResponseChannel(), requests);
       networkServer.start();
@@ -303,7 +303,7 @@ public class AmbryServer {
         AmbryServerRequests ambryServerRequestsForHttp2 =
             new AmbryServerRequests(storageManager, requestResponseChannel, clusterMap, nodeId, registry, metrics,
                 findTokenHelper, notificationSystem, replicationManager, storeKeyFactory, serverConfig,
-                storeKeyConverterFactory, statsManager, clusterParticipants.get(0));
+                diskManagerConfig, storeKeyConverterFactory, statsManager, clusterParticipants.get(0));
         requestHandlerPoolForHttp2 =
             new RequestHandlerPool(serverConfig.serverRequestHandlerNumOfThreads, requestResponseChannel,
                 ambryServerRequestsForHttp2);

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryServerRequests.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryServerRequests.java
@@ -18,6 +18,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.ClusterParticipant;
 import com.github.ambry.clustermap.DataNodeId;
+import com.github.ambry.clustermap.DiskId;
 import com.github.ambry.clustermap.HardwareState;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.clustermap.PartitionState;
@@ -25,6 +26,7 @@ import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.clustermap.ReplicaState;
 import com.github.ambry.clustermap.ReplicaStatusDelegate;
 import com.github.ambry.commons.ServerMetrics;
+import com.github.ambry.config.DiskManagerConfig;
 import com.github.ambry.config.ServerConfig;
 import com.github.ambry.network.NetworkRequest;
 import com.github.ambry.network.RequestResponseChannel;
@@ -44,6 +46,8 @@ import com.github.ambry.replication.FindTokenHelper;
 import com.github.ambry.replication.ReplicationAPI;
 import com.github.ambry.replication.ReplicationManager;
 import com.github.ambry.store.BlobStore;
+import com.github.ambry.store.DiskHealthStatus;
+import com.github.ambry.store.DiskManager;
 import com.github.ambry.store.StorageManager;
 import com.github.ambry.store.Store;
 import com.github.ambry.store.StoreException;
@@ -56,9 +60,13 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -78,6 +86,7 @@ public class AmbryServerRequests extends AmbryRequests {
           RequestOrResponseType.UndeleteRequest);
   private static final Logger logger = LoggerFactory.getLogger(AmbryServerRequests.class);
   private final ServerConfig serverConfig;
+  private final DiskManagerConfig diskManagerConfig;
   private final StatsManager statsManager;
   private final ClusterParticipant clusterParticipant;
   private final ConcurrentHashMap<RequestOrResponseType, Set<PartitionId>> requestsDisableInfo =
@@ -86,10 +95,11 @@ public class AmbryServerRequests extends AmbryRequests {
   AmbryServerRequests(StoreManager storeManager, RequestResponseChannel requestResponseChannel, ClusterMap clusterMap,
       DataNodeId nodeId, MetricRegistry registry, ServerMetrics serverMetrics, FindTokenHelper findTokenHelper,
       NotificationSystem operationNotification, ReplicationAPI replicationEngine, StoreKeyFactory storeKeyFactory,
-      ServerConfig serverConfig, StoreKeyConverterFactory storeKeyConverterFactory, StatsManager statsManager,
-      ClusterParticipant clusterParticipant) {
+      ServerConfig serverConfig, DiskManagerConfig diskManagerConfig,StoreKeyConverterFactory storeKeyConverterFactory,
+      StatsManager statsManager, ClusterParticipant clusterParticipant) {
     super(storeManager, requestResponseChannel, clusterMap, nodeId, registry, serverMetrics, findTokenHelper,
         operationNotification, replicationEngine, storeKeyFactory, storeKeyConverterFactory);
+    this.diskManagerConfig = diskManagerConfig;
     this.serverConfig = serverConfig;
     this.statsManager = statsManager;
     this.clusterParticipant = clusterParticipant;
@@ -419,18 +429,19 @@ public class AmbryServerRequests extends AmbryRequests {
    */
   private AdminResponse handleHealthCheckRequest(DataInputStream requestStream, AdminRequest adminRequest)
       throws StoreException, IOException {
-    boolean hostHealthy = false; //used to determine if the host is ever unhealthy
+    ServerHealthStatus serverHealthStatus = ServerHealthStatus.BAD; //used to determine if the server is ever unhealthy
+    JSONArray brokenDisks = new JSONArray();
 
     if (this.storeManager instanceof StorageManager) {
       StorageManager storageManager = (StorageManager) this.storeManager;
-      hostHealthy = true;
+      serverHealthStatus = ServerHealthStatus.GOOD;
 
       //Finds all partitions on this host
       List<PartitionId> partitionsInThisHost =Collections.list(storageManager.getPartitionToDiskManager().keys());
 
       /*
-       * Checks if the Host's BlobStore exists,started and is Leader/Standby ReplicaState for all Partitions
-       * this Host is apart of
+       Checks if the Host's BlobStore exists,started and is Leader/Standby ReplicaState for all Partitions
+       this Host is apart of
        */
       for (PartitionId partitionId : partitionsInThisHost) {
         BlobStore hostBlobStore = (BlobStore) storageManager.getStore(partitionId);
@@ -439,14 +450,39 @@ public class AmbryServerRequests extends AmbryRequests {
         if (hostBlobStore == null || !hostBlobStore.isStarted() ||
             ((hostBlobStore.getCurrentState() != ReplicaState.STANDBY) &&
                 (hostBlobStore.getCurrentState() != ReplicaState.LEADER))) {
-          hostHealthy = false;
+          serverHealthStatus = ServerHealthStatus.BAD;
           break;
+        }
+      }
+
+      /*
+       Checks if every disk that's assigned to a partition is also mounted and disk is healthy
+       */
+      HashSet<DiskManager> partitionsDiskManagers = new HashSet<>(storageManager.getPartitionToDiskManager().values());
+      for(Map.Entry<DiskId,DiskManager> entry : storageManager.getDiskToDiskManager().entrySet()){
+        DiskManager mountedDiskManager = entry.getValue();
+
+        //Checks Disk healthchecking is enabled and
+        // if a disk isn't healthy then store that disk to return in the response
+        if(diskManagerConfig.diskManagerDiskHealthCheckEnabled &&
+            (!partitionsDiskManagers.contains(mountedDiskManager) ||
+            mountedDiskManager.getDiskHealthStatus() != DiskHealthStatus.HEALTHY)){
+
+          serverHealthStatus = ServerHealthStatus.BAD;
+          JSONObject brokenDisk = new JSONObject();
+          brokenDisk.put("disk",entry.getKey().getMountPath());
+          brokenDisk.put("reason",mountedDiskManager.getDiskHealthStatus());
+          brokenDisks.put(brokenDisk);
         }
       }
     }
 
-    //Initializing the Content of the response and return it
-    byte[] content = (hostHealthy ? "{\"health\":\"GOOD\"}" : "{\"health\":\"BAD\"}").getBytes(StandardCharsets.UTF_8);
+    //Initializing the content of the response as a json
+    JSONObject contentJSON = new JSONObject();
+    contentJSON.put("health",serverHealthStatus);
+    contentJSON.put("brokenDisks",brokenDisks);
+
+    byte[] content =  contentJSON.toString().getBytes(StandardCharsets.UTF_8);
     ServerErrorCode error = ServerErrorCode.No_Error;
 
     return new AdminResponseWithContent(adminRequest.getCorrelationId(), adminRequest.getClientId(), error, content);

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryServerRequests.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryServerRequests.java
@@ -454,7 +454,7 @@ public class AmbryServerRequests extends AmbryRequests {
 
           JSONObject unstablePartition = new JSONObject();
           unstablePartition.put("partitionId", partitionId);
-          unstablePartition.put("reason", hostBlobStore.getCurrentState());
+          unstablePartition.put("reason", hostBlobStore != null ? hostBlobStore.getCurrentState() : "Missing");
           unstablePartitions.put(unstablePartition);
         }
       }

--- a/ambry-server/src/main/java/com/github/ambry/server/ServerHealthStatus.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/ServerHealthStatus.java
@@ -18,11 +18,13 @@ package com.github.ambry.server;
  * Each level determines the health of the server. This can be extended to include bootstrapping
  */
 public enum ServerHealthStatus {
-
-  /** The server is healthy based on the replica state's and disk state*/
+  /**
+   * The server is healthy based on the replica state's and disk state
+   */
   GOOD,
-
-  /** There was at least one issue with either the replica state or disk state on this server*/
+  /**
+   * There was at least one issue with either the replica state or disk state on this server
+   */
   BAD,
 }
 

--- a/ambry-server/src/main/java/com/github/ambry/server/ServerHealthStatus.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/ServerHealthStatus.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.server;
+
+/**
+ * Server Health Status Levels
+ * Each level determines the health of the server. This can be extended to include bootstrapping
+ */
+public enum ServerHealthStatus {
+
+  /** The server is healthy based on the replica state's and disk state*/
+  GOOD,
+
+  /** There was at least one issue with either the replica state or disk state on this server*/
+  BAD,
+}
+

--- a/ambry-server/src/test/java/com/github/ambry/server/AmbryServerRequestsTest.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/AmbryServerRequestsTest.java
@@ -16,6 +16,7 @@ package com.github.ambry.server;
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.DataNodeId;
+import com.github.ambry.clustermap.DiskId;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.clustermap.MockDataNodeId;
 import com.github.ambry.clustermap.MockHelixParticipant;
@@ -32,6 +33,7 @@ import com.github.ambry.commons.CommonTestUtils;
 import com.github.ambry.commons.ErrorMapping;
 import com.github.ambry.commons.ServerMetrics;
 import com.github.ambry.config.ClusterMapConfig;
+import com.github.ambry.config.DiskManagerConfig;
 import com.github.ambry.config.ReplicationConfig;
 import com.github.ambry.config.ServerConfig;
 import com.github.ambry.config.StatsManagerConfig;
@@ -79,6 +81,7 @@ import com.github.ambry.replication.MockReplicationManager;
 import com.github.ambry.replication.ReplicationException;
 import com.github.ambry.replication.ReplicationManager;
 import com.github.ambry.store.BlobStore;
+import com.github.ambry.store.DiskHealthStatus;
 import com.github.ambry.store.IdUndeletedStoreException;
 import com.github.ambry.store.MessageInfo;
 import com.github.ambry.store.MessageInfoTest;
@@ -112,7 +115,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import org.json.JSONArray;
+import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Assume;
@@ -145,6 +151,7 @@ public class AmbryServerRequestsTest {
   private final MockStoreKeyConverterFactory storeKeyConverterFactory;
   private final ReplicationConfig replicationConfig;
   private final ServerConfig serverConfig;
+  private final DiskManagerConfig diskManagerConfig;
   private final ClusterMapConfig clusterMapConfig;
   private final ServerMetrics serverMetrics;
   private final String localDc;
@@ -164,6 +171,7 @@ public class AmbryServerRequestsTest {
     VerifiableProperties verifiableProperties = new VerifiableProperties(properties);
     replicationConfig = new ReplicationConfig(verifiableProperties);
     serverConfig = new ServerConfig(verifiableProperties);
+    diskManagerConfig = new DiskManagerConfig(verifiableProperties);
     clusterMapConfig = new ClusterMapConfig(verifiableProperties);
     StatsManagerConfig statsManagerConfig = new StatsManagerConfig(verifiableProperties);
     dataNodeId =
@@ -184,7 +192,7 @@ public class AmbryServerRequestsTest {
     serverMetrics = new ServerMetrics(clusterMap.getMetricRegistry(), AmbryRequests.class, AmbryServer.class);
     ambryRequests = new AmbryServerRequests(storageManager, requestResponseChannel, clusterMap, dataNodeId,
         clusterMap.getMetricRegistry(), serverMetrics, findTokenHelper, null, replicationManager, null, serverConfig,
-        storeKeyConverterFactory, statsManager, helixParticipant);
+        diskManagerConfig, storeKeyConverterFactory, statsManager, helixParticipant);
     storageManager.start();
     Mockito.when(mockDelegate.unseal(any())).thenReturn(true);
     Mockito.when(mockDelegate.unmarkStopped(anyList())).thenReturn(true);
@@ -503,7 +511,7 @@ public class AmbryServerRequestsTest {
         new MockStorageManager(validKeysInStore, clusterMap, dataNodeId, findTokenHelper, helixParticipant);
     ambryRequests = new AmbryServerRequests(storageManager, requestResponseChannel, clusterMap, dataNodeId,
         clusterMap.getMetricRegistry(), serverMetrics, findTokenHelper, null, replicationManager, null, serverConfig,
-        storeKeyConverterFactory, statsManager, helixParticipant);
+        diskManagerConfig, storeKeyConverterFactory, statsManager, helixParticipant);
     List<? extends PartitionId> partitionIds = clusterMap.getAllPartitionIds(null);
     PartitionId id = partitionIds.get(0);
     List<? extends ReplicaId> replicaIds = id.getReplicaIds();
@@ -628,7 +636,7 @@ public class AmbryServerRequestsTest {
         new MockStorageManager(validKeysInStore, clusterMap, dataNodeId, findTokenHelper, helixParticipant);
     ambryRequests = new AmbryServerRequests(storageManager, requestResponseChannel, clusterMap, dataNodeId,
         clusterMap.getMetricRegistry(), serverMetrics, findTokenHelper, null, replicationManager, null, serverConfig,
-        storeKeyConverterFactory, statsManager, helixParticipant);
+        diskManagerConfig, storeKeyConverterFactory, statsManager, helixParticipant);
 
     // find a partition that has a replica on current node
     ReplicaId localReplica = clusterMap.getReplicaIds(dataNodeId).get(0);
@@ -861,7 +869,7 @@ public class AmbryServerRequestsTest {
         new ServerMetrics(clusterMap.getMetricRegistry(), AmbryRequests.class, AmbryServer.class);
     AmbryServerRequests other = new AmbryServerRequests(storageManager, requestResponseChannel, clusterMap, dataNodeId,
         clusterMap.getMetricRegistry(), serverMetrics, findTokenHelper, null, replicationManager, null, serverConfig,
-        storeKeyConverterFactory, statsManager, null);
+        diskManagerConfig, storeKeyConverterFactory, statsManager, null);
 
     AmbryServerRequests temp = ambryRequests;
     ambryRequests = other;
@@ -942,20 +950,88 @@ public class AmbryServerRequestsTest {
   }
 
   /**
-   * Tests for appropriate responses from healthCheck admin endpoint
+   * Checks the response is a valid JSON Object
+   * @param content the content from {@link AdminResponseWithContent}
+   * @return True/False if Json or not
+   */
+  public boolean isJSONValid(String content) {
+    try {
+      new JSONObject(content);
+    } catch (JSONException ex) {
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Performs the AdminRequest and Response as well as checking if the content is a json and expected
+   * @param partitionId necessary to fulfill the {@link AdminRequest}
+   * @param description for what this function call is attempting to test
+   * @param expectedResponse the response that should be returned from {@link AdminResponseWithContent}
+   * @throws IOException
+   * @throws InterruptedException
+   */
+  public void doRequestAndHealthCheck(PartitionId partitionId, String description,JSONObject expectedResponse)
+      throws IOException, InterruptedException {
+
+    int correlationId = TestUtils.RANDOM.nextInt();
+    String clientId = TestUtils.getRandomString(10);
+
+    AdminRequest adminRequest = new AdminRequest(AdminRequestOrResponseType.HealthCheck, partitionId, correlationId,
+        clientId);
+
+    AdminResponseWithContent response =
+        (AdminResponseWithContent) sendRequestGetResponse(adminRequest, ServerErrorCode.No_Error);
+    String content = new String(response.getContent(),StandardCharsets.UTF_8);
+
+    //Ensures the response is AdminResponse, json and as expected
+    assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
+    assertTrue("Response is not a json object",isJSONValid(content));
+    JSONObject contentJSON  = new JSONObject(content);
+    assertEquals(description,expectedResponse.toString(), contentJSON.toString());
+  }
+
+  /**
+   * Allows an extra property to be made and then encapsulates this property in a new environment to be tested on
+   * @param properties the set of properties this environment will have
+   * @param propertyKey the new key to be added to the properties variable
+   * @param propertyValue the new value for the propertyKey
+   * @throws IOException
+   * @throws InterruptedException
+   * @throws StoreException
+   */
+  public void setPropertyToAmbryRequests(Properties properties,String propertyKey,String propertyValue)
+      throws IOException, InterruptedException, StoreException {
+    storageManager.shutdown();
+    properties.setProperty(propertyKey,propertyValue); //Adds the new key-value pair
+
+    //Initializes the new environment through clusterMap, storageManager, and AmbryRequests
+    ClusterMap clusterMap = new MockClusterMap();
+    DiskManagerConfig diskManagerConfig = new DiskManagerConfig(new VerifiableProperties(properties));
+    storageManager =
+        new MockStorageManager(validKeysInStore, clusterMap, dataNodeId, findTokenHelper, null,diskManagerConfig);
+    ambryRequests =
+        new AmbryServerRequests(storageManager, requestResponseChannel, clusterMap, dataNodeId,
+            clusterMap.getMetricRegistry(), serverMetrics, findTokenHelper, null, replicationManager,
+            null, serverConfig, diskManagerConfig, storeKeyConverterFactory, statsManager, helixParticipant);
+    storageManager.start();
+  }
+
+  /**
+   * Tests Replica State and Disk State for appropriate responses from healthCheck admin endpoint
    * @throws InterruptedException
    * @throws IOException
    */
   @Test
-  public void healthCheckTest() throws InterruptedException, IOException {
+  public void healthCheckTest()
+      throws InterruptedException, StoreException, IOException {
 
     //retrieves writeable partitions to test with
     List<? extends PartitionId> partitionIds = clusterMap.getWritablePartitionIds(DEFAULT_PARTITION_CLASS);
+    JSONObject expectedJSONReponse = new JSONObject();
+    expectedJSONReponse.put("brokenDisks",new JSONArray());
 
     for (PartitionId id : partitionIds) {
-
-      int correlationId = TestUtils.RANDOM.nextInt();
-      String clientId = TestUtils.getRandomString(10);
 
       // Test 1: "Good" response excepted where the host state is in either Standby or Leader
       ReplicaState originalPartitionState = storageManager.getStore(id).getCurrentState();
@@ -964,28 +1040,54 @@ public class AmbryServerRequestsTest {
       storageManager.getStore(id).setCurrentState(
             TestUtils.RANDOM.nextInt() % 2 == 0 ? ReplicaState.STANDBY : ReplicaState.LEADER);
 
-      AdminRequest adminRequest = new AdminRequest(AdminRequestOrResponseType.HealthCheck, id, correlationId, clientId);
-      AdminResponseWithContent response =
-          (AdminResponseWithContent) sendRequestGetResponse(adminRequest, ServerErrorCode.No_Error);
+      expectedJSONReponse.put("health",ServerHealthStatus.GOOD);
+      doRequestAndHealthCheck(id,"Payload was expected to indicate healthy host",expectedJSONReponse);
 
-      assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
-      assertEquals("Payload was expected to be {\"health\":\"GOOD\"}","{\"health\":\"GOOD\"}",
-          new String(response.getContent(),StandardCharsets.UTF_8));
-
-      //Test 2: "BAD" response expected where change replicas to error State on this partition
+      //Test 2: "BAD" response expected where we change partition to error State
       //change all replica states in partition to ERROR
       storageManager.getStore(id).setCurrentState(ReplicaState.ERROR);
 
-      adminRequest = new AdminRequest(AdminRequestOrResponseType.HealthCheck, id, correlationId, clientId);
-      response = (AdminResponseWithContent) sendRequestGetResponse(adminRequest, ServerErrorCode.No_Error);
-
-      assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
-      assertEquals("Payload was expected to be {\"health\":\"BAD\"}","{\"health\":\"BAD\"}",
-          new String(response.getContent(),StandardCharsets.UTF_8));
+      expectedJSONReponse.put("health",ServerHealthStatus.BAD);
+      doRequestAndHealthCheck(id,"Payload was expected to be BAD with no disk healthchecks",expectedJSONReponse);
 
       //restore the state of the Partition
       storageManager.getStore(id).setCurrentState(originalPartitionState);
+
     }
+
+    //Test 3: "GOOD" response expected, enabling disk healthchecking on the partition of interest and
+    // disk's should be healthy
+
+    Properties currentProperties = createProperties(validateRequestOnStoreState, true);
+    setPropertyToAmbryRequests(currentProperties,"disk.manager.disk.healthcheck.enabled","true");
+    TimeUnit.SECONDS.sleep(5); // Enough time to perform each step of disk healthcheck(create,write,read,delete)
+
+    expectedJSONReponse.put("health",ServerHealthStatus.GOOD);
+    doRequestAndHealthCheck(partitionIds.get(0),"Payload was expected to be GOOD with all disks passing disk healthcheck",
+        expectedJSONReponse);
+
+    //Test 4: "BAD" response expected, insufficient Write Timeouts on partition of interest so the test will fail
+    // when writing to disk
+    setPropertyToAmbryRequests(currentProperties,"disk.manager.disk.healthcheck.operation.timeout.seconds","0");
+    TimeUnit.SECONDS.sleep(5); //Sufficient time to write, fail and save the health of disk to then retrieve
+
+    //All the disks should have failed since the all their write timeouts were set to 0
+    JSONArray brokenDisks = new JSONArray();
+    for(DiskId entry : storageManager.getDiskToDiskManager().keySet()) {
+      JSONObject brokenDisk = new JSONObject();
+      brokenDisk.put("disk", entry.getMountPath());
+      brokenDisk.put("reason", DiskHealthStatus.WRITE_TIMEOUT);
+      brokenDisks.put(brokenDisk);
+    }
+    expectedJSONReponse.put("brokenDisks",brokenDisks);
+    expectedJSONReponse.put("health",ServerHealthStatus.BAD);
+
+    doRequestAndHealthCheck(partitionIds.get(0),"Payload was expected to be BAD with one disk failing timeout",
+        expectedJSONReponse);
+
+    //Restores the environment from no longer using disk healthchecks
+    currentProperties = createProperties(validateRequestOnStoreState, true);
+    setPropertyToAmbryRequests(currentProperties,"disk.manager.disk.healthcheck.enabled","false");
   }
 
   // helpers

--- a/ambry-server/src/test/java/com/github/ambry/server/AmbryServerRequestsTest.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/AmbryServerRequestsTest.java
@@ -949,20 +949,36 @@ public class AmbryServerRequestsTest {
   }
 
   /**
-   * Compares two json arrays to ensure what is seen is the same as what is expected
+   * Compares two json arrays to ensure what is seen is the same as what is expected without caring about order
    * @param expected JSONArray of what's expected in the response's content
    * @param seen JSONArray of what's seen in the response's content
    * @return True/False indicate if the two arrays were equal or not
    */
   public boolean compareJSONArrayNoOrder(JSONArray expected, JSONArray seen) {
-    HashSet<JSONObject> seenJSONObjects = new HashSet<>();
-    for (int i = 0; i < seen.length(); i++) {
-      seenJSONObjects.add((JSONObject) expected.get(i));
-    }
-    for (int i = 0; i < expected.length(); i++) {
-      if (seenJSONObjects.contains((JSONObject) expected.get(i))) {
-        seenJSONObjects.remove((JSONObject) expected.get(i));
-      } else {
+
+    //Iterates through the expected elements
+    for (Object expectedObject : expected) {
+      JSONObject expectedJSONObject = (JSONObject) expectedObject;
+      boolean comparisonMatch = false;
+
+      //Finds which seen json object is identical to what's expected
+      for (int i = 0; i < seen.length(); i++) {
+        JSONObject seenJSONObject = (JSONObject) seen.get(i);
+        boolean foundCopy = true;
+
+        //compares each value by string
+        for (String key : expectedJSONObject.keySet()) {
+          foundCopy = foundCopy && seenJSONObject.get(key).toString().equals(expectedJSONObject.get(key).toString());
+        }
+
+        //if this is the identical copy then we can compare the next expected element
+        if (foundCopy) {
+          comparisonMatch = true;
+          break;
+        }
+      }
+      //the match wasn't found so the seen array isn't identical to the expected array
+      if (!comparisonMatch) {
         return false;
       }
     }

--- a/ambry-server/src/test/java/com/github/ambry/server/MockStorageManager.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/MockStorageManager.java
@@ -496,10 +496,9 @@ class MockStorageManager extends StorageManager {
   MockStorageManager(Set<StoreKey> validKeysInStore, ClusterMap clusterMap, DataNodeId dataNodeId,
       FindTokenHelper findTokenHelper, ClusterParticipant clusterParticipant, DiskManagerConfig diskManagerConfig)
       throws StoreException {
-    super(new StoreConfig(VPROPS), diskManagerConfig, Utils.newScheduler(1, true), new MetricRegistry(),
-        null, clusterMap, dataNodeId, null,
-        clusterParticipant == null ? null : Collections.singletonList(clusterParticipant), new MockTime(), null,
-        new InMemAccountService(false, false));
+    super(new StoreConfig(VPROPS), diskManagerConfig, Utils.newScheduler(1, true), new MetricRegistry(), null,
+        clusterMap, dataNodeId, null, clusterParticipant == null ? null : Collections.singletonList(clusterParticipant),
+        new MockTime(), null, new InMemAccountService(false, false));
     this.validKeysInStore = validKeysInStore;
     this.findTokenHelper = findTokenHelper;
     for (ReplicaId replica : clusterMap.getReplicaIds(dataNodeId)) {
@@ -614,7 +613,7 @@ class MockStorageManager extends StorageManager {
   @Override
   public void start() throws InterruptedException, StoreException {
     super.start();
-    for(Store store: storeMap.values()){
+    for (Store store : storeMap.values()) {
       ((TestStore) store).start();
     }
   }

--- a/ambry-server/src/test/java/com/github/ambry/server/MockStorageManager.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/MockStorageManager.java
@@ -493,6 +493,20 @@ class MockStorageManager extends StorageManager {
     }
   }
 
+  MockStorageManager(Set<StoreKey> validKeysInStore, ClusterMap clusterMap, DataNodeId dataNodeId,
+      FindTokenHelper findTokenHelper, ClusterParticipant clusterParticipant, DiskManagerConfig diskManagerConfig)
+      throws StoreException {
+    super(new StoreConfig(VPROPS), diskManagerConfig, Utils.newScheduler(1, true), new MetricRegistry(),
+        null, clusterMap, dataNodeId, null,
+        clusterParticipant == null ? null : Collections.singletonList(clusterParticipant), new MockTime(), null,
+        new InMemAccountService(false, false));
+    this.validKeysInStore = validKeysInStore;
+    this.findTokenHelper = findTokenHelper;
+    for (ReplicaId replica : clusterMap.getReplicaIds(dataNodeId)) {
+      storeMap.put(replica.getPartitionId(), new TestStore(replica, clusterParticipant));
+    }
+  }
+
   MockStorageManager(Map<PartitionId, Store> map, DataNodeId dataNodeId) throws Exception {
     super(new StoreConfig(VPROPS), new DiskManagerConfig(VPROPS), null, new MetricRegistry(), null,
         new MockClusterMap(), dataNodeId, null, null, SystemTime.getInstance(), null,

--- a/ambry-store/src/main/java/com/github/ambry/store/DiskHealthStatus.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/DiskHealthStatus.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.store;
+
+/**
+ * Disk Health Status Levels
+ * When determining the health of the disk we can use these levels to determine what went wrong with the healthcheck
+ */
+public enum DiskHealthStatus {
+
+  /** The Disk is healthy after performing the disk healthcheck */
+  HEALTHY,
+
+  /** Initialization purposes until the health checking begins */
+  UNKNOWN_HEALTH,
+
+  /** There is no space to write the file used for healthcheck */
+  INSUFFICIENT_SPACE,
+
+  /** The Disk's healthcheck encountered an io exception when creating a file to disk */
+  CREATE_IO_EXCEPTION,
+
+  /** The Disk's healthcheck encountered a timeout when writing to disk */
+  WRITE_TIMEOUT,
+
+  /** The Disk's healthcheck encountered an io exception when writing to disk */
+  WRITE_IO_EXCEPTION,
+
+  /** The Disk's healthcheck encountered a timeout when reading from disk */
+  READ_TIMEOUT,
+
+  /** The Disk's healthcheck encountered an io exception when reading from disk */
+  READ_IO_EXCEPTION,
+
+  /** The Disk's healthcheck reads a different value than what was expected */
+  READ_DIFFERENT,
+
+  /** The Disk's healthcheck encountered an io exception when deleting a file from disk */
+  DELETE_IO_EXCEPTION,
+}
+

--- a/ambry-store/src/main/java/com/github/ambry/store/DiskHealthStatus.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/DiskHealthStatus.java
@@ -28,8 +28,8 @@ public enum DiskHealthStatus {
   /** There is no space to write the file used for healthcheck */
   INSUFFICIENT_SPACE,
 
-  /** The Disk's healthcheck encountered an io exception when creating a file to disk */
-  CREATE_IO_EXCEPTION,
+  /** The Disk's healthcheck encountered an exception when creating a file or directory to disk */
+  CREATE_EXCEPTION,
 
   /** The Disk's healthcheck encountered a timeout when writing to disk */
   WRITE_TIMEOUT,

--- a/ambry-store/src/main/java/com/github/ambry/store/DiskHealthStatus.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/DiskHealthStatus.java
@@ -18,35 +18,45 @@ package com.github.ambry.store;
  * When determining the health of the disk we can use these levels to determine what went wrong with the healthcheck
  */
 public enum DiskHealthStatus {
-
-  /** The Disk is healthy after performing the disk healthcheck */
+  /**
+   * The Disk is healthy after performing the disk healthcheck
+   */
   HEALTHY,
-
-  /** Initialization purposes until the health checking begins */
+  /**
+   * Initialization purposes until the health checking begins
+   */
   UNKNOWN_HEALTH,
-
-  /** There is no space to write the file used for healthcheck */
+  /**
+   * There is no space to write the file used for healthcheck
+   */
   INSUFFICIENT_SPACE,
-
-  /** The Disk's healthcheck encountered an exception when creating a file or directory to disk */
+  /**
+   * The Disk's healthcheck encountered an exception when creating a file or directory to disk
+   */
   CREATE_EXCEPTION,
-
-  /** The Disk's healthcheck encountered a timeout when writing to disk */
+  /**
+   * The Disk's healthcheck encountered a timeout when writing to disk
+   */
   WRITE_TIMEOUT,
-
-  /** The Disk's healthcheck encountered any other exception when writing to disk */
+  /**
+   * The Disk's healthcheck encountered any other exception when writing to disk
+   */
   WRITE_EXCEPTION,
-
-  /** The Disk's healthcheck encountered a timeout when reading from disk */
+  /**
+   * The Disk's healthcheck encountered a timeout when reading from disk
+   */
   READ_TIMEOUT,
-
-  /** The Disk's healthcheck encountered any other exception when reading from disk */
+  /**
+   * The Disk's healthcheck encountered any other exception when reading from disk
+   */
   READ_EXCEPTION,
-
-  /** The Disk's healthcheck reads a different value than what was expected */
+  /**
+   * The Disk's healthcheck reads a different value than what was expected
+   */
   READ_DIFFERENT,
-
-  /** The Disk's healthcheck encountered an io exception when deleting a file from disk */
+  /**
+   * The Disk's healthcheck encountered an io exception when deleting a file from disk
+   */
   DELETE_IO_EXCEPTION,
 }
 

--- a/ambry-store/src/main/java/com/github/ambry/store/DiskHealthStatus.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/DiskHealthStatus.java
@@ -34,14 +34,14 @@ public enum DiskHealthStatus {
   /** The Disk's healthcheck encountered a timeout when writing to disk */
   WRITE_TIMEOUT,
 
-  /** The Disk's healthcheck encountered an io exception when writing to disk */
-  WRITE_IO_EXCEPTION,
+  /** The Disk's healthcheck encountered any other exception when writing to disk */
+  WRITE_EXCEPTION,
 
   /** The Disk's healthcheck encountered a timeout when reading from disk */
   READ_TIMEOUT,
 
-  /** The Disk's healthcheck encountered an io exception when reading from disk */
-  READ_IO_EXCEPTION,
+  /** The Disk's healthcheck encountered any other exception when reading from disk */
+  READ_EXCEPTION,
 
   /** The Disk's healthcheck reads a different value than what was expected */
   READ_DIFFERENT,

--- a/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
@@ -686,7 +686,7 @@ public class DiskManager {
         Path path = Paths.get(healthcheckDir, "temp");
         AsynchronousFileChannel fileChannel =
             AsynchronousFileChannel.open(path, StandardOpenOption.WRITE, StandardOpenOption.READ,
-                StandardOpenOption.CREATE, StandardOpenOption.DELETE_ON_CLOSE);
+                StandardOpenOption.SYNC, StandardOpenOption.CREATE, StandardOpenOption.DELETE_ON_CLOSE);
         return fileChannel;
       } catch (Exception e) {
         diskHealthStatus = DiskHealthStatus.CREATE_EXCEPTION;

--- a/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
@@ -597,10 +597,10 @@ public class DiskManager {
     Manages the disk healthchecking tasks such as creating,writing, reading, and deleting a file
    */
   private class DiskHealthCheck{
-    private int intervalSeconds;             //time between checking the state of the disk
+    private final int intervalSeconds;             //time between checking the state of the disk
     private final int operationTimeoutSeconds;      //how long a read/write operation is allotted
     private final boolean enabled;                  //enabled healthchecking
-    private String heathcheckDir;                //filepath of where the file will be created
+    private final String heathcheckDir;                //filepath of where the file will be created
 
 
     DiskHealthCheck(int intervalSeconds, int operationTimeoutSeconds, boolean enabled, String heathcheckDir){

--- a/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
@@ -686,7 +686,7 @@ public class DiskManager {
         Path path = Paths.get(healthcheckDir, "temp");
         AsynchronousFileChannel fileChannel =
             AsynchronousFileChannel.open(path, StandardOpenOption.WRITE, StandardOpenOption.READ,
-                StandardOpenOption.DSYNC, StandardOpenOption.CREATE, StandardOpenOption.DELETE_ON_CLOSE);
+                StandardOpenOption.SYNC, StandardOpenOption.CREATE, StandardOpenOption.DELETE_ON_CLOSE);
         return fileChannel;
       } catch (Exception e) {
         diskHealthStatus = DiskHealthStatus.CREATE_EXCEPTION;

--- a/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
@@ -643,13 +643,13 @@ public class DiskManager {
      * operation if there was an exception
      * @param fileChannel used to perform the read/write operation
      * @param buffer either used to write from or read to the buffer in the respective operation
-     * @param timeoutException indicate if the timeout is from reading or writing
-     * @param otherException indicate if the other exceptions are from reading or writing
+     * @param timeoutStatus indicate if the timeout is from reading or writing
+     * @param otherStatus indicate if the other exceptions are from reading or writing
      * @param isWriting inform the function to either write or read with the buffer and filechannel
      * @return True/False to indicate if the operation completed with no issues or not
      */
     private boolean performOperation(AsynchronousFileChannel fileChannel, ByteBuffer buffer,
-        DiskHealthStatus timeoutException, DiskHealthStatus otherException, boolean isWriting) {
+        DiskHealthStatus timeoutStatus, DiskHealthStatus otherStatus, boolean isWriting) {
       Future<Integer> result = null;
       try {
         if (isWriting) {
@@ -660,10 +660,10 @@ public class DiskManager {
         result.get(operationTimeoutSeconds, TimeUnit.SECONDS);
         return true;
       } catch (TimeoutException e) {
-        diskHealthStatus = timeoutException;
+        diskHealthStatus = timeoutStatus;
         logger.error("Timeout Exception occurred when operating on a file for disk healthcheck", e);
       } catch (Exception e) {
-        diskHealthStatus = otherException;
+        diskHealthStatus = otherStatus;
         logger.error("Exception occurred when operating on a file for disk healthcheck", e);
       }
       if (result != null) {
@@ -686,7 +686,7 @@ public class DiskManager {
         Path path = Paths.get(healthcheckDir, "temp");
         AsynchronousFileChannel fileChannel =
             AsynchronousFileChannel.open(path, StandardOpenOption.WRITE, StandardOpenOption.READ,
-                StandardOpenOption.SYNC, StandardOpenOption.CREATE, StandardOpenOption.DELETE_ON_CLOSE);
+                StandardOpenOption.CREATE, StandardOpenOption.DELETE_ON_CLOSE);
         return fileChannel;
       } catch (Exception e) {
         diskHealthStatus = DiskHealthStatus.CREATE_EXCEPTION;
@@ -748,7 +748,6 @@ public class DiskManager {
       if (deleteFile(fileChannel, successful) && successful) {
         diskHealthStatus = DiskHealthStatus.HEALTHY;
       }
-      ;
     }
   }
 }

--- a/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
@@ -686,8 +686,7 @@ public class DiskManager {
         Path path = Paths.get(healthcheckDir, "temp");
         AsynchronousFileChannel fileChannel =
             AsynchronousFileChannel.open(path, StandardOpenOption.WRITE, StandardOpenOption.READ,
-                StandardOpenOption.CREATE, StandardOpenOption.DELETE_ON_CLOSE);
-        fileChannel.force(true); //writes to disk immediately
+                StandardOpenOption.DSYNC, StandardOpenOption.CREATE, StandardOpenOption.DELETE_ON_CLOSE);
         return fileChannel;
       } catch (Exception e) {
         diskHealthStatus = DiskHealthStatus.CREATE_EXCEPTION;

--- a/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
@@ -454,7 +454,7 @@ public class StorageManager implements StoreManager {
    * Getter utility for protected diskToDiskManager
    * @return diskToDiskManager
    */
-  public ConcurrentHashMap<DiskId, DiskManager> getDiskToDiskManager(){
+  public ConcurrentHashMap<DiskId, DiskManager> getDiskToDiskManager() {
     return diskToDiskManager;
   }
 
@@ -462,7 +462,7 @@ public class StorageManager implements StoreManager {
    * Getter utility for protected parititontoDiskManager
    * @return parititontoDiskManager
    */
-  public ConcurrentHashMap<PartitionId, DiskManager> getPartitionToDiskManager(){
+  public ConcurrentHashMap<PartitionId, DiskManager> getPartitionToDiskManager() {
     return partitionToDiskManager;
   }
 


### PR DESCRIPTION
This PR changes the Ambry HealthCheck Admin Endpoint(AHAE) to include disk healthchecking. The disk healthcheck implementation will CRUD a file asynchronously every minute to determine the health of each disk in the background. The AHAE will fetch the current state of the disk and if any disk isn't healthy or any helix state isn't standby/leader then the server is deemed BAD, otherwise GOOD.