### PR TITLE
Update DeleteOperation to handle at least one replica success properly

### DIFF
--- a/ambry-router/src/main/java/com/github/ambry/router/DeleteOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/DeleteOperation.java
@@ -361,8 +361,15 @@ class DeleteOperation {
             new RouterException("DeleteOperation failed possibly because some replicas are unavailable",
                 RouterErrorCode.AmbryUnavailable));
       } else if (operationTracker.hasFailedOnNotFound()) {
-        operationException.set(
-            new RouterException("DeleteOperation failed because of BlobNotFound", RouterErrorCode.BlobDoesNotExist));
+        if (operationTracker.getSuccessCount() > 0) {
+          routerMetrics.failedMaybeDueToUnavailableReplicasCount.inc();
+          operationException.set(
+              new RouterException("DeleteOperation failed possibly because of unavailable replicas",
+                  RouterErrorCode.AmbryUnavailable));
+        } else {
+          operationException.set(
+              new RouterException("DeleteOperation failed because of BlobNotFound", RouterErrorCode.BlobDoesNotExist));
+        }
       }
       if (QuotaUtils.postProcessCharge(quotaChargeCallback)) {
         try {

--- a/ambry-router/src/main/java/com/github/ambry/router/DeleteOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/DeleteOperation.java
@@ -361,6 +361,12 @@ class DeleteOperation {
             new RouterException("DeleteOperation failed possibly because some replicas are unavailable",
                 RouterErrorCode.AmbryUnavailable));
       } else if (operationTracker.hasFailedOnNotFound()) {
+        /*
+        We are relying on the fact that at least one replica has the blob. Scenarios like below are rare, so that we don’t need to handle them for now.
+          1. put parallelism is 3 && all three replicas of originating dc are down && remote replication is not caught up
+          2. put parallelism is 2 && 2 replicas are down (note that 2 replicas down happen all the time) && replication has not caught up such that blob doesn’t exist in at least one other replica.
+              i.e, its very rare for 2 replicas to be down simultaneously and immediately after taking a POST (with parallelism 2)
+         */
         if (operationTracker.getSuccessCount() > 0) {
           routerMetrics.failedMaybeDueToUnavailableReplicasCount.inc();
           operationException.set(

--- a/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateOperation.java
@@ -361,6 +361,12 @@ class TtlUpdateOperation {
         operationException.set(new RouterException("TtlUpdateOperation failed possibly because of offline replicas",
             RouterErrorCode.AmbryUnavailable));
       } else if (operationTracker.hasFailedOnNotFound()) {
+        /*
+        We are relying on the fact that at least one replica has the blob. Scenarios like below are rare, so that we don’t need to handle them for now.
+          1. put parallelism is 3 && all three replicas of originating dc are down && remote replication is not caught up
+          2. put parallelism is 2 && 2 replicas are down (note that 2 replicas down happen all the time) && replication has not caught up such that blob doesn’t exist in at least one other replica.
+              i.e, its very rare for 2 replicas to be down simultaneously and immediately after taking a POST (with parallelism 2)
+        */
         if (operationTracker.getSuccessCount() > 0) {
           routerMetrics.failedMaybeDueToUnavailableReplicasCount.inc();
           operationException.set(


### PR DESCRIPTION
Return 503 instead of 404 when one replica returns success but others return not_found for DELETE operation