### PR TITLE
Start using IndexSegment offsets from compaction log to generate new token in PersistentIndex

### DIFF
--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -257,6 +257,7 @@ public class BlobStore implements Store {
             && config.storePartitionsToRebuildTokenBasedOnCompactionHistory.contains(
             replicaId.getPartitionId().getId())) {
           compactor.enablePersistIndexSegmentOffsets();
+          index.enableRebuildTokenBasedOnCompactionHistory();
           buildCompactionHistory();
         }
         if (blobStoreStats == null) {

--- a/ambry-store/src/main/java/com/github/ambry/store/StoreMetrics.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StoreMetrics.java
@@ -57,6 +57,8 @@ public class StoreMetrics {
   public final Counter indexBasedTokenResetCount;
   public final Counter journalBasedTokenResetCount;
   public final Counter resetKeyFoundInCurrentIndex;
+  public final Counter generateTokenBasedOnCompactionHistoryCount;
+  public final Counter offsetFoundInBeforeAfterMapCount;
   public final Counter beforeAndAfterOffsetSanityCheckFailureCount;
   public final Timer recoveryTime;
   public final Timer findTime;
@@ -158,6 +160,10 @@ public class StoreMetrics {
         registry.counter(MetricRegistry.name(PersistentIndex.class, name + "JournalBasedTokenResetCount"));
     resetKeyFoundInCurrentIndex =
         registry.counter(MetricRegistry.name(PersistentIndex.class, name + "ResetKeyFoundInCurrentIndex"));
+    generateTokenBasedOnCompactionHistoryCount = registry.counter(
+        MetricRegistry.name(PersistentIndex.class, name + "GenerateTokenBasedOnCompactionHistoryCount"));
+    offsetFoundInBeforeAfterMapCount =
+        registry.counter(MetricRegistry.name(PersistentIndex.class, name + "OffsetFoundInBeforeAfterMapCount"));
     beforeAndAfterOffsetSanityCheckFailureCount = registry.counter(
         MetricRegistry.name(PersistentIndex.class, name + "BeforeAndAfterOffsetSanityCheckFailureCount"));
     recoveryTime = registry.timer(MetricRegistry.name(PersistentIndex.class, name + "IndexRecoveryTime"));

--- a/ambry-store/src/test/java/com/github/ambry/store/IndexTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/IndexTest.java
@@ -770,11 +770,22 @@ public class IndexTest {
 
     state.reloadIndex(true, false);
     assertFalse(state.index.isSanityCheckFailed());
+    beforeAndAfter.clear();
     // Create two non-existing offsets
     Offset nonExistingBefore =
         new Offset(secondIndexSegmentOffset.getName().getNextGenerationName(), LogSegment.HEADER_SIZE);
     Offset nonExistingAfter = new Offset(nonExistingBefore.getName().getNextGenerationName(), LogSegment.HEADER_SIZE);
     beforeAndAfter.put(nonExistingBefore, nonExistingAfter);
+    state.index.updateBeforeAndAfterCompactionIndexSegmentOffsets(state.time.milliseconds(), beforeAndAfter, false);
+    state.index.sanityCheckBeforeAndAfterCompactionIndexSegmentOffsets();
+    assertTrue(state.index.isSanityCheckFailed());
+
+    state.reloadIndex(true, false);
+    assertFalse(state.index.isSanityCheckFailed());
+    beforeAndAfter.clear();
+    // Create a loop
+    beforeAndAfter.put(nonExistingBefore, nonExistingAfter);
+    beforeAndAfter.put(nonExistingAfter, nonExistingBefore);
     state.index.updateBeforeAndAfterCompactionIndexSegmentOffsets(state.time.milliseconds(), beforeAndAfter, false);
     state.index.sanityCheckBeforeAndAfterCompactionIndexSegmentOffsets();
     assertTrue(state.index.isSanityCheckFailed());

--- a/ambry-store/src/test/java/com/github/ambry/store/IndexTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/IndexTest.java
@@ -1719,6 +1719,81 @@ public class IndexTest {
     compareTokens(expectedToken, token);
   }
 
+  @Test
+  public void rebuildTokenBasedOnCompactionHistoryTest() throws StoreException {
+    assumeTrue(isLogSegmented);
+    stateForTokenTest.index.enableRebuildTokenBasedOnCompactionHistory();
+
+    IndexSegment firstIndexSegment = stateForTokenTest.index.getIndexSegments().firstEntry().getValue();
+    IndexSegment secondIndexSegment =
+        stateForTokenTest.index.getIndexSegments().higherEntry(firstIndexSegment.getStartOffset()).getValue();
+    long now = stateForTokenTest.time.milliseconds();
+    Map<Offset, Offset> indexSegmentOffsets = new HashMap<>();
+    Offset secondIndexSegmentOffset = secondIndexSegment.getStartOffset();
+    Offset before =
+        new Offset(secondIndexSegmentOffset.getName().getNextGenerationName(), secondIndexSegmentOffset.getOffset());
+    indexSegmentOffsets.put(before, secondIndexSegmentOffset);
+    stateForTokenTest.index.updateBeforeAndAfterCompactionIndexSegmentOffsets(now, indexSegmentOffsets, false);
+    stateForTokenTest.index.sanityCheckBeforeAndAfterCompactionIndexSegmentOffsets();
+
+    // 1. Generate an invalid index-based token with invalid offset, but it can be found in the before and after compaction map
+    Offset invalidOffset = before;
+    StoreKey keyFromFirstIndexSegment = firstIndexSegment.iterator().next().getKey();
+    StoreKey keyFromSecondIndexSegment = secondIndexSegment.iterator().next().getKey();
+    StoreFindToken startToken = new StoreFindToken(keyFromFirstIndexSegment, invalidOffset, stateForTokenTest.sessionId,
+        stateForTokenTest.incarnationId, null, null, (short) -1);
+    // The invalid token should be revalidated by looking up the before and after compaction index segment map
+    FindInfo findInfo = stateForTokenTest.index.findEntriesSince(startToken, 1);
+    StoreFindToken token = (StoreFindToken) findInfo.getFindToken();
+    StoreFindToken expectedToken =
+        new StoreFindToken(keyFromSecondIndexSegment, secondIndexSegmentOffset, stateForTokenTest.sessionId,
+            stateForTokenTest.incarnationId, secondIndexSegment.getResetKey(), secondIndexSegment.getResetKeyType(),
+            secondIndexSegment.getResetKeyLifeVersion());
+    compareTokens(expectedToken, token);
+
+    // 2. Generate an invalid index-based token with invalid offset, but it can't be found in the before and after compaction map
+    invalidOffset = new Offset(before.getName().getNextGenerationName(), before.getOffset());
+    startToken = new StoreFindToken(keyFromSecondIndexSegment, invalidOffset, stateForTokenTest.sessionId,
+        stateForTokenTest.incarnationId, null, null, (short) -1);
+    // The invalid token will be revalidated to the beginning of the log
+    findInfo = stateForTokenTest.index.findEntriesSince(startToken, 1);
+    token = (StoreFindToken) findInfo.getFindToken();
+    expectedToken =
+        new StoreFindToken(keyFromFirstIndexSegment, firstIndexSegment.getStartOffset(), stateForTokenTest.sessionId,
+            stateForTokenTest.incarnationId, firstIndexSegment.getResetKey(), firstIndexSegment.getResetKeyType(),
+            firstIndexSegment.getResetKeyLifeVersion());
+    compareTokens(expectedToken, token);
+
+    // 3. Generate an invalid index-based token with invalid offset, but it can be found by multiple redirections.
+    Offset beforeBefore = new Offset(before.getName().getNextGenerationName(), before.getOffset() + 100);
+    indexSegmentOffsets.put(beforeBefore, before);
+    stateForTokenTest.index.updateBeforeAndAfterCompactionIndexSegmentOffsets(now, indexSegmentOffsets, false);
+    stateForTokenTest.index.sanityCheckBeforeAndAfterCompactionIndexSegmentOffsets();
+    invalidOffset = beforeBefore;
+    startToken = new StoreFindToken(keyFromFirstIndexSegment, invalidOffset, stateForTokenTest.sessionId,
+        stateForTokenTest.incarnationId, null, null, (short) -1);
+    // The invalid token should be revalidated by looking up the before and after compaction index segment map
+    findInfo = stateForTokenTest.index.findEntriesSince(startToken, 1);
+    token = (StoreFindToken) findInfo.getFindToken();
+    expectedToken = new StoreFindToken(keyFromSecondIndexSegment, secondIndexSegmentOffset, stateForTokenTest.sessionId,
+        stateForTokenTest.incarnationId, secondIndexSegment.getResetKey(), secondIndexSegment.getResetKeyType(),
+        secondIndexSegment.getResetKeyLifeVersion());
+    compareTokens(expectedToken, token);
+
+    // Generate an invalid journal-based token with invalid offset, but it can be found in the before and after compaction map
+    invalidOffset = new Offset(before.getName(), before.getOffset() + 100);
+    startToken =
+        new StoreFindToken(invalidOffset, stateForTokenTest.sessionId, stateForTokenTest.incarnationId, false, null,
+            null, (short) -1);
+    // The invalid token should be revalidated by looking up the before and after compaction index segment map
+    findInfo = stateForTokenTest.index.findEntriesSince(startToken, 1);
+    token = (StoreFindToken) findInfo.getFindToken();
+    expectedToken = new StoreFindToken(keyFromSecondIndexSegment, secondIndexSegmentOffset, stateForTokenTest.sessionId,
+        stateForTokenTest.incarnationId, secondIndexSegment.getResetKey(), secondIndexSegment.getResetKeyType(),
+        secondIndexSegment.getResetKeyLifeVersion());
+    compareTokens(expectedToken, token);
+  }
+
   /**
    * Auto close last log segment and clean up journal.
    * @throws StoreException


### PR DESCRIPTION
This PR would enable persistent index to start using index segment offsets from compaction log to generate reset token if the index segment can't be found due compaction. 