### PR TITLE
Remove some unused server configurations wrt storage stats

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
@@ -33,7 +33,6 @@ public class ClusterMapConfig {
   public static final String AMBRY_STATE_MODEL_DEF = "AmbryLeaderStandby";
   public static final String OLD_STATE_MODEL_DEF = "LeaderStandby";
   public static final String DEFAULT_STATE_MODEL_DEF = AMBRY_STATE_MODEL_DEF;
-  public static final String ENABLE_MYSQL_AGGREGATION_TASK = "clustermap.enable.mysql.aggregation.task";
   public static final String ENABLE_DELETE_INVALID_DATA_IN_MYSQL_AGGREGATION_TASK =
       "clustermap.enable.delete.invalid.data.in.mysql.aggregation.task";
   public static final String ENABLE_AGGREGATED_MONTHLY_ACCOUNT_REPORT =
@@ -324,13 +323,6 @@ public class ClusterMapConfig {
   public final boolean clustermapEnableAggregatedMonthlyAccountReport;
 
   /**
-   * True to enable aggregation task of stats data in mysql database.
-   */
-  @Config(ENABLE_MYSQL_AGGREGATION_TASK)
-  @Default("false")
-  public final boolean clustermapEnableMySqlAggregationTask;
-
-  /**
    * True to enable deleting invalid aggregated data in mysql aggregation task.
    */
   @Config(ENABLE_DELETE_INVALID_DATA_IN_MYSQL_AGGREGATION_TASK)
@@ -401,7 +393,6 @@ public class ClusterMapConfig {
     clustermapRetryDisablePartitionCompletionBackoffMs =
         verifiableProperties.getIntInRange("clustermap.retry.disable.partition.completion.backoff.ms", 10 * 1000, 1,
             Integer.MAX_VALUE);
-    clustermapEnableMySqlAggregationTask = verifiableProperties.getBoolean(ENABLE_MYSQL_AGGREGATION_TASK, false);
     clustermapEnableAggregatedMonthlyAccountReport =
         verifiableProperties.getBoolean(ENABLE_AGGREGATED_MONTHLY_ACCOUNT_REPORT, false);
     clustermapEnableDeleteInvalidDataInMysqlAggregationTask =

--- a/ambry-api/src/main/java/com/github/ambry/config/ServerConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/ServerConfig.java
@@ -38,20 +38,6 @@ public class ServerConfig {
   public final int serverSchedulerNumOfthreads;
 
   /**
-   * The option to enable or disable publishing stats locally.
-   */
-  @Config("server.stats.publish.local.enabled")
-  @Default("false")
-  public final boolean serverStatsPublishLocalEnabled;
-
-  /**
-   * The option to enable or disable publishing stats reports
-   */
-  @Config("server.stats.publish.report.enabled")
-  @Default("false")
-  public final boolean serverStatsPublishReportEnabled;
-
-  /**
    * The frequency in mins at which cluster wide quota stats will be aggregated
    */
   @Config("server.quota.stats.aggregate.interval.in.minutes")
@@ -73,7 +59,7 @@ public class ServerConfig {
   public final String serverMessageTransformer;
 
   /**
-   * The comma separated list of stats reports to publish in Helix.
+   * The comma separated list of stats reports to aggregate and then publish to AccountStatsStore.
    */
   @Config("server.stats.reports.to.publish")
   @Default("")
@@ -117,17 +103,14 @@ public class ServerConfig {
   public ServerConfig(VerifiableProperties verifiableProperties) {
     serverRequestHandlerNumOfThreads = verifiableProperties.getInt("server.request.handler.num.of.threads", 7);
     serverSchedulerNumOfthreads = verifiableProperties.getInt("server.scheduler.num.of.threads", 10);
-    serverStatsPublishLocalEnabled = verifiableProperties.getBoolean("server.stats.publish.local.enabled", false);
-    serverStatsPublishReportEnabled =
-        verifiableProperties.getBoolean("server.stats.publish.report.enabled", false);
+    serverStatsReportsToPublish =
+        Utils.splitString(verifiableProperties.getString("server.stats.reports.to.publish", ""), ",");
     serverQuotaStatsAggregateIntervalInMinutes =
         verifiableProperties.getLong("server.quota.stats.aggregate.interval.in.minutes", 60);
     serverStoreKeyConverterFactory = verifiableProperties.getString("server.store.key.converter.factory",
         "com.github.ambry.store.StoreKeyConverterFactoryImpl");
     serverMessageTransformer = verifiableProperties.getString("server.message.transformer",
         "com.github.ambry.messageformat.ValidatingTransformer");
-    serverStatsReportsToPublish =
-        Utils.splitString(verifiableProperties.getString("server.stats.reports.to.publish", ""), ",");
     serverValidateRequestBasedOnStoreState =
         verifiableProperties.getBoolean("server.validate.request.based.on.store.state", false);
     serverHandleUndeleteRequestEnabled =

--- a/ambry-api/src/main/java/com/github/ambry/config/StatsManagerConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StatsManagerConfig.java
@@ -23,31 +23,31 @@ import java.util.List;
  * The configs for stats.
  */
 public class StatsManagerConfig {
-  public static final String STATS_OUTPUT_FILE_PATH = "stats.output.file.path";
+  public static final String STATS_ENABLE_MYSQL_REPORT = "stats.enable.mysql.report";
   public static final String STATS_PUBLISH_PERIOD_IN_SECS = "stats.publish.period.in.secs";
   public static final String STATS_INITIAL_DELAY_UPPER_BOUND_IN_SECS = "stats.initial.delay.upper.bound.in.secs";
-  public static final String STATS_ENABLE_MYSQL_REPORT = "stats.enable.mysql.report";
-  public static final String STATS_HEALTH_REPORT_EXCLUDE_ACCOUNT_NAMES = "stats.health.report.exclude.account.names";
   public static final String STATS_PUBLISH_EXCLUDE_ACCOUNT_NAMES = "stats.publish.exclude.account.names";
   public static final String STATS_PUBLISH_PARTITION_CLASS_REPORT_PERIOD_IN_SECS =
       "stats.publish.partition.class.report.period.in.secs";
 
   /**
-   * The file path (including filename) to be used for publishing the stats.
+   * True to enable publishing stats to mysql database. StatsManager is tightly coupled with mysql database for now.
+   * Enable mysql report is the only way to enable stats reports.
    */
-  @Config(STATS_OUTPUT_FILE_PATH)
-  @Default("/tmp/stats_output.json")
-  public final String outputFilePath;
+  @Config(STATS_ENABLE_MYSQL_REPORT)
+  @Default("false")
+  public final boolean enableMysqlReport;
 
   /**
-   * The time period in seconds that configures how often stats are published.
+   * The time period in seconds that configures how often account stats are published. This configuration is only useful
+   * when {@link #STATS_ENABLE_MYSQL_REPORT} is true.
    */
   @Config(STATS_PUBLISH_PERIOD_IN_SECS)
   @Default("7200")
   public final long publishPeriodInSecs;
 
   /**
-   * The upper bound for the initial delay in seconds before the first stats collection is triggered. The delay is a
+   * The upper bound for the initial delay in seconds before the first account stats collection is triggered. The delay is a
    * random number b/w 0 (inclusive) and this number (exclusive). If no initial delay is desired, this can be set to 0.
    */
   @Config(STATS_INITIAL_DELAY_UPPER_BOUND_IN_SECS)
@@ -55,22 +55,7 @@ public class StatsManagerConfig {
   public final int initialDelayUpperBoundInSecs;
 
   /**
-   * True to enable publishing stats to mysql database
-   */
-  @Config(STATS_ENABLE_MYSQL_REPORT)
-  @Default("false")
-  public final boolean enableMysqlReport;
-
-  /**
-   * The account names to exclude from the health report. Multiple account names should be separated with ",".
-   */
-  @Config(STATS_HEALTH_REPORT_EXCLUDE_ACCOUNT_NAMES)
-  @Default("")
-  public final List<String> healthReportExcludeAccountNames;
-
-  /**
-   * The account names to exclude from publishing to local disk and mysql database. Multiple account names should be
-   * separated with ",".
+   * The account names to exclude from publishing to mysql database. Multiple account names should be separated with ",".
    */
   @Config(STATS_PUBLISH_EXCLUDE_ACCOUNT_NAMES)
   @Default("")
@@ -85,15 +70,11 @@ public class StatsManagerConfig {
   public final long publishPartitionClassReportPeriodInSecs;
 
   public StatsManagerConfig(VerifiableProperties verifiableProperties) {
-    outputFilePath = verifiableProperties.getString(STATS_OUTPUT_FILE_PATH, "/tmp/stats_output.json");
     publishPeriodInSecs = verifiableProperties.getLongInRange(STATS_PUBLISH_PERIOD_IN_SECS, 7200, 0, Long.MAX_VALUE);
     initialDelayUpperBoundInSecs =
         verifiableProperties.getIntInRange(STATS_INITIAL_DELAY_UPPER_BOUND_IN_SECS, 600, 0, Integer.MAX_VALUE);
     enableMysqlReport = verifiableProperties.getBoolean(STATS_ENABLE_MYSQL_REPORT, false);
-    String excludeNames = verifiableProperties.getString(STATS_HEALTH_REPORT_EXCLUDE_ACCOUNT_NAMES, "").trim();
-    healthReportExcludeAccountNames =
-        excludeNames.isEmpty() ? Collections.EMPTY_LIST : Arrays.asList(excludeNames.split(","));
-    excludeNames = verifiableProperties.getString(STATS_PUBLISH_EXCLUDE_ACCOUNT_NAMES, "").trim();
+    String excludeNames = verifiableProperties.getString(STATS_PUBLISH_EXCLUDE_ACCOUNT_NAMES, "").trim();
     publishExcludeAccountNames =
         excludeNames.isEmpty() ? Collections.EMPTY_LIST : Arrays.asList(excludeNames.split(","));
     publishPartitionClassReportPeriodInSecs =

--- a/ambry-mysql/src/main/java/com/github/ambry/accountstats/AccountStatsMySqlStore.java
+++ b/ambry-mysql/src/main/java/com/github/ambry/accountstats/AccountStatsMySqlStore.java
@@ -158,7 +158,6 @@ public class AccountStatsMySqlStore implements AccountStatsStore {
    * @param dataSource The {@link DataSource}.
    * @param clusterName  The name of the cluster, like Ambry-test.
    * @param hostname The name of the host.
-   * @param localBackupFilePath The filepath to local backup file.
    * @param hostnameHelper The {@link HostnameHelper} to simplify the hostname.
    * @param registry The {@link MetricRegistry}.
    */

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryServer.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryServer.java
@@ -271,9 +271,7 @@ public class AmbryServer {
               clusterMapConfig, registry).getAccountStatsStore() : null;
       statsManager = new StatsManager(storageManager, clusterMap.getReplicaIds(nodeId), registry, statsConfig, time,
           clusterParticipants.get(0), accountStatsMySqlStore, accountService);
-      if (serverConfig.serverStatsPublishLocalEnabled) {
-        statsManager.start();
-      }
+      statsManager.start();
 
       ArrayList<Port> ports = new ArrayList<Port>();
       ports.add(new Port(networkConfig.port, PortType.PLAINTEXT));
@@ -321,7 +319,13 @@ public class AmbryServer {
       for (StatsReportType type : StatsReportType.values()) {
         validStatsTypes.add(type.toString());
       }
-      if (serverConfig.serverStatsPublishReportEnabled) {
+
+      // StatsManager would publish account stats to AccountStatsStore, and optionally publish partition class stats
+      // as well. So if serverStatsReportsToPublish contains PARTITION_CLASS_REPORT, then be sure to enable partition
+      // class stats with StatsManagerConfig.publishPartitionClassReportPeriodInSecs.
+      // Also, since StatsManager is tightly coupled with mysql database right now, if variable accountStatsMySqlStore
+      // is null, there is no report to aggregate and publish.
+      if (!serverConfig.serverStatsReportsToPublish.isEmpty() && accountStatsMySqlStore != null) {
         serverConfig.serverStatsReportsToPublish.forEach(e -> {
           if (validStatsTypes.contains(e)) {
             ambryStatsReports.add(new AmbryStatsReportImpl(serverConfig.serverQuotaStatsAggregateIntervalInMinutes,

--- a/ambry-server/src/test/java/com/github/ambry/server/StatsManagerTest.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/StatsManagerTest.java
@@ -179,7 +179,6 @@ public class StatsManagerTest {
     String excludedAccountNames = "account0,account10";
     Properties properties = new Properties();
     properties.put(StatsManagerConfig.STATS_PUBLISH_EXCLUDE_ACCOUNT_NAMES, excludedAccountNames);
-    properties.put(StatsManagerConfig.STATS_HEALTH_REPORT_EXCLUDE_ACCOUNT_NAMES, excludedAccountNames);
     StatsManagerConfig newStatsManagerConfig = new StatsManagerConfig(new VerifiableProperties(properties));
     // prepare account service, we are only going to fetch account0, and account10
     inMemoryAccountService.updateAccounts(
@@ -187,10 +186,7 @@ public class StatsManagerTest {
     StatsManager testManager =
         new StatsManager(storageManager, replicas, new MetricRegistry(), newStatsManagerConfig, new MockTime(), null,
             null, inMemoryAccountService);
-    List<Short> ids = testManager.getHealthReportExcludeAccountIds();
-    assertEquals(1, ids.size());
-    assertEquals((short) 0, ids.get(0).shortValue());
-    ids = testManager.getPublishExcludeAccountIds();
+    List<Short> ids = testManager.getPublishExcludeAccountIds();
     assertEquals(1, ids.size());
     assertEquals((short) 0, ids.get(0).shortValue());
   }
@@ -283,9 +279,8 @@ public class StatsManagerTest {
       Map<Short, Map<Short, ContainerStorageStats>> containerStatsMapForPartition =
           hostAccountStorageStatsMap.get(partitionId.getId());
       if (partitionId.getId() < 3) {
-        assertEquals("Actual map does not match with expected snapshot with partition id "
-                + partitionId.toPathString(), hostAccountStorageStats.getStorageStats().get(partitionId.getId()),
-            containerStatsMapForPartition);
+        assertEquals("Actual map does not match with expected snapshot with partition id " + partitionId.toPathString(),
+            hostAccountStorageStats.getStorageStats().get(partitionId.getId()), containerStatsMapForPartition);
       }
     }
   }


### PR DESCRIPTION
When switching from helix to mysql database for stats publishing, we added lots of configurations that are not used any where. This PR would remove those configurations and make thing simpler.