### PR TITLE
Enable PutRequest format V5 and enable config by default.

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/CompressionConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/CompressionConfig.java
@@ -21,9 +21,9 @@ package com.github.ambry.config;
 public class CompressionConfig {
 
   // Boolean whether compression is enabled in PUT operation.
-  // TODO - Compression is disabled by default.  Need to enable after testing and verification.
+  // Compression is enabled by default.  It can be disabled using config.
   static final String COMPRESSION_ENABLED = "router.compression.enabled";
-  static final boolean DEFAULT_COMPRESSION_ENABLED = false;
+  static final boolean DEFAULT_COMPRESSION_ENABLED = true;
 
   // Whether to skip compression if content-encoding present.
   static final String SKIP_IF_CONTENT_ENCODED = "router.compression.skip.if.content.encoded";

--- a/ambry-api/src/main/java/com/github/ambry/config/CompressionConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/CompressionConfig.java
@@ -21,7 +21,7 @@ package com.github.ambry.config;
 public class CompressionConfig {
 
   // Boolean whether compression is enabled in PUT operation.
-  // Compression is enabled by default.  It can be disabled using config.
+  // TODO - Compression is disabled by default.  Need to enable after testing and verification.
   static final String COMPRESSION_ENABLED = "router.compression.enabled";
   static final boolean DEFAULT_COMPRESSION_ENABLED = false;
 

--- a/ambry-api/src/main/java/com/github/ambry/config/CompressionConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/CompressionConfig.java
@@ -23,7 +23,7 @@ public class CompressionConfig {
   // Boolean whether compression is enabled in PUT operation.
   // Compression is enabled by default.  It can be disabled using config.
   static final String COMPRESSION_ENABLED = "router.compression.enabled";
-  static final boolean DEFAULT_COMPRESSION_ENABLED = true;
+  static final boolean DEFAULT_COMPRESSION_ENABLED = false;
 
   // Whether to skip compression if content-encoding present.
   static final String SKIP_IF_CONTENT_ENCODED = "router.compression.skip.if.content.encoded";

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/PutRequest.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/PutRequest.java
@@ -76,13 +76,10 @@ public class PutRequest extends RequestOrResponse {
   private static final int IS_COMPRESSED_SIZE_IN_BYTES = 1;
   private static final int CRC_SIZE_IN_BYTES = Long.BYTES;
   private static final short PUT_REQUEST_VERSION_V3 = 3;
+  private static final short PUT_REQUEST_VERSION_V4 = 4;
+  private static final short PUT_REQUEST_VERSION_V5 = 5;
 
-  // TODO - The V4 and V5 constants are public to allow config to control the version during deployment and testing.
-  // After compression feature tested and deploy, it will be converted back to private.
-  public static final short PUT_REQUEST_VERSION_V4 = 4;
-  public static final short PUT_REQUEST_VERSION_V5 = 5;
-
-  public static short currentVersion = PUT_REQUEST_VERSION_V4;
+  private static short currentVersion = PUT_REQUEST_VERSION_V5;
 
   /**
    * Construct a PutRequest

--- a/ambry-protocol/src/test/java/com/github/ambry/protocol/RequestResponseTest.java
+++ b/ambry-protocol/src/test/java/com/github/ambry/protocol/RequestResponseTest.java
@@ -211,13 +211,11 @@ public class RequestResponseTest {
   private void testPutRequest(MockClusterMap clusterMap, int correlationId, String clientId, BlobId blobId,
       BlobProperties blobProperties, byte[] userMetadata, BlobType blobType, byte[] blob, int blobSize, byte[] blobKey)
       throws IOException {
-    doPutRequestTest((short) -1, clusterMap, correlationId, clientId, blobId, blobProperties, userMetadata, blobType,
-        blob, blobSize, blobKey, blobKey);
-    doPutRequestTest(PutRequest.PUT_REQUEST_VERSION_V4, clusterMap, correlationId, clientId, blobId, blobProperties,
+    doPutRequestTest((short) -1, clusterMap, correlationId, clientId, blobId, blobProperties,
         userMetadata, blobType, blob, blobSize, null, null);
-    doPutRequestTest(PutRequest.PUT_REQUEST_VERSION_V4, clusterMap, correlationId, clientId, blobId, blobProperties,
+    doPutRequestTest((short) -1, clusterMap, correlationId, clientId, blobId, blobProperties,
         userMetadata, blobType, blob, blobSize, new byte[0], null);
-    doPutRequestTest(PutRequest.PUT_REQUEST_VERSION_V4, clusterMap, correlationId, clientId, blobId, blobProperties,
+    doPutRequestTest((short) -1, clusterMap, correlationId, clientId, blobId, blobProperties,
         userMetadata, blobType, blob, blobSize, blobKey, blobKey);
   }
 
@@ -392,18 +390,11 @@ public class RequestResponseTest {
     BlobType blobType = BlobType.DataBlob;
     byte[] encryptionKey = new byte[]{1, 2, 3, 4, 5};
 
-    ByteBuf content;
-    short savedVersion = PutRequest.currentVersion;
-    try {
-      PutRequest.currentVersion = PutRequest.PUT_REQUEST_VERSION_V5;
-      // Compose and serialize the PutRequest with V5 enabled.
-      PutRequest request =
-          new PutRequest(correlationId, clientId, blobId, blobProperties, userMetadata, blobData, blobSize, blobType,
-              ByteBuffer.wrap(encryptionKey), true);
-      content = request.content();
-    } finally {
-      PutRequest.currentVersion = savedVersion;
-    }
+    // Compose and serialize the PutRequest with V5 enabled.
+    PutRequest request =
+        new PutRequest(correlationId, clientId, blobId, blobProperties, userMetadata, blobData, blobSize, blobType,
+            ByteBuffer.wrap(encryptionKey), true);
+    ByteBuf content = request.content();
 
     // Read back binary.  The content binary contains extra fields(total size and operation type).
     // Those extra fields must be read from the stream before calling readFrom().

--- a/ambry-router/src/main/java/com/github/ambry/router/CompressionService.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/CompressionService.java
@@ -124,11 +124,6 @@ public class CompressionService {
           + ", specified in config does not exist.  This default has changed to " + compressor.getAlgorithmName());
     }
     defaultCompressor = compressor;
-
-    // TODO - Temporary deployment control code that will be removed after testing and deployment.
-    if (config.isCompressionEnabled) {
-      PutRequest.currentVersion = PutRequest.PUT_REQUEST_VERSION_V5;
-    }
   }
 
   /**


### PR DESCRIPTION
According to Blob Compression deployment plan, the last step is enable PutRequest V5 in frontend and enable compression by default.