### PR TITLE
Temporarily return 404 when two replicas not found but one succeed

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
@@ -122,8 +122,8 @@ public class RouterConfig {
   public static final String ROUTER_NOT_FOUND_CACHE_TTL_IN_MS = "router.not.found.cache.ttl.in.ms";
   public static final String ROUTER_UPDATE_OP_METADATA_RELIANCE_TIMESTAMP_IN_MS =
       "router.update.op.metadata.reliance.timestamp.in.ms";
-  public static final String ROUTER_UNAVAILABLE_DUE_TO_SUCCESS_COUNT_IS_NON_ZERO =
-      "router.unavailable.due.to.success.count.is.non.zero";
+  public static final String ROUTER_UNAVAILABLE_DUE_TO_SUCCESS_COUNT_IS_NON_ZERO_FOR_DELETE =
+      "router.unavailable.due.to.success.count.is.non.zero.for.delete";
 
   /**
    * Number of independent scaling units for the router.
@@ -583,9 +583,9 @@ public class RouterConfig {
   /**
    * If true the simple operation tracker will check if there's one replica return success, router will return unavailable error.
    */
-  @Config(ROUTER_UNAVAILABLE_DUE_TO_SUCCESS_COUNT_IS_NON_ZERO)
+  @Config(ROUTER_UNAVAILABLE_DUE_TO_SUCCESS_COUNT_IS_NON_ZERO_FOR_DELETE)
   @Default("true")
-  public final boolean routerUnavailableDueToSuccessCountIsNonZero;
+  public final boolean routerUnavailableDueToSuccessCountIsNonZeroForDelete;
 
   /**
    * Expiration time for Blob IDs stored in not-found cache. Default value is 15 seconds.
@@ -771,8 +771,8 @@ public class RouterConfig {
         "com.github.ambry.store.StoreKeyConverterFactoryImpl");
     routerUnavailableDueToOfflineReplicas =
         verifiableProperties.getBoolean(ROUTER_UNAVAILABLE_DUE_TO_OFFLINE_REPLICAS, false);
-    routerUnavailableDueToSuccessCountIsNonZero =
-        verifiableProperties.getBoolean(ROUTER_UNAVAILABLE_DUE_TO_SUCCESS_COUNT_IS_NON_ZERO, true);
+    routerUnavailableDueToSuccessCountIsNonZeroForDelete =
+        verifiableProperties.getBoolean(ROUTER_UNAVAILABLE_DUE_TO_SUCCESS_COUNT_IS_NON_ZERO_FOR_DELETE, true);
     routerNotFoundCacheTtlInMs = verifiableProperties.getLongInRange(ROUTER_NOT_FOUND_CACHE_TTL_IN_MS, 15 * 1000L, 0,
         ROUTER_NOT_FOUND_CACHE_MAX_TTL_IN_MS);
     routerUpdateOpMetadataRelianceTimestampInMs = verifiableProperties.getLong(

--- a/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
@@ -122,6 +122,8 @@ public class RouterConfig {
   public static final String ROUTER_NOT_FOUND_CACHE_TTL_IN_MS = "router.not.found.cache.ttl.in.ms";
   public static final String ROUTER_UPDATE_OP_METADATA_RELIANCE_TIMESTAMP_IN_MS =
       "router.update.op.metadata.reliance.timestamp.in.ms";
+  public static final String ROUTER_UNAVAILABLE_DUE_TO_SUCCESS_COUNT_IS_NON_ZERO =
+      "router.unavailable.due.to.success.count.is.non.zero";
 
   /**
    * Number of independent scaling units for the router.
@@ -579,6 +581,13 @@ public class RouterConfig {
   public final boolean routerUnavailableDueToOfflineReplicas;
 
   /**
+   * If true the simple operation tracker will check if there's one replica return success, router will return unavailable error.
+   */
+  @Config(ROUTER_UNAVAILABLE_DUE_TO_SUCCESS_COUNT_IS_NON_ZERO)
+  @Default("true")
+  public final boolean routerUnavailableDueToSuccessCountIsNonZero;
+
+  /**
    * Expiration time for Blob IDs stored in not-found cache. Default value is 15 seconds.
    * Setting it to 0 would disable the cache and avoid storing any blob IDs.
    * TODO: With PR https://github.com/linkedin/ambry/pull/2072, when operation tracker fails due to blob-not-found and
@@ -762,6 +771,8 @@ public class RouterConfig {
         "com.github.ambry.store.StoreKeyConverterFactoryImpl");
     routerUnavailableDueToOfflineReplicas =
         verifiableProperties.getBoolean(ROUTER_UNAVAILABLE_DUE_TO_OFFLINE_REPLICAS, false);
+    routerUnavailableDueToSuccessCountIsNonZero =
+        verifiableProperties.getBoolean(ROUTER_UNAVAILABLE_DUE_TO_SUCCESS_COUNT_IS_NON_ZERO, true);
     routerNotFoundCacheTtlInMs = verifiableProperties.getLongInRange(ROUTER_NOT_FOUND_CACHE_TTL_IN_MS, 15 * 1000L, 0,
         ROUTER_NOT_FOUND_CACHE_MAX_TTL_IN_MS);
     routerUpdateOpMetadataRelianceTimestampInMs = verifiableProperties.getLong(

--- a/ambry-router/src/main/java/com/github/ambry/router/DeleteOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/DeleteOperation.java
@@ -361,10 +361,22 @@ class DeleteOperation {
             new RouterException("DeleteOperation failed possibly because some replicas are unavailable",
                 RouterErrorCode.AmbryUnavailable));
       } else if (operationTracker.hasFailedOnNotFound()) {
-        //TODO: Temporarily return 404 when delete operation returns two NOT_FOUND.
-        //TODO: Will check all local replicas and return succeed if one replica return succeed in this case.
-        operationException.set(
-            new RouterException("DeleteOperation failed because of BlobNotFound", RouterErrorCode.BlobDoesNotExist));
+        /*
+        We are relying on the fact that at least one replica has the blob. Scenarios like below are rare, so that we don’t need to handle them for now.
+          1. put parallelism is 3 && all three replicas of originating dc are down && remote replication is not caught up
+          2. put parallelism is 2 && 2 replicas are down (note that 2 replicas down happen all the time) && replication has not caught up such that blob doesn’t exist in at least one other replica.
+              i.e, its very rare for 2 replicas to be down simultaneously and immediately after taking a POST (with parallelism 2)
+         */
+        if (routerConfig.routerUnavailableDueToSuccessCountIsNonZero && operationTracker.getSuccessCount() > 0) {
+          routerMetrics.failedMaybeDueToUnavailableReplicasCount.inc();
+          operationException.set(new RouterException("DeleteOperation failed possibly because of unavailable replicas",
+              RouterErrorCode.AmbryUnavailable));
+        } else {
+          //TODO: Temporarily return 404 when delete operation returns two NOT_FOUND.
+          //TODO: Will check all local replicas and return succeed if one replica return succeed in this case.
+          operationException.set(
+              new RouterException("DeleteOperation failed because of BlobNotFound", RouterErrorCode.BlobDoesNotExist));
+        }
       }
       if (QuotaUtils.postProcessCharge(quotaChargeCallback)) {
         try {

--- a/ambry-router/src/main/java/com/github/ambry/router/DeleteOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/DeleteOperation.java
@@ -367,7 +367,7 @@ class DeleteOperation {
           2. put parallelism is 2 && 2 replicas are down (note that 2 replicas down happen all the time) && replication has not caught up such that blob doesn’t exist in at least one other replica.
               i.e, its very rare for 2 replicas to be down simultaneously and immediately after taking a POST (with parallelism 2)
          */
-        if (routerConfig.routerUnavailableDueToSuccessCountIsNonZero && operationTracker.getSuccessCount() > 0) {
+        if (routerConfig.routerUnavailableDueToSuccessCountIsNonZeroForDelete && operationTracker.getSuccessCount() > 0) {
           routerMetrics.failedMaybeDueToUnavailableReplicasCount.inc();
           operationException.set(new RouterException("DeleteOperation failed possibly because of unavailable replicas",
               RouterErrorCode.AmbryUnavailable));

--- a/ambry-router/src/main/java/com/github/ambry/router/DeleteOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/DeleteOperation.java
@@ -361,21 +361,10 @@ class DeleteOperation {
             new RouterException("DeleteOperation failed possibly because some replicas are unavailable",
                 RouterErrorCode.AmbryUnavailable));
       } else if (operationTracker.hasFailedOnNotFound()) {
-        /*
-        We are relying on the fact that at least one replica has the blob. Scenarios like below are rare, so that we don’t need to handle them for now.
-          1. put parallelism is 3 && all three replicas of originating dc are down && remote replication is not caught up
-          2. put parallelism is 2 && 2 replicas are down (note that 2 replicas down happen all the time) && replication has not caught up such that blob doesn’t exist in at least one other replica.
-              i.e, its very rare for 2 replicas to be down simultaneously and immediately after taking a POST (with parallelism 2)
-         */
-        if (operationTracker.getSuccessCount() > 0) {
-          routerMetrics.failedMaybeDueToUnavailableReplicasCount.inc();
-          operationException.set(
-              new RouterException("DeleteOperation failed possibly because of unavailable replicas",
-                  RouterErrorCode.AmbryUnavailable));
-        } else {
-          operationException.set(
-              new RouterException("DeleteOperation failed because of BlobNotFound", RouterErrorCode.BlobDoesNotExist));
-        }
+        //TODO: Temporarily return 404 when delete operation returns two NOT_FOUND.
+        //TODO: Will check all local replicas and return succeed if one replica return succeed in this case.
+        operationException.set(
+            new RouterException("DeleteOperation failed because of BlobNotFound", RouterErrorCode.BlobDoesNotExist));
       }
       if (QuotaUtils.postProcessCharge(quotaChargeCallback)) {
         try {

--- a/ambry-router/src/test/java/com/github/ambry/router/DeleteManagerTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/DeleteManagerTest.java
@@ -349,7 +349,7 @@ public class DeleteManagerTest {
   }
 
   @Test
-  public void testBlobNotFoundReturned() throws Exception {
+  public void testBlobNotFoundReturnedWhenAllReplicasReturnNotFound() throws Exception {
     int serverCount = serverLayout.getMockServers().size();
     List<ServerErrorCode> serverErrorCodes = Collections.nCopies(serverCount, ServerErrorCode.Blob_Not_Found);
     setServerErrorCodes(serverErrorCodes, serverLayout);
@@ -366,7 +366,7 @@ public class DeleteManagerTest {
   }
 
   @Test
-  public void testAmbryUnavailableReturned() throws Exception {
+  public void testBlobNotFoundReturnedWhenOneReplicaReturnSucceed() throws Exception {
     List<MockServer> serversInLocalDc = new ArrayList<>();
     serverLayout.getMockServers().forEach(mockServer -> {
       if (mockServer.getDataCenter().equals(LOCAL_DC)) {
@@ -380,7 +380,7 @@ public class DeleteManagerTest {
       serversInLocalDc.get(i).setServerErrorForAllRequests(ServerErrorCode.Disk_Unavailable);
     }
     serversInLocalDc.get(2).setServerErrorForAllRequests(ServerErrorCode.No_Error);
-    RouterErrorCode expectedErrorCode = RouterErrorCode.AmbryUnavailable;
+    RouterErrorCode expectedErrorCode = RouterErrorCode.BlobDoesNotExist;
     FutureResult<Void> future = new FutureResult<>();
     TestCallback<Void> callback = new TestCallback<>();
     deleteManager.submitDeleteBlobOperation(blobIdString, LOCAL_DC, future, callback,
@@ -389,7 +389,6 @@ public class DeleteManagerTest {
     router.incrementOperationsCount(1);
     sendRequestsGetResponses(future, deleteManager);
     assertFailureAndCheckErrorCode(future, expectedErrorCode);
-    assertEquals("There should be an Ambry Unavailable error", routerMetrics.ambryUnavailableErrorCount.getCount(), 1);
   }
 
   /**

--- a/ambry-router/src/test/java/com/github/ambry/router/DeleteManagerTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/DeleteManagerTest.java
@@ -382,7 +382,7 @@ public class DeleteManagerTest {
       throws Exception {
     router.close();
     Properties properties = getNonBlockingRouterProperties();
-    properties.setProperty(RouterConfig.ROUTER_UNAVAILABLE_DUE_TO_SUCCESS_COUNT_IS_NON_ZERO,
+    properties.setProperty(RouterConfig.ROUTER_UNAVAILABLE_DUE_TO_SUCCESS_COUNT_IS_NON_ZERO_FOR_DELETE,
         Boolean.toString(routerUnavailableDueToSuccessCountIsNonZero));
     VerifiableProperties vProps = new VerifiableProperties(properties);
     RouterConfig routerConfig = new RouterConfig(vProps);


### PR DESCRIPTION
There’s a case that due to some reason two replicas don’t have the data(maybe due to OSUA wiping out some data), but the third one still has the DELETE records. 
In current scenario, we return 503 which is not appropriate.
This is the short term fix to revert the changes to the previous version which return 404.
For the long term fix, we should check all replica status for delete operation and return succeed(200) when one replica succeed. 
