### PR TITLE
Compression library accept ByteBuffer.

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/compression/Compression.java
+++ b/ambry-api/src/main/java/com/github/ambry/compression/Compression.java
@@ -15,6 +15,8 @@ package com.github.ambry.compression;
 
 import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.Utils;
+import java.nio.ByteBuffer;
+
 
 /**
  * Compression interface that provides compression and decompression feature.
@@ -25,17 +27,17 @@ import com.github.ambry.utils.Utils;
  * Shared buffer APIs (caller management memory).
  *   Compression example:
  *   {@code
- *     byte[] originalData = ...;
- *     int compressedBufferSize = Compression.getCompressBufferSize(originalData.length);
- *     byte[] compressedBuffer = new byte[compressedBufferSize];
+ *     ByteBuffer originalData = ...;
+ *     int compressedBufferSize = Compression.getCompressBufferSize(originalData.remaining());
+ *     ByteBuffer compressedBuffer = ByteBuffer.allocateDirect(compressedBufferSize);
  *     int compressedSize = Compression.compress(originalData, 0, originalData.length,
- *                                   compressedBuffer, 0, compressedBuffer.length);
+ *                                   compressedBuffer, 0, compressedBuffer.capacity());
  *   }
  *
  *   Decompression example:
  *   {@code
- *     byte[] compressedBuffer = ...;
- *     int originalDataSize = Compression.getDecompressBufferSize(compressedBuffer, 0, compressedBuffer.length);
+ *     ByteBuffer compressedBuffer = ...;
+ *     int originalDataSize = Compression.getDecompressBufferSize(compressedBuffer, compressedBuffer.position(), compressedBuffer.remaining());
  *     byte[] originalData = new byte[originalDataSize];
  *     int decompressedSize = Compression.decompress(compressedBuffer, 0, compressedBuffer.length,
  *                                   originalData, 0, originalData.length);
@@ -224,6 +226,88 @@ public interface Compression {
     byte[] originalData = new byte[originalDataSize];
     decompress(compressedBuffer, compressedBufferOffset, compressedDataSize,
         originalData, 0, originalData.length);
+    return originalData;
+  }
+
+  /**
+   * Get the original data size stored inside the shared/composite compressed buffer.  The compressed buffer
+   * contains version, algorithm name, original data size, and compressed data.  This method helps to determine
+   * the decompressed buffer size before calling decompress().
+   * This method does not change the index of compressedBuffer.
+   *
+   * @param compressedBuffer The compressed buffer.  The buffer must be position to the beginning of buffer.
+   *                         The indexes are not affected and remain unchanged.
+   * @return The size of original data.
+   * @throws CompressionException Throws this exception if compression has internal failure.
+   */
+  int getDecompressBufferSize(ByteBuffer compressedBuffer) throws CompressionException;
+
+  /**
+   * Compress the buffer specified in {@code sourceData}.  The entire sourceBuffer will be read,
+   * so set the position and limit to the range of data to read in sourceBuffer before calling this method.
+   * After calling this method, sourceBuffer position will be advanced to the buffer limit,
+   * and the compressedBuffer position will be advanced to the end of the compressed binary.
+   *
+   * @param sourceBuffer The source/uncompressed data to compress.  It cannot be null or empty.
+   * @param compressedBuffer The compressed buffer where the compressed data will be written to.  Its size must be
+   *                       at least the size return from getCompressBufferSize() or it may fail due to buffer size.
+   * @return The actual compressed data size in bytes.
+   * @throws CompressionException Throws this exception if compression has internal failure.
+   */
+  int compress(ByteBuffer sourceBuffer, ByteBuffer compressedBuffer) throws CompressionException;
+
+  /**
+   * Compress the buffer specified in {@code sourceBuffer}.  This method allocates either direct memory or heap memory,
+   * based on the allocateDirectBuffer parameter, to store the compressed data.  The output compressed buffer capacity
+   * may be bigger than necessary in case sourceBuffer is incompressible.  The index of sourceBuffer will be updated
+   * and flipped, so it's ready for reading.
+   *
+   * @param sourceBuffer The source uncompressed data to compress.  It cannot be null or empty.
+   * @param allocateDirectBuffer Whether to allocate direct buffer or heap buffer to store compressed data.
+   * @return The compressed buffer.
+   * @throws CompressionException Throws this exception if compression has internal failure.
+   */
+  default ByteBuffer compress(ByteBuffer sourceBuffer, boolean allocateDirectBuffer) throws CompressionException {
+    Utils.checkNotNullOrEmpty(sourceBuffer, "sourceBuffer cannot be null or empty.");
+    int compressedBufferSize = getCompressBufferSize(sourceBuffer.remaining());
+    ByteBuffer compressedBuffer = allocateDirectBuffer ? ByteBuffer.allocateDirect(compressedBufferSize) :
+        ByteBuffer.allocate(compressedBufferSize);
+    compress(sourceBuffer, compressedBuffer);
+    compressedBuffer.flip();
+    return compressedBuffer;
+  }
+
+  /**
+   * Decompress the buffer specified in {@code compressedBuffer}.  Since compressedBuffer structure contains the
+   * original data size, it reads only the portion required to decompress.
+   * After calling, compressedBuffer position will be advanced to right after the compressed binary, and the
+   * decompressedBuffer position will be advanced to the end of the decompressed binary.
+   *
+   * @param compressedBuffer The buffer that contains compressed data generated by the compress() method.
+   * @param decompressedBuffer The buffer to hold the decompressed/original data.  The size should be at least the
+   *                           size returned by getDecompressBufferSize().
+   * @return The original data size which is same as number of bytes written to sourceData buffer.
+   * @throws CompressionException Throws this exception if decompression has internal failure.
+   */
+  int decompress(ByteBuffer compressedBuffer, ByteBuffer decompressedBuffer) throws CompressionException;
+
+  /**
+   * Decompress the compressed buffer.  The compressedBuffer index will be updated after reading.
+   * This method allocates either direct memory or heap memory, based on the allocateDirectBuffer parameter,
+   * to hold the output of decompression.  The output buffer is flipped so that it is ready for reading.
+   *
+   * @param compressedBuffer The compressed buffer generated by the compress() method.
+   * @param allocateDirectBuffer Whether to allocate direct buffer or heap buffer to store decompressed data.
+   * @return The original/decompressed data.
+   * @throws CompressionException Throws this exception if decompression has internal failure.
+   */
+  default ByteBuffer decompress(ByteBuffer compressedBuffer, boolean allocateDirectBuffer) throws CompressionException {
+    Utils.checkNotNullOrEmpty (compressedBuffer, "compressedBuffer cannot be null or empty.");
+    int originalDataSize = getDecompressBufferSize(compressedBuffer);
+    ByteBuffer originalData = allocateDirectBuffer ? ByteBuffer.allocateDirect(originalDataSize) :
+        ByteBuffer.allocate(originalDataSize);
+    decompress(compressedBuffer, originalData);
+    originalData.flip();
     return originalData;
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/compression/Compression.java
+++ b/ambry-api/src/main/java/com/github/ambry/compression/Compression.java
@@ -20,41 +20,31 @@ import java.nio.ByteBuffer;
 
 /**
  * Compression interface that provides compression and decompression feature.
- * It supports composite/shared memory where caller manages the buffer allocation.
- * It also supports simple APIs that lets the implementation allocate memory from Java heap.
  *
  * <pre>
- * Shared buffer APIs (caller management memory).
  *   Compression example:
  *   {@code
  *     ByteBuffer originalData = ...;
+ *     ByteBuffer compressedBuffer = Compression.compress(originalData, true);
+ *
+ *     // Same as
+ *     ByteBuffer originalData = ...;
  *     int compressedBufferSize = Compression.getCompressBufferSize(originalData.remaining());
  *     ByteBuffer compressedBuffer = ByteBuffer.allocateDirect(compressedBufferSize);
- *     int compressedSize = Compression.compress(originalData, 0, originalData.length,
- *                                   compressedBuffer, 0, compressedBuffer.capacity());
+ *     int compressedSize = Compression.compress(originalData, compressedBuffer);
  *   }
  *
  *   Decompression example:
  *   {@code
  *     ByteBuffer compressedBuffer = ...;
- *     int originalDataSize = Compression.getDecompressBufferSize(compressedBuffer, compressedBuffer.position(), compressedBuffer.remaining());
- *     byte[] originalData = new byte[originalDataSize];
- *     int decompressedSize = Compression.decompress(compressedBuffer, 0, compressedBuffer.length,
- *                                   originalData, 0, originalData.length);
+ *     ByteBuffer originalData = Compression.decompress(compressedBuffer, true);
+ *
+ *     // Same as
+ *     ByteBuffer compressedBuffer = ...;
+ *     int originalDataSize = Compression.getDecompressBufferSize(compressedBuffer);
+ *     ByteBuffer originalData = ByteBuffer.allocateDirect(originalDataSize);
+ *     int decompressedSize = Compression.decompress(compressedBuffer, originalData);
  *    }
- *
- * Dedicated buffer APIs (implementation allocate memory).
- *   Compression example:
- *   {@code
- *     byte[] originalData = ...;
- *     Pair&lt;Integer, byte[]&gt; compressedBuffer = Compression.compress(originalData);
- *   }
- *
- *   Decompression example:
- *   {@code
- *     byte[] compressedBuffer = ...;
- *     byte[] originalData = Compression.decompress(compressedBuffer);
- *   }
  * </pre>
  */
 public interface Compression {

--- a/ambry-commons/src/main/java/com/github/ambry/compression/BaseCompression.java
+++ b/ambry-commons/src/main/java/com/github/ambry/compression/BaseCompression.java
@@ -14,6 +14,7 @@
 package com.github.ambry.compression;
 
 import com.github.ambry.utils.Utils;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 
 /**
@@ -30,15 +31,21 @@ public abstract class BaseCompression implements Compression {
 
   /**
    * The minimal overhead size of the compressed data structure in bytes.
-   * The overhead structure contains:
-   * - 1 (version)
-   * - 1 (name size)
-   * - N (name chars)
-   * - 4 (original size)
+   * The compressed data structure contains:
+   * - 1 byte version
+   * - 1 byte name size
+   * - N bytes name characters
+   * - 4 bytes original size.
+   * - N bytes compressed data.
    * Excluding the name chars, the minimal size is 6 bytes.
    */
+  private static final int VERSION_AND_ORIGINAL_SIZE_SIZE = 5;
+  private static final int ALGORITHM_NAME_LENGTH_SIZE = 1;
+
+  // Will be removed.
   private static final int SIZE_OF_VERSION_AND_ORIGINAL_SIZE = 5;
   static final int MINIMUM_OVERHEAD_SIZE = SIZE_OF_VERSION_AND_ORIGINAL_SIZE + 1;
+
 
   /**
    * The binary representation of the algorithm name.
@@ -57,9 +64,9 @@ public abstract class BaseCompression implements Compression {
 
   /**
    * Invoke the native compression algorithm given the source data.  The compression output is stored in the
-   * compressed buffer at the specific offset.
-   * The compression implementation is algorithm specific.
-   * All parameters have been verified before calling so implementation can skip verification.
+   * compressed buffer at the specific offset.  The compression implementation is algorithm specific.
+   * This method may or may not alter the indexes of sourceBuffer and compressedBuffer, so set the indexes after calling.
+   * Assume all parameters have been verified before calling so implementation can skip verification.
    *
    * @param sourceBuffer The source uncompressed data.  This buffer may be shared.
    *                     It has already been null and empty verified.
@@ -71,6 +78,13 @@ public abstract class BaseCompression implements Compression {
    *                         This size should be same as estimateMaxCompressedDataSize().
    * @return The size of the actual compressed data in bytes.
    */
+  protected int compressNative(ByteBuffer sourceBuffer, int sourceBufferOffset, int sourceDataSize,
+      ByteBuffer compressedBuffer, int compressedBufferOffset, int compressedDataSize) throws CompressionException {
+    // TODO - will provide in next PR and make abstract.
+    return 0;
+  }
+
+  // Old code - Will be deleted.
   protected abstract int compressNative(byte[] sourceBuffer, int sourceBufferOffset, int sourceDataSize,
       byte[] compressedBuffer, int compressedBufferOffset, int compressedDataSize) throws CompressionException;
 
@@ -78,6 +92,7 @@ public abstract class BaseCompression implements Compression {
    * Invoke the native decompression algorithm given the compressedBuffer and the offset of the compression output.
    * The size of sourceDataBuffer must be at least the original data source size.
    * The decompression implementation is algorithm specific.
+   * This method may or may not alter the indexes of compressedBuffer and compressedBuffer, so set the indexes after calling.
    *
    * @param compressedBuffer The compressed buffer.  This buffer may be shared.
    * @param compressedBufferOffset The offset in compressedBuffer where the decompression should start reading.
@@ -87,16 +102,22 @@ public abstract class BaseCompression implements Compression {
    * @param decompressedDataSize Size of the buffer to hold the decompressed data in decompressedBuffer.
    *                           It should be same as the original data size.
    */
+  protected void decompressNative(ByteBuffer compressedBuffer, int compressedBufferOffset, int compressedDataSize,
+      ByteBuffer decompressedBuffer, int decompressedBufferOffset, int decompressedDataSize) throws CompressionException {
+    // TODO - will provide in next PR and make abstract.
+  }
+
+  // Old code - Will be deleted.
   protected abstract void decompressNative(byte[] compressedBuffer, int compressedBufferOffset, int compressedDataSize,
       byte[] decompressedBuffer, int decompressedBufferOffset, int decompressedDataSize) throws CompressionException;
 
   /**
    * Get the algorithm name in binary format.
    * This binary will be saved into the compressed buffer.  The algorithm name will be used to find the decompressor.
-   * The byte array contains the size (1 byte) and the algorithm name.
+   * The byte array contains the algorithm name.
    * The binary generation happens only once per algorithm (cached) and is thread safe.
    *
-   * @return Binary presentation of algorithm name.
+   * @return Binary presentation of algorithm name.  Its length cannot exceed MAX_ALGORITHM_NAME_LENGTH bytes.
    */
   private byte[] getAlgorithmNameBinary() {
     if (algorithmNameBinary != null) return algorithmNameBinary;
@@ -108,17 +129,13 @@ public abstract class BaseCompression implements Compression {
           throw new IllegalArgumentException("algorithmName cannot be null or empty.");
         }
 
+        // Convert name to binary.
         byte[] binary = algorithmName.getBytes(StandardCharsets.UTF_8);
         if (binary.length > MAX_ALGORITHM_NAME_LENGTH) {
           throw new IllegalArgumentException("algorithmName " + algorithmName + " exceeds the size of " +
                   MAX_ALGORITHM_NAME_LENGTH + " bytes.");
         }
-
-        byte[] binaryWithSize = new byte[binary.length + 1];
-        binaryWithSize[0] = (byte) binary.length;
-        System.arraycopy(binary, 0, binaryWithSize, 1, binary.length);
-
-        algorithmNameBinary = binaryWithSize;
+        algorithmNameBinary = binary;
       }
     }
 
@@ -127,21 +144,18 @@ public abstract class BaseCompression implements Compression {
 
   /**
    * Given the source data size, what is the maximum compressed buffer size?
-   * The max buffer size must sufficient to hold:
-   * - version (1 byte)
-   * - algorithm name binary (1 byte size + N bytes name)
-   * - original data size (4 bytes)
-   * - worst-case compression output.
+   * The max buffer size must sufficient to hold the compressed data structure.
    * This is an estimate calculation it is usually slightly larger than the sourceDataSize.
    *
    * @param sourceDataSize The source data size.
    * @return The estimated buffer size required to hold the compressed data.
    */
   public int getCompressBufferSize(int sourceDataSize) {
-    return estimateMaxCompressedDataSize(sourceDataSize) + getAlgorithmNameBinary().length +
-        SIZE_OF_VERSION_AND_ORIGINAL_SIZE;
+    return VERSION_AND_ORIGINAL_SIZE_SIZE + ALGORITHM_NAME_LENGTH_SIZE + getAlgorithmNameBinary().length +
+        estimateMaxCompressedDataSize(sourceDataSize);
   }
 
+  // --- Old Code, will be removed Begin --
   /**
    * Get the original data size stored inside the shared/composite compressed buffer.  The compressed buffer
    * contains version, algorithm name, original data size, and compressed data.
@@ -212,7 +226,7 @@ public abstract class BaseCompression implements Compression {
     verifySourceData(sourceBuffer, sourceBufferOffset, sourceDataSize);
     verifyCompressedBuffer(compressedBuffer, compressedBufferOffset, compressedDataSize);
 
-    int overheadSize = SIZE_OF_VERSION_AND_ORIGINAL_SIZE + getAlgorithmNameBinary().length;
+    int overheadSize = SIZE_OF_VERSION_AND_ORIGINAL_SIZE + ALGORITHM_NAME_LENGTH_SIZE + getAlgorithmNameBinary().length;
     if (compressedDataSize < overheadSize) {
       throw new IllegalArgumentException("compressedDataSize " + compressedDataSize + " is too small.");
     }
@@ -220,6 +234,9 @@ public abstract class BaseCompression implements Compression {
     // Write version #.
     int offset = compressedBufferOffset;
     compressedBuffer[offset] = 1;
+    offset++;
+
+    compressedBuffer[offset] = (byte) algorithmNameBinary.length;
     offset++;
 
     // Write algorithm name.
@@ -252,9 +269,9 @@ public abstract class BaseCompression implements Compression {
   private void verifySourceData(byte[] sourceData, int sourceDataOffset, int sourceDataSize) {
     Utils.checkNotNullOrEmpty(sourceData, "sourceData cannot be null");
     Utils.checkValueInRange(sourceDataOffset, 0, sourceData.length - 1,
-      "sourceDataOffset is outside of sourceData.");
+        "sourceDataOffset is outside of sourceData.");
     Utils.checkValueInRange(sourceDataSize, 0, sourceData.length - sourceDataOffset,
-      "sourceDataSize is outside of sourceData.");
+        "sourceDataSize is outside of sourceData.");
   }
 
   /**
@@ -305,5 +322,147 @@ public abstract class BaseCompression implements Compression {
     decompressNative(compressedBuffer, compressedBufferOffset + overheadSize,
         compressedDataSize - overheadSize, decompressedBuffer, decompressedBufferOffset, originalSize);
     return originalSize;
+  }
+
+  // --- Old Code, will be removed End --
+
+  /**
+   * Get the original data size stored inside the compressed buffer.  The compressed buffer contains version,
+   * algorithm name, original data size, and compressed data.  The compressedBuffer indexes will not be changed.
+   * @param compressedBuffer The compressed buffer.
+   * @return The size of original data.
+   */
+  public int getDecompressBufferSize(ByteBuffer compressedBuffer) throws CompressionException {
+    Utils.checkNotNullOrEmpty(compressedBuffer, "compressedBuffer cannot be null or empty.");
+    if (compressedBuffer.remaining() < VERSION_AND_ORIGINAL_SIZE_SIZE + ALGORITHM_NAME_LENGTH_SIZE) {
+      throw new IllegalArgumentException("compressedDataSize of " + compressedBuffer.remaining() + " bytes is too small.");
+    }
+
+    // Check version.  For now, only version 1 is supported.  Modify this code when more version added.
+    compressedBuffer.mark();
+    try {
+      byte version = compressedBuffer.get();
+      if (version != 1) {
+        // It throws CompressionException to indicate internal error instead of illegal argument because
+        // the compressed buffer contains a version that is not supported.  It's probably a code problem, not data problem.
+        // Modify this condition as new versions are added.
+        throw new CompressionException("compressedBuffer has unsupported version " + version);
+      }
+
+      // Assume the algorithm name is correct, so skip the name verification.
+      // Original size offset = version (1 byte) + name size (1 byte) + name (N byte) + data size (4 bytes);
+      int nameSizeInBytes = compressedBuffer.get();
+      int dataSizePosition = compressedBuffer.position() + nameSizeInBytes;
+      if (dataSizePosition + 4 >= compressedBuffer.limit()) {
+        throw new IllegalArgumentException("compressedBuffer too small and does not contain original data size.");
+      }
+      compressedBuffer.position(dataSizePosition);
+      return compressedBuffer.getInt();
+    } finally {
+      compressedBuffer.reset();
+    }
+  }
+
+  /**
+   * Compress the buffer specified in {@code sourceBuffer}.  The entire sourceBuffer will be read,
+   * so set the position and limit to the range of data to read in sourceBuffer before calling this method.
+   * After calling, sourceBuffer position will be advanced to the buffer limit, and the compressedBuffer position
+   * will be advanced to the end of the compressed binary.
+   * If compression failed, the sourceBuffer position will not be advanced.
+   *
+   * @param sourceBuffer The source/uncompressed data to compress.  It cannot be null or empty.
+   * @param compressedBuffer The compressed buffer where the compressed data will be written to.  Its size must be
+   *                       at least the size return from getCompressBufferSize() or it may fail due to buffer size.
+   * @return The actual compressed data size in bytes.
+   * @throws CompressionException Throws this exception if compression has internal failure.
+   */
+  @Override
+  public int compress(ByteBuffer sourceBuffer, ByteBuffer compressedBuffer) throws CompressionException {
+    Utils.checkNotNullOrEmpty(sourceBuffer, "sourceBuffer cannot be null or empty.");
+    Utils.checkNotNullOrEmpty(compressedBuffer, "compressedBuffer cannot be null or empty.");
+
+    int overheadSize = VERSION_AND_ORIGINAL_SIZE_SIZE + ALGORITHM_NAME_LENGTH_SIZE + getAlgorithmNameBinary().length;
+    if (compressedBuffer.remaining() < overheadSize) {
+      throw new IllegalArgumentException("compressedBuffer " + compressedBuffer.remaining() + " is too small.");
+    }
+
+    // Write version, algorithm name, and source data size.
+    int compressedBufferStartPosition = compressedBuffer.position();
+    int sourceBufferStartPosition = sourceBuffer.position();
+    try {
+      byte[] algorithmNameBinary = getAlgorithmNameBinary();
+      compressedBuffer.put((byte) 1);
+      compressedBuffer.put((byte) algorithmNameBinary.length);
+      compressedBuffer.put(algorithmNameBinary);
+      compressedBuffer.putInt(sourceBuffer.remaining());
+
+      // Apply compression and store the output in the compressed buffer.
+      // Note: compressNative() uses less memory than buffer size and that's why it returns the actual compressed size.
+      int sourceBufferLimit = sourceBuffer.limit();
+      int compressedDataLength =
+          compressNative(sourceBuffer, sourceBuffer.position(), sourceBuffer.remaining(), compressedBuffer,
+              compressedBuffer.position(), compressedBuffer.capacity() - compressedBuffer.position());
+
+      // compressNative() may or may not alter the position indexes, so set them just in case.
+      sourceBuffer.position(sourceBufferLimit);  // Advance the sourceBuffer to limit to indicate entire buffer read.
+      compressedBuffer.position(compressedBufferStartPosition + overheadSize + compressedDataLength);
+      return (overheadSize + compressedDataLength);
+    } catch (Exception ex) {
+      // Exception thrown.  Restore the position of the buffers.
+      sourceBuffer.position(sourceBufferStartPosition);
+      compressedBuffer.position(compressedBufferStartPosition);
+      throw ex;
+    }
+  }
+
+  /**
+   * Decompress the buffer specified in {@code compressedBuffer}.  Since compressedBuffer structure contains the
+   * original data size, it reads only the portion required to decompress.
+   * After calling, compressedBuffer position will be advanced to right after the compressed binary, and the
+   * decompressedBuffer position will be advanced to the end of the decompressed binary.
+   * If exception is thrown, the position index would not be updated.
+   *
+   * @param compressedBuffer The buffer that contains compressed data generated by the compress() method.
+   * @param decompressedBuffer The buffer to hold the decompressed/original data.  The size should be at least the
+   *                           size returned by getDecompressBufferSize().
+   * @return The original data size which is same as number of bytes written to sourceData buffer.
+   * @throws CompressionException Throws this exception if decompression has internal failure.
+   */
+  @Override
+  public int decompress(ByteBuffer compressedBuffer, ByteBuffer decompressedBuffer) throws CompressionException {
+    Utils.checkNotNullOrEmpty(compressedBuffer, "compressedBuffer cannot be null or empty.");
+    Utils.checkNotNullOrEmpty(decompressedBuffer, "decompressedBuffer cannot be null or empty.");
+
+    // Save the position.  Use position instead of mark just in case decompressNative() uses mark().
+    int compressedBufferPosition = compressedBuffer.position();
+    int decompressedBufferPosition = decompressedBuffer.position();
+    try {
+      // Get the algorithm name and advance compressedBuffer position to the source data size.
+      compressedBuffer.get();  // skip the version.
+      int algorithmNameLength = compressedBuffer.get();  // Get the data source size.
+      compressedBuffer.position(compressedBuffer.position() + algorithmNameLength);
+
+      // Get the original size from the compressed buffer.  It also verifies compressed buffer parameters.
+      int originalSize = compressedBuffer.getInt();
+      int decompressedBufferSize = decompressedBuffer.capacity() - decompressedBuffer.position();
+      if (decompressedBufferSize < originalSize) {
+        throw new IllegalArgumentException(
+            "decompressedBuffer size " + decompressedBufferSize + " is too small to hold decompressed data size " + originalSize);
+      }
+
+      // Invoke native decompress method and advance the index positions.
+      int compressedBufferLimit = compressedBuffer.limit();
+      int newDecompressionBufferPosition = decompressedBuffer.position() + originalSize;
+      decompressNative(compressedBuffer, compressedBuffer.position(), compressedBuffer.remaining(), decompressedBuffer,
+          decompressedBuffer.position(), originalSize);
+      compressedBuffer.position(compressedBufferLimit);
+      decompressedBuffer.position(newDecompressionBufferPosition);
+      return originalSize;
+    } catch (Exception ex) {
+      // Exception thrown, restore the positions.
+      compressedBuffer.position(compressedBufferPosition);
+      decompressedBuffer.position(decompressedBufferPosition);
+      throw ex;
+    }
   }
 }

--- a/ambry-commons/src/main/java/com/github/ambry/compression/BaseCompression.java
+++ b/ambry-commons/src/main/java/com/github/ambry/compression/BaseCompression.java
@@ -190,10 +190,10 @@ public abstract class BaseCompression implements Compression {
     }
 
     // Read the original source size.
-    return (compressedBuffer[offset] & 0xFF) +
-        ((compressedBuffer[offset + 1] & 0xFF) << 8) +
-        ((compressedBuffer[offset + 2] & 0xFF) << 16) +
-        (compressedBuffer[offset + 3] << 24);
+    return (compressedBuffer[offset] << 24) +
+          ((compressedBuffer[offset + 1] & 0xFF) << 16) +
+          ((compressedBuffer[offset + 2] & 0xFF) << 8) +
+           (compressedBuffer[offset + 3] & 0xFF);
   }
 
   /**
@@ -245,10 +245,10 @@ public abstract class BaseCompression implements Compression {
 
     // Write original source data size.
     int sourceSize = sourceBuffer.length;
-    compressedBuffer[offset] = (byte) (sourceSize & 0xFF);
-    compressedBuffer[offset + 1] = (byte)(sourceSize >> 8 & 0xFF);
-    compressedBuffer[offset + 2] = (byte)(sourceSize >> 16 & 0xFF);
-    compressedBuffer[offset + 3] = (byte)(sourceSize >> 24);
+    compressedBuffer[offset] = (byte)(sourceSize >> 24);
+    compressedBuffer[offset + 1] = (byte)(sourceSize >> 16 & 0xFF);
+    compressedBuffer[offset + 2] = (byte)(sourceSize >> 8 & 0xFF);
+    compressedBuffer[offset + 3] = (byte) (sourceSize & 0xFF);
     offset += 4;
 
     // Apply compression and store the output in the remaining buffer.

--- a/ambry-commons/src/main/java/com/github/ambry/compression/BaseCompression.java
+++ b/ambry-commons/src/main/java/com/github/ambry/compression/BaseCompression.java
@@ -46,7 +46,6 @@ public abstract class BaseCompression implements Compression {
   private static final int SIZE_OF_VERSION_AND_ORIGINAL_SIZE = 5;
   static final int MINIMUM_OVERHEAD_SIZE = SIZE_OF_VERSION_AND_ORIGINAL_SIZE + 1;
 
-
   /**
    * The binary representation of the algorithm name.
    * Since this binary is written to every compressed buffer, it caches the binary form for performance purpose.
@@ -226,7 +225,8 @@ public abstract class BaseCompression implements Compression {
     verifySourceData(sourceBuffer, sourceBufferOffset, sourceDataSize);
     verifyCompressedBuffer(compressedBuffer, compressedBufferOffset, compressedDataSize);
 
-    int overheadSize = SIZE_OF_VERSION_AND_ORIGINAL_SIZE + ALGORITHM_NAME_LENGTH_SIZE + getAlgorithmNameBinary().length;
+    byte[] algorithmNameBinary = getAlgorithmNameBinary();
+    int overheadSize = SIZE_OF_VERSION_AND_ORIGINAL_SIZE + ALGORITHM_NAME_LENGTH_SIZE + algorithmNameBinary.length;
     if (compressedDataSize < overheadSize) {
       throw new IllegalArgumentException("compressedDataSize " + compressedDataSize + " is too small.");
     }
@@ -240,7 +240,6 @@ public abstract class BaseCompression implements Compression {
     offset++;
 
     // Write algorithm name.
-    byte[] algorithmNameBinary = getAlgorithmNameBinary();
     System.arraycopy(algorithmNameBinary, 0, compressedBuffer, offset, algorithmNameBinary.length);
     offset += algorithmNameBinary.length;
 

--- a/ambry-commons/src/test/java/com/github/ambry/compression/BaseCompressionTest.java
+++ b/ambry-commons/src/test/java/com/github/ambry/compression/BaseCompressionTest.java
@@ -13,8 +13,8 @@
  */
 package com.github.ambry.compression;
 
-import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.TestUtils;
+import java.nio.ByteBuffer;
 import org.apache.commons.lang3.reflect.MethodUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -28,18 +28,16 @@ public class BaseCompressionTest {
     BaseCompression compressor = Mockito.mock(BaseCompression.class);
     Mockito.when(compressor.getAlgorithmName()).thenReturn("A");
     byte[] binary = (byte[]) MethodUtils.invokeMethod(compressor, true, "getAlgorithmNameBinary");
-    Assert.assertEquals(2, binary.length);
-    Assert.assertEquals(1, binary[0]);
-    Assert.assertEquals((int) 'A', binary[1]);
+    Assert.assertEquals(1, binary.length);
+    Assert.assertEquals((int) 'A', binary[0]);
 
     // Test: Large 10 char algorithm name.
     compressor = Mockito.mock(BaseCompression.class);
     Mockito.when(compressor.getAlgorithmName()).thenReturn("0123456789");
     binary = (byte[]) MethodUtils.invokeMethod(compressor, true, "getAlgorithmNameBinary");
-    Assert.assertEquals(11, binary.length);
-    Assert.assertEquals(10, binary[0]);
-    Assert.assertEquals((int) '0', binary[1]);
-    Assert.assertEquals((int) '9', binary[10]);
+    Assert.assertEquals(10, binary.length);
+    Assert.assertEquals((int) '0', binary[0]);
+    Assert.assertEquals((int) '9', binary[9]);
 
     // Test: Error case - no algorithm name.
     compressor = Mockito.mock(BaseCompression.class);
@@ -70,24 +68,22 @@ public class BaseCompressionTest {
     compressedBuffer[0] = 10; // Bad version
     compressedBuffer[1] = 1;  // Name size.
     compressedBuffer[2] = 66; // Name is one-char long.
-    compressedBuffer[3] = 3;  // original size.
+    compressedBuffer[3] = 0;  // original size (Big-endian encoding).
     compressedBuffer[4] = 0;
     compressedBuffer[5] = 0;
-    compressedBuffer[6] = 0;
+    compressedBuffer[6] = 3;
     compressedBuffer[7] = 1;   // compressed data
 
     BaseCompression decompressor = Mockito.mock(BaseCompression.class, Mockito.CALLS_REAL_METHODS);
 
     // Test: Invalid version in compressed buffer.
-    Exception ex = TestUtils.getException(() -> decompressor.getDecompressBufferSize(compressedBuffer));
+    ByteBuffer sourceBuffer = ByteBuffer.wrap(compressedBuffer);
+    Exception ex = TestUtils.getException(() -> decompressor.getDecompressBufferSize(sourceBuffer));
     Assert.assertTrue(ex instanceof CompressionException);
 
     // Test: Valid compressed buffer.
     compressedBuffer[0] = 1;  // Fix version
-    int originalSize = decompressor.getDecompressBufferSize(compressedBuffer);
-    Assert.assertEquals(3, originalSize);
-
-    originalSize = decompressor.getDecompressBufferSize(compressedBuffer, 0, compressedBuffer.length);
+    int originalSize = decompressor.getDecompressBufferSize(sourceBuffer);
     Assert.assertEquals(3, originalSize);
   }
 
@@ -101,62 +97,51 @@ public class BaseCompressionTest {
     Throwable ex = TestUtils.getException(() -> compressor.compress(null));
     Assert.assertTrue(ex instanceof IllegalArgumentException);
 
-    ex = TestUtils.getException(() -> compressor.compress(null, 0, 10));
-    Assert.assertTrue(ex instanceof IllegalArgumentException);
-
-    // Test: Invalid source buffer offset (10) in buffer size 10.  Should throw.
-    ex = TestUtils.getException(() -> compressor.compress(new byte[10], 10, 10));
-    Assert.assertTrue(ex instanceof IllegalArgumentException);
-
-    // Test: Invalid source buffer size (11) in buffer size 10.  Should throw.
-    ex = TestUtils.getException(() -> compressor.compress(new byte[10], 0, 11));
+    ex = TestUtils.getException(() -> compressor.compress(ByteBuffer.wrap(new byte[1]), null));
     Assert.assertTrue(ex instanceof IllegalArgumentException);
 
     // Test: Compressed buffer size of 4 is too small.
-    ex = TestUtils.getException(() -> compressor.compress(new byte[10], 0, 10,
-        new byte[4], 0, 4));
-    Assert.assertTrue(ex instanceof IllegalArgumentException);
-
-    // Test: Compressed buffer size invalid buffer parameters.
-    ex = TestUtils.getException(() -> compressor.compress(null, 0, 10,
-        new byte[4], 0, 4));
+    ex = TestUtils.getException(() -> compressor.compress(ByteBuffer.wrap(new byte[10]), ByteBuffer.wrap(new byte[4])));
     Assert.assertTrue(ex instanceof IllegalArgumentException);
 
     // Test: Valid case - compressed data is simply a prefix plus the source data.
-    Mockito.when(compressor.compressNative(Mockito.any(byte[].class), Mockito.anyInt(), Mockito.anyInt(),
-            Mockito.any(byte[].class), Mockito.anyInt(), Mockito.anyInt()))
+    Mockito.when(compressor.compressNative(Mockito.any(ByteBuffer.class), Mockito.anyInt(), Mockito.anyInt(),
+            Mockito.any(ByteBuffer.class), Mockito.anyInt(), Mockito.anyInt()))
         .thenAnswer(invocation -> {
-          byte[] sourceBuffer = invocation.getArgument(0);
+          ByteBuffer sourceBuffer = invocation.getArgument(0);
           int sourceBufferOffset = invocation.getArgument(1);
           int sourceBufferSize = invocation.getArgument(2);
-          byte[] targetBuffer = invocation.getArgument(3);
+          ByteBuffer targetBuffer = invocation.getArgument(3);
           int targetBufferOffset = invocation.getArgument(4);
 
           // In this test, just copy sourceBuffer to compressedBuffer.
-          System.arraycopy(sourceBuffer, sourceBufferOffset, targetBuffer, targetBufferOffset, sourceBufferSize);
+          byte[] temp = new byte[sourceBufferSize];
+          sourceBuffer.position(sourceBufferOffset);
+          sourceBuffer.get(temp);
+          targetBuffer.position(targetBufferOffset);
+          targetBuffer.put(temp);
           return sourceBufferSize;
         });
 
-    byte[] testSourceData = new byte[] { 100, 101, 102 };
-    Pair<Integer, byte[]> compressResult = compressor.compress(testSourceData);
+    ByteBuffer testSourceData = ByteBuffer.wrap(new byte[] { 100, 101, 102 });
+    ByteBuffer compressedBuffer = compressor.compress(testSourceData, false);
     // Make sure the format is
     // - 1 byte version.
     // - 1 byte name size
     // - N bytes for name (4 bytes in this case)
     // - 4 bytes original size (testSourceData size)
     // - X bytes of compressed data (3 bytes in this case).
-    Assert.assertEquals((Integer)13, compressResult.getFirst());
-    byte[] compressedBuffer = compressResult.getSecond();
-    Assert.assertEquals(110, compressedBuffer.length);  //100 + 6 bytes overhead + 4 bytes name.
-    Assert.assertEquals(1, compressedBuffer[0]);
-    Assert.assertEquals(4, compressedBuffer[1]);
-    Assert.assertEquals(3, compressedBuffer[6]);
-    Assert.assertEquals(0, compressedBuffer[7]);
-    Assert.assertEquals(0, compressedBuffer[8]);
-    Assert.assertEquals(0, compressedBuffer[9]);
-    Assert.assertEquals(testSourceData[0], compressedBuffer[10]);
-    Assert.assertEquals(testSourceData[1], compressedBuffer[11]);
-    Assert.assertEquals(testSourceData[2], compressedBuffer[12]);
+    Assert.assertEquals(13, compressedBuffer.remaining());
+    Assert.assertEquals(110, compressedBuffer.capacity());  //100 + 6 bytes overhead + 4 bytes name.
+    Assert.assertEquals(1, compressedBuffer.get(0));
+    Assert.assertEquals(4, compressedBuffer.get(1));
+    Assert.assertEquals(0, compressedBuffer.get(6));
+    Assert.assertEquals(0, compressedBuffer.get(7));
+    Assert.assertEquals(0, compressedBuffer.get(8));
+    Assert.assertEquals(3, compressedBuffer.get(9));
+    Assert.assertEquals(testSourceData.get(0), compressedBuffer.get(10));
+    Assert.assertEquals(testSourceData.get(1), compressedBuffer.get(11));
+    Assert.assertEquals(testSourceData.get(2), compressedBuffer.get(12));
   }
 
   @Test
@@ -167,15 +152,7 @@ public class BaseCompressionTest {
     Throwable ex = TestUtils.getException(() -> decompressor.decompress(null));
     Assert.assertTrue(ex instanceof IllegalArgumentException);
 
-    ex = TestUtils.getException(() -> decompressor.decompress(null, 0, 10));
-    Assert.assertTrue(ex instanceof IllegalArgumentException);
-
-    // Test: Invalid compressed buffer offset (10) in buffer size 10.  Should throw.
-    ex = TestUtils.getException(() -> decompressor.decompress(new byte[10], 10, 10));
-    Assert.assertTrue(ex instanceof IllegalArgumentException);
-
-    // Test: Invalid compression buffer size (11) in buffer size 10.  Should throw.
-    ex = TestUtils.getException(() -> decompressor.decompress(new byte[10], 0, 11));
+    ex = TestUtils.getException(() -> decompressor.decompress(ByteBuffer.wrap(new byte[0]), false));
     Assert.assertTrue(ex instanceof IllegalArgumentException);
 
     //  Note the compressed buffer format is:
@@ -186,44 +163,41 @@ public class BaseCompressionTest {
     // - X bytes of compressed data (6 bytes in this case).
 
     // Test: decompress an invalid buffer that is too small.  Version is 1, Name size is 10, but only 2 bytes long.
-    ex = TestUtils.getException(() -> decompressor.decompress(new byte[] { 1, 10, 66 }));
+    ex = TestUtils.getException(() -> decompressor.decompress(ByteBuffer.wrap(new byte[] { 1, 10, 66 }), false));
     Assert.assertTrue(ex instanceof IllegalArgumentException);
 
     // Test: Another invalid buffer case - Version is 1, Name size is 2, 2-char name, but original size incomplete.
-    ex = TestUtils.getException(() -> decompressor.decompress(new byte[] { 1, 2, 66, 67, 3, 0 , 0}));
+    ex = TestUtils.getException(() -> decompressor.decompress(ByteBuffer.wrap(new byte[] { 1, 2, 66, 67, 3, 0 , 0}), false));
     Assert.assertTrue(ex instanceof IllegalArgumentException);
 
     // Test: decompress a valid compressed buffer, but source data buffer size (2) is too small.  Original size = 3.
     // Version is 1, name length is 2, 2-char name, size is 3, 3 bytes of compressed data.
-    final byte[] compressedBuffer = new byte[] { 1, 2, 66, 67, 3, 0, 0, 0, 100, 101, 102};
-    ex = TestUtils.getException(() -> decompressor.decompress(
-        compressedBuffer, 0, compressedBuffer.length, new byte[2], 0, 2));
+    final ByteBuffer testCompressedBuffer = ByteBuffer.wrap(new byte[] { 1, 2, 66, 67, 0, 0, 0, 3, 100, 101, 102});
+    ex = TestUtils.getException(() -> decompressor.decompress(testCompressedBuffer, ByteBuffer.wrap(new byte[2])));
     Assert.assertTrue(ex instanceof IllegalArgumentException);
 
-    // Test: Compressed buffer size invalid buffer parameters.
-    ex = TestUtils.getException(() -> decompressor.decompress(null, 0, 10,
-        new byte[4], 0, 4));
-    Assert.assertTrue(ex instanceof IllegalArgumentException);
-
-    // Test: Valid case.
+    // Test: decompressNative() simply copies data compressed buffer to decompressed buffer.
     Mockito.doAnswer(invocation -> {
-      byte[] compressedData = invocation.getArgument(0);
-      int compressedDataOffset = invocation.getArgument(1);
-      int compressedDataSize = invocation.getArgument(2);
-      byte[] sourceBuffer = invocation.getArgument(3);
-      int sourceBufferOffset = invocation.getArgument(4);
+      ByteBuffer compressedBuffer = invocation.getArgument(0);
+      int compressedBufferOffset = invocation.getArgument(1);
+      int compressedBufferSize = invocation.getArgument(2);
+      ByteBuffer decompressedBuffer = invocation.getArgument(3);
+      int decompressedBufferOffset = invocation.getArgument(4);
 
       // In this test, just copy compressed data to sourceBuffer.
-      System.arraycopy(compressedData, compressedDataOffset,
-          sourceBuffer, sourceBufferOffset, compressedDataSize);
+      byte[] temp = new byte[compressedBufferSize];
+      compressedBuffer.position(compressedBufferOffset);
+      compressedBuffer.get(temp);
+      decompressedBuffer.position(decompressedBufferOffset);
+      decompressedBuffer.put(temp);
       return null;
-    }).when(decompressor).decompressNative(Mockito.any(byte[].class), Mockito.anyInt(), Mockito.anyInt(),
-        Mockito.any(byte[].class), Mockito.anyInt(), Mockito.anyInt());
+    }).when(decompressor).decompressNative(Mockito.any(ByteBuffer.class), Mockito.anyInt(), Mockito.anyInt(),
+        Mockito.any(ByteBuffer.class), Mockito.anyInt(), Mockito.anyInt());
 
-    byte[] originalData = decompressor.decompress(compressedBuffer);
-    Assert.assertEquals(3, originalData.length);
-    Assert.assertEquals(100, originalData[0]);
-    Assert.assertEquals(101, originalData[1]);
-    Assert.assertEquals(102, originalData[2]);
+    ByteBuffer originalData = decompressor.decompress(testCompressedBuffer, false);
+    Assert.assertEquals(3, originalData.remaining());
+    Assert.assertEquals(100, originalData.get(0));
+    Assert.assertEquals(101, originalData.get(1));
+    Assert.assertEquals(102, originalData.get(2));
   }
 }

--- a/ambry-utils/src/main/java/com/github/ambry/utils/Utils.java
+++ b/ambry-utils/src/main/java/com/github/ambry/utils/Utils.java
@@ -1349,6 +1349,18 @@ public class Utils {
   }
 
   /**
+   * Check whether the given byte buffer is null or empty.  If so, throw IllegalArgumentException.
+   *
+   * @param buffer The buffer to check.
+   * @param exceptionMessage The IllegalArgumentException message to use if null or empty.
+   */
+  public static void checkNotNullOrEmpty(ByteBuffer buffer, String exceptionMessage) {
+    if (buffer == null || !buffer.hasRemaining()) {
+      throw new IllegalArgumentException(exceptionMessage);
+    }
+  }
+
+  /**
    * Check the given value is in the specific range (min and max).
    * If outside the range, through IllegalArgumentException using the provided message.
    * @param value The value to check.


### PR DESCRIPTION
Previous implementation accepts byte[] or Heap.  It relies on JVM byte array pinning to avoid memory copy when calling native compression library.  However, pinning is not reliable and unpredictable.  A better alternative is to use ByteBuffer that can hold either Heap or Direct memory.  This change adds ByteBuffer to API.  After ByteBuffer API code changes are mere, the byte[] will be deleted.