### PR TITLE
Adding metric to record the direct memory usage for index segment files

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -429,6 +429,12 @@ public class StoreConfig {
   @Default("false")
   public final boolean storeEnableCurrentInvalidSizeMetric;
 
+  @Config(storeEnableIndexDirectMemoryUsageMetricName)
+  @Default("false")
+  public final boolean storeEnableIndexDirectMemoryUsageMetric;
+  public static final String storeEnableIndexDirectMemoryUsageMetricName =
+      "store.enable.index.direct.memory.usage.metric";
+
   @Config(storeAlwaysEnableTargetIndexDuplicateCheckingName)
   @Default("false")
   public final boolean storeAlwaysEnableTargetIndexDuplicateChecking;
@@ -541,8 +547,10 @@ public class StoreConfig {
         verifiableProperties.getIntInRange("store.io.error.count.to.trigger.shutdown", Integer.MAX_VALUE, 1,
             Integer.MAX_VALUE);
     storeSetFilePermissionEnabled = verifiableProperties.getBoolean("store.set.file.permission.enabled", false);
-    storeAutoCloseLastLogSegmentEnabled = verifiableProperties.getBoolean(storeAutoCloseLastLogSegmentEnabledName, false);
-    storeUnsealReplicaMinimumLagBytes = verifiableProperties.getLongInRange(storeUnsealReplicaMinimumLagBytesName, 0, 0, Long.MAX_VALUE);
+    storeAutoCloseLastLogSegmentEnabled =
+        verifiableProperties.getBoolean(storeAutoCloseLastLogSegmentEnabledName, false);
+    storeUnsealReplicaMinimumLagBytes =
+        verifiableProperties.getLongInRange(storeUnsealReplicaMinimumLagBytesName, 0, 0, Long.MAX_VALUE);
     String storeDataFilePermissionStr = verifiableProperties.getString("store.data.file.permission", "rw-rw----");
     storeDataFilePermission = PosixFilePermissions.fromString(storeDataFilePermissionStr);
     String storeOperationFilePermissionStr =
@@ -560,6 +568,8 @@ public class StoreConfig {
         verifiableProperties.getBoolean("store.enable.bucket.for.log.segment.reports", false);
     storeEnableCurrentInvalidSizeMetric =
         verifiableProperties.getBoolean("store.enable.current.invalid.size.metric", false);
+    storeEnableIndexDirectMemoryUsageMetric =
+        verifiableProperties.getBoolean(storeEnableIndexDirectMemoryUsageMetricName, false);
     storeAlwaysEnableTargetIndexDuplicateChecking =
         verifiableProperties.getBoolean(storeAlwaysEnableTargetIndexDuplicateCheckingName, false);
     storeRebuildTokenBasedOnResetKey = verifiableProperties.getBoolean("store.rebuild.token.based.on.reset.key", false);

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -256,7 +256,7 @@ public class BlobStore implements Store {
                   metrics);
         }
         metrics.initializeIndexGauges(storeId, index, capacityInBytes, blobStoreStats,
-            config.storeEnableCurrentInvalidSizeMetric);
+            config.storeEnableCurrentInvalidSizeMetric, config.storeEnableIndexDirectMemoryUsageMetric);
         checkCapacityAndUpdateReplicaStatusDelegate();
         logger.trace("The store {} is successfully started", storeId);
         onSuccess("START");

--- a/ambry-store/src/main/java/com/github/ambry/store/IndexSegment.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/IndexSegment.java
@@ -351,6 +351,22 @@ class IndexSegment implements Iterable<IndexEntry> {
   }
 
   /**
+   * @return The direct memory usage for this Index Segment in bytes.
+   */
+  long getDirectMemoryUsage() {
+    rwLock.readLock().lock();
+    try {
+      if (sealed.get() && config.storeIndexMemState == IndexMemState.IN_DIRECT_MEM) {
+        return serEntries.capacity();
+      } else {
+        return 0;
+      }
+    } finally {
+      rwLock.readLock().unlock();
+    }
+  }
+
+  /**
    * @return life version of reset key.
    */
   short getResetKeyLifeVersion() throws StoreException {

--- a/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
@@ -1531,6 +1531,13 @@ class PersistentIndex {
   }
 
   /**
+   * @return The direct memory usage for this persistent index in bytes.
+   */
+  long getDirectMemoryUsage() {
+    return validIndexSegments.values().stream().mapToLong(IndexSegment::getDirectMemoryUsage).sum();
+  }
+
+  /**
    * @return absolute end position (in bytes) of latest PUT record when this method is invoked. If no PUT is found in
    *         current store, -1 will be returned.
    * @throws StoreException

--- a/ambry-store/src/main/java/com/github/ambry/store/StoreMetrics.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StoreMetrics.java
@@ -20,6 +20,7 @@ import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -110,6 +111,8 @@ public class StoreMetrics {
   public final Timer statsRecentEntryQueueProcessTimeMs;
   public final Histogram statsRecentEntryQueueSize;
   public final Histogram statsForwardScanEntryCount;
+
+  private final ConcurrentHashMap<String, PersistentIndex> indexes = new ConcurrentHashMap<>();
 
   private final MetricRegistry registry;
 
@@ -246,7 +249,8 @@ public class StoreMetrics {
   }
 
   void initializeIndexGauges(String storeId, final PersistentIndex index, final long capacityInBytes,
-      BlobStoreStats blobStoreStats, boolean enableStoreCurrentInvalidSize) {
+      BlobStoreStats blobStoreStats, boolean enableStoreCurrentInvalidSize,
+      boolean enableStoreIndexDirectMemoryUsageMetric) {
     String prefix = storeId + SEPARATOR;
     Gauge<Long> currentCapacityUsed = index::getLogUsedCapacity;
     registry.register(MetricRegistry.name(Log.class, prefix + "CurrentCapacityUsed"), currentCapacityUsed);
@@ -258,6 +262,13 @@ public class StoreMetrics {
       Gauge<Long> currentInvalidDataSize =
           () -> index.getLogUsedCapacity() - blobStoreStats.getCachedValidSize().getSecond();
       registry.register(MetricRegistry.name(Log.class, prefix + "CurrentInvalidDataSize"), currentInvalidDataSize);
+    }
+    if (enableStoreIndexDirectMemoryUsageMetric) {
+      indexes.putIfAbsent(storeId, index);
+      Gauge<Long> indexDirectMemoryUsage =
+          () -> indexes.values().stream().mapToLong(PersistentIndex::getDirectMemoryUsage).sum();
+      registry.gauge(MetricRegistry.name(BlobStore.class, prefix + "IndexDirectMemoryUsage"),
+          () -> indexDirectMemoryUsage);
     }
   }
 

--- a/ambry-store/src/main/java/com/github/ambry/store/StoreMetrics.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StoreMetrics.java
@@ -265,8 +265,15 @@ public class StoreMetrics {
     }
     if (enableStoreIndexDirectMemoryUsageMetric) {
       indexes.putIfAbsent(storeId, index);
-      Gauge<Long> indexDirectMemoryUsage =
-          () -> indexes.values().stream().mapToLong(PersistentIndex::getDirectMemoryUsage).sum();
+      Gauge<Long> indexDirectMemoryUsage = () -> {
+        long start = System.nanoTime();
+        long usage = indexes.values().stream().mapToLong(PersistentIndex::getDirectMemoryUsage).sum();
+        if (logger.isTraceEnabled()) {
+          logger.trace("Time to get direct memory usage from persistent index is: {} nano seconds",
+              System.nanoTime() - start);
+        }
+        return usage;
+      };
       registry.gauge(MetricRegistry.name(BlobStore.class, prefix + "IndexDirectMemoryUsage"),
           () -> indexDirectMemoryUsage);
     }


### PR DESCRIPTION
Adding metric so record the direct memory usage for index segment files, so combined with the netty bytebuf pool, we can get a much better understanding of the direct memory usage of ambry-server.