### PR TITLE
Adding two new fields to container

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/account/Container.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/Container.java
@@ -467,10 +467,8 @@ public class Container {
         && Objects.equals(this.getReplicationPolicy(), containerToCompare.getReplicationPolicy())
         && Objects.equals(this.isSecurePathRequired(), containerToCompare.isSecurePathRequired())
         && Objects.equals(this.isBackupEnabled(), containerToCompare.isBackupEnabled())
-        && Objects.equals(this.getContentTypeWhitelistForFilenamesOnDownload(),
-                          containerToCompare.getContentTypeWhitelistForFilenamesOnDownload())
-        && Objects.equals(this.isAccountAclOverridden(), containerToCompare.isAccountAclOverridden())
-        && Objects.equals(this.getCacheTtlInSecond(), containerToCompare.getCacheTtlInSecond());
+        && Objects.equals(this.getContentTypeWhitelistForFilenamesOnDownload(), containerToCompare.getContentTypeWhitelistForFilenamesOnDownload())
+        && Objects.equals(this.isAccountAclOverridden(), containerToCompare.isAccountAclOverridden());
     //@formatter:on
   }
 

--- a/ambry-api/src/main/java/com/github/ambry/account/ContainerBuilder.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/ContainerBuilder.java
@@ -54,6 +54,9 @@ public class ContainerBuilder {
   private long lastModifiedTime = LAST_MODIFIED_TIME_DEFAULT_VALUE;
   private int snapshotVersion = SNAPSHOT_VERSION_DEFAULT_VALUE;
   private String accessControlAllowOrigin = ACCESS_CONTROL_ALLOW_ORIGIN_DEFAULT_VALUE;
+  private Long cacheTtlInSecond = CACHE_TTL_IN_SECOND_DEFAULT_VALUE;
+  private Set<String> userMetadataKeysToNotPrefixInResponse =
+      USER_METADATA_KEYS_TO_NOT_PREFIX_IN_RESPONSE_DEFAULT_VALUE;
 
   /**
    * Constructor. This will allow building a new {@link Container} from an existing {@link Container}. The builder will
@@ -85,6 +88,8 @@ public class ContainerBuilder {
     backupEnabled = origin.isBackupEnabled();
     lastModifiedTime = origin.getLastModifiedTime();
     snapshotVersion = origin.getSnapshotVersion();
+    cacheTtlInSecond = origin.getCacheTtlInSecond();
+    userMetadataKeysToNotPrefixInResponse = origin.getUserMetadataKeysToNotPrefixInResponse();
   }
 
   /**
@@ -312,6 +317,26 @@ public class ContainerBuilder {
   }
 
   /**
+   * Sets the cacheTtlInSecond of the {@link Container} to build.
+   * @param cacheTtlInSecond The value to set.
+   * @return This builder.
+   */
+  public ContainerBuilder setCacheTtlInSecond(Long cacheTtlInSecond) {
+    this.cacheTtlInSecond = cacheTtlInSecond;
+    return this;
+  }
+
+  /**
+   * Sets the set of user metadata keys to not prefix in response of the {@link Container} to build.
+   * @param userMetadataKeys The value to set
+   * @return This builder.
+   */
+  public ContainerBuilder setUserMetadataKeysToNotPrefixInResponse(Set<String> userMetadataKeys) {
+    this.userMetadataKeysToNotPrefixInResponse = userMetadataKeys;
+    return this;
+  }
+
+  /**
    * Builds a {@link Container} object. {@code id}, {@code name}, {@code status}, {@code isPrivate}, and
    * {@code parentAccountId} are required before build.
    * @return A {@link Container} object.
@@ -325,6 +350,7 @@ public class ContainerBuilder {
         mediaScanDisabled, replicationPolicy, ttlRequired, securePathRequired,
         contentTypeWhitelistForFilenamesOnDownload, backupEnabled, overrideAccountAcl, namedBlobMode,
         parentAccountId == null ? UNKNOWN_CONTAINER_PARENT_ACCOUNT_ID : parentAccountId.shortValue(), deleteTriggerTime,
-        lastModifiedTime, snapshotVersion, accessControlAllowOrigin);
+        lastModifiedTime, snapshotVersion, accessControlAllowOrigin, cacheTtlInSecond,
+        userMetadataKeysToNotPrefixInResponse);
   }
 }

--- a/ambry-api/src/test/java/com/github/ambry/account/AccountContainerTest.java
+++ b/ambry-api/src/test/java/com/github/ambry/account/AccountContainerTest.java
@@ -777,7 +777,12 @@ public class AccountContainerTest {
         .setTtlRequired(container.isTtlRequired())
         .setContentTypeWhitelistForFilenamesOnDownload(container.getContentTypeWhitelistForFilenamesOnDownload())
         .setDeleteTriggerTime(container.getDeleteTriggerTime())
+        .setOverrideAccountAcl(container.isAccountAclOverridden())
+        .setSecurePathRequired(container.isSecurePathRequired())
         .setAccessControlAllowOrigin(container.getAccessControlAllowOrigin())
+        .setNamedBlobMode(container.getNamedBlobMode())
+        .setLastModifiedTime(container.getLastModifiedTime())
+        .setSnapshotVersion(container.getSnapshotVersion())
         .setCacheTtlInSecond(container.getCacheTtlInSecond())
         .setUserMetadataKeysToNotPrefixInResponse(container.getUserMetadataKeysToNotPrefixInResponse())
         .build();
@@ -839,9 +844,11 @@ public class AccountContainerTest {
             container.getAccessControlAllowOrigin());
         assertEquals("Wrong cacheTtlInSeconds", refContainerCacheTtlInSeconds.get(index),
             container.getCacheTtlInSecond());
+        Set<String> expectedUserMetadataKeysToNotPrefixInResponse =
+            refContainerUserMetadataKeysToNotPrefixInResponses.get(index) == null ? Collections.emptySet()
+                : refContainerUserMetadataKeysToNotPrefixInResponses.get(index);
         assertEquals("Wrong user metadata keys to not prefix in response",
-            refContainerUserMetadataKeysToNotPrefixInResponses.get(index),
-            container.getUserMetadataKeysToNotPrefixInResponse());
+            expectedUserMetadataKeysToNotPrefixInResponse, container.getUserMetadataKeysToNotPrefixInResponse());
         break;
       default:
         throw new IllegalStateException("Unsupported version: " + Container.getCurrentJsonVersion());

--- a/ambry-api/src/test/java/com/github/ambry/account/AccountContainerTest.java
+++ b/ambry-api/src/test/java/com/github/ambry/account/AccountContainerTest.java
@@ -62,6 +62,8 @@ public class AccountContainerTest {
   private final boolean refAccountAclInheritedByContainer;
 
   // Reference Container fields
+  private List<Container> refContainers;
+
   private List<Short> refContainerIds;
   private List<String> refContainerNames;
   private List<String> refContainerDescriptions;
@@ -80,8 +82,14 @@ public class AccountContainerTest {
   private List<Set<String>> refContainerContentTypeAllowListForFilenamesOnDownloadValues;
   private List<Long> refContainerLastModifiedTimes;
   private List<Integer> refContainerSnapshotVersions;
-  private List<Container> refContainers;
   private List<String> refAccessControlAllowOriginValues;
+
+  // Newly added fields to Container (2022/10/19)
+  private List<Long> refContainerCacheTtlInSeconds;
+  private List<Set<String>> refContainerUserMetadataKeysToNotPrefixInResponses;
+
+  private List<String> newContainerFieldNames =
+      Arrays.asList("cacheTtlInSecond", "userMetadataKeysToNotPrefixInResponse");
 
   /**
    * Initialize the metadata in JsonObject for account and container.
@@ -137,31 +145,13 @@ public class AccountContainerTest {
   public void testDuplicateContainerName() throws Exception {
     ArrayList<Container> containers = new ArrayList<>();
     // first container with (id=0, name="0")
-    containers.add(new ContainerBuilder((short) 0, "0", refContainerStatuses.get(0), refContainerDescriptions.get(0),
-        refAccountId).setEncrypted(refContainerEncryptionValues.get(0))
-        .setPreviouslyEncrypted(refContainerPreviousEncryptionValues.get(0))
-        .setCacheable(refContainerCachingValues.get(0))
-        .setBackupEnabled(refContainerBackupEnabledValues.get(0))
-        .setMediaScanDisabled(refContainerMediaScanDisabledValues.get(0))
-        .setReplicationPolicy(refContainerReplicationPolicyValues.get(0))
-        .setTtlRequired(refContainerTtlRequiredValues.get(0))
-        .setContentTypeWhitelistForFilenamesOnDownload(
-            refContainerContentTypeAllowListForFilenamesOnDownloadValues.get(0))
-        .setDeleteTriggerTime(refContainerDeleteTriggerTime.get(0))
-        .build());
+    containers.add(buildContainerWithOtherFields(
+        new ContainerBuilder((short) 0, "0", refContainerStatuses.get(0), refContainerDescriptions.get(0),
+            refAccountId), refContainers.get(0)));
     // second container with (id=1, name="0")
-    containers.add(new ContainerBuilder((short) 1, "0", refContainerStatuses.get(0), refContainerDescriptions.get(0),
-        refAccountId).setEncrypted(refContainerEncryptionValues.get(0))
-        .setPreviouslyEncrypted(refContainerPreviousEncryptionValues.get(0))
-        .setCacheable(refContainerCachingValues.get(0))
-        .setBackupEnabled(refContainerBackupEnabledValues.get(0))
-        .setMediaScanDisabled(refContainerMediaScanDisabledValues.get(0))
-        .setReplicationPolicy(refContainerReplicationPolicyValues.get(0))
-        .setTtlRequired(refContainerTtlRequiredValues.get(0))
-        .setContentTypeWhitelistForFilenamesOnDownload(
-            refContainerContentTypeAllowListForFilenamesOnDownloadValues.get(0))
-        .setDeleteTriggerTime(refContainerDeleteTriggerTime.get(0))
-        .build());
+    containers.add(buildContainerWithOtherFields(
+        new ContainerBuilder((short) 1, "0", refContainerStatuses.get(0), refContainerDescriptions.get(0),
+            refAccountId), refContainers.get(0)));
     createAccountWithBadContainersAndFail(containers, IllegalStateException.class);
   }
 
@@ -172,31 +162,13 @@ public class AccountContainerTest {
   public void testDuplicateContainerId() throws Exception {
     ArrayList<Container> containers = new ArrayList<>();
     // first container with (id=0, name="0")
-    containers.add(new ContainerBuilder((short) 0, "0", refContainerStatuses.get(0), refContainerDescriptions.get(0),
-        refAccountId).setEncrypted(refContainerEncryptionValues.get(0))
-        .setPreviouslyEncrypted(refContainerPreviousEncryptionValues.get(0))
-        .setCacheable(refContainerCachingValues.get(0))
-        .setBackupEnabled(refContainerBackupEnabledValues.get(0))
-        .setMediaScanDisabled(refContainerMediaScanDisabledValues.get(0))
-        .setReplicationPolicy(refContainerReplicationPolicyValues.get(0))
-        .setTtlRequired(refContainerTtlRequiredValues.get(0))
-        .setContentTypeWhitelistForFilenamesOnDownload(
-            refContainerContentTypeAllowListForFilenamesOnDownloadValues.get(0))
-        .setDeleteTriggerTime(refContainerDeleteTriggerTime.get(0))
-        .build());
+    containers.add(buildContainerWithOtherFields(
+        new ContainerBuilder((short) 0, "0", refContainerStatuses.get(0), refContainerDescriptions.get(0),
+            refAccountId), refContainers.get(0)));
     // second container with (id=0, name="1")
-    containers.add(new ContainerBuilder((short) 0, "1", refContainerStatuses.get(0), refContainerDescriptions.get(0),
-        refAccountId).setEncrypted(refContainerEncryptionValues.get(0))
-        .setPreviouslyEncrypted(refContainerPreviousEncryptionValues.get(0))
-        .setCacheable(refContainerCachingValues.get(0))
-        .setBackupEnabled(refContainerBackupEnabledValues.get(0))
-        .setMediaScanDisabled(refContainerMediaScanDisabledValues.get(0))
-        .setReplicationPolicy(refContainerReplicationPolicyValues.get(0))
-        .setTtlRequired(refContainerTtlRequiredValues.get(0))
-        .setContentTypeWhitelistForFilenamesOnDownload(
-            refContainerContentTypeAllowListForFilenamesOnDownloadValues.get(0))
-        .setDeleteTriggerTime(refContainerDeleteTriggerTime.get(0))
-        .build());
+    containers.add(buildContainerWithOtherFields(
+        new ContainerBuilder((short) 0, "1", refContainerStatuses.get(0), refContainerDescriptions.get(0),
+            refAccountId), refContainers.get(0)));
     createAccountWithBadContainersAndFail(containers, IllegalStateException.class);
   }
 
@@ -207,57 +179,21 @@ public class AccountContainerTest {
   public void testDuplicateContainerNameAndId() throws Exception {
     ArrayList<Container> containers = new ArrayList<>();
     // first container with (id=0, name="0")
-    containers.add(new ContainerBuilder((short) 0, "0", refContainerStatuses.get(0), refContainerDescriptions.get(0),
-        refAccountId).setEncrypted(refContainerEncryptionValues.get(0))
-        .setPreviouslyEncrypted(refContainerPreviousEncryptionValues.get(0))
-        .setCacheable(refContainerCachingValues.get(0))
-        .setBackupEnabled(refContainerBackupEnabledValues.get(0))
-        .setMediaScanDisabled(refContainerMediaScanDisabledValues.get(0))
-        .setReplicationPolicy(refContainerReplicationPolicyValues.get(0))
-        .setTtlRequired(refContainerTtlRequiredValues.get(0))
-        .setContentTypeWhitelistForFilenamesOnDownload(
-            refContainerContentTypeAllowListForFilenamesOnDownloadValues.get(0))
-        .setDeleteTriggerTime(refContainerDeleteTriggerTime.get(0))
-        .build());
+    containers.add(buildContainerWithOtherFields(
+        new ContainerBuilder((short) 0, "0", refContainerStatuses.get(0), refContainerDescriptions.get(0),
+            refAccountId), refContainers.get(0)));
     // second container with (id=1, name="0")
-    containers.add(new ContainerBuilder((short) 1, "0", refContainerStatuses.get(0), refContainerDescriptions.get(0),
-        refAccountId).setEncrypted(refContainerEncryptionValues.get(0))
-        .setPreviouslyEncrypted(refContainerPreviousEncryptionValues.get(0))
-        .setCacheable(refContainerCachingValues.get(0))
-        .setBackupEnabled(refContainerBackupEnabledValues.get(0))
-        .setMediaScanDisabled(refContainerMediaScanDisabledValues.get(0))
-        .setReplicationPolicy(refContainerReplicationPolicyValues.get(0))
-        .setTtlRequired(refContainerTtlRequiredValues.get(0))
-        .setContentTypeWhitelistForFilenamesOnDownload(
-            refContainerContentTypeAllowListForFilenamesOnDownloadValues.get(0))
-        .setDeleteTriggerTime(refContainerDeleteTriggerTime.get(0))
-        .build());
+    containers.add(buildContainerWithOtherFields(
+        new ContainerBuilder((short) 1, "0", refContainerStatuses.get(0), refContainerDescriptions.get(0),
+            refAccountId), refContainers.get(0)));
     // third container with (id=10, name="10")
-    containers.add(new ContainerBuilder((short) 10, "10", refContainerStatuses.get(0), refContainerDescriptions.get(0),
-        refAccountId).setEncrypted(refContainerEncryptionValues.get(0))
-        .setPreviouslyEncrypted(refContainerPreviousEncryptionValues.get(0))
-        .setCacheable(refContainerCachingValues.get(0))
-        .setBackupEnabled(refContainerBackupEnabledValues.get(0))
-        .setMediaScanDisabled(refContainerMediaScanDisabledValues.get(0))
-        .setReplicationPolicy(refContainerReplicationPolicyValues.get(0))
-        .setTtlRequired(refContainerTtlRequiredValues.get(0))
-        .setContentTypeWhitelistForFilenamesOnDownload(
-            refContainerContentTypeAllowListForFilenamesOnDownloadValues.get(0))
-        .setDeleteTriggerTime(refContainerDeleteTriggerTime.get(0))
-        .build());
+    containers.add(buildContainerWithOtherFields(
+        new ContainerBuilder((short) 10, "10", refContainerStatuses.get(0), refContainerDescriptions.get(0),
+            refAccountId), refContainers.get(0)));
     // second container with (id=10, name="11")
-    containers.add(new ContainerBuilder((short) 10, "11", refContainerStatuses.get(0), refContainerDescriptions.get(0),
-        refAccountId).setEncrypted(refContainerEncryptionValues.get(0))
-        .setPreviouslyEncrypted(refContainerPreviousEncryptionValues.get(0))
-        .setCacheable(refContainerCachingValues.get(0))
-        .setBackupEnabled(refContainerBackupEnabledValues.get(0))
-        .setMediaScanDisabled(refContainerMediaScanDisabledValues.get(0))
-        .setReplicationPolicy(refContainerReplicationPolicyValues.get(0))
-        .setTtlRequired(refContainerTtlRequiredValues.get(0))
-        .setContentTypeWhitelistForFilenamesOnDownload(
-            refContainerContentTypeAllowListForFilenamesOnDownloadValues.get(0))
-        .setDeleteTriggerTime(refContainerDeleteTriggerTime.get(0))
-        .build());
+    containers.add(buildContainerWithOtherFields(
+        new ContainerBuilder((short) 10, "11", refContainerStatuses.get(0), refContainerDescriptions.get(0),
+            refAccountId), refContainers.get(0)));
     createAccountWithBadContainersAndFail(containers, IllegalStateException.class);
   }
 
@@ -268,18 +204,9 @@ public class AccountContainerTest {
   public void testMismatchForAccountId() throws Exception {
     ArrayList<Container> containers = new ArrayList<>();
     // container with parentAccountId = refAccountId + 1
-    containers.add(new ContainerBuilder(refContainerIds.get(0), refContainerNames.get(0), refContainerStatuses.get(0),
-        refContainerDescriptions.get(0), (short) (refAccountId + 1)).setEncrypted(refContainerEncryptionValues.get(0))
-        .setPreviouslyEncrypted(refContainerPreviousEncryptionValues.get(0))
-        .setCacheable(refContainerCachingValues.get(0))
-        .setBackupEnabled(refContainerBackupEnabledValues.get(0))
-        .setMediaScanDisabled(refContainerMediaScanDisabledValues.get(0))
-        .setReplicationPolicy(refContainerReplicationPolicyValues.get(0))
-        .setTtlRequired(refContainerTtlRequiredValues.get(0))
-        .setContentTypeWhitelistForFilenamesOnDownload(
-            refContainerContentTypeAllowListForFilenamesOnDownloadValues.get(0))
-        .setDeleteTriggerTime(refContainerDeleteTriggerTime.get(0))
-        .build());
+    containers.add(buildContainerWithOtherFields(
+        new ContainerBuilder(refContainerIds.get(0), refContainerNames.get(0), refContainerStatuses.get(0),
+            refContainerDescriptions.get(0), (short) (refAccountId + 1)), refContainers.get(0)));
     createAccountWithBadContainersAndFail(containers, IllegalStateException.class);
   }
 
@@ -336,31 +263,15 @@ public class AccountContainerTest {
   public void testContainerBuilder() {
     for (int i = 0; i < CONTAINER_COUNT; i++) {
       // build a container with arguments supplied
-      ContainerBuilder containerBuilder =
+      Container containerFromBuilder = buildContainerWithOtherFields(
           new ContainerBuilder(refContainerIds.get(i), refContainerNames.get(i), refContainerStatuses.get(i),
-              refContainerDescriptions.get(i), refAccountId).setEncrypted(refContainerEncryptionValues.get(i))
-              .setPreviouslyEncrypted(refContainerPreviousEncryptionValues.get(i))
-              .setCacheable(refContainerCachingValues.get(i))
-              .setBackupEnabled(refContainerBackupEnabledValues.get(i))
-              .setMediaScanDisabled(refContainerMediaScanDisabledValues.get(i))
-              .setReplicationPolicy(refContainerReplicationPolicyValues.get(i))
-              .setTtlRequired(refContainerTtlRequiredValues.get(i))
-              .setSecurePathRequired(refContainerSignedPathRequiredValues.get(i))
-              .setContentTypeWhitelistForFilenamesOnDownload(
-                  refContainerContentTypeAllowListForFilenamesOnDownloadValues.get(i))
-              .setOverrideAccountAcl(refContainerOverrideAccountAcls.get(i))
-              .setNamedBlobMode(refContainerNamedBlobModes.get(i))
-              .setDeleteTriggerTime(refContainerDeleteTriggerTime.get(i))
-              .setLastModifiedTime(refContainerLastModifiedTimes.get(i))
-              .setSnapshotVersion(refContainerSnapshotVersions.get(i))
-              .setAccessControlAllowOrigin(refAccessControlAllowOriginValues.get(i));
-      Container containerFromBuilder = containerBuilder.build();
+              refContainerDescriptions.get(i), refAccountId), refContainers.get(i));
       assertContainer(containerFromBuilder, i);
 
       // build a container from existing container
-      containerBuilder = new ContainerBuilder(containerFromBuilder);
-      containerFromBuilder = containerBuilder.build();
-      assertContainer(containerFromBuilder, i);
+      Container anotherContainerFromBuilder = new ContainerBuilder(containerFromBuilder).build();
+      assertContainer(anotherContainerFromBuilder, i);
+      assertEquals("Two container should be equal", containerFromBuilder, anotherContainerFromBuilder);
 
       boolean previouslyEncrypted = containerFromBuilder.wasPreviouslyEncrypted();
       // turn off encryption, check that previouslyEncrypted is the same as the previous value.
@@ -506,6 +417,11 @@ public class AccountContainerTest {
               .stream()
               .map(contentType -> contentType + "--updated")
               .collect(Collectors.toSet());
+      Long updatedCacheTtlInSecond = System.currentTimeMillis();
+      Set<String> updatedUserMetadataKeysToNotPrefixInResponse = container.getUserMetadataKeysToNotPrefixInResponse()
+          .stream()
+          .map(key -> key + "--updated")
+          .collect(Collectors.toSet());
 
       containerBuilder.setId(updatedContainerId)
           .setName(updatedContainerName)
@@ -518,7 +434,9 @@ public class AccountContainerTest {
           .setTtlRequired(updatedTtlRequired)
           .setSecurePathRequired(updatedSignedPathRequired)
           .setContentTypeWhitelistForFilenamesOnDownload(updatedContentTypeAllowListForFilenamesOnDownloadValues)
-          .setAccessControlAllowOrigin(updatedAccessControlAllowOrigin);
+          .setAccessControlAllowOrigin(updatedAccessControlAllowOrigin)
+          .setCacheTtlInSecond(updatedCacheTtlInSecond)
+          .setUserMetadataKeysToNotPrefixInResponse(updatedUserMetadataKeysToNotPrefixInResponse);
       accountBuilder.addOrUpdateContainer(containerBuilder.build());
 
       // build account and assert
@@ -561,6 +479,10 @@ public class AccountContainerTest {
               updatedContainer.getContentTypeWhitelistForFilenamesOnDownload());
           assertEquals("Wrong accessControlAllowOrigin", updatedAccessControlAllowOrigin,
               updatedContainer.getAccessControlAllowOrigin());
+          assertEquals("Wrong cacheTtlInSeconds", updatedCacheTtlInSecond, updatedContainer.getCacheTtlInSecond());
+          assertEquals("Wrong user metadata keys to not prefix in response",
+              updatedUserMetadataKeysToNotPrefixInResponse,
+              updatedContainer.getUserMetadataKeysToNotPrefixInResponse());
           break;
         default:
           throw new IllegalStateException("Unsupported version: " + Container.getCurrentJsonVersion());
@@ -587,20 +509,9 @@ public class AccountContainerTest {
   public void testRemoveNonExistContainer() {
     Account origin = refAccount;
     AccountBuilder accountBuilder = new AccountBuilder(origin);
-    ContainerBuilder containerBuilder =
+    Container container = buildContainerWithOtherFields(
         new ContainerBuilder((short) -999, refContainerNames.get(0), refContainerStatuses.get(0),
-            refContainerDescriptions.get(0), refAccountId).setEncrypted(refContainerEncryptionValues.get(0))
-            .setPreviouslyEncrypted(refContainerPreviousEncryptionValues.get(0))
-            .setCacheable(refContainerCachingValues.get(0))
-            .setBackupEnabled(refContainerBackupEnabledValues.get(0))
-            .setMediaScanDisabled(refContainerMediaScanDisabledValues.get(0))
-            .setReplicationPolicy(refContainerReplicationPolicyValues.get(0))
-            .setTtlRequired(refContainerTtlRequiredValues.get(0))
-            .setContentTypeWhitelistForFilenamesOnDownload(
-                refContainerContentTypeAllowListForFilenamesOnDownloadValues.get(0))
-            .setDeleteTriggerTime(refContainerDeleteTriggerTime.get(0))
-            .setAccessControlAllowOrigin(refAccessControlAllowOriginValues.get(0));
-    Container container = containerBuilder.build();
+            refContainerDescriptions.get(0), refAccountId), refContainers.get(0));
     accountBuilder.removeContainer(container);
     accountBuilder.removeContainer(null);
     Account account = accountBuilder.build();
@@ -707,24 +618,9 @@ public class AccountContainerTest {
 
     // Check two accounts with the same fields and the same number of containers. One container of one account has one
     // field different from the other one.
-    Container updatedContainer =
+    Container updatedContainer = buildContainerWithOtherFields(
         new ContainerBuilder(refContainerIds.get(0), refContainerNames.get(0), refContainerStatuses.get(0),
-            "A changed container description", refAccountId).setEncrypted(refContainerEncryptionValues.get(0))
-            .setPreviouslyEncrypted(refContainerPreviousEncryptionValues.get(0))
-            .setCacheable(refContainerCachingValues.get(0))
-            .setBackupEnabled(refContainerBackupEnabledValues.get(0))
-            .setMediaScanDisabled(refContainerMediaScanDisabledValues.get(0))
-            .setReplicationPolicy(refContainerReplicationPolicyValues.get(0))
-            .setTtlRequired(refContainerTtlRequiredValues.get(0))
-            .setSecurePathRequired(refContainerSignedPathRequiredValues.get(0))
-            .setOverrideAccountAcl(refContainerOverrideAccountAcls.get(0))
-            .setNamedBlobMode(refContainerNamedBlobModes.get(0))
-            .setContentTypeWhitelistForFilenamesOnDownload(
-                refContainerContentTypeAllowListForFilenamesOnDownloadValues.get(0))
-            .setDeleteTriggerTime(refContainerDeleteTriggerTime.get(0))
-            .setLastModifiedTime(refContainerLastModifiedTimes.get(0))
-            .setSnapshotVersion(refContainerSnapshotVersions.get(0))
-            .build();
+            "A changed container description", refAccountId), refContainers.get(0));
     refContainers.remove(0);
     refContainers.add(updatedContainer);
     Account accountWithModifiedContainers = new AccountBuilder(refAccountId, refAccountName, refAccountStatus).build();
@@ -732,7 +628,7 @@ public class AccountContainerTest {
   }
 
   @Test
-  public void testAccountAndContainerSerDeWithObjectMapper() throws IOException {
+  public void testAccountAndContainerSerDe() throws IOException {
     assumeTrue(Container.getCurrentJsonVersion() == JSON_VERSION_2);
     Account origin = refAccount;
     String serializedAccountStr = objectMapper.writeValueAsString(origin);
@@ -758,6 +654,36 @@ public class AccountContainerTest {
           new ContainerBuilder(objectMapper.readValue(serializedContainerStr, Container.class)).setParentAccountId(
               container.getParentAccountId()).build();
       assertEquals("Two containers should be equal", container, deserializedContainer);
+    }
+  }
+
+  /**
+   * Test container serialization and deserialization without the new fields
+   * @throws IOException
+   */
+  @Test
+  public void testContainerSerDeWithoutNewFields() throws IOException {
+    assumeTrue(Container.getCurrentJsonVersion() == JSON_VERSION_2);
+    for (int i = 0; i < CONTAINER_COUNT; i++) {
+      Container container = refContainers.get(i);
+
+      String serializedContainerStr = objectMapper.writeValueAsString(container);
+      ObjectNode newRefContainerJsonNode = (ObjectNode) objectMapper.readTree(serializedContainerStr);
+      for (String fieldName : newContainerFieldNames) {
+        newRefContainerJsonNode.remove(fieldName);
+      }
+      Container deseriazlied =
+          objectMapper.readValue(objectMapper.writeValueAsString(newRefContainerJsonNode), Container.class);
+      assertEquals(Container.CACHE_TTL_IN_SECOND_DEFAULT_VALUE, deseriazlied.getCacheTtlInSecond());
+      assertEquals(USER_METADATA_KEYS_TO_NOT_PREFIX_IN_RESPONSE_DEFAULT_VALUE,
+          deseriazlied.getUserMetadataKeysToNotPrefixInResponse());
+
+      Container newContainer = new ContainerBuilder(deseriazlied).setCacheTtlInSecond(container.getCacheTtlInSecond())
+          .setUserMetadataKeysToNotPrefixInResponse(container.getUserMetadataKeysToNotPrefixInResponse())
+          .setParentAccountId(container.getParentAccountId())
+          .build();
+
+      assertEquals(container, newContainer);
     }
   }
 
@@ -835,6 +761,29 @@ public class AccountContainerTest {
   }
 
   /**
+   * Build a container in the {@link ContainerBuilder} with the values from {@code container}. It expects the
+   * {@code builder} to already have name, id, description and status.
+   * @param builder The {@link ContainerBuilder}.
+   * @param container The {@link Container}.
+   * @return
+   */
+  private Container buildContainerWithOtherFields(ContainerBuilder builder, Container container) {
+    return builder.setEncrypted(container.isEncrypted())
+        .setPreviouslyEncrypted(container.wasPreviouslyEncrypted())
+        .setCacheable(container.isCacheable())
+        .setBackupEnabled(container.isBackupEnabled())
+        .setMediaScanDisabled(container.isMediaScanDisabled())
+        .setReplicationPolicy(container.getReplicationPolicy())
+        .setTtlRequired(container.isTtlRequired())
+        .setContentTypeWhitelistForFilenamesOnDownload(container.getContentTypeWhitelistForFilenamesOnDownload())
+        .setDeleteTriggerTime(container.getDeleteTriggerTime())
+        .setAccessControlAllowOrigin(container.getAccessControlAllowOrigin())
+        .setCacheTtlInSecond(container.getCacheTtlInSecond())
+        .setUserMetadataKeysToNotPrefixInResponse(container.getUserMetadataKeysToNotPrefixInResponse())
+        .build();
+  }
+
+  /**
    * Asserts a {@link Container} against the reference account for every internal field
    * @param container The {@link Container} to assert.
    * @param index The index in the reference container list to assert against.
@@ -888,6 +837,11 @@ public class AccountContainerTest {
             container.getSnapshotVersion());
         assertEquals("Wrong accessControlAllowOrigin", refAccessControlAllowOriginValues.get(index),
             container.getAccessControlAllowOrigin());
+        assertEquals("Wrong cacheTtlInSeconds", refContainerCacheTtlInSeconds.get(index),
+            container.getCacheTtlInSecond());
+        assertEquals("Wrong user metadata keys to not prefix in response",
+            refContainerUserMetadataKeysToNotPrefixInResponses.get(index),
+            container.getUserMetadataKeysToNotPrefixInResponse());
         break;
       default:
         throw new IllegalStateException("Unsupported version: " + Container.getCurrentJsonVersion());
@@ -952,7 +906,7 @@ public class AccountContainerTest {
     TestUtils.assertException(exceptionClass, () -> {
       new Container((short) 0, name, status, "description", encrypted, previouslyEncrypted, false, false, null, false,
           false, Collections.emptySet(), false, false, NamedBlobMode.DISABLED, (short) 0, System.currentTimeMillis(),
-          System.currentTimeMillis(), 0, null);
+          System.currentTimeMillis(), 0, null, null, null);
     }, null);
   }
 
@@ -980,6 +934,8 @@ public class AccountContainerTest {
     refContainerSnapshotVersions = new ArrayList<>();
     refContainers = new ArrayList<>();
     refAccessControlAllowOriginValues = new ArrayList<>();
+    refContainerCacheTtlInSeconds = new ArrayList<>();
+    refContainerUserMetadataKeysToNotPrefixInResponses = new ArrayList<>();
     Set<Short> containerIdSet = new HashSet<>();
     Set<String> containerNameSet = new HashSet<>();
     for (int i = 0; i < CONTAINER_COUNT; i++) {
@@ -1012,20 +968,25 @@ public class AccountContainerTest {
       refContainerDeleteTriggerTime.add((long) 0);
       if (i == 0) {
         refContainerContentTypeAllowListForFilenamesOnDownloadValues.add(null);
+        refContainerUserMetadataKeysToNotPrefixInResponses.add(null);
       } else if (i == 1) {
         refContainerContentTypeAllowListForFilenamesOnDownloadValues.add(Collections.emptySet());
+        refContainerUserMetadataKeysToNotPrefixInResponses.add(Collections.emptySet());
       } else {
-        refContainerContentTypeAllowListForFilenamesOnDownloadValues.add(
-            getRandomContentTypeAllowListForFilenamesOnDownload());
+        refContainerContentTypeAllowListForFilenamesOnDownloadValues.add(getRandomStringSet());
+        refContainerUserMetadataKeysToNotPrefixInResponses.add(getRandomStringSet());
       }
       refContainerLastModifiedTimes.add(System.currentTimeMillis());
       refContainerSnapshotVersions.add(random.nextInt());
       if (i == 0) {
         refAccessControlAllowOriginValues.add("*");
+        refContainerCacheTtlInSeconds.add(null);
       } else if (i == 1) {
         refAccessControlAllowOriginValues.add("");
+        refContainerCacheTtlInSeconds.add(null);
       } else {
         refAccessControlAllowOriginValues.add("https://" + TestUtils.getRandomString(10) + ".com");
+        refContainerCacheTtlInSeconds.add(System.currentTimeMillis());
       }
       refContainers.add(new Container(refContainerIds.get(i), refContainerNames.get(i), refContainerStatuses.get(i),
           refContainerDescriptions.get(i), refContainerEncryptionValues.get(i),
@@ -1035,14 +996,15 @@ public class AccountContainerTest {
           refContainerContentTypeAllowListForFilenamesOnDownloadValues.get(i), refContainerBackupEnabledValues.get(i),
           refContainerOverrideAccountAcls.get(i), refContainerNamedBlobModes.get(i), refAccountId,
           refContainerDeleteTriggerTime.get(i), refContainerLastModifiedTimes.get(i),
-          refContainerSnapshotVersions.get(i), refAccessControlAllowOriginValues.get(i)));
+          refContainerSnapshotVersions.get(i), refAccessControlAllowOriginValues.get(i),
+          refContainerCacheTtlInSeconds.get(i), refContainerUserMetadataKeysToNotPrefixInResponses.get(i)));
     }
   }
 
   /**
    * @return a random set of strings
    */
-  private Set<String> getRandomContentTypeAllowListForFilenamesOnDownload() {
+  private Set<String> getRandomStringSet() {
     Set<String> toRet = new HashSet<>();
     IntStream.range(0, random.nextInt(10) + 1).boxed().forEach(i -> toRet.add(TestUtils.getRandomString(10)));
     return toRet;


### PR DESCRIPTION
Adding two new fields to container
1. CacheTtlInSecond: This would dictate how long the blob of this container can be cached by the cdn and the browser. This would be null and if it's null, the user of this field can set it a value that the user deems reasonable.
2. UserMetadataKeysToNotPrefixInResponse: For each user metadata, when we return it in the response, we already prefix the key with x-ambry-um-. For some applications, they want to return the user metadata without prefix. This new fields would be a set of user metadata keys that we would not prefix when returning in response.