### PR TITLE
Optimize Updates: Ensure blobInfo is set for encrypted blobs' getChunkIdsOnly option response.

### DIFF
--- a/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterMetrics.java
@@ -186,6 +186,7 @@ public class NonBlockingRouterMetrics {
   public final Counter compositeBlobSizeMismatchCount;
   public final Counter unknownPartitionClassCount;
   public final Counter updateOptimizedCount;
+  public final Counter updateUnOptimizedCount;
   // Number of unnecessary blob gets avoided via use of BlobDataType
   public final Counter skippedGetBlobCount;
   public Gauge<Long> chunkFillerThreadRunning;
@@ -481,7 +482,9 @@ public class NonBlockingRouterMetrics {
     unknownPartitionClassCount =
         metricRegistry.counter(MetricRegistry.name(PutOperation.class, "UnknownPartitionClassCount"));
     updateOptimizedCount =
-        metricRegistry.counter(MetricRegistry.name(OperationController.class, "updateOptimizedCount"));
+        metricRegistry.counter(MetricRegistry.name(OperationController.class, "UpdateOptimizedCount"));
+    updateUnOptimizedCount =
+        metricRegistry.counter(MetricRegistry.name(OperationController.class, "UpdateUnOptimizedCount"));
 
     // metrics to track blob sizes and chunking.
     putBlobSizeBytes = metricRegistry.histogram(MetricRegistry.name(PutManager.class, "PutBlobSizeBytes"));

--- a/ambry-router/src/main/java/com/github/ambry/router/OperationController.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/OperationController.java
@@ -319,9 +319,13 @@ public class OperationController implements Runnable {
           // If we are here then we can rely that the metadata chunk was updated only after all data chunks were updated.
           // So this means we are sure that all data chunks are successfully updated.
           // Send an update for metadata chunk only to ensure that metadata chunk's update meets quorum.
+          nonBlockingRouter.incrementOperationsCount(1);
           helper.getDoOperation().accept(blobIdStr, Collections.emptyList());
           routerMetrics.updateOptimizedCount.inc();
         } else {
+          if (result.getBlobInfo() != null && helper.getAlreadyUpdated().apply(result.getBlobInfo())) {
+            routerMetrics.updateUnOptimizedCount.inc();
+          }
           List<String> blobIdStrs = new ArrayList<>();
           if (result != null && result.getBlobChunkIds() != null) {
             result.getBlobChunkIds().forEach(key -> blobIdStrs.add(key.getID()));

--- a/ambry-server/src/integration-test/java/com/github/ambry/server/RouterServerPlaintextTest.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/RouterServerPlaintextTest.java
@@ -253,6 +253,8 @@ public class RouterServerPlaintextTest {
       operations.add(OperationType.GET);
       operations.add(OperationType.TTL_UPDATE);
       operations.add(OperationType.AWAIT_TTL_UPDATE);
+      operations.add(OperationType.TTL_UPDATE);
+      operations.add(OperationType.AWAIT_TTL_UPDATE);
       operations.add(OperationType.GET);
       operations.add(OperationType.GET_INFO);
       operations.add(OperationType.DELETE_AUTHORIZATION_FAILURE);


### PR DESCRIPTION
Due to this for encrypted blobs, update operations were not getting optimized.

Also, Add metric for cases where update operation for already updated blob is not optimized.