### PR TITLE
Remove some unused BlobStoreCompactor configuration

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -439,12 +439,6 @@ public class StoreConfig {
   public static final String storeEnableIndexDirectMemoryUsageMetricName =
       "store.enable.index.direct.memory.usage.metric";
 
-  @Config(storeCompactionEnableBasicInfoOnMissingDuplicateName)
-  @Default("false")
-  public final boolean storeCompactionEnableBasicInfoOnMissingDuplicate;
-  public static final String storeCompactionEnableBasicInfoOnMissingDuplicateName =
-      "store.compaction.enable.basic.info.on.missing.duplicate";
-
   /**
    * A normalized disk IO read latency threshold(per MB). If actual normalized disk read latency is higher than the
    * threshold, we need to decrease compaction speed.
@@ -616,8 +610,6 @@ public class StoreConfig {
     storeEnableIndexDirectMemoryUsageMetric =
         verifiableProperties.getBoolean(storeEnableIndexDirectMemoryUsageMetricName, false);
     storeRebuildTokenBasedOnResetKey = verifiableProperties.getBoolean("store.rebuild.token.based.on.reset.key", false);
-    storeCompactionEnableBasicInfoOnMissingDuplicate =
-        verifiableProperties.getBoolean(storeCompactionEnableBasicInfoOnMissingDuplicateName, false);
     storeCompactionIoPerMbReadLatencyThresholdMs =
         verifiableProperties.getIntInRange("store.compaction.io.per.mb.read.latency.threshold.ms", 20, 0,
             Integer.MAX_VALUE);

--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -439,12 +439,6 @@ public class StoreConfig {
   public static final String storeEnableIndexDirectMemoryUsageMetricName =
       "store.enable.index.direct.memory.usage.metric";
 
-  @Config(storeAlwaysEnableTargetIndexDuplicateCheckingName)
-  @Default("false")
-  public final boolean storeAlwaysEnableTargetIndexDuplicateChecking;
-  public static final String storeAlwaysEnableTargetIndexDuplicateCheckingName =
-      "store.always.enable.target.index.duplicate.checking";
-
   @Config(storeCompactionEnableBasicInfoOnMissingDuplicateName)
   @Default("false")
   public final boolean storeCompactionEnableBasicInfoOnMissingDuplicate;
@@ -621,8 +615,6 @@ public class StoreConfig {
         verifiableProperties.getBoolean("store.enable.current.invalid.size.metric", false);
     storeEnableIndexDirectMemoryUsageMetric =
         verifiableProperties.getBoolean(storeEnableIndexDirectMemoryUsageMetricName, false);
-    storeAlwaysEnableTargetIndexDuplicateChecking =
-        verifiableProperties.getBoolean(storeAlwaysEnableTargetIndexDuplicateCheckingName, false);
     storeRebuildTokenBasedOnResetKey = verifiableProperties.getBoolean("store.rebuild.token.based.on.reset.key", false);
     storeCompactionEnableBasicInfoOnMissingDuplicate =
         verifiableProperties.getBoolean(storeCompactionEnableBasicInfoOnMissingDuplicateName, false);

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
@@ -1430,23 +1430,6 @@ class BlobStoreCompactor {
       copyCandidates.removeIf(copyCandidate ->
           isDuplicate(copyCandidate, duplicateSearchSpan, indexSegment.getStartOffset(), checkAlreadyCopied) || (
               config.storeContainerDeletionEnabled && isFromDeprecatedContainer(copyCandidate)));
-      if (duplicateSearchSpan != null && validEntriesSize == copyCandidates.size()) {
-        // When duplicate search span is not null, which mean it's highly likely that we would see duplicates from
-        // source. If we are here, then there is no duplicate at all, this might be an error.
-        logger.trace(
-            "Processing IndexSegment {} with duplicate search span {} in {}, we probably should have duplicates.",
-            indexSegment.toString(), duplicateSearchSpan, storeId);
-        logger.trace("IndexSegments in source persistent index with {}", storeId);
-        srcIndex.getIndexSegments().values().forEach(seg -> logger.info("{}", seg.getFile()));
-        Map<PersistentIndex.IndexEntryType, Long> collect = copyCandidates.stream()
-            .collect(Collectors.groupingBy(entry -> entry.getValue().getIndexValueType(), Collectors.counting()));
-        logger.trace("{} with {}", collect.entrySet()
-            .stream()
-            .map(ent -> ent.getValue().toString() + " " + String.valueOf(ent.getKey()))
-            .collect(Collectors.joining(",")), storeId);
-        logger.trace("Valid entry size {}, number of keys found: {}", validEntriesSize,
-            numKeysFoundInDuplicateChecking);
-      }
       // order by offset in log.
       copyCandidates.sort(PersistentIndex.INDEX_ENTRIES_OFFSET_COMPARATOR);
       logger.debug("Out of {} entries, {} are valid and {} will be copied in this round", allIndexEntries.size(),

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
@@ -1430,22 +1430,22 @@ class BlobStoreCompactor {
       copyCandidates.removeIf(copyCandidate ->
           isDuplicate(copyCandidate, duplicateSearchSpan, indexSegment.getStartOffset(), checkAlreadyCopied) || (
               config.storeContainerDeletionEnabled && isFromDeprecatedContainer(copyCandidate)));
-      if (duplicateSearchSpan != null && validEntriesSize == copyCandidates.size()
-          && config.storeCompactionEnableBasicInfoOnMissingDuplicate) {
+      if (duplicateSearchSpan != null && validEntriesSize == copyCandidates.size()) {
         // When duplicate search span is not null, which mean it's highly likely that we would see duplicates from
         // source. If we are here, then there is no duplicate at all, this might be an error.
-        logger.info(
+        logger.trace(
             "Processing IndexSegment {} with duplicate search span {} in {}, we probably should have duplicates.",
             indexSegment.toString(), duplicateSearchSpan, storeId);
-        logger.info("IndexSegments in source persistent index with {}", storeId);
+        logger.trace("IndexSegments in source persistent index with {}", storeId);
         srcIndex.getIndexSegments().values().forEach(seg -> logger.info("{}", seg.getFile()));
         Map<PersistentIndex.IndexEntryType, Long> collect = copyCandidates.stream()
             .collect(Collectors.groupingBy(entry -> entry.getValue().getIndexValueType(), Collectors.counting()));
-        logger.info("{} with {}", collect.entrySet()
+        logger.trace("{} with {}", collect.entrySet()
             .stream()
             .map(ent -> ent.getValue().toString() + " " + String.valueOf(ent.getKey()))
             .collect(Collectors.joining(",")), storeId);
-        logger.info("Valid entry size {}, number of keys found: {}", validEntriesSize, numKeysFoundInDuplicateChecking);
+        logger.trace("Valid entry size {}, number of keys found: {}", validEntriesSize,
+            numKeysFoundInDuplicateChecking);
       }
       // order by offset in log.
       copyCandidates.sort(PersistentIndex.INDEX_ENTRIES_OFFSET_COMPARATOR);

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
@@ -664,8 +664,7 @@ class BlobStoreCompactor {
 
     // call into diskIOScheduler to make sure we can proceed (assuming it won't be 0).
     diskIOScheduler.getSlice(INDEX_SEGMENT_READ_JOB_NAME, INDEX_SEGMENT_READ_JOB_NAME, 1);
-    boolean checkAlreadyCopied = config.storeAlwaysEnableTargetIndexDuplicateChecking || isIndexSegmentUnderCopy(
-        indexSegmentToCopy.getStartOffset());
+    boolean checkAlreadyCopied = isIndexSegmentUnderCopy(indexSegmentToCopy.getStartOffset());
     logger.trace("Should check already copied for {}: {} ", indexSegmentToCopy.getFile(), checkAlreadyCopied);
 
     List<IndexEntry> indexEntriesToCopy =
@@ -737,10 +736,6 @@ class BlobStoreCompactor {
         logger.trace("{} in segment with start offset {} in {} is a duplicate because it has already been copied",
             copyCandidate, indexSegmentStartOffset, storeId);
         isDuplicate = true;
-        if (!isIndexSegmentUnderCopy(indexSegmentStartOffset)) {
-          // This is not for recovery purpose, then it must be due to always checking target index duplicate.
-          tgtMetrics.compactionTargetIndexDuplicateOnNonRecoveryCount.inc();
-        }
       } else {
         // not a duplicate
         logger.trace("{} in index segment with start offset {} in {} is not a duplicate", copyCandidate,


### PR DESCRIPTION
In this PR, we remove two unused configurations for BlobStoreCompactor.
1. store.always.enable.target.index.duplicate.checking: This configuration was used to always check if there is a duplicate in target index in compaction. We don't have to do this since only the crashed compaction would need to check duplicates in target index.
2. store.compaction.enable.basic.info.on.missing.duplicate: This configuration is used to print out some basic index and entry information when we are expecting duplicates and not getting any. Change it to trace log.