### PR TITLE
Replication Optimization: Treating deleted put record's size same as delete 

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -521,7 +521,7 @@ public class StoreConfig {
   /**
    * If true, then in findEntriesSince method, use Delete entry's size for a deleted Put entry. This is useful for replication.
    * In replication, when handling ReplicaMetadataRequest, server would scan through index segments. One Put entry could be
-   * as big as 4MB, but is this Put entry is already deleted, then in the requester server side it will do nothing. This is bad
+   * as big as 4MB, but if this Put entry is already deleted, then in the requester server side it will do nothing. This is bad
    * because we are using one roundtrip to bypass on blob id.
    * Set this to true would help mitigate this issue. We know the put's final state is delete and the requester server won't
    * do anything, then we just move on to scan more entries.

--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -518,6 +518,18 @@ public class StoreConfig {
   public final boolean storeUseBlobFormatV3;
   public static final String storeUseBlobFormatV3Name = "store.use.blob.format.v3";
 
+  /**
+   * If true, then in findEntriesSince method, use Delete entry's size for a deleted Put entry. This is useful for replication.
+   * In replication, when handling ReplicaMetadataRequest, server would scan through index segments. One Put entry could be
+   * as big as 4MB, but is this Put entry is already deleted, then in the requester server side it will do nothing. This is bad
+   * because we are using one roundtrip to bypass on blob id.
+   * Set this to true would help mitigate this issue. We know the put's final state is delete and the requester server won't
+   * do anything, then we just move on to scan more entries.
+   */
+  @Config(storeDeletedPutAsDeleteInFindEntriesName)
+  public final boolean storeDeletedPutAsDeleteInFindEntries;
+  public static final String storeDeletedPutAsDeleteInFindEntriesName = "store.deleted.put.as.delete.in.find.entries";
+
   public StoreConfig(VerifiableProperties verifiableProperties) {
 
     storeKeyFactory = verifiableProperties.getString("store.key.factory", "com.github.ambry.commons.BlobIdFactory");
@@ -646,5 +658,7 @@ public class StoreConfig {
     }
 
     storeUseBlobFormatV3 = verifiableProperties.getBoolean(storeUseBlobFormatV3Name, false);
+    storeDeletedPutAsDeleteInFindEntries =
+        verifiableProperties.getBoolean(storeDeletedPutAsDeleteInFindEntriesName, false);
   }
 }

--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/DeleteMessageFormatInputStream.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/DeleteMessageFormatInputStream.java
@@ -69,7 +69,7 @@ public class DeleteMessageFormatInputStream extends MessageFormatInputStream {
   }
 
   /**
-   * Return the {@link DeleteMessageFormatInputStream} size for the given {@code key}.
+   * Only used in test. Return the {@link DeleteMessageFormatInputStream} size for the given {@code key}.
    * @param key The {@link StoreKey}
    * @return The size of {@link DeleteMessageFormatInputStream}
    */

--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/DeleteMessageFormatInputStream.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/DeleteMessageFormatInputStream.java
@@ -31,18 +31,6 @@ import java.nio.ByteBuffer;
  *
  */
 public class DeleteMessageFormatInputStream extends MessageFormatInputStream {
-  private static final int HEADER_SIZE;
-  private static final int DELETE_RECORD_SIZE;
-
-  static {
-    try {
-      HEADER_SIZE = MessageFormatRecord.getHeaderSizeForVersion(MessageFormatRecord.headerVersionToUse);
-    } catch (Exception e) {
-      throw new RuntimeException("Failed to get Header size for version " + MessageFormatRecord.headerVersionToUse, e);
-    }
-    DELETE_RECORD_SIZE = MessageFormatRecord.Update_Format_V3.getRecordSize(SubRecord.Type.DELETE);
-  }
-
   public DeleteMessageFormatInputStream(StoreKey key, short accountId, short containerId, long deletionTimeMs)
       throws MessageFormatException {
     this(key, accountId, containerId, deletionTimeMs, (short) 0);
@@ -50,23 +38,25 @@ public class DeleteMessageFormatInputStream extends MessageFormatInputStream {
 
   public DeleteMessageFormatInputStream(StoreKey key, short accountId, short containerId, long deletionTimeMs,
       short lifeVersion) throws MessageFormatException {
-    buffer = ByteBuffer.allocate(HEADER_SIZE + key.sizeInBytes() + DELETE_RECORD_SIZE);
+    int headerSize = MessageFormatRecord.getHeaderSizeForVersion(MessageFormatRecord.headerVersionToUse);
+    int deleteRecordSize = MessageFormatRecord.Update_Format_V3.getRecordSize(SubRecord.Type.DELETE);
+    buffer = ByteBuffer.allocate(headerSize + key.sizeInBytes() + deleteRecordSize);
 
     if (MessageFormatRecord.headerVersionToUse == MessageFormatRecord.Message_Header_Version_V1) {
-      MessageFormatRecord.MessageHeader_Format_V1.serializeHeader(buffer, DELETE_RECORD_SIZE,
-          MessageFormatRecord.Message_Header_Invalid_Relative_Offset, HEADER_SIZE + key.sizeInBytes(),
+      MessageFormatRecord.MessageHeader_Format_V1.serializeHeader(buffer, deleteRecordSize,
+          MessageFormatRecord.Message_Header_Invalid_Relative_Offset, headerSize + key.sizeInBytes(),
           MessageFormatRecord.Message_Header_Invalid_Relative_Offset,
           MessageFormatRecord.Message_Header_Invalid_Relative_Offset);
     } else if (MessageFormatRecord.headerVersionToUse == MessageFormatRecord.Message_Header_Version_V2) {
-      MessageFormatRecord.MessageHeader_Format_V2.serializeHeader(buffer, DELETE_RECORD_SIZE,
+      MessageFormatRecord.MessageHeader_Format_V2.serializeHeader(buffer, deleteRecordSize,
           MessageFormatRecord.Message_Header_Invalid_Relative_Offset,
-          MessageFormatRecord.Message_Header_Invalid_Relative_Offset, HEADER_SIZE + key.sizeInBytes(),
+          MessageFormatRecord.Message_Header_Invalid_Relative_Offset, headerSize + key.sizeInBytes(),
           MessageFormatRecord.Message_Header_Invalid_Relative_Offset,
           MessageFormatRecord.Message_Header_Invalid_Relative_Offset);
     } else {
-      MessageFormatRecord.MessageHeader_Format_V3.serializeHeader(buffer, lifeVersion, DELETE_RECORD_SIZE,
+      MessageFormatRecord.MessageHeader_Format_V3.serializeHeader(buffer, lifeVersion, deleteRecordSize,
           MessageFormatRecord.Message_Header_Invalid_Relative_Offset,
-          MessageFormatRecord.Message_Header_Invalid_Relative_Offset, HEADER_SIZE + key.sizeInBytes(),
+          MessageFormatRecord.Message_Header_Invalid_Relative_Offset, headerSize + key.sizeInBytes(),
           MessageFormatRecord.Message_Header_Invalid_Relative_Offset,
           MessageFormatRecord.Message_Header_Invalid_Relative_Offset);
     }
@@ -84,6 +74,12 @@ public class DeleteMessageFormatInputStream extends MessageFormatInputStream {
    * @return The size of {@link DeleteMessageFormatInputStream}
    */
   public static long getDeleteMessageFormatInputStreamSize(StoreKey key) {
-    return HEADER_SIZE + key.sizeInBytes() + DELETE_RECORD_SIZE;
+    try {
+      int headerSize = MessageFormatRecord.getHeaderSizeForVersion(MessageFormatRecord.headerVersionToUse);
+      int deleteRecordSize = MessageFormatRecord.Update_Format_V3.getRecordSize(SubRecord.Type.DELETE);
+      return headerSize + key.sizeInBytes() + deleteRecordSize;
+    } catch (MessageFormatException e) {
+      throw new IllegalArgumentException("Failed to get DeleteMessageFormatInputStreamSize for key " + key, e);
+    }
   }
 }

--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/DeleteMessageFormatInputStream.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/DeleteMessageFormatInputStream.java
@@ -67,4 +67,10 @@ public class DeleteMessageFormatInputStream extends MessageFormatInputStream {
     messageLength = buffer.capacity();
     buffer.flip();
   }
+
+  public static long getDeleteMessageFormatInputStreamSize(StoreKey key) throws MessageFormatException {
+    int headerSize = MessageFormatRecord.getHeaderSizeForVersion(MessageFormatRecord.headerVersionToUse);
+    int deleteRecordSize = MessageFormatRecord.Update_Format_V3.getRecordSize(SubRecord.Type.DELETE);
+    return headerSize + key.sizeInBytes() + deleteRecordSize;
+  }
 }

--- a/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
@@ -1826,6 +1826,7 @@ class PersistentIndex {
         startTimeInMs = time.milliseconds();
         StoreFindToken newToken;
         long sizeSum = 0;
+        int messageEntryIndex = 0;
         while (true) {
           //if index based token points to the last entry of last index segment, and journal size cleaned up after last log
           //segment auto close, we should return the original index based token instead of getting from journal.
@@ -1841,7 +1842,8 @@ class PersistentIndex {
           logger.trace("Segment based token, Time used to find entries: {}", (time.milliseconds() - startTimeInMs));
 
           startTimeInMs = time.milliseconds();
-          updateStateForMessages(messageEntries);
+          // UpdateState for the messageEntries that has not yet been updated
+          updateStateForMessages(messageEntries.subList(messageEntryIndex, messageEntries.size()));
           logger.trace("Segment based token, Time used to update state: {}", (time.milliseconds() - startTimeInMs));
 
           startTimeInMs = time.milliseconds();
@@ -1856,6 +1858,7 @@ class PersistentIndex {
               "Index {}: keep scanning index segment since new token is {}, number of MessageEntries {}, maxTotalSize {} and scanned total size {}",
               dataDir, newToken, messageEntries.size(), maxTotalSizeOfEntries, sizeSum);
           storeToken = newToken;
+          messageEntryIndex = messageEntries.size();
         }
 
         long totalBytesRead = getTotalBytesRead(newToken, messageEntries, logEndOffsetBeforeFind, indexSegments);

--- a/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
@@ -1875,14 +1875,15 @@ class PersistentIndex {
    * 1. storeDeletedPutAsDeleteInFindEntries is false or
    * 2. No message entries was found in the last scan or
    * 3. new Token is not IndexBased anymore or
-   * 4. the total size of returned message infos are already larger than the max totals zie of entries.
+   * 4. the total size of returned message infos are already larger than the max total size of entries.
    *
    * If we are comparing the size of returned message infos, then we are treating a deleted Put Message
    * as a Delete message.
-   * @param messageEntries
-   * @param newToken
-   * @param maxTotalSizeOfEntries
-   * @param messageInfoSizeSum
+   * @param messageEntries the list of {@link MessageInfo} from scanning index segments
+   * @param newToken the new token after scanning
+   * @param maxTotalSizeOfEntries The maximum total size of entries that needs to be returned. The api will try to
+   *                              return a list of entries whose total size is close to this value.
+   * @param messageInfoSizeSum the sum of message infos' sizes from the list.
    * @return
    */
   private boolean shouldStopScanning(List<MessageInfo> messageEntries, StoreFindToken newToken,

--- a/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
@@ -1852,8 +1852,9 @@ class PersistentIndex {
           if (shouldStopScanning(messageEntries, newToken, maxTotalSizeOfEntries, sizeSum)) {
             break;
           }
-          logger.trace("Index {}: keep scanning index segment since new token is {}, number of MessageEntries {}",
-              dataDir, newToken.getType(), messageEntries.size());
+          logger.trace(
+              "Index {}: keep scanning index segment since new token is {}, number of MessageEntries {}, maxTotalSize {} and scanned total size {}",
+              dataDir, newToken, messageEntries.size(), maxTotalSizeOfEntries, sizeSum);
           storeToken = newToken;
         }
 
@@ -1886,13 +1887,12 @@ class PersistentIndex {
    */
   private boolean shouldStopScanning(List<MessageInfo> messageEntries, StoreFindToken newToken,
       long maxTotalSizeOfEntries, long messageInfoSizeSum) {
-    if (!config.storeDeletedPutAsDeleteInFindEntries || messageEntries.isEmpty() || !newToken.getType()
-        .equals(FindTokenType.IndexBased)) {
-      return true;
-    }
-    logger.trace("Index {}: Check if keep scanning based on message size: {}, max total size: {}", dataDir,
-        messageInfoSizeSum, maxTotalSizeOfEntries);
-    return messageInfoSizeSum >= maxTotalSizeOfEntries;
+    //@formatter:off
+    return !config.storeDeletedPutAsDeleteInFindEntries
+        || messageEntries.isEmpty()
+        || !newToken.getType().equals(FindTokenType.IndexBased)
+        || messageInfoSizeSum >= maxTotalSizeOfEntries;
+    //@formatter:on
   }
 
   /**

--- a/ambry-store/src/test/java/com/github/ambry/store/CuratedLogIndexState.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CuratedLogIndexState.java
@@ -75,8 +75,8 @@ class CuratedLogIndexState {
   static final long DELAY_BETWEEN_LAST_MODIFIED_TIMES_MS = 10 * Time.MsPerSec;
   static final StoreKeyFactory STORE_KEY_FACTORY;
   // deliberately do not divide the capacities perfectly.
-  static final long PUT_RECORD_SIZE = 53;
-  static final long DELETE_RECORD_SIZE = 29;
+  static long PUT_RECORD_SIZE = 53;
+  static long DELETE_RECORD_SIZE = 29;
   static final long TTL_UPDATE_RECORD_SIZE = 37;
   static final long UNDELETE_RECORD_SIZE = 29;
 

--- a/ambry-store/src/test/java/com/github/ambry/store/IndexTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/IndexTest.java
@@ -19,6 +19,7 @@ import com.github.ambry.account.Account;
 import com.github.ambry.account.Container;
 import com.github.ambry.config.StoreConfig;
 import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.messageformat.DeleteMessageFormatInputStream;
 import com.github.ambry.replication.FindToken;
 import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.SystemTime;
@@ -1248,6 +1249,94 @@ public class IndexTest {
     findEntriesSinceInEmptyIndexTest(false);
     findEntriesSinceTtlUpdateCornerCaseTest();
     findEntriesSinceTtlUpdateAndPutInJournalTest();
+  }
+
+  @Test
+  public void findEntriesSinceDeletedPutAsDeleteTest() throws StoreException {
+    // first we have to change PUT and DELETE size, they are not the same as the real size.
+    assumeTrue(isLogSegmented && persistentIndexVersion == PersistentIndex.VERSION_4 && !addUndeletes);
+    state.closeAndClearIndex();
+
+    long oldPutSize = PUT_RECORD_SIZE;
+    long oldDeleteSize = DELETE_RECORD_SIZE;
+    try {
+      MockId id = state.getUniqueId();
+      long deleteSize = DeleteMessageFormatInputStream.getDeleteMessageFormatInputStreamSize(id);
+      DELETE_RECORD_SIZE = deleteSize;
+      PUT_RECORD_SIZE = DEFAULT_MAX_IN_MEM_ELEMENTS * DELETE_RECORD_SIZE;
+      state.properties.put("store.deleted.put.as.delete.in.find.entries", "true");
+      state.reloadIndex(false, false);
+
+      // Adding 10 PUT record, 5 for the first index segment, and 5 for the second index segment
+      List<IndexEntry> entries = state.addPutEntries(10, PUT_RECORD_SIZE, Utils.Infinite_Time);
+      // Delete all of them
+      for (IndexEntry entry : entries) {
+        state.addDeleteEntry((MockId) entry.getKey());
+      }
+
+      // Now use an uninitialized token, read the first PUT RECORD. Since this is a uninitialized token, we will return
+      // right after the first put.
+      StoreFindToken startToken = new StoreFindToken();
+      long maxSize = PUT_RECORD_SIZE;
+      MockId firstId = (MockId) state.referenceIndex.firstEntry().getValue().firstKey();
+      IndexSegment firstIndexSegment = state.index.getIndexSegments().get(state.referenceIndex.firstKey());
+      StoreFindToken expectedToken =
+          new StoreFindToken(firstId, state.referenceIndex.firstKey(), state.sessionId, state.incarnationId,
+              firstIndexSegment.getResetKey(), firstIndexSegment.getResetKeyType(),
+              firstIndexSegment.getResetKeyLifeVersion());
+      long byteRead = state.index.getAbsolutePositionInLogForOffset(state.referenceIndex.firstKey());
+      expectedToken.setBytesRead(byteRead);
+      doFindEntriesSinceTest(startToken, maxSize, Collections.singleton(firstId), expectedToken);
+
+      // Now use an index based token. The max size still is the size of the PUT, which is 5 * delete size.
+      // We set up this state by adding 10 Put records and delete all of them. The first Put record is already scanned
+      // by the first findEntriesSince, now we will scan up to 5 Put records even the max byte size is only one Put
+      // record size
+      startToken = expectedToken;
+      Set<MockId> expectedKeys = new HashSet<>();
+      // Add all mock keys from the first index segments
+      expectedKeys.addAll(state.referenceIndex.firstEntry().getValue().keySet());
+      // remove the first id because the index based token is exclusive
+      expectedKeys.remove(firstId);
+      Map.Entry<Offset, IndexSegment> secondIndexSegmentEntry =
+          state.index.getIndexSegments().higherEntry(firstIndexSegment.getStartOffset());
+      Offset secondIndexSegemtnOffset = secondIndexSegmentEntry.getKey();
+      IndexSegment secondIndexSegemnt = secondIndexSegmentEntry.getValue();
+      MockId firstKeyInSecondIndexSegement = state.referenceIndex.get(secondIndexSegemtnOffset).firstKey();
+      expectedKeys.add(firstKeyInSecondIndexSegement);
+
+      expectedToken = new StoreFindToken(firstKeyInSecondIndexSegement, secondIndexSegemtnOffset, state.sessionId,
+          state.incarnationId, secondIndexSegemnt.getResetKey(), secondIndexSegemnt.getResetKeyType(),
+          secondIndexSegemnt.getResetKeyLifeVersion());
+      byteRead = state.index.getAbsolutePositionInLogForOffset(secondIndexSegemtnOffset);
+      expectedToken.setBytesRead(byteRead);
+      doFindEntriesSinceTest(startToken, maxSize, expectedKeys, expectedToken);
+
+      // Add another PUT and DELETE, this new put and delete would be stored in the journal
+      Offset offsetOfLastEntryInJournal = state.index.journal.getLastOffset();
+      MockId newPutId = (MockId)state.addPutEntries(1, PUT_RECORD_SIZE, Utils.Infinite_Time).get(0).getKey();
+      Offset putOffset = state.index.journal.getLastOffset();
+      MockId uniqueId = state.getUniqueId();
+      state.addDeleteEntry(uniqueId,
+          new MessageInfo(uniqueId, Integer.MAX_VALUE, state.time.milliseconds(), uniqueId.getAccountId(),
+              uniqueId.getContainerId(), state.time.milliseconds()));
+
+      // Now user journal based token, it will only read one Put Records
+      startToken =
+          new StoreFindToken(offsetOfLastEntryInJournal, state.sessionId, state.incarnationId, false, null, null,
+              UNINITIALIZED_RESET_KEY_VERSION);
+      expectedKeys.clear();
+      expectedKeys.add(newPutId);
+      IndexSegment lastSegment = state.index.getIndexSegments().lastEntry().getValue();
+      expectedToken =
+          new StoreFindToken(putOffset, state.sessionId, state.incarnationId, false, lastSegment.getResetKey(),
+              lastSegment.getResetKeyType(), lastSegment.getResetKeyLifeVersion());
+      expectedToken.setBytesRead(state.index.getAbsolutePositionInLogForOffset(state.index.journal.getLastOffset()));
+      doFindEntriesSinceTest(startToken, maxSize, expectedKeys, expectedToken);
+    } finally {
+      PUT_RECORD_SIZE = oldPutSize;
+      DELETE_RECORD_SIZE = oldDeleteSize;
+    }
   }
 
   /**

--- a/ambry-store/src/test/java/com/github/ambry/store/IndexTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/IndexTest.java
@@ -1261,8 +1261,7 @@ public class IndexTest {
     long oldDeleteSize = DELETE_RECORD_SIZE;
     try {
       MockId id = state.getUniqueId();
-      long deleteSize = DeleteMessageFormatInputStream.getDeleteMessageFormatInputStreamSize(id);
-      DELETE_RECORD_SIZE = deleteSize;
+      DELETE_RECORD_SIZE = DeleteMessageFormatInputStream.getDeleteMessageFormatInputStreamSize(id);
       PUT_RECORD_SIZE = DEFAULT_MAX_IN_MEM_ELEMENTS * DELETE_RECORD_SIZE;
       state.properties.put("store.deleted.put.as.delete.in.find.entries", "true");
       state.reloadIndex(false, false);


### PR DESCRIPTION
This is an optimization for replication. 
In replication, when replicator sends a ReplicaMetadataRequest to remote server, remote server would scan through the index segment files. It will stop when the number of scanned bytes are larger than the max number of byte in the ReplicaMetadataRequest. And the max number of bytes is usually 4MB (one PutBlob size).

In this case, when the remote server sees a Put record in the index segment file, it will stop scanning right away. However, if this Put record is already deleted (there is a Delete record after this Put), the size in the MessageInfo would be changed to size of Delete.  When the replicator sees this id, it knows that this id is deleted in the remote server so it does nothing. This is a terrible waste of roundtrip since we are spending one round trip to deal with one blob id. 

In this PR, we would keep scanning if this put Record is already deleted. In this way, we can return more ids back to the replicator in one request. We only do this for IndexBased replication token.