### PR TITLE
Fix issues related to Simple Operation Tracker response logic

### DIFF
--- a/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterMetrics.java
@@ -221,6 +221,7 @@ public class NonBlockingRouterMetrics {
   public final Counter failedOnTotalNotFoundCount;
   public final Counter failedMaybeDueToOriginatingDcOfflineReplicasCount;
   public final Counter failedMaybeDueToTotalOfflineReplicasCount;
+  public final Counter failedMaybeDueToUnavailableReplicasCount;
 
   // Workload characteristics
   public final AgeAtAccessMetrics ageAtGet;
@@ -536,6 +537,8 @@ public class NonBlockingRouterMetrics {
         MetricRegistry.name(SimpleOperationTracker.class, "FailedMaybeDueToTotalOfflineReplicasCount"));
     failedMaybeDueToOriginatingDcOfflineReplicasCount = metricRegistry.counter(
         MetricRegistry.name(SimpleOperationTracker.class, "FailedMaybeDueToOriginatingDcOfflineReplicasCount"));
+    failedMaybeDueToUnavailableReplicasCount = metricRegistry.counter(
+        MetricRegistry.name(SimpleOperationTracker.class, "FailedMaybeDueToUnavailableReplicasCount"));
 
     // Workload
     ageAtGet = new AgeAtAccessMetrics(metricRegistry, "OnGet");

--- a/ambry-router/src/main/java/com/github/ambry/router/OperationTracker.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/OperationTracker.java
@@ -95,4 +95,10 @@ interface OperationTracker {
    * @return An iterator that iterates all possible and valid replicas.
    */
   Iterator<ReplicaId> getReplicaIterator();
+
+  /**
+   * Return the count of successful responses from replicates
+   * @return an {@code int} that represent the number of successful responses from replicates
+   */
+  int getSuccessCount();
 }

--- a/ambry-router/src/main/java/com/github/ambry/router/SimpleOperationTracker.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/SimpleOperationTracker.java
@@ -16,11 +16,9 @@ package com.github.ambry.router;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.clustermap.ReplicaState;
-import com.github.ambry.clustermap.ReplicaType;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.config.RouterConfig;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -199,7 +197,7 @@ class SimpleOperationTracker implements OperationTracker {
     totalOfflineReplicaCount =
         getReplicasByState(null, EnumSet.of(ReplicaState.OFFLINE)).getOrDefault(ReplicaState.OFFLINE,
             Collections.emptyList()).size();
-    allReplicas = allDcReplicasByState.values().stream().flatMap(Collection::stream).collect(Collectors.toList());
+    allReplicas = partitionId.getReplicaIds().stream().collect(Collectors.toList());
     allReplicaCount = allReplicas.size();
 
     switch (routerOperation) {
@@ -472,6 +470,11 @@ class SimpleOperationTracker implements OperationTracker {
   }
 
   @Override
+  public int getSuccessCount() {
+    return replicaSuccessCount;
+  }
+
+  @Override
   public boolean isDone() {
     return hasSucceeded() || hasFailed();
   }
@@ -674,10 +677,6 @@ class SimpleOperationTracker implements OperationTracker {
    */
   int getFailedCount() {
     return failedCount;
-  }
-
-  int getSuccessCount() {
-    return replicaSuccessCount;
   }
 
   /**

--- a/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateOperation.java
@@ -361,8 +361,14 @@ class TtlUpdateOperation {
         operationException.set(new RouterException("TtlUpdateOperation failed possibly because of offline replicas",
             RouterErrorCode.AmbryUnavailable));
       } else if (operationTracker.hasFailedOnNotFound()) {
-        operationException.set(
-            new RouterException("TtlUpdateOperation failed because of BlobNotFound", RouterErrorCode.BlobDoesNotExist));
+        if (operationTracker.getSuccessCount() > 0) {
+          operationException.set(
+              new RouterException("TtlUpdateOperation failed possibly because of unavailable replicas",
+                  RouterErrorCode.AmbryUnavailable));
+        } else {
+          operationException.set(new RouterException("TtlUpdateOperation failed because of BlobNotFound",
+              RouterErrorCode.BlobDoesNotExist));
+        }
       }
       if (QuotaUtils.postProcessCharge(quotaChargeCallback)) {
         try {

--- a/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateOperation.java
@@ -362,6 +362,7 @@ class TtlUpdateOperation {
             RouterErrorCode.AmbryUnavailable));
       } else if (operationTracker.hasFailedOnNotFound()) {
         if (operationTracker.getSuccessCount() > 0) {
+          routerMetrics.failedMaybeDueToUnavailableReplicasCount.inc();
           operationException.set(
               new RouterException("TtlUpdateOperation failed possibly because of unavailable replicas",
                   RouterErrorCode.AmbryUnavailable));

--- a/ambry-router/src/test/java/com/github/ambry/router/TtlUpdateManagerTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/TtlUpdateManagerTest.java
@@ -450,7 +450,8 @@ public class TtlUpdateManagerTest {
     for (int i = 0; i < successfulResponsesCount; i++) {
       serversInLocalDc.get(i).setServerErrorForAllRequests(errorCodeToReturn);
     }
-    executeOpAndVerify(blobIds, shouldSucceed ? null : RouterErrorCode.BlobDoesNotExist, false, true, true, false);
+    RouterErrorCode expectedErrorCode = (successfulResponsesCount > 0) ? RouterErrorCode.AmbryUnavailable : RouterErrorCode.BlobDoesNotExist;
+    executeOpAndVerify(blobIds, shouldSucceed ? null : expectedErrorCode, false, true, true, false);
     serverLayout.getMockServers().forEach(MockServer::resetServerErrors);
   }
 


### PR DESCRIPTION
Fix issues related to Simple Operation Tracker response logic:
1. Return 503 Error instead of NOT_FOUND when there is a success in replica
2. Set allReplicas to include all replicas regardless of its state