### PR TITLE
Enable compression by default.

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/CompressionConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/CompressionConfig.java
@@ -21,9 +21,8 @@ package com.github.ambry.config;
 public class CompressionConfig {
 
   // Boolean whether compression is enabled in PUT operation.
-  // TODO - Compression is disabled by default.  Need to enable after testing and verification.
   static final String COMPRESSION_ENABLED = "router.compression.enabled";
-  static final boolean DEFAULT_COMPRESSION_ENABLED = false;
+  static final boolean DEFAULT_COMPRESSION_ENABLED = true;
 
   // Whether to skip compression if content-encoding present.
   static final String SKIP_IF_CONTENT_ENCODED = "router.compression.skip.if.content.encoded";


### PR DESCRIPTION
Compression structure changes and implementation have been tested. Compression end-to-end also tested in Perf environment. This change enable compression by default.  In case something goes wrong, it can be disabled by ambry-frontend-config entry <property name="ambry.routerCompressionEnabled" value="false" />