### PR TITLE
Downgrade azure sdk

### DIFF
--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -24,7 +24,7 @@ ext {
     jaydioVersion = "0.1"
     azureStorageBlobVersion = "12.15.0"
     azureStorageBlobBatchVersion = "12.12.0"
-    azureCosmosDbAsyncVersion = "4.37.0"
+    azureCosmosDbAsyncVersion = "4.29.1"
     azureMsal4jVersion="1.7.1"
     azureMsalClientCredentialVersion="1.0.0"
     azureIdentityVersion= "1.3.6"


### PR DESCRIPTION
Azure sdk 4.39 pulls in netty 4.1.82 which does not have a method bioSetFd used by SSL in ambry. So as a short term solution, we downgrade azure sdk.