### PR TITLE
Support Blob Format V3 in PutMessage stream.

### DIFF
--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageFormatRecord.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageFormatRecord.java
@@ -55,6 +55,7 @@ public class MessageFormatRecord {
   public static final short UserMetadata_Version_V1 = 1;
   public static final short Blob_Version_V1 = 1;
   public static final short Blob_Version_V2 = 2;
+  public static final short Blob_Version_V3 = 3;
   public static final short Metadata_Content_Version_V2 = 2;
   public static final short Metadata_Content_Version_V3 = 3;
   public static final int Message_Header_Invalid_Relative_Offset = -1;
@@ -232,20 +233,17 @@ public class MessageFormatRecord {
         return new DeserializedBlob(Blob_Version_V1, Blob_Format_V1.deserializeBlobRecord(crcStream));
       case Blob_Version_V2:
         return new DeserializedBlob(Blob_Version_V2, Blob_Format_V2.deserializeBlobRecord(crcStream));
+      case Blob_Version_V3:
+        return new DeserializedBlob(Blob_Version_V3, Blob_Format_V3.deserializeBlobRecord(crcStream));
       default:
         throw new MessageFormatException("data version not supported", MessageFormatErrorCodes.Unknown_Format_Version);
     }
   }
 
   static boolean isValidBlobRecordVersion(short blobRecordVersion) {
-    switch (blobRecordVersion) {
-      case Blob_Version_V1:
-        return true;
-      case Blob_Version_V2:
-        return true;
-      default:
-        return false;
-    }
+    return blobRecordVersion == Blob_Version_V1 ||
+        blobRecordVersion == Blob_Version_V2 ||
+        blobRecordVersion == Blob_Version_V3;
   }
 
   /**
@@ -1734,7 +1732,7 @@ public class MessageFormatRecord {
     public static BlobData deserializeBlobRecord(CrcInputStream crcStream) throws IOException, MessageFormatException {
       DataInputStream dataStream = new DataInputStream(crcStream);
       short blobTypeOrdinal = dataStream.readShort();
-      if (blobTypeOrdinal > BlobType.values().length) {
+      if (blobTypeOrdinal >= BlobType.values().length) {
         logger.error("corrupt data while parsing blob content BlobContentType {}", blobTypeOrdinal);
         throw new MessageFormatException("corrupt data while parsing blob content",
             MessageFormatErrorCodes.Data_Corrupt);
@@ -1753,6 +1751,78 @@ public class MessageFormatRecord {
             MessageFormatErrorCodes.Data_Corrupt);
       }
       return new BlobData(blobContentType, dataSize, byteBuf);
+    }
+  }
+
+  /**
+   *  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   * |         |           |              |            |            |            |
+   * | version | blobType  | isCompressed |    size    |  content   |     Crc    |
+   * |(2 bytes)| (2 bytes) | (1 byte)     |  (8 bytes) |  (n bytes) |  (8 bytes) |
+   * |         |           |              |            |            |            |
+   *  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   *  version    - The version of the blob record
+   *
+   *  blobType   - The type of the blob
+   *
+   *  isCompressed - Whether the content is compressed.
+   *
+   *  size       - The size of the blob content
+   *
+   *  content    - The actual content that represents the blob
+   *
+   *  crc        - The crc of the blob record
+   *
+   */
+  public static class Blob_Format_V3 {
+    public static final int Blob_Size_Field_In_Bytes = 8;
+    public static final int Blob_Type_Field_In_Bytes = 2;
+    public static final int Is_Compressed_In_Bytes = 1;
+
+    private static final Logger logger = LoggerFactory.getLogger(Blob_Format_V3.class);
+
+    public static long getBlobRecordSize(long blobSize) {
+      return Version_Field_Size_In_Bytes + Blob_Type_Field_In_Bytes + Blob_Size_Field_In_Bytes + blobSize + Crc_Size
+          + Is_Compressed_In_Bytes;
+    }
+
+    public static void serializePartialBlobRecord(ByteBuffer outputBuffer, long blobContentSize, BlobType blobType,
+        boolean isCompressed) {
+      outputBuffer.putShort(Blob_Version_V3);
+      outputBuffer.putShort((short) blobType.ordinal());
+      outputBuffer.put(isCompressed ? (byte) 1 : 0);
+      outputBuffer.putLong(blobContentSize);
+    }
+
+    public static BlobData deserializeBlobRecord(CrcInputStream crcStream) throws IOException, MessageFormatException {
+      DataInputStream dataStream = new DataInputStream(crcStream);
+      // Get the BlobType.
+      short blobTypeOrdinal = dataStream.readShort();
+      if (blobTypeOrdinal >= BlobType.values().length) {
+        logger.error("corrupt data while parsing blob content BlobContentType {}", blobTypeOrdinal);
+        throw new MessageFormatException("corrupt data while parsing blob content",
+            MessageFormatErrorCodes.Data_Corrupt);
+      }
+      BlobType blobContentType = BlobType.values()[blobTypeOrdinal];
+
+      // Get whether the blob is compressed.
+      boolean isCompressed = dataStream.readByte() == 1;
+
+      // Get the blob binary.
+      long dataSize = dataStream.readLong();
+      if (dataSize > Integer.MAX_VALUE) {
+        throw new IOException("We only support data of max size == MAX_INT. Error while reading blob from store");
+      }
+      ByteBuf byteBuf = Utils.readNettyByteBufFromCrcInputStream(crcStream, (int) dataSize);
+      long crc = crcStream.getValue();
+      long streamCrc = dataStream.readLong();
+      if (crc != streamCrc) {
+        logger.error("corrupt data while parsing blob content expectedcrc {} actualcrc {}", crc, streamCrc);
+        throw new MessageFormatException("corrupt data while parsing blob content",
+            MessageFormatErrorCodes.Data_Corrupt);
+      }
+
+      return new BlobData(blobContentType, dataSize, byteBuf, isCompressed);
     }
   }
 

--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/PutMessageFormatInputStream.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/PutMessageFormatInputStream.java
@@ -40,25 +40,35 @@ import java.nio.ByteBuffer;
  */
 public class PutMessageFormatInputStream extends MessageFormatInputStream {
 
+  // Temporary config for deployment control.  It will be removed after successfully deployed.
+  public static boolean useBlobFormatV3 = false;
+
   public PutMessageFormatInputStream(StoreKey key, ByteBuffer blobEncryptionKey, BlobProperties blobProperties,
       ByteBuffer userMetadata, InputStream blobStream, long streamSize, BlobType blobType)
       throws MessageFormatException {
-    this(key, blobEncryptionKey, blobProperties, userMetadata, blobStream, streamSize, blobType, (short) 0);
+    this(key, blobEncryptionKey, blobProperties, userMetadata, blobStream, streamSize, blobType, (short) 0, false);
   }
 
   public PutMessageFormatInputStream(StoreKey key, ByteBuffer blobEncryptionKey, BlobProperties blobProperties,
       ByteBuffer userMetadata, InputStream blobStream, long streamSize) throws MessageFormatException {
-    this(key, blobEncryptionKey, blobProperties, userMetadata, blobStream, streamSize, BlobType.DataBlob, (short) 0);
+    this(key, blobEncryptionKey, blobProperties, userMetadata, blobStream, streamSize, BlobType.DataBlob, (short) 0, false);
   }
 
   public PutMessageFormatInputStream(StoreKey key, ByteBuffer blobEncryptionKey, BlobProperties blobProperties,
       ByteBuffer userMetadata, InputStream blobStream, long streamSize, BlobType blobType, short lifeVersion)
       throws MessageFormatException {
+    this(key, blobEncryptionKey, blobProperties, userMetadata, blobStream, streamSize, blobType, lifeVersion, false);
+  }
+
+  public PutMessageFormatInputStream(StoreKey key, ByteBuffer blobEncryptionKey, BlobProperties blobProperties,
+      ByteBuffer userMetadata, InputStream blobStream, long streamSize, BlobType blobType, short lifeVersion,
+      boolean isCompressed)
+      throws MessageFormatException {
     if (MessageFormatRecord.headerVersionToUse == MessageFormatRecord.Message_Header_Version_V1) {
-      createStreamWithMessageHeaderV1(key, blobProperties, userMetadata, blobStream, streamSize, blobType);
+      createStreamWithMessageHeaderV1(key, blobProperties, userMetadata, blobStream, streamSize, blobType, isCompressed);
     } else {
       createStreamWithMessageHeader(key, blobEncryptionKey, blobProperties, userMetadata, blobStream, streamSize,
-          blobType, lifeVersion);
+          blobType, lifeVersion, isCompressed);
     }
   }
 
@@ -67,7 +77,8 @@ public class PutMessageFormatInputStream extends MessageFormatInputStream {
    * understand reading messages with encryption key record.
    */
   private void createStreamWithMessageHeader(StoreKey key, ByteBuffer blobEncryptionKey, BlobProperties blobProperties,
-      ByteBuffer userMetadata, InputStream blobStream, long streamSize, BlobType blobType, short lifeVersion)
+      ByteBuffer userMetadata, InputStream blobStream, long streamSize, BlobType blobType, short lifeVersion,
+      boolean isCompressed)
       throws MessageFormatException {
     int headerSize = MessageFormatRecord.getHeaderSizeForVersion(MessageFormatRecord.headerVersionToUse);
     int blobEncryptionKeySize = blobEncryptionKey == null ? 0
@@ -75,7 +86,8 @@ public class PutMessageFormatInputStream extends MessageFormatInputStream {
     int blobPropertiesRecordSize =
         MessageFormatRecord.BlobProperties_Format_V1.getBlobPropertiesRecordSize(blobProperties);
     int userMetadataSize = MessageFormatRecord.UserMetadata_Format_V1.getUserMetadataSize(userMetadata);
-    long blobSize = MessageFormatRecord.Blob_Format_V2.getBlobRecordSize(streamSize);
+    long blobSize = useBlobFormatV3 ? MessageFormatRecord.Blob_Format_V3.getBlobRecordSize(streamSize) :
+        MessageFormatRecord.Blob_Format_V2.getBlobRecordSize(streamSize);
 
     buffer = ByteBuffer.allocate(
         headerSize + key.sizeInBytes() + blobEncryptionKeySize + blobPropertiesRecordSize + userMetadataSize + (int) (
@@ -106,7 +118,11 @@ public class PutMessageFormatInputStream extends MessageFormatInputStream {
     MessageFormatRecord.BlobProperties_Format_V1.serializeBlobPropertiesRecord(buffer, blobProperties);
     MessageFormatRecord.UserMetadata_Format_V1.serializeUserMetadataRecord(buffer, userMetadata);
     int bufferBlobStart = buffer.position();
-    MessageFormatRecord.Blob_Format_V2.serializePartialBlobRecord(buffer, streamSize, blobType);
+    if (useBlobFormatV3) {
+      MessageFormatRecord.Blob_Format_V3.serializePartialBlobRecord(buffer, streamSize, blobType, isCompressed);
+    } else {
+      MessageFormatRecord.Blob_Format_V2.serializePartialBlobRecord(buffer, streamSize, blobType);
+    }
     Crc32 crc = new Crc32();
     crc.update(buffer.array(), bufferBlobStart, buffer.position() - bufferBlobStart);
     stream = new CrcInputStream(crc, blobStream);
@@ -119,14 +135,18 @@ public class PutMessageFormatInputStream extends MessageFormatInputStream {
    * Helper method to create a stream without encryption key record. This is the default currently, but once all nodes
    * once all nodes in a cluster understand reading messages with encryption key record, and writing in the new format
    * is enabled, this method can be removed.
+   *
+   * TODO - remove Header Message V1 since V3 is already deployed.
    */
+  @Deprecated
   private void createStreamWithMessageHeaderV1(StoreKey key, BlobProperties blobProperties, ByteBuffer userMetadata,
-      InputStream blobStream, long streamSize, BlobType blobType) throws MessageFormatException {
+      InputStream blobStream, long streamSize, BlobType blobType, boolean isCompressed) throws MessageFormatException {
     int headerSize = MessageFormatRecord.MessageHeader_Format_V1.getHeaderSize();
     int blobPropertiesRecordSize =
         MessageFormatRecord.BlobProperties_Format_V1.getBlobPropertiesRecordSize(blobProperties);
     int userMetadataSize = MessageFormatRecord.UserMetadata_Format_V1.getUserMetadataSize(userMetadata);
-    long blobSize = MessageFormatRecord.Blob_Format_V2.getBlobRecordSize(streamSize);
+    long blobSize = useBlobFormatV3 ? MessageFormatRecord.Blob_Format_V3.getBlobRecordSize(streamSize) :
+        MessageFormatRecord.Blob_Format_V2.getBlobRecordSize(streamSize);
 
     buffer = ByteBuffer.allocate(
         headerSize + key.sizeInBytes() + blobPropertiesRecordSize + userMetadataSize + (int) (blobSize - streamSize
@@ -141,7 +161,12 @@ public class PutMessageFormatInputStream extends MessageFormatInputStream {
     MessageFormatRecord.BlobProperties_Format_V1.serializeBlobPropertiesRecord(buffer, blobProperties);
     MessageFormatRecord.UserMetadata_Format_V1.serializeUserMetadataRecord(buffer, userMetadata);
     int bufferBlobStart = buffer.position();
-    MessageFormatRecord.Blob_Format_V2.serializePartialBlobRecord(buffer, streamSize, blobType);
+
+    if (useBlobFormatV3) {
+      MessageFormatRecord.Blob_Format_V3.serializePartialBlobRecord(buffer, streamSize, blobType, isCompressed);
+    } else {
+      MessageFormatRecord.Blob_Format_V2.serializePartialBlobRecord(buffer, streamSize, blobType);
+    }
     Crc32 crc = new Crc32();
     crc.update(buffer.array(), bufferBlobStart, buffer.position() - bufferBlobStart);
     stream = new CrcInputStream(crc, blobStream);

--- a/ambry-messageformat/src/test/java/com/github/ambry/messageformat/MessageFormatTestUtils.java
+++ b/ambry-messageformat/src/test/java/com/github/ambry/messageformat/MessageFormatTestUtils.java
@@ -28,9 +28,15 @@ public class MessageFormatTestUtils {
   public static ByteBuffer getBlobContentForMetadataBlob(int blobSize) {
     ByteBuffer blobContent = ByteBuffer.allocate(blobSize);
     new Random().nextBytes(blobContent.array());
-    int size = (int) MessageFormatRecord.Blob_Format_V2.getBlobRecordSize(blobSize);
+    int size = PutMessageFormatInputStream.useBlobFormatV3 ?
+        (int) MessageFormatRecord.Blob_Format_V3.getBlobRecordSize(blobSize) :
+        (int) MessageFormatRecord.Blob_Format_V2.getBlobRecordSize(blobSize);
     ByteBuffer entireBlob = ByteBuffer.allocate(size);
-    MessageFormatRecord.Blob_Format_V2.serializePartialBlobRecord(entireBlob, blobSize, BlobType.MetadataBlob);
+    if (PutMessageFormatInputStream.useBlobFormatV3) {
+      MessageFormatRecord.Blob_Format_V3.serializePartialBlobRecord(entireBlob, blobSize, BlobType.MetadataBlob, false);
+    } else {
+      MessageFormatRecord.Blob_Format_V2.serializePartialBlobRecord(entireBlob, blobSize, BlobType.MetadataBlob);
+    }
     entireBlob.put(blobContent);
     Crc32 crc = new Crc32();
     crc.update(entireBlob.array(), 0, entireBlob.position());

--- a/ambry-messageformat/src/test/java/com/github/ambry/messageformat/PutMessageFormatBlobV1InputStream.java
+++ b/ambry-messageformat/src/test/java/com/github/ambry/messageformat/PutMessageFormatBlobV1InputStream.java
@@ -23,6 +23,7 @@ import java.nio.ByteBuffer;
 /**
  * PutMessageFormatInputStream which uses Blob Format V1 instead of the default V2
  */
+@Deprecated   // PutMessageV1 is deprecated and should never be called.  Using it could lead to data lost.
 public class PutMessageFormatBlobV1InputStream extends MessageFormatInputStream {
   public PutMessageFormatBlobV1InputStream(StoreKey key, BlobProperties blobProperties, ByteBuffer userMetadata,
       InputStream blobStream, long streamSize, BlobType blobType) throws MessageFormatException {

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/AmbryRequests.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/AmbryRequests.java
@@ -984,7 +984,7 @@ public class AmbryRequests implements RequestAPI {
     MessageFormatInputStream stream =
         new PutMessageFormatInputStream(receivedRequest.getBlobId(), receivedRequest.getBlobEncryptionKey(),
             receivedRequest.getBlobProperties(), receivedRequest.getUsermetadata(), receivedRequest.getBlobStream(),
-            receivedRequest.getBlobSize(), receivedRequest.getBlobType());
+            receivedRequest.getBlobSize(), receivedRequest.getBlobType(), (short) 0, receivedRequest.isCompressed);
     BlobProperties properties = receivedRequest.getBlobProperties();
     long expirationTime = Utils.addSecondsToEpochTime(receivedRequest.getBlobProperties().getCreationTimeInMs(),
         properties.getTimeToLiveInSeconds());

--- a/ambry-router/src/test/java/com/github/ambry/router/MockServer.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/MockServer.java
@@ -17,6 +17,8 @@ import com.github.ambry.account.Account;
 import com.github.ambry.account.Container;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.commons.BlobId;
+import com.github.ambry.compression.Compression;
+import com.github.ambry.config.CompressionConfig;
 import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.messageformat.BlobType;
 import com.github.ambry.messageformat.MessageFormatException;
@@ -73,7 +75,7 @@ class MockServer {
   private LinkedList<ServerErrorCode> serverErrors = new LinkedList<ServerErrorCode>();
   private final Map<String, StoredBlob> blobs = new ConcurrentHashMap<>();
   private boolean shouldRespond = true;
-  private short blobFormatVersion = MessageFormatRecord.Blob_Version_V2;
+  private short blobFormatVersion = MessageFormatRecord.Blob_Version_V3;
   private boolean getErrorOnDataBlobOnly = false;
   private final ClusterMap clusterMap;
   private final String dataCenter;
@@ -252,6 +254,17 @@ class MockServer {
             break;
           case Blob:
             switch (blobFormatVersion) {
+              case MessageFormatRecord.Blob_Version_V3:
+                if (originalBlobPutReq.getBlobEncryptionKey() != null) {
+                  msgMetadata = new MessageMetadata(originalBlobPutReq.getBlobEncryptionKey().duplicate());
+                }
+                byteBufferSize =
+                    (int) MessageFormatRecord.Blob_Format_V3.getBlobRecordSize((int) originalBlobPutReq.getBlobSize());
+                byteBuffer = ByteBuffer.allocate(byteBufferSize);
+                MessageFormatRecord.Blob_Format_V3.serializePartialBlobRecord(byteBuffer,
+                    (int) originalBlobPutReq.getBlobSize(), originalBlobPutReq.getBlobType(),
+                    originalBlobPutReq.isCompressed());
+                break;
               case MessageFormatRecord.Blob_Version_V2:
                 if (originalBlobPutReq.getBlobEncryptionKey() != null) {
                   msgMetadata = new MessageMetadata(originalBlobPutReq.getBlobEncryptionKey().duplicate());
@@ -294,6 +307,10 @@ class MockServer {
             int blobInfoSize = blobPropertiesSize + userMetadataSize;
             int blobRecordSize;
             switch (blobFormatVersion) {
+              case MessageFormatRecord.Blob_Version_V3:
+                blobRecordSize =
+                    (int) MessageFormatRecord.Blob_Format_V3.getBlobRecordSize((int) originalBlobPutReq.getBlobSize());
+                break;
               case MessageFormatRecord.Blob_Version_V2:
                 blobRecordSize =
                     (int) MessageFormatRecord.Blob_Format_V2.getBlobRecordSize((int) originalBlobPutReq.getBlobSize());
@@ -329,6 +346,10 @@ class MockServer {
             MessageFormatRecord.UserMetadata_Format_V1.serializeUserMetadataRecord(byteBuffer, userMetadata);
             int blobRecordStart = byteBuffer.position();
             switch (blobFormatVersion) {
+              case MessageFormatRecord.Blob_Version_V3:
+                MessageFormatRecord.Blob_Format_V3.serializePartialBlobRecord(byteBuffer,
+                    (int) originalBlobPutReq.getBlobSize(), originalBlobPutReq.getBlobType(), originalBlobPutReq.isCompressed());
+                break;
               case MessageFormatRecord.Blob_Version_V2:
                 MessageFormatRecord.Blob_Format_V2.serializePartialBlobRecord(byteBuffer,
                     (int) originalBlobPutReq.getBlobSize(), originalBlobPutReq.getBlobType());

--- a/ambry-server/src/integration-test/java/com/github/ambry/server/CloudAndStoreReplicationTest.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/CloudAndStoreReplicationTest.java
@@ -305,9 +305,10 @@ public class CloudAndStoreReplicationTest {
     for (PartitionResponseInfo partitionResponseInfo : getResponse.getPartitionResponseInfoList()) {
       assertEquals("Error in getting the recovered blobs", ServerErrorCode.No_Error,
           partitionResponseInfo.getErrorCode());
-      //old value is 272. Adding 8 Bytes due to the two fields added 4 + 4 Blob Property BYTE.
+      //old value is 272. Adding 9 Bytes due to the two fields added 4 + 4 Blob Property BYTE, +1 for compression.
+      int putMessageSize = PutMessageFormatInputStream.useBlobFormatV3 ? 281 : 280;
       for (MessageInfo messageInfo : partitionResponseInfo.getMessageInfoList()) {
-        assertEquals(blobIdToSizeMap.get(messageInfo.getStoreKey()) + 280, messageInfo.getSize());
+        assertEquals(blobIdToSizeMap.get(messageInfo.getStoreKey()) + putMessageSize, messageInfo.getSize());
       }
     }
   }

--- a/ambry-server/src/integration-test/java/com/github/ambry/server/ServerTestUtil.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/ServerTestUtil.java
@@ -2469,9 +2469,10 @@ final class ServerTestUtil {
       return MessageFormatRecord.getHeaderSizeForVersion(MessageFormatRecord.getCurrentMessageHeaderVersion())
           + blobId.sizeInBytes() + (blobEncryptionKey != null
           ? MessageFormatRecord.BlobEncryptionKey_Format_V1.getBlobEncryptionKeyRecordSize(blobEncryptionKey) : 0)
-          + +MessageFormatRecord.BlobProperties_Format_V1.getBlobPropertiesRecordSize(properties)
+          + MessageFormatRecord.BlobProperties_Format_V1.getBlobPropertiesRecordSize(properties)
           + MessageFormatRecord.UserMetadata_Format_V1.getUserMetadataSize(usermetadata)
-          + MessageFormatRecord.Blob_Format_V2.getBlobRecordSize(data.length);
+          + (PutMessageFormatInputStream.useBlobFormatV3 ? MessageFormatRecord.Blob_Format_V3.getBlobRecordSize(data.length)
+             : MessageFormatRecord.Blob_Format_V2.getBlobRecordSize(data.length));
     } catch (Exception e) {
       fail("Unexpected exception" + e);
     }

--- a/ambry-server/src/integration-test/java/com/github/ambry/server/VcrRecoveryTest.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/VcrRecoveryTest.java
@@ -188,9 +188,10 @@ public class VcrRecoveryTest {
     for (PartitionResponseInfo partitionResponseInfo : getResponse.getPartitionResponseInfoList()) {
       assertEquals("Error in getting the recovered blobs", ServerErrorCode.No_Error,
           partitionResponseInfo.getErrorCode());
-      //old value is 272. Adding 8 Bytes due to the two fields added 4 + 4 Blob Property BYTE.
+      //old value is 272. Adding 9 Bytes due to the two fields added 4 + 4 Blob Property BYTE, + 1 for compression.
+      int putMessageSize = PutMessageFormatInputStream.useBlobFormatV3 ? 281 : 280;
       for (MessageInfo messageInfo : partitionResponseInfo.getMessageInfoList()) {
-        assertEquals(blobIdToSizeMap.get(messageInfo.getStoreKey()) + 280, messageInfo.getSize());
+        assertEquals(blobIdToSizeMap.get(messageInfo.getStoreKey()) + putMessageSize, messageInfo.getSize());
       }
     }
   }


### PR DESCRIPTION
- Blob Data format V3 is introduced to include compression information.  By default, it is disabled.  Future PR will enable it.  The unit tests continue to test V2 plus the newly introduced V3.

This change seems big but probably 95% of the changes are unit test and all related to BlobFormat version selection.  It's not appropriate to sub-divide this PR.   As shown in this PR, we continue to unit test V1 and V2 Blob Data format serialization.  However, we should remove V1 and V2 serialization code and unit tests since they should no longer be used after V3 is deployed.  When I submit the clean PR in the future, I plan to remove V1 and V2 serialization.