### PR TITLE
Make ssl engine supported protocol log messages to trace

### DIFF
--- a/ambry-commons/src/main/java/com/github/ambry/commons/NettySslFactory.java
+++ b/ambry-commons/src/main/java/com/github/ambry/commons/NettySslFactory.java
@@ -73,10 +73,12 @@ public class NettySslFactory implements SSLFactory {
       sslParams.setEndpointIdentificationAlgorithm(endpointIdentification);
       sslEngine.setSSLParameters(sslParams);
     }
-    String[] supportedProtocols = sslEngine.getSupportedProtocols();
-    String[] enabledProtocols = sslEngine.getEnabledProtocols();
-    logger.info("NettySslFactory creating SSLEngine for {}: supportedProtocols: {}, enabledProtocols: {}", mode.name(),
-        String.join(",", supportedProtocols), String.join(",", enabledProtocols));
+    if (logger.isTraceEnabled()) {
+      String[] supportedProtocols = sslEngine.getSupportedProtocols();
+      String[] enabledProtocols = sslEngine.getEnabledProtocols();
+      logger.info("NettySslFactory creating SSLEngine for {}: supportedProtocols: {}, enabledProtocols: {}", mode.name(),
+          String.join(",", supportedProtocols), String.join(",", enabledProtocols));
+    }
     return sslEngine;
   }
 

--- a/ambry-commons/src/main/java/com/github/ambry/commons/NettySslFactory.java
+++ b/ambry-commons/src/main/java/com/github/ambry/commons/NettySslFactory.java
@@ -76,7 +76,7 @@ public class NettySslFactory implements SSLFactory {
     if (logger.isTraceEnabled()) {
       String[] supportedProtocols = sslEngine.getSupportedProtocols();
       String[] enabledProtocols = sslEngine.getEnabledProtocols();
-      logger.info("NettySslFactory creating SSLEngine for {}: supportedProtocols: {}, enabledProtocols: {}", mode.name(),
+      logger.trace("NettySslFactory creating SSLEngine for {}: supportedProtocols: {}, enabledProtocols: {}", mode.name(),
           String.join(",", supportedProtocols), String.join(",", enabledProtocols));
     }
     return sslEngine;

--- a/ambry-commons/src/main/java/com/github/ambry/commons/NettySslHttp2Factory.java
+++ b/ambry-commons/src/main/java/com/github/ambry/commons/NettySslHttp2Factory.java
@@ -74,7 +74,8 @@ public class NettySslHttp2Factory implements SSLFactory {
     if (logger.isTraceEnabled()) {
       String[] supportedProtocols = sslEngine.getSupportedProtocols();
       String[] enabledProtocols = sslEngine.getEnabledProtocols();
-      logger.trace("NettySslHttp2Factory creating SSLEngine for {}: supportedProtocols: {}, enabledProtocols: {}", mode.name(), String.join(",", supportedProtocols), String.join(",", enabledProtocols));
+      logger.trace("NettySslHttp2Factory creating SSLEngine for {}: supportedProtocols: {}, enabledProtocols: {}",
+          mode.name(), String.join(",", supportedProtocols), String.join(",", enabledProtocols));
     }
     return sslEngine;
   }

--- a/ambry-commons/src/main/java/com/github/ambry/commons/NettySslHttp2Factory.java
+++ b/ambry-commons/src/main/java/com/github/ambry/commons/NettySslHttp2Factory.java
@@ -71,10 +71,11 @@ public class NettySslHttp2Factory implements SSLFactory {
       sslParams.setEndpointIdentificationAlgorithm(endpointIdentification);
       sslEngine.setSSLParameters(sslParams);
     }
-    String[] supportedProtocols = sslEngine.getSupportedProtocols();
-    String[] enabledProtocols = sslEngine.getEnabledProtocols();
-    logger.info("NettySslHttp2Factory creating SSLEngine for {}: supportedProtocols: {}, enabledProtocols: {}",
-        mode.name(), String.join(",", supportedProtocols), String.join(",", enabledProtocols));
+    if (logger.isTraceEnabled()) {
+      String[] supportedProtocols = sslEngine.getSupportedProtocols();
+      String[] enabledProtocols = sslEngine.getEnabledProtocols();
+      logger.trace("NettySslHttp2Factory creating SSLEngine for {}: supportedProtocols: {}, enabledProtocols: {}", mode.name(), String.join(",", supportedProtocols), String.join(",", enabledProtocols));
+    }
     return sslEngine;
   }
 


### PR DESCRIPTION
Every time there is a ssl engine created, we log out this message. This is too much unnecessary logging.