### PR TITLE
GetBlob Operations should call ResponseHandler on partition response error

### DIFF
--- a/ambry-router/src/main/java/com/github/ambry/router/GetBlobInfoOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/GetBlobInfoOperation.java
@@ -94,10 +94,10 @@ class GetBlobInfoOperation extends GetOperation {
    * @param nonBlockingRouter The non-blocking router object
    */
   GetBlobInfoOperation(RouterConfig routerConfig, NonBlockingRouterMetrics routerMetrics, ClusterMap clusterMap,
-      ResponseHandler responseHandler, BlobId blobId, GetBlobOptionsInternal options,
-      Callback<GetBlobResult> callback, RouterCallback routerCallback, KeyManagementService kms,
-      CryptoService cryptoService, CryptoJobHandler cryptoJobHandler, Time time, boolean isEncrypted,
-      QuotaChargeCallback quotaChargeCallback, NonBlockingRouter nonBlockingRouter) {
+      ResponseHandler responseHandler, BlobId blobId, GetBlobOptionsInternal options, Callback<GetBlobResult> callback,
+      RouterCallback routerCallback, KeyManagementService kms, CryptoService cryptoService,
+      CryptoJobHandler cryptoJobHandler, Time time, boolean isEncrypted, QuotaChargeCallback quotaChargeCallback,
+      NonBlockingRouter nonBlockingRouter) {
     super(routerConfig, routerMetrics, clusterMap, responseHandler, blobId, options, callback, kms, cryptoService,
         cryptoJobHandler, time, isEncrypted);
     this.routerCallback = routerCallback;
@@ -300,6 +300,7 @@ class GetBlobInfoOperation extends GetOperation {
   private void processGetBlobInfoResponse(RequestInfo getRequestInfo, GetResponse getResponse)
       throws IOException, MessageFormatException {
     ServerErrorCode getError = getResponse.getError();
+    responseHandler.onEvent(getRequestInfo.getReplicaId(), getError);
     if (getError == ServerErrorCode.No_Error) {
       int partitionsInResponse = getResponse.getPartitionResponseInfoList().size();
       // Each get request issued by the router is for a single blob.

--- a/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
@@ -1183,6 +1183,7 @@ class GetBlobOperation extends GetOperation {
               RouterErrorCode.UnexpectedInternalError));
         } else {
           getError = getResponse.getPartitionResponseInfoList().get(0).getErrorCode();
+          responseHandler.onEvent(getRequestInfo.getReplicaId(), getError);
           if (getError == ServerErrorCode.No_Error) {
             PartitionResponseInfo partitionResponseInfo = getResponse.getPartitionResponseInfoList().get(0);
             int objectsInPartitionResponse = partitionResponseInfo.getMessageInfoList().size();


### PR DESCRIPTION
We are only calling ResponseHandler.onEvent on ResponseInfo's network error and the Response's server error code, but we didn't call onEvent on Partition response error for GetBlob operations.
This PR would start doing that.