### PR TITLE
Store index segment offset information in compaction and use it to generate replication token

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -490,15 +490,22 @@ public class StoreConfig {
   public static final String storeNumOfCacheMissForFindMissingKeysInBatchModeName =
       "store.num.of.cache.miss.for.find.missing.keys.in.batch.mode";
 
+  /**
+   * How many days of compactionlogs we have to read from disk to build the compaction history
+   */
   @Config(storeCompactionHistoryInDayName)
   @Default("7")
   public final int storeCompactionHistoryInDay;
   public static final String storeCompactionHistoryInDayName = "store.compaction.history.in.day";
 
-  @Config(storeEnableOffsetBasedTokenResetName)
+  /**
+   * True to enable rebuilding replication token based on compaction history.
+   */
+  @Config(storeRebuildTokenBasedOnCompactionHistoryName)
   @Default("false")
-  public final boolean storeEnableOffsetBasedTokenReset;
-  public static final String storeEnableOffsetBasedTokenResetName = "store.enable.offset.based.tokne.reset";
+  public final boolean storeRebuildTokenBasedOnCompactionHistory;
+  public static final String storeRebuildTokenBasedOnCompactionHistoryName =
+      "store.rebuild.token.based.on.compaction.history";
 
   public StoreConfig(VerifiableProperties verifiableProperties) {
 
@@ -620,6 +627,7 @@ public class StoreConfig {
     storeNumOfCacheMissForFindMissingKeysInBatchMode =
         verifiableProperties.getIntInRange(storeNumOfCacheMissForFindMissingKeysInBatchModeName, 5, 3, 100);
     storeCompactionHistoryInDay = verifiableProperties.getIntInRange(storeCompactionHistoryInDayName, 7, 1, 30);
-    storeEnableOffsetBasedTokenReset = verifiableProperties.getBoolean(storeEnableOffsetBasedTokenResetName, false);
+    storeRebuildTokenBasedOnCompactionHistory =
+        verifiableProperties.getBoolean(storeRebuildTokenBasedOnCompactionHistoryName, false);
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -498,7 +498,7 @@ public class StoreConfig {
    * How many days of compactionlogs we have to read from disk to build the compaction history
    */
   @Config(storeCompactionHistoryInDayName)
-  @Default("7")
+  @Default("21")
   public final int storeCompactionHistoryInDay;
   public static final String storeCompactionHistoryInDayName = "store.compaction.history.in.day";
 
@@ -640,7 +640,7 @@ public class StoreConfig {
         verifiableProperties.getIntInRange(storeCacheSizeForFindMissingKeysInBatchModeName, 3, 1, 100);
     storeNumOfCacheMissForFindMissingKeysInBatchMode =
         verifiableProperties.getIntInRange(storeNumOfCacheMissForFindMissingKeysInBatchModeName, 5, 3, 100);
-    storeCompactionHistoryInDay = verifiableProperties.getIntInRange(storeCompactionHistoryInDayName, 7, 1, 30);
+    storeCompactionHistoryInDay = verifiableProperties.getIntInRange(storeCompactionHistoryInDayName, 21, 1, 365);
     storeRebuildTokenBasedOnCompactionHistory =
         verifiableProperties.getBoolean(storeRebuildTokenBasedOnCompactionHistoryName, false);
     String partitions =

--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -16,7 +16,11 @@ package com.github.ambry.config;
 import com.github.ambry.store.IndexMemState;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Collections;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 
 /**
@@ -507,6 +511,16 @@ public class StoreConfig {
   public static final String storeRebuildTokenBasedOnCompactionHistoryName =
       "store.rebuild.token.based.on.compaction.history";
 
+  /**
+   * Partition id to enable rebuild token based on compaction history. In order to enable this feature, we have to enable
+   * the storeRebuildTokenBasedOnCompactionHistory and add partition id here. This is a comma separated list.
+   */
+  @Config(storePartitionsToRebuildTokenBasedOnCompactionHistoryName)
+  @Default("")
+  public List<Long> storePartitionsToRebuildTokenBasedOnCompactionHistory;
+  public static final String storePartitionsToRebuildTokenBasedOnCompactionHistoryName =
+      "store.partitions.to.rebuild.token.based.on.compaction.history";
+
   public StoreConfig(VerifiableProperties verifiableProperties) {
 
     storeKeyFactory = verifiableProperties.getString("store.key.factory", "com.github.ambry.commons.BlobIdFactory");
@@ -629,5 +643,13 @@ public class StoreConfig {
     storeCompactionHistoryInDay = verifiableProperties.getIntInRange(storeCompactionHistoryInDayName, 7, 1, 30);
     storeRebuildTokenBasedOnCompactionHistory =
         verifiableProperties.getBoolean(storeRebuildTokenBasedOnCompactionHistoryName, false);
+    String partitions =
+        verifiableProperties.getString(storePartitionsToRebuildTokenBasedOnCompactionHistoryName, "").trim();
+    if (partitions.isEmpty()) {
+      storePartitionsToRebuildTokenBasedOnCompactionHistory = Collections.EMPTY_LIST;
+    } else {
+      storePartitionsToRebuildTokenBasedOnCompactionHistory =
+          Stream.of(partitions.split(",")).map(Long::valueOf).collect(Collectors.toList());
+    }
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -490,6 +490,16 @@ public class StoreConfig {
   public static final String storeNumOfCacheMissForFindMissingKeysInBatchModeName =
       "store.num.of.cache.miss.for.find.missing.keys.in.batch.mode";
 
+  @Config(storeCompactionHistoryInDayName)
+  @Default("7")
+  public final int storeCompactionHistoryInDay;
+  public static final String storeCompactionHistoryInDayName = "store.compaction.history.in.day";
+
+  @Config(storeEnableOffsetBasedTokenResetName)
+  @Default("false")
+  public final boolean storeEnableOffsetBasedTokenReset;
+  public static final String storeEnableOffsetBasedTokenResetName = "store.enable.offset.based.tokne.reset";
+
   public StoreConfig(VerifiableProperties verifiableProperties) {
 
     storeKeyFactory = verifiableProperties.getString("store.key.factory", "com.github.ambry.commons.BlobIdFactory");
@@ -609,5 +619,7 @@ public class StoreConfig {
         verifiableProperties.getIntInRange(storeCacheSizeForFindMissingKeysInBatchModeName, 3, 1, 100);
     storeNumOfCacheMissForFindMissingKeysInBatchMode =
         verifiableProperties.getIntInRange(storeNumOfCacheMissForFindMissingKeysInBatchModeName, 5, 3, 100);
+    storeCompactionHistoryInDay = verifiableProperties.getIntInRange(storeCompactionHistoryInDayName, 7, 1, 30);
+    storeEnableOffsetBasedTokenReset = verifiableProperties.getBoolean(storeEnableOffsetBasedTokenResetName, false);
   }
 }

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
@@ -1131,11 +1131,12 @@ class BlobStoreCompactor {
 
     if (compactionLog.isIndexSegmentOffsetsPersisted()) {
       srcIndex.updateBeforeAndAfterCompactionIndexSegmentOffsets(compactionLog.getStartTime(),
-          compactionLog.getIndexSegmentOffsets());
+          compactionLog.getIndexSegmentOffsetsForCurrentCycle(), true);
     }
     // Update the index segments, this would remove some index segments and add others. We have to update the before and
     // after compaction index segment offsets before this method.
     srcIndex.changeIndexSegments(indexSegmentFilesToAdd, indexSegmentsToRemove);
+    srcIndex.sanityCheckBeforeAndAfterCompactionIndexSegmentOffsets();
   }
 
   /**

--- a/ambry-store/src/main/java/com/github/ambry/store/CompactionLog.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/CompactionLog.java
@@ -329,6 +329,21 @@ class CompactionLog implements Closeable {
     flush();
   }
 
+  void updateIndexSegmentOffsetsWithValidOffset(Offset validOffset) {
+    if (!isIndexSegmentOffsetsPersisted()) {
+      return;
+    }
+    logger.info("{}: validate offsets map with: {}", file, validOffset);
+    if (validOffset == null) {
+      beforeAndAfterIndexSegmentOffsets.clear();
+    } else {
+      for (Offset before : beforeAndAfterIndexSegmentOffsets.keySet()) {
+        beforeAndAfterIndexSegmentOffsets.put(before, validOffset);
+      }
+    }
+    flush();
+  }
+
   /**
    * Return the index segment offset map. Each key and value is before and after pair passed to {@link #addIndexSegmentOffsetPair}.
    * DON'T modify this map.

--- a/ambry-store/src/main/java/com/github/ambry/store/Log.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/Log.java
@@ -255,6 +255,10 @@ class Log implements Write {
     return segmentsByName.lastEntry().getValue();
   }
 
+  List<LogSegmentName> getAllLogSegmentNames() {
+    return new ArrayList<>(segmentsByName.keySet());
+  }
+
   /**
    * Returns the {@link LogSegment} that is logically after the given {@code segment}.
    * @param segment the {@link LogSegment} whose "next" segment is required.

--- a/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
@@ -584,6 +584,14 @@ class PersistentIndex {
     }
   }
 
+  NavigableMap<Offset, Offset> getBeforeAndAfterCompactionIndexSegmentOffsets() {
+    return beforeAndAfterCompactionIndexSegmentOffsets;
+  }
+
+  TreeMap<Long, Set<Offset>> getCompactionTimestampToIndexSegmentOffsets() {
+    return compactionTimestampToIndexSegmentOffsets;
+  }
+
   /**
    * Adds a new entry to the index. For recovery, only the index segments belongs to last log segment should be put into
    * journal, otherwise it won't be compacted. And we will face the issue when last log segment is empty but journal size
@@ -632,10 +640,10 @@ class PersistentIndex {
    */
   Offset getActiveIndexSegmentOffset() {
     Offset logEndOffset = log.getEndOffset();
-    Offset lastKey = validIndexSegments.lastKey();
+    Map.Entry<Offset, IndexSegment> lastEntry = validIndexSegments.lastEntry();
     // Fetch the log end offset before last key in the map
-    if (lastKey != null) {
-      return lastKey;
+    if (lastEntry != null) {
+      return lastEntry.getKey();
     } else {
       // No index segment in the map, then this log is empty. End offset is the start offset.
       return logEndOffset;

--- a/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
@@ -659,15 +659,6 @@ class PersistentIndex {
     shouldRebuildTokenBasedOnCompactionHistory = true;
   }
 
-  boolean shouldRebuildTokenBasedOnCompactionHistory() {
-    return  shouldRebuildTokenBasedOnCompactionHistory;
-  }
-
-  boolean isSanityCheckFailed(){
-    return sanityCheckFailed;
-  }
-
-
   /**
    * Adds a new entry to the index. For recovery, only the index segments belongs to last log segment should be put into
    * journal, otherwise it won't be compacted. And we will face the issue when last log segment is empty but journal size

--- a/ambry-store/src/main/java/com/github/ambry/store/StoreMetrics.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StoreMetrics.java
@@ -57,6 +57,8 @@ public class StoreMetrics {
   public final Counter indexBasedTokenResetCount;
   public final Counter journalBasedTokenResetCount;
   public final Counter resetKeyFoundInCurrentIndex;
+  public final Counter generateTokenBasedOnCompactionHistoryCount;
+  public final Counter offsetFoundInBeforeAfterMapCount;
   public final Timer recoveryTime;
   public final Timer findTime;
   public final Timer indexFlushTime;
@@ -157,6 +159,10 @@ public class StoreMetrics {
         registry.counter(MetricRegistry.name(PersistentIndex.class, name + "JournalBasedTokenResetCount"));
     resetKeyFoundInCurrentIndex =
         registry.counter(MetricRegistry.name(PersistentIndex.class, name + "ResetKeyFoundInCurrentIndex"));
+    generateTokenBasedOnCompactionHistoryCount = registry.counter(
+        MetricRegistry.name(PersistentIndex.class, name + "GenerateTokenBasedOnCompactionHistoryCount"));
+    offsetFoundInBeforeAfterMapCount =
+        registry.counter(MetricRegistry.name(PersistentIndex.class, name + "OffsetFoundInBeforeAfterMapCount"));
     recoveryTime = registry.timer(MetricRegistry.name(PersistentIndex.class, name + "IndexRecoveryTime"));
     findTime = registry.timer(MetricRegistry.name(PersistentIndex.class, name + "IndexFindTime"));
     indexFlushTime = registry.timer(MetricRegistry.name(PersistentIndex.class, name + "IndexFlushTime"));

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
@@ -63,6 +63,7 @@ import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import org.junit.After;
 import org.junit.Test;
@@ -286,6 +287,97 @@ public class BlobStoreCompactorTest {
     List<LogSegmentName> logSegmentNames = details.getLogSegmentsUnderCompaction();
     assertEquals(1, logSegmentNames.size());
     assertEquals("3" + BlobStore.SEPARATOR + "0", logSegmentNames.get(0).toString());
+  }
+
+  /**
+   * Test the cases where the whole log segment is removed by the compaction, before and after compaction index segment
+   * offsets has to be correct.
+   * @throws Exception
+   */
+  @Test
+  public void emptyOneLogSegmentInCompactionTest() throws Exception {
+    refreshState(false, false, false);
+    // Set up log segment like this
+    // 0_0 doesn't have any valid values (all expired put), will compact 0_0 by itself.
+    // 1_0 is full of PUT, some of them are going to be compacted.
+    // 2_0 doesn't have any valid values (all expired put), will compact 1_0 and 2_0 together
+    // 3_0 is full of valid PUTs
+    // 4_0 is doesn't have any valid values (all expired put), will compact 4_0 by itself.
+
+    int numPuts = (int) ((state.log.getSegmentCapacity() - LogSegment.HEADER_SIZE) / (PUT_RECORD_SIZE));
+    state.addPutEntries(numPuts, PUT_RECORD_SIZE, 0);
+    assertEquals(1, state.index.getLogSegmentCount());
+    state.addPutEntries(numPuts - 3, PUT_RECORD_SIZE, Utils.Infinite_Time);
+    state.addPutEntries(3, PUT_RECORD_SIZE, 0);
+    assertEquals(2, state.index.getLogSegmentCount());
+    state.addPutEntries(numPuts, PUT_RECORD_SIZE, 0);
+    assertEquals(3, state.index.getLogSegmentCount());
+    state.addPutEntries(numPuts, PUT_RECORD_SIZE, Utils.Infinite_Time);
+    assertEquals(4, state.index.getLogSegmentCount());
+    state.addPutEntries(numPuts, PUT_RECORD_SIZE, 0);
+    assertEquals(5, state.index.getLogSegmentCount());
+    writeDataToMeetRequiredSegmentCount(6, Collections.singletonList(Utils.Infinite_Time));
+
+    state.time.setCurrentMilliseconds(System.currentTimeMillis());
+    state.reloadIndex(true, false);
+
+    // Compact 0_0, the target would be empty, and there is no index segment before the target, the before and after index
+    // segment offset map would be empty in compaction log.
+    List<LogSegmentName> segmentsUnderCompaction = getLogSegments(0, 1);
+    compactor = getCompactor(state.log, DISK_IO_SCHEDULER, null, false);
+    compactor.initialize(state.index);
+
+    CompactionDetails details = new CompactionDetails(time.milliseconds(), segmentsUnderCompaction, null);
+    try {
+      compactor.compact(details, bundleReadBuffer);
+    } finally {
+      compactor.close(0);
+    }
+
+    CompactionLog latestLog = getLatestCompactionLog();
+    assertEquals(0, latestLog.getIndexSegmentOffsets().size());
+
+    state.reloadIndex(true, false);
+    // 0_0 is gone, now 1_0 is the first log segment
+    segmentsUnderCompaction = getLogSegments(0, 2);
+    details = new CompactionDetails(time.milliseconds(), segmentsUnderCompaction, null);
+    compactor = getCompactor(state.log, DISK_IO_SCHEDULER, null, false);
+    compactor.initialize(state.index);
+    try {
+      compactor.compact(details, bundleReadBuffer);
+    } finally {
+      compactor.close(0);
+    }
+    state.reloadIndex(true, false);
+    latestLog = getLatestCompactionLog();
+    Offset lastIndexSegmentOffsetForTarget =
+        state.index.getIndexSegments().floorKey(new Offset(LogSegmentName.fromPositionAndGeneration(3, 0), 0));
+    assertEquals(LogSegmentName.fromPositionAndGeneration(1, 1), lastIndexSegmentOffsetForTarget.getName());
+    for (Map.Entry<Offset, Offset> entry : latestLog.getIndexSegmentOffsets().entrySet()) {
+      if (entry.getKey().getName().equals(LogSegmentName.fromPositionAndGeneration(2, 0))) {
+        assertEquals(lastIndexSegmentOffsetForTarget, entry.getValue());
+      }
+    }
+
+    state.reloadIndex(true, false);
+    // 0_0 and 2_0 are gone, now it's 1_1, 3_0, 4_0
+    segmentsUnderCompaction = getLogSegments(2, 1);
+    details = new CompactionDetails(time.milliseconds(), segmentsUnderCompaction, null);
+    compactor = getCompactor(state.log, DISK_IO_SCHEDULER, null, false);
+    compactor.initialize(state.index);
+    try {
+      compactor.compact(details, bundleReadBuffer);
+    } finally {
+      compactor.close(0);
+    }
+    state.reloadIndex(true, false);
+    latestLog = getLatestCompactionLog();
+    Offset lastIndexSegmentOffsetFromSource =
+        state.index.getIndexSegments().floorKey(new Offset(LogSegmentName.fromPositionAndGeneration(4, 0), 0));
+    assertEquals(LogSegmentName.fromPositionAndGeneration(3, 0), lastIndexSegmentOffsetFromSource.getName());
+    for (Map.Entry<Offset, Offset> entry : latestLog.getIndexSegmentOffsets().entrySet()) {
+      assertEquals(lastIndexSegmentOffsetFromSource, entry.getValue());
+    }
   }
 
   /**
@@ -1527,6 +1619,19 @@ public class BlobStoreCompactorTest {
     writeDataToMeetRequiredSegmentCount(3, null);
     state.reloadIndex(true, false);
 
+    final LogSegmentName firstLogSegmentName = p1.getValue().getOffset().getName();
+    TreeSet<Offset> firstLogSegmentIndexOffsets = state.index.getIndexSegments()
+        .keySet()
+        .stream()
+        .filter(offset -> offset.getName().equals(firstLogSegmentName))
+        .collect(Collectors.toCollection(TreeSet::new));
+    final LogSegmentName secondLogSegmentName = firstLogSegmentName.getNextPositionName();
+    TreeSet<Offset> secondLogSegmentIndexOffsets = state.index.getIndexSegments()
+        .keySet()
+        .stream()
+        .filter(offset -> offset.getName().equals(secondLogSegmentName))
+        .collect(Collectors.toCollection(TreeSet::new));
+
     LogSegmentName logSegmentName = p1.getValue().getOffset().getName();
     List<LogSegmentName> segmentsUnderCompaction = getLogSegments(0, 1);
     state.advanceTime(expirationTime - state.time.milliseconds() + 1000);
@@ -1558,6 +1663,10 @@ public class BlobStoreCompactorTest {
         endOffsetOfSegmentBeforeCompaction - cleanedUpSize,
         state.log.getSegment(compactedLogSegmentName).getEndOffset());
 
+    CompactionLog cLog = getLatestCompactionLog();
+    Map<Offset, Offset> indexSegmentOffsets = cLog.getIndexSegmentOffsets();
+    Map<Offset, Offset> expectedIndexSegmentOffsets = new HashMap<>();
+
     LogSegment compactedLogSegment = state.log.getSegment(compactedLogSegmentName);
     ConcurrentNavigableMap<Offset, IndexSegment> indexSegments = state.index.getIndexSegments();
     FindEntriesCondition condition = new FindEntriesCondition(Long.MAX_VALUE);
@@ -1575,6 +1684,11 @@ public class BlobStoreCompactorTest {
     verifyIndexEntry(indexEntries.get(1), (MockId) p1.getKey(), currentExpectedOffset, us, Utils.Infinite_Time, false,
         false, true, (short) 1);
     currentExpectedOffset += us + 3 * ps; // skip three puts
+
+    Offset before = firstLogSegmentIndexOffsets.first();
+    expectedIndexSegmentOffsets.put(before, segment.getStartOffset()); // before 1 -> after 1
+    before = firstLogSegmentIndexOffsets.higher(before);
+    expectedIndexSegmentOffsets.put(before, segment.getStartOffset()); // before 2 -> after 1
 
     // Get the entries in the second segment
     segment = indexSegments.higherEntry(segment.getStartOffset()).getValue();
@@ -1596,6 +1710,13 @@ public class BlobStoreCompactorTest {
         false, true, (short) 4);
     currentExpectedOffset += us;
 
+    before = firstLogSegmentIndexOffsets.higher(before);
+    expectedIndexSegmentOffsets.put(before, segment.getStartOffset()); // before 3 -> after 2
+    before = firstLogSegmentIndexOffsets.higher(before);
+    expectedIndexSegmentOffsets.put(before, segment.getStartOffset()); // before 4 -> after 2
+    before = firstLogSegmentIndexOffsets.higher(before);
+    expectedIndexSegmentOffsets.put(before, segment.getStartOffset()); // before 5 -> after 2
+
     // Get the entries in the third segment
     segment = indexSegments.higherEntry(segment.getStartOffset()).getValue();
     indexEntries.clear();
@@ -1609,6 +1730,14 @@ public class BlobStoreCompactorTest {
     verifyIndexEntry(indexEntries.get(3), (MockId) p7.getKey(), currentExpectedOffset, ds, expirationTime, true, false,
         false, (short) 1);
     currentExpectedOffset += ds + ps; // skip one puts
+
+    before = firstLogSegmentIndexOffsets.higher(before);
+    expectedIndexSegmentOffsets.put(before, segment.getStartOffset()); // before 6 -> after 3
+    before = firstLogSegmentIndexOffsets.higher(before);
+    expectedIndexSegmentOffsets.put(before, segment.getStartOffset()); // before 7 -> after 3
+    before = firstLogSegmentIndexOffsets.higher(before);
+    expectedIndexSegmentOffsets.put(before, segment.getStartOffset()); // before 8 -> after 3
+    // when copying 8th index segment, the third index segment after compaction didn't roll over yet.
 
     // Get the entries in the fourth segment
     segment = indexSegments.higherEntry(segment.getStartOffset()).getValue();
@@ -1624,6 +1753,18 @@ public class BlobStoreCompactorTest {
     currentExpectedOffset += ps;
     verifyIndexEntry(indexEntries.get(4), (MockId) p9.getKey(), currentExpectedOffset, us, Utils.Infinite_Time, false,
         false, true, (short) 2);
+
+    before = firstLogSegmentIndexOffsets.higher(before);
+    expectedIndexSegmentOffsets.put(before, segment.getStartOffset()); // before 9 -> after 4
+
+    for (Map.Entry<Offset, Offset> expectedEntry : expectedIndexSegmentOffsets.entrySet()) {
+      Offset expectedBefore = expectedEntry.getKey();
+      Offset expectedAfter = expectedEntry.getValue();
+      Offset obtainedAfter = indexSegmentOffsets.get(expectedBefore);
+      assertEquals("Mismatch for offset " + expectedBefore + " " + firstLogSegmentIndexOffsets, expectedAfter,
+          obtainedAfter);
+    }
+    expectedIndexSegmentOffsets.clear();
 
     // no clean shutdown file should exist
     assertFalse("Clean shutdown file not deleted",
@@ -1657,6 +1798,9 @@ public class BlobStoreCompactorTest {
         endOffsetOfSegmentBeforeCompaction - cleanedUpSize,
         state.log.getSegment(compactedLogSegmentName).getEndOffset());
 
+    cLog = getLatestCompactionLog();
+    indexSegmentOffsets = cLog.getIndexSegmentOffsets();
+
     compactedLogSegment = state.log.getSegment(compactedLogSegmentName);
     indexSegments = state.index.getIndexSegments()
         .subMap(new Offset(compactedLogSegmentName, 0), true,
@@ -1678,6 +1822,11 @@ public class BlobStoreCompactorTest {
         false, true, (short) 2);
     currentExpectedOffset += us;
 
+    before = secondLogSegmentIndexOffsets.first();
+    expectedIndexSegmentOffsets.put(before, segment.getStartOffset()); // before 1 -> after 1
+    before = secondLogSegmentIndexOffsets.higher(before);
+    expectedIndexSegmentOffsets.put(before, segment.getStartOffset()); // before 2 -> after 1
+
     // Get the entries in the second segment
     segment = indexSegments.higherEntry(segment.getStartOffset()).getValue();
     indexEntries.clear();
@@ -1687,6 +1836,18 @@ public class BlobStoreCompactorTest {
     currentExpectedOffset += ps; // skip one put
     verifyIndexEntry(indexEntries.get(1), (MockId) p13.getKey(), currentExpectedOffset, ps, Utils.Infinite_Time, false,
         false, false, (short) 2);
+
+    before = secondLogSegmentIndexOffsets.higher(before);
+    expectedIndexSegmentOffsets.put(before, segment.getStartOffset()); // before 3 -> after 2
+
+    for (Map.Entry<Offset, Offset> expectedEntry : expectedIndexSegmentOffsets.entrySet()) {
+      Offset expectedBefore = expectedEntry.getKey();
+      Offset expectedAfter = expectedEntry.getValue();
+      Offset obtainedAfter = indexSegmentOffsets.get(expectedBefore);
+      assertEquals("Mismatch for offset " + expectedBefore + " " + secondLogSegmentIndexOffsets, expectedAfter,
+          obtainedAfter);
+    }
+    expectedIndexSegmentOffsets.clear();
 
     // no clean shutdown file should exist
     assertFalse("Clean shutdown file not deleted",
@@ -3009,6 +3170,12 @@ public class BlobStoreCompactorTest {
     long logSegmentCountBeforeCompaction = state.index.getLogSegmentCount();
     long indexSegmentCountBeforeCompaction = state.index.getIndexSegments().size();
 
+    Set<Offset> indexSegmentOffsetsUnderCompaction = state.index.getIndexSegments()
+        .keySet()
+        .stream()
+        .filter(offset -> segmentsUnderCompaction.contains(offset.getName()))
+        .collect(Collectors.toSet());
+
     ScheduledExecutorService scheduler = Utils.newScheduler(1, true);
     BlobStoreStats stats =
         new BlobStoreStats("", state.index, 0, Time.MsPerSec, 0, 100, Time.SecsPerMin, false, purgeDeleteTombstone,
@@ -3042,6 +3209,9 @@ public class BlobStoreCompactorTest {
     } finally {
       compactor.close(0);
     }
+    // First, verify the index segment offset map is good
+    verifyIndexSegmentOffsetsBeforeAndAfterCompaction(indexSegmentOffsetsUnderCompaction);
+
     Set<MockId> remainingBlobIds = getCurrentBlobIdsFromWholeIndex(state.index, null, purgeDeleteTombstone);
     // since this method aims to verify success compaction case, we only need to account for some deletes with PUTs are
     // compacted in the multi-cycle compaction (i.e. PUT is 1st log segment and gets compacted in 1st cycle. DELETE is
@@ -3099,6 +3269,12 @@ public class BlobStoreCompactorTest {
     long logSegmentCountBeforeCompaction = state.index.getLogSegmentCount();
     long indexSegmentCountBeforeCompaction = state.index.getIndexSegments().size();
 
+    Set<Offset> indexSegmentOffsetsUnderCompaction = state.index.getIndexSegments()
+        .keySet()
+        .stream()
+        .filter(offset -> segmentsUnderCompaction.contains(offset.getName()))
+        .collect(Collectors.toSet());
+
     CompactionDetails details = new CompactionDetails(deleteReferenceTimeMs, segmentsUnderCompaction, null);
     long expectedValidDataSize = getValidDataSize(segmentsUnderCompaction, deleteReferenceTimeMs, purgeDeleteTombstone);
     List<LogSegmentName> unaffectedSegments = getUnaffectedSegments(segmentsUnderCompaction);
@@ -3146,6 +3322,8 @@ public class BlobStoreCompactorTest {
     } finally {
       compactor.close(0);
     }
+
+    verifyIndexSegmentOffsetsBeforeAndAfterCompaction(indexSegmentOffsetsUnderCompaction);
     Set<MockId> remainingBlobIds = getCurrentBlobIdsFromWholeIndex(state.index, null, purgeDeleteTombstone);
     // find those deletes initially had PUTs but were compacted in the subsequent compaction cycle.
     deletesWithPuts.removeAll(remainingBlobIds);
@@ -3224,6 +3402,64 @@ public class BlobStoreCompactorTest {
           state.index.getLogSegmentCount());
       assertEquals("Index segment count changed after compaction", originalIndexSegmentCount,
           state.index.getIndexSegments().size());
+    }
+  }
+
+  private CompactionLog getLatestCompactionLog() throws IOException {
+    AtomicReference<CompactionLog> latestLogRef = new AtomicReference<>(null);
+    CompactionLog.processCompactionLogs(tempDirStr, STORE_ID, STORE_KEY_FACTORY, state.time, state.config, cLog -> {
+      latestLogRef.set(cLog);
+      return false;
+    });
+    CompactionLog latestLog = latestLogRef.get();
+    assertNotNull(latestLog);
+    return latestLog;
+  }
+
+  private void verifyIndexSegmentOffsetsBeforeAndAfterCompaction(Set<Offset> indexSegmentOffsetsUnderCompaction)
+      throws Exception {
+    CompactionLog latestLog = getLatestCompactionLog();
+    TreeMap<Offset, Offset> indexSegmentOffsets = latestLog.getIndexSegmentOffsets();
+    Map<Offset, Offset> indexSegmentOffsetsFromIndex = state.index.getBeforeAndAfterCompactionIndexSegmentOffsets();
+    assertEquals(indexSegmentOffsetsFromIndex, indexSegmentOffsets);
+    TreeMap<Long, Set<Offset>> compactionTimestampToOffsets = state.index.getCompactionTimestampToIndexSegmentOffsets();
+    assertEquals(1, compactionTimestampToOffsets.size());
+    assertTrue(compactionTimestampToOffsets.containsKey(latestLog.getStartTime()));
+    assertEquals(compactionTimestampToOffsets.get(latestLog.getStartTime()), indexSegmentOffsets.keySet());
+    assertEquals(indexSegmentOffsetsUnderCompaction, indexSegmentOffsets.keySet());
+    Set<Long> positionsUnderCompaction = indexSegmentOffsetsUnderCompaction.stream()
+        .map(offset -> offset.getName().getPosition())
+        .collect(Collectors.toSet());
+    Map<LogSegmentName, TreeSet<Offset>> indexSegmentOffsetsAfterCompaction =
+        new TreeSet<>(state.index.getIndexSegments().keySet()).stream()
+            .filter(offset -> positionsUnderCompaction.contains(offset.getName().getPosition()))
+            .collect(Collectors.groupingBy(offset -> offset.getName(), Collectors.toCollection(TreeSet::new)));
+    // After compaction, we would have several new index segments. The values of map indexSegmentOffsets should either
+    // equal to the new index segment offsets, or a subset of it(excluding the last index segment).
+    Map<LogSegmentName, Set<Offset>> values = new TreeSet<>(indexSegmentOffsets.values()).stream()
+        .collect(Collectors.groupingBy(offset -> offset.getName(), Collectors.toSet()));
+    for (Map.Entry<LogSegmentName, TreeSet<Offset>> entry : indexSegmentOffsetsAfterCompaction.entrySet()) {
+      TreeSet<Offset> afterCompaction = entry.getValue();
+      Set<Offset> offsets = values.get(entry.getKey());
+      if (offsets == null) {
+        assertEquals(1, afterCompaction.size());
+      } else {
+        if (offsets.size() == afterCompaction.size()) {
+          assertEquals(afterCompaction, offsets);
+        } else {
+          afterCompaction.remove(afterCompaction.last());
+          assertEquals(afterCompaction, offsets);
+        }
+      }
+    }
+
+    Offset prevAfterCompactionOffset = null;
+    for (Map.Entry<Offset, Offset> entry : indexSegmentOffsets.entrySet()) {
+      Offset curr = entry.getValue();
+      if (prevAfterCompactionOffset != null) {
+        assertFalse(curr.compareTo(prevAfterCompactionOffset) < 0);
+      }
+      prevAfterCompactionOffset = curr;
     }
   }
 


### PR DESCRIPTION
We know all the index segment offset information in the compaction, we should use them to later reset replication token when the index in the token is removed by compaction. The design doc is here. 
https://docs.google.com/document/d/1eETr1ifIQXihN3DA0P3KIclLUiIxXKRwBKPNSyij4is/edit#