### PR TITLE
Add index segment start offsets before and after compaction to compaction log

### DIFF
--- a/ambry-store/src/main/java/com/github/ambry/store/CompactionLog.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/CompactionLog.java
@@ -324,7 +324,7 @@ class CompactionLog implements Closeable {
     // copying. Either way, we should keep the original after offset, since the after offset should reference to the
     // first index segment that has data from before index segment.
     if (beforeAndAfterIndexSegmentOffsets.containsKey(before)) {
-      logger.trace("{}: Offset already exist in the map", file, before);
+      logger.trace("{}: Offset {} already exist in the map", file, before);
       return;
     }
     LogSegmentName logSegmentName = before.getName();

--- a/ambry-store/src/main/java/com/github/ambry/store/CompactionLog.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/CompactionLog.java
@@ -360,9 +360,7 @@ class CompactionLog implements Closeable {
   }
 
   /**
-   * Return the index segment offset map. Each key and value is before and after pair passed to {@link #addIndexSegmentOffsetPair}.
-   * DON'T modify this map.
-   * @return
+   * @return The index segment offset map. Each key and value is before and after pair passed to {@link #addIndexSegmentOffsetPair}.
    */
   NavigableMap<Offset, Offset> getIndexSegmentOffsets() {
     return Collections.unmodifiableNavigableMap(beforeAndAfterIndexSegmentOffsets);

--- a/ambry-store/src/main/java/com/github/ambry/store/CompactionLog.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/CompactionLog.java
@@ -27,9 +27,11 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.NavigableMap;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
@@ -132,7 +134,7 @@ class CompactionLog implements Closeable {
    * @return The start time in milliseconds.
    */
   static long getStartTimeFromFile(File file) {
-    return Long.valueOf(file.getName().split(BlobStore.SEPARATOR)[2]);
+    return Long.parseLong(file.getName().split(BlobStore.SEPARATOR)[2]);
   }
 
   /**
@@ -362,8 +364,8 @@ class CompactionLog implements Closeable {
    * DON'T modify this map.
    * @return
    */
-  TreeMap<Offset, Offset> getIndexSegmentOffsets() {
-    return beforeAndAfterIndexSegmentOffsets;
+  NavigableMap<Offset, Offset> getIndexSegmentOffsets() {
+    return Collections.unmodifiableNavigableMap(beforeAndAfterIndexSegmentOffsets);
   }
 
   /**
@@ -545,10 +547,6 @@ class CompactionLog implements Closeable {
    * Flushes all changes to the file backing this compaction log.
    */
   private void flush() {
-    /*
-        Description of serialized format
-
-       */
     File tempFile = new File(file.getAbsolutePath() + ".tmp");
     try (FileOutputStream fileOutputStream = new FileOutputStream(tempFile)) {
       CrcOutputStream crcOutputStream = new CrcOutputStream(fileOutputStream);

--- a/ambry-store/src/main/java/com/github/ambry/store/CompactionLog.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/CompactionLog.java
@@ -29,6 +29,11 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,7 +44,8 @@ import org.slf4j.LoggerFactory;
 class CompactionLog implements Closeable {
   static final short VERSION_0 = 0;
   static final short VERSION_1 = 1;
-  static final short CURRENT_VERSION = VERSION_1;
+  static final short VERSION_2 = 2;
+  static final short CURRENT_VERSION = VERSION_2;
   static final String COMPACTION_LOG_SUFFIX = "_compactionLog";
 
   private static final byte[] ZERO_LENGTH_ARRAY = new byte[0];
@@ -58,6 +64,9 @@ class CompactionLog implements Closeable {
   final List<CycleLog> cycleLogs;
   private final File file;
   private final Time time;
+  private final TreeMap<Offset, Offset> beforeAndAfterIndexSegmentOffsets = new TreeMap<>();
+  private final short version;
+  private final StoreConfig config;
 
   private int currentIdx = 0;
   private Offset startOffsetOfLastIndexSegmentForDeleteCheck = null;
@@ -73,6 +82,60 @@ class CompactionLog implements Closeable {
   }
 
   /**
+   * The {@link CompactionLog} processor.
+   */
+  @FunctionalInterface
+  interface CompactionLogProcessor {
+
+    /**
+     * Process a given {@link CompactionLog}.
+     * @param log The {@link CompactionLog} to process.
+     * @return True if you want to process more compaction log.
+     */
+    boolean process(CompactionLog log);
+  }
+
+  /**
+   * Process all the available {@link CompactionLog}s in descending order. The CompactionLog created most recently would
+   * be processed first.
+   * @param dir The data dir that contains all the compaction log files.
+   * @param storeId The store id.
+   * @param storeKeyFactory The {@link StoreKeyFactory}.
+   * @param time The time instance.
+   * @param config The {@link StoreConfig} object.
+   * @param processor The {@link CompactionLogProcessor}.
+   * @throws IOException
+   */
+  static void processCompactionLogs(String dir, String storeId, StoreKeyFactory storeKeyFactory, Time time,
+      StoreConfig config, CompactionLogProcessor processor) throws IOException {
+    // Ignore current in process compaction.
+    File storeDir = new File(dir);
+    File[] files =
+        storeDir.listFiles((fileDir, name) -> name.startsWith(storeId + COMPACTION_LOG_SUFFIX + BlobStore.SEPARATOR));
+    List<File> sortedFiles = Stream.of(files)
+        .sorted((file1, file2) -> (int) (getStartTimeFromFile(file2) - getStartTimeFromFile(file1)))
+        .collect(Collectors.toList());
+    File inProgressCompactionLog = new File(dir, storeId + COMPACTION_LOG_SUFFIX);
+    if (inProgressCompactionLog.exists()) {
+      sortedFiles.add(0, inProgressCompactionLog); // If there is an in progress compaction log, put it in the front.
+    }
+    for (File file : sortedFiles) {
+      if (!processor.process(new CompactionLog(file, storeKeyFactory, time, config))) {
+        break;
+      }
+    }
+  }
+
+  /**
+   * Getting start time from the compaction log file.
+   * @param file The compaction log file.
+   * @return The start time in milliseconds.
+   */
+  static long getStartTimeFromFile(File file) {
+    return Long.valueOf(file.getName().split(BlobStore.SEPARATOR)[2]);
+  }
+
+  /**
    * Creates a new compaction log.
    * @param dir the directory at which the compaction log must be created.
    * @param storeId the ID of the store.
@@ -82,7 +145,25 @@ class CompactionLog implements Closeable {
    */
   CompactionLog(String dir, String storeId, Time time, CompactionDetails compactionDetails, StoreConfig config)
       throws IOException {
+    this(dir, storeId, CURRENT_VERSION, time, compactionDetails, config);
+  }
+
+  /**
+   * Creates a new compaction log, with custom version. This should only be used in test.
+   * @param dir the directory at which the compaction log must be created.
+   * @param storeId the ID of the store.
+   * @param version the version number.
+   * @param time the {@link Time} instance to use.
+   * @param compactionDetails the details about the compaction.
+   * @param config the store config to use in this compaction log.
+   */
+  CompactionLog(String dir, String storeId, short version, Time time, CompactionDetails compactionDetails,
+      StoreConfig config) throws IOException {
     this.time = time;
+    if (version < VERSION_0 || version > VERSION_2) {
+      throw new IllegalArgumentException("Invalid version number: " + version);
+    }
+    this.version = version;
     file = new File(dir, storeId + COMPACTION_LOG_SUFFIX);
     if (!file.createNewFile()) {
       throw new IllegalArgumentException(file.getAbsolutePath() + " already exists");
@@ -94,6 +175,7 @@ class CompactionLog implements Closeable {
     if (config.storeSetFilePermissionEnabled) {
       Files.setPosixFilePermissions(file.toPath(), config.storeOperationFilePermission);
     }
+    this.config = config;
     logger.trace("Created compaction log: {}", file);
   }
 
@@ -125,10 +207,11 @@ class CompactionLog implements Closeable {
     }
     this.file = compactionLogFile;
     this.time = time;
+    this.config = config;
     try (FileInputStream fileInputStream = new FileInputStream(file)) {
       CrcInputStream crcInputStream = new CrcInputStream(fileInputStream);
       DataInputStream stream = new DataInputStream(crcInputStream);
-      short version = stream.readShort();
+      this.version = stream.readShort();
       switch (version) {
         case VERSION_0:
           startTime = stream.readLong();
@@ -144,6 +227,7 @@ class CompactionLog implements Closeable {
           }
           break;
         case VERSION_1:
+        case VERSION_2:
           startTime = stream.readLong();
           if (stream.readByte() == (byte) 1) {
             startOffsetOfLastIndexSegmentForDeleteCheck = Offset.fromBytes(stream);
@@ -153,6 +237,14 @@ class CompactionLog implements Closeable {
           cycleLogs = new ArrayList<>(cycleLogsSize);
           while (cycleLogs.size() < cycleLogsSize) {
             cycleLogs.add(CycleLog.fromBytes(stream, storeKeyFactory));
+          }
+          if (version == VERSION_2) {
+            int mapSize = stream.readInt();
+            for (int i = 0; i < mapSize; i++) {
+              Offset before = Offset.fromBytes(stream);
+              Offset after = Offset.fromBytes(stream);
+              beforeAndAfterIndexSegmentOffsets.put(before, after);
+            }
           }
           crc = crcInputStream.getValue();
           if (crc != stream.readLong()) {
@@ -167,6 +259,10 @@ class CompactionLog implements Closeable {
       }
       logger.trace("Loaded compaction log: {}", file);
     }
+  }
+
+  long getStartTime() {
+    return startTime;
   }
 
   /**
@@ -211,6 +307,111 @@ class CompactionLog implements Closeable {
     flush();
     logger.trace("{}: Set safe token to {} during compaction of {}", file, cycleLog.safeToken,
         cycleLog.compactionDetails);
+  }
+
+  /**
+   * Add a pair of index segment start offsets. The first offset has to be an index segment start offset that belongs to
+   * an under compaction log segment. The second offset hast to be an index segment start offset that belongs to a log
+   * segment created this compaction.
+   * @param before The index segment start offset before compaction
+   * @param after The index segment start offset after compaction
+   */
+  void addIndexSegmentOffsetPair(Offset before, Offset after) {
+    if (!isIndexSegmentOffsetsPersisted()) {
+      return;
+    }
+    // If the before offset already exists, it means the index segment has already been copied, or half way through
+    // copying. Either way, we should keep the original after offset, since the after offset should reference to the
+    // first index segment that has data from before index segment.
+    if (beforeAndAfterIndexSegmentOffsets.containsKey(before)) {
+      logger.trace("{}: Offset already exist in the map", file, before);
+      return;
+    }
+    LogSegmentName logSegmentName = before.getName();
+    if (!getCompactionDetails().getLogSegmentsUnderCompaction().contains(logSegmentName)) {
+      throw new IllegalArgumentException("Offset is not part of the under compaction log segments: " + before);
+    }
+    // TODO: Can we find a way to validate the after offset?
+    beforeAndAfterIndexSegmentOffsets.put(before, after);
+    logger.trace("{}: Add offsets pair to {}: {}", file, before, after);
+    flush();
+  }
+
+  /**
+   * Update all the index segment offset values added through method {@link #addIndexSegmentOffsetPair}. If the input is
+   * null, the index segment offsets map would be cleared.
+   * @param validOffset The valid {@link Offset} to replace all the previous invalid {@link Offset}.
+   */
+  void updateIndexSegmentOffsetsWithValidOffset(Offset validOffset) {
+    if (!isIndexSegmentOffsetsPersisted()) {
+      return;
+    }
+    logger.info("{}: Validate offsets map with: {}", file, validOffset);
+    if (validOffset == null) {
+      beforeAndAfterIndexSegmentOffsets.clear();
+    } else {
+      for (Offset before : beforeAndAfterIndexSegmentOffsets.keySet()) {
+        beforeAndAfterIndexSegmentOffsets.put(before, validOffset);
+      }
+    }
+    flush();
+  }
+
+  /**
+   * Return the index segment offset map. Each key and value is before and after pair passed to {@link #addIndexSegmentOffsetPair}.
+   * DON'T modify this map.
+   * @return
+   */
+  TreeMap<Offset, Offset> getIndexSegmentOffsets() {
+    return beforeAndAfterIndexSegmentOffsets;
+  }
+
+  /**
+   * Return index segment offset map for completed cycles. Each key offset's LogSegmentName has to finish the compaction.
+   */
+  SortedMap<Offset, Offset> getIndexSegmentOffsetsForCompletedCycles() {
+    if (beforeAndAfterIndexSegmentOffsets.size() == 0 || currentIdx >= cycleLogs.size()) {
+      return beforeAndAfterIndexSegmentOffsets;
+    }
+
+    if (currentIdx == 0) {
+      return new TreeMap<>();
+    }
+
+    List<CycleLog> cycles = cycleLogs.subList(0, currentIdx);
+    List<LogSegmentName> completedLogSegmentNames = cycles.stream()
+        .flatMap(cycleLog -> cycleLog.compactionDetails.getLogSegmentsUnderCompaction().stream())
+        .collect(Collectors.toList());
+    return getIndexSegmentOffsetsForLogSegments(completedLogSegmentNames);
+  }
+
+  /**
+   * Return index segment offset map for current cycle. Each key offset's LogSegmentName has to be in current cycle.
+   */
+  SortedMap<Offset, Offset> getIndexSegmentOffsetsForCurrentCycle() {
+    if (currentIdx == -1) {
+      throw new IllegalArgumentException(file.getName() + "Current Index is -1, no current cycle");
+    }
+    return getIndexSegmentOffsetsForLogSegments(getCurrentCycleLog().compactionDetails.getLogSegmentsUnderCompaction());
+  }
+
+  private SortedMap<Offset, Offset> getIndexSegmentOffsetsForLogSegments(List<LogSegmentName> logSegmentNames) {
+    if (logSegmentNames.size() == 0) {
+      return new TreeMap<>();
+    }
+
+    Offset start = new Offset(logSegmentNames.get(0), 0);
+    Offset end = new Offset(logSegmentNames.get(logSegmentNames.size() - 1), config.storeSegmentSizeInBytes);
+    return beforeAndAfterIndexSegmentOffsets.subMap(start, end);
+  }
+
+  /**
+   * True when the {@link CompactionLog} persists index segment offset. Starting from version 2, compaction log should
+   * persist index segment offsets.
+   * @return
+   */
+  boolean isIndexSegmentOffsetsPersisted() {
+    return version >= VERSION_2;
   }
 
   /**
@@ -268,8 +469,8 @@ class CompactionLog implements Closeable {
         newList.add(segmentUnderCompaction);
       }
     }
-    getCurrentCycleLog().compactionDetails = new CompactionDetails(currentDetails.getReferenceTimeMs(), updatedList,
-        null);
+    getCurrentCycleLog().compactionDetails =
+        new CompactionDetails(currentDetails.getReferenceTimeMs(), updatedList, null);
     cycleLogs.add(new CycleLog(new CompactionDetails(currentDetails.getReferenceTimeMs(), newList, null)));
     flush();
     logger.trace("{}: Split current cycle into two lists: {} and {}", file, updatedList, newList);
@@ -365,24 +566,54 @@ class CompactionLog implements Closeable {
           cycleLog1 (see CycleLog#toBytes())
           cycleLog2
           ...
+         Version 2:
+          version
+          startTime
+          byte to indicate whether startOffsetOfLastIndexSegmentForDeleteCheck is present (1) or not (0)
+          startOffsetOfLastIndexSegmentForDeleteCheck if not null
+          index of current cycle's log
+          size of cycle log list
+          cycleLog1 (see CycleLog#toBytes())
+          cycleLog2
+          ...
+          size of beforeAndAfterIndexSegmentOffsetsMap
+          beforeOffset1, afterOffset1
+          beforeOffset2, afterOffset2
+          ...
           crc
        */
     File tempFile = new File(file.getAbsolutePath() + ".tmp");
     try (FileOutputStream fileOutputStream = new FileOutputStream(tempFile)) {
       CrcOutputStream crcOutputStream = new CrcOutputStream(fileOutputStream);
       DataOutputStream stream = new DataOutputStream(crcOutputStream);
-      stream.writeShort(CURRENT_VERSION);
-      stream.writeLong(startTime);
-      if (startOffsetOfLastIndexSegmentForDeleteCheck == null) {
-        stream.writeByte(0);
-      } else {
-        stream.writeByte(1);
-        stream.write(startOffsetOfLastIndexSegmentForDeleteCheck.toBytes());
-      }
-      stream.writeInt(currentIdx);
-      stream.writeInt(cycleLogs.size());
-      for (CycleLog cycleLog : cycleLogs) {
-        stream.write(cycleLog.toBytes());
+      stream.writeShort(version); // If we read this log from file, then keep this the same version.
+      switch (version) {
+        case VERSION_0:
+          flushVersion_0(stream);
+          break;
+        case VERSION_1:
+        case VERSION_2:
+          stream.writeLong(startTime);
+          if (startOffsetOfLastIndexSegmentForDeleteCheck == null) {
+            stream.writeByte(0);
+          } else {
+            stream.writeByte(1);
+            stream.write(startOffsetOfLastIndexSegmentForDeleteCheck.toBytes());
+          }
+          stream.writeInt(currentIdx);
+          stream.writeInt(cycleLogs.size());
+          for (CycleLog cycleLog : cycleLogs) {
+            stream.write(cycleLog.toBytes());
+          }
+          if (version >= VERSION_2) {
+            stream.writeInt(beforeAndAfterIndexSegmentOffsets.size());
+            // BeforeAndAfterIndexSegmentOffsets is a tree map that would return offset in order
+            for (Map.Entry<Offset, Offset> entry : beforeAndAfterIndexSegmentOffsets.entrySet()) {
+              stream.write(entry.getKey().toBytes());
+              stream.write(entry.getValue().toBytes());
+            }
+          }
+          break;
       }
       stream.writeLong(crcOutputStream.getValue());
       fileOutputStream.getChannel().force(true);
@@ -391,6 +622,15 @@ class CompactionLog implements Closeable {
     }
     if (!tempFile.renameTo(file)) {
       throw new IllegalStateException("Newly written compaction log could not be saved");
+    }
+  }
+
+  private void flushVersion_0(DataOutputStream stream) throws IOException {
+    stream.writeLong(startTime);
+    stream.writeInt(currentIdx);
+    stream.writeInt(cycleLogs.size());
+    for (CycleLog cycleLog : cycleLogs) {
+      stream.write(cycleLog.toBytes());
     }
   }
 

--- a/ambry-store/src/test/java/com/github/ambry/store/CompactionLogTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CompactionLogTest.java
@@ -28,10 +28,10 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.NavigableMap;
 import java.util.Properties;
 import java.util.Set;
 import java.util.SortedMap;
-import java.util.TreeMap;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.After;
@@ -125,7 +125,7 @@ public class CompactionLogTest {
         Offset before = new Offset(logSegmentName, LogSegment.HEADER_SIZE);
         Offset after = new Offset(logSegmentName.getNextGenerationName(), LogSegment.HEADER_SIZE);
         cLog.addIndexSegmentOffsetPair(before, after);
-        fail("Offset " + before + " doesn't belong to under compaction log seegment, should fail");
+        fail("Offset " + before + " doesn't belong to under compaction log segment, should fail");
       } catch (Exception e) {
         // Expect to see exception
       }
@@ -369,7 +369,7 @@ public class CompactionLogTest {
     for (LogSegmentName name : segmentsUnderCompaction) {
       addOneIndexSegmentOffsetPair(name, cLog);
     }
-    TreeMap<Offset, Offset> indexSegmentOffsets = cLog.getIndexSegmentOffsets();
+    NavigableMap<Offset, Offset> indexSegmentOffsets = cLog.getIndexSegmentOffsets();
     for (LogSegmentName name : segmentsUnderCompaction) {
       Offset before = new Offset(name, LogSegment.HEADER_SIZE);
       Offset expectedAfter = new Offset(name.getNextGenerationName(), LogSegment.HEADER_SIZE);

--- a/ambry-store/src/test/java/com/github/ambry/store/CompactionLogTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CompactionLogTest.java
@@ -15,23 +15,27 @@ package com.github.ambry.store;
 
 import com.github.ambry.config.StoreConfig;
 import com.github.ambry.config.VerifiableProperties;
-import com.github.ambry.utils.CrcOutputStream;
 import com.github.ambry.utils.MockTime;
+import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
-import java.io.DataOutputStream;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Test;
 
 import static com.github.ambry.store.StoreFindToken.*;
@@ -111,6 +115,20 @@ public class CompactionLogTest {
               new UUID(1, 1), new UUID(1, 1), null, null, UNINITIALIZED_RESET_KEY_VERSION);
       cLog.setSafeToken(safeToken);
       assertEquals("Returned token not the same as the one that was set", safeToken, cLog.getSafeToken());
+      assertTrue(cLog.isIndexSegmentOffsetsPersisted());
+      int sizeBefore = cLog.getIndexSegmentOffsets().size();
+      Pair<Offset, Offset> pair = addOneIndexSegmentOffsetPair(cLog);
+      cLog.addIndexSegmentOffsetPair(pair.getFirst(), pair.getSecond());
+      assertEquals(sizeBefore + 1, cLog.getIndexSegmentOffsets().size());
+      try {
+        LogSegmentName logSegmentName = StoreTestUtils.getRandomLogSegmentName(generatedSegmentNames);
+        Offset before = new Offset(logSegmentName, LogSegment.HEADER_SIZE);
+        Offset after = new Offset(logSegmentName.getNextGenerationName(), LogSegment.HEADER_SIZE);
+        cLog.addIndexSegmentOffsetPair(before, after);
+        fail("Offset " + before + " doesn't belong to under compaction log seegment, should fail");
+      } catch (Exception e) {
+        // Expect to see exception
+      }
       CompactionDetails nextDetails = detailsIterator.hasNext() ? detailsIterator.next() : null;
       if (nextDetails != null) {
         cLog.splitCurrentCycle(nextDetails.getLogSegmentsUnderCompaction().get(0));
@@ -177,6 +195,26 @@ public class CompactionLogTest {
       cLog.close();
       cLog = new CompactionLog(tempDirStr, storeName, STORE_KEY_FACTORY, time, config);
       assertEquals("Returned token not the same as the one that was set", safeToken, cLog.getSafeToken());
+      assertTrue(cLog.isIndexSegmentOffsetsPersisted());
+      int sizeBefore = cLog.getIndexSegmentOffsets().size();
+      Pair<Offset, Offset> pair = addOneIndexSegmentOffsetPair(cLog);
+      assertEquals(sizeBefore + 1, cLog.getIndexSegmentOffsets().size());
+      cLog.addIndexSegmentOffsetPair(pair.getFirst(), pair.getSecond());
+      assertEquals(sizeBefore + 1, cLog.getIndexSegmentOffsets().size());
+      try {
+        LogSegmentName logSegmentName = StoreTestUtils.getRandomLogSegmentName(generatedSegmentNames);
+        Offset before = new Offset(logSegmentName, LogSegment.HEADER_SIZE);
+        Offset after = new Offset(logSegmentName.getNextGenerationName(), LogSegment.HEADER_SIZE);
+        cLog.addIndexSegmentOffsetPair(before, after);
+        fail("Offset " + before + " doesn't belong to under compaction log seegment, should fail");
+      } catch (Exception e) {
+        // Expect to see exception
+      }
+
+      cLog.close();
+      cLog = new CompactionLog(tempDirStr, storeName, STORE_KEY_FACTORY, time, config);
+      assertTrue(cLog.isIndexSegmentOffsetsPersisted());
+      assertEquals(sizeBefore + 1, cLog.getIndexSegmentOffsets().size());
       CompactionDetails nextDetails = detailsIterator.hasNext() ? detailsIterator.next() : null;
       if (nextDetails != null) {
         cLog.splitCurrentCycle(nextDetails.getLogSegmentsUnderCompaction().get(0));
@@ -275,38 +313,174 @@ public class CompactionLogTest {
   }
 
   /**
-   * Tests the reading of versions older than the current versions.
+   * Tests the reading of version 0
    * @throws IOException
    */
   @Test
-  public void oldVersionsReadTest() throws IOException {
+  public void versionZeroReadTest() throws IOException {
     String storeName = "store";
-    long startTimeMs = Utils.getRandomLong(TestUtils.RANDOM, Long.MAX_VALUE);
     long referenceTimeMs = Utils.getRandomLong(TestUtils.RANDOM, Long.MAX_VALUE);
     CompactionDetails details = getCompactionDetails(referenceTimeMs);
-    for (int i = 0; i < CompactionLog.CURRENT_VERSION; i++) {
-      File file = new File(tempDir, storeName + CompactionLog.COMPACTION_LOG_SUFFIX);
-      switch (i) {
-        case CompactionLog.VERSION_0:
-          try (FileOutputStream fileOutputStream = new FileOutputStream(file)) {
-            CrcOutputStream crcOutputStream = new CrcOutputStream(fileOutputStream);
-            DataOutputStream stream = new DataOutputStream(crcOutputStream);
-            stream.writeShort(i);
-            stream.writeLong(startTimeMs);
-            stream.writeInt(0);
-            stream.writeInt(1);
-            stream.write(new CompactionLog.CycleLog(details).toBytes());
-            stream.writeLong(crcOutputStream.getValue());
-            fileOutputStream.getChannel().force(true);
-          }
-          CompactionLog cLog = new CompactionLog(tempDirStr, storeName, STORE_KEY_FACTORY, time, config);
-          verifyEquality(details, cLog.getCompactionDetails());
-          assertEquals("Current Idx not as expected", 0, cLog.getCurrentIdx());
-          break;
-        default:
-          throw new IllegalStateException("No serialization implementation for version: " + i);
+    CompactionLog cLog = new CompactionLog(tempDirStr, storeName, CompactionLog.VERSION_0, time, details, config);
+    cLog.close();
+    cLog = new CompactionLog(tempDirStr, storeName, STORE_KEY_FACTORY, time, config);
+    verifyEquality(details, cLog.getCompactionDetails());
+    assertEquals("Current Idx not as expected", 0, cLog.getCurrentIdx());
+  }
+
+  /**
+   * Tests the reading of version 1
+   * @throws IOException
+   */
+  @Test
+  public void versionOneReadTest() throws IOException {
+    String storeName = "store";
+    long referenceTimeMs = Utils.getRandomLong(TestUtils.RANDOM, Long.MAX_VALUE);
+    CompactionDetails details = getCompactionDetails(referenceTimeMs);
+    CompactionLog cLog = new CompactionLog(tempDirStr, storeName, CompactionLog.VERSION_1, time, details, config);
+    LogSegmentName logSegmentName = details.getLogSegmentsUnderCompaction().get(0);
+    Offset before = new Offset(logSegmentName, LogSegment.HEADER_SIZE);
+    Offset after = new Offset(logSegmentName.getNextGenerationName(), LogSegment.HEADER_SIZE);
+    cLog.addIndexSegmentOffsetPair(before, after);
+    Assert.assertFalse(cLog.isIndexSegmentOffsetsPersisted());
+    Assert.assertEquals(0, cLog.getIndexSegmentOffsets().size());
+    cLog.close();
+    // Adding index segment offset pair shouldn't change any of the version 1 compaction log
+    cLog = new CompactionLog(tempDirStr, storeName, STORE_KEY_FACTORY, time, config);
+    Assert.assertFalse(cLog.isIndexSegmentOffsetsPersisted());
+    Assert.assertEquals(0, cLog.getIndexSegmentOffsets().size());
+    verifyEquality(details, cLog.getCompactionDetails());
+    assertEquals("Current Idx not as expected", 0, cLog.getCurrentIdx());
+  }
+
+  /**
+   * Testing the methods to get the before and after index segment maps
+   * @throws IOException
+   */
+  @Test
+  public void testIndexSegmentOffsetsMethods() throws IOException {
+    String storeName = "store";
+    CompactionDetails details = getCompactionDetails(0);
+    List<LogSegmentName> segmentsUnderCompaction = details.getLogSegmentsUnderCompaction();
+    segmentsUnderCompaction.sort(LogSegmentName::compareTo);
+    details = new CompactionDetails(0, segmentsUnderCompaction, null);
+
+    CompactionLog cLog = new CompactionLog(tempDirStr, storeName, time, details, config);
+    for (LogSegmentName name : segmentsUnderCompaction) {
+      addOneIndexSegmentOffsetPair(name, cLog);
+    }
+    TreeMap<Offset, Offset> indexSegmentOffsets = cLog.getIndexSegmentOffsets();
+    for (LogSegmentName name : segmentsUnderCompaction) {
+      Offset before = new Offset(name, LogSegment.HEADER_SIZE);
+      Offset expectedAfter = new Offset(name.getNextGenerationName(), LogSegment.HEADER_SIZE);
+      Assert.assertEquals(expectedAfter, indexSegmentOffsets.get(before));
+    }
+    SortedMap<Offset, Offset> indexSegmentOffsetsCompleted = cLog.getIndexSegmentOffsetsForCompletedCycles();
+    // There is no completedCycle yet
+    Assert.assertEquals(0, indexSegmentOffsetsCompleted.size());
+    // All log segments are under compaction at current cycle.
+    SortedMap<Offset, Offset> indexSegmentOffsetsCurrent = cLog.getIndexSegmentOffsetsForCurrentCycle();
+    Assert.assertEquals(segmentsUnderCompaction.size(), indexSegmentOffsetsCurrent.size());
+
+    for (int i = 0; i < segmentsUnderCompaction.size(); i++) {
+      LogSegmentName name = segmentsUnderCompaction.get(i);
+      cLog.markCopyStart();
+      if (i != segmentsUnderCompaction.size() - 1) {
+        cLog.splitCurrentCycle(segmentsUnderCompaction.get(i + 1));
+      }
+      cLog.markCommitStart();
+      cLog.markCleanupStart();
+
+      indexSegmentOffsetsCurrent = cLog.getIndexSegmentOffsetsForCurrentCycle();
+      Assert.assertEquals(1, indexSegmentOffsetsCurrent.size());
+      Assert.assertEquals(new Offset(name, LogSegment.HEADER_SIZE),
+          indexSegmentOffsetsCurrent.keySet().iterator().next());
+
+      cLog.close();
+      cLog = new CompactionLog(tempDirStr, storeName, STORE_KEY_FACTORY, time, config);
+
+      // Before completing this cycle, get the
+      indexSegmentOffsetsCompleted = cLog.getIndexSegmentOffsetsForCompletedCycles();
+      Assert.assertEquals(i, indexSegmentOffsetsCompleted.size());
+      for (int idx = 0; idx < i; idx++) {
+        LogSegmentName sname = segmentsUnderCompaction.get(idx);
+        Assert.assertTrue(indexSegmentOffsetsCompleted.containsKey(new Offset(sname, LogSegment.HEADER_SIZE)));
+      }
+      cLog.markCycleComplete();
+      indexSegmentOffsetsCompleted = cLog.getIndexSegmentOffsetsForCompletedCycles();
+      Assert.assertEquals(i + 1, indexSegmentOffsetsCompleted.size());
+      for (int idx = 0; idx < i + 1; idx++) {
+        LogSegmentName sname = segmentsUnderCompaction.get(idx);
+        Assert.assertTrue(indexSegmentOffsetsCompleted.containsKey(new Offset(sname, LogSegment.HEADER_SIZE)));
+      }
+
+      cLog.close();
+      if (i != segmentsUnderCompaction.size() - 1) {
+        cLog = new CompactionLog(tempDirStr, storeName, STORE_KEY_FACTORY, time, config);
+      } else {
+        AtomicReference<CompactionLog> compactionLogRef = new AtomicReference<>();
+        CompactionLog.processCompactionLogs(tempDirStr, storeName, STORE_KEY_FACTORY, time, config, compactionLog -> {
+          compactionLogRef.set(compactionLog);
+          return false;
+        });
+        cLog = compactionLogRef.get();
+      }
+      indexSegmentOffsetsCompleted = cLog.getIndexSegmentOffsetsForCompletedCycles();
+      Assert.assertEquals(i + 1, indexSegmentOffsetsCompleted.size());
+      for (int idx = 0; idx < i + 1; idx++) {
+        LogSegmentName sname = segmentsUnderCompaction.get(idx);
+        Assert.assertTrue(indexSegmentOffsetsCompleted.containsKey(new Offset(sname, LogSegment.HEADER_SIZE)));
       }
     }
+  }
+
+  /**
+   * Test {@link CompactionLog#processCompactionLogs}.
+   * @throws Exception
+   */
+  @Test
+  public void testProcessCompactionLogs() throws Exception {
+    // First create some compaction logs
+    String storeName = "store";
+    List<CompactionDetails> detailsList = getCompactionDetailsList(10);
+    List<Long> expectedStartTimes = new ArrayList<>();
+    Map<Offset, Offset> expectedIndexSegmentOffsets = new HashMap<>();
+    for (CompactionDetails details : detailsList) {
+      CompactionLog cLog = new CompactionLog(tempDirStr, storeName, time, details, config);
+      Pair<Offset, Offset> pair = addOneIndexSegmentOffsetPair(cLog);
+      expectedIndexSegmentOffsets.put(pair.getFirst(), pair.getSecond());
+      expectedStartTimes.add(0, time.milliseconds());
+      cLog.markCopyStart();
+      cLog.markCommitStart();
+      cLog.markCleanupStart();
+      cLog.markCycleComplete();
+      cLog.close();
+      Assert.assertFalse(CompactionLog.isCompactionInProgress(tempDirStr, storeName));
+      time.sleep(10000);
+    }
+
+    CompactionDetails details = getCompactionDetailsList(1).get(0);
+    CompactionLog cLog = new CompactionLog(tempDirStr, storeName, time, details, config);
+    Pair<Offset, Offset> pair = addOneIndexSegmentOffsetPair(cLog);
+    expectedIndexSegmentOffsets.put(pair.getFirst(), pair.getSecond());
+    expectedStartTimes.add(0, time.milliseconds());
+    cLog.close();
+    Assert.assertTrue(CompactionLog.isCompactionInProgress(tempDirStr, storeName));
+
+    // Now we have 10 completed compaction logs and one in progress compaction log
+    List<Long> obtainedStartTimes = new ArrayList<>();
+    Map<Offset, Offset> obtainedIndexSegmentOffsets = new HashMap<>();
+    CompactionLog.processCompactionLogs(tempDirStr, storeName, STORE_KEY_FACTORY, time, config, log -> {
+      obtainedStartTimes.add(log.getStartTime());
+      obtainedIndexSegmentOffsets.putAll(log.getIndexSegmentOffsets());
+      return true;
+    });
+
+    Assert.assertEquals(11, obtainedStartTimes.size());
+    Assert.assertEquals(11, obtainedIndexSegmentOffsets.size());
+
+    Assert.assertEquals(expectedIndexSegmentOffsets, obtainedIndexSegmentOffsets);
+    Assert.assertEquals(expectedStartTimes, obtainedStartTimes);
   }
 
   // helpers
@@ -421,5 +595,17 @@ public class CompactionLogTest {
         // expected. Nothing to do.
       }
     }
+  }
+
+  private Pair<Offset, Offset> addOneIndexSegmentOffsetPair(CompactionLog cLog) {
+    LogSegmentName logSegmentName = cLog.getCompactionDetails().getLogSegmentsUnderCompaction().get(0);
+    return addOneIndexSegmentOffsetPair(logSegmentName, cLog);
+  }
+
+  private Pair<Offset, Offset> addOneIndexSegmentOffsetPair(LogSegmentName logSegmentName, CompactionLog cLog) {
+    Offset before = new Offset(logSegmentName, LogSegment.HEADER_SIZE);
+    Offset after = new Offset(logSegmentName.getNextGenerationName(), LogSegment.HEADER_SIZE);
+    cLog.addIndexSegmentOffsetPair(before, after);
+    return new Pair<>(before, after);
   }
 }


### PR DESCRIPTION
Adding several new features to CompactionLog.
1. Adding a new version to keep index segment start offsets pair before and after compaction. This would be used in BlobStoreCompactor.
2. Adding a static method to process CompactionLogs in the disk.