### PR TITLE
ReplicateBlob supports AmbryLI StoreKeyConverterFactory. 

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/store/Transformer.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/Transformer.java
@@ -36,9 +36,11 @@ public interface Transformer {
    * @param messageInfos message infos that will be used to warmup transformer,
    *                     each message info corresponds to a message the transformer
    *                     is expected to convert in the immediate future
+   * @param includeAll if true, will warmup transformer with all the messages.
+   *                   if false, will ignore the deleted or expired messages.
    * @throws Exception
    */
-  void warmup(List<MessageInfo> messageInfos) throws Exception;
+  void warmup(List<MessageInfo> messageInfos, boolean includeAll) throws Exception;
 }
 
 

--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageSievingInputStream.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageSievingInputStream.java
@@ -161,9 +161,21 @@ public class MessageSievingInputStream extends InputStream {
       return msg;
     }
 
+    List<MessageInfo> messageInfos = new ArrayList<>();
+    messageInfos.add(msgInfo);
+
     logger.trace("transferInputStream for message {}", msgInfo);
     TransformationOutput output = null;
     for (Transformer transformer : transformers) {
+      // Warms up transformer with message infos representing messages it will transform later.
+      // It may convert the key with transformer.converter and cache them.
+      try {
+        transformer.warmup(messageInfos, true);
+      } catch (Exception e) {
+        throw new IOException("Encountered exception during transformer.warmup", e);
+      }
+
+      // transform the message. It may use the converted key in the warmup stage.
       output = transformer.transform(msg);
       if (output.getException() != null || output.getMsg() == null) {
         break;

--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageSievingInputStream.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageSievingInputStream.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.SequenceInputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.ListIterator;
@@ -161,16 +162,13 @@ public class MessageSievingInputStream extends InputStream {
       return msg;
     }
 
-    List<MessageInfo> messageInfos = new ArrayList<>();
-    messageInfos.add(msgInfo);
-
     logger.trace("transferInputStream for message {}", msgInfo);
     TransformationOutput output = null;
     for (Transformer transformer : transformers) {
       // Warms up transformer with message infos representing messages it will transform later.
       // It may convert the key with transformer.converter and cache them.
       try {
-        transformer.warmup(messageInfos, true);
+        transformer.warmup(Collections.singletonList(msgInfo), true);
       } catch (Exception e) {
         throw new IOException("Encountered exception during transformer.warmup", e);
       }

--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/ValidatingTransformer.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/ValidatingTransformer.java
@@ -104,7 +104,7 @@ public class ValidatingTransformer implements Transformer {
   }
 
   @Override
-  public void warmup(List<MessageInfo> messageInfos) throws Exception {
+  public void warmup(List<MessageInfo> messageInfos, boolean includeAll) throws Exception {
     //no-op
   }
 }

--- a/ambry-messageformat/src/test/java/com/github/ambry/messageformat/MessageSievingInputStreamTest.java
+++ b/ambry-messageformat/src/test/java/com/github/ambry/messageformat/MessageSievingInputStreamTest.java
@@ -1197,7 +1197,7 @@ class ValidatingKeyConvertingTransformer implements Transformer {
   }
 
   @Override
-  public void warmup(List<MessageInfo> messageInfos) throws Exception {
+  public void warmup(List<MessageInfo> messageInfos, boolean includeAll) throws Exception {
     //no-op
   }
 }

--- a/ambry-replication/src/main/java/com/github/ambry/replication/BlobIdTransformer.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/BlobIdTransformer.java
@@ -87,10 +87,12 @@ public class BlobIdTransformer implements Transformer {
   }
 
   @Override
-  public void warmup(List<MessageInfo> messageInfos) throws Exception {
+  public void warmup(List<MessageInfo> messageInfos, boolean includeAll) throws Exception {
     List<StoreKey> storeKeys = new ArrayList<>();
     for (MessageInfo messageInfo : messageInfos) {
-      if (!messageInfo.isExpired() && !messageInfo.isDeleted()) {
+      // if includeAll is true, add this key.
+      // otherwise, only add the key if the message is not deleted or expired.
+      if (includeAll || (!messageInfo.isExpired() && !messageInfo.isDeleted())) {
         storeKeys.add(messageInfo.getStoreKey());
       }
     }

--- a/ambry-replication/src/test/java/com/github/ambry/replication/BlobIdTransformerTest.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/BlobIdTransformerTest.java
@@ -341,7 +341,7 @@ public class BlobIdTransformerTest {
     BlobIdTransformer transformer = new BlobIdTransformer(blobIdFactory, factory.getStoreKeyConverter());
     TransformationOutput output = transformer.transform(inputAndExpected.getInput());
     Assert.assertTrue("Should lead to IllegalStateException", output.getException() instanceof IllegalStateException);
-    transformer.warmup(Collections.singletonList(inputAndExpected.getInput().getMessageInfo()));
+    transformer.warmup(Collections.singletonList(inputAndExpected.getInput().getMessageInfo()), false);
     output = transformer.transform(inputAndExpected.getInput());
     assertNull(output.getException());
     verifyOutput(output.getMsg(), inputAndExpected.getExpected());

--- a/ambry-tools/src/main/java/com/github/ambry/store/StoreCopier.java
+++ b/ambry-tools/src/main/java/com/github/ambry/store/StoreCopier.java
@@ -207,7 +207,7 @@ public class StoreCopier implements Closeable {
       FindInfo findInfo = src.findEntriesSince(lastToken, fetchSizeInBytes, null, null);
       List<MessageInfo> messageInfos = findInfo.getMessageEntries();
       for (Transformer transformer : transformers) {
-        transformer.warmup(messageInfos);
+        transformer.warmup(messageInfos, false);
       }
       for (MessageInfo messageInfo : messageInfos) {
         logger.trace("Processing {} - isDeleted: {}, isExpired {}", messageInfo.getStoreKey(), messageInfo.isDeleted(),


### PR DESCRIPTION
ReplicateBlob supports AmbryLI StoreKeyConverterFactory.  
AmbryLI StoreKeyConverterFactory requires the caller to warmup the keyConverter cache first and then do the transfer.
