### PR TITLE
Added ReplicateBlobRequest handling to replicate one Blob.

### DIFF
--- a/ambry-account/src/test/java/com/github/ambry/account/MockRouter.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/MockRouter.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.account;
 
+import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.commons.ByteBufferReadableStreamChannel;
 import com.github.ambry.commons.ReadableStreamChannelInputStream;
 import com.github.ambry.messageformat.BlobInfo;
@@ -160,6 +161,12 @@ public class MockRouter implements Router {
     } finally {
       lock.unlock();
     }
+  }
+
+  @Override
+  public Future<Void> replicateBlob(String blobId, String serviceId, DataNodeId sourceDataNode, Callback<Void> callback,
+      QuotaChargeCallback quotaChargeCallback) {
+    throw new UnsupportedOperationException("replicateBlob is not supported by this mock");
   }
 
   @Override

--- a/ambry-api/src/main/java/com/github/ambry/notification/NotificationSystem.java
+++ b/ambry-api/src/main/java/com/github/ambry/notification/NotificationSystem.java
@@ -68,6 +68,16 @@ public interface NotificationSystem extends Closeable {
   }
 
   /**
+   * Notifies the underlying system when the blob is replicated on-demand.
+   * @param blobId The id of the blob that was replicated to the local store.
+   * @param serviceId The service ID of the service undeleting the blob. This can be null if unknown.
+   * @param account The {@link Account} for the blob
+   * @param container The {@link Container} for the blob
+   */
+  default void onBlobReplicated(String blobId, String serviceId, Account account, Container container) {
+  }
+
+  /**
    * Notifies the underlying system when a blob is replicated to a node
    * @param sourceHost The source host from where the notification is being invoked
    * @param port The port of the source host from where the notification is being invoked.

--- a/ambry-api/src/main/java/com/github/ambry/protocol/RequestAPI.java
+++ b/ambry-api/src/main/java/com/github/ambry/protocol/RequestAPI.java
@@ -72,6 +72,14 @@ public interface RequestAPI {
   void handleReplicaMetadataRequest(NetworkRequest request) throws IOException, InterruptedException;
 
   /**
+   * Replicate one specific Blob from a remote host to the local store.
+   * @param request The request that contains the remote host information and the blob id to be replicated.
+   * @throws IOException if there are I/O errors carrying our the required operation.
+   * @throws InterruptedException if request processing is interrupted.
+   */
+  void handleReplicateBlobRequest(NetworkRequest request) throws IOException, InterruptedException;
+
+  /**
    * Handles an administration request. These requests can query for or change the internal state of the server.
    * @param request the request that needs to be handled.
    * @throws IOException if there are I/O errors carrying our the required operation.

--- a/ambry-api/src/main/java/com/github/ambry/router/Router.java
+++ b/ambry-api/src/main/java/com/github/ambry/router/Router.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.router;
 
+import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.commons.Callback;
 import com.github.ambry.commons.CallbackUtils;
 import com.github.ambry.messageformat.BlobInfo;
@@ -57,6 +58,18 @@ public interface Router extends Closeable {
    */
   Future<String> putBlob(BlobProperties blobProperties, byte[] userMetadata, ReadableStreamChannel channel,
       PutBlobOptions options, Callback<String> callback, QuotaChargeCallback quotaChargeCallback);
+
+  /**
+   * Requests to on-demand replicate one specific blob asynchronously and invokes the {@link Callback} when the request completes.
+   * @param blobId The ID of the blob to be replicated.
+   * @param serviceId The service ID of the service replicating the blob. This can be null if unknown.
+   * @param sourceDataNode The source {@link DataNodeId} to get the blob from.
+   * @param callback The {@link Callback} which will be invoked on the completion of the request.
+   * @param quotaChargeCallback Listener interface to charge quota cost for the operation.
+   * @return A future that would contain information about whether the replicateBlob succeeded or not, eventually.
+   */
+  Future<Void> replicateBlob(String blobId, String serviceId, DataNodeId sourceDataNode, Callback<Void> callback,
+      QuotaChargeCallback quotaChargeCallback);
 
   /**
    * Requests for a new metadata blob to be put asynchronously and invokes the {@link Callback} when the request
@@ -170,6 +183,20 @@ public interface Router extends Closeable {
       ReadableStreamChannel channel, PutBlobOptions options) {
     CompletableFuture<String> future = new CompletableFuture<>();
     putBlob(blobProperties, userMetadata, channel, options, CallbackUtils.fromCompletableFuture(future), null);
+    return future;
+  }
+
+  /**
+   * Requests for a blob to be replicated asynchronously and returns a future that will eventually contain information
+   * about whether the request succeeded or not.
+   * @param blobId The ID of the blob to be replicated.
+   * @param serviceId The service ID of the service replicating the blob. This can be null if unknown.
+   * @param sourceDataNode The source {@link DataNodeId} to get the blob from.
+   * @return A future that would contain information about whether the replicateBlob succeeded or not, eventually.
+   */
+  default CompletableFuture<Void> replicateBlob(String blobId, String serviceId, DataNodeId sourceDataNode) {
+    CompletableFuture<Void> future = new CompletableFuture<>();
+    replicateBlob(blobId, serviceId, sourceDataNode, CallbackUtils.fromCompletableFuture(future), null);
     return future;
   }
 

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrRequests.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrRequests.java
@@ -67,6 +67,11 @@ public class VcrRequests extends AmbryRequests {
   }
 
   @Override
+  public void handleReplicateBlobRequest(NetworkRequest request) throws IOException, InterruptedException {
+    throw new UnsupportedOperationException("Request type not supported");
+  }
+
+  @Override
   protected ServerErrorCode validateRequest(PartitionId partition, RequestOrResponseType requestType,
       boolean skipPartitionAvailableCheck) {
     // 1. Check partition is null

--- a/ambry-commons/src/main/java/com/github/ambry/commons/LoggingNotificationSystem.java
+++ b/ambry-commons/src/main/java/com/github/ambry/commons/LoggingNotificationSystem.java
@@ -69,7 +69,14 @@ public class LoggingNotificationSystem implements NotificationSystem {
         ", " + serviceId + ", accountName " + (account == null ? null : account.getName()) + ", accountId" + (
             account == null ? null : account.getId()) + ", containerName " + (container == null ? null
             : container.getName()) + ", containerId " + (container == null ? null : container.getId()));
+  }
 
+  @Override
+  public void onBlobReplicated(String blobId, String serviceId, Account account, Container container) {
+    logger.debug("onBlobReplicated {}", blobId,
+        ", " + serviceId + ", accountName " + (account == null ? null : account.getName()) + ", accountId" + (
+            account == null ? null : account.getId()) + ", containerName " + (container == null ? null
+            : container.getName()) + ", containerId " + (container == null ? null : container.getId()));
   }
 
   @Override

--- a/ambry-commons/src/main/java/com/github/ambry/commons/ServerMetrics.java
+++ b/ambry-commons/src/main/java/com/github/ambry/commons/ServerMetrics.java
@@ -114,6 +114,12 @@ public class ServerMetrics {
   public final Histogram updateBlobTtlSendTimeInMs;
   public final Histogram updateBlobTtlTotalTimeInMs;
 
+  public final Histogram replicateBlobRequestQueueTimeInMs;
+  public final Histogram replicateBlobProcessingTimeInMs;
+  public final Histogram replicateBlobResponseQueueTimeInMs;
+  public final Histogram replicateBlobSendTimeInMs;
+  public final Histogram replicateBlobTotalTimeInMs;
+
   public final Histogram replicaMetadataRequestQueueTimeInMs;
   public final Histogram replicaMetadataRequestProcessingTimeInMs;
   public final Histogram replicaMetadataResponseQueueTimeInMs;
@@ -176,6 +182,7 @@ public class ServerMetrics {
   public final Meter getBlobAllByReplicaRequestRate;
   public final Meter getBlobInfoRequestRate;
   public final Meter deleteBlobRequestRate;
+  public final Meter replicateBlobRequestRate;
   public final Meter undeleteBlobRequestRate;
   public final Meter updateBlobTtlRequestRate;
   public final Meter replicaMetadataRequestRate;
@@ -364,6 +371,15 @@ public class ServerMetrics {
     updateBlobTtlSendTimeInMs = registry.histogram(MetricRegistry.name(requestClass, "UpdateBlobTtlSendTime"));
     updateBlobTtlTotalTimeInMs = registry.histogram(MetricRegistry.name(requestClass, "UpdateBlobTtlTotalTime"));
 
+    replicateBlobRequestQueueTimeInMs =
+        registry.histogram(MetricRegistry.name(requestClass, "ReplicateBlobRequestQueueTime"));
+    replicateBlobProcessingTimeInMs =
+        registry.histogram(MetricRegistry.name(requestClass, "ReplicateBlobProcessingTime"));
+    replicateBlobResponseQueueTimeInMs =
+        registry.histogram(MetricRegistry.name(requestClass, "ReplicateBlobResponseQueueTime"));
+    replicateBlobSendTimeInMs = registry.histogram(MetricRegistry.name(requestClass, "ReplicateBlobSendTime"));
+    replicateBlobTotalTimeInMs = registry.histogram(MetricRegistry.name(requestClass, "ReplicateBlobTotalTime"));
+
     replicaMetadataRequestQueueTimeInMs =
         registry.histogram(MetricRegistry.name(requestClass, "ReplicaMetadataRequestQueueTime"));
     replicaMetadataRequestProcessingTimeInMs =
@@ -470,6 +486,7 @@ public class ServerMetrics {
     deleteBlobRequestRate = registry.meter(MetricRegistry.name(requestClass, "DeleteBlobRequestRate"));
     undeleteBlobRequestRate = registry.meter(MetricRegistry.name(requestClass, "UndeleteBlobRequestRate"));
     updateBlobTtlRequestRate = registry.meter(MetricRegistry.name(requestClass, "UpdateBlobTtlRequestRate"));
+    replicateBlobRequestRate = registry.meter(MetricRegistry.name(requestClass, "ReplicateBlobRequestRate"));
     replicaMetadataRequestRate = registry.meter(MetricRegistry.name(requestClass, "ReplicaMetadataRequestRate"));
     triggerCompactionRequestRate = registry.meter(MetricRegistry.name(requestClass, "TriggerCompactionRequestRate"));
     requestControlRequestRate = registry.meter(MetricRegistry.name(requestClass, "RequestControlRequestRate"));

--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/ValidatingTransformer.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/ValidatingTransformer.java
@@ -88,8 +88,10 @@ public class ValidatingTransformer implements Transformer {
             new PutMessageFormatInputStream(keyInStream, encryptionKey, props, metadata,
                 new ByteBufInputStream(blobData.content(), true), blobData.getSize(), blobData.getBlobType(),
                 msgInfo.getLifeVersion());
+        // Keep the isDeleted same as msgInfo.isDeleted().
+        // For normal replication, the isDeleted message will be filtered out any way.
+        // For on-demand blob replication, we keep the isDeleted flag so we can apply delete message to the Blob.
         MessageInfo transformedMsgInfo = new MessageInfo.Builder(msgInfo).size(transformedStream.getSize())
-            .isDeleted(false)
             .isUndeleted(false)
             .build();
         transformationOutput = new TransformationOutput(new Message(transformedMsgInfo, transformedStream));

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/ReplicateBlobRequest.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/ReplicateBlobRequest.java
@@ -1,0 +1,171 @@
+/**
+ * Copyright 2022 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.protocol;
+
+import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.commons.BlobId;
+import com.github.ambry.utils.Utils;
+import java.io.DataInputStream;
+import java.io.IOException;
+
+
+/**
+ * ReplicateBlob request to replicate one particular blob
+ */
+public class ReplicateBlobRequest extends RequestOrResponse {
+  static final short ReplicateBlob_REQUEST_VERSION_1 = 1;
+  private final static short CURRENT_VERSION = ReplicateBlob_REQUEST_VERSION_1;
+  private final BlobId blobId;
+  private final String sourceHostName;
+  private final int sourceHostPort;
+
+  private static final short Source_Host_Name_Size_In_Bytes = Integer.BYTES;
+  private static final short Source_Host_Port_Size_In_Bytes = Integer.BYTES;
+
+  /**
+   * Constructs {@link ReplicateBlobRequest} in {@link #ReplicateBlob_REQUEST_VERSION_1}
+   * @param correlationId correlationId of the ReplicateBlob request
+   * @param clientId clientId of the ReplicateBlob request
+   * @param blobId blobId of the ReplicateBlob request
+   * @param sourceHostName the name of the source host to get the blob from
+   * @param sourceHostPort the port of the source host to get the blob from
+   */
+  public ReplicateBlobRequest(int correlationId, String clientId, BlobId blobId,
+      String sourceHostName, int sourceHostPort) {
+    this(correlationId, clientId, blobId, sourceHostName, sourceHostPort, CURRENT_VERSION);
+  }
+
+  /**
+   * Constructs {@link ReplicateBlobRequest} in given version.
+   * @param correlationId correlationId of the ReplicateBlob request
+   * @param clientId clientId of the ReplicateBlob request
+   * @param blobId blobId of the ReplicateBlob request
+   * @param sourceHostName the name of the source host to get the blob from
+   * @param sourceHostPort the port of the source host to get the blob from
+   * @param version version of the {@link ReplicateBlobRequest}
+   */
+  public ReplicateBlobRequest(int correlationId, String clientId, BlobId blobId,
+      String sourceHostName, int sourceHostPort, short version) {
+    super(RequestOrResponseType.ReplicateBlobRequest, version, correlationId, clientId);
+    this.blobId = blobId;
+    this.sourceHostName = sourceHostName;
+    this.sourceHostPort = sourceHostPort;
+  }
+
+  /**
+   * Deserialize {@link ReplicateBlobRequest} from a given {@link DataInputStream}.
+   * @param stream The stream that contains the serialized bytes.
+   * @param map The {@link ClusterMap} to help build {@link BlobId}.
+   * @return A deserialized {@link ReplicateBlobRequest}.
+   * @throws IOException Any I/O Errors.
+   */
+  public static ReplicateBlobRequest readFrom(DataInputStream stream, ClusterMap map) throws IOException {
+    Short version = stream.readShort();
+    switch (version) {
+      case ReplicateBlob_REQUEST_VERSION_1:
+        return ReplicateBlobRequest_V1.readFrom(stream, map);
+      default:
+        throw new IllegalStateException("Unknown ReplicateBlob Request version " + version);
+    }
+  }
+
+  /**
+   * Construct the bufferToSend to serialize the request
+   */
+  @Override
+  protected void prepareBuffer() {
+    super.prepareBuffer();
+    bufferToSend.writeBytes(blobId.toBytes());
+    bufferToSend.writeInt(sourceHostName.length());
+    bufferToSend.writeBytes(sourceHostName.getBytes());
+    bufferToSend.writeInt(sourceHostPort);
+  }
+
+  /**
+   * @return the {@link BlobId} associated with the blob in this request.
+   */
+  public BlobId getBlobId() {
+    return blobId;
+  }
+
+  /**
+   * @return the account Id.
+   */
+  public short getAccountId() {
+    return blobId.getAccountId();
+  }
+
+  /**
+   * @return the container Id.
+   */
+  public short getContainerId() {
+    return blobId.getContainerId();
+  }
+
+  /**
+   * @return the name of the source host from where to get the Blob.
+   */
+  public String getSourceHostName() {
+    return sourceHostName;
+  }
+
+  /**
+   * @return the port of the source host from where to get the Blob.
+   */
+  public int getSourceHostPort() {
+    return sourceHostPort;
+  }
+
+  /**
+   * @return the size of the serialized ReplicateBlobRequest stream
+   */
+  @Override
+  public long sizeInBytes() {
+    // header + blobId + sourceHostName + sourceHostPort
+    long sizeInBytes = super.sizeInBytes() + blobId.sizeInBytes();
+    sizeInBytes += Source_Host_Name_Size_In_Bytes + sourceHostName.length();
+    sizeInBytes += Source_Host_Port_Size_In_Bytes;
+    return sizeInBytes;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("ReplicateBlobRequest[");
+    sb.append("BlobID=").append(blobId);
+    sb.append(", ").append("PartitionId=").append(blobId.getPartition());
+    sb.append(", ").append("ClientId=").append(clientId);
+    sb.append(", ").append("CorrelationId=").append(correlationId);
+    sb.append(", ").append("AccountId=").append(blobId.getAccountId());
+    sb.append(", ").append("ContainerId=").append(blobId.getContainerId());
+    sb.append(", ").append("SourceHostName=").append(sourceHostName);
+    sb.append(", ").append("SourceHostPort=").append(sourceHostPort);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  /**
+   * Class to read protocol version 1 ReplicateBlobRequest from the stream.
+   */
+  private static class ReplicateBlobRequest_V1 {
+    static ReplicateBlobRequest readFrom(DataInputStream stream, ClusterMap map) throws IOException {
+      int correlationId = stream.readInt();
+      String clientId = Utils.readIntString(stream);
+      BlobId id = new BlobId(stream, map);
+      String sourceHostName = Utils.readIntString(stream);
+      int sourceHostPort = stream.readInt();
+      return new ReplicateBlobRequest(correlationId, clientId, id, sourceHostName, sourceHostPort, ReplicateBlob_REQUEST_VERSION_1);
+    }
+  }
+}

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/ReplicateBlobResponse.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/ReplicateBlobResponse.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2022 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.protocol;
+
+import com.github.ambry.server.ServerErrorCode;
+import com.github.ambry.utils.Utils;
+import java.io.DataInputStream;
+import java.io.IOException;
+
+
+/**
+ * Response of ReplicateBlob request
+ */
+public class ReplicateBlobResponse extends Response {
+  private static final short ReplicateBlob_Response_Version_V1 = 1;
+
+  public ReplicateBlobResponse(int correlationId, String clientId, ServerErrorCode error) {
+    super(RequestOrResponseType.ReplicateBlobResponse, ReplicateBlob_Response_Version_V1, correlationId, clientId, error);
+  }
+
+  /**
+   * Deserialize {@link ReplicateBlobResponse} from a given {@link DataInputStream}.
+   * @param stream The stream that contains the serialized bytes.
+   * @return A deserialized {@link ReplicateBlobResponse}.
+   * @throws IOException Any I/O Errors.
+   */
+  public static ReplicateBlobResponse readFrom(DataInputStream stream) throws IOException {
+    RequestOrResponseType type = RequestOrResponseType.values()[stream.readShort()];
+    if (type != RequestOrResponseType.ReplicateBlobResponse) {
+      throw new IllegalArgumentException("The type of request response is not compatible");
+    }
+    short versionId = stream.readShort();
+    int correlationId = stream.readInt();
+    String clientId = Utils.readIntString(stream);
+    ServerErrorCode error = ServerErrorCode.values()[stream.readShort()];
+    if (versionId != ReplicateBlob_Response_Version_V1) {
+      throw new IllegalArgumentException("Unexpected ReplicateBlobResponse version " + versionId);
+    }
+    return new ReplicateBlobResponse(correlationId, clientId, error);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("ReplicateBlobResponse[");
+    sb.append("ServerErrorCode=").append(getError());
+    sb.append("]");
+    return sb.toString();
+  }
+}

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/RequestOrResponseType.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/RequestOrResponseType.java
@@ -31,5 +31,7 @@ public enum RequestOrResponseType {
   AdminRequest,
   AdminResponse,
   UndeleteRequest,
-  UndeleteResponse
+  UndeleteResponse,
+  ReplicateBlobRequest,
+  ReplicateBlobResponse,
 }

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -1135,9 +1135,10 @@ public class ReplicaThread implements Runnable {
                   remoteReplicaInfo.getLocalReplicaId().getMountPath());
 
               MessageFormatWriteSet writeset;
+              // set keepDeletedExpired to false. MessageSievingInputStream will filter out deleted and expired messages.
               MessageSievingInputStream validMessageDetectionInputStream =
                   new MessageSievingInputStream(getResponse.getInputStream(), messageInfoList,
-                      Collections.singletonList(transformer), metricRegistry);
+                      Collections.singletonList(transformer), metricRegistry, false);
               if (validMessageDetectionInputStream.hasInvalidMessages()) {
                 replicationMetrics.incrementInvalidMessageError(partitionResponseInfo.getPartition());
                 logger.error("Out of {} messages, {} invalid messages were found in message stream from {}",

--- a/ambry-replication/src/test/java/com/github/ambry/replication/MockConnectionPool.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/MockConnectionPool.java
@@ -63,11 +63,13 @@ public class MockConnectionPool implements ConnectionPool {
   private final Map<DataNodeId, MockHost> hosts;
   private final ClusterMap clusterMap;
   private final int maxEntriesToReturn;
+  private Map<DataNodeId, MockConnection> connections;
 
   public MockConnectionPool(Map<DataNodeId, MockHost> hosts, ClusterMap clusterMap, int maxEntriesToReturn) {
     this.hosts = hosts;
     this.clusterMap = clusterMap;
     this.maxEntriesToReturn = maxEntriesToReturn;
+    this.connections = new HashMap<DataNodeId, MockConnection>();
   }
 
   @Override
@@ -82,7 +84,10 @@ public class MockConnectionPool implements ConnectionPool {
   public ConnectedChannel checkOutConnection(String host, Port port, long timeout) {
     DataNodeId dataNodeId = clusterMap.getDataNodeId(host, port.getPort());
     MockHost hostObj = hosts.get(dataNodeId);
-    return new MockConnection(hostObj, maxEntriesToReturn);
+    if (!connections.containsKey(dataNodeId)) {
+      connections.put(dataNodeId, new MockConnection(hostObj, maxEntriesToReturn));
+    }
+    return connections.get(dataNodeId);
   }
 
   @Override

--- a/ambry-replication/src/test/java/com/github/ambry/replication/MockHost.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/MockHost.java
@@ -46,7 +46,7 @@ public class MockHost {
   final Map<PartitionId, List<MessageInfo>> infosByPartition = new HashMap<>();
   final Map<PartitionId, List<ByteBuffer>> buffersByPartition = new HashMap<>();
 
-  MockHost(DataNodeId dataNodeId, ClusterMap clusterMap) {
+  public MockHost(DataNodeId dataNodeId, ClusterMap clusterMap) {
     this.dataNodeId = dataNodeId;
     this.clusterMap = clusterMap;
   }

--- a/ambry-router/src/main/java/com/github/ambry/router/ReplicateBlobManager.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/ReplicateBlobManager.java
@@ -1,0 +1,210 @@
+/**
+ * Copyright 2022 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.router;
+
+import com.github.ambry.account.Account;
+import com.github.ambry.account.AccountService;
+import com.github.ambry.account.Container;
+import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.clustermap.DataNodeId;
+import com.github.ambry.commons.BlobId;
+import com.github.ambry.commons.Callback;
+import com.github.ambry.commons.ResponseHandler;
+import com.github.ambry.config.RouterConfig;
+import com.github.ambry.network.RequestInfo;
+import com.github.ambry.network.ResponseInfo;
+import com.github.ambry.notification.NotificationSystem;
+import com.github.ambry.protocol.ReplicateBlobRequest;
+import com.github.ambry.protocol.ReplicateBlobResponse;
+import com.github.ambry.quota.QuotaChargeCallback;
+import com.github.ambry.utils.Pair;
+import com.github.ambry.utils.Time;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Handles {@link ReplicateBlobOperation}. A {@code ReplicateBlobManager} keeps track of all the ReplicateBlob
+ * operations that are assigned to it, and manages their states and life cycles.
+ */
+class ReplicateBlobManager {
+  private final Set<ReplicateBlobOperation> replicateBlobOperations;
+  private final HashMap<Integer, ReplicateBlobOperation> correlationIdToReplicateBlobOperation;
+  private final NotificationSystem notificationSystem;
+  private final Time time;
+  private final ResponseHandler responseHandler;
+  private final AccountService accountService;
+  private final NonBlockingRouterMetrics routerMetrics;
+  private final ClusterMap clusterMap;
+  private final RouterConfig routerConfig;
+
+  private static final Logger logger = LoggerFactory.getLogger(ReplicateBlobManager.class);
+
+  private final RequestRegistrationCallback<ReplicateBlobOperation> requestRegistrationCallback;
+
+  /**
+   * Creates a ReplicateBlobManager.
+   * @param clusterMap The {@link ClusterMap} of the cluster.
+   * @param responseHandler The {@link ResponseHandler} used to notify failures for failure detection.
+   * @param accountService The {@link AccountService} used for account/container id and name mapping.
+   * @param notificationSystem The {@link NotificationSystem} used for notifying blob replication.
+   * @param routerConfig The {@link RouterConfig} containing the configs for the ReplicateBlobManager.
+   * @param routerMetrics The {@link NonBlockingRouterMetrics} to be used for reporting metrics.
+   * @param time The {@link Time} instance to use.
+   */
+  ReplicateBlobManager(ClusterMap clusterMap, ResponseHandler responseHandler, AccountService accountService,
+      NotificationSystem notificationSystem, RouterConfig routerConfig, NonBlockingRouterMetrics routerMetrics,
+      Time time) {
+    this.clusterMap = clusterMap;
+    this.responseHandler = responseHandler;
+    this.accountService = accountService;
+    this.notificationSystem = notificationSystem;
+    this.routerConfig = routerConfig;
+    this.routerMetrics = routerMetrics;
+    this.time = time;
+    replicateBlobOperations = ConcurrentHashMap.newKeySet();
+    correlationIdToReplicateBlobOperation = new HashMap<>();
+    requestRegistrationCallback = new RequestRegistrationCallback<>(correlationIdToReplicateBlobOperation);
+  }
+
+  /**
+   * Submits a {@link ReplicateBlobOperation} to this {@code ReplicateBlobManager}.
+   * @param blobIdStr The original blobId string for a {@link BlobId}.
+   * @param serviceId The service ID of the service replicating the blob. This can be null if unknown.
+   * @param sourceDataNode The source {@link DataNodeId} to get the blob from.
+   * @param futureResult The {@link FutureResult} that will contain the result eventually and exception if any.
+   * @param callback The {@link Callback} that will be called on completion of the request.
+   * @param quotaChargeCallback Listener interface to charge quota cost for the operation.
+   * @throws RouterException if blob replication failed.
+   */
+  void submitReplicateBlobOperation(String blobIdStr, String serviceId, DataNodeId sourceDataNode,
+      FutureResult<Void> futureResult, Callback<Void> callback, QuotaChargeCallback quotaChargeCallback)
+      throws RouterException {
+    final BlobId blobId = RouterUtils.getBlobIdFromString(blobIdStr, clusterMap);
+    ReplicateBlobOperation replicateBlobOperation =
+        new ReplicateBlobOperation(clusterMap, routerConfig, routerMetrics, responseHandler, blobId, serviceId,
+            sourceDataNode, callback, time,
+            futureResult, quotaChargeCallback);
+    replicateBlobOperations.add(replicateBlobOperation);
+  }
+
+  /**
+   * Polls all ReplicateBlob operations and populates a list of {@link RequestInfo} to be sent to data nodes in order to
+   * complete ReplicateBlob operations.
+   * @param requestsToSend list to be filled with the requests created.
+   * @param requestsToDrop list to be filled with the requests to drop.
+   */
+  public void poll(List<RequestInfo> requestsToSend, Set<Integer> requestsToDrop) {
+    long startTime = time.milliseconds();
+    requestRegistrationCallback.setRequestsToSend(requestsToSend);
+    requestRegistrationCallback.setRequestsToDrop(requestsToDrop);
+    for (ReplicateBlobOperation op : replicateBlobOperations) {
+      boolean exceptionEncountered = false;
+      try {
+        op.poll(requestRegistrationCallback);
+      } catch (Exception e) {
+        exceptionEncountered = true;
+        op.setOperationException(new RouterException("ReplicateBlob poll encountered unexpected error", e,
+            RouterErrorCode.UnexpectedInternalError));
+      }
+      if (exceptionEncountered || op.isOperationComplete()) {
+        if (replicateBlobOperations.remove(op)) {
+          // In order to ensure that an operation is completed only once, call onComplete() only at the place where the
+          // operation actually gets removed from the set of operations. See comment within close().
+          onComplete(op);
+        }
+      }
+    }
+    routerMetrics.replicateBlobManagerPollTimeMs.update(time.milliseconds() - startTime);
+  }
+
+  /**
+   * Handles responses received for each of the {@link ReplicateBlobOperation} within this ReplicateBlob manager.
+   * @param responseInfo the {@link ResponseInfo} containing the response.
+   */
+  void handleResponse(ResponseInfo responseInfo) {
+    long startTime = time.milliseconds();
+    ReplicateBlobResponse replicateBlobResponse =
+        RouterUtils.extractResponseAndNotifyResponseHandler(responseHandler, routerMetrics, responseInfo,
+            ReplicateBlobResponse::readFrom, ReplicateBlobResponse::getError);
+    RequestInfo routerRequestInfo = responseInfo.getRequestInfo();
+    int correlationId = ((ReplicateBlobRequest) routerRequestInfo.getRequest()).getCorrelationId();
+    ReplicateBlobOperation replicateBlobOperation = correlationIdToReplicateBlobOperation.remove(correlationId);
+    // If it is still an active operation, hand over the response. Otherwise, ignore.
+    if (replicateBlobOperations.contains(replicateBlobOperation)) {
+      boolean exceptionEncountered = false;
+      try {
+        replicateBlobOperation.handleResponse(responseInfo, replicateBlobResponse);
+      } catch (Exception e) {
+        exceptionEncountered = true;
+        replicateBlobOperation.setOperationException(
+            new RouterException("ReplicateBlob handleResponse encountered unexpected error", e,
+                RouterErrorCode.UnexpectedInternalError));
+      }
+      if (exceptionEncountered || replicateBlobOperation.isOperationComplete()) {
+        if (replicateBlobOperations.remove(replicateBlobOperation)) {
+          onComplete(replicateBlobOperation);
+        }
+      }
+      routerMetrics.replicateBlobManagerHandleResponseTimeMs.update(time.milliseconds() - startTime);
+    } else {
+      routerMetrics.ignoredResponseCount.inc();
+    }
+  }
+
+  /**
+   * Called when the ReplicateBlob operation is completed. The {@code ReplicateBlobManager} also finishes the ReplicateBlob operation
+   * by performing the callback and notification.
+   * @param op The {@link ReplicateBlobOperation} that has completed.
+   */
+  void onComplete(ReplicateBlobOperation op) {
+    Exception e = op.getOperationException();
+    if (e == null) {
+      BlobId blobId = op.getBlobId();
+      Pair<Account, Container> accountContainer =
+          RouterUtils.getAccountContainer(accountService, blobId.getAccountId(), blobId.getContainerId());
+      notificationSystem.onBlobReplicated(blobId.getID(), op.getServiceId(), accountContainer.getFirst(),
+          accountContainer.getSecond());
+    } else {
+      routerMetrics.onReplicateBlobError(e);
+    }
+    routerMetrics.operationDequeuingRate.mark();
+    routerMetrics.replicateBlobOperationLatencyMs.update(time.milliseconds() - op.getSubmissionTimeMs());
+    NonBlockingRouter.completeOperation(op.getFutureResult(), op.getCallback(), op.getOperationResult(),
+        op.getOperationException());
+  }
+
+  /**
+   * Closes the {@code ReplicateBlobManager}. A {@code ReplicateBlobManager} can be closed for only once. Any further close action
+   * will have no effect.
+   */
+  void close() {
+    for (ReplicateBlobOperation op : replicateBlobOperations) {
+      // There is a rare scenario where the operation gets removed from this set and gets completed concurrently by
+      // the RequestResponseHandler thread when it is in poll() or handleResponse(). In order to avoid the completion
+      // from happening twice, complete it here only if the remove was successful.
+      if (replicateBlobOperations.remove(op)) {
+        Exception e = new RouterException("Aborted operation because Router is closed.", RouterErrorCode.RouterClosed);
+        routerMetrics.operationDequeuingRate.mark();
+        routerMetrics.operationAbortCount.inc();
+        routerMetrics.onReplicateBlobError(e);
+        NonBlockingRouter.completeOperation(op.getFutureResult(), op.getCallback(), null, e);
+      }
+    }
+  }
+}

--- a/ambry-router/src/main/java/com/github/ambry/router/ReplicateBlobOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/ReplicateBlobOperation.java
@@ -1,0 +1,484 @@
+/**
+ * Copyright 2022 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.router;
+
+import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.clustermap.DataNodeId;
+import com.github.ambry.clustermap.ReplicaId;
+import com.github.ambry.commons.BlobId;
+import com.github.ambry.commons.Callback;
+import com.github.ambry.commons.ResponseHandler;
+import com.github.ambry.config.RouterConfig;
+import com.github.ambry.network.Port;
+import com.github.ambry.network.RequestInfo;
+import com.github.ambry.network.ResponseInfo;
+import com.github.ambry.protocol.ReplicateBlobRequest;
+import com.github.ambry.protocol.ReplicateBlobResponse;
+import com.github.ambry.quota.QuotaChargeCallback;
+import com.github.ambry.quota.QuotaException;
+import com.github.ambry.quota.QuotaUtils;
+import com.github.ambry.server.ServerErrorCode;
+import com.github.ambry.utils.Time;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * This class manages the internal state of a {@code ReplicateBlobOperation} during its life cycle. A {@code ReplicateBlobOperation}
+ * can be issued to two types of blobs.
+ */
+class ReplicateBlobOperation {
+  private static final Logger logger = LoggerFactory.getLogger(ReplicateBlobOperation.class);
+  //Operation arguments
+  private final RouterConfig routerConfig;
+  private final ResponseHandler responseHandler;
+  private final BlobId blobId;
+  private final String serviceId;
+  private final DataNodeId sourceDataNode;
+  private final FutureResult<Void> futureResult;
+  private final Callback<Void> callback;
+  private final Time time;
+  private final NonBlockingRouterMetrics routerMetrics;
+  private final long submissionTimeMs;
+
+  // The operation tracker that tracks the state of this operation.
+  private final OperationTracker operationTracker;
+  // A map used to find inflight requests using a correlation id.
+  private final Map<Integer, RequestInfo> ReplicateBlobRequestInfos;
+  // The result of this operation to be set into FutureResult.
+  private final Void operationResult = null;
+  private final QuotaChargeCallback quotaChargeCallback;
+  // the cause for failure of this operation. This will be set if and when the operation encounters an irrecoverable
+  // failure.
+  private final AtomicReference<Exception> operationException = new AtomicReference<Exception>();
+  // Quota charger for this operation.
+  private final OperationQuotaCharger operationQuotaCharger;
+  // Denotes whether the operation is complete.
+  private boolean operationCompleted = false;
+
+  /**
+   * Instantiates a {@link ReplicateBlobOperation}.
+   * @param clusterMap the {@link ClusterMap} to use.
+   * @param routerConfig The {@link RouterConfig} that contains router-level configurations.
+   * @param routerMetrics The {@link NonBlockingRouterMetrics} to record all router-related metrics.
+   * @param responsehandler The {@link ResponseHandler} used to notify failures for failure detection.
+   * @param blobId The {@link BlobId} that is to be replicated by this {@code ReplicateBlobOperation}.
+   * @param serviceId The service ID of the service replicating the blob. This can be null if unknown.
+   * @param sourceDataNode The source {@link DataNodeId} to get the blob from.
+   * @param callback The {@link Callback} that is supplied by the caller.
+   * @param time A {@link Time} reference.
+   * @param futureResult The {@link FutureResult} that is returned to the caller.
+   * @param quotaChargeCallback The {@link QuotaChargeCallback} object.
+   */
+  ReplicateBlobOperation(ClusterMap clusterMap, RouterConfig routerConfig, NonBlockingRouterMetrics routerMetrics,
+      ResponseHandler responsehandler, BlobId blobId, String serviceId,
+      DataNodeId sourceDataNode, Callback<Void> callback, Time time,
+      FutureResult<Void> futureResult, QuotaChargeCallback quotaChargeCallback) {
+    this.submissionTimeMs = time.milliseconds();
+    this.routerConfig = routerConfig;
+    this.routerMetrics = routerMetrics;
+    this.responseHandler = responsehandler;
+    this.blobId = blobId;
+    this.serviceId = serviceId;
+    this.sourceDataNode = sourceDataNode;
+    this.futureResult = futureResult;
+    this.callback = callback;
+    this.time = time;
+    this.quotaChargeCallback = quotaChargeCallback;
+    this.ReplicateBlobRequestInfos = new LinkedHashMap<>();
+    byte blobDcId = blobId.getDatacenterId();
+    String originatingDcName = clusterMap.getDatacenterName(blobDcId);
+    this.operationTracker =
+        new SimpleOperationTracker(routerConfig, RouterOperation.ReplicateBlobOperation, blobId.getPartition(),
+            originatingDcName, false, routerMetrics, blobId);
+    operationQuotaCharger =
+        new OperationQuotaCharger(quotaChargeCallback, blobId, this.getClass().getSimpleName(), routerMetrics);
+  }
+
+  /**
+   * Gets a list of {@link ReplicateBlobRequest} for sending to replicas.
+   * @param requestRegistrationCallback the {@link RequestRegistrationCallback} to call for every request
+   *                            that gets created as part of this poll operation.
+   */
+  void poll(RequestRegistrationCallback<ReplicateBlobOperation> requestRegistrationCallback) {
+    cleanupExpiredInflightRequests(requestRegistrationCallback);
+    checkAndMaybeComplete();
+    if (!isOperationComplete()) {
+      fetchRequests(requestRegistrationCallback);
+    }
+  }
+
+  /**
+   * Fetch {@link ReplicateBlobRequest}s to send for the operation.
+   * @param requestRegistrationCallback the {@link RequestRegistrationCallback} to register requests to send.
+   */
+  private void fetchRequests(RequestRegistrationCallback<ReplicateBlobOperation> requestRegistrationCallback) {
+    Iterator<ReplicaId> replicaIterator = operationTracker.getReplicaIterator();
+    while (replicaIterator.hasNext()) {
+      ReplicaId replica = replicaIterator.next();
+      String hostname = replica.getDataNodeId().getHostname();
+      Port port = RouterUtils.getPortToConnectTo(replica, routerConfig.routerEnableHttp2NetworkClient);
+      ReplicateBlobRequest replicateBlobRequest = createReplicateBlobRequest();
+      RequestInfo requestInfo =
+          new RequestInfo(hostname, port, replicateBlobRequest, replica, operationQuotaCharger, time.milliseconds(),
+              routerConfig.routerRequestNetworkTimeoutMs, routerConfig.routerRequestTimeoutMs);
+      ReplicateBlobRequestInfos.put(replicateBlobRequest.getCorrelationId(), requestInfo);
+      requestRegistrationCallback.registerRequestToSend(this, requestInfo);
+      replicaIterator.remove();
+      if (RouterUtils.isRemoteReplica(routerConfig, replica)) {
+        logger.trace("Making request with correlationId {} to a remote replica {} in {} ",
+            replicateBlobRequest.getCorrelationId(), replica.getDataNodeId(), replica.getDataNodeId().getDatacenterName());
+        routerMetrics.crossColoRequestCount.inc();
+      } else {
+        logger.trace("Making request with correlationId {} to a local replica {} ", replicateBlobRequest.getCorrelationId(),
+            replica.getDataNodeId());
+      }
+      routerMetrics.getDataNodeBasedMetrics(replica.getDataNodeId()).replicateBlobRequestRate.mark();
+    }
+  }
+
+  /**
+   * Create a {@link ReplicateBlobRequest} for sending to a replica.
+   * @return The ReplicateBlobRequest.
+   */
+  private ReplicateBlobRequest createReplicateBlobRequest() {
+    // ON_DEMAND_REPLICATION_TODO only support http2 port
+    return new ReplicateBlobRequest(NonBlockingRouter.correlationIdGenerator.incrementAndGet(), routerConfig.routerHostname,
+        blobId, sourceDataNode.getHostname(), sourceDataNode.getHttp2Port());
+  }
+
+  /**
+   * Handles a response for a ReplicateBlob operation. It determines whether the request was successful,
+   * updates operation tracker, and notifies the response handler for failure detection.
+   * can be different cases during handling a response. For the same ReplicateBlob operation, it is possible
+   * that different {@link ServerErrorCode} are received from different replicas. These error codes
+   * are eventually resolved to a single {@link RouterErrorCode}.
+   * @param responseInfo The {@link ResponseInfo} to be handled.
+   * @param ReplicateBlobResponse The {@link ReplicateBlobResponse} associated with this response.
+   */
+  void handleResponse(ResponseInfo responseInfo, ReplicateBlobResponse ReplicateBlobResponse) {
+    ReplicateBlobRequest ReplicateBlobRequest = (ReplicateBlobRequest) responseInfo.getRequestInfo().getRequest();
+    RequestInfo ReplicateBlobRequestInfo = ReplicateBlobRequestInfos.remove(ReplicateBlobRequest.getCorrelationId());
+    // ReplicateBlobRequestInfo can be null if this request was timed out before this response is received. No
+    // metric is updated here, as corresponding metrics have been updated when the request was timed out.
+    if (ReplicateBlobRequestInfo == null) {
+      return;
+    }
+    ReplicaId replica = ReplicateBlobRequestInfo.getReplicaId();
+    if (responseInfo.isQuotaRejected()) {
+      processQuotaRejectedResponse(ReplicateBlobRequest.getCorrelationId(), replica);
+      return;
+    }
+    // Track the over all time taken for the response since the creation of the request.
+    long requestLatencyMs = time.milliseconds() - ReplicateBlobRequestInfo.getRequestCreateTime();
+    routerMetrics.routerRequestLatencyMs.update(requestLatencyMs);
+    routerMetrics.getDataNodeBasedMetrics(replica.getDataNodeId()).replicateBlobRequestLatencyMs.update(requestLatencyMs);
+    // Check the error code from NetworkClient.
+    if (responseInfo.getError() != null) {
+      logger.trace("ReplicateBlobRequest with response correlationId {} timed out for replica {} ",
+          ReplicateBlobRequest.getCorrelationId(), replica.getDataNodeId());
+      onErrorResponse(replica, new RouterException(
+          "Operation to ReplicateBlob " + blobId + " timed out because of " + responseInfo.getError() + " at DataNode "
+              + responseInfo.getDataNode(), RouterErrorCode.OperationTimedOut));
+    } else {
+      if (ReplicateBlobResponse == null) {
+        logger.trace(
+            "ReplicateBlobRequest with response correlationId {} received UnexpectedInternalError on response deserialization for replica {} ",
+            ReplicateBlobRequest.getCorrelationId(), replica.getDataNodeId());
+        onErrorResponse(replica, new RouterException("Response deserialization received an unexpected error",
+            RouterErrorCode.UnexpectedInternalError));
+      } else {
+        // The true case below should not really happen. This means a response has been received
+        // not for its original request. We will immediately fail this operation.
+        if (ReplicateBlobResponse.getCorrelationId() != ReplicateBlobRequest.getCorrelationId()) {
+          logger.error(
+              "The correlation id in the ReplicateBlobResponse {} is not the same as the correlation id in the associated ReplicateBlobRequest: {}",
+              ReplicateBlobResponse.getCorrelationId(), ReplicateBlobRequest.getCorrelationId());
+          routerMetrics.unknownReplicaResponseError.inc();
+          onErrorResponse(replica,
+              new RouterException("Received wrong response that is not for the corresponding request.",
+                  RouterErrorCode.UnexpectedInternalError));
+        } else {
+          ServerErrorCode serverError = ReplicateBlobResponse.getError();
+          if (serverError == ServerErrorCode.No_Error || serverError == ServerErrorCode.Blob_Already_Exists) {
+            operationTracker.onResponse(replica, TrackedRequestFinalState.SUCCESS);
+            if (RouterUtils.isRemoteReplica(routerConfig, replica)) {
+              logger.trace("Cross colo request successful for remote replica {} in {} ", replica.getDataNodeId(),
+                  replica.getDataNodeId().getDatacenterName());
+              routerMetrics.crossColoSuccessCount.inc();
+            }
+          } else if (serverError == ServerErrorCode.Disk_Unavailable) {
+            logger.trace("Replica {} returned Disk_Unavailable for a ReplicateBlob request with correlationId : {} ",
+                replica.getDataNodeId(), ReplicateBlobRequest.getCorrelationId());
+            operationTracker.onResponse(replica, TrackedRequestFinalState.DISK_DOWN);
+            setOperationException(
+                new RouterException("Server returned: " + serverError, RouterErrorCode.AmbryUnavailable));
+            routerMetrics.routerRequestErrorCount.inc();
+            routerMetrics.getDataNodeBasedMetrics(replica.getDataNodeId()).replicateBlobRequestErrorCount.inc();
+          } else {
+            logger.trace("Replica {} returned error {} for a ReplicateBlob request with response correlationId : {} ",
+                replica.getDataNodeId(), serverError, ReplicateBlobRequest.getCorrelationId());
+            RouterErrorCode routerErrorCode = processServerError(serverError);
+            if (serverError == ServerErrorCode.Blob_Authorization_Failure) {
+              // this is a successful response and one that completes the operation regardless of whether the
+              // success target has been reached or not.
+              operationCompleted = true;
+            }
+            // any server error code that is not equal to ServerErrorCode.No_Error, the onErrorResponse should be invoked
+            onErrorResponse(replica, new RouterException("Server returned: " + serverError, routerErrorCode));
+          }
+        }
+      }
+    }
+    checkAndMaybeComplete();
+  }
+
+  /**
+   * Process response if it was rejected due to quota compliance.
+   * @param correlationId correlation id of the request.
+   * @param replicaId {@link ReplicaId} of the request.
+   */
+  private void processQuotaRejectedResponse(int correlationId, ReplicaId replicaId) {
+    logger.trace("ReplicateBlobRequest with response correlationId {} was rejected because quota was exceeded.",
+        correlationId);
+    onErrorResponse(replicaId, new RouterException("QuotaExceeded", RouterErrorCode.TooManyRequests), false);
+    checkAndMaybeComplete();
+  }
+
+  /**
+   * Goes through the inflight request list of this {@code ReplicateBlobOperation} and remove those that
+   * have been timed out.
+   * @param requestRegistrationCallback The callback to use to notify the networking layer of dropped requests.
+   */
+  private void cleanupExpiredInflightRequests(
+      RequestRegistrationCallback<ReplicateBlobOperation> requestRegistrationCallback) {
+    Iterator<Map.Entry<Integer, RequestInfo>> itr = ReplicateBlobRequestInfos.entrySet().iterator();
+    while (itr.hasNext()) {
+      Map.Entry<Integer, RequestInfo> entry = itr.next();
+      int correlationId = entry.getKey();
+      RequestInfo requestInfo = entry.getValue();
+      // If request times out due to no response from server or due to being stuck in router itself (due to bandwidth
+      // throttling, etc) for long time, drop the request.
+      long currentTimeInMs = time.milliseconds();
+      RouterUtils.RouterRequestExpiryReason routerRequestExpiryReason =
+          RouterUtils.isRequestExpired(requestInfo, currentTimeInMs);
+      if (routerRequestExpiryReason != RouterUtils.RouterRequestExpiryReason.NO_TIMEOUT) {
+        itr.remove();
+        logger.trace("ReplicateBlob Request with correlationId {} in flight has expired for replica {} due to {}",
+            correlationId, requestInfo.getReplicaId().getDataNodeId(), routerRequestExpiryReason.name());
+        // Do not notify this as a failure to the response handler, as this timeout could simply be due to
+        // connection unavailability. If there is indeed a network error, the NetworkClient will provide an error
+        // response and the response handler will be notified accordingly.
+        onErrorResponse(requestInfo.getReplicaId(),
+            RouterUtils.buildTimeoutException(correlationId, requestInfo.getReplicaId().getDataNodeId(), blobId));
+        requestRegistrationCallback.registerRequestToDrop(correlationId);
+      } else {
+        // Note: Even though the requests are ordered by correlation id and their creation time, we cannot break out of
+        // the while loop here. This is because time outs for all requests may not be equal now.
+
+        // For example, request 1 in the map may have been assigned high time out since it might be sent at a
+        // time when the load is high and request 2 may have been assigned lower time out value since the load might have
+        // decreased by the time it is sent out. In this case, we should continue iterating the loop and clean up
+        // request 2 in the map.
+
+        // The cost of iterating all entries should be okay since the map contains outstanding requests whose number
+        // should be small. The maximum outstanding requests possible would be equal to the operation parallelism value
+        // and may be few more if adaptive operation tracker is used.
+      }
+    }
+  }
+
+  /**
+   * Processes {@link ServerErrorCode} received from {@code replica}. This method maps a {@link ServerErrorCode}
+   * to a {@link RouterErrorCode}.
+   * @param serverErrorCode The ServerErrorCode received from the replica.
+   * @return the {@link RouterErrorCode} mapped from server error code.
+   */
+  private RouterErrorCode processServerError(ServerErrorCode serverErrorCode) {
+    switch (serverErrorCode) {
+      case Blob_Authorization_Failure:
+        return RouterErrorCode.BlobAuthorizationFailure;
+      case Blob_Expired:
+        return RouterErrorCode.BlobExpired;
+      case Blob_Not_Found:
+        return RouterErrorCode.BlobDoesNotExist;
+      case Disk_Unavailable:
+      case Replica_Unavailable:
+        return RouterErrorCode.AmbryUnavailable;
+      default:
+        return RouterErrorCode.UnexpectedInternalError;
+    }
+  }
+
+  /**
+   * Perform the necessary actions when a request to a replica fails.
+   * @param replicaId the {@link ReplicaId} associated with the failed response.
+   * @param exception the {@link RouterException} associated with the failed response.
+   */
+  private void onErrorResponse(ReplicaId replicaId, RouterException exception) {
+    onErrorResponse(replicaId, exception, true);
+  }
+
+  /**
+   * Perform the necessary actions when a request to a replica fails.
+   * @param replicaId the {@link ReplicaId} associated with the failed response.
+   * @param exception the {@link RouterException} associated with the failed response.
+   * @param updateDataNodeMetrics {@code true} if data node metrics should be updated. {@code false} otherwise.
+   */
+  private void onErrorResponse(ReplicaId replicaId, RouterException exception, boolean updateDataNodeMetrics) {
+    operationTracker.onResponse(replicaId,
+        TrackedRequestFinalState.fromRouterErrorCodeToFinalState(exception.getErrorCode()));
+    setOperationException(exception);
+    routerMetrics.routerRequestErrorCount.inc();
+    if (updateDataNodeMetrics) {
+      routerMetrics.getDataNodeBasedMetrics(replicaId.getDataNodeId()).replicateBlobRequestErrorCount.inc();
+    }
+  }
+
+  /**
+   * Completes the {@code ReplicateBlobOperation} if it is done.
+   */
+  private void checkAndMaybeComplete() {
+    // operationCompleted is true if Blob_Authorization_Failure was received.
+    if (operationTracker.isDone() || operationCompleted) {
+      if (operationTracker.hasSucceeded()) {
+        operationException.set(null);
+      } else if (operationTracker.maybeFailedDueToOfflineReplicas()) {
+        operationException.set(
+            new RouterException("ReplicateBlobOperation failed possibly because some replicas are unavailable",
+                RouterErrorCode.AmbryUnavailable));
+      } else if (operationTracker.hasFailedOnNotFound()) {
+        operationException.set(
+            new RouterException("ReplicateBlobOperation failed because of BlobNotFound", RouterErrorCode.BlobDoesNotExist));
+      }
+      if (QuotaUtils.postProcessCharge(quotaChargeCallback)) {
+        try {
+          quotaChargeCallback.checkAndCharge(false, true);
+        } catch (QuotaException quotaException) {
+          logger.error("Exception  {} in quota charge event listener during ReplicateBlob operation",
+              quotaException.toString());
+        }
+      }
+      operationCompleted = true;
+    }
+  }
+
+  /**
+   * Gets the precedence level for a {@link RouterErrorCode}. A precedence level is a relative priority assigned
+   * to a {@link RouterErrorCode}. If a {@link RouterErrorCode} has not been assigned a precedence level, a
+   * {@code Integer.MIN_VALUE} will be returned.
+   * @param routerErrorCode The {@link RouterErrorCode} for which to get its precedence level.
+   * @return The precedence level of the {@link RouterErrorCode}.
+   */
+  private Integer getPrecedenceLevel(RouterErrorCode routerErrorCode) {
+    switch (routerErrorCode) {
+      case BlobAuthorizationFailure:
+        return 1;
+      case BlobExpired:
+        return 2;
+      case TooManyRequests:
+        return 3;
+      case AmbryUnavailable:
+        return 4;
+      case UnexpectedInternalError:
+        return 5;
+      case OperationTimedOut:
+        return 6;
+      case BlobDoesNotExist:
+        return 7;
+      default:
+        return Integer.MIN_VALUE;
+    }
+  }
+
+  /**
+   * Returns whether the operation has completed.
+   * @return whether the operation has completed.
+   */
+  boolean isOperationComplete() {
+    return operationCompleted;
+  }
+
+  /**
+   * Gets {@link BlobId} of this {@code ReplicateBlobOperation}.
+   * @return The {@link BlobId}.
+   */
+  BlobId getBlobId() {
+    return blobId;
+  }
+
+  /**
+   * @return the service ID for the service requesting this ReplicateBlobOperation.
+   */
+  String getServiceId() {
+    return serviceId;
+  }
+
+  /**
+   * Get the {@link FutureResult} for this {@code ReplicateBlobOperation}.
+   * @return The {@link FutureResult}.
+   */
+  FutureResult<Void> getFutureResult() {
+    return futureResult;
+  }
+
+  /**
+   * Gets the {@link Callback} for this {@code ReplicateBlobOperation}.
+   * @return The {@link Callback}.
+   */
+  Callback<Void> getCallback() {
+    return callback;
+  }
+
+  /**
+   * Gets the exception associated with this operation if it failed; null otherwise.
+   * @return exception associated with this operation if it failed; null otherwise.
+   */
+  Exception getOperationException() {
+    return operationException.get();
+  }
+
+  /**
+   * Set the exception associated with this operation.
+   * If operationException exists, compare ErrorCodes of exception and existing operation Exception depending
+   * on precedence level. An ErrorCode with a smaller precedence level overrides an ErrorCode with a larger precedence
+   * level. Update the operationException if necessary.
+   * @param exception the {@link RouterException} to possibly set.
+   */
+  void setOperationException(RouterException exception) {
+    RouterUtils.replaceOperationException(operationException, exception, this::getPrecedenceLevel);
+  }
+
+  /**
+   * Gets the result for this {@code ReplicateBlobOperation}. In a {@link ReplicateBlobOperation}, nothing is returned
+   * to the caller as a result of this operation. Including this {@link Void} result is for consistency
+   * with other operations.
+   * @return Void.
+   */
+  Void getOperationResult() {
+    return operationResult;
+  }
+
+  /**
+   * The time at which this operation was submitted.
+   * @return the time at which the operation was submitted.
+   */
+  long getSubmissionTimeMs() {
+    return submissionTimeMs;
+  }
+}

--- a/ambry-router/src/main/java/com/github/ambry/router/RouterOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/RouterOperation.java
@@ -14,5 +14,5 @@
 package com.github.ambry.router;
 
 public enum RouterOperation {
-  GetBlobOperation, GetBlobInfoOperation, PutOperation, DeleteOperation, TtlUpdateOperation, UndeleteOperation
+  GetBlobOperation, GetBlobInfoOperation, PutOperation, DeleteOperation, TtlUpdateOperation, UndeleteOperation, ReplicateBlobOperation
 }

--- a/ambry-router/src/main/java/com/github/ambry/router/SimpleOperationTracker.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/SimpleOperationTracker.java
@@ -248,6 +248,17 @@ class SimpleOperationTracker implements OperationTracker {
         // Here set the success target to the number of eligible replicas.
         replicaSuccessTarget = eligibleReplicas.size();
         break;
+      case ReplicateBlobOperation:
+        // Replicate one blob. Use the same "success target" and "request parallelism" as PutOperation.
+        // Only difference is for ReplicateBlobOperation, crossColoEnabled is true.
+        eligibleReplicas = getEligibleReplicas(datacenterName, EnumSet.of(ReplicaState.STANDBY, ReplicaState.LEADER));
+        replicaSuccessTarget =
+            routerConfig.routerGetEligibleReplicasByStateEnabled ? Math.max(eligibleReplicas.size() - 1,
+                routerConfig.routerPutSuccessTarget) : routerConfig.routerPutSuccessTarget;
+        replicaParallelism = routerConfig.routerGetEligibleReplicasByStateEnabled ? Math.min(eligibleReplicas.size(),
+            routerConfig.routerPutRequestParallelism) : routerConfig.routerPutRequestParallelism;
+        crossColoEnabled = true;
+        break;
       default:
         throw new IllegalArgumentException("Unsupported operation: " + routerOperation);
     }

--- a/ambry-router/src/test/java/com/github/ambry/router/MockServerLayout.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/MockServerLayout.java
@@ -38,7 +38,8 @@ class MockServerLayout {
     this.mockServers = new HashMap<DataNodeId, MockServer>();
     this.clustermap = clusterMap;
     for (DataNodeId dataNodeId : clusterMap.getDataNodeIds()) {
-      mockServers.put(dataNodeId, new MockServer(clusterMap, dataNodeId.getDatacenterName()));
+      mockServers.put(dataNodeId, new MockServer(clusterMap, dataNodeId.getDatacenterName(),
+          dataNodeId.getHostname(), dataNodeId.getHttp2Port(), this));
     }
   }
 
@@ -48,7 +49,8 @@ class MockServerLayout {
    * @param clusterMap the {@link ClusterMap} used to associate a host and port with a MockServer.
    */
   public void addMockServers(List<? extends DataNodeId> newNodes, ClusterMap clusterMap) {
-    newNodes.forEach(node -> mockServers.putIfAbsent(node, new MockServer(clusterMap, node.getDatacenterName())));
+    newNodes.forEach(node -> mockServers.putIfAbsent(node, new MockServer(clusterMap, node.getDatacenterName(),
+        node.getHostname(), node.getHttp2Port(), this)));
   }
 
   /**

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryServer.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryServer.java
@@ -303,7 +303,8 @@ public class AmbryServer {
         AmbryServerRequests ambryServerRequestsForHttp2 =
             new AmbryServerRequests(storageManager, requestResponseChannel, clusterMap, nodeId, registry, metrics,
                 findTokenHelper, notificationSystem, replicationManager, storeKeyFactory, serverConfig,
-                diskManagerConfig, storeKeyConverterFactory, statsManager, clusterParticipants.get(0));
+                diskManagerConfig, storeKeyConverterFactory, statsManager, clusterParticipants.get(0),
+                connectionPool);
         requestHandlerPoolForHttp2 =
             new RequestHandlerPool(serverConfig.serverRequestHandlerNumOfThreads, requestResponseChannel,
                 ambryServerRequestsForHttp2);

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryServerRequests.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryServerRequests.java
@@ -28,6 +28,7 @@ import com.github.ambry.clustermap.ReplicaStatusDelegate;
 import com.github.ambry.commons.ServerMetrics;
 import com.github.ambry.config.DiskManagerConfig;
 import com.github.ambry.config.ServerConfig;
+import com.github.ambry.network.ConnectionPool;
 import com.github.ambry.network.NetworkRequest;
 import com.github.ambry.network.RequestResponseChannel;
 import com.github.ambry.network.ServerNetworkResponseMetrics;
@@ -85,7 +86,6 @@ public class AmbryServerRequests extends AmbryRequests {
       EnumSet.of(RequestOrResponseType.DeleteRequest, RequestOrResponseType.TtlUpdateRequest,
           RequestOrResponseType.UndeleteRequest);
   private static final Logger logger = LoggerFactory.getLogger(AmbryServerRequests.class);
-  private final ServerConfig serverConfig;
   private final DiskManagerConfig diskManagerConfig;
   private final StatsManager statsManager;
   private final ClusterParticipant clusterParticipant;
@@ -97,10 +97,19 @@ public class AmbryServerRequests extends AmbryRequests {
       NotificationSystem operationNotification, ReplicationAPI replicationEngine, StoreKeyFactory storeKeyFactory,
       ServerConfig serverConfig, DiskManagerConfig diskManagerConfig, StoreKeyConverterFactory storeKeyConverterFactory,
       StatsManager statsManager, ClusterParticipant clusterParticipant) {
+    this(storeManager, requestResponseChannel, clusterMap, nodeId, registry, serverMetrics, findTokenHelper,
+        operationNotification, replicationEngine, storeKeyFactory, serverConfig, diskManagerConfig, storeKeyConverterFactory,
+        statsManager, clusterParticipant, null);
+  }
+
+  AmbryServerRequests(StoreManager storeManager, RequestResponseChannel requestResponseChannel, ClusterMap clusterMap,
+      DataNodeId nodeId, MetricRegistry registry, ServerMetrics serverMetrics, FindTokenHelper findTokenHelper,
+      NotificationSystem operationNotification, ReplicationAPI replicationEngine, StoreKeyFactory storeKeyFactory,
+      ServerConfig serverConfig, DiskManagerConfig diskManagerConfig, StoreKeyConverterFactory storeKeyConverterFactory,
+      StatsManager statsManager, ClusterParticipant clusterParticipant, ConnectionPool connectionPool) {
     super(storeManager, requestResponseChannel, clusterMap, nodeId, registry, serverMetrics, findTokenHelper,
-        operationNotification, replicationEngine, storeKeyFactory, storeKeyConverterFactory);
+        operationNotification, replicationEngine, storeKeyFactory, storeKeyConverterFactory, connectionPool, serverConfig);
     this.diskManagerConfig = diskManagerConfig;
-    this.serverConfig = serverConfig;
     this.statsManager = statsManager;
     this.clusterParticipant = clusterParticipant;
 

--- a/ambry-server/src/test/java/com/github/ambry/server/AmbryServerRequestsTest.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/AmbryServerRequestsTest.java
@@ -67,6 +67,8 @@ import com.github.ambry.protocol.ReplicaMetadataRequest;
 import com.github.ambry.protocol.ReplicaMetadataRequestInfo;
 import com.github.ambry.protocol.ReplicaMetadataResponse;
 import com.github.ambry.protocol.ReplicaMetadataResponseInfo;
+import com.github.ambry.protocol.ReplicateBlobRequest;
+import com.github.ambry.protocol.ReplicateBlobResponse;
 import com.github.ambry.protocol.ReplicationControlAdminRequest;
 import com.github.ambry.protocol.RequestControlAdminRequest;
 import com.github.ambry.protocol.RequestOrResponse;
@@ -75,10 +77,13 @@ import com.github.ambry.protocol.Response;
 import com.github.ambry.protocol.TtlUpdateRequest;
 import com.github.ambry.protocol.UndeleteRequest;
 import com.github.ambry.replication.FindTokenHelper;
+import com.github.ambry.replication.MockConnectionPool;
 import com.github.ambry.replication.MockFindTokenHelper;
+import com.github.ambry.replication.MockHost;
 import com.github.ambry.replication.MockReplicationManager;
 import com.github.ambry.replication.ReplicationException;
 import com.github.ambry.replication.ReplicationManager;
+import com.github.ambry.replication.ReplicationTestHelper;
 import com.github.ambry.store.BlobStore;
 import com.github.ambry.store.IdUndeletedStoreException;
 import com.github.ambry.store.MessageInfo;
@@ -135,7 +140,7 @@ import static org.mockito.Mockito.*;
  * Tests for {@link AmbryServerRequests}.
  */
 @RunWith(Parameterized.class)
-public class AmbryServerRequestsTest {
+public class AmbryServerRequestsTest extends ReplicationTestHelper {
 
   private final FindTokenHelper findTokenHelper;
   private final MockClusterMap clusterMap;
@@ -158,9 +163,11 @@ public class AmbryServerRequestsTest {
   private MockStorageManager storageManager;
   private MockHelixParticipant helixParticipant;
   private AmbryServerRequests ambryRequests;
+  private final StoreKeyFactory storeKeyFactory;
 
   public AmbryServerRequestsTest(boolean validateRequestOnStoreState)
       throws IOException, ReplicationException, StoreException, InterruptedException, ReflectiveOperationException {
+    super(ReplicaMetadataRequest.Replica_Metadata_Request_Version_V2, ReplicaMetadataResponse.REPLICA_METADATA_RESPONSE_VERSION_V_6);
     this.validateRequestOnStoreState = validateRequestOnStoreState;
     clusterMap = new MockClusterMap();
     localDc = clusterMap.getDatacenterName(clusterMap.getLocalDatacenterId());
@@ -173,7 +180,7 @@ public class AmbryServerRequestsTest {
     StatsManagerConfig statsManagerConfig = new StatsManagerConfig(verifiableProperties);
     dataNodeId =
         clusterMap.getDataNodeIds().stream().filter(node -> node.getDatacenterName().equals(localDc)).findFirst().get();
-    StoreKeyFactory storeKeyFactory = Utils.getObj("com.github.ambry.commons.BlobIdFactory", clusterMap);
+    storeKeyFactory = Utils.getObj("com.github.ambry.commons.BlobIdFactory", clusterMap);
     findTokenHelper = new MockFindTokenHelper(storeKeyFactory, replicationConfig);
     MockHelixParticipant.metricRegistry = new MetricRegistry();
     helixParticipant = new MockHelixParticipant(clusterMapConfig);
@@ -188,7 +195,7 @@ public class AmbryServerRequestsTest {
             statsManagerConfig, null);
     serverMetrics = new ServerMetrics(clusterMap.getMetricRegistry(), AmbryRequests.class, AmbryServer.class);
     ambryRequests = new AmbryServerRequests(storageManager, requestResponseChannel, clusterMap, dataNodeId,
-        clusterMap.getMetricRegistry(), serverMetrics, findTokenHelper, null, replicationManager, null, serverConfig,
+        clusterMap.getMetricRegistry(), serverMetrics, findTokenHelper, null, replicationManager, storeKeyFactory, serverConfig,
         diskManagerConfig, storeKeyConverterFactory, statsManager, helixParticipant);
     storageManager.start();
     Mockito.when(mockDelegate.unseal(any())).thenReturn(true);
@@ -912,6 +919,233 @@ public class AmbryServerRequestsTest {
     changePartitionState(id, false);
 
     miscUndeleteFailuresTest();
+  }
+
+  /**
+   * Tests success case for ReplicateBlobRequest.
+   * Should replicate the PutBlob from the remote host.
+   */
+  @Test
+  public void testReplicateBlobSuccess() throws Exception {
+    Map<DataNodeId, MockHost> hosts = new HashMap<>();
+    MockPartitionId partitionId = (MockPartitionId)clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0);
+    MockHost remoteHost = null;
+    for (ReplicaId replica : partitionId.getReplicaIds()) {
+      MockHost host = new MockHost(replica.getDataNodeId(), clusterMap);
+      if (dataNodeId != host.dataNodeId && remoteHost == null) {
+        remoteHost = host;
+      }
+      hosts.put(host.dataNodeId, host);
+    }
+    StoreKey storeKey = addPutMessagesToReplicasOfPartition(partitionId, Arrays.asList(remoteHost), 1).get(0);
+
+    MockConnectionPool connectionPool = new MockConnectionPool(hosts, clusterMap, 5);
+    ambryRequests = new AmbryServerRequests(storageManager, requestResponseChannel, clusterMap, dataNodeId,
+        clusterMap.getMetricRegistry(), serverMetrics, findTokenHelper, null, replicationManager, storeKeyFactory, serverConfig,
+        diskManagerConfig, storeKeyConverterFactory, statsManager, helixParticipant, connectionPool);
+
+    Assume.assumeTrue(
+        MessageFormatRecord.getCurrentMessageHeaderVersion() >= MessageFormatRecord.Message_Header_Version_V3);
+    int correlationId = TestUtils.RANDOM.nextInt();
+    String clientId = TestUtils.getRandomString(10);
+    BlobId blobId = (BlobId)storeKey;
+
+    ReplicateBlobRequest request = new ReplicateBlobRequest(correlationId, clientId, blobId,
+        remoteHost.dataNodeId.getHostname(), remoteHost.dataNodeId.getPort(), (short)1);
+
+    storageManager.resetStore();
+    RequestOrResponseType requestType = request.getRequestType();
+    Response response = sendRequestGetResponse(request, ServerErrorCode.No_Error);
+    assertEquals("Operation received at the store not as expected", RequestOrResponseType.PutRequest,
+        MockStorageManager.operationReceived);
+    ReplicateBlobResponse replicateBlobResponse = (ReplicateBlobResponse) response;
+    assertEquals("expect ReplicateBlobRequest is successful. ", replicateBlobResponse.getError(), ServerErrorCode.No_Error);
+  }
+
+  /**
+   * Tests ReplicateBlobRequest when the Blob on the source host is deleted.
+   * Should replicate both the PutBlob and the DELETE.
+   */
+  @Test
+  public void testReplicateBlobWhenSourceIsDeleted() throws Exception {
+    Map<DataNodeId, MockHost> hosts = new HashMap<>();
+    MockPartitionId partitionId = (MockPartitionId)clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0);
+    MockHost remoteHost = null;
+    for (ReplicaId replica : partitionId.getReplicaIds()) {
+      MockHost host = new MockHost(replica.getDataNodeId(), clusterMap);
+      if (dataNodeId != host.dataNodeId && remoteHost == null) {
+        remoteHost = host;
+      }
+      hosts.put(host.dataNodeId, host);
+    }
+    StoreKey storeKey = addPutMessagesToReplicasOfPartition(partitionId, Arrays.asList(remoteHost), 1).get(0);
+    // add delete to the remote host
+    addDeleteMessagesToReplicasOfPartition(partitionId, storeKey, Arrays.asList(remoteHost));
+
+    MockConnectionPool connectionPool = new MockConnectionPool(hosts, clusterMap, 5);
+    ambryRequests = new AmbryServerRequests(storageManager, requestResponseChannel, clusterMap, dataNodeId,
+        clusterMap.getMetricRegistry(), serverMetrics, findTokenHelper, null, replicationManager, storeKeyFactory, serverConfig,
+        diskManagerConfig, storeKeyConverterFactory, statsManager, helixParticipant, connectionPool);
+
+    Assume.assumeTrue(
+        MessageFormatRecord.getCurrentMessageHeaderVersion() >= MessageFormatRecord.Message_Header_Version_V3);
+    int correlationId = TestUtils.RANDOM.nextInt();
+    String clientId = TestUtils.getRandomString(10);
+    BlobId blobId = (BlobId)storeKey;
+
+    ReplicateBlobRequest request = new ReplicateBlobRequest(correlationId, clientId, blobId,
+        remoteHost.dataNodeId.getHostname(), remoteHost.dataNodeId.getPort(), (short)1);
+
+    storageManager.resetStore();
+    validKeysInStore.add(blobId);
+    RequestOrResponseType requestType = request.getRequestType();
+    Response response = sendRequestGetResponse(request, ServerErrorCode.No_Error);
+    assertEquals("Operation received at the store not as expected", RequestOrResponseType.DeleteRequest,
+        MockStorageManager.operationReceived);
+    ReplicateBlobResponse replicateBlobResponse = (ReplicateBlobResponse) response;
+    assertEquals("expect ReplicateBlobRequest is successful. ", replicateBlobResponse.getError(), ServerErrorCode.No_Error);
+  }
+
+  /**
+   * Tests ReplicateBlobRequest when the Blob on the source host is updated.
+   * Should replicate both the PutBlob and the TtlUpdate.
+   */
+  @Test
+  public void testReplicateBlobWhenSourceTtlUpdated() throws Exception {
+    Map<DataNodeId, MockHost> hosts = new HashMap<>();
+    MockPartitionId partitionId = (MockPartitionId)clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0);
+    MockHost remoteHost = null;
+    for (ReplicaId replica : partitionId.getReplicaIds()) {
+      MockHost host = new MockHost(replica.getDataNodeId(), clusterMap);
+      if (dataNodeId != host.dataNodeId && remoteHost == null) {
+        remoteHost = host;
+      }
+      hosts.put(host.dataNodeId, host);
+    }
+    StoreKey storeKey = addPutMessagesToReplicasOfPartition(partitionId, Arrays.asList(remoteHost), 1).get(0);
+    // add TtlUpdate to the remote host
+    addTtlUpdateMessagesToReplicasOfPartition(partitionId, storeKey, Arrays.asList(remoteHost), -1);
+
+    MockConnectionPool connectionPool = new MockConnectionPool(hosts, clusterMap, 5);
+    ambryRequests = new AmbryServerRequests(storageManager, requestResponseChannel, clusterMap, dataNodeId,
+        clusterMap.getMetricRegistry(), serverMetrics, findTokenHelper, null, replicationManager, storeKeyFactory, serverConfig,
+        diskManagerConfig, storeKeyConverterFactory, statsManager, helixParticipant, connectionPool);
+
+    Assume.assumeTrue(
+        MessageFormatRecord.getCurrentMessageHeaderVersion() >= MessageFormatRecord.Message_Header_Version_V3);
+    int correlationId = TestUtils.RANDOM.nextInt();
+    String clientId = TestUtils.getRandomString(10);
+    BlobId blobId = (BlobId)storeKey;
+
+    ReplicateBlobRequest request = new ReplicateBlobRequest(correlationId, clientId, blobId,
+        remoteHost.dataNodeId.getHostname(), remoteHost.dataNodeId.getPort(), (short)1);
+    storageManager.resetStore();
+    validKeysInStore.add(blobId);
+    RequestOrResponseType requestType = request.getRequestType();
+    Response response = sendRequestGetResponse(request, ServerErrorCode.No_Error);
+    assertEquals("Operation received at the store not as expected", RequestOrResponseType.TtlUpdateRequest,
+        MockStorageManager.operationReceived);
+    ReplicateBlobResponse replicateBlobResponse = (ReplicateBlobResponse) response;
+    assertEquals("expect ReplicateBlobRequest is successful. ", replicateBlobResponse.getError(), ServerErrorCode.No_Error);
+  }
+
+  /**
+   * Tests ReplicateBlobRequest when the Blob on the source host is expired.
+   * Should replicate both the PutBlob and the TtlUpdate.
+   */
+  @Test
+  public void testReplicateBlobWhenSourceIsExpired() throws Exception {
+    Map<DataNodeId, MockHost> hosts = new HashMap<>();
+    MockPartitionId partitionId = (MockPartitionId)clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0);
+    MockHost remoteHost = null;
+    for (ReplicaId replica : partitionId.getReplicaIds()) {
+      MockHost host = new MockHost(replica.getDataNodeId(), clusterMap);
+      if (dataNodeId != host.dataNodeId && remoteHost == null) {
+        remoteHost = host;
+      }
+      hosts.put(host.dataNodeId, host);
+    }
+    StoreKey storeKey = addPutMessagesToReplicasOfPartition(partitionId, Arrays.asList(remoteHost), 1).get(0);
+    // add TtlUpdate to the remote host and make the blob expired.
+    addTtlUpdateMessagesToReplicasOfPartition(partitionId, storeKey, Arrays.asList(remoteHost), SystemTime.getInstance().milliseconds());
+
+    MockConnectionPool connectionPool = new MockConnectionPool(hosts, clusterMap, 5);
+    ambryRequests = new AmbryServerRequests(storageManager, requestResponseChannel, clusterMap, dataNodeId,
+        clusterMap.getMetricRegistry(), serverMetrics, findTokenHelper, null, replicationManager, storeKeyFactory, serverConfig,
+        diskManagerConfig, storeKeyConverterFactory, statsManager, helixParticipant, connectionPool);
+
+    Assume.assumeTrue(
+        MessageFormatRecord.getCurrentMessageHeaderVersion() >= MessageFormatRecord.Message_Header_Version_V3);
+    int correlationId = TestUtils.RANDOM.nextInt();
+    String clientId = TestUtils.getRandomString(10);
+    BlobId blobId = (BlobId)storeKey;
+
+    ReplicateBlobRequest request = new ReplicateBlobRequest(correlationId, clientId, blobId,
+        remoteHost.dataNodeId.getHostname(), remoteHost.dataNodeId.getPort(), (short)1);
+
+    storageManager.resetStore();
+    validKeysInStore.add(blobId);
+    RequestOrResponseType requestType = request.getRequestType();
+    Response response = sendRequestGetResponse(request, ServerErrorCode.No_Error);
+    assertEquals("Operation received at the store not as expected", RequestOrResponseType.TtlUpdateRequest,
+        MockStorageManager.operationReceived);
+    ReplicateBlobResponse replicateBlobResponse = (ReplicateBlobResponse) response;
+    assertEquals("expect ReplicateBlobRequest is successful. ", replicateBlobResponse.getError(), ServerErrorCode.No_Error);
+  }
+
+  /**
+   * Tests ReplicateBlobRequest when the Blob on the source host doesn't exist.
+   */
+  @Test
+  public void testReplicateBlobWhenSourceNotExist() throws Exception {
+    Map<DataNodeId, MockHost> hosts = new HashMap<>();
+    MockPartitionId partitionId = (MockPartitionId)clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0);
+    MockHost remoteHost = null;
+    MockHost randomHost = null;
+    for (ReplicaId replica : partitionId.getReplicaIds()) {
+      MockHost host = new MockHost(replica.getDataNodeId(), clusterMap);
+      if (dataNodeId != host.dataNodeId) {
+        if (remoteHost == null) {
+          remoteHost = host;
+        } else {
+          randomHost = host;
+        }
+      }
+      hosts.put(host.dataNodeId, host);
+    }
+    // remoteHost has the Blob with "storeKey" key but doesn't have the BLob with "storeKeyNotExist" key
+    StoreKey storeKey = addPutMessagesToReplicasOfPartition(partitionId, Arrays.asList(remoteHost), 1).get(0);
+    StoreKey storeKeyNotExist = addPutMessagesToReplicasOfPartition(partitionId, Arrays.asList(randomHost), 1).get(0);
+
+    MockConnectionPool connectionPool = new MockConnectionPool(hosts, clusterMap, 5);
+    ambryRequests = new AmbryServerRequests(storageManager, requestResponseChannel, clusterMap, dataNodeId,
+        clusterMap.getMetricRegistry(), serverMetrics, findTokenHelper, null, replicationManager, storeKeyFactory, serverConfig,
+        diskManagerConfig, storeKeyConverterFactory, statsManager, helixParticipant, connectionPool);
+
+    Assume.assumeTrue(
+        MessageFormatRecord.getCurrentMessageHeaderVersion() >= MessageFormatRecord.Message_Header_Version_V3);
+    int correlationId = TestUtils.RANDOM.nextInt();
+    String clientId = TestUtils.getRandomString(10);
+    BlobId blobId = (BlobId)storeKeyNotExist;
+
+    ReplicateBlobRequest request = new ReplicateBlobRequest(correlationId, clientId, blobId,
+        remoteHost.dataNodeId.getHostname(), remoteHost.dataNodeId.getPort(), (short)1);
+    storageManager.resetStore();
+    RequestOrResponseType requestType = request.getRequestType();
+    Response response = sendRequestGetResponse(request, ServerErrorCode.Blob_Not_Found);
+    assertEquals("Operation received at the store not as expected", null, MockStorageManager.operationReceived);
+    ReplicateBlobResponse replicateBlobResponse = (ReplicateBlobResponse) response;
+    assertEquals("expect ReplicateBlobRequest fails with Blob_Not_Found.", replicateBlobResponse.getError(), ServerErrorCode.Blob_Not_Found);
+  }
+
+  @Test
+  public void testReplicateBlobWhenTargetConditions() throws Exception {
+    // ON_DEMAND_REPLICATION_TODO:
+    // Besides the above test cases to test the different conditions on the source host, need verify the different cases on the local store.
+    // But doesn't have a good way to simulate these local store errors with unit test yet.
+    // test PutBlob but StoreErrorCodes.Already_Exist
+    // test PutBlob and applyTTLUpdate but hit StoreErrorCodes.Already_Updated or StoreErrorCodes.ID_Deleted
+    // test PutBlob and applyDelete but hit StoreErrorCodes.ID_Deleted or StoreErrorCodes.Life_Version_Conflict
   }
 
   /**

--- a/ambry-test-utils/src/main/java/com/github/ambry/router/InMemoryRouter.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/router/InMemoryRouter.java
@@ -14,6 +14,7 @@
 package com.github.ambry.router;
 
 import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.Callback;
@@ -282,6 +283,12 @@ public class InMemoryRouter implements Router {
     operationPool.submit(new InMemoryBlobPoster(postData, blobs, notificationSystem, clusterMap,
         CommonTestUtils.getCurrentBlobIdVersion()));
     return futureResult;
+  }
+
+  @Override
+  public Future<Void> replicateBlob(String blobId, String serviceId, DataNodeId sourceDataNode,
+      Callback<Void> callback, QuotaChargeCallback quotaChargeCallback) {
+    throw new UnsupportedOperationException("replicateBlob is not supported by this mock");
   }
 
   @Override

--- a/ambry-tools/src/main/java/com/github/ambry/tools/perf/rest/PerfRouter.java
+++ b/ambry-tools/src/main/java/com/github/ambry/tools/perf/rest/PerfRouter.java
@@ -15,6 +15,7 @@ package com.github.ambry.tools.perf.rest;
 
 import com.github.ambry.account.Account;
 import com.github.ambry.account.Container;
+import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.commons.Callback;
 import com.github.ambry.messageformat.BlobInfo;
 import com.github.ambry.messageformat.BlobProperties;
@@ -208,6 +209,21 @@ class PerfRouter implements Router {
       completeOperation(futureResult, callback, null, null);
     }
     return futureResult;
+  }
+
+  /**
+   * Requests for a new blob to be replicated on-demand asynchronously and invokes the {@link Callback} when the request completes.
+   * @param blobId The ID of the blob to be replicated.
+   * @param serviceId The service id that is replicating the blob.
+   * @param sourceDataNode The source {@link DataNodeId} to get the blob from.
+   * @param callback The {@link Callback} which will be invoked on the completion of the request.
+   * @param quotaChargeCallback Listener interface to charge quota cost for the operation.
+   * @return A future that would contain information about whether the replicateBlob succeeded or not, eventually.
+   */
+  @Override
+  public Future<Void> replicateBlob(String blobId, String serviceId, DataNodeId sourceDataNode, Callback<Void> callback,
+      QuotaChargeCallback quotaChargeCallback) {
+    throw new UnsupportedOperationException("replicateBlob is not supported by this mock");
   }
 
   @Override


### PR DESCRIPTION
Added ReplicateBlobRequest which is used to replicate one blob on-demand.

Comments for reviewers:
1. The retry logic after TTLUpdate, Delete 503 will be in another PR.
2. There are some ON_DEMAND_REPLICATION_TODO. They are related to configuration setting, metrics etc. Will be address in the third PR.