### PR TITLE
Add a new FindMissingKey implementation to make it faster

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -470,6 +470,26 @@ public class StoreConfig {
   @Default("200")
   public final int storeDiskIoReservoirTimeWindowMs;
 
+  /**
+   * True to enable batch mode in findMissingKeys
+   */
+  @Config(storeEnableFindMissingKeysInBatchModeName)
+  @Default("false")
+  public final boolean storeEnableFindMissingKeysInBatchMode;
+  public static final String storeEnableFindMissingKeysInBatchModeName = "store.enable.find.missing.keys.in.batch.mode";
+
+  @Config(storeCacheSizeForFindMissingKeysInBatchModeName)
+  @Default("3")
+  public final int storeCacheSizeForFindMissingKeysInBatchMode;
+  public static final String storeCacheSizeForFindMissingKeysInBatchModeName =
+      "store.cache.size.for.find.missing.keys.in.batch.mode";
+
+  @Config(storeNumOfCacheMissForFindMissingKeysInBatchModeName)
+  @Default("5")
+  public final int storeNumOfCacheMissForFindMissingKeysInBatchMode;
+  public static final String storeNumOfCacheMissForFindMissingKeysInBatchModeName =
+      "store.num.of.cache.miss.for.find.missing.keys.in.batch.mode";
+
   public StoreConfig(VerifiableProperties verifiableProperties) {
 
     storeKeyFactory = verifiableProperties.getString("store.key.factory", "com.github.ambry.commons.BlobIdFactory");
@@ -583,5 +603,11 @@ public class StoreConfig {
             Integer.MAX_VALUE);
     storeDiskIoReservoirTimeWindowMs =
         verifiableProperties.getIntInRange("store.disk.io.reservoir.time.window.ms", 200, 0, Integer.MAX_VALUE);
+    storeEnableFindMissingKeysInBatchMode =
+        verifiableProperties.getBoolean(storeEnableFindMissingKeysInBatchModeName, false);
+    storeCacheSizeForFindMissingKeysInBatchMode =
+        verifiableProperties.getIntInRange(storeCacheSizeForFindMissingKeysInBatchModeName, 3, 1, 100);
+    storeNumOfCacheMissForFindMissingKeysInBatchMode =
+        verifiableProperties.getIntInRange(storeNumOfCacheMissForFindMissingKeysInBatchModeName, 5, 3, 100);
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/store/Store.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/Store.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.store;
 
+import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.ReplicaState;
 import com.github.ambry.replication.FindToken;
 import java.util.EnumSet;
@@ -89,13 +90,26 @@ public interface Store {
   FindInfo findEntriesSince(FindToken token, long maxTotalSizeOfEntries, String hostname, String remoteReplicaPath)
       throws StoreException;
 
+
+  /**
+   * Finds all the keys that are not present in the store from the input keys
+   * @param keys The list of keys that need to be checked for existence
+   * @param sourceDataNodeId The {@link DataNodeId} that we are replicating from, that calls this method. Set to null if
+   *                         this is not called from a replication thread.
+   * @return The list of keys that are not present in the store
+   * @throws StoreException
+   */
+  Set<StoreKey> findMissingKeys(List<StoreKey> keys, DataNodeId sourceDataNodeId) throws StoreException;
+
   /**
    * Finds all the keys that are not present in the store from the input keys
    * @param keys The list of keys that need to be checked for existence
    * @return The list of keys that are not present in the store
    * @throws StoreException
    */
-  Set<StoreKey> findMissingKeys(List<StoreKey> keys) throws StoreException;
+  default Set<StoreKey> findMissingKeys(List<StoreKey> keys) throws StoreException {
+    return findMissingKeys(keys, null);
+  }
 
   /**
    * Return {@link MessageInfo} of given key. This method will only be used in replication thread.

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobStore.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobStore.java
@@ -15,6 +15,7 @@ package com.github.ambry.cloud;
 
 import com.codahale.metrics.Timer;
 import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.clustermap.ReplicaState;
 import com.github.ambry.commons.BlobId;
@@ -1254,7 +1255,7 @@ class CloudBlobStore implements Store {
   }
 
   @Override
-  public Set<StoreKey> findMissingKeys(List<StoreKey> keys) throws StoreException {
+  public Set<StoreKey> findMissingKeys(List<StoreKey> keys, DataNodeId sourceDataNodeId) throws StoreException {
     checkStarted();
     // Check existence of keys in cloud metadata
     // Note that it is ok to refer cache here, because all we are doing is eliminating blobs that were seen before and

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -45,7 +45,6 @@ import com.github.ambry.protocol.ReplicaMetadataRequestInfo;
 import com.github.ambry.protocol.ReplicaMetadataResponse;
 import com.github.ambry.protocol.ReplicaMetadataResponseInfo;
 import com.github.ambry.server.ServerErrorCode;
-import com.github.ambry.store.BlobStore;
 import com.github.ambry.store.MessageInfo;
 import com.github.ambry.store.StoreErrorCodes;
 import com.github.ambry.store.StoreException;
@@ -825,8 +824,9 @@ public class ReplicaThread implements Runnable {
         remoteMessageToConvertedKeyNonNull.put(messageInfo, convertedKey);
       }
     }
-    Set<StoreKey> convertedMissingStoreKeys =
-        remoteReplicaInfo.getLocalStore().findMissingKeys(new ArrayList<>(remoteMessageToConvertedKeyNonNull.values()));
+    Set<StoreKey> convertedMissingStoreKeys = remoteReplicaInfo.getLocalStore()
+        .findMissingKeys(new ArrayList<>(remoteMessageToConvertedKeyNonNull.values()),
+            remoteReplicaInfo.getReplicaId().getDataNodeId());
     Set<MessageInfo> missingRemoteMessages = new HashSet<>();
     remoteMessageToConvertedKeyNonNull.forEach((messageInfo, convertedKey) -> {
       if (convertedMissingStoreKeys.contains(convertedKey)) {
@@ -1481,7 +1481,8 @@ public class ReplicaThread implements Runnable {
 
         // Find the set of store keys that are still missing in the store
         Set<StoreKey> convertedMissingStoreKeys = remoteReplicaInfo.getLocalStore()
-            .findMissingKeys(new ArrayList<>(remoteMessageToConvertedKeyNonNull.values()));
+            .findMissingKeys(new ArrayList<>(remoteMessageToConvertedKeyNonNull.values()),
+                remoteReplicaInfo.getReplicaId().getDataNodeId());
 
         // Filter the remote messages whose keys are now found in store, i.e. not present in convertedMissingStoreKeys set.
         remoteMessageToConvertedKeyNonNull.forEach((messageInfo, convertedKey) -> {

--- a/ambry-replication/src/test/java/com/github/ambry/replication/InMemoryStore.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/InMemoryStore.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.replication;
 
+import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.clustermap.ReplicaState;
 import com.github.ambry.commons.Callback;
@@ -389,7 +390,7 @@ class InMemoryStore implements Store {
   }
 
   @Override
-  public Set<StoreKey> findMissingKeys(List<StoreKey> keys) throws StoreException {
+  public Set<StoreKey> findMissingKeys(List<StoreKey> keys, DataNodeId sourceDataNodeId) throws StoreException {
     Set<StoreKey> keysMissing = new HashSet<>();
     for (StoreKey key : keys) {
       boolean found = false;

--- a/ambry-server/src/test/java/com/github/ambry/server/StatsManagerTest.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/StatsManagerTest.java
@@ -620,7 +620,7 @@ public class StatsManagerTest {
     }
 
     @Override
-    public Set<StoreKey> findMissingKeys(List<StoreKey> keys) throws StoreException {
+    public Set<StoreKey> findMissingKeys(List<StoreKey> keys, DataNodeId sourceDataNodeId) throws StoreException {
       throw new IllegalStateException("Not implemented");
     }
 

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -15,6 +15,7 @@ package com.github.ambry.store;
 
 import com.codahale.metrics.Timer;
 import com.github.ambry.account.AccountService;
+import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.clustermap.ReplicaState;
 import com.github.ambry.clustermap.ReplicaStatusDelegate;
@@ -904,7 +905,7 @@ public class BlobStore implements Store {
         remoteTokenTracker.updateTokenFromPeerReplica(token, hostname, remoteReplicaPath);
       }
       FindInfo findInfo = index.findEntriesSince(token, maxTotalSizeOfEntries);
-      // We don't call onSuccess here because findEntries only involvs reading index entries from the index
+      // We don't call onSuccess here because findEntries only involves reading index entries from the index
       // files, which have already been loaded to memory, thus there is no disk operations.
       return findInfo;
     } catch (StoreException e) {
@@ -918,12 +919,13 @@ public class BlobStore implements Store {
   }
 
   @Override
-  public Set<StoreKey> findMissingKeys(List<StoreKey> keys) throws StoreException {
+  public Set<StoreKey> findMissingKeys(List<StoreKey> keys, DataNodeId sourceDataNodeId) throws StoreException {
     checkStarted();
     final Timer.Context context = metrics.findMissingKeysResponse.time();
     try {
-      Set<StoreKey> missingKeys = config.storeEnableFindMissingKeysInBatchMode ? index.findMissingKeysInBatch(keys)
-          : index.findMissingKeys(keys);
+      Set<StoreKey> missingKeys =
+          config.storeEnableFindMissingKeysInBatchMode && sourceDataNodeId != null ? index.findMissingKeysInBatch(keys,
+              sourceDataNodeId.toString()) : index.findMissingKeys(keys);
       return missingKeys;
     } catch (StoreException e) {
       if (e.getErrorCode() == StoreErrorCodes.IOError) {

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -922,7 +922,8 @@ public class BlobStore implements Store {
     checkStarted();
     final Timer.Context context = metrics.findMissingKeysResponse.time();
     try {
-      Set<StoreKey> missingKeys = index.findMissingKeys(keys);
+      Set<StoreKey> missingKeys = config.storeEnableFindMissingKeysInBatchMode ? index.findMissingKeysInBatch(keys)
+          : index.findMissingKeys(keys);
       return missingKeys;
     } catch (StoreException e) {
       if (e.getErrorCode() == StoreErrorCodes.IOError) {

--- a/ambry-store/src/main/java/com/github/ambry/store/IndexSegment.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/IndexSegment.java
@@ -461,6 +461,29 @@ class IndexSegment implements Iterable<IndexEntry> {
   }
 
   /**
+   * Return all the keys in the IndexSegment in a set.
+   * @return
+   */
+  Set<StoreKey> getAllStoreKeys() throws StoreException {
+    Set<StoreKey> keys = new HashSet<>();
+    rwLock.readLock().lock();
+    boolean isSealed = sealed.get();
+    NavigableMap<StoreKey, ConcurrentSkipListSet<IndexValue>> indexCopy = index;
+    ByteBuffer buffer = serEntries;
+    rwLock.readLock().unlock();
+    if (isSealed) {
+      buffer = buffer.duplicate();
+      int numOfIndexEntries = numberOfEntries(buffer);
+      for (int i = 0; i < numOfIndexEntries; i++) {
+        keys.add(getKeyAt(buffer, i));
+      }
+    } else {
+      keys.addAll(indexCopy.keySet());
+    }
+    return keys;
+  }
+
+  /**
    * According to config, get the {@link ByteBuffer} of {@link StoreKey} for bloom filter. The store config specifies
    * whether to populate bloom filter with key's UUID only.
    * @param key the store key to use in bloom filter.

--- a/ambry-store/src/test/java/com/github/ambry/store/CuratedLogIndexState.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CuratedLogIndexState.java
@@ -80,6 +80,8 @@ class CuratedLogIndexState {
   static final long TTL_UPDATE_RECORD_SIZE = 37;
   static final long UNDELETE_RECORD_SIZE = 29;
 
+  static final int DEFAULT_NUMBER_CACHE_MISS_IN_FIND_MISSING_KEY_IN_BATCH_MODE = 3;
+
   static final int deleteRetentionHour = 1;
 
   static {
@@ -124,6 +126,10 @@ class CuratedLogIndexState {
   MessageStoreRecovery recovery = new DummyMessageStoreRecovery();
   // The MessageStoreHardDelete that is used with the index
   MessageStoreHardDelete hardDelete = new MockMessageStoreHardDelete();
+  // The metrics
+  StoreMetrics metrics;
+  // The StoreConfig
+  StoreConfig config;
   // The Log which has the data
   Log log;
   // The index of the log
@@ -143,8 +149,6 @@ class CuratedLogIndexState {
   private final String tempDirStr;
   // used by getUniqueId() to make sure keys are never regenerated in a single test run.
   private final Set<MockId> generatedKeys = new HashSet<>();
-
-  private StoreMetrics metrics;
 
   /**
    * Creates state in order to make sure all cases are represented and log-index tests don't need to do any setup
@@ -208,6 +212,8 @@ class CuratedLogIndexState {
     properties.put("store.deleted.message.retention.hours", Integer.toString(CuratedLogIndexState.deleteRetentionHour));
     properties.put("store.rebuild.token.based.on.reset.key", Boolean.toString(enableResetKey));
     properties.put("store.auto.close.last.log.segment.enabled", Boolean.toString(enableAutoCloseLastLogSegment));
+    properties.put(StoreConfig.storeNumOfCacheMissForFindMissingKeysInBatchModeName,
+        String.valueOf(DEFAULT_NUMBER_CACHE_MISS_IN_FIND_MISSING_KEY_IN_BATCH_MODE));
     if (addUndeletes) {
       // If we have undelete, than we need undelete filter
       properties.put("store.compaction.filter",
@@ -1050,7 +1056,7 @@ class CuratedLogIndexState {
    * @throws StoreException
    */
   void initIndex(ScheduledExecutorService newScheduler) throws StoreException {
-    StoreConfig config = new StoreConfig(new VerifiableProperties(properties));
+    config = new StoreConfig(new VerifiableProperties(properties));
     sessionId = UUID.randomUUID();
     metricRegistry = new MetricRegistry();
     metrics = new StoreMetrics(metricRegistry);

--- a/ambry-store/src/test/java/com/github/ambry/store/IndexTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/IndexTest.java
@@ -35,6 +35,7 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -82,7 +83,7 @@ public class IndexTest {
   private final boolean isLogSegmented;
   private final File tempDir;
   private final File tokenTestDir;
-  private final CuratedLogIndexState state;
+  private CuratedLogIndexState state;
   private final CuratedLogIndexState stateForTokenTest;
   private final short persistentIndexVersion;
   private final boolean addUndeletes;
@@ -358,7 +359,7 @@ public class IndexTest {
    */
   @Test
   public void findMissingKeysTest() throws StoreException {
-    List<StoreKey> idsToProvide = new ArrayList<StoreKey>(state.allKeys.keySet());
+    List<StoreKey> idsToProvide = new ArrayList<>(state.allKeys.keySet());
     Set<StoreKey> nonExistentIds = new HashSet<>();
     for (int i = 0; i < 10; i++) {
       nonExistentIds.add(state.getUniqueId());
@@ -368,6 +369,86 @@ public class IndexTest {
     Set<StoreKey> missingKeys = state.index.findMissingKeys(idsToProvide);
     assertEquals("Set of missing keys not as expected", nonExistentIds, missingKeys);
   }
+
+  @Test
+  public void findMissingKeysInBatchTest() throws Exception {
+    Assume.assumeTrue(isLogSegmented);
+    Assume.assumeFalse(addUndeletes);
+    Assume.assumeTrue(persistentIndexVersion >= VERSION_3);
+    if (state != null) {
+      state.destroy();
+    }
+    state = new CuratedLogIndexState(true, tempDir, false, false, true, false, false, false);
+
+    final int maxEntriesInOneIndexSegment = DEFAULT_MAX_IN_MEM_ELEMENTS;
+    final int numberOfIndexSegments = 10;
+    // Let's deal with DELETEs for now
+    List<StoreKey> deletedStoreKeys = new ArrayList<>(maxEntriesInOneIndexSegment * numberOfIndexSegments);
+    for (int i = 0; i < numberOfIndexSegments * maxEntriesInOneIndexSegment; i++) {
+      MockId p = state.getUniqueId();
+      state.addDeleteEntry(p, new MessageInfo(p, DELETE_RECORD_SIZE, true, false, p.getAccountId(), p.getContainerId(),
+          state.time.milliseconds()), (short) 0);
+      deletedStoreKeys.add(p);
+    }
+
+
+    // Make sure we persist the index and seal the index segments.
+    state.index.persistIndex();
+    List<Offset> indexSegmentOffsets = new ArrayList<>();
+    // referenceIndex is a tree map, it returns keys in order
+    state.referenceIndex.keySet().forEach(offset -> indexSegmentOffsets.add(offset));
+
+    // FindMissingKeysInBatch should only call findKey for the first key in first index segment
+    LinkedList<Offset> cachedKeysOffsets = new LinkedList<>();
+    Offset indexSegmentOffset = state.referenceIndex.firstKey();
+    boolean isFirst = true;
+    for (int i = 0; i < state.config.storeCacheSizeForFindMissingKeysInBatchMode; i++) {
+      cachedKeysOffsets.addFirst(indexSegmentOffset);
+      findMissingKeysInBatchForIndexSegmentAndVerify(indexSegmentOffset, isFirst ? 1L : 0, cachedKeysOffsets);
+      indexSegmentOffset = state.referenceIndex.higherKey(indexSegmentOffset);
+      isFirst = false;
+    }
+
+    // Back to first index segment, it shouldn't call find key here
+    findMissingKeysInBatchForIndexSegmentAndVerify(state.referenceIndex.firstKey(), 0, cachedKeysOffsets);
+    // Move on to fourth index segment, the first index segment would be removed from the cache
+    cachedKeysOffsets.removeLast();
+    cachedKeysOffsets.addFirst(indexSegmentOffset);
+    findMissingKeysInBatchForIndexSegmentAndVerify(indexSegmentOffset, 0, cachedKeysOffsets);
+
+    Offset lastIndexSegmentOffset = state.referenceIndex.lastKey();
+    // Last index segment is not sealed, find missing keys in the last index segment would clear the cache.
+    StoreKey cacheClearKey = state.referenceIndex.get(lastIndexSegmentOffset).keySet().iterator().next();
+    Assert.assertEquals(0, state.index.findMissingKeysInBatch(Collections.singletonList(cacheClearKey)).size());
+    Assert.assertEquals(0, state.index.getCachedKeys().size());
+
+    // First key is in second index segment, and second key is in first index segment
+    List<StoreKey> keys = getRandomKeyFromIndexSegment(1, 0);
+    Assert.assertEquals(0, state.index.findMissingKeysInBatch(keys).size());
+    LinkedList<Pair<Offset, Set<StoreKey>>> cachedKeys = state.index.getCachedKeys();
+    Assert.assertEquals(2, cachedKeys.size());
+    Assert.assertEquals(indexSegmentOffsets.get(0), cachedKeys.get(0).getFirst());
+    Assert.assertEquals(indexSegmentOffsets.get(1), cachedKeys.get(1).getFirst());
+
+    // missing one key won't clear the cache
+    keys = Collections.singletonList(state.getUniqueId());
+    Assert.assertEquals(1, state.index.findMissingKeysInBatch(keys).size());
+    Assert.assertEquals(2, state.index.getCachedKeys().size());
+
+    // Missing several keys would clear the cache
+    int numKeys = DEFAULT_NUMBER_CACHE_MISS_IN_FIND_MISSING_KEY_IN_BATCH_MODE;
+    keys = new ArrayList<>(numKeys);
+    for (int i = 0; i < numKeys; i ++) {
+      keys.add(state.getUniqueId());
+    }
+    keys.addAll(getRandomKeyFromIndexSegment(0, 1));
+    long findKeyCallCountBefore = state.metrics.findTime.getCount();
+    Assert.assertEquals(numKeys, state.index.findMissingKeysInBatch(keys).size());
+    long findKeyCallCountAfter = state.metrics.findTime.getCount();
+    Assert.assertEquals(keys.size(), findKeyCallCountAfter - findKeyCallCountBefore);
+    Assert.assertEquals(0, state.index.getCachedKeys().size());
+  }
+
 
   /**
    * Tests error cases for {@link PersistentIndex#addToIndex(IndexEntry, FileSpan)}.
@@ -3778,4 +3859,47 @@ public class IndexTest {
           value.getContainerId());
     }
   }
+
+  /**
+   * Call {@link PersistentIndex#findMissingKeysInBatch} on all the keys from {@link IndexSegment} referenced by the given
+   * {@code offset}.
+   * @param offset The given offset referencing the IndexSegment.
+   * @param expectedFindKeyCallCount Expected findKey call count.
+   * @param expectedCachedKeysOffsets Expected cached keys offsets.
+   * @throws StoreException
+   */
+  private void findMissingKeysInBatchForIndexSegmentAndVerify(Offset offset, long expectedFindKeyCallCount,
+      List<Offset> expectedCachedKeysOffsets) throws StoreException {
+    List<StoreKey> indexSegmentKeys = new LinkedList<>(state.referenceIndex.get(offset).keySet());
+    long findKeyCallCountBefore = state.metrics.findTime.getCount();
+    Assert.assertEquals(0, state.index.findMissingKeysInBatch(indexSegmentKeys).size());
+    long findKeyCallCountAfter = state.metrics.findTime.getCount();
+    Assert.assertEquals(expectedFindKeyCallCount, findKeyCallCountAfter - findKeyCallCountBefore);
+    if (expectedCachedKeysOffsets != null) {
+      LinkedList<Pair<Offset, Set<StoreKey>>> cachedKeys = state.index.getCachedKeys();
+      Assert.assertEquals(expectedCachedKeysOffsets.size(), cachedKeys.size());
+      for (int j = 0; j < expectedCachedKeysOffsets.size(); j++) {
+        Assert.assertEquals(expectedCachedKeysOffsets.get(j), cachedKeys.get(j).getFirst());
+      }
+    }
+  }
+
+  /**
+   * Return random keys from the referenceIndex in curated log index state. the given indexes are the indexes of index
+   * segments, it starts with 0.
+   * @param indexes the list of indexes.
+   * @return A list of store keys.
+   */
+  private List<StoreKey> getRandomKeyFromIndexSegment(int... indexes) {
+    List<Offset> offsets = new ArrayList<>();
+    state.referenceIndex.keySet().forEach(offset-> offsets.add(offset));
+
+    List<StoreKey> results = new ArrayList<>(indexes.length);
+    for (int index : indexes) {
+      Offset offset = offsets.get(index);
+      results.add(state.referenceIndex.get(offset).keySet().iterator().next());
+    }
+    return results;
+  }
+
 }


### PR DESCRIPTION
In ReplicaThread, when we get a list of MessageInfos from the source host, we call findMissingKeys to see if those keys are missing in the local store. However, this is really slow since for each key, we have to do a search on all the index files. But those keys should be pretty close to each other, so they might be stored in the same index segment file or file that are close to the one that has the first key.  In same extreme cases, those keys returned in the same ReplicaMetadataRequest all belongs to one index segment. This is true when the replication token is reset by compaction in source host and now we are replicating from the beginning of the log again.

We should leverage the replication key locality to make replication faster.