### PR TITLE
Only create one metric for IndexSegmentFilesDirectMemoryUsage

### DIFF
--- a/ambry-store/src/main/java/com/github/ambry/store/StoreMetrics.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StoreMetrics.java
@@ -277,17 +277,9 @@ public class StoreMetrics {
     }
     if (enableStoreIndexDirectMemoryUsageMetric) {
       indexes.putIfAbsent(storeId, index);
-      Gauge<Long> indexDirectMemoryUsage = () -> {
-        long start = System.nanoTime();
-        long usage = indexes.values().stream().mapToLong(PersistentIndex::getDirectMemoryUsage).sum();
-        if (logger.isTraceEnabled()) {
-          logger.trace("Time to get direct memory usage from persistent index is: {} nano seconds",
-              System.nanoTime() - start);
-        }
-        return usage;
-      };
-      registry.gauge(MetricRegistry.name(BlobStore.class, prefix + "IndexDirectMemoryUsage"),
-          () -> indexDirectMemoryUsage);
+      Gauge<Long> indexDirectMemoryUsage =
+          () -> indexes.values().stream().mapToLong(PersistentIndex::getDirectMemoryUsage).sum();
+      registry.gauge(MetricRegistry.name(BlobStore.class, "IndexDirectMemoryUsage"), () -> indexDirectMemoryUsage);
     }
   }
 


### PR DESCRIPTION
Before this PR, we are using store id prefix when creating metric for index segment files' direct memory usage metric. This would end up creating multiple metrics with the same value.

This PR fixes that.