### PR TITLE
GetBlob return 503 if fails due to originating DC replicas are offline.

### DIFF
--- a/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
@@ -1007,7 +1007,10 @@ class GetBlobOperation extends GetOperation {
       if (progressTracker.isDone()) {
         if (progressTracker.hasSucceeded() && !retainChunkExceptionOnSuccess) {
           chunkException = null;
-        } else if (chunkOperationTracker.hasFailedOnNotFound()) {
+        } else if (chunkOperationTracker.maybeFailedDueToOfflineReplicas()) {
+          chunkException =
+              buildChunkException("Get Chunk failed because of offline replicas", RouterErrorCode.AmbryUnavailable);
+        } else if (chunkOperationTracker.hasFailedOnNotFound()){
           chunkException =
               buildChunkException("Get Chunk failed because of BlobNotFound", RouterErrorCode.BlobDoesNotExist);
         }

--- a/ambry-router/src/test/java/com/github/ambry/router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/GetBlobOperationTest.java
@@ -19,9 +19,11 @@ import com.github.ambry.account.InMemAccountService;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.clustermap.MockDataNodeId;
 import com.github.ambry.clustermap.MockPartitionId;
+import com.github.ambry.clustermap.MockReplicaId;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.clustermap.PartitionState;
 import com.github.ambry.clustermap.ReplicaId;
+import com.github.ambry.clustermap.ReplicaState;
 import com.github.ambry.commons.AmbryCache;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.BlobIdFactory;
@@ -840,6 +842,153 @@ public class GetBlobOperationTest {
     props.setProperty("router.datacenter.name", oldLocal);
     props.setProperty("router.get.request.parallelism", "2");
     props.setProperty("router.operation.tracker.max.inflight.requests", "2");
+    routerConfig = new RouterConfig(new VerifiableProperties(props));
+  }
+
+  /**
+   * Test the case where two origin replicas are down and not in the clustermap, all others return NOT_FOUND.
+   * Expect Ambry Unavailable for GetBlob
+   * @throws Exception
+   */
+  @Test
+  public void testBlobOriginDcTwoDownAndOthersNotFound() throws Exception {
+    assumeTrue(operationTrackerType.equals(AdaptiveOperationTracker.class.getSimpleName()));
+    doPut();
+
+    MockPartitionId partitionId = (MockPartitionId) blobId.getPartition();
+    // Pick a remote DC as the new local DC.
+    Properties props = getDefaultNonBlockingRouterProperties(true);
+    String newLocal = "DC1";
+    String oldLocal = localDcName;
+    String oldPropTerminate = props.getProperty("router.operation.tracker.terminate.on.not.found.enabled");
+    String oldPropOffline = props.getProperty("router.unavailable.due.to.offline.replicas");
+    String oldPropGetEligible = props.getProperty("router.get.eligible.replicas.by.state.enabled");
+    props.setProperty("router.datacenter.name", newLocal);
+    props.setProperty("router.operation.tracker.terminate.on.not.found.enabled", "false");
+    props.setProperty("router.unavailable.due.to.offline.replicas", "true");
+    props.setProperty("router.get.eligible.replicas.by.state.enabled", "true");
+    routerConfig = new RouterConfig(new VerifiableProperties(props));
+
+    // change replica state.
+    // set two originating replica state to ERROR. exclude them from the eligible replica pool.
+    List<ReplicaId> replicaIds = partitionId.getReplicaIds();
+    int i = 0;
+    for (ReplicaId replicaId : replicaIds) {
+      MockReplicaId r = (MockReplicaId) replicaId;
+      // set two originating replica state to ERROR.
+      if (r.getDataNodeId().getDatacenterName().equals(oldLocal) && i < 2) {
+        partitionId.setReplicaState(r, ReplicaState.ERROR);
+        i++;
+      }
+    }
+
+    GetBlobOperation op = createOperation(routerConfig, null);
+    correlationIdToGetOperation.clear();
+    // all return Blob_Not_Found
+    for (MockServer server : mockServerLayout.getMockServers()) {
+      server.setServerErrorForAllRequests(ServerErrorCode.Blob_Not_Found);
+    }
+    op.poll(requestRegistrationCallback);
+
+    while (!op.isOperationComplete()) {
+      op.poll(requestRegistrationCallback);
+      List<ResponseInfo> responses = sendAndWaitForResponses(requestRegistrationCallback.getRequestsToSend());
+      for (ResponseInfo responseInfo : responses) {
+        GetResponse getResponse = responseInfo.getError() == null ? GetResponse.readFrom(
+            new NettyByteBufDataInputStream(responseInfo.content()), mockClusterMap) : null;
+        op.handleResponse(responseInfo, getResponse);
+        responseInfo.release();
+      }
+    }
+
+    RouterException routerException = (RouterException) op.getOperationException();
+    Assert.assertEquals(RouterErrorCode.AmbryUnavailable, routerException.getErrorCode());
+
+    props = getDefaultNonBlockingRouterProperties(true);
+    props.setProperty("router.datacenter.name", oldLocal);
+    if (oldPropTerminate != null) {
+      props.setProperty("router.operation.tracker.terminate.on.not.found.enabled", oldPropTerminate);
+    }
+    if (oldPropOffline != null) {
+      props.setProperty("router.unavailable.due.to.offline.replicas", oldPropOffline);
+    }
+    if (oldPropGetEligible != null) {
+      props.setProperty("router.get.eligible.replicas.by.state.enabled", oldPropGetEligible);
+    }
+    routerConfig = new RouterConfig(new VerifiableProperties(props));
+  }
+
+  /**
+   * Test the case where two remote replicas are down and not in the clustermap,
+   * all others return NOT_FOUND including originating replicas.
+   * Expect Not Found for GetBlob
+   * @throws Exception
+   */
+  @Test
+  public void testBlobRemoteTwoDownAndOthersNotFound() throws Exception {
+    assumeTrue(operationTrackerType.equals(AdaptiveOperationTracker.class.getSimpleName()));
+    doPut();
+
+    MockPartitionId partitionId = (MockPartitionId) blobId.getPartition();
+    // Pick a remote DC as the new local DC.
+    Properties props = getDefaultNonBlockingRouterProperties(true);
+    String newLocal = "DC1";
+    String oldLocal = localDcName;
+    String oldPropTerminate = props.getProperty("router.operation.tracker.terminate.on.not.found.enabled");
+    String oldPropOffline = props.getProperty("router.unavailable.due.to.offline.replicas");
+    String oldPropGetEligible = props.getProperty("router.get.eligible.replicas.by.state.enabled");
+    props.setProperty("router.datacenter.name", newLocal);
+    props.setProperty("router.operation.tracker.terminate.on.not.found.enabled", "false");
+    props.setProperty("router.unavailable.due.to.offline.replicas", "true");
+    props.setProperty("router.get.eligible.replicas.by.state.enabled", "true");
+    routerConfig = new RouterConfig(new VerifiableProperties(props));
+
+    // change replica state.
+    // set two remote replica state to ERROR. exclude them from the eligible replica pool.
+    List<ReplicaId> replicaIds = partitionId.getReplicaIds();
+    int i = 0;
+    for (ReplicaId replicaId : replicaIds) {
+      MockReplicaId r = (MockReplicaId) replicaId;
+      // set two originating replica state to ERROR.
+      if (r.getDataNodeId().getDatacenterName().equals(newLocal) && i < 2) {
+        partitionId.setReplicaState(r, ReplicaState.ERROR);
+        i++;
+      }
+    }
+
+    GetBlobOperation op = createOperation(routerConfig, null);
+    correlationIdToGetOperation.clear();
+    // all return Blob_Not_Found
+    for (MockServer server : mockServerLayout.getMockServers()) {
+      server.setServerErrorForAllRequests(ServerErrorCode.Blob_Not_Found);
+    }
+    op.poll(requestRegistrationCallback);
+
+    while (!op.isOperationComplete()) {
+      op.poll(requestRegistrationCallback);
+      List<ResponseInfo> responses = sendAndWaitForResponses(requestRegistrationCallback.getRequestsToSend());
+      for (ResponseInfo responseInfo : responses) {
+        GetResponse getResponse = responseInfo.getError() == null ? GetResponse.readFrom(
+            new NettyByteBufDataInputStream(responseInfo.content()), mockClusterMap) : null;
+        op.handleResponse(responseInfo, getResponse);
+        responseInfo.release();
+      }
+    }
+
+    RouterException routerException = (RouterException) op.getOperationException();
+    Assert.assertEquals(RouterErrorCode.BlobDoesNotExist, routerException.getErrorCode());
+
+    props = getDefaultNonBlockingRouterProperties(true);
+    props.setProperty("router.datacenter.name", oldLocal);
+    if (oldPropTerminate != null) {
+      props.setProperty("router.operation.tracker.terminate.on.not.found.enabled", oldPropTerminate);
+    }
+    if (oldPropOffline != null) {
+      props.setProperty("router.unavailable.due.to.offline.replicas", oldPropOffline);
+    }
+    if (oldPropGetEligible != null) {
+      props.setProperty("router.get.eligible.replicas.by.state.enabled", oldPropGetEligible);
+    }
     routerConfig = new RouterConfig(new VerifiableProperties(props));
   }
 

--- a/ambry-router/src/test/java/com/github/ambry/router/OperationTrackerTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/OperationTrackerTest.java
@@ -463,23 +463,26 @@ public class OperationTrackerTest {
 
   /**
    * Duplicate the GCN issue:
-   * Among the 9 replicas, 8 replicas were offline due to OOM, 1 replica was online and returned DISK_DOWN
-   * Helix external view only showed one replica. The 8 replicas were NOT in the ReplicaState.OFFLINE list.
+   * Among the 9 replicas, some are ERROR(in the GCN case, these are not listed in the Helix external view.
+   * All the eligible replica returns either DiskDown or NotFound.
+   * Originating Colo only has 1 replica in the eligible replica, so we return Ambry Unavailable instead of Not_Found.
    */
   @Test
-  public void getOperationWithReplicaStateTest2() {
+  public void getOperationFailDueToNotFoundWithOriginatingTwoDown() {
     assumeTrue(replicasStateEnabled);
     assumeTrue(routerUnavailableDueToOfflineReplicas);
 
     List<Port> portList = Collections.singletonList(new Port(PORT, PortType.PLAINTEXT));
     List<String> mountPaths = Collections.singletonList("mockMountPath");
-    datanodes = new ArrayList<>(Arrays.asList(
-        new MockDataNodeId(portList, mountPaths, "dc-0"),
-        new MockDataNodeId(portList, mountPaths, "dc-1"),
-        new MockDataNodeId(portList, mountPaths, "dc-2")));
+    MockDataNodeId localDcNode = new MockDataNodeId(portList, mountPaths, "dc-0");
+    MockDataNodeId remoteNode1 = new MockDataNodeId(portList, mountPaths, "dc-1");
+    MockDataNodeId remoteNode2 = new MockDataNodeId(portList, mountPaths, "dc-2");
+    datanodes = new ArrayList<>(Arrays.asList(localDcNode, remoteNode1, remoteNode2));
     mockPartition = new MockPartitionId();
-    populateReplicaList(1, ReplicaState.LEADER);
-    populateReplicaList(8, ReplicaState.ERROR);
+    populateReplicaList(1, ReplicaState.LEADER, Collections.singletonList(localDcNode));
+    populateReplicaList(2, ReplicaState.ERROR, Collections.singletonList(localDcNode));
+    populateReplicaList(3, ReplicaState.OFFLINE, Collections.singletonList(remoteNode1));
+    populateReplicaList(3, ReplicaState.OFFLINE, Collections.singletonList(remoteNode2));
 
     localDcName = datanodes.get(0).getDatacenterName();
     originatingDcName = localDcName;
@@ -489,8 +492,22 @@ public class OperationTrackerTest {
     ReplicaId inflightReplica;
     sendRequests(ot, 1, false);
     inflightReplica = inflightReplicas.poll();
+    assertNotSame("Replica state should not be OFFLINE ", mockPartition.replicaAndState.get(inflightReplica),
+        ReplicaState.OFFLINE);
     ot.onResponse(inflightReplica, TrackedRequestFinalState.DISK_DOWN);
-    assertTrue("Operation should be done", ot.isDone());
+    assertFalse("Operation should not complete", ot.isDone());
+
+    for (int i = 0; i < 6; ++i) {
+      sendRequests(ot, 1, false);
+      inflightReplica = inflightReplicas.poll();
+      ot.onResponse(inflightReplica, TrackedRequestFinalState.NOT_FOUND);
+      if (i == 5) {
+        // the last one
+        assertTrue("Operation should complete", ot.isDone());
+      } else {
+        assertFalse("Operation should not complete", ot.isDone());
+      }
+    }
     assertTrue(ot.maybeFailedDueToOfflineReplicas());
     assertTrue(ot.hasFailedOnNotFound());
 
@@ -502,6 +519,69 @@ public class OperationTrackerTest {
     ot.onResponse(inflightReplica, TrackedRequestFinalState.DISK_DOWN);
     assertTrue("Operation should be done", ot.isDone());
     assertTrue(ot.maybeFailedDueToOfflineReplicas());
+    assertTrue(ot.hasFailedOnNotFound());
+  }
+
+  /**
+   * Duplicate the GCN issue:
+   * Among the 9 replicas, some are ERROR(in the GCN case, these are not listed in the Helix external view.
+   * All the eligible replica returns either DiskDown or NotFound.
+   * Originating Colo has 2 replica in the eligible replica, so we return NOT_FOUND.
+   */
+  @Test
+  public void getOperationFailDueToNotFoundWithOriginatingTwoOnline() {
+    assumeTrue(replicasStateEnabled);
+    assumeTrue(routerUnavailableDueToOfflineReplicas);
+
+    List<Port> portList = Collections.singletonList(new Port(PORT, PortType.PLAINTEXT));
+    List<String> mountPaths = Collections.singletonList("mockMountPath");
+    MockDataNodeId localDcNode = new MockDataNodeId(portList, mountPaths, "dc-0");
+    MockDataNodeId remoteNode1 = new MockDataNodeId(portList, mountPaths, "dc-1");
+    MockDataNodeId remoteNode2 = new MockDataNodeId(portList, mountPaths, "dc-2");
+    datanodes = new ArrayList<>(Arrays.asList(localDcNode, remoteNode1, remoteNode2));
+    mockPartition = new MockPartitionId();
+    populateReplicaList(2, ReplicaState.STANDBY, Collections.singletonList(localDcNode));
+    populateReplicaList(1, ReplicaState.OFFLINE, Collections.singletonList(localDcNode));
+    populateReplicaList(3, ReplicaState.ERROR, Collections.singletonList(remoteNode1));
+    populateReplicaList(3, ReplicaState.OFFLINE, Collections.singletonList(remoteNode2));
+
+    localDcName = datanodes.get(0).getDatacenterName();
+    originatingDcName = localDcName;
+    mockClusterMap = new MockClusterMap(false, datanodes, 1, Collections.singletonList(mockPartition), localDcName);
+    // 1. include down replicas (OFFLINE replicas are eligible for GET)
+    OperationTracker ot = getOperationTrackerForGetOrPut(true, 1, 1, RouterOperation.GetBlobOperation, true);
+    ReplicaId inflightReplica;
+    // two originating returns DISK_DOWN or NOT_FOUND
+    sendRequests(ot, 1, false);
+    inflightReplica = inflightReplicas.poll();
+    ot.onResponse(inflightReplica, TrackedRequestFinalState.DISK_DOWN);
+    assertFalse("Operation should not complete", ot.isDone());
+    sendRequests(ot, 1, false);
+    inflightReplica = inflightReplicas.poll();
+    ot.onResponse(inflightReplica, TrackedRequestFinalState.NOT_FOUND);
+    assertFalse("Operation should not complete", ot.isDone());
+    //ROUTER_OPERATION_TRACKER_TERMINATE_ON_NOT_FOUND_ENABLED is enabled in the test.
+    //Although there are 6 replicas, it'll go through the originating replica only.
+    sendRequests(ot, 1, false);
+    inflightReplica = inflightReplicas.poll();
+    ot.onResponse(inflightReplica, TrackedRequestFinalState.NOT_FOUND);
+    assertTrue("Operation should complete", ot.isDone());
+    assertFalse(ot.maybeFailedDueToOfflineReplicas());
+    assertTrue(ot.hasFailedOnNotFound());
+
+    // 2. exclude down replicas
+    repetitionTracker.clear();
+    ot = getOperationTrackerForGetOrPut(true, 1, 1, RouterOperation.GetBlobOperation, false);
+    // two originating returns DISK_DOWN
+    sendRequests(ot, 1, false);
+    inflightReplica = inflightReplicas.poll();
+    ot.onResponse(inflightReplica, TrackedRequestFinalState.DISK_DOWN);
+    assertFalse("Operation should not complete", ot.isDone());
+    sendRequests(ot, 1, false);
+    inflightReplica = inflightReplicas.poll();
+    ot.onResponse(inflightReplica, TrackedRequestFinalState.NOT_FOUND);
+    assertTrue("Operation should not complete", ot.isDone());
+    assertFalse(ot.maybeFailedDueToOfflineReplicas());
     assertTrue(ot.hasFailedOnNotFound());
   }
 

--- a/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockPartitionId.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockPartitionId.java
@@ -182,6 +182,8 @@ public class MockPartitionId implements PartitionId {
    */
   public void setReplicaState(ReplicaId replicaId, ReplicaState state) {
     replicaAndState.computeIfPresent(replicaId, (k, v) -> state);
+    MockReplicaId r = (MockReplicaId) replicaId;
+    r.setReplicaState(state);
   }
 
   /**


### PR DESCRIPTION
For GetBlob, iff eligible replicas from the originating DC is less than 2 and operation fails, we return retryable status 503.
