### PR TITLE
Dont update state delete state when undelete is disabled

### DIFF
--- a/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
@@ -227,8 +227,8 @@ class PersistentIndex {
     this.incarnationId = incarnationId;
     this.maxInMemoryIndexSizeInBytes = config.storeIndexMaxMemorySizeBytes;
     this.maxInMemoryNumElements = config.storeIndexMaxNumberOfInmemElements;
-    if (config.storeCompactionFilter
-        == BlobStoreCompactor.IndexSegmentValidEntryFilterWithoutUndelete.class.getSimpleName()) {
+    if (config.storeCompactionFilter.equals(
+        BlobStoreCompactor.IndexSegmentValidEntryFilterWithoutUndelete.class.getSimpleName())) {
       logger.info("Undelete is not enabled, DELETE is considered as the final state of a blob");
       isDeleteFinalStateOfBlob = true;
     } else {

--- a/ambry-store/src/test/java/com/github/ambry/store/CuratedLogIndexState.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CuratedLogIndexState.java
@@ -208,6 +208,11 @@ class CuratedLogIndexState {
     properties.put("store.deleted.message.retention.hours", Integer.toString(CuratedLogIndexState.deleteRetentionHour));
     properties.put("store.rebuild.token.based.on.reset.key", Boolean.toString(enableResetKey));
     properties.put("store.auto.close.last.log.segment.enabled", Boolean.toString(enableAutoCloseLastLogSegment));
+    if (addUndeletes) {
+      // If we have undelete, than we need undelete filter
+      properties.put("store.compaction.filter",
+          BlobStoreCompactor.IndexSegmentValidEntryFilterWithUndelete.class.getSimpleName());
+    }
     // switch off time movement for the hard delete thread. Otherwise blobs expire too quickly
     time.suspend(Collections.singleton(HardDeleter.getThreadName(tempDirStr)));
     initIndex(null);


### PR DESCRIPTION
When undelete is disabled, DELETE will be the final state of the blob's life cycle. 
In this case, when we iterate through IndexSegment in findEntriesSince, we have to call update state for the DELETE record, since we already know it's the final state.

This PR should greatly improve the performance of replicating through a log segment that is full of DELETEs.