### PR TITLE
Determine the frontend usage cost amplification factor from RouterConfig.

### DIFF
--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestServiceFactory.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestServiceFactory.java
@@ -20,6 +20,7 @@ import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.FrontendConfig;
 import com.github.ambry.config.QuotaConfig;
+import com.github.ambry.config.RouterConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.named.NamedBlobDb;
 import com.github.ambry.named.NamedBlobDbFactory;
@@ -98,7 +99,7 @@ public class FrontendRestRequestServiceFactory implements RestRequestServiceFact
       QuotaConfig quotaConfig = new QuotaConfig(verifiableProperties);
       QuotaManager quotaManager = ((QuotaManagerFactory) Utils.getObj(quotaConfig.quotaManagerFactory, quotaConfig,
           new SimpleQuotaRecommendationMergePolicy(quotaConfig), accountService, accountStatsStore,
-          clusterMap.getMetricRegistry())).getQuotaManager();
+          clusterMap.getMetricRegistry(), new RouterConfig(verifiableProperties))).getQuotaManager();
       SecurityServiceFactory securityServiceFactory =
           Utils.getObj(frontendConfig.securityServiceFactory, verifiableProperties, clusterMap, accountService,
               urlSigningService, idSigningService, accountAndContainerInjector, quotaManager);

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/AmbrySecurityServiceTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/AmbrySecurityServiceTest.java
@@ -131,7 +131,8 @@ public class AmbrySecurityServiceTest {
       ACCOUNT_SERVICE.updateAccounts(Collections.singletonList(InMemAccountService.UNKNOWN_ACCOUNT));
       QuotaConfig quotaConfig = QuotaTestUtils.createQuotaConfig(Collections.emptyMap(), false, QuotaMode.TRACKING);
       QUOTA_MANAGER = new AmbryQuotaManager(quotaConfig, new SimpleQuotaRecommendationMergePolicy(quotaConfig),
-          mock(AccountService.class), null, new QuotaMetrics(new MetricRegistry()));
+          mock(AccountService.class), null, new QuotaMetrics(new MetricRegistry()),
+          QuotaTestUtils.getDefaultRouterConfig());
     } catch (Exception e) {
       throw new IllegalStateException(e);
     }

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceFactoryTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceFactoryTest.java
@@ -51,7 +51,7 @@ public class FrontendRestRequestServiceFactoryTest {
       QuotaConfig quotaConfig = QuotaTestUtils.createQuotaConfig(Collections.emptyMap(), false, QuotaMode.TRACKING);
       QUOTA_MANAGER =
           new AmbryQuotaManager(quotaConfig, new SimpleQuotaRecommendationMergePolicy(quotaConfig), Mockito.mock(AccountService.class),
-              null, new QuotaMetrics(new MetricRegistry()));
+              null, new QuotaMetrics(new MetricRegistry()), QuotaTestUtils.getDefaultRouterConfig());
     } catch (Exception e) {
       throw new IllegalStateException(e);
     }

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
@@ -139,7 +139,8 @@ public class FrontendRestRequestServiceTest {
       QuotaConfig quotaConfig = QuotaTestUtils.createQuotaConfig(Collections.emptyMap(), false, QuotaMode.TRACKING);
       QUOTA_MANAGER =
           new AmbryQuotaManager(quotaConfig, new SimpleQuotaRecommendationMergePolicy(quotaConfig),
-              Mockito.mock(AccountService.class), null, new QuotaMetrics(new MetricRegistry()));
+              Mockito.mock(AccountService.class), null, new QuotaMetrics(new MetricRegistry()),
+              QuotaTestUtils.getDefaultRouterConfig());
     } catch (Exception e) {
       throw new IllegalStateException(e);
     }

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/PostBlobHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/PostBlobHandlerTest.java
@@ -114,7 +114,8 @@ public class PostBlobHandlerTest {
         QuotaConfig quotaConfig = QuotaTestUtils.createQuotaConfig(Collections.emptyMap(), false, QuotaMode.TRACKING);
         QUOTA_MANAGER =
             new AmbryQuotaManager(quotaConfig, new SimpleQuotaRecommendationMergePolicy(quotaConfig),
-                Mockito.mock(AccountService.class), null, new QuotaMetrics(new MetricRegistry()));
+                Mockito.mock(AccountService.class), null, new QuotaMetrics(new MetricRegistry()),
+                QuotaTestUtils.getDefaultRouterConfig());
       } catch (Exception e) {
         throw new IllegalStateException(e);
       }

--- a/ambry-quota/src/main/java/com/github/ambry/quota/AmbryQuotaManagerFactory.java
+++ b/ambry-quota/src/main/java/com/github/ambry/quota/AmbryQuotaManagerFactory.java
@@ -17,6 +17,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.account.AccountService;
 import com.github.ambry.accountstats.AccountStatsStore;
 import com.github.ambry.config.QuotaConfig;
+import com.github.ambry.config.RouterConfig;
 
 
 /**
@@ -31,13 +32,15 @@ public class AmbryQuotaManagerFactory implements QuotaManagerFactory {
    * @param accountService {@link AccountService} object.
    * @param accountStatsStore {@link AccountStatsStore} object.
    * @param metricRegistry {@link MetricRegistry} object.
+   * @param routerConfig {@link RouterConfig} object.
    * @throws ReflectiveOperationException
    */
   public AmbryQuotaManagerFactory(QuotaConfig quotaConfig,
       QuotaRecommendationMergePolicy quotaRecommendationMergePolicy, AccountService accountService,
-      AccountStatsStore accountStatsStore, MetricRegistry metricRegistry) throws ReflectiveOperationException {
+      AccountStatsStore accountStatsStore, MetricRegistry metricRegistry, RouterConfig routerConfig)
+      throws ReflectiveOperationException {
     quotaManager = new AmbryQuotaManager(quotaConfig, quotaRecommendationMergePolicy, accountService, accountStatsStore,
-        new QuotaMetrics(metricRegistry));
+        new QuotaMetrics(metricRegistry), routerConfig);
   }
 
   @Override

--- a/ambry-quota/src/main/java/com/github/ambry/quota/AtomicAmbryQuotaManager.java
+++ b/ambry-quota/src/main/java/com/github/ambry/quota/AtomicAmbryQuotaManager.java
@@ -16,6 +16,7 @@ package com.github.ambry.quota;
 import com.github.ambry.account.AccountService;
 import com.github.ambry.accountstats.AccountStatsStore;
 import com.github.ambry.config.QuotaConfig;
+import com.github.ambry.config.RouterConfig;
 import com.github.ambry.rest.RestRequest;
 import java.util.Map;
 
@@ -48,12 +49,13 @@ public class AtomicAmbryQuotaManager extends AmbryQuotaManager {
    * @param accountService {@link AccountService} object.
    * @param accountStatsStore {@link AccountStatsStore} object.
    * @param quotaMetrics {@link QuotaMetrics} object.
+   * @param routerConfig {@link RouterConfig} object.
    * @throws ReflectiveOperationException if {@link AtomicAmbryQuotaManager} could not be created.
    */
   public AtomicAmbryQuotaManager(QuotaConfig quotaConfig, QuotaRecommendationMergePolicy quotaRecommendationMergePolicy,
-      AccountService accountService, AccountStatsStore accountStatsStore, QuotaMetrics quotaMetrics)
-      throws ReflectiveOperationException {
-    super(quotaConfig, quotaRecommendationMergePolicy, accountService, accountStatsStore, quotaMetrics);
+      AccountService accountService, AccountStatsStore accountStatsStore, QuotaMetrics quotaMetrics,
+      RouterConfig routerConfig) throws ReflectiveOperationException {
+    super(quotaConfig, quotaRecommendationMergePolicy, accountService, accountStatsStore, quotaMetrics, routerConfig);
     quotaResourceSynchronizer = new QuotaResourceSynchronizer(quotaMetrics);
   }
 

--- a/ambry-quota/src/main/java/com/github/ambry/quota/capacityunit/AmbryCUQuotaSourceFactory.java
+++ b/ambry-quota/src/main/java/com/github/ambry/quota/capacityunit/AmbryCUQuotaSourceFactory.java
@@ -15,6 +15,7 @@ package com.github.ambry.quota.capacityunit;
 
 import com.github.ambry.account.AccountService;
 import com.github.ambry.config.QuotaConfig;
+import com.github.ambry.config.RouterConfig;
 import com.github.ambry.quota.QuotaMetrics;
 import com.github.ambry.quota.QuotaSource;
 import com.github.ambry.quota.QuotaSourceFactory;
@@ -32,9 +33,11 @@ public class AmbryCUQuotaSourceFactory implements QuotaSourceFactory {
    * @param quotaConfig {@link QuotaConfig} object.
    * @param accountService {@link AccountService} object.
    * @param quotaMetrics {@link QuotaMetrics} object.
+   * @param routerConfig {@link RouterConfig} object.
    */
-  public AmbryCUQuotaSourceFactory(QuotaConfig quotaConfig, AccountService accountService, QuotaMetrics quotaMetrics) throws IOException {
-    ambryCUQuotaSource = new AmbryCUQuotaSource(quotaConfig, accountService, quotaMetrics);
+  public AmbryCUQuotaSourceFactory(QuotaConfig quotaConfig, AccountService accountService, QuotaMetrics quotaMetrics,
+      RouterConfig routerConfig) throws IOException {
+    ambryCUQuotaSource = new AmbryCUQuotaSource(quotaConfig, accountService, quotaMetrics, routerConfig);
   }
 
   @Override

--- a/ambry-quota/src/main/java/com/github/ambry/quota/storage/JSONStringStorageQuotaSourceFactory.java
+++ b/ambry-quota/src/main/java/com/github/ambry/quota/storage/JSONStringStorageQuotaSourceFactory.java
@@ -15,6 +15,7 @@ package com.github.ambry.quota.storage;
 
 import com.github.ambry.account.AccountService;
 import com.github.ambry.config.QuotaConfig;
+import com.github.ambry.config.RouterConfig;
 import com.github.ambry.quota.QuotaMetrics;
 import com.github.ambry.quota.QuotaSource;
 import com.github.ambry.quota.QuotaSourceFactory;
@@ -32,10 +33,11 @@ public class JSONStringStorageQuotaSourceFactory implements QuotaSourceFactory {
    * @param quotaConfig The {@link QuotaConfig} to use.
    * @param accountService The {@link AccountService} to use.
    * @param quotaMetrics The {@link QuotaMetrics} to use.
+   * @param routerConfig The {@link RouterConfig} to use.
    * @throws IOException
    */
   public JSONStringStorageQuotaSourceFactory(QuotaConfig quotaConfig, AccountService accountService,
-      QuotaMetrics quotaMetrics) throws IOException {
+      QuotaMetrics quotaMetrics, RouterConfig routerConfig) throws IOException {
     source = new JSONStringStorageQuotaSource(quotaConfig.storageQuotaConfig, accountService);
   }
 

--- a/ambry-quota/src/test/java/com/github/ambry/quota/AmbryQuotaManagerUpdateNotificationTest.java
+++ b/ambry-quota/src/test/java/com/github/ambry/quota/AmbryQuotaManagerUpdateNotificationTest.java
@@ -54,7 +54,7 @@ public class AmbryQuotaManagerUpdateNotificationTest {
             new AccountServiceMetrics(metricRegistry), null);
     AmbryQuotaManager ambryQuotaManager =
         new AmbryQuotaManager(quotaConfig, quotaRecommendationMergePolicy, accountService, null,
-            new QuotaMetrics(metricRegistry));
+            new QuotaMetrics(metricRegistry), QuotaTestUtils.getDefaultRouterConfig());
     AmbryCUQuotaSource quotaSource = (AmbryCUQuotaSource) getQuotaSourceMember(ambryQuotaManager);
     assertTrue("updated accounts should be empty", quotaSource.getAllQuota().isEmpty());
 

--- a/ambry-quota/src/test/java/com/github/ambry/quota/capacityunit/AmbryCUQuotaEnforcerFactoryTest.java
+++ b/ambry-quota/src/test/java/com/github/ambry/quota/capacityunit/AmbryCUQuotaEnforcerFactoryTest.java
@@ -20,6 +20,7 @@ import com.github.ambry.config.QuotaConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.quota.QuotaMetrics;
 import com.github.ambry.quota.QuotaSource;
+import com.github.ambry.quota.QuotaTestUtils;
 import java.io.IOException;
 import java.util.Properties;
 import org.junit.Assert;
@@ -35,7 +36,8 @@ public class AmbryCUQuotaEnforcerFactoryTest {
   public void testGetRequestQuotaEnforcer() throws IOException {
     QuotaConfig quotaConfig = new QuotaConfig(new VerifiableProperties(new Properties()));
     QuotaSource quotaSource =
-        new AmbryCUQuotaSource(quotaConfig, Mockito.mock(AccountService.class), new QuotaMetrics(new MetricRegistry()));
+        new AmbryCUQuotaSource(quotaConfig, Mockito.mock(AccountService.class), new QuotaMetrics(new MetricRegistry()),
+            QuotaTestUtils.getDefaultRouterConfig());
     AccountStatsStore mockAccountStatsStore = Mockito.mock(AccountStatsStore.class);
     AmbryCUQuotaEnforcerFactory ambryCUQuotaEnforcerFactory =
         new AmbryCUQuotaEnforcerFactory(quotaConfig, quotaSource, mockAccountStatsStore,

--- a/ambry-quota/src/test/java/com/github/ambry/quota/capacityunit/AmbryCUQuotaEnforcerTest.java
+++ b/ambry-quota/src/test/java/com/github/ambry/quota/capacityunit/AmbryCUQuotaEnforcerTest.java
@@ -299,7 +299,7 @@ public class AmbryCUQuotaEnforcerTest {
     private boolean throwException = false;
 
     public ExceptionQuotaSource(QuotaConfig config, AccountService accountService) throws IOException {
-      super(config, accountService, new QuotaMetrics(new MetricRegistry()));
+      super(config, accountService, new QuotaMetrics(new MetricRegistry()), QuotaTestUtils.getDefaultRouterConfig());
     }
 
     @Override

--- a/ambry-quota/src/test/java/com/github/ambry/quota/capacityunit/AmbryCUQuotaSourceFactoryTest.java
+++ b/ambry-quota/src/test/java/com/github/ambry/quota/capacityunit/AmbryCUQuotaSourceFactoryTest.java
@@ -18,6 +18,7 @@ import com.github.ambry.account.AccountService;
 import com.github.ambry.config.QuotaConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.quota.QuotaMetrics;
+import com.github.ambry.quota.QuotaTestUtils;
 import java.io.IOException;
 import java.util.Properties;
 import org.junit.Assert;
@@ -34,7 +35,8 @@ public class AmbryCUQuotaSourceFactoryTest {
     QuotaConfig quotaConfig = new QuotaConfig(new VerifiableProperties(new Properties()));
     AccountService mockAccountService = Mockito.mock(AccountService.class);
     AmbryCUQuotaSourceFactory ambryCUQuotaSourceFactory =
-        new AmbryCUQuotaSourceFactory(quotaConfig, mockAccountService, new QuotaMetrics(new MetricRegistry()));
+        new AmbryCUQuotaSourceFactory(quotaConfig, mockAccountService, new QuotaMetrics(new MetricRegistry()),
+            QuotaTestUtils.getDefaultRouterConfig());
     Assert.assertEquals(AmbryCUQuotaSource.class, ambryCUQuotaSourceFactory.getQuotaSource().getClass());
   }
 }

--- a/ambry-quota/src/test/java/com/github/ambry/quota/capacityunit/AmbryCUQuotaSourceTest.java
+++ b/ambry-quota/src/test/java/com/github/ambry/quota/capacityunit/AmbryCUQuotaSourceTest.java
@@ -23,6 +23,7 @@ import com.github.ambry.account.Container;
 import com.github.ambry.account.ContainerBuilder;
 import com.github.ambry.account.InMemAccountService;
 import com.github.ambry.config.QuotaConfig;
+import com.github.ambry.config.RouterConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.quota.QuotaException;
 import com.github.ambry.quota.QuotaMetrics;
@@ -30,6 +31,7 @@ import com.github.ambry.quota.QuotaName;
 import com.github.ambry.quota.QuotaResource;
 import com.github.ambry.quota.QuotaResourceType;
 import com.github.ambry.quota.QuotaSource;
+import com.github.ambry.quota.QuotaTestUtils;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -59,6 +61,7 @@ public class AmbryCUQuotaSourceTest {
   private static Map<String, JsonCUQuotaDataProviderUtil.MapOrQuota> testQuotas;
   private static InMemAccountService inMemAccountService;
   private static QuotaConfig quotaConfig;
+  private static RouterConfig routerConfig;
 
   /**
    * Create {@link Account} object with specified quota and accountId.
@@ -118,8 +121,9 @@ public class AmbryCUQuotaSourceTest {
     for (String s : testQuotas.keySet()) {
       inMemAccountService.updateAccounts(Collections.singletonList(createAccountForQuota(testQuotas.get(s), s)));
     }
+    routerConfig = QuotaTestUtils.getDefaultRouterConfig();
     ambryCUQuotaSource = (AmbryCUQuotaSource) new AmbryCUQuotaSourceFactory(quotaConfig, inMemAccountService,
-        new QuotaMetrics(new MetricRegistry())).getQuotaSource();
+        new QuotaMetrics(new MetricRegistry()), routerConfig).getQuotaSource();
     ambryCUQuotaSource.init();
   }
 
@@ -133,7 +137,7 @@ public class AmbryCUQuotaSourceTest {
   public void testInit() throws Exception {
     QuotaSource quotaSource =
         new AmbryCUQuotaSourceFactory(new QuotaConfig(new VerifiableProperties(new Properties())), inMemAccountService,
-            new QuotaMetrics(new MetricRegistry())).getQuotaSource();
+            new QuotaMetrics(new MetricRegistry()), QuotaTestUtils.getDefaultRouterConfig()).getQuotaSource();
     Assert.assertFalse(quotaSource.isReady());
     quotaSource.init();
     Assert.assertTrue(quotaSource.isReady());
@@ -254,20 +258,27 @@ public class AmbryCUQuotaSourceTest {
     Assert.assertEquals(0, ambryCUQuotaSource.getSystemResourceUsage(QuotaName.READ_CAPACITY_UNIT), 0.01);
 
     ambryCUQuotaSource.chargeSystemResourceUsage(QuotaName.READ_CAPACITY_UNIT, 819);
-    Assert.assertEquals(79.98, ambryCUQuotaSource.getSystemResourceUsage(QuotaName.READ_CAPACITY_UNIT), 0.01);
+    Assert.assertEquals(79.98 * routerConfig.routerGetRequestParallelism,
+        ambryCUQuotaSource.getSystemResourceUsage(QuotaName.READ_CAPACITY_UNIT), 0.01);
     Assert.assertEquals(0, ambryCUQuotaSource.getSystemResourceUsage(QuotaName.WRITE_CAPACITY_UNIT), 0.01);
 
     ambryCUQuotaSource.chargeSystemResourceUsage(QuotaName.WRITE_CAPACITY_UNIT, 819);
-    Assert.assertEquals(79.98, ambryCUQuotaSource.getSystemResourceUsage(QuotaName.READ_CAPACITY_UNIT), 0.01);
-    Assert.assertEquals(79.98, ambryCUQuotaSource.getSystemResourceUsage(QuotaName.WRITE_CAPACITY_UNIT), 0.01);
+    Assert.assertEquals(79.98 * routerConfig.routerGetRequestParallelism,
+        ambryCUQuotaSource.getSystemResourceUsage(QuotaName.READ_CAPACITY_UNIT), 0.01);
+    Assert.assertEquals(79.98 * routerConfig.routerPutRequestParallelism,
+        ambryCUQuotaSource.getSystemResourceUsage(QuotaName.WRITE_CAPACITY_UNIT), 0.01);
 
     ambryCUQuotaSource.chargeSystemResourceUsage(QuotaName.READ_CAPACITY_UNIT, 1);
-    Assert.assertEquals(80.07, ambryCUQuotaSource.getSystemResourceUsage(QuotaName.READ_CAPACITY_UNIT), 0.01);
-    Assert.assertEquals(79.98, ambryCUQuotaSource.getSystemResourceUsage(QuotaName.WRITE_CAPACITY_UNIT), 0.01);
+    Assert.assertEquals(80.07 * routerConfig.routerGetRequestParallelism,
+        ambryCUQuotaSource.getSystemResourceUsage(QuotaName.READ_CAPACITY_UNIT), 0.1);
+    Assert.assertEquals(79.98 * routerConfig.routerPutRequestParallelism,
+        ambryCUQuotaSource.getSystemResourceUsage(QuotaName.WRITE_CAPACITY_UNIT), 0.01);
 
     ambryCUQuotaSource.chargeSystemResourceUsage(QuotaName.WRITE_CAPACITY_UNIT, 1);
-    Assert.assertEquals(80.07, ambryCUQuotaSource.getSystemResourceUsage(QuotaName.READ_CAPACITY_UNIT), 0.01);
-    Assert.assertEquals(80.07, ambryCUQuotaSource.getSystemResourceUsage(QuotaName.WRITE_CAPACITY_UNIT), 0.01);
+    Assert.assertEquals(80.07 * routerConfig.routerGetRequestParallelism,
+        ambryCUQuotaSource.getSystemResourceUsage(QuotaName.READ_CAPACITY_UNIT), 0.1);
+    Assert.assertEquals(80.07 * routerConfig.routerPutRequestParallelism,
+        ambryCUQuotaSource.getSystemResourceUsage(QuotaName.WRITE_CAPACITY_UNIT), 0.1);
   }
 
   @Test

--- a/ambry-router/src/test/java/com/github/ambry/router/NonBlockingQuotaTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/NonBlockingQuotaTest.java
@@ -38,6 +38,7 @@ import com.github.ambry.quota.QuotaName;
 import com.github.ambry.quota.QuotaRecommendationMergePolicy;
 import com.github.ambry.quota.QuotaResource;
 import com.github.ambry.quota.QuotaResourceType;
+import com.github.ambry.quota.QuotaTestUtils;
 import com.github.ambry.quota.QuotaUtils;
 import com.github.ambry.quota.SimpleQuotaRecommendationMergePolicy;
 import com.github.ambry.quota.capacityunit.AmbryCUQuotaEnforcer;
@@ -390,6 +391,10 @@ public class NonBlockingQuotaTest extends NonBlockingRouterTestBase {
           quotaMetrics.perQuotaResourceOutOfQuotaMap.get(Integer.toString(account.getId())).getCount() > 0);
       Assert.assertTrue(
           quotaMetrics.perQuotaResourceWouldBeThrottledMap.get(Integer.toString(account.getId())).getCount() > 0);
+      Assert.assertEquals(quotaMetrics.frontendUsageReadAmplificationGauge.getValue(),
+          (Integer) ChargeTesterQuotaManager.routerConfig.routerGetRequestParallelism);
+      Assert.assertEquals(quotaMetrics.frontendUsageWriteAmplificationGauge.getValue(),
+          (Integer) ChargeTesterQuotaManager.routerConfig.routerPutRequestParallelism);
       retainingAsyncWritableChannel.consumeContentAsInputStream().close();
     } finally {
       if (router != null) {
@@ -466,6 +471,7 @@ public class NonBlockingQuotaTest extends NonBlockingRouterTestBase {
    * {@link AmbryQuotaManager} extension to test behavior with default implementation.
    */
   static class ChargeTesterQuotaManager extends AmbryQuotaManager {
+    public static final RouterConfig routerConfig = QuotaTestUtils.getDefaultRouterConfig();
     private final AtomicInteger chargeCalledCount;
 
     /**
@@ -481,7 +487,7 @@ public class NonBlockingQuotaTest extends NonBlockingRouterTestBase {
         QuotaRecommendationMergePolicy quotaRecommendationMergePolicy, AccountService accountService,
         AccountStatsStore accountStatsStore, QuotaMetrics quotaMetrics, AtomicInteger chargeCalledCount)
         throws ReflectiveOperationException {
-      super(quotaConfig, quotaRecommendationMergePolicy, accountService, accountStatsStore, quotaMetrics);
+      super(quotaConfig, quotaRecommendationMergePolicy, accountService, accountStatsStore, quotaMetrics, routerConfig);
       this.chargeCalledCount = chargeCalledCount;
     }
 

--- a/ambry-router/src/test/java/com/github/ambry/router/TestCUQuotaSourceFactory.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/TestCUQuotaSourceFactory.java
@@ -15,6 +15,7 @@ package com.github.ambry.router;
 
 import com.github.ambry.account.AccountService;
 import com.github.ambry.config.QuotaConfig;
+import com.github.ambry.config.RouterConfig;
 import com.github.ambry.quota.QuotaMetrics;
 import com.github.ambry.quota.QuotaSource;
 import com.github.ambry.quota.QuotaSourceFactory;
@@ -32,23 +33,27 @@ public class TestCUQuotaSourceFactory implements QuotaSourceFactory {
   private final QuotaConfig quotaConfig;
   private final AccountService accountService;
   private final QuotaMetrics quotaMetrics;
+  private final RouterConfig routerConfig;
 
   /**
    * Constructor for {@link AmbryCUQuotaSourceFactory}.
    * @param quotaConfig {@link QuotaConfig} object.
    * @param accountService {@link AccountService} object.
    * @param quotaMetrics {@link QuotaMetrics} object.
+   * @param routerConfig {@link RouterConfig} object.
    */
-  public TestCUQuotaSourceFactory(QuotaConfig quotaConfig, AccountService accountService, QuotaMetrics quotaMetrics) {
+  public TestCUQuotaSourceFactory(QuotaConfig quotaConfig, AccountService accountService, QuotaMetrics quotaMetrics,
+      RouterConfig routerConfig) {
     this.quotaConfig = quotaConfig;
     this.accountService = accountService;
     this.quotaMetrics = quotaMetrics;
+    this.routerConfig = routerConfig;
   }
 
   @Override
   public QuotaSource getQuotaSource() {
     try {
-      return new TestCUQuotaSource(quotaConfig, accountService, quotaMetrics);
+      return new TestCUQuotaSource(quotaConfig, accountService, quotaMetrics, routerConfig);
     } catch (IOException ioException) {
       return null;
     }
@@ -65,10 +70,12 @@ class TestCUQuotaSource extends AmbryCUQuotaSource {
    * @param quotaConfig {@link QuotaConfig} object.
    * @param accountService {@link AccountService} object.
    * @param quotaMetrics {@link QuotaMetrics} object.
+   * @param routerConfig {@link RouterConfig} object.
    * @throws IOException in case of any exception.
    */
-  public TestCUQuotaSource(QuotaConfig quotaConfig, AccountService accountService, QuotaMetrics quotaMetrics) throws IOException {
-    super(quotaConfig, accountService, quotaMetrics);
+  public TestCUQuotaSource(QuotaConfig quotaConfig, AccountService accountService, QuotaMetrics quotaMetrics,
+      RouterConfig routerConfig) throws IOException {
+    super(quotaConfig, accountService, quotaMetrics, routerConfig);
   }
 
   /**

--- a/ambry-test-utils/src/main/java/com/github/ambry/quota/DummyQuotaSourceFactory.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/quota/DummyQuotaSourceFactory.java
@@ -15,6 +15,7 @@ package com.github.ambry.quota;
 
 import com.github.ambry.account.AccountService;
 import com.github.ambry.config.QuotaConfig;
+import com.github.ambry.config.RouterConfig;
 
 
 /**
@@ -27,8 +28,10 @@ public class DummyQuotaSourceFactory implements QuotaSourceFactory {
    * @param quotaConfig {@link QuotaConfig} object.
    * @param accountService {@link AccountService} object.
    * @param quotaMetrics {@link QuotaMetrics} object.
+   * @param routerConfig {@link RouterConfig} object.
    */
-  public DummyQuotaSourceFactory(QuotaConfig quotaConfig, AccountService accountService, QuotaMetrics quotaMetrics) {
+  public DummyQuotaSourceFactory(QuotaConfig quotaConfig, AccountService accountService, QuotaMetrics quotaMetrics,
+      RouterConfig routerConfig) {
 
   }
 

--- a/ambry-test-utils/src/main/java/com/github/ambry/quota/QuotaTestUtils.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/quota/QuotaTestUtils.java
@@ -16,6 +16,7 @@ package com.github.ambry.quota;
 import com.github.ambry.account.Account;
 import com.github.ambry.account.Container;
 import com.github.ambry.config.QuotaConfig;
+import com.github.ambry.config.RouterConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.rest.MockRestRequest;
 import com.github.ambry.rest.RestMethod;
@@ -54,6 +55,16 @@ public class QuotaTestUtils {
     properties.setProperty(QuotaConfig.REQUEST_QUOTA_ENFORCER_SOURCE_PAIR_INFO_JSON,
         new JSONObject().put(QuotaConfig.QUOTA_ENFORCER_SOURCE_PAIR_INFO_STR, jsonArray).toString());
     return new QuotaConfig(new VerifiableProperties(properties));
+  }
+
+  /**
+   * @return the default {@link RouterConfig} object.
+   */
+  public static RouterConfig getDefaultRouterConfig() {
+    Properties properties = new Properties();
+    properties.setProperty(RouterConfig.ROUTER_HOSTNAME, "localhost");
+    properties.setProperty(RouterConfig.ROUTER_DATACENTER_NAME, "DEV");
+    return new RouterConfig(new VerifiableProperties(properties));
   }
 
   /**


### PR DESCRIPTION
Frontend usage cost could get amplified because to serve one copy of data, frontend might need to simultaneously read or write the data over network to multiple storage nodes. The amplification factor is determined by the RouterConfig.

The main change in this PR is that now RouterConfig is passed to QuotaSource constructor to get the configs. All the other changes are test changes. This PR also create a Gauge Metric in QuotaMetrics.java so that on deployment, it will be easy to infer the amplification factor being used by frontend.