### PR TITLE
Upgrade to helix 1.1.0

### DIFF
--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -19,7 +19,7 @@ ext {
     javaxVersion = "3.0.1"
     nettyVersion = "4.1.74.Final"
     nettyTcnativeVersion = "2.0.42.Final"
-    helixVersion = "1.0.4"
+    helixVersion = "1.1.0"
     jacksonVersion = "2.10.2"
     jaydioVersion = "0.1"
     azureStorageBlobVersion = "12.15.0"


### PR DESCRIPTION
The helixBootstrapTool is used to bootstrap clusters and accesses zookeeper. We need to secure it by turning on ZK SSL and on-board to ACLs. For this we need to pull in latest zookeeper. Upgrade to helix 1.1.0 to pull in latest zookeeper 3.6.3+