### PR TITLE
Removing Filepath from Disk Manager Config

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/DiskManagerConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/DiskManagerConfig.java
@@ -40,10 +40,6 @@ public class DiskManagerConfig {
   @Default("180")
   public final int diskManagerDiskHealthCheckIntervalSeconds;
 
-  @Config("disk.manager.disk.healthcheck.file.path")
-  @Default("/ambry-data/")
-  public final String diskManagerDiskHealthCheckFilePath;
-
   @Config("disk.manager.disk.healthcheck.operation.timeout.seconds")
   @Default("5")
   public final int diskManagerDiskHealthCheckOperationTimeoutSeconds;
@@ -57,8 +53,6 @@ public class DiskManagerConfig {
     diskManagerDiskHealthCheckEnabled = verifiableProperties.getBoolean("disk.manager.disk.healthcheck.enabled", false);
     diskManagerDiskHealthCheckIntervalSeconds =
         verifiableProperties.getInt("disk.manager.disk.healthcheck.interval.seconds", 60);
-    diskManagerDiskHealthCheckFilePath =
-        verifiableProperties.getString("disk.manager.disk.healthcheck.file.path", "/ambry-data/");
     diskManagerDiskHealthCheckOperationTimeoutSeconds =
         verifiableProperties.getInt("disk.manager.disk.healthcheck.operation.timeout.seconds", 5);
   }

--- a/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
@@ -131,8 +131,7 @@ public class DiskManager {
     diskSpaceAllocator = new DiskSpaceAllocator(diskManagerConfig.diskManagerEnableSegmentPooling, reserveFileDir,
         diskManagerConfig.diskManagerRequiredSwapSegmentsPerSize, metrics);
     diskHealthCheck = new DiskHealthCheck(diskManagerConfig.diskManagerDiskHealthCheckOperationTimeoutSeconds,
-        diskManagerConfig.diskManagerDiskHealthCheckEnabled,
-        disk.getMountPath() + diskManagerConfig.diskManagerDiskHealthCheckFilePath);
+        diskManagerConfig.diskManagerDiskHealthCheckEnabled, disk.getMountPath());
     this.replicaStatusDelegates = replicaStatusDelegates;
     this.stoppedReplicas = stoppedReplicas;
     expectedDirs.add(reserveFileDir.getAbsolutePath());


### PR DESCRIPTION
This PR aims to remove file path from the disk healthchecker as getMountPath() already contains the path needed for disk healthchecker