### PR TITLE
Draft: ReplicateBlobRequest in AmbryServer. Splitting to small ones.

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/protocol/RequestAPI.java
+++ b/ambry-api/src/main/java/com/github/ambry/protocol/RequestAPI.java
@@ -72,6 +72,14 @@ public interface RequestAPI {
   void handleReplicaMetadataRequest(NetworkRequest request) throws IOException, InterruptedException;
 
   /**
+   * Replicate one specific Blob from a remote host to the local store.
+   * @param request The request that contains the remote host information and the blob id to be replicated.
+   * @throws IOException if there are I/O errors carrying our the required operation.
+   * @throws InterruptedException if request processing is interrupted.
+   */
+  void handleReplicateBlobRequest(NetworkRequest request) throws IOException, InterruptedException;
+
+  /**
    * Handles an administration request. These requests can query for or change the internal state of the server.
    * @param request the request that needs to be handled.
    * @throws IOException if there are I/O errors carrying our the required operation.

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrRequests.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrRequests.java
@@ -67,6 +67,11 @@ public class VcrRequests extends AmbryRequests {
   }
 
   @Override
+  public void handleReplicateBlobRequest(NetworkRequest request) throws IOException, InterruptedException {
+    throw new UnsupportedOperationException("Request type not supported");
+  }
+
+  @Override
   protected ServerErrorCode validateRequest(PartitionId partition, RequestOrResponseType requestType,
       boolean skipPartitionAvailableCheck) {
     // 1. Check partition is null

--- a/ambry-commons/src/main/java/com/github/ambry/commons/ServerMetrics.java
+++ b/ambry-commons/src/main/java/com/github/ambry/commons/ServerMetrics.java
@@ -114,6 +114,12 @@ public class ServerMetrics {
   public final Histogram updateBlobTtlSendTimeInMs;
   public final Histogram updateBlobTtlTotalTimeInMs;
 
+  public final Histogram replicateBlobRequestQueueTimeInMs;
+  public final Histogram replicateBlobProcessingTimeInMs;
+  public final Histogram replicateBlobResponseQueueTimeInMs;
+  public final Histogram replicateBlobSendTimeInMs;
+  public final Histogram replicateBlobTotalTimeInMs;
+
   public final Histogram replicaMetadataRequestQueueTimeInMs;
   public final Histogram replicaMetadataRequestProcessingTimeInMs;
   public final Histogram replicaMetadataResponseQueueTimeInMs;
@@ -176,6 +182,7 @@ public class ServerMetrics {
   public final Meter getBlobAllByReplicaRequestRate;
   public final Meter getBlobInfoRequestRate;
   public final Meter deleteBlobRequestRate;
+  public final Meter replicateBlobRequestRate;
   public final Meter undeleteBlobRequestRate;
   public final Meter updateBlobTtlRequestRate;
   public final Meter replicaMetadataRequestRate;
@@ -364,6 +371,15 @@ public class ServerMetrics {
     updateBlobTtlSendTimeInMs = registry.histogram(MetricRegistry.name(requestClass, "UpdateBlobTtlSendTime"));
     updateBlobTtlTotalTimeInMs = registry.histogram(MetricRegistry.name(requestClass, "UpdateBlobTtlTotalTime"));
 
+    replicateBlobRequestQueueTimeInMs =
+        registry.histogram(MetricRegistry.name(requestClass, "ReplicateBlobRequestQueueTime"));
+    replicateBlobProcessingTimeInMs =
+        registry.histogram(MetricRegistry.name(requestClass, "ReplicateBlobProcessingTime"));
+    replicateBlobResponseQueueTimeInMs =
+        registry.histogram(MetricRegistry.name(requestClass, "ReplicateBlobResponseQueueTime"));
+    replicateBlobSendTimeInMs = registry.histogram(MetricRegistry.name(requestClass, "ReplicateBlobSendTime"));
+    replicateBlobTotalTimeInMs = registry.histogram(MetricRegistry.name(requestClass, "ReplicateBlobTotalTime"));
+
     replicaMetadataRequestQueueTimeInMs =
         registry.histogram(MetricRegistry.name(requestClass, "ReplicaMetadataRequestQueueTime"));
     replicaMetadataRequestProcessingTimeInMs =
@@ -470,6 +486,7 @@ public class ServerMetrics {
     deleteBlobRequestRate = registry.meter(MetricRegistry.name(requestClass, "DeleteBlobRequestRate"));
     undeleteBlobRequestRate = registry.meter(MetricRegistry.name(requestClass, "UndeleteBlobRequestRate"));
     updateBlobTtlRequestRate = registry.meter(MetricRegistry.name(requestClass, "UpdateBlobTtlRequestRate"));
+    replicateBlobRequestRate = registry.meter(MetricRegistry.name(requestClass, "ReplicateBlobRequestRate"));
     replicaMetadataRequestRate = registry.meter(MetricRegistry.name(requestClass, "ReplicaMetadataRequestRate"));
     triggerCompactionRequestRate = registry.meter(MetricRegistry.name(requestClass, "TriggerCompactionRequestRate"));
     requestControlRequestRate = registry.meter(MetricRegistry.name(requestClass, "RequestControlRequestRate"));

--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/ValidatingTransformer.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/ValidatingTransformer.java
@@ -88,8 +88,10 @@ public class ValidatingTransformer implements Transformer {
             new PutMessageFormatInputStream(keyInStream, encryptionKey, props, metadata,
                 new ByteBufInputStream(blobData.content(), true), blobData.getSize(), blobData.getBlobType(),
                 msgInfo.getLifeVersion());
+        // Keep the isDeleted same as msgInfo.isDeleted().
+        // For normal replication, the isDeleted message will be filtered out any way.
+        // For on-demand blob replication, we keep the isDeleted flag so we can apply delete message to the Blob.
         MessageInfo transformedMsgInfo = new MessageInfo.Builder(msgInfo).size(transformedStream.getSize())
-            .isDeleted(false)
             .isUndeleted(false)
             .build();
         transformationOutput = new TransformationOutput(new Message(transformedMsgInfo, transformedStream));

--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/ValidatingTransformer.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/ValidatingTransformer.java
@@ -88,10 +88,8 @@ public class ValidatingTransformer implements Transformer {
             new PutMessageFormatInputStream(keyInStream, encryptionKey, props, metadata,
                 new ByteBufInputStream(blobData.content(), true), blobData.getSize(), blobData.getBlobType(),
                 msgInfo.getLifeVersion());
-        // Keep the isDeleted same as msgInfo.isDeleted().
-        // For normal replication, the isDeleted message will be filtered out any way.
-        // For on-demand blob replication, we keep the isDeleted flag so we can apply delete message to the Blob.
         MessageInfo transformedMsgInfo = new MessageInfo.Builder(msgInfo).size(transformedStream.getSize())
+            .isDeleted(false)
             .isUndeleted(false)
             .build();
         transformationOutput = new TransformationOutput(new Message(transformedMsgInfo, transformedStream));

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/ReplicateBlobRequest.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/ReplicateBlobRequest.java
@@ -1,0 +1,171 @@
+/**
+ * Copyright 2022 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.protocol;
+
+import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.commons.BlobId;
+import com.github.ambry.utils.Utils;
+import java.io.DataInputStream;
+import java.io.IOException;
+
+
+/**
+ * ReplicateBlob request to replicate one particular blob
+ */
+public class ReplicateBlobRequest extends RequestOrResponse {
+  static final short ReplicateBlob_REQUEST_VERSION_1 = 1;
+  private final static short CURRENT_VERSION = ReplicateBlob_REQUEST_VERSION_1;
+  private final BlobId blobId;
+  private final String sourceHostName;
+  private final int sourceHostPort;
+
+  private static final short Source_Host_Name_Size_In_Bytes = Integer.BYTES;
+  private static final short Source_Host_Port_Size_In_Bytes = Integer.BYTES;
+
+  /**
+   * Constructs {@link ReplicateBlobRequest} in {@link #ReplicateBlob_REQUEST_VERSION_1}
+   * @param correlationId correlationId of the ReplicateBlob request
+   * @param clientId clientId of the ReplicateBlob request
+   * @param blobId blobId of the ReplicateBlob request
+   * @param sourceHostName the name of the source host to get the blob from
+   * @param sourceHostPort the port of the source host to get the blob from
+   */
+  public ReplicateBlobRequest(int correlationId, String clientId, BlobId blobId,
+      String sourceHostName, int sourceHostPort) {
+    this(correlationId, clientId, blobId, sourceHostName, sourceHostPort, CURRENT_VERSION);
+  }
+
+  /**
+   * Constructs {@link ReplicateBlobRequest} in given version.
+   * @param correlationId correlationId of the ReplicateBlob request
+   * @param clientId clientId of the ReplicateBlob request
+   * @param blobId blobId of the ReplicateBlob request
+   * @param sourceHostName the name of the source host to get the blob from
+   * @param sourceHostPort the port of the source host to get the blob from
+   * @param version version of the {@link ReplicateBlobRequest}
+   */
+  public ReplicateBlobRequest(int correlationId, String clientId, BlobId blobId,
+      String sourceHostName, int sourceHostPort, short version) {
+    super(RequestOrResponseType.ReplicateBlobRequest, version, correlationId, clientId);
+    this.blobId = blobId;
+    this.sourceHostName = sourceHostName;
+    this.sourceHostPort = sourceHostPort;
+  }
+
+  /**
+   * Deserialize {@link ReplicateBlobRequest} from a given {@link DataInputStream}.
+   * @param stream The stream that contains the serialized bytes.
+   * @param map The {@link ClusterMap} to help build {@link BlobId}.
+   * @return A deserialized {@link ReplicateBlobRequest}.
+   * @throws IOException Any I/O Errors.
+   */
+  public static ReplicateBlobRequest readFrom(DataInputStream stream, ClusterMap map) throws IOException {
+    Short version = stream.readShort();
+    switch (version) {
+      case ReplicateBlob_REQUEST_VERSION_1:
+        return ReplicateBlobRequest_V1.readFrom(stream, map);
+      default:
+        throw new IllegalStateException("Unknown ReplicateBlob Request version " + version);
+    }
+  }
+
+  /**
+   * Construct the bufferToSend to serialize the request
+   */
+  @Override
+  protected void prepareBuffer() {
+    super.prepareBuffer();
+    bufferToSend.writeBytes(blobId.toBytes());
+    bufferToSend.writeInt(sourceHostName.length());
+    bufferToSend.writeBytes(sourceHostName.getBytes());
+    bufferToSend.writeInt(sourceHostPort);
+  }
+
+  /**
+   * @return the {@link BlobId} associated with the blob in this request.
+   */
+  public BlobId getBlobId() {
+    return blobId;
+  }
+
+  /**
+   * @return the account Id.
+   */
+  public short getAccountId() {
+    return blobId.getAccountId();
+  }
+
+  /**
+   * @return the container Id.
+   */
+  public short getContainerId() {
+    return blobId.getContainerId();
+  }
+
+  /**
+   * @return the name of the source host from where to get the Blob.
+   */
+  public String getSourceHostName() {
+    return sourceHostName;
+  }
+
+  /**
+   * @return the port of the source host from where to get the Blob.
+   */
+  public int getSourceHostPort() {
+    return sourceHostPort;
+  }
+
+  /**
+   * @return the size of the serialized ReplicateBlobRequest stream
+   */
+  @Override
+  public long sizeInBytes() {
+    // header + blobId + sourceHostName + sourceHostPort
+    long sizeInBytes = super.sizeInBytes() + blobId.sizeInBytes();
+    sizeInBytes += Source_Host_Name_Size_In_Bytes + sourceHostName.length();
+    sizeInBytes += Source_Host_Port_Size_In_Bytes;
+    return sizeInBytes;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("ReplicateBlobRequest[");
+    sb.append("BlobID=").append(blobId);
+    sb.append(", ").append("PartitionId=").append(blobId.getPartition());
+    sb.append(", ").append("ClientId=").append(clientId);
+    sb.append(", ").append("CorrelationId=").append(correlationId);
+    sb.append(", ").append("AccountId=").append(blobId.getAccountId());
+    sb.append(", ").append("ContainerId=").append(blobId.getContainerId());
+    sb.append(", ").append("SourceHostName=").append(sourceHostName);
+    sb.append(", ").append("SourceHostPort=").append(sourceHostPort);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  /**
+   * Class to read protocol version 1 ReplicateBlobRequest from the stream.
+   */
+  private static class ReplicateBlobRequest_V1 {
+    static ReplicateBlobRequest readFrom(DataInputStream stream, ClusterMap map) throws IOException {
+      int correlationId = stream.readInt();
+      String clientId = Utils.readIntString(stream);
+      BlobId id = new BlobId(stream, map);
+      String sourceHostName = Utils.readIntString(stream);
+      int sourceHostPort = stream.readInt();
+      return new ReplicateBlobRequest(correlationId, clientId, id, sourceHostName, sourceHostPort, ReplicateBlob_REQUEST_VERSION_1);
+    }
+  }
+}

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/ReplicateBlobResponse.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/ReplicateBlobResponse.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2022 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.protocol;
+
+import com.github.ambry.server.ServerErrorCode;
+import com.github.ambry.utils.Utils;
+import java.io.DataInputStream;
+import java.io.IOException;
+
+
+/**
+ * Response of ReplicateBlob request
+ */
+public class ReplicateBlobResponse extends Response {
+  private static final short ReplicateBlob_Response_Version_V1 = 1;
+
+  public ReplicateBlobResponse(int correlationId, String clientId, ServerErrorCode error) {
+    super(RequestOrResponseType.ReplicateBlobResponse, ReplicateBlob_Response_Version_V1, correlationId, clientId, error);
+  }
+
+  /**
+   * Deserialize {@link ReplicateBlobResponse} from a given {@link DataInputStream}.
+   * @param stream The stream that contains the serialized bytes.
+   * @return A deserialized {@link ReplicateBlobResponse}.
+   * @throws IOException Any I/O Errors.
+   */
+  public static ReplicateBlobResponse readFrom(DataInputStream stream) throws IOException {
+    RequestOrResponseType type = RequestOrResponseType.values()[stream.readShort()];
+    if (type != RequestOrResponseType.ReplicateBlobResponse) {
+      throw new IllegalArgumentException("The type of request response is not compatible");
+    }
+    short versionId = stream.readShort();
+    int correlationId = stream.readInt();
+    String clientId = Utils.readIntString(stream);
+    ServerErrorCode error = ServerErrorCode.values()[stream.readShort()];
+    if (versionId != ReplicateBlob_Response_Version_V1) {
+      throw new IllegalArgumentException("Unexpected ReplicateBlobResponse version " + versionId);
+    }
+    return new ReplicateBlobResponse(correlationId, clientId, error);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("ReplicateBlobResponse[");
+    sb.append("ServerErrorCode=").append(getError());
+    sb.append("]");
+    return sb.toString();
+  }
+}

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/RequestOrResponseType.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/RequestOrResponseType.java
@@ -31,5 +31,7 @@ public enum RequestOrResponseType {
   AdminRequest,
   AdminResponse,
   UndeleteRequest,
-  UndeleteResponse
+  UndeleteResponse,
+  ReplicateBlobRequest,
+  ReplicateBlobResponse,
 }

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -1135,10 +1135,10 @@ public class ReplicaThread implements Runnable {
                   remoteReplicaInfo.getLocalReplicaId().getMountPath());
 
               MessageFormatWriteSet writeset;
-              // set keepDeletedExpired to false. MessageSievingInputStream will filter out deleted and expired messages.
+              // MessageSievingInputStream will filter out deleted and expired messages.
               MessageSievingInputStream validMessageDetectionInputStream =
                   new MessageSievingInputStream(getResponse.getInputStream(), messageInfoList,
-                      Collections.singletonList(transformer), metricRegistry, false);
+                      Collections.singletonList(transformer), metricRegistry);
               if (validMessageDetectionInputStream.hasInvalidMessages()) {
                 replicationMetrics.incrementInvalidMessageError(partitionResponseInfo.getPartition());
                 logger.error("Out of {} messages, {} invalid messages were found in message stream from {}",

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -1135,9 +1135,10 @@ public class ReplicaThread implements Runnable {
                   remoteReplicaInfo.getLocalReplicaId().getMountPath());
 
               MessageFormatWriteSet writeset;
+              // set keepDeletedExpired to false. MessageSievingInputStream will filter out deleted and expired messages.
               MessageSievingInputStream validMessageDetectionInputStream =
                   new MessageSievingInputStream(getResponse.getInputStream(), messageInfoList,
-                      Collections.singletonList(transformer), metricRegistry);
+                      Collections.singletonList(transformer), metricRegistry, false);
               if (validMessageDetectionInputStream.hasInvalidMessages()) {
                 replicationMetrics.incrementInvalidMessageError(partitionResponseInfo.getPartition());
                 logger.error("Out of {} messages, {} invalid messages were found in message stream from {}",

--- a/ambry-replication/src/test/java/com/github/ambry/replication/MockConnectionPool.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/MockConnectionPool.java
@@ -298,6 +298,7 @@ public class MockConnectionPool implements ConnectionPool {
       }
       buffer.flip();
       buffer.getLong();
+      response.release();
       return new ChannelOutput(new DataInputStream(new ByteBufferInputStream(buffer)), buffer.remaining());
     }
 

--- a/ambry-replication/src/test/java/com/github/ambry/replication/MockConnectionPool.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/MockConnectionPool.java
@@ -63,11 +63,13 @@ public class MockConnectionPool implements ConnectionPool {
   private final Map<DataNodeId, MockHost> hosts;
   private final ClusterMap clusterMap;
   private final int maxEntriesToReturn;
+  private Map<DataNodeId, MockConnection> connections;
 
   public MockConnectionPool(Map<DataNodeId, MockHost> hosts, ClusterMap clusterMap, int maxEntriesToReturn) {
     this.hosts = hosts;
     this.clusterMap = clusterMap;
     this.maxEntriesToReturn = maxEntriesToReturn;
+    this.connections = new HashMap<DataNodeId, MockConnection>();
   }
 
   @Override
@@ -82,7 +84,10 @@ public class MockConnectionPool implements ConnectionPool {
   public ConnectedChannel checkOutConnection(String host, Port port, long timeout) {
     DataNodeId dataNodeId = clusterMap.getDataNodeId(host, port.getPort());
     MockHost hostObj = hosts.get(dataNodeId);
-    return new MockConnection(hostObj, maxEntriesToReturn);
+    if (!connections.containsKey(dataNodeId)) {
+      connections.put(dataNodeId, new MockConnection(hostObj, maxEntriesToReturn));
+    }
+    return connections.get(dataNodeId);
   }
 
   @Override

--- a/ambry-replication/src/test/java/com/github/ambry/replication/MockHost.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/MockHost.java
@@ -46,7 +46,7 @@ public class MockHost {
   final Map<PartitionId, List<MessageInfo>> infosByPartition = new HashMap<>();
   final Map<PartitionId, List<ByteBuffer>> buffersByPartition = new HashMap<>();
 
-  MockHost(DataNodeId dataNodeId, ClusterMap clusterMap) {
+  public MockHost(DataNodeId dataNodeId, ClusterMap clusterMap) {
     this.dataNodeId = dataNodeId;
     this.clusterMap = clusterMap;
   }

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryServer.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryServer.java
@@ -303,7 +303,8 @@ public class AmbryServer {
         AmbryServerRequests ambryServerRequestsForHttp2 =
             new AmbryServerRequests(storageManager, requestResponseChannel, clusterMap, nodeId, registry, metrics,
                 findTokenHelper, notificationSystem, replicationManager, storeKeyFactory, serverConfig,
-                diskManagerConfig, storeKeyConverterFactory, statsManager, clusterParticipants.get(0));
+                diskManagerConfig, storeKeyConverterFactory, statsManager, clusterParticipants.get(0),
+                connectionPool);
         requestHandlerPoolForHttp2 =
             new RequestHandlerPool(serverConfig.serverRequestHandlerNumOfThreads, requestResponseChannel,
                 ambryServerRequestsForHttp2);

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryServerRequests.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryServerRequests.java
@@ -28,6 +28,7 @@ import com.github.ambry.clustermap.ReplicaStatusDelegate;
 import com.github.ambry.commons.ServerMetrics;
 import com.github.ambry.config.DiskManagerConfig;
 import com.github.ambry.config.ServerConfig;
+import com.github.ambry.network.ConnectionPool;
 import com.github.ambry.network.NetworkRequest;
 import com.github.ambry.network.RequestResponseChannel;
 import com.github.ambry.network.ServerNetworkResponseMetrics;
@@ -85,7 +86,6 @@ public class AmbryServerRequests extends AmbryRequests {
       EnumSet.of(RequestOrResponseType.DeleteRequest, RequestOrResponseType.TtlUpdateRequest,
           RequestOrResponseType.UndeleteRequest);
   private static final Logger logger = LoggerFactory.getLogger(AmbryServerRequests.class);
-  private final ServerConfig serverConfig;
   private final DiskManagerConfig diskManagerConfig;
   private final StatsManager statsManager;
   private final ClusterParticipant clusterParticipant;
@@ -97,10 +97,19 @@ public class AmbryServerRequests extends AmbryRequests {
       NotificationSystem operationNotification, ReplicationAPI replicationEngine, StoreKeyFactory storeKeyFactory,
       ServerConfig serverConfig, DiskManagerConfig diskManagerConfig, StoreKeyConverterFactory storeKeyConverterFactory,
       StatsManager statsManager, ClusterParticipant clusterParticipant) {
+    this(storeManager, requestResponseChannel, clusterMap, nodeId, registry, serverMetrics, findTokenHelper,
+        operationNotification, replicationEngine, storeKeyFactory, serverConfig, diskManagerConfig, storeKeyConverterFactory,
+        statsManager, clusterParticipant, null);
+  }
+
+  AmbryServerRequests(StoreManager storeManager, RequestResponseChannel requestResponseChannel, ClusterMap clusterMap,
+      DataNodeId nodeId, MetricRegistry registry, ServerMetrics serverMetrics, FindTokenHelper findTokenHelper,
+      NotificationSystem operationNotification, ReplicationAPI replicationEngine, StoreKeyFactory storeKeyFactory,
+      ServerConfig serverConfig, DiskManagerConfig diskManagerConfig, StoreKeyConverterFactory storeKeyConverterFactory,
+      StatsManager statsManager, ClusterParticipant clusterParticipant, ConnectionPool connectionPool) {
     super(storeManager, requestResponseChannel, clusterMap, nodeId, registry, serverMetrics, findTokenHelper,
-        operationNotification, replicationEngine, storeKeyFactory, storeKeyConverterFactory);
+        operationNotification, replicationEngine, storeKeyFactory, storeKeyConverterFactory, connectionPool, serverConfig);
     this.diskManagerConfig = diskManagerConfig;
-    this.serverConfig = serverConfig;
     this.statsManager = statsManager;
     this.clusterParticipant = clusterParticipant;
 

--- a/ambry-server/src/test/java/com/github/ambry/server/AmbryServerRequestsTest.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/AmbryServerRequestsTest.java
@@ -67,6 +67,8 @@ import com.github.ambry.protocol.ReplicaMetadataRequest;
 import com.github.ambry.protocol.ReplicaMetadataRequestInfo;
 import com.github.ambry.protocol.ReplicaMetadataResponse;
 import com.github.ambry.protocol.ReplicaMetadataResponseInfo;
+import com.github.ambry.protocol.ReplicateBlobRequest;
+import com.github.ambry.protocol.ReplicateBlobResponse;
 import com.github.ambry.protocol.ReplicationControlAdminRequest;
 import com.github.ambry.protocol.RequestControlAdminRequest;
 import com.github.ambry.protocol.RequestOrResponse;
@@ -75,10 +77,13 @@ import com.github.ambry.protocol.Response;
 import com.github.ambry.protocol.TtlUpdateRequest;
 import com.github.ambry.protocol.UndeleteRequest;
 import com.github.ambry.replication.FindTokenHelper;
+import com.github.ambry.replication.MockConnectionPool;
 import com.github.ambry.replication.MockFindTokenHelper;
+import com.github.ambry.replication.MockHost;
 import com.github.ambry.replication.MockReplicationManager;
 import com.github.ambry.replication.ReplicationException;
 import com.github.ambry.replication.ReplicationManager;
+import com.github.ambry.replication.ReplicationTestHelper;
 import com.github.ambry.store.BlobStore;
 import com.github.ambry.store.IdUndeletedStoreException;
 import com.github.ambry.store.MessageInfo;
@@ -135,7 +140,7 @@ import static org.mockito.Mockito.*;
  * Tests for {@link AmbryServerRequests}.
  */
 @RunWith(Parameterized.class)
-public class AmbryServerRequestsTest {
+public class AmbryServerRequestsTest extends ReplicationTestHelper {
 
   private final FindTokenHelper findTokenHelper;
   private final MockClusterMap clusterMap;
@@ -158,9 +163,11 @@ public class AmbryServerRequestsTest {
   private MockStorageManager storageManager;
   private MockHelixParticipant helixParticipant;
   private AmbryServerRequests ambryRequests;
+  private final StoreKeyFactory storeKeyFactory;
 
   public AmbryServerRequestsTest(boolean validateRequestOnStoreState)
       throws IOException, ReplicationException, StoreException, InterruptedException, ReflectiveOperationException {
+    super(ReplicaMetadataRequest.Replica_Metadata_Request_Version_V2, ReplicaMetadataResponse.REPLICA_METADATA_RESPONSE_VERSION_V_6);
     this.validateRequestOnStoreState = validateRequestOnStoreState;
     clusterMap = new MockClusterMap();
     localDc = clusterMap.getDatacenterName(clusterMap.getLocalDatacenterId());
@@ -173,7 +180,7 @@ public class AmbryServerRequestsTest {
     StatsManagerConfig statsManagerConfig = new StatsManagerConfig(verifiableProperties);
     dataNodeId =
         clusterMap.getDataNodeIds().stream().filter(node -> node.getDatacenterName().equals(localDc)).findFirst().get();
-    StoreKeyFactory storeKeyFactory = Utils.getObj("com.github.ambry.commons.BlobIdFactory", clusterMap);
+    storeKeyFactory = Utils.getObj("com.github.ambry.commons.BlobIdFactory", clusterMap);
     findTokenHelper = new MockFindTokenHelper(storeKeyFactory, replicationConfig);
     MockHelixParticipant.metricRegistry = new MetricRegistry();
     helixParticipant = new MockHelixParticipant(clusterMapConfig);
@@ -188,7 +195,7 @@ public class AmbryServerRequestsTest {
             statsManagerConfig, null);
     serverMetrics = new ServerMetrics(clusterMap.getMetricRegistry(), AmbryRequests.class, AmbryServer.class);
     ambryRequests = new AmbryServerRequests(storageManager, requestResponseChannel, clusterMap, dataNodeId,
-        clusterMap.getMetricRegistry(), serverMetrics, findTokenHelper, null, replicationManager, null, serverConfig,
+        clusterMap.getMetricRegistry(), serverMetrics, findTokenHelper, null, replicationManager, storeKeyFactory, serverConfig,
         diskManagerConfig, storeKeyConverterFactory, statsManager, helixParticipant);
     storageManager.start();
     Mockito.when(mockDelegate.unseal(any())).thenReturn(true);
@@ -912,6 +919,233 @@ public class AmbryServerRequestsTest {
     changePartitionState(id, false);
 
     miscUndeleteFailuresTest();
+  }
+
+  /**
+   * Tests success case for ReplicateBlobRequest.
+   * Should replicate the PutBlob from the remote host.
+   */
+  @Test
+  public void testReplicateBlobSuccess() throws Exception {
+    Map<DataNodeId, MockHost> hosts = new HashMap<>();
+    MockPartitionId partitionId = (MockPartitionId)clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0);
+    MockHost remoteHost = null;
+    for (ReplicaId replica : partitionId.getReplicaIds()) {
+      MockHost host = new MockHost(replica.getDataNodeId(), clusterMap);
+      if (dataNodeId != host.dataNodeId && remoteHost == null) {
+        remoteHost = host;
+      }
+      hosts.put(host.dataNodeId, host);
+    }
+    StoreKey storeKey = addPutMessagesToReplicasOfPartition(partitionId, Arrays.asList(remoteHost), 1).get(0);
+
+    MockConnectionPool connectionPool = new MockConnectionPool(hosts, clusterMap, 5);
+    ambryRequests = new AmbryServerRequests(storageManager, requestResponseChannel, clusterMap, dataNodeId,
+        clusterMap.getMetricRegistry(), serverMetrics, findTokenHelper, null, replicationManager, storeKeyFactory, serverConfig,
+        diskManagerConfig, storeKeyConverterFactory, statsManager, helixParticipant, connectionPool);
+
+    Assume.assumeTrue(
+        MessageFormatRecord.getCurrentMessageHeaderVersion() >= MessageFormatRecord.Message_Header_Version_V3);
+    int correlationId = TestUtils.RANDOM.nextInt();
+    String clientId = TestUtils.getRandomString(10);
+    BlobId blobId = (BlobId)storeKey;
+
+    ReplicateBlobRequest request = new ReplicateBlobRequest(correlationId, clientId, blobId,
+        remoteHost.dataNodeId.getHostname(), remoteHost.dataNodeId.getPort(), (short)1);
+
+    storageManager.resetStore();
+    RequestOrResponseType requestType = request.getRequestType();
+    Response response = sendRequestGetResponse(request, ServerErrorCode.No_Error);
+    assertEquals("Operation received at the store not as expected", RequestOrResponseType.PutRequest,
+        MockStorageManager.operationReceived);
+    ReplicateBlobResponse replicateBlobResponse = (ReplicateBlobResponse) response;
+    assertEquals("expect ReplicateBlobRequest is successful. ", replicateBlobResponse.getError(), ServerErrorCode.No_Error);
+  }
+
+  /**
+   * Tests ReplicateBlobRequest when the Blob on the source host is deleted.
+   * Should replicate both the PutBlob and the DELETE.
+   */
+  @Test
+  public void testReplicateBlobWhenSourceIsDeleted() throws Exception {
+    Map<DataNodeId, MockHost> hosts = new HashMap<>();
+    MockPartitionId partitionId = (MockPartitionId)clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0);
+    MockHost remoteHost = null;
+    for (ReplicaId replica : partitionId.getReplicaIds()) {
+      MockHost host = new MockHost(replica.getDataNodeId(), clusterMap);
+      if (dataNodeId != host.dataNodeId && remoteHost == null) {
+        remoteHost = host;
+      }
+      hosts.put(host.dataNodeId, host);
+    }
+    StoreKey storeKey = addPutMessagesToReplicasOfPartition(partitionId, Arrays.asList(remoteHost), 1).get(0);
+    // add delete to the remote host
+    addDeleteMessagesToReplicasOfPartition(partitionId, storeKey, Arrays.asList(remoteHost));
+
+    MockConnectionPool connectionPool = new MockConnectionPool(hosts, clusterMap, 5);
+    ambryRequests = new AmbryServerRequests(storageManager, requestResponseChannel, clusterMap, dataNodeId,
+        clusterMap.getMetricRegistry(), serverMetrics, findTokenHelper, null, replicationManager, storeKeyFactory, serverConfig,
+        diskManagerConfig, storeKeyConverterFactory, statsManager, helixParticipant, connectionPool);
+
+    Assume.assumeTrue(
+        MessageFormatRecord.getCurrentMessageHeaderVersion() >= MessageFormatRecord.Message_Header_Version_V3);
+    int correlationId = TestUtils.RANDOM.nextInt();
+    String clientId = TestUtils.getRandomString(10);
+    BlobId blobId = (BlobId)storeKey;
+
+    ReplicateBlobRequest request = new ReplicateBlobRequest(correlationId, clientId, blobId,
+        remoteHost.dataNodeId.getHostname(), remoteHost.dataNodeId.getPort(), (short)1);
+
+    storageManager.resetStore();
+    validKeysInStore.add(blobId);
+    RequestOrResponseType requestType = request.getRequestType();
+    Response response = sendRequestGetResponse(request, ServerErrorCode.No_Error);
+    assertEquals("Operation received at the store not as expected", RequestOrResponseType.DeleteRequest,
+        MockStorageManager.operationReceived);
+    ReplicateBlobResponse replicateBlobResponse = (ReplicateBlobResponse) response;
+    assertEquals("expect ReplicateBlobRequest is successful. ", replicateBlobResponse.getError(), ServerErrorCode.No_Error);
+  }
+
+  /**
+   * Tests ReplicateBlobRequest when the Blob on the source host is updated.
+   * Should replicate both the PutBlob and the TtlUpdate.
+   */
+  @Test
+  public void testReplicateBlobWhenSourceTtlUpdated() throws Exception {
+    Map<DataNodeId, MockHost> hosts = new HashMap<>();
+    MockPartitionId partitionId = (MockPartitionId)clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0);
+    MockHost remoteHost = null;
+    for (ReplicaId replica : partitionId.getReplicaIds()) {
+      MockHost host = new MockHost(replica.getDataNodeId(), clusterMap);
+      if (dataNodeId != host.dataNodeId && remoteHost == null) {
+        remoteHost = host;
+      }
+      hosts.put(host.dataNodeId, host);
+    }
+    StoreKey storeKey = addPutMessagesToReplicasOfPartition(partitionId, Arrays.asList(remoteHost), 1).get(0);
+    // add TtlUpdate to the remote host
+    addTtlUpdateMessagesToReplicasOfPartition(partitionId, storeKey, Arrays.asList(remoteHost), -1);
+
+    MockConnectionPool connectionPool = new MockConnectionPool(hosts, clusterMap, 5);
+    ambryRequests = new AmbryServerRequests(storageManager, requestResponseChannel, clusterMap, dataNodeId,
+        clusterMap.getMetricRegistry(), serverMetrics, findTokenHelper, null, replicationManager, storeKeyFactory, serverConfig,
+        diskManagerConfig, storeKeyConverterFactory, statsManager, helixParticipant, connectionPool);
+
+    Assume.assumeTrue(
+        MessageFormatRecord.getCurrentMessageHeaderVersion() >= MessageFormatRecord.Message_Header_Version_V3);
+    int correlationId = TestUtils.RANDOM.nextInt();
+    String clientId = TestUtils.getRandomString(10);
+    BlobId blobId = (BlobId)storeKey;
+
+    ReplicateBlobRequest request = new ReplicateBlobRequest(correlationId, clientId, blobId,
+        remoteHost.dataNodeId.getHostname(), remoteHost.dataNodeId.getPort(), (short)1);
+    storageManager.resetStore();
+    validKeysInStore.add(blobId);
+    RequestOrResponseType requestType = request.getRequestType();
+    Response response = sendRequestGetResponse(request, ServerErrorCode.No_Error);
+    assertEquals("Operation received at the store not as expected", RequestOrResponseType.TtlUpdateRequest,
+        MockStorageManager.operationReceived);
+    ReplicateBlobResponse replicateBlobResponse = (ReplicateBlobResponse) response;
+    assertEquals("expect ReplicateBlobRequest is successful. ", replicateBlobResponse.getError(), ServerErrorCode.No_Error);
+  }
+
+  /**
+   * Tests ReplicateBlobRequest when the Blob on the source host is expired.
+   * Should replicate both the PutBlob and the TtlUpdate.
+   */
+  @Test
+  public void testReplicateBlobWhenSourceIsExpired() throws Exception {
+    Map<DataNodeId, MockHost> hosts = new HashMap<>();
+    MockPartitionId partitionId = (MockPartitionId)clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0);
+    MockHost remoteHost = null;
+    for (ReplicaId replica : partitionId.getReplicaIds()) {
+      MockHost host = new MockHost(replica.getDataNodeId(), clusterMap);
+      if (dataNodeId != host.dataNodeId && remoteHost == null) {
+        remoteHost = host;
+      }
+      hosts.put(host.dataNodeId, host);
+    }
+    StoreKey storeKey = addPutMessagesToReplicasOfPartition(partitionId, Arrays.asList(remoteHost), 1).get(0);
+    // add TtlUpdate to the remote host and make the blob expired.
+    addTtlUpdateMessagesToReplicasOfPartition(partitionId, storeKey, Arrays.asList(remoteHost), SystemTime.getInstance().milliseconds());
+
+    MockConnectionPool connectionPool = new MockConnectionPool(hosts, clusterMap, 5);
+    ambryRequests = new AmbryServerRequests(storageManager, requestResponseChannel, clusterMap, dataNodeId,
+        clusterMap.getMetricRegistry(), serverMetrics, findTokenHelper, null, replicationManager, storeKeyFactory, serverConfig,
+        diskManagerConfig, storeKeyConverterFactory, statsManager, helixParticipant, connectionPool);
+
+    Assume.assumeTrue(
+        MessageFormatRecord.getCurrentMessageHeaderVersion() >= MessageFormatRecord.Message_Header_Version_V3);
+    int correlationId = TestUtils.RANDOM.nextInt();
+    String clientId = TestUtils.getRandomString(10);
+    BlobId blobId = (BlobId)storeKey;
+
+    ReplicateBlobRequest request = new ReplicateBlobRequest(correlationId, clientId, blobId,
+        remoteHost.dataNodeId.getHostname(), remoteHost.dataNodeId.getPort(), (short)1);
+
+    storageManager.resetStore();
+    validKeysInStore.add(blobId);
+    RequestOrResponseType requestType = request.getRequestType();
+    Response response = sendRequestGetResponse(request, ServerErrorCode.No_Error);
+    assertEquals("Operation received at the store not as expected", RequestOrResponseType.TtlUpdateRequest,
+        MockStorageManager.operationReceived);
+    ReplicateBlobResponse replicateBlobResponse = (ReplicateBlobResponse) response;
+    assertEquals("expect ReplicateBlobRequest is successful. ", replicateBlobResponse.getError(), ServerErrorCode.No_Error);
+  }
+
+  /**
+   * Tests ReplicateBlobRequest when the Blob on the source host doesn't exist.
+   */
+  @Test
+  public void testReplicateBlobWhenSourceNotExist() throws Exception {
+    Map<DataNodeId, MockHost> hosts = new HashMap<>();
+    MockPartitionId partitionId = (MockPartitionId)clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0);
+    MockHost remoteHost = null;
+    MockHost randomHost = null;
+    for (ReplicaId replica : partitionId.getReplicaIds()) {
+      MockHost host = new MockHost(replica.getDataNodeId(), clusterMap);
+      if (dataNodeId != host.dataNodeId) {
+        if (remoteHost == null) {
+          remoteHost = host;
+        } else {
+          randomHost = host;
+        }
+      }
+      hosts.put(host.dataNodeId, host);
+    }
+    // remoteHost has the Blob with "storeKey" key but doesn't have the BLob with "storeKeyNotExist" key
+    StoreKey storeKey = addPutMessagesToReplicasOfPartition(partitionId, Arrays.asList(remoteHost), 1).get(0);
+    StoreKey storeKeyNotExist = addPutMessagesToReplicasOfPartition(partitionId, Arrays.asList(randomHost), 1).get(0);
+
+    MockConnectionPool connectionPool = new MockConnectionPool(hosts, clusterMap, 5);
+    ambryRequests = new AmbryServerRequests(storageManager, requestResponseChannel, clusterMap, dataNodeId,
+        clusterMap.getMetricRegistry(), serverMetrics, findTokenHelper, null, replicationManager, storeKeyFactory, serverConfig,
+        diskManagerConfig, storeKeyConverterFactory, statsManager, helixParticipant, connectionPool);
+
+    Assume.assumeTrue(
+        MessageFormatRecord.getCurrentMessageHeaderVersion() >= MessageFormatRecord.Message_Header_Version_V3);
+    int correlationId = TestUtils.RANDOM.nextInt();
+    String clientId = TestUtils.getRandomString(10);
+    BlobId blobId = (BlobId)storeKeyNotExist;
+
+    ReplicateBlobRequest request = new ReplicateBlobRequest(correlationId, clientId, blobId,
+        remoteHost.dataNodeId.getHostname(), remoteHost.dataNodeId.getPort(), (short)1);
+    storageManager.resetStore();
+    RequestOrResponseType requestType = request.getRequestType();
+    Response response = sendRequestGetResponse(request, ServerErrorCode.Blob_Not_Found);
+    assertEquals("Operation received at the store not as expected", null, MockStorageManager.operationReceived);
+    ReplicateBlobResponse replicateBlobResponse = (ReplicateBlobResponse) response;
+    assertEquals("expect ReplicateBlobRequest fails with Blob_Not_Found.", replicateBlobResponse.getError(), ServerErrorCode.Blob_Not_Found);
+  }
+
+  @Test
+  public void testReplicateBlobWhenTargetConditions() throws Exception {
+    // ON_DEMAND_REPLICATION_TODO:
+    // Besides the above test cases to test the different conditions on the source host, need verify the different cases on the local store.
+    // But doesn't have a good way to simulate these local store errors with unit test yet.
+    // test PutBlob but StoreErrorCodes.Already_Exist
+    // test PutBlob and applyTTLUpdate but hit StoreErrorCodes.Already_Updated or StoreErrorCodes.ID_Deleted
+    // test PutBlob and applyDelete but hit StoreErrorCodes.ID_Deleted or StoreErrorCodes.Life_Version_Conflict
   }
 
   /**


### PR DESCRIPTION
It's the first PR of the on-demand replication.
1. This RP, implemented ReplicateBlobRequest handling in AmbryServer.

Will split to multiple small PRs,
1. Interface change:
   a. Add ReplicateBlobRequest and ReplicateBlobResponse.
   b. For all the classes implements RequestAPI, add the dummy handling, throw UnsupportedOperationException.