### PR TITLE
Update LZ4 and Zstd compression to support ByteBuffer

### DIFF
--- a/ambry-commons/src/main/java/com/github/ambry/compression/ZstdCompression.java
+++ b/ambry-commons/src/main/java/com/github/ambry/compression/ZstdCompression.java
@@ -14,6 +14,10 @@
 package com.github.ambry.compression;
 
 import com.github.luben.zstd.Zstd;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import java.nio.ByteBuffer;
+
 
 /**
  * Zstandard compression algorithm using Zstandard native and JNI.
@@ -95,6 +99,51 @@ public class ZstdCompression extends BaseCompressionWithLevel {
    * @return The size of the compressed data in bytes.
    */
   @Override
+  protected int compressNative(ByteBuffer sourceBuffer, int sourceBufferOffset, int sourceDataSize,
+      ByteBuffer compressedBuffer, int compressedBufferOffset, int compressedDataSize) throws CompressionException {
+
+    // Zstd requires both buffers type be the same (either both direct memory or both heap), no mixed.
+    ByteBuffer newSourceBuffer = sourceBuffer;
+    if (sourceBuffer.isDirect() != compressedBuffer.isDirect()) {
+      // We have a mixture of heap and direct buffer, change source to match the output buffer type.
+      newSourceBuffer = compressedBuffer.isDirect() ? ByteBuffer.allocateDirect(sourceDataSize) :
+          ByteBuffer.allocate(sourceDataSize);
+      newSourceBuffer.put(sourceBuffer);
+      newSourceBuffer.flip();
+      sourceBufferOffset = 0;
+    }
+
+    // Invoke compress byte array or direct buffer based on buffer type.
+    long compressedSize;
+    if (newSourceBuffer.isDirect()) {
+      compressedSize = Zstd.compressDirectByteBuffer(compressedBuffer, compressedBufferOffset, compressedDataSize,
+          newSourceBuffer, sourceBufferOffset, sourceDataSize, getCompressionLevel());
+    } else {
+      compressedSize = Zstd.compressByteArray(compressedBuffer.array(), compressedBufferOffset, compressedDataSize,
+          newSourceBuffer.array(), sourceBufferOffset, sourceDataSize, getCompressionLevel());
+    }
+
+    // If sourceByteBuffer is a copy, free it.
+    if (newSourceBuffer != sourceBuffer && newSourceBuffer.isDirect()) {
+      ByteBuf tempByteBuf = Unpooled.wrappedBuffer(newSourceBuffer);
+      tempByteBuf.release();
+    }
+
+    // Check for error.
+    if (Zstd.isError(compressedSize)) {
+      throw new CompressionException(String.format("Zstd compression failed with error code: %d, name: %s. "
+              + "sourceBuffer.limit=%d, sourceBufferOffset=%d, sourceDataSize=%d, "
+              + "compressedBuffer.capacity=%d, compressedBufferOffset=%d, compressedDataSize=%d, compressionLevel=%d",
+          compressedSize, Zstd.getErrorName(compressedSize),
+          sourceBuffer.limit(), sourceBufferOffset, sourceDataSize,
+          compressedBuffer.capacity(), compressedBufferOffset, compressedDataSize, getCompressionLevel()));
+    }
+
+    return (int) compressedSize;
+  }
+
+  // TODO - This method will be deleted after ByteBuffer API has been pushed.
+  @Override
   protected int compressNative(byte[] sourceBuffer, int sourceBufferOffset, int sourceDataSize,
       byte[] compressedBuffer, int compressedBufferOffset, int compressedDataSize) throws CompressionException {
 
@@ -124,6 +173,49 @@ public class ZstdCompression extends BaseCompressionWithLevel {
    * @param decompressedBufferOffset Offset where to write the decompressed data.
    * @param decompressedDataSize Size of the buffer to hold the decompressed data.  It should be size of original data.
    */
+  @Override
+  protected void decompressNative(ByteBuffer compressedBuffer, int compressedBufferOffset, int compressedDataSize,
+      ByteBuffer decompressedBuffer, int decompressedBufferOffset, int decompressedDataSize) throws CompressionException {
+
+    // Zstd requires both buffers type be the same (either both direct memory or both heap), no mixed.
+    ByteBuffer newCompressedBuffer = compressedBuffer;
+    if (compressedBuffer.isDirect() != decompressedBuffer.isDirect()) {
+        // We have a mixture of heap and direct buffer, change source buffer to match the output buffer type.
+      newCompressedBuffer = decompressedBuffer.isDirect() ? ByteBuffer.allocateDirect(compressedDataSize) :
+            ByteBuffer.allocate(compressedDataSize);
+      newCompressedBuffer.put(compressedBuffer);
+      newCompressedBuffer.flip();
+      compressedBufferOffset = 0;
+    }
+
+    // Decompress the buffer either as both direct memory buffer or both heap buffers.
+    long decompressedSize;
+    if (newCompressedBuffer.isDirect()) {
+      decompressedSize = Zstd.decompressDirectByteBuffer(decompressedBuffer, decompressedBufferOffset,
+          decompressedDataSize, newCompressedBuffer, compressedBufferOffset, compressedDataSize);
+    } else {
+      decompressedSize = Zstd.decompressByteArray(decompressedBuffer.array(), decompressedBufferOffset,
+          decompressedDataSize, newCompressedBuffer.array(), compressedBufferOffset, compressedDataSize);
+    }
+
+    // If sourceByteBuffer is a copy, free it.
+    if (newCompressedBuffer != compressedBuffer && newCompressedBuffer.isDirect()) {
+      ByteBuf tempByteBuf = Unpooled.wrappedBuffer(newCompressedBuffer);
+      tempByteBuf.release();
+    }
+
+    // Check for error.
+    if (Zstd.isError(decompressedSize)) {
+      throw new CompressionException(String.format("Zstd decompression failed with error code: %d, name: %s. "
+              + "compressedBuffer.limit=%d, compressedBufferOffset=%d, compressedDataSize=%d, "
+              + "decompressedBuffer.capacity=%d, decompressedBufferOffset=%d, decompressedDataSize=%d",
+          decompressedSize, Zstd.getErrorName(decompressedSize),
+          compressedBuffer.limit(), compressedBufferOffset, compressedDataSize,
+          decompressedBuffer.capacity(), decompressedBufferOffset, decompressedDataSize));
+    }
+  }
+
+  // TODO - This method will be deleted after ByteBuffer API has been pushed.
   @Override
   protected void decompressNative(byte[] compressedBuffer, int compressedBufferOffset, int compressedDataSize,
       byte[] decompressedBuffer, int decompressedBufferOffset, int decompressedDataSize) throws CompressionException {

--- a/ambry-commons/src/main/java/com/github/ambry/compression/ZstdCompression.java
+++ b/ambry-commons/src/main/java/com/github/ambry/compression/ZstdCompression.java
@@ -14,8 +14,6 @@
 package com.github.ambry.compression;
 
 import com.github.luben.zstd.Zstd;
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
 import java.nio.ByteBuffer;
 
 

--- a/ambry-commons/src/main/java/com/github/ambry/compression/ZstdCompression.java
+++ b/ambry-commons/src/main/java/com/github/ambry/compression/ZstdCompression.java
@@ -123,11 +123,6 @@ public class ZstdCompression extends BaseCompressionWithLevel {
           newSourceBuffer.array(), sourceBufferOffset, sourceDataSize, getCompressionLevel());
     }
 
-    // If sourceByteBuffer is a copy, free it.
-    if (newSourceBuffer != sourceBuffer && newSourceBuffer.isDirect()) {
-      Unpooled.wrappedBuffer(newSourceBuffer).release();
-    }
-
     // Check for error.
     if (Zstd.isError(compressedSize)) {
       throw new CompressionException(String.format("Zstd compression failed with error code: %d, name: %s. "
@@ -195,11 +190,6 @@ public class ZstdCompression extends BaseCompressionWithLevel {
     } else {
       decompressedSize = Zstd.decompressByteArray(decompressedBuffer.array(), decompressedBufferOffset,
           decompressedDataSize, newCompressedBuffer.array(), compressedBufferOffset, compressedDataSize);
-    }
-
-    // If sourceByteBuffer is a copy, free it.
-    if (newCompressedBuffer != compressedBuffer && newCompressedBuffer.isDirect()) {
-      Unpooled.wrappedBuffer(newCompressedBuffer).release();
     }
 
     // Check for error.

--- a/ambry-commons/src/main/java/com/github/ambry/compression/ZstdCompression.java
+++ b/ambry-commons/src/main/java/com/github/ambry/compression/ZstdCompression.java
@@ -125,8 +125,7 @@ public class ZstdCompression extends BaseCompressionWithLevel {
 
     // If sourceByteBuffer is a copy, free it.
     if (newSourceBuffer != sourceBuffer && newSourceBuffer.isDirect()) {
-      ByteBuf tempByteBuf = Unpooled.wrappedBuffer(newSourceBuffer);
-      tempByteBuf.release();
+      Unpooled.wrappedBuffer(newSourceBuffer).release();
     }
 
     // Check for error.
@@ -200,8 +199,7 @@ public class ZstdCompression extends BaseCompressionWithLevel {
 
     // If sourceByteBuffer is a copy, free it.
     if (newCompressedBuffer != compressedBuffer && newCompressedBuffer.isDirect()) {
-      ByteBuf tempByteBuf = Unpooled.wrappedBuffer(newCompressedBuffer);
-      tempByteBuf.release();
+      Unpooled.wrappedBuffer(newCompressedBuffer).release();
     }
 
     // Check for error.

--- a/ambry-commons/src/test/java/com/github/ambry/compression/LZ4CompressionTest.java
+++ b/ambry-commons/src/test/java/com/github/ambry/compression/LZ4CompressionTest.java
@@ -55,15 +55,20 @@ public class LZ4CompressionTest {
   }
 
   @Test
-  public void testCompressAndDecompress_MinimumLevel() throws CompressionException {
+  public void testCompressAndDecompressNative_MinimumLevel() throws CompressionException {
     LZ4Compression compression = new LZ4Compression();
     compression.setCompressionLevel(compression.getMinimumCompressionLevel());
     // Test dedicated buffer (without extra bytes on left or right of buffer).
-    compressAndDecompressNativeTest(compression, "Test my minimum compression message using minimum level.", 0 , 0);
+    compressAndDecompressNativeTest(compression, "Test my minimum compression message using minimum level.", 0, 0);
 
     // Test mid-buffer (with extra bytes on left and right of buffer.)
-    compressAndDecompressNativeTest(compression, "Test my minimum compression message using minimum level.", 2 , 3);
+    compressAndDecompressNativeTest(compression, "Test my minimum compression message using minimum level.", 2, 3);
+  }
 
+  @Test
+  public void testCompressAndDecompress_MinimumLevel() throws CompressionException {
+    LZ4Compression compression = new LZ4Compression();
+    compression.setCompressionLevel(compression.getMinimumCompressionLevel());
     // Test compression API with dedicated buffer (without extra bytes on left or right of buffer).
     compressAndDecompressTest(compression, "Test my minimum compression message using minimum level.", 0 , 0);
 
@@ -72,7 +77,7 @@ public class LZ4CompressionTest {
   }
 
   @Test
-  public void testCompressAndDecompress_MaximumLevel() throws CompressionException {
+  public void testCompressAndDecompressNative_MaximumLevel() throws CompressionException {
     LZ4Compression compression = new LZ4Compression();
     compression.setCompressionLevel(compression.getMaximumCompressionLevel());
     // Test dedicated buffer (without extra bytes on left or right of buffer).
@@ -80,7 +85,12 @@ public class LZ4CompressionTest {
 
     // Test mid-buffer (with extra bytes on left and right of buffer.)
     compressAndDecompressNativeTest(compression, "Test my maximum compression message using maximum level.", 2, 1);
+  }
 
+  @Test
+  public void testCompressAndDecompress_MaximumLevel() throws CompressionException {
+    LZ4Compression compression = new LZ4Compression();
+    compression.setCompressionLevel(compression.getMaximumCompressionLevel());
     // Test compression API with dedicated buffer (without extra bytes on left or right of buffer).
     compressAndDecompressTest(compression, "Test my maximum compression message using maximum level.", 0, 0);
 

--- a/ambry-commons/src/test/java/com/github/ambry/compression/LZ4CompressionTest.java
+++ b/ambry-commons/src/test/java/com/github/ambry/compression/LZ4CompressionTest.java
@@ -14,6 +14,7 @@
 package com.github.ambry.compression;
 
 import com.github.ambry.utils.TestUtils;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import net.jpountz.lz4.LZ4Compressor;
 import net.jpountz.lz4.LZ4FastDecompressor;
@@ -22,9 +23,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+@PowerMockIgnore("javax.management.*")
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(LZ4Compression.class)
 public class LZ4CompressionTest {
@@ -60,6 +63,12 @@ public class LZ4CompressionTest {
 
     // Test mid-buffer (with extra bytes on left and right of buffer.)
     compressAndDecompressNativeTest(compression, "Test my minimum compression message using minimum level.", 2 , 3);
+
+    // Test compression API with dedicated buffer (without extra bytes on left or right of buffer).
+    compressAndDecompressTest(compression, "Test my minimum compression message using minimum level.", 0 , 0);
+
+    // Test compression API with mid-buffer (with extra bytes on left and right of buffer.)
+    compressAndDecompressTest(compression, "Test my minimum compression message using minimum level.", 2 , 3);
   }
 
   @Test
@@ -71,6 +80,12 @@ public class LZ4CompressionTest {
 
     // Test mid-buffer (with extra bytes on left and right of buffer.)
     compressAndDecompressNativeTest(compression, "Test my maximum compression message using maximum level.", 2, 1);
+
+    // Test compression API with dedicated buffer (without extra bytes on left or right of buffer).
+    compressAndDecompressTest(compression, "Test my maximum compression message using maximum level.", 0, 0);
+
+    // Test compression API with mid-buffer (with extra bytes on left and right of buffer.)
+    compressAndDecompressTest(compression, "Test my maximum compression message using maximum level.", 2, 1);
   }
 
   @Test
@@ -79,15 +94,15 @@ public class LZ4CompressionTest {
     // compress(byte[] src, int srcOff, int srcLen, byte[] dest, int destOff, int maxDestLen)
     LZ4Compressor throwCompressor = Mockito.mock(LZ4Compressor.class, Mockito.CALLS_REAL_METHODS);
     Exception theException = new RuntimeException("test");
-    Mockito.when(throwCompressor.compress(Mockito.any(byte[].class), Mockito.anyInt(), Mockito.anyInt(),
-      Mockito.any(byte[].class), Mockito.anyInt(), Mockito.anyInt())).thenThrow(theException);
+    Mockito.when(throwCompressor.compress(Mockito.any(ByteBuffer.class), Mockito.anyInt(), Mockito.anyInt(),
+      Mockito.any(ByteBuffer.class), Mockito.anyInt(), Mockito.anyInt())).thenThrow(theException);
 
     // Mock getCompressor() to return a compressor that throws when compress() is called.
     LZ4Compression lz4 = PowerMockito.mock(LZ4Compression.class, Mockito.CALLS_REAL_METHODS);
     PowerMockito.when(lz4, "getCompressor").thenReturn(throwCompressor);
     Exception ex = TestUtils.getException(() ->
-        lz4.compressNative("ABC".getBytes(StandardCharsets.UTF_8), 0, 3,
-            new byte[10], 0, 10));
+        lz4.compressNative(ByteBuffer.wrap("ABC".getBytes(StandardCharsets.UTF_8)), 0, 3,
+            ByteBuffer.wrap(new byte[10]), 0, 10));
     Assert.assertTrue(ex instanceof CompressionException);
     Assert.assertEquals(theException, ex.getCause());
   }
@@ -99,42 +114,151 @@ public class LZ4CompressionTest {
     // decompress(byte[] src, int srcOff, byte[] dest, int destOff, int destLen)
     LZ4FastDecompressor throwDecompressor = Mockito.mock(LZ4FastDecompressor.class, Mockito.CALLS_REAL_METHODS);
     Exception theException = new RuntimeException("failed");
-    Mockito.when(throwDecompressor.decompress(Mockito.any(byte[].class), Mockito.anyInt(),
-        Mockito.any(byte[].class), Mockito.anyInt(), Mockito.anyInt())).thenThrow(theException);
+    Mockito.when(throwDecompressor.decompress(Mockito.any(ByteBuffer.class), Mockito.anyInt(),
+        Mockito.any(ByteBuffer.class), Mockito.anyInt(), Mockito.anyInt())).thenThrow(theException);
 
     // Mock getDecompressor() to return a decompressor that throws when decompress() is called.
     LZ4Compression lz4 = PowerMockito.mock(LZ4Compression.class, Mockito.CALLS_REAL_METHODS);
     PowerMockito.when(lz4, "getDecompressor").thenReturn(throwDecompressor);
     Exception ex = TestUtils.getException(() ->
-        lz4.decompressNative(new byte[10], 0, 10, new byte[10], 0, 10));
+        lz4.decompressNative(ByteBuffer.wrap(new byte[10]), 0, 10, ByteBuffer.wrap(new byte[10]), 0, 10));
     Assert.assertTrue(ex instanceof CompressionException);
     Assert.assertEquals(theException, ex.getCause());
   }
 
+  /**
+   * Test compression using compressNative() and decompressNative() APIs.
+   * It does not use the structural formatting introduced by compress().
+   */
   public static void compressAndDecompressNativeTest(BaseCompression compression, String testMessage,
       int bufferLeftPadSize, int bufferRightPadSize) throws CompressionException {
     // Apply compression to testMessage.
-    // oversizeCompressedBuffer consists of bytes[bufferLeftPadSize] + bytes[actualCompressedSize]
+    // compressedBuffer consists of bytes[bufferLeftPadSize] + bytes[actualCompressedSize]
     // + bytes[compressUnusedSpace] + bytes[bufferRightPadSize]
-    byte[] sourceBuffer = testMessage.getBytes(StandardCharsets.UTF_8);
-    int estimatedCompressedSize = compression.estimateMaxCompressedDataSize(sourceBuffer.length);
-    byte[] oversizeCompressedBuffer = new byte[bufferLeftPadSize + estimatedCompressedSize + bufferRightPadSize];
-    int actualCompressedSize = compression.compressNative(sourceBuffer, 0, sourceBuffer.length,
-        oversizeCompressedBuffer, bufferLeftPadSize, estimatedCompressedSize);
+    ByteBuffer sourceBuffer = ByteBuffer.wrap(testMessage.getBytes(StandardCharsets.UTF_8));
+    int sourceBufferSize = sourceBuffer.remaining();
+    int compressedBufferSize = compression.estimateMaxCompressedDataSize(sourceBufferSize);
+    ByteBuffer compressedBuffer = ByteBuffer.wrap(new byte[bufferLeftPadSize + compressedBufferSize + bufferRightPadSize]);
+    int actualCompressedSize = compression.compressNative(sourceBuffer, 0, sourceBufferSize,
+        compressedBuffer, bufferLeftPadSize, compressedBufferSize);
     Assert.assertTrue(actualCompressedSize > 0);
 
     // Apply decompression.
     // compressedBuffer has bytes[bufferLeftPadSize] + bytes[actualCompressedSize] + bytes[bufferRightPadSize]
     // decompressedBuffer contains bytes[bufferLeftPadSize] + bytes[sourceBufferSize] + bytes[bufferRightPadSize]
-    byte[] compressedBuffer = new byte[bufferLeftPadSize + actualCompressedSize + bufferRightPadSize];
-    System.arraycopy(oversizeCompressedBuffer, bufferLeftPadSize, compressedBuffer, bufferLeftPadSize,
-        actualCompressedSize);
-    byte[] decompressedBuffer = new byte[bufferLeftPadSize + sourceBuffer.length + bufferRightPadSize];
+    ByteBuffer decompressedBuffer = ByteBuffer.wrap(new byte[bufferLeftPadSize + sourceBufferSize + bufferRightPadSize]);
     compression.decompressNative(compressedBuffer, bufferLeftPadSize, actualCompressedSize,
-        decompressedBuffer, bufferLeftPadSize, sourceBuffer.length);
+        decompressedBuffer, bufferLeftPadSize, sourceBufferSize);
 
-    String decompressedMessage = new String(decompressedBuffer, bufferLeftPadSize, sourceBuffer.length,
+    String decompressedMessage = new String(decompressedBuffer.array(), bufferLeftPadSize, sourceBufferSize,
         StandardCharsets.UTF_8);
     Assert.assertEquals(testMessage, decompressedMessage);
+  }
+
+  /**
+   * Test compression using compress() and decompress() APIs that uses an internal structure.
+   * It tests a combination of heap buffers and direct memory as input and output.
+   */
+  public static void compressAndDecompressTest(Compression compression, String testMessage,
+      int bufferLeftPadSize, int bufferRightPadSize) throws CompressionException {
+
+    byte[] testMessageBinary = testMessage.getBytes(StandardCharsets.UTF_8);
+    int testMessageSize = testMessageBinary.length;
+    int compressedBufferSize = compression.getCompressBufferSize(testMessageSize);
+    int paddedCompressedBufferSize = bufferLeftPadSize + compressedBufferSize + bufferRightPadSize;
+
+    // Apply compression to testMessage using Heap and Direct memory.
+    // compressedBuffer consists of bytes[bufferLeftPadSize] + bytes[actualCompressedSize] + bytes[bufferRightPadSize]
+    ByteBuffer sourceBufferHeap = ByteBuffer.wrap(testMessageBinary);
+    ByteBuffer sourceBufferDirect = ByteBuffer.wrap(testMessageBinary);
+    ByteBuffer compressedBufferHeap = ByteBuffer.allocate(paddedCompressedBufferSize);
+    ByteBuffer compressedBufferDirect = ByteBuffer.allocateDirect(paddedCompressedBufferSize);
+
+    // Compress Heap source to Heap output.
+    sourceBufferHeap.position(0);
+    compressedBufferHeap.position(bufferLeftPadSize);
+    int actualCompressedSize = compression.compress(sourceBufferHeap, compressedBufferHeap);
+    Assert.assertTrue(actualCompressedSize > 0);
+    Assert.assertEquals(0, sourceBufferHeap.remaining());
+    Assert.assertEquals(testMessageSize, sourceBufferHeap.position());
+    Assert.assertEquals(actualCompressedSize, compressedBufferHeap.position() - bufferLeftPadSize);
+
+    // Compress Heap source to Direct output.
+    sourceBufferHeap.position(0);
+    compressedBufferDirect.position(bufferLeftPadSize);
+    int nextActualCompressedSize = compression.compress(sourceBufferHeap, compressedBufferDirect);
+    Assert.assertEquals(actualCompressedSize, nextActualCompressedSize);
+    Assert.assertTrue(nextActualCompressedSize > 0);
+    Assert.assertEquals(0, sourceBufferHeap.remaining());
+    Assert.assertEquals(testMessageSize, sourceBufferHeap.position());
+    Assert.assertEquals(nextActualCompressedSize, compressedBufferDirect.position() - bufferLeftPadSize);
+
+    // Compress Direct source to Heap output.
+    sourceBufferDirect.position(0);
+    compressedBufferHeap.position(bufferLeftPadSize);
+    nextActualCompressedSize = compression.compress(sourceBufferDirect, compressedBufferHeap);
+    Assert.assertEquals(actualCompressedSize, nextActualCompressedSize);
+    Assert.assertTrue(nextActualCompressedSize > 0);
+    Assert.assertEquals(0, sourceBufferDirect.remaining());
+    Assert.assertEquals(testMessageSize, sourceBufferDirect.position());
+    Assert.assertEquals(actualCompressedSize, compressedBufferHeap.position() - bufferLeftPadSize);
+
+    // Compress Direct source to Direct output.
+    sourceBufferDirect.position(0);
+    compressedBufferDirect.position(bufferLeftPadSize);
+    nextActualCompressedSize = compression.compress(sourceBufferDirect, compressedBufferDirect);
+    Assert.assertEquals(actualCompressedSize, nextActualCompressedSize);
+    Assert.assertTrue(nextActualCompressedSize > 0);
+    Assert.assertEquals(0, sourceBufferDirect.remaining());
+    Assert.assertEquals(testMessageSize, sourceBufferDirect.position());
+    Assert.assertEquals(actualCompressedSize, compressedBufferDirect.position() - bufferLeftPadSize);
+
+    // Apply decompression.
+    // compressedBuffer has bytes[bufferLeftPadSize] + bytes[actualCompressedSize] + bytes[bufferRightPadSize]
+    // decompressedBuffer contains bytes[bufferLeftPadSize] + bytes[sourceBufferSize] + bytes[bufferRightPadSize]
+    compressedBufferHeap.limit(bufferLeftPadSize + actualCompressedSize);
+    compressedBufferDirect.limit(bufferLeftPadSize + actualCompressedSize);
+    int paddedDecompressedBufferSize = bufferLeftPadSize + testMessageSize + bufferRightPadSize;
+    ByteBuffer decompressedBufferHeap = ByteBuffer.allocate(paddedDecompressedBufferSize);
+    ByteBuffer decompressedBufferDirect = ByteBuffer.allocateDirect(paddedDecompressedBufferSize);
+    byte[] decompressedMessage = new byte[testMessageSize];
+
+    // Decompress Heap to Heap.
+    compressedBufferHeap.position(bufferLeftPadSize);
+    decompressedBufferHeap.position(bufferLeftPadSize);
+    int decompressedSize = compression.decompress(compressedBufferHeap, decompressedBufferHeap);
+    Assert.assertEquals(testMessageSize, decompressedSize);
+    Assert.assertEquals(testMessageSize, decompressedBufferHeap.position() - bufferLeftPadSize);
+    Assert.assertEquals(0, compressedBufferHeap.remaining());
+    Assert.assertEquals(testMessage, new String(decompressedBufferHeap.array(), bufferLeftPadSize, testMessageSize, StandardCharsets.UTF_8));
+
+    // Decompress Heap to Direct.
+    compressedBufferHeap.position(bufferLeftPadSize);
+    decompressedBufferDirect.position(bufferLeftPadSize);
+    decompressedSize = compression.decompress(compressedBufferHeap, decompressedBufferDirect);
+    Assert.assertEquals(testMessageSize, decompressedSize);
+    Assert.assertEquals(testMessageSize, decompressedBufferDirect.position() - bufferLeftPadSize);
+    Assert.assertEquals(0, compressedBufferHeap.remaining());
+    decompressedBufferDirect.position(bufferLeftPadSize).get(decompressedMessage);
+    Assert.assertEquals(testMessage, new String(decompressedMessage, StandardCharsets.UTF_8));
+
+    // Decompress Direct to Heap.
+    compressedBufferDirect.position(bufferLeftPadSize);
+    decompressedBufferHeap.position(bufferLeftPadSize);
+    decompressedSize = compression.decompress(compressedBufferDirect, decompressedBufferHeap);
+    Assert.assertEquals(testMessageSize, decompressedSize);
+    Assert.assertEquals(testMessageSize, decompressedBufferHeap.position() - bufferLeftPadSize);
+    Assert.assertEquals(0, compressedBufferDirect.remaining());
+    Assert.assertEquals(testMessage, new String(decompressedBufferHeap.array(), bufferLeftPadSize, testMessageSize, StandardCharsets.UTF_8));
+
+    // Decompress Direct to Direct.
+    compressedBufferDirect.position(bufferLeftPadSize);
+    decompressedBufferDirect.position(bufferLeftPadSize);
+    decompressedSize = compression.decompress(compressedBufferDirect, decompressedBufferDirect);
+    Assert.assertEquals(testMessageSize, decompressedSize);
+    Assert.assertEquals(testMessageSize, decompressedBufferDirect.position() - bufferLeftPadSize);
+    Assert.assertEquals(0, compressedBufferDirect.remaining());
+    decompressedBufferDirect.position(bufferLeftPadSize).get(decompressedMessage);
+    Assert.assertEquals(testMessage, new String(decompressedMessage, StandardCharsets.UTF_8));
   }
 }

--- a/ambry-commons/src/test/java/com/github/ambry/compression/ZstdCompressionFailedTests.java
+++ b/ambry-commons/src/test/java/com/github/ambry/compression/ZstdCompressionFailedTests.java
@@ -15,6 +15,7 @@ package com.github.ambry.compression;
 
 import com.github.ambry.utils.TestUtils;
 import com.github.luben.zstd.Zstd;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import org.junit.Assert;
 import org.junit.Test;
@@ -37,8 +38,8 @@ public class ZstdCompressionFailedTests {
 
     ZstdCompression zstd = new ZstdCompression();
     Exception ex = TestUtils.getException(() ->
-        zstd.compressNative("ABC".getBytes(StandardCharsets.UTF_8), 0, 3,
-            new byte[10], 0, 10));
+        zstd.compressNative(ByteBuffer.wrap("ABC".getBytes(StandardCharsets.UTF_8)), 0, 3,
+            ByteBuffer.wrap(new byte[10]), 0, 10));
     Assert.assertTrue(ex instanceof CompressionException);
   }
 
@@ -53,7 +54,7 @@ public class ZstdCompressionFailedTests {
 
     ZstdCompression zstd = new ZstdCompression();
     Exception ex = TestUtils.getException(() ->
-        zstd.decompressNative(new byte[10], 0, 10, new byte[10], 0, 10));
+        zstd.decompressNative(ByteBuffer.wrap(new byte[10]), 0, 10, ByteBuffer.wrap(new byte[10]), 0, 10));
     Assert.assertTrue(ex instanceof CompressionException);
   }
 }

--- a/ambry-commons/src/test/java/com/github/ambry/compression/ZstdCompressionTest.java
+++ b/ambry-commons/src/test/java/com/github/ambry/compression/ZstdCompressionTest.java
@@ -55,6 +55,17 @@ public class ZstdCompressionTest {
     ZstdCompression compression = new ZstdCompression();
     compression.setCompressionLevel(compression.getMinimumCompressionLevel());
     // Test dedicated buffer (without extra bytes on left or right of buffer).
+    LZ4CompressionTest.compressAndDecompressTest(compression, "Test minimum compression using minimum level.", 0, 0);
+
+    // Test mid-buffer (with extra bytes on left and right of buffer.)
+    LZ4CompressionTest.compressAndDecompressTest(compression, "Test minimum compression using minimum level.", 2, 2);
+  }
+
+  @Test
+  public void testCompressAndDecompressNative_MinimumLevel() throws CompressionException {
+    ZstdCompression compression = new ZstdCompression();
+    compression.setCompressionLevel(compression.getMinimumCompressionLevel());
+    // Test dedicated buffer (without extra bytes on left or right of buffer).
     LZ4CompressionTest.compressAndDecompressNativeTest(compression, "Test minimum compression using minimum level.", 0, 0);
 
     // Test mid-buffer (with extra bytes on left and right of buffer.)
@@ -63,6 +74,17 @@ public class ZstdCompressionTest {
 
   @Test
   public void testCompressAndDecompress_MaximumLevel() throws CompressionException {
+    ZstdCompression compression = new ZstdCompression();
+    compression.setCompressionLevel(compression.getMaximumCompressionLevel());
+    // Test dedicated buffer (without extra bytes on left or right of buffer).
+    LZ4CompressionTest.compressAndDecompressTest(compression, "Test maximum compression using maximum level.", 0, 0);
+
+    // Test mid-buffer (with extra bytes on left and right of buffer.)
+    LZ4CompressionTest.compressAndDecompressTest(compression, "Test maximum compression using maximum level.", 3, 0);
+  }
+
+  @Test
+  public void testCompressAndDecompressNative_MaximumLevel() throws CompressionException {
     ZstdCompression compression = new ZstdCompression();
     compression.setCompressionLevel(compression.getMaximumCompressionLevel());
     // Test dedicated buffer (without extra bytes on left or right of buffer).


### PR DESCRIPTION
Added more unit tests to test all combination of Heap & Direct input, with Heap & Direct Output, for both compression and decompression combinations.