### PR TITLE
Frontend: Fix size mismatch error for compressed blobs in GetBlobOperations

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/CompressionConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/CompressionConfig.java
@@ -21,8 +21,8 @@ package com.github.ambry.config;
 public class CompressionConfig {
 
   // Boolean whether compression is enabled in PUT operation.
-  static final String COMPRESSION_ENABLED = "router.compression.enabled";
-  static final boolean DEFAULT_COMPRESSION_ENABLED = true;
+  public static final String COMPRESSION_ENABLED = "router.compression.enabled";
+  static final boolean DEFAULT_COMPRESSION_ENABLED = false;
 
   // Whether to skip compression if content-encoding present.
   static final String SKIP_IF_CONTENT_ENCODED = "router.compression.skip.if.content.encoded";


### PR DESCRIPTION
After enabling compression, we saw lots of size mismatch error log in frontend. Turns out it's because we are setting the blob size in blob properties to the size of compressed content. This PR fixes it.

Along with the fix, this PR also does:
1. Add more test cases for compression in GetBlobOperation
2. Set the default value of compression to false. We should use configuration file to change the value.