### PR TITLE
Correct mount checks and diskManager health checks

### DIFF
--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryServerRequests.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryServerRequests.java
@@ -469,9 +469,9 @@ public class AmbryServerRequests extends AmbryRequests {
           DiskManager mountedDiskManager = entry.getValue();
 
           //Checks Disk healthchecking is enabled and
-          // if a disk isn't mounted as expected or isn't healthy then store it as part of the response
-          if (!partitionsDiskManagers.contains(mountedDiskManager)
-              || mountedDiskManager.getDiskHealthStatus() != DiskHealthStatus.HEALTHY) {
+          // if a disk manager is assigned to a partition and isn't healthy then store it as part of the response
+          if (partitionsDiskManagers.contains(mountedDiskManager)
+              && mountedDiskManager.getDiskHealthStatus() != DiskHealthStatus.HEALTHY) {
 
             JSONObject brokenDisk = new JSONObject();
             brokenDisk.put("disk", entry.getKey().getMountPath());

--- a/ambry-store/src/main/java/com/github/ambry/store/DiskHealthStatus.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/DiskHealthStatus.java
@@ -23,13 +23,9 @@ public enum DiskHealthStatus {
    */
   HEALTHY,
   /**
-   * Initialization purposes until the health checking begins
+   * The Disk's mountpath isn't accessible
    */
-  UNKNOWN_HEALTH,
-  /**
-   * There is no space to write the file used for healthcheck
-   */
-  INSUFFICIENT_SPACE,
+  MOUNT_NOT_ACCESSIBLE,
   /**
    * The Disk's healthcheck encountered an exception when creating a file or directory to disk
    */

--- a/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
@@ -683,12 +683,16 @@ public class DiskManager {
             AsynchronousFileChannel.open(path, StandardOpenOption.WRITE, StandardOpenOption.READ,
                 StandardOpenOption.SYNC, StandardOpenOption.CREATE, StandardOpenOption.DELETE_ON_CLOSE);
         return fileChannel;
+      } catch (StoreException e) {
+        if (e.getErrorCode() == StoreErrorCodes.Initialization_Error) {
+          diskHealthStatus = DiskHealthStatus.MOUNT_NOT_ACCESSIBLE;
+          logger.error("Exception occurred when checking if the mount is accessible", e);
+        }
       } catch (Exception e) {
-        diskHealthStatus =
-            e instanceof StoreException ? DiskHealthStatus.MOUNT_NOT_ACCESSIBLE : DiskHealthStatus.CREATE_EXCEPTION;
+        diskHealthStatus = DiskHealthStatus.CREATE_EXCEPTION;
         logger.error("Exception occurred when creating a file/directory for disk healthcheck", e);
-        return null;
       }
+      return null;
     }
 
     /**


### PR DESCRIPTION
This PR corrects how disk healthchecks checks a mount by initializing a disk to mount_not_accessible and utilizing checkMountAccessible() at each disk healthceck test. Also, this PR fixes how it only chooses disks that belong to a partitionId as part of the healthcheck response.