### PR TITLE
Fix comapction log comparison issue

### DIFF
--- a/ambry-store/src/main/java/com/github/ambry/store/CompactionLog.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/CompactionLog.java
@@ -115,7 +115,7 @@ class CompactionLog implements Closeable {
     File[] files =
         storeDir.listFiles((fileDir, name) -> name.startsWith(storeId + COMPACTION_LOG_SUFFIX + BlobStore.SEPARATOR));
     List<File> sortedFiles = Stream.of(files)
-        .sorted((file1, file2) -> (int) (getStartTimeFromFile(file2) - getStartTimeFromFile(file1)))
+        .sorted((file1, file2) -> getStartTimeFromFile(file2) - getStartTimeFromFile(file1) > 0 ? 1 : -1)
         .collect(Collectors.toList());
     File inProgressCompactionLog = new File(dir, storeId + COMPACTION_LOG_SUFFIX);
     if (inProgressCompactionLog.exists()) {

--- a/ambry-store/src/test/java/com/github/ambry/store/CompactionLogTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CompactionLogTest.java
@@ -18,7 +18,6 @@ import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.utils.MockTime;
 import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.TestUtils;
-import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
 import java.io.File;
 import java.io.IOException;
@@ -61,7 +60,7 @@ public class CompactionLogTest {
   private final String tempDirStr;
   private final StoreConfig config;
   // the time instance that will be used in the index
-  private final Time time = new MockTime();
+  private final MockTime time = new MockTime();
   private final Set<LogSegmentName> generatedSegmentNames = new HashSet<>();
 
   /**
@@ -375,7 +374,8 @@ public class CompactionLogTest {
       Offset expectedAfter = new Offset(name.getNextGenerationName(), LogSegment.HEADER_SIZE);
       Assert.assertEquals(expectedAfter, indexSegmentOffsets.get(before));
     }
-    SortedMap<Offset, Offset> indexSegmentOffsetsCompleted = cLog.getBeforeAndAfterIndexSegmentOffsetsForCompletedCycles();
+    SortedMap<Offset, Offset> indexSegmentOffsetsCompleted =
+        cLog.getBeforeAndAfterIndexSegmentOffsetsForCompletedCycles();
     // There is no completedCycle yet
     Assert.assertEquals(0, indexSegmentOffsetsCompleted.size());
     // All log segments are under compaction at current cycle.
@@ -441,6 +441,7 @@ public class CompactionLogTest {
   @Test
   public void testProcessCompactionLogs() throws Exception {
     // First create some compaction logs
+    time.setCurrentMilliseconds(System.currentTimeMillis());
     String storeName = "store";
     List<CompactionDetails> detailsList = getCompactionDetailsList(10);
     List<Long> expectedStartTimes = new ArrayList<>();
@@ -456,7 +457,8 @@ public class CompactionLogTest {
       cLog.markCycleComplete();
       cLog.close();
       Assert.assertFalse(CompactionLog.isCompactionInProgress(tempDirStr, storeName));
-      time.sleep(10000);
+      long sleepTime = 3 * Integer.MAX_VALUE;
+      time.sleep(sleepTime);
     }
 
     CompactionDetails details = getCompactionDetailsList(1).get(0);


### PR DESCRIPTION
We saw this exception in compaction logs:

`java.lang.IllegalArgumentException: Comparison method violates its general contract!
        at java.util.TimSort.mergeHi(TimSort.java:903) ~[?:?]
        at java.util.TimSort.mergeAt(TimSort.java:520) ~[?:?]
        at java.util.TimSort.mergeCollapse(TimSort.java:448) ~[?:?]
        at java.util.TimSort.sort(TimSort.java:245) ~[?:?]
        at java.util.Arrays.sort(Arrays.java:1515) ~[?:?]
        at java.util.stream.SortedOps$SizedRefSortingSink.end(SortedOps.java:353) ~[?:?]
        at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:485) ~[?:?]
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474) ~[?:?]
        at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913) ~[?:?]
        at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
        at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578) ~[?:?]
        at com.github.ambry.store.CompactionLog.processCompactionLogs(CompactionLog.java:119) ~[ambry-store-0.3.870.jar:?]
        at com.github.ambry.store.BlobStore.buildCompactionHistory(BlobStore.java:1326) ~[ambry-store-0.3.870.jar:?]
        at com.github.ambry.store.BlobStore.start(BlobStore.java:261) ~[ambry-store-0.3.870.jar:?]
        at com.github.ambry.store.DiskManager.lambda$start$0(DiskManager.java:173) ~[ambry-store-0.3.870.jar:?]
        at java.lang.Thread.run(Thread.java:834) [?:?]`
