### PR TITLE
ServerAdminTool: prevent `IllegalReferenceCountException`

### DIFF
--- a/ambry-tools/src/main/java/com/github/ambry/tools/admin/ServerAdminTool.java
+++ b/ambry-tools/src/main/java/com/github/ambry/tools/admin/ServerAdminTool.java
@@ -826,7 +826,6 @@ public class ServerAdminTool implements Closeable {
         new GetRequest(correlationId.incrementAndGet(), CLIENT_ID, flags, partitionRequestInfos, getOption);
     ResponseInfo response = sendRequestGetResponse(dataNodeId, partitionId, getRequest);
     InputStream serverResponseStream = new NettyByteBufDataInputStream(response.content());
-//  response.release();
     GetResponse getResponse = GetResponse.readFrom(new DataInputStream(serverResponseStream), clusterMap);
     ServerErrorCode partitionErrorCode = getResponse.getPartitionResponseInfoList().get(0).getErrorCode();
     ServerErrorCode errorCode =

--- a/ambry-tools/src/main/java/com/github/ambry/tools/admin/ServerAdminTool.java
+++ b/ambry-tools/src/main/java/com/github/ambry/tools/admin/ServerAdminTool.java
@@ -822,7 +822,6 @@ public class ServerAdminTool implements Closeable {
         new GetRequest(correlationId.incrementAndGet(), CLIENT_ID, flags, partitionRequestInfos, getOption);
     ResponseInfo response = sendRequestGetResponse(dataNodeId, partitionId, getRequest);
     InputStream serverResponseStream = new NettyByteBufDataInputStream(response.content());
-    response.release();
     GetResponse getResponse = GetResponse.readFrom(new DataInputStream(serverResponseStream), clusterMap);
     ServerErrorCode partitionErrorCode = getResponse.getPartitionResponseInfoList().get(0).getErrorCode();
     ServerErrorCode errorCode =

--- a/ambry-tools/src/main/java/com/github/ambry/tools/admin/ServerAdminTool.java
+++ b/ambry-tools/src/main/java/com/github/ambry/tools/admin/ServerAdminTool.java
@@ -594,11 +594,12 @@ public class ServerAdminTool implements Closeable {
    */
   public Pair<ServerErrorCode, BlobProperties> getBlobProperties(DataNodeId dataNodeId, BlobId blobId,
       GetOption getOption, ClusterMap clusterMap) throws Exception {
-    Pair<ServerErrorCode, InputStream> response =
+    Pair<Pair<ServerErrorCode, InputStream>, ResponseInfo> response =
         getGetResponse(dataNodeId, blobId, MessageFormatFlags.BlobProperties, getOption, clusterMap);
-    InputStream stream = response.getSecond();
+    InputStream stream = response.getFirst().getSecond();
     BlobProperties blobProperties = stream != null ? MessageFormatRecord.deserializeBlobProperties(stream) : null;
-    return new Pair<>(response.getFirst(), blobProperties);
+    response.getSecond().release();
+    return new Pair<>(response.getFirst().getFirst(), blobProperties);
   }
 
   /**
@@ -612,11 +613,12 @@ public class ServerAdminTool implements Closeable {
    */
   public Pair<ServerErrorCode, ByteBuffer> getUserMetadata(DataNodeId dataNodeId, BlobId blobId, GetOption getOption,
       ClusterMap clusterMap) throws Exception {
-    Pair<ServerErrorCode, InputStream> response =
+    Pair<Pair<ServerErrorCode, InputStream>, ResponseInfo> response =
         getGetResponse(dataNodeId, blobId, MessageFormatFlags.BlobUserMetadata, getOption, clusterMap);
-    InputStream stream = response.getSecond();
+    InputStream stream = response.getFirst().getSecond();
     ByteBuffer userMetadata = stream != null ? MessageFormatRecord.deserializeUserMetadata(stream) : null;
-    return new Pair<>(response.getFirst(), userMetadata);
+    response.getSecond().release();
+    return new Pair<>(response.getFirst().getFirst(), userMetadata);
   }
 
   /**
@@ -630,11 +632,12 @@ public class ServerAdminTool implements Closeable {
    */
   public Pair<ServerErrorCode, BlobData> getBlob(DataNodeId dataNodeId, BlobId blobId, GetOption getOption,
       ClusterMap clusterMap) throws Exception {
-    Pair<ServerErrorCode, InputStream> response =
+    Pair<Pair<ServerErrorCode, InputStream>, ResponseInfo> response =
         getGetResponse(dataNodeId, blobId, MessageFormatFlags.Blob, getOption, clusterMap);
-    InputStream stream = response.getSecond();
+    InputStream stream = response.getFirst().getSecond();
     BlobData blobData = stream != null ? MessageFormatRecord.deserializeBlob(stream) : null;
-    return new Pair<>(response.getFirst(), blobData);
+    response.getSecond().release();
+    return new Pair<>(response.getFirst().getFirst(), blobData);
   }
 
   /**
@@ -649,11 +652,12 @@ public class ServerAdminTool implements Closeable {
    */
   public Pair<ServerErrorCode, BlobAll> getAll(DataNodeId dataNodeId, BlobId blobId, GetOption getOption,
       ClusterMap clusterMap, StoreKeyFactory storeKeyFactory) throws Exception {
-    Pair<ServerErrorCode, InputStream> response =
+    Pair<Pair<ServerErrorCode, InputStream>, ResponseInfo> response =
         getGetResponse(dataNodeId, blobId, MessageFormatFlags.All, getOption, clusterMap);
-    InputStream stream = response.getSecond();
+    InputStream stream = response.getFirst().getSecond();
     BlobAll blobAll = stream != null ? MessageFormatRecord.deserializeBlobAll(stream, storeKeyFactory) : null;
-    return new Pair<>(response.getFirst(), blobAll);
+    response.getSecond().release();
+    return new Pair<>(response.getFirst().getFirst(), blobAll);
   }
 
   /**
@@ -811,7 +815,7 @@ public class ServerAdminTool implements Closeable {
    * response stream otherwise.
    * @throws Exception
    */
-  private Pair<ServerErrorCode, InputStream> getGetResponse(DataNodeId dataNodeId, BlobId blobId,
+  private Pair<Pair<ServerErrorCode, InputStream>, ResponseInfo> getGetResponse(DataNodeId dataNodeId, BlobId blobId,
       MessageFormatFlags flags, GetOption getOption, ClusterMap clusterMap) throws Exception {
     PartitionId partitionId = blobId.getPartition();
     PartitionRequestInfo partitionRequestInfo =
@@ -822,12 +826,13 @@ public class ServerAdminTool implements Closeable {
         new GetRequest(correlationId.incrementAndGet(), CLIENT_ID, flags, partitionRequestInfos, getOption);
     ResponseInfo response = sendRequestGetResponse(dataNodeId, partitionId, getRequest);
     InputStream serverResponseStream = new NettyByteBufDataInputStream(response.content());
+//  response.release();
     GetResponse getResponse = GetResponse.readFrom(new DataInputStream(serverResponseStream), clusterMap);
     ServerErrorCode partitionErrorCode = getResponse.getPartitionResponseInfoList().get(0).getErrorCode();
     ServerErrorCode errorCode =
         partitionErrorCode == ServerErrorCode.No_Error ? getResponse.getError() : partitionErrorCode;
     InputStream stream = errorCode == ServerErrorCode.No_Error ? getResponse.getInputStream() : null;
-    return new Pair<>(errorCode, stream);
+    return new Pair<>(new Pair<>(errorCode, stream), response);
   }
 
   /**


### PR DESCRIPTION
`response.release();` was called too early resulting in
```
Exception in thread "main" io.netty.util.IllegalReferenceCountException: refCnt: 0
	at io.netty.buffer.AbstractByteBuf.ensureAccessible(AbstractByteBuf.java:1454)
	at io.netty.buffer.AbstractByteBuf.checkReadableBytes0(AbstractByteBuf.java:1440)
	at io.netty.buffer.AbstractByteBuf.readByte(AbstractByteBuf.java:730)
	at io.netty.buffer.ByteBufInputStream.read(ByteBufInputStream.java:172)
	at java.base/java.io.FilterInputStream.read(FilterInputStream.java:83)
	at java.base/java.io.DataInputStream.readShort(DataInputStream.java:317)
	at com.github.ambry.protocol.GetResponse.readFrom(GetResponse.java:99)
	at com.github.ambry.tools.admin.ServerAdminTool.getGetResponse(ServerAdminTool.java:826)
	at com.github.ambry.tools.admin.ServerAdminTool.getBlob(ServerAdminTool.java:634)
	at com.github.ambry.tools.admin.ServerAdminTool.main(ServerAdminTool.java:320)
```

Moving it just one line below is not a solution, the exception will trigger a bit later:
```
Exception in thread "main" io.netty.util.IllegalReferenceCountException: refCnt: 0
	at io.netty.buffer.AbstractByteBuf.ensureAccessible(AbstractByteBuf.java:1454)
	at io.netty.buffer.AbstractByteBuf.checkReadableBytes0(AbstractByteBuf.java:1440)
	at io.netty.buffer.AbstractByteBuf.readByte(AbstractByteBuf.java:730)
	at io.netty.buffer.ByteBufInputStream.read(ByteBufInputStream.java:172)
	at java.base/java.io.FilterInputStream.read(FilterInputStream.java:83)
	at java.base/java.io.FilterInputStream.read(FilterInputStream.java:83)
	at com.github.ambry.utils.CrcInputStream.read(CrcInputStream.java:47)
	at java.base/java.io.DataInputStream.readShort(DataInputStream.java:317)
	at com.github.ambry.messageformat.MessageFormatRecord.deserializeAndGetBlobWithVersion(MessageFormatRecord.java:230)
	at com.github.ambry.messageformat.MessageFormatRecord.deserializeBlob(MessageFormatRecord.java:223)
	at com.github.ambry.tools.admin.ServerAdminTool.getBlob(ServerAdminTool.java:636)
	at com.github.ambry.tools.admin.ServerAdminTool.main(ServerAdminTool.java:320)
```

So, supporting response's lifetime correctly would require adding much more code. As `ServerAdminTool` is just a command line utility performing short tasks, it is affordable to leak the memory