### PR TITLE
Added replicateBlob interface to the router.

### DIFF
--- a/ambry-account/src/test/java/com/github/ambry/account/MockRouter.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/MockRouter.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.account;
 
+import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.commons.ByteBufferReadableStreamChannel;
 import com.github.ambry.commons.ReadableStreamChannelInputStream;
 import com.github.ambry.messageformat.BlobInfo;
@@ -160,6 +161,12 @@ public class MockRouter implements Router {
     } finally {
       lock.unlock();
     }
+  }
+
+  @Override
+  public Future<Void> replicateBlob(String blobId, String serviceId, DataNodeId sourceDataNode, Callback<Void> callback,
+      QuotaChargeCallback quotaChargeCallback) {
+    throw new UnsupportedOperationException("replicateBlob is not supported by this mock");
   }
 
   @Override

--- a/ambry-api/src/main/java/com/github/ambry/notification/NotificationSystem.java
+++ b/ambry-api/src/main/java/com/github/ambry/notification/NotificationSystem.java
@@ -15,6 +15,7 @@ package com.github.ambry.notification;
 
 import com.github.ambry.account.Account;
 import com.github.ambry.account.Container;
+import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.store.MessageInfo;
 import java.io.Closeable;
@@ -65,6 +66,18 @@ public interface NotificationSystem extends Closeable {
    * @param container The {@link Container} for the blob
    */
   default void onBlobUndeleted(String blobId, String serviceId, Account account, Container container) {
+  }
+
+  /**
+   * Notifies the underlying system when the blob is replicated on-demand.
+   * @param blobId The id of the blob that was replicated to the local store.
+   * @param serviceId The service ID of the service replicating the blob. This can be null if unknown.
+   * @param account The {@link Account} for the blob
+   * @param container The {@link Container} for the blob
+   * @param sourceHost The source {@link DataNodeId} to replicate the blob from
+   */
+  default void onBlobReplicated(String blobId, String serviceId, Account account, Container container,
+      DataNodeId sourceHost) {
   }
 
   /**

--- a/ambry-api/src/main/java/com/github/ambry/router/Router.java
+++ b/ambry-api/src/main/java/com/github/ambry/router/Router.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.router;
 
+import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.commons.Callback;
 import com.github.ambry.commons.CallbackUtils;
 import com.github.ambry.messageformat.BlobInfo;
@@ -57,6 +58,18 @@ public interface Router extends Closeable {
    */
   Future<String> putBlob(BlobProperties blobProperties, byte[] userMetadata, ReadableStreamChannel channel,
       PutBlobOptions options, Callback<String> callback, QuotaChargeCallback quotaChargeCallback);
+
+  /**
+   * Requests to on-demand replicate one specific blob asynchronously and invokes the {@link Callback} when the request completes.
+   * @param blobId The ID of the blob to be replicated.
+   * @param serviceId The service ID of the service replicating the blob. This can be null if unknown.
+   * @param sourceDataNode The source {@link DataNodeId} to get the blob from.
+   * @param callback The {@link Callback} which will be invoked on the completion of the request.
+   * @param quotaChargeCallback Listener interface to charge quota cost for the operation.
+   * @return A future that would contain information about whether the replicateBlob succeeded or not, eventually.
+   */
+  Future<Void> replicateBlob(String blobId, String serviceId, DataNodeId sourceDataNode, Callback<Void> callback,
+      QuotaChargeCallback quotaChargeCallback);
 
   /**
    * Requests for a new metadata blob to be put asynchronously and invokes the {@link Callback} when the request
@@ -170,6 +183,20 @@ public interface Router extends Closeable {
       ReadableStreamChannel channel, PutBlobOptions options) {
     CompletableFuture<String> future = new CompletableFuture<>();
     putBlob(blobProperties, userMetadata, channel, options, CallbackUtils.fromCompletableFuture(future), null);
+    return future;
+  }
+
+  /**
+   * Requests for a blob to be replicated asynchronously and returns a future that will eventually contain information
+   * about whether the request succeeded or not.
+   * @param blobId The ID of the blob to be replicated.
+   * @param serviceId The service ID of the service replicating the blob. This can be null if unknown.
+   * @param sourceDataNode The source {@link DataNodeId} to get the blob from.
+   * @return A future that would contain information about whether the replicateBlob succeeded or not, eventually.
+   */
+  default CompletableFuture<Void> replicateBlob(String blobId, String serviceId, DataNodeId sourceDataNode) {
+    CompletableFuture<Void> future = new CompletableFuture<>();
+    replicateBlob(blobId, serviceId, sourceDataNode, CallbackUtils.fromCompletableFuture(future), null);
     return future;
   }
 

--- a/ambry-commons/src/main/java/com/github/ambry/commons/LoggingNotificationSystem.java
+++ b/ambry-commons/src/main/java/com/github/ambry/commons/LoggingNotificationSystem.java
@@ -15,6 +15,7 @@ package com.github.ambry.commons;
 
 import com.github.ambry.account.Account;
 import com.github.ambry.account.Container;
+import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.notification.BlobReplicaSourceType;
 import com.github.ambry.notification.NotificationBlobType;
@@ -69,7 +70,19 @@ public class LoggingNotificationSystem implements NotificationSystem {
         ", " + serviceId + ", accountName " + (account == null ? null : account.getName()) + ", accountId" + (
             account == null ? null : account.getId()) + ", containerName " + (container == null ? null
             : container.getName()) + ", containerId " + (container == null ? null : container.getId()));
+  }
 
+  @Override
+  public void onBlobReplicated(String blobId, String serviceId, Account account, Container container,
+      DataNodeId sourceHost) {
+    logger.debug("onBlobReplicated {}", blobId, ", " + serviceId
+            + ", accountName " + (account == null ? null : account.getName())
+            + ", accountId" + (account == null ? null : account.getId())
+            + ", containerName " + (container == null ? null : container.getName())
+            + ", containerId " + (container == null ? null : container.getId())
+            + ", sourceHostName " + sourceHost.getHostname()
+            + ", sourceHostPort " + sourceHost.getPort()
+        );
   }
 
   @Override

--- a/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouter.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouter.java
@@ -15,6 +15,7 @@ package com.github.ambry.router;
 
 import com.github.ambry.account.AccountService;
 import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.commons.AmbryCache;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.Callback;
@@ -319,6 +320,21 @@ class NonBlockingRouter implements Router {
       completeOperation(futureResult, callback, null, routerException);
     }
     return futureResult;
+  }
+
+  /**
+   * Requests for a new blob to be replicated on-demand asynchronously and invokes the {@link Callback} when the request completes.
+   * @param blobId The ID of the blob to be replicated.
+   * @param serviceId The service ID of the service replicating the blob. This can be null if unknown.
+   * @param sourceDataNode The source {@link DataNodeId} to get the blob from.
+   * @param callback The {@link Callback} which will be invoked on the completion of the request.
+   * @param quotaChargeCallback Listener interface to charge quota cost for the operation.
+   * @return A future that would contain information about whether the replicateBlob succeeded or not, eventually.
+   */
+  @Override
+  public Future<Void> replicateBlob(String blobId, String serviceId, DataNodeId sourceDataNode, Callback<Void> callback,
+      QuotaChargeCallback quotaChargeCallback) {
+    throw new UnsupportedOperationException("replicateBlob is not supported by the NonBlockingRouter");
   }
 
   @Override

--- a/ambry-router/src/main/java/com/github/ambry/router/RouterOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/RouterOperation.java
@@ -14,5 +14,5 @@
 package com.github.ambry.router;
 
 public enum RouterOperation {
-  GetBlobOperation, GetBlobInfoOperation, PutOperation, DeleteOperation, TtlUpdateOperation, UndeleteOperation
+  GetBlobOperation, GetBlobInfoOperation, PutOperation, DeleteOperation, TtlUpdateOperation, UndeleteOperation, ReplicateBlobOperation
 }

--- a/ambry-test-utils/src/main/java/com/github/ambry/router/InMemoryRouter.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/router/InMemoryRouter.java
@@ -14,6 +14,7 @@
 package com.github.ambry.router;
 
 import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.Callback;
@@ -282,6 +283,12 @@ public class InMemoryRouter implements Router {
     operationPool.submit(new InMemoryBlobPoster(postData, blobs, notificationSystem, clusterMap,
         CommonTestUtils.getCurrentBlobIdVersion()));
     return futureResult;
+  }
+
+  @Override
+  public Future<Void> replicateBlob(String blobId, String serviceId, DataNodeId sourceDataNode,
+      Callback<Void> callback, QuotaChargeCallback quotaChargeCallback) {
+    throw new UnsupportedOperationException("replicateBlob is not supported by the InMemoryRouter");
   }
 
   @Override

--- a/ambry-tools/src/main/java/com/github/ambry/tools/perf/rest/PerfRouter.java
+++ b/ambry-tools/src/main/java/com/github/ambry/tools/perf/rest/PerfRouter.java
@@ -15,6 +15,7 @@ package com.github.ambry.tools.perf.rest;
 
 import com.github.ambry.account.Account;
 import com.github.ambry.account.Container;
+import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.commons.Callback;
 import com.github.ambry.messageformat.BlobInfo;
 import com.github.ambry.messageformat.BlobProperties;
@@ -208,6 +209,21 @@ class PerfRouter implements Router {
       completeOperation(futureResult, callback, null, null);
     }
     return futureResult;
+  }
+
+  /**
+   * Requests for a new blob to be replicated on-demand asynchronously and invokes the {@link Callback} when the request completes.
+   * @param blobId The ID of the blob to be replicated.
+   * @param serviceId The service id that is replicating the blob.
+   * @param sourceDataNode The source {@link DataNodeId} to get the blob from.
+   * @param callback The {@link Callback} which will be invoked on the completion of the request.
+   * @param quotaChargeCallback Listener interface to charge quota cost for the operation.
+   * @return A future that would contain information about whether the replicateBlob succeeded or not, eventually.
+   */
+  @Override
+  public Future<Void> replicateBlob(String blobId, String serviceId, DataNodeId sourceDataNode, Callback<Void> callback,
+      QuotaChargeCallback quotaChargeCallback) {
+    throw new UnsupportedOperationException("replicateBlob is not supported by the PerfRouter");
   }
 
   @Override


### PR DESCRIPTION
Added replicateBlob interface to the router. It's not supported yet.

Wanted to open the interface up. And add http interface to support curl as well.
Had discussion with Justin. Justin suggested that we don't open the ReplicateBlob up to the client. We may use it only internally.

Change the PR to draft first.