### PR TITLE
{DRAFT} Remove quota checks from AmbrySecurityService.

### DIFF
--- a/ambry-frontend/src/integration-test/java/com/github/ambry/frontend/FrontendQuotaIntegrationTest.java
+++ b/ambry-frontend/src/integration-test/java/com/github/ambry/frontend/FrontendQuotaIntegrationTest.java
@@ -107,8 +107,7 @@ public class FrontendQuotaIntegrationTest extends FrontendIntegrationTestBase {
   @Parameterized.Parameters
   public static List<Object[]> data() {
     return Arrays.asList(
-        new Object[][]{{true, QuotaMode.TRACKING}, {false, QuotaMode.TRACKING}, {true, QuotaMode.THROTTLING},
-            {false, QuotaMode.THROTTLING}});
+        new Object[][]{{false, QuotaMode.TRACKING}, {false, QuotaMode.THROTTLING}});
   }
 
   /**

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbrySecurityService.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbrySecurityService.java
@@ -133,15 +133,6 @@ class AmbrySecurityService implements SecurityService {
       } else if (hostLevelThrottler.shouldThrottle(restRequest)) {
         exception = new RestServiceException("Too many requests", RestServiceErrorCode.TooManyRequests);
       } else {
-        if (QuotaUtils.isRequestResourceQuotaManaged(restRequest) && quotaManager != null) {
-          ThrottlingRecommendation throttlingRecommendation = quotaManager.recommend(restRequest);
-          if (throttlingRecommendation != null && throttlingRecommendation.shouldThrottle()
-              && quotaManager.getQuotaMode() == QuotaMode.THROTTLING) {
-            Map<String, String> quotaHeaderMap = RestUtils.buildUserQuotaHeadersMap(throttlingRecommendation);
-            throw new RestServiceException("User Quota Exceeded", RestServiceErrorCode.TooManyRequests, true, true,
-                quotaHeaderMap);
-          }
-        }
         if (restRequest.getRestMethod() == RestMethod.DELETE || restRequest.getRestMethod() == RestMethod.PUT) {
           accountAndContainerNamePreconditionCheck(restRequest);
         } else if (restRequest.getRestMethod() == RestMethod.GET) {


### PR DESCRIPTION
We do not need quota checks in AmbrySecurityService after the implementation of bandwidth throttling is enabled. This PR removes those checks.