### PR TITLE
Optimize Updates: Ensure that frontend sends ttlupdate and undelete for the metadata chunk of a composite blob last.

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
@@ -34,6 +34,7 @@ public class RouterConfig {
   public static final long DEFAULT_OPERATION_TRACKER_HISTOGRAM_CACHE_TIMEOUT_MS = 1000L;
   public static final long ROUTER_NOT_FOUND_CACHE_MAX_TTL_IN_MS = 24 * 60 * 1000L;
   public static final int MAX_NETWORK_TIMEOUT_VALUE_FOR_A_REQUEST_IN_MS = 60 * 1000;
+  public static final long DEFAULT_ROUTER_UPDATE_OP_METADATA_RELIANCE_TIMESTAMP_IN_MS = Long.MAX_VALUE;
   // This is a theoretical maximum value. Configured value may be much smaller since we might need to respond back to
   // client with either success or failure much sooner.
   public static final int MAX_OVERALL_TIMEOUT_VALUE_FOR_A_REQUEST_IN_MS = 60 * 60 * 1000;
@@ -119,6 +120,8 @@ public class RouterConfig {
   public static final String ROUTER_STORE_KEY_CONVERTER_FACTORY = "router.store.key.converter.factory";
   public static final String ROUTER_UNAVAILABLE_DUE_TO_OFFLINE_REPLICAS = "router.unavailable.due.to.offline.replicas";
   public static final String ROUTER_NOT_FOUND_CACHE_TTL_IN_MS = "router.not.found.cache.ttl.in.ms";
+  public static final String ROUTER_UPDATE_OP_METADATA_RELIANCE_TIMESTAMP_IN_MS =
+      "router.update.op.metadata.reliance.timestamp.in.ms";
 
   /**
    * Number of independent scaling units for the router.
@@ -614,6 +617,19 @@ public class RouterConfig {
   public static final int MAX_NUM_METADATA_CACHE_ENTRIES_DEFAULT = 10;
 
   /**
+   * Blobs created after this timestamp can rely on metadata chunk to get the overall status of update operations
+   * (ttl update, undelete) on the blob.
+   * This config is expected to be a temporary stop gap to improve the resiliency of update operations on a blob, until
+   * the server version changes are deployed to identify update operations that can rely on metadata chunk for the
+   * update status of the entire blob.
+   * The value of this config will be an upper bound of the timestamp when the frontend code version that updates
+   * metadata chunk last has been deployed to all frontend hosts on a cluster.
+   * A value of LONG.MAX_VALUE for this config would mean that this config is effectively disabled.
+   */
+  @Config(ROUTER_UPDATE_OP_METADATA_RELIANCE_TIMESTAMP_IN_MS)
+  public final long routerUpdateOpMetadataRelianceTimestampInMs;
+
+  /**
    * Create a RouterConfig instance.
    * @param verifiableProperties the properties map to refer to.
    */
@@ -748,5 +764,7 @@ public class RouterConfig {
         verifiableProperties.getBoolean(ROUTER_UNAVAILABLE_DUE_TO_OFFLINE_REPLICAS, false);
     routerNotFoundCacheTtlInMs = verifiableProperties.getLongInRange(ROUTER_NOT_FOUND_CACHE_TTL_IN_MS, 15 * 1000L, 0,
         ROUTER_NOT_FOUND_CACHE_MAX_TTL_IN_MS);
+    routerUpdateOpMetadataRelianceTimestampInMs = verifiableProperties.getLong(
+        ROUTER_UPDATE_OP_METADATA_RELIANCE_TIMESTAMP_IN_MS, DEFAULT_ROUTER_UPDATE_OP_METADATA_RELIANCE_TIMESTAMP_IN_MS);
   }
 }

--- a/ambry-router/src/main/java/com/github/ambry/router/BatchOperationCallbackTracker.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/BatchOperationCallbackTracker.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BiConsumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,6 +38,9 @@ class BatchOperationCallbackTracker {
   private final FutureResult<Void> futureResult;
   private final Callback<Void> callback;
   private final long numBlobIds;
+  private final AtomicBoolean finalOperationReadyToDo = new AtomicBoolean(false);
+  private final BlobId finalBlobId;
+  private final BiConsumer<BlobId, Callback> finalOperation;
   private final QuotaChargeCallback quotaChargeCallback;
   private final ConcurrentMap<BlobId, Boolean> blobIdToAck = new ConcurrentHashMap<>();
   private final AtomicLong ackedCount = new AtomicLong(0);
@@ -45,11 +49,14 @@ class BatchOperationCallbackTracker {
   /**
    * Constructor
    * @param blobIds the {@link BlobId}s being tracked
+   * @param finalBlobId the final {@link BlobId} to send after all the {@code blobids} are acked.
    * @param futureResult the {@link FutureResult} to be triggered once acks are received for all blobs
    * @param callback the {@link Callback} to be triggered once acks are received for all blobs
    * @param quotaChargeCallback The {@link QuotaChargeCallback} to be triggered to account for quota usage.
+   * @param finalOperation The operation to call on the {@code finalBlobId}.
    */
-  BatchOperationCallbackTracker(List<BlobId> blobIds, FutureResult<Void> futureResult, Callback<Void> callback, QuotaChargeCallback quotaChargeCallback) {
+  BatchOperationCallbackTracker(List<BlobId> blobIds, BlobId finalBlobId, FutureResult<Void> futureResult,
+      Callback<Void> callback, QuotaChargeCallback quotaChargeCallback, BiConsumer<BlobId, Callback> finalOperation) {
     numBlobIds = blobIds.size();
     blobIds.forEach(blobId -> blobIdToAck.put(blobId, false));
     if (blobIdToAck.size() != numBlobIds) {
@@ -58,6 +65,8 @@ class BatchOperationCallbackTracker {
     this.futureResult = futureResult;
     this.callback = callback;
     this.quotaChargeCallback = quotaChargeCallback;
+    this.finalOperation = finalOperation;
+    this.finalBlobId = finalBlobId;
   }
 
   /**
@@ -68,18 +77,37 @@ class BatchOperationCallbackTracker {
   Callback<Void> getCallback(final BlobId blobId) {
     return (result, exception) -> {
       if (exception == null) {
-        if (blobIdToAck.put(blobId, true)) {
+        if (!blobIdToAck.containsKey(blobId)) {
+          complete(new RouterException("Ack for unknown " + blobId + " arrived",
+              RouterErrorCode.UnexpectedInternalError));
+        } else if (blobIdToAck.put(blobId, true)) {
           // already acked once
           complete(new RouterException("Ack for " + blobId + " arrived more than once",
               RouterErrorCode.UnexpectedInternalError));
         } else if (ackedCount.incrementAndGet() >= numBlobIds) {
           // acked for the first time for this blob id and all the blob ids have been acked
-          complete(null);
+          if(finalOperationReadyToDo.compareAndSet(false, true)) {
+            // if final operation hasn't been started yet, then start it.
+            blobIdToAck.put(finalBlobId, false);
+            NonBlockingRouter.currentOperationsCount.incrementAndGet();
+            finalOperation.accept(finalBlobId, getCallback(finalBlobId));
+          }
+
+          if(blobId.equals(finalBlobId)) {
+              complete(null);
+          }
         }
       } else {
         complete(exception);
       }
     };
+  }
+
+  /**
+   * @return if the operation is completed. Used for tests.
+   */
+  boolean isCompleted() {
+    return completed.get();
   }
 
   /**

--- a/ambry-router/src/main/java/com/github/ambry/router/CompositeBlobOperationHelper.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/CompositeBlobOperationHelper.java
@@ -13,9 +13,12 @@
  */
 package com.github.ambry.router;
 
+import com.github.ambry.messageformat.BlobInfo;
 import com.github.ambry.protocol.GetOption;
 import java.util.List;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 
 /**
@@ -25,7 +28,8 @@ public class CompositeBlobOperationHelper {
   private final String opName;
   private final GetOption getOption;
   private final NonBlockingRouterMetrics.AgeAtAccessMetrics metrics;
-  private final Consumer<List<String>> doOperation;
+  private final BiConsumer<String, List<String>> doOperation;
+  private final Function<BlobInfo, Boolean> alreadyUpdated;
   private final Consumer<RouterException> completeOperationAtException;
 
   /**
@@ -34,16 +38,19 @@ public class CompositeBlobOperationHelper {
    * @param getOption The {@link GetOption} while fetching the blob ids of a composite blob.
    * @param metrics The {@link NonBlockingRouterMetrics.AgeAtAccessMetrics} to use while fetching blob ids of a composite
    *                blob with {@link GetManager}.
-   * @param doOperation The function to call to submit a list of blob ids in String to corresponding manager after fetching
-   *                    blob ids.
+   * @param doOperation The function to call to submit the metadata blob id and a list of chunk ids in String to
+   *                    corresponding manager after fetching blob ids.
+   * @param alreadyUpdated The function to call to check if the operation is already done.
    * @param completeOperationAtException The function to call when there is exception when calling {@link  OperationController#getBlob}.
    */
   CompositeBlobOperationHelper(String opName, GetOption getOption, NonBlockingRouterMetrics.AgeAtAccessMetrics metrics,
-      Consumer<List<String>> doOperation, Consumer<RouterException> completeOperationAtException) {
+      BiConsumer<String, List<String>> doOperation, Function<BlobInfo, Boolean> alreadyUpdated,
+      Consumer<RouterException> completeOperationAtException) {
     this.opName = opName;
     this.getOption = getOption;
     this.metrics = metrics;
     this.doOperation = doOperation;
+    this.alreadyUpdated = alreadyUpdated;
     this.completeOperationAtException = completeOperationAtException;
   }
 
@@ -59,8 +66,12 @@ public class CompositeBlobOperationHelper {
     return metrics;
   }
 
-  public Consumer<List<String>> getDoOperation() {
+  public BiConsumer<String, List<String>> getDoOperation() {
     return doOperation;
+  }
+
+  public Function<BlobInfo, Boolean> getAlreadyUpdated() {
+    return alreadyUpdated;
   }
 
   public Consumer<RouterException> getCompleteOperationAtException() {

--- a/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterMetrics.java
@@ -185,6 +185,7 @@ public class NonBlockingRouterMetrics {
   public final Counter simpleUnencryptedBlobSizeMismatchCount;
   public final Counter compositeBlobSizeMismatchCount;
   public final Counter unknownPartitionClassCount;
+  public final Counter updateOptimizedCount;
   // Number of unnecessary blob gets avoided via use of BlobDataType
   public final Counter skippedGetBlobCount;
   public Gauge<Long> chunkFillerThreadRunning;
@@ -479,6 +480,8 @@ public class NonBlockingRouterMetrics {
         metricRegistry.counter(MetricRegistry.name(GetBlobOperation.class, "CompositeBlobSizeMismatchCount"));
     unknownPartitionClassCount =
         metricRegistry.counter(MetricRegistry.name(PutOperation.class, "UnknownPartitionClassCount"));
+    updateOptimizedCount =
+        metricRegistry.counter(MetricRegistry.name(OperationController.class, "updateOptimizedCount"));
 
     // metrics to track blob sizes and chunking.
     putBlobSizeBytes = metricRegistry.histogram(MetricRegistry.name(PutManager.class, "PutBlobSizeBytes"));

--- a/ambry-router/src/main/java/com/github/ambry/router/RouterUtils.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/RouterUtils.java
@@ -308,6 +308,16 @@ public class RouterUtils {
   }
 
   /**
+   * @param blobId {@link BlobId} to check.
+   * @param clusterMap {@link ClusterMap} object.
+   * @return {@code true} if it can be determined that the blobid's originating dc is remote. {@code false} otherwise.
+   */
+  public static boolean isOriginatingDcRemote(BlobId blobId, ClusterMap clusterMap) {
+    return blobId.getDatacenterId() != ClusterMap.UNKNOWN_DATACENTER_ID
+        && blobId.getDatacenterId() != clusterMap.getLocalDatacenterId();
+  }
+
+  /**
    * {@link Enum} All the reasons for router request expiry.
    */
   public enum RouterRequestExpiryReason {

--- a/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateManager.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateManager.java
@@ -81,7 +81,8 @@ class TtlUpdateManager {
 
   /**
    * Submits {@link TtlUpdateOperation}(s) to this {@link TtlUpdateManager}.
-   * @param blobIdStrs The original blobId strings
+   * @param blobIdStr The blobId of the simple blob or the metadata blob in case of composite blob.
+   * @param chunkIdStrs The blob ids of the metadata blob's chunks.
    * @param serviceId The service ID of the service updating the ttl of the blob(s). This can be null if unknown.
    * @param expiresAtMs The new expiry time (in ms) of the blob.
    * @param futureResult The {@link FutureResult} that will contain the result eventually and exception if any.
@@ -89,34 +90,54 @@ class TtlUpdateManager {
    * @param quotaChargeCallback {@link QuotaChargeCallback} object to account for quota.
    * @throws RouterException if the blobIdStr is invalid.
    */
-  void submitTtlUpdateOperation(Collection<String> blobIdStrs, String serviceId, long expiresAtMs,
+  void submitTtlUpdateOperation(String blobIdStr, Collection<String> chunkIdStrs, String serviceId, long expiresAtMs,
       FutureResult<Void> futureResult, Callback<Void> callback, QuotaChargeCallback quotaChargeCallback)
       throws RouterException {
-    List<BlobId> blobIds = new ArrayList<>();
-    for (String blobIdStr : blobIdStrs) {
-      BlobId blobId = RouterUtils.getBlobIdFromString(blobIdStr, clusterMap);
-      if (blobId.getDatacenterId() != ClusterMap.UNKNOWN_DATACENTER_ID
-          && blobId.getDatacenterId() != clusterMap.getLocalDatacenterId()) {
+    BlobId blobId = RouterUtils.getBlobIdFromString(blobIdStr, clusterMap);
+    if (RouterUtils.isOriginatingDcRemote(blobId, clusterMap)) {
+      routerMetrics.ttlUpdateBlobNotOriginateLocalOperationRate.mark();
+    }
+
+    List<BlobId> chunkIds = new ArrayList<>();
+    for (String chunkIdStr : chunkIdStrs) {
+      if (chunkIdStr.equals(blobIdStr)) {
+        // ChunkId list should not contain the metadata blobId itself.
+        LOGGER.warn("metadata chunk id {} was filtered out from data chunk id list.", blobIdStr);
+        continue;
+      }
+      BlobId chunkId = RouterUtils.getBlobIdFromString(chunkIdStr, clusterMap);
+      if (RouterUtils.isOriginatingDcRemote(chunkId, clusterMap)) {
         routerMetrics.ttlUpdateBlobNotOriginateLocalOperationRate.mark();
       }
-      blobIds.add(blobId);
+      chunkIds.add(chunkId);
     }
-    if (blobIds.size() == 1) {
+
+    if (chunkIds.isEmpty()) {
+      // If there are no chunkIds, then its a simple blob, and we have to update only blob's ttl.
       TtlUpdateOperation ttlUpdateOperation =
-          new TtlUpdateOperation(clusterMap, routerConfig, routerMetrics, blobIds.get(0), serviceId, expiresAtMs,
+          new TtlUpdateOperation(clusterMap, routerConfig, routerMetrics, blobId, serviceId, expiresAtMs,
               time.milliseconds(), callback, time, futureResult, quotaChargeCallback);
       ttlUpdateOperations.add(ttlUpdateOperation);
-    } else {
-      BatchOperationCallbackTracker tracker =
-          new BatchOperationCallbackTracker(blobIds, futureResult, callback, quotaChargeCallback);
-      long operationTimeMs = time.milliseconds();
-      for (BlobId blobId : blobIds) {
-        TtlUpdateOperation ttlUpdateOperation =
-            new TtlUpdateOperation(clusterMap, routerConfig, routerMetrics, blobId, serviceId, expiresAtMs,
-                operationTimeMs, tracker.getCallback(blobId), time, BatchOperationCallbackTracker.DUMMY_FUTURE,
-                quotaChargeCallback);
-        ttlUpdateOperations.add(ttlUpdateOperation);
-      }
+      return;
+    }
+
+    // If we are here, that means the blob is a composite blob. So we will do a batch operation.
+    BatchOperationCallbackTracker tracker =
+        new BatchOperationCallbackTracker(chunkIds, blobId, futureResult, callback, quotaChargeCallback,
+            (finalBlobId, callBack) -> {
+              TtlUpdateOperation ttlUpdateOperation =
+                  new TtlUpdateOperation(clusterMap, routerConfig, routerMetrics, finalBlobId, serviceId, expiresAtMs,
+                      time.milliseconds(), callBack, time, BatchOperationCallbackTracker.DUMMY_FUTURE,
+                      quotaChargeCallback);
+              ttlUpdateOperations.add(ttlUpdateOperation);
+            });
+    long operationTimeMs = time.milliseconds();
+    for (BlobId chunkId : chunkIds) {
+      TtlUpdateOperation ttlUpdateOperation =
+          new TtlUpdateOperation(clusterMap, routerConfig, routerMetrics, chunkId, serviceId, expiresAtMs,
+              operationTimeMs, tracker.getCallback(chunkId), time, BatchOperationCallbackTracker.DUMMY_FUTURE,
+              quotaChargeCallback);
+      ttlUpdateOperations.add(ttlUpdateOperation);
     }
   }
 

--- a/ambry-router/src/test/java/com/github/ambry/router/NonBlockingQuotaTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/NonBlockingQuotaTest.java
@@ -267,7 +267,7 @@ public class NonBlockingQuotaTest extends NonBlockingRouterTestBase {
       assertEquals(expectedChargeCallbackCount += (quotaAccountingSize * numChunks), listenerCalledCount.get());
 
       router.deleteBlob(stitchedBlobId, null, null, quotaChargeCallback).get();
-      assertEquals(expectedChargeCallbackCount += quotaAccountingSize, listenerCalledCount.get());
+      assertEquals(expectedChargeCallbackCount + quotaAccountingSize, listenerCalledCount.get());
     } finally {
       router.close();
       assertExpectedThreadCounts(0, 0);

--- a/ambry-router/src/test/java/com/github/ambry/router/UndeleteManagerTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/UndeleteManagerTest.java
@@ -338,10 +338,10 @@ public class UndeleteManagerTest {
    */
   @Test
   public void duplicateBlobIdsTest() throws RouterException {
-    blobIds.add(blobIds.get(0));
+    blobIds.add(blobIds.get(1));
     try {
-      undeleteManager.submitUndeleteOperation(blobIds, UNDELETE_SERVICE_ID, new FutureResult<>(), null,
-          quotaChargeCallback);
+      undeleteManager.submitUndeleteOperation(blobIds.get(0), blobIds.subList(1, blobIds.size()), UNDELETE_SERVICE_ID,
+          new FutureResult<>(), null, quotaChargeCallback);
       fail("Should have failed to submit operation because the provided blob id list contains duplicates");
     } catch (IllegalArgumentException e) {
       // expected. Nothing to do.
@@ -413,8 +413,10 @@ public class UndeleteManagerTest {
   private void executeOpAndVerify(Collection<String> ids, RouterErrorCode expectedErrorCode, boolean advanceTime)
       throws Exception {
     FutureResult<Void> future = new FutureResult<>();
-    NonBlockingRouter.currentOperationsCount.addAndGet(ids.size());
-    undeleteManager.submitUndeleteOperation(ids, UNDELETE_SERVICE_ID, future, future::done, quotaChargeCallback);
+    NonBlockingRouter.currentOperationsCount.addAndGet(ids.size() == 1 ? 1 : ids.size() - 1);
+    List<String> chunkIds = new ArrayList<>(ids);
+    undeleteManager.submitUndeleteOperation(chunkIds.get(0), chunkIds.subList(1, chunkIds.size()), UNDELETE_SERVICE_ID,
+        future, future::done, quotaChargeCallback);
     sendRequestsGetResponse(future, undeleteManager, advanceTime, false);
     if (expectedErrorCode == null) {
       // Should return no error
@@ -437,7 +439,9 @@ public class UndeleteManagerTest {
       throws Exception {
     FutureResult<Void> future = new FutureResult<>();
     NonBlockingRouter.currentOperationsCount.addAndGet(ids.size());
-    undeleteManager.submitUndeleteOperation(ids, UNDELETE_SERVICE_ID, future, future::done, quotaChargeCallback);
+    List<String> chunkIds = new ArrayList<>(ids);
+    undeleteManager.submitUndeleteOperation(chunkIds.get(0), chunkIds.subList(1, chunkIds.size()), UNDELETE_SERVICE_ID,
+        future, future::done, quotaChargeCallback);
     sendRequestsGetResponse(future, undeleteManager, false, true);
     try {
       future.get(1, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
This is first of the multiple PRs to optimize update operations in the Ambry frontend. It ensures that when frontend does a ttlupdate or undelete operation, it does the operation for metadata chunk (in case of composite blobs) at the last.

It also introduces a config `RouterConfig.routerUpdateOpMetadataRelianceTimestampInMs`. Blobs created after this timestamp can rely on metadata chunk to get the overall status of update operations on the blob.

Next PRs will follow to:
1. Add a new version of ttl update message in the Index and log, to indicate that ttl update can be terminated on the metadata blob.
2. Make changes in Get Request to ensure that a new flag is returned to check if ttl was updated with the new logic.
3. Make changes in frontend ttl update logic, to ensure that on ttl update, if the metadata chunk is already ttl updated with the new version, then no need to update individual chunks.

For more details refer: https://docs.google.com/document/d/1P5uxWOTlUUdDIMn43PLeGkuGuHPZ6nt_DeOy0HT-hxk/edit#