### PR TITLE
Don't rely on router.getOperaionCount to be zero in tests

### DIFF
--- a/ambry-router/src/test/java/com/github/ambry/router/RouterTestHelpers.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/RouterTestHelpers.java
@@ -132,8 +132,7 @@ class RouterTestHelpers {
    * @param errorCodeChecker Performs the checks that ensure that {@link RouterErrorCode#TooManyRequests} is returned .
    * @throws Exception
    */
-  static void testWithQuotaRejection(ErrorCodeChecker errorCodeChecker)
-      throws Exception {
+  static void testWithQuotaRejection(ErrorCodeChecker errorCodeChecker) throws Exception {
     errorCodeChecker.testAndAssert(RouterErrorCode.TooManyRequests);
   }
 
@@ -198,13 +197,14 @@ class RouterTestHelpers {
   /**
    * Asserts that expected threads are not running after the router is closed.
    */
-  static void assertCloseCleanup(NonBlockingRouter router) {
+  static void assertCloseCleanup(NonBlockingRouter router, long operationCount) {
     router.close();
     Assert.assertEquals("No ChunkFiller Thread should be running after the router is closed", 0,
         TestUtils.numThreadsByThisName("ChunkFillerThread"));
     Assert.assertEquals("No RequestResponseHandler should be running after the router is closed", 0,
         TestUtils.numThreadsByThisName("RequestResponseHandlerThread"));
-    Assert.assertEquals("All operations should have completed", 0, router.getOperationsCount());
+    long operationCountAfterTest = router.getOperationsCount();
+    Assert.assertEquals("All operations should have completed", operationCount, operationCountAfterTest);
   }
 
   /**
@@ -312,7 +312,7 @@ class RouterTestHelpers {
   static List<ChunkInfo> buildChunkList(ClusterMap clusterMap, BlobId.BlobDataType blobDataType, long ttl,
       LongStream chunkSizeStream) {
     return chunkSizeStream.mapToObj(
-        chunkSize -> new ChunkInfo(getRandomBlobId(clusterMap, blobDataType), chunkSize, ttl))
+            chunkSize -> new ChunkInfo(getRandomBlobId(clusterMap, blobDataType), chunkSize, ttl))
         .collect(Collectors.toList());
   }
 

--- a/ambry-router/src/test/java/com/github/ambry/router/TtlUpdateManagerTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/TtlUpdateManagerTest.java
@@ -88,6 +88,7 @@ public class TtlUpdateManagerTest {
   private final AccountService accountService = new InMemAccountService(true, false);
   private final QuotaChargeCallback quotaChargeCallback = QuotaTestUtils.createTestQuotaChargeCallback();
   private NettyByteBufLeakHelper nettyByteBufLeakHelper = new NettyByteBufLeakHelper();
+  private long operationCount = 0;
 
   /**
    * Sets up all required components including a blob.
@@ -121,6 +122,7 @@ public class TtlUpdateManagerTest {
   @Before
   public void before() {
     nettyByteBufLeakHelper.beforeTest();
+    operationCount = router.getOperationsCount();
   }
 
   @After
@@ -132,7 +134,7 @@ public class TtlUpdateManagerTest {
   @After
   public void cleanUp() {
     ttlUpdateManager.close();
-    assertCloseCleanup(router);
+    assertCloseCleanup(router, operationCount);
   }
 
   /**

--- a/ambry-router/src/test/java/com/github/ambry/router/UndeleteManagerTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/UndeleteManagerTest.java
@@ -88,6 +88,7 @@ public class UndeleteManagerTest {
   private final NonBlockingRouterMetrics metrics;
   private UndeleteManager undeleteManager;
   private SocketNetworkClient networkClient;
+  private long operationCountBeforeTest = 0;
 
   /**
    * Constructor to setup UndeleteManagerTest
@@ -102,6 +103,7 @@ public class UndeleteManagerTest {
     router =
         new NonBlockingRouter(routerConfig, metrics, networkClientFactory, notificationSystem, clusterMap, null, null,
             null, new InMemAccountService(false, true), time, MockClusterMap.DEFAULT_PARTITION_CLASS, null);
+    operationCountBeforeTest = router.getOperationsCount();
   }
 
   @Before
@@ -112,7 +114,8 @@ public class UndeleteManagerTest {
       BlobProperties putBlobProperties =
           new BlobProperties(-1, "serviceId", "memberId", "contentType", false, Utils.Infinite_Time,
               Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM), false, null, null, null);
-      String blobId = router.putBlob(putBlobProperties, new byte[0], putChannel, new PutBlobOptionsBuilder().build()).get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+      String blobId = router.putBlob(putBlobProperties, new byte[0], putChannel, new PutBlobOptionsBuilder().build())
+          .get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
       blobIds.add(blobId);
       // Make sure all the mock servers have this put
       BlobId id = new BlobId(blobId, clusterMap);
@@ -137,7 +140,7 @@ public class UndeleteManagerTest {
   public void cleanup() {
     undeleteManager.close();
     // Only first test would use router, so close it here.
-    assertCloseCleanup(router);
+    assertCloseCleanup(router, operationCountBeforeTest);
   }
 
   /**
@@ -151,8 +154,7 @@ public class UndeleteManagerTest {
     for (String blobId : blobIds) {
       deleteBlobInAllServer(blobId);
       // Undelete requires global quorum, so we have to make sure all the mock servers received a delete.
-      router.undeleteBlob(blobId, UNDELETE_SERVICE_ID)
-          .get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+      router.undeleteBlob(blobId, UNDELETE_SERVICE_ID).get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
       verifyUndelete(blobId);
     }
   }
@@ -363,8 +365,7 @@ public class UndeleteManagerTest {
 
   private void assertDeleted(String blobId) throws Exception {
     try {
-      router.getBlob(blobId, new GetBlobOptionsBuilder().build())
-          .get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+      router.getBlob(blobId, new GetBlobOptionsBuilder().build()).get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
       fail("blob " + blobId + " Should be deleted");
     } catch (ExecutionException e) {
       assertTrue(e.getCause() instanceof RouterException);
@@ -373,14 +374,12 @@ public class UndeleteManagerTest {
   }
 
   private void assertNotDeleted(String blobId) throws Exception {
-    router.getBlob(blobId, new GetBlobOptionsBuilder().build())
-        .get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    router.getBlob(blobId, new GetBlobOptionsBuilder().build()).get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
   }
 
   private void deleteBlobInAllServer(String blobId) throws Exception {
     // Delete this blob
-    router.deleteBlob(blobId, "serviceid")
-        .get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    router.deleteBlob(blobId, "serviceid").get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
     // Then make sure all the mock servers have the delete request.
     assertDeleted(blobId);
     BlobId id = new BlobId(blobId, clusterMap);
@@ -456,8 +455,8 @@ public class UndeleteManagerTest {
     executeOpAndVerify(ids, expectedErrorCode, false);
   }
 
-  private void sendRequestsGetResponse(FutureResult<Void> future, UndeleteManager undeleteManager,
-      boolean advanceTime, boolean isQuotaRejected) {
+  private void sendRequestsGetResponse(FutureResult<Void> future, UndeleteManager undeleteManager, boolean advanceTime,
+      boolean isQuotaRejected) {
     List<RequestInfo> requestInfoList = new ArrayList<>();
     Set<Integer> requestsToDrop = new HashSet<>();
     Set<RequestInfo> requestAcks = new HashSet<>();
@@ -468,8 +467,9 @@ public class UndeleteManagerTest {
 
       List<ResponseInfo> responseInfoList;
       if (isQuotaRejected) {
-        responseInfoList = requestInfoList.stream().map(requestInfo -> new ResponseInfo(requestInfo, true)).collect(
-            Collectors.toList());
+        responseInfoList = requestInfoList.stream()
+            .map(requestInfo -> new ResponseInfo(requestInfo, true))
+            .collect(Collectors.toList());
       } else {
         responseInfoList = new ArrayList<>();
         try {


### PR DESCRIPTION
In tests, let's compare the operation counts before and after tests.