### PR TITLE
Enable blob format V3 by default.

### DIFF
--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/PutMessageFormatInputStream.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/PutMessageFormatInputStream.java
@@ -41,7 +41,7 @@ import java.nio.ByteBuffer;
 public class PutMessageFormatInputStream extends MessageFormatInputStream {
 
   // Temporary config for deployment control.  It will be removed after successfully deployed.
-  public static boolean useBlobFormatV3 = false;
+  public static boolean useBlobFormatV3 = true;
 
   public PutMessageFormatInputStream(StoreKey key, ByteBuffer blobEncryptionKey, BlobProperties blobProperties,
       ByteBuffer userMetadata, InputStream blobStream, long streamSize, BlobType blobType)


### PR DESCRIPTION
Testing in EI Perf has completed and compression is working as expected.
Proceeding to EI testing, then deploy to production.

This is a step toward deploying blob compression.  
First we need to enable Blob V3 format in server.
After this change has deployed to Prod servers, I will submit another PR to set blobCompressionEnabled = true to enable compression by default.