### PR TITLE
Fix Leak in ReplicateBlob

### DIFF
--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageSievingInputStream.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageSievingInputStream.java
@@ -156,7 +156,9 @@ public class MessageSievingInputStream extends InputStream {
    */
   public static Message transferInputStream(List<Transformer> transformers, InputStream inStream, MessageInfo msgInfo)
       throws IOException {
-    Message msg = new Message(msgInfo, inStream);
+    // Read the entire stream out so the underlying transformer won't increase the ref counter for the GetResponse ByteBuf.
+    Message msg =
+        new Message(msgInfo, new ByteArrayInputStream(Utils.readBytesFromStream(inStream, (int) msgInfo.getSize())));
     if (transformers == null || transformers.isEmpty()) {
       // Write the message without any transformations.
       return msg;


### PR DESCRIPTION
This PR would fix a memory in ReplicateBlob request.

In ReplicateBlobRequest, ambry-server would issue GetRequest to remote host and get a GetResponse back. After that, ambry-server would go through a transformer to transform PutBlob. In BlobIdTransformer, we would increase the ref counter for the GetResponse's InputStream when it detects that the InputStream is a NettyByteBufDataInputStream. We didn't decrease the counter any where so there is a memory leak.

This PR fixes that, by creating a new InputStream and pass this new InputStream to transformer. Since this new InputStream is not a NettyByteBufDataInputStream, the ref counter is not going to be increased. Thus, we don't have memory leak issue.