### PR TITLE
Update Hard Delete to support Blob Format V3.

### DIFF
--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/BlobStoreHardDelete.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/BlobStoreHardDelete.java
@@ -233,7 +233,7 @@ class HardDeleteRecoveryMetadata {
     userMetadataVersion = stream.readShort();
     userMetadataSize = stream.readInt();
     blobRecordVersion = stream.readShort();
-    if (blobRecordVersion == Blob_Version_V2) {
+    if (blobRecordVersion >= Blob_Version_V2) {
       blobType = BlobType.values()[stream.readShort()];
     } else {
       blobType = BlobType.DataBlob;
@@ -279,8 +279,9 @@ class HardDeleteRecoveryMetadata {
   byte[] toBytes() {
     // create a byte array to hold the headerVersion + userMetadataVersion + userMetadataSize + blobRecordVersion +
     // blobType + blobRecordSize + storeKey.
+    // Note: Blob Version 3 has introduced compression, but we don't want to add that to hard delete metadata.
     byte[] bytes = new byte[Version_Field_Size_In_Bytes + Version_Field_Size_In_Bytes + Integer.SIZE / 8
-        + Version_Field_Size_In_Bytes + (blobRecordVersion == Blob_Version_V2 ? (Short.SIZE / 8) : 0) + Long.SIZE / 8
+        + Version_Field_Size_In_Bytes + (blobRecordVersion >= Blob_Version_V2 ? (Short.SIZE / 8) : 0) + Long.SIZE / 8
         + storeKey.sizeInBytes()];
 
     ByteBuffer bufWrap = ByteBuffer.wrap(bytes);
@@ -288,7 +289,7 @@ class HardDeleteRecoveryMetadata {
     bufWrap.putShort(userMetadataVersion);
     bufWrap.putInt(userMetadataSize);
     bufWrap.putShort(blobRecordVersion);
-    if (blobRecordVersion == Blob_Version_V2) {
+    if (blobRecordVersion >= Blob_Version_V2) {
       bufWrap.putShort((short) blobType.ordinal());
     }
     bufWrap.putLong(blobStreamSize);

--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/HardDeleteMessageFormatInputStream.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/HardDeleteMessageFormatInputStream.java
@@ -96,6 +96,14 @@ public class HardDeleteMessageFormatInputStream extends MessageFormatInputStream
             blobType);
         serializedBlobPartialRecord.flip();
         break;
+      case MessageFormatRecord.Blob_Version_V3:
+        blobRecordSize = MessageFormatRecord.Blob_Format_V3.getBlobRecordSize(blobStreamSize);
+        serializedBlobPartialRecord =
+            ByteBuffer.allocate((int) (blobRecordSize - blobStreamSize - MessageFormatRecord.Crc_Size));
+        MessageFormatRecord.Blob_Format_V3.serializePartialBlobRecord(serializedBlobPartialRecord, blobStreamSize,
+            blobType, false);
+        serializedBlobPartialRecord.flip();
+        break;
       default:
         throw new MessageFormatException("Unknown version encountered when creating hard delete stream",
             MessageFormatErrorCodes.Unknown_Format_Version);

--- a/ambry-messageformat/src/test/java/com/github/ambry/messageformat/BlobStoreHardDeleteTest.java
+++ b/ambry-messageformat/src/test/java/com/github/ambry/messageformat/BlobStoreHardDeleteTest.java
@@ -211,7 +211,7 @@ public class BlobStoreHardDeleteTest {
     private MessageFormatInputStream getPutMessage(StoreKey key, ByteBuffer encryptionKey,
         BlobProperties blobProperties, byte[] usermetadata, byte[] blob, int blobSize, short blobVersion,
         BlobType blobType) throws MessageFormatException {
-      if (blobVersion == MessageFormatRecord.Blob_Version_V2) {
+      if (blobVersion >= MessageFormatRecord.Blob_Version_V2) {
         return new PutMessageFormatInputStream(key, encryptionKey, blobProperties, ByteBuffer.wrap(usermetadata),
             new ByteBufferInputStream(ByteBuffer.wrap(blob)), blobSize, blobType);
       } else {
@@ -333,6 +333,7 @@ public class BlobStoreHardDeleteTest {
     blobStoreHardDeleteTestUtil(blobVersions, blobTypes);
   }
 
+  @Deprecated // V2 is being replaced by V3.  Remove after deployed V3.
   @Test
   public void blobStoreHardDeleteTestBlobV2Simple() throws MessageFormatException, IOException {
     short[] blobVersions = new short[5];
@@ -353,6 +354,33 @@ public class BlobStoreHardDeleteTest {
     blobStoreHardDeleteTestUtil(blobVersions, blobTypes);
   }
 
+  @Test
+  public void blobStoreHardDeleteTestBlobV3Simple() throws MessageFormatException, IOException {
+    boolean useBlobVersionSaved = PutMessageFormatInputStream.useBlobFormatV3;
+    PutMessageFormatInputStream.useBlobFormatV3 = true;
+    try {
+      short[] blobVersions = new short[5];
+      BlobType[] blobTypes = new BlobType[5];
+      for (int i = 0; i < 5; i++) {
+        blobVersions[i] = MessageFormatRecord.Blob_Version_V3;
+        blobTypes[i] = BlobType.DataBlob;
+      }
+      // all blobs V3 with Data blob
+      blobStoreHardDeleteTestUtil(blobVersions, blobTypes);
+      blobVersions = new short[5];
+      blobTypes = new BlobType[5];
+      for (int i = 0; i < 5; i++) {
+        blobVersions[i] = MessageFormatRecord.Blob_Version_V3;
+        blobTypes[i] = BlobType.MetadataBlob;
+      }
+      // all blobs V3 with Metadata blob
+      blobStoreHardDeleteTestUtil(blobVersions, blobTypes);
+    } finally {
+      PutMessageFormatInputStream.useBlobFormatV3 = useBlobVersionSaved;
+    }
+  }
+
+  @Deprecated()  // Has been replaced by blobStoreHardDeleteTestBlobV3Mixed().  Remove after V3 deployed.
   @Test
   public void blobStoreHardDeleteTestBlobV2Mixed() throws MessageFormatException, IOException {
 
@@ -391,6 +419,49 @@ public class BlobStoreHardDeleteTest {
     blobTypes[3] = BlobType.DataBlob;
 
     blobVersions[4] = MessageFormatRecord.Blob_Version_V2;
+    blobTypes[4] = BlobType.MetadataBlob;
+
+    blobStoreHardDeleteTestUtil(blobVersions, blobTypes);
+  }
+
+  @Test
+  public void blobStoreHardDeleteTestBlobV3Mixed() throws MessageFormatException, IOException {
+
+    short[] blobVersions = new short[5];
+    BlobType[] blobTypes = new BlobType[5];
+
+    blobVersions[0] = MessageFormatRecord.Blob_Version_V1;
+    blobTypes[0] = BlobType.DataBlob;
+
+    blobVersions[1] = MessageFormatRecord.Blob_Version_V2;
+    blobTypes[1] = BlobType.MetadataBlob;
+
+    blobVersions[2] = MessageFormatRecord.Blob_Version_V2;
+    blobTypes[2] = BlobType.DataBlob;
+
+    blobVersions[3] = MessageFormatRecord.Blob_Version_V3;
+    blobTypes[3] = BlobType.MetadataBlob;
+
+    blobVersions[4] = MessageFormatRecord.Blob_Version_V3;
+    blobTypes[4] = BlobType.DataBlob;
+
+    blobStoreHardDeleteTestUtil(blobVersions, blobTypes);
+
+    blobVersions = new short[5];
+    blobTypes = new BlobType[5];
+    blobVersions[0] = MessageFormatRecord.Blob_Version_V1;
+    blobTypes[0] = BlobType.DataBlob;
+
+    blobVersions[1] = MessageFormatRecord.Blob_Version_V2;
+    blobTypes[1] = BlobType.DataBlob;
+
+    blobVersions[2] = MessageFormatRecord.Blob_Version_V2;
+    blobTypes[2] = BlobType.MetadataBlob;
+
+    blobVersions[3] = MessageFormatRecord.Blob_Version_V3;
+    blobTypes[3] = BlobType.DataBlob;
+
+    blobVersions[4] = MessageFormatRecord.Blob_Version_V3;
     blobTypes[4] = BlobType.MetadataBlob;
 
     blobStoreHardDeleteTestUtil(blobVersions, blobTypes);

--- a/ambry-messageformat/src/test/java/com/github/ambry/messageformat/BlobStoreHardDeleteTest.java
+++ b/ambry-messageformat/src/test/java/com/github/ambry/messageformat/BlobStoreHardDeleteTest.java
@@ -429,6 +429,10 @@ public class BlobStoreHardDeleteTest {
   @Test
   public void blobStoreHardDeleteTestBlobV3Mixed() throws MessageFormatException, IOException {
 
+    // The 2 blocks of tests look very similar, but they are slightly different.
+    // The 1st sequence is Data, Metadata, Data, Metadata, Data.
+    // The 2nd sequence is Data, Data, Metadata, Data, Metadata.
+
     short[] blobVersions = new short[5];
     BlobType[] blobTypes = new BlobType[5];
 

--- a/ambry-messageformat/src/test/java/com/github/ambry/messageformat/BlobStoreHardDeleteTest.java
+++ b/ambry-messageformat/src/test/java/com/github/ambry/messageformat/BlobStoreHardDeleteTest.java
@@ -368,7 +368,6 @@ public class BlobStoreHardDeleteTest {
             blobTypes[i] = blobType;
           }
           try {
-            // all blobs V3 with Data blob
             blobStoreHardDeleteTestUtil(blobVersions, blobTypes);
           } catch (Exception ex) {
             throw new RuntimeException(ex);

--- a/ambry-messageformat/src/test/java/com/github/ambry/messageformat/BlobStoreHardDeleteTest.java
+++ b/ambry-messageformat/src/test/java/com/github/ambry/messageformat/BlobStoreHardDeleteTest.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Consumer;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -359,22 +360,23 @@ public class BlobStoreHardDeleteTest {
     boolean useBlobVersionSaved = PutMessageFormatInputStream.useBlobFormatV3;
     PutMessageFormatInputStream.useBlobFormatV3 = true;
     try {
-      short[] blobVersions = new short[5];
-      BlobType[] blobTypes = new BlobType[5];
-      for (int i = 0; i < 5; i++) {
-        blobVersions[i] = MessageFormatRecord.Blob_Version_V3;
-        blobTypes[i] = BlobType.DataBlob;
-      }
-      // all blobs V3 with Data blob
-      blobStoreHardDeleteTestUtil(blobVersions, blobTypes);
-      blobVersions = new short[5];
-      blobTypes = new BlobType[5];
-      for (int i = 0; i < 5; i++) {
-        blobVersions[i] = MessageFormatRecord.Blob_Version_V3;
-        blobTypes[i] = BlobType.MetadataBlob;
-      }
-      // all blobs V3 with Metadata blob
-      blobStoreHardDeleteTestUtil(blobVersions, blobTypes);
+      Consumer<BlobType> runTest = blobType -> {
+          short[] blobVersions = new short[5];
+          BlobType[] blobTypes = new BlobType[5];
+          for (int i = 0; i < 5; i++) {
+            blobVersions[i] = MessageFormatRecord.Blob_Version_V3;
+            blobTypes[i] = blobType;
+          }
+          try {
+            // all blobs V3 with Data blob
+            blobStoreHardDeleteTestUtil(blobVersions, blobTypes);
+          } catch (Exception ex) {
+            throw new RuntimeException(ex);
+          }
+      };
+
+      runTest.accept(BlobType.DataBlob);
+      runTest.accept(BlobType.MetadataBlob);
     } finally {
       PutMessageFormatInputStream.useBlobFormatV3 = useBlobVersionSaved;
     }

--- a/ambry-messageformat/src/test/java/com/github/ambry/messageformat/HardDeleteMessageFormatInputStreamTest.java
+++ b/ambry-messageformat/src/test/java/com/github/ambry/messageformat/HardDeleteMessageFormatInputStreamTest.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2022 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.messageformat;
+
+import java.io.IOException;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+/**
+ * Test hard-delete input stream message format.
+ */
+public class HardDeleteMessageFormatInputStreamTest {
+
+  /**
+   * Majority of the logic resides in the constructor. Test constructor to make sure it does not throw.
+   */
+  @Test
+  public void testConstructor() throws MessageFormatException, IOException {
+    HardDeleteMessageFormatInputStream inputStream = new HardDeleteMessageFormatInputStream(1000,
+        MessageFormatRecord.UserMetadata_Version_V1, 100, MessageFormatRecord.Blob_Version_V3,
+        BlobType.DataBlob, 2000);
+
+    Assert.assertTrue(inputStream.streamLength > 0);
+  }
+}


### PR DESCRIPTION
HardDelete was originally written in 2016.  It zeros user metadata and blob data.  I believe it is deprecated and replaced by compaction. It is not active, but the code is there, so update it.