### PR TITLE
Updates to Helix aggregated view

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/clustermap/ClusterMapSnapshotConstants.java
+++ b/ambry-api/src/main/java/com/github/ambry/clustermap/ClusterMapSnapshotConstants.java
@@ -56,7 +56,7 @@ public class ClusterMapSnapshotConstants {
   // partitions
   public static final String PARTITION_ID = "id";
   public static final String PARTITION_CLASS = "class";
-  public static final String PARTITION_RESOURCE_NAME = "resourceName";
+  public static final String PARTITION_RESOURCE_NAMES = "resourceNames";
   public static final String PARTITION_WRITE_STATE = "writeState";
   public static final String PARTITION_REPLICAS = "replicas";
 

--- a/ambry-api/src/main/java/com/github/ambry/clustermap/PartitionId.java
+++ b/ambry-api/src/main/java/com/github/ambry/clustermap/PartitionId.java
@@ -91,9 +91,9 @@ public interface PartitionId extends Resource, Comparable<PartitionId> {
   String getPartitionClass();
 
   /**
-   * @return the resource name which this partition belongs to. Can be null if resource is not defined or applicable.
+   * @return the resource names which this partition belongs to. Can be null if resource is not defined or applicable.
    */
-  default String getResourceName() {
+  default List<String> getResourceNames() {
     return null;
   }
 }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryPartition.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryPartition.java
@@ -157,8 +157,8 @@ public class AmbryPartition implements PartitionId {
   }
 
   @Override
-  public String getResourceName() {
-    return clusterManagerQueryHelper.getResourceNameForPartition(this);
+  public List<String> getResourceNames() {
+    return clusterManagerQueryHelper.getResourceNamesForPartition(this);
   }
 
   @Override
@@ -167,7 +167,7 @@ public class AmbryPartition implements PartitionId {
     snapshot.put(PARTITION_ID, toPathString());
     snapshot.put(PARTITION_WRITE_STATE, getPartitionState().name());
     snapshot.put(PARTITION_CLASS, getPartitionClass());
-    snapshot.put(PARTITION_RESOURCE_NAME, getResourceName());
+    snapshot.put(PARTITION_RESOURCE_NAMES, getResourceNames());
     JSONArray replicas = new JSONArray();
     getReplicaIds().forEach(replica -> replicas.put(replica.getSnapshot()));
     snapshot.put(PARTITION_REPLICAS, replicas);

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterManagerQueryHelper.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterManagerQueryHelper.java
@@ -37,7 +37,7 @@ interface ClusterManagerQueryHelper<R extends ReplicaId, D extends DiskId, P ext
    * @param partition the {@link PartitionId} for which to get the resource name.
    * @return the resource name associated with given partition.
    */
-  default String getResourceNameForPartition(P partition) {
+  default List<String> getResourceNamesForPartition(P partition) {
     return null;
   }
 

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixAggregatedViewClusterInfo.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixAggregatedViewClusterInfo.java
@@ -18,6 +18,7 @@ import com.github.ambry.clustermap.HelixClusterManager.HelixClusterChangeHandler
 import java.io.Closeable;
 import java.util.List;
 import org.apache.helix.HelixManager;
+import org.apache.helix.spectator.RoutingTableProvider;
 
 
 /**
@@ -29,19 +30,22 @@ public class HelixAggregatedViewClusterInfo implements Closeable {
   private final List<DataNodeConfigSource> dataNodeConfigSources;
   // Handler that handles resource state changes in the entire cluster.
   final HelixClusterChangeHandler clusterChangeHandler;
+  private RoutingTableProvider routingTableProvider;
 
   /**
    * Construct a HelixAggregatedViewClusterInfo object with the given parameters.
-   * @param helixManager the associated {@link HelixManager} for this cluster.
-   * @param clusterChangeHandler the associated {@link HelixClusterChangeHandler}
-   *                            for this datacenter.
+   *
+   * @param helixManager          the associated {@link HelixManager} for this cluster.
+   * @param clusterChangeHandler  the associated {@link HelixClusterChangeHandler} for this datacenter.
    * @param dataNodeConfigSources the list of {@link DataNodeConfigSource}s for data centers in this cluster.
+   * @param routingTableProvider a helix helper class to provide snapshot of the cluster
    */
   HelixAggregatedViewClusterInfo(HelixManager helixManager, HelixClusterChangeHandler clusterChangeHandler,
-      List<DataNodeConfigSource> dataNodeConfigSources) {
+      List<DataNodeConfigSource> dataNodeConfigSources, RoutingTableProvider routingTableProvider) {
     this.helixManager = helixManager;
     this.dataNodeConfigSources = dataNodeConfigSources;
     this.clusterChangeHandler = clusterChangeHandler;
+    this.routingTableProvider = routingTableProvider;
   }
 
   @Override
@@ -52,6 +56,7 @@ public class HelixAggregatedViewClusterInfo implements Closeable {
       }
     } finally {
       dataNodeConfigSources.forEach(DataNodeConfigSource::close);
+      routingTableProvider.shutdown();
     }
   }
 }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixAggregatedViewClusterInitializer.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixAggregatedViewClusterInitializer.java
@@ -18,6 +18,7 @@ package com.github.ambry.clustermap;
 import com.github.ambry.clustermap.ClusterMapUtils.DcZkInfo;
 import com.github.ambry.clustermap.HelixClusterManager.HelixClusterChangeHandler;
 import com.github.ambry.config.ClusterMapConfig;
+import com.github.ambry.utils.Utils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -44,6 +45,8 @@ class HelixAggregatedViewClusterInitializer {
   private final HelixClusterManager helixClusterManager;
   private final Map<String, DcZkInfo> dataCenterToZkAddress;
   private Exception exception = null;
+  List<DataNodeConfigSource> dataNodeConfigSources = new ArrayList<>();
+  HelixClusterChangeHandler clusterChangeHandler;
 
   /**
    * @param clusterMapConfig {@link ClusterMapConfig} to help some admin operations
@@ -91,39 +94,60 @@ class HelixAggregatedViewClusterInitializer {
    * @throws Exception if something went wrong during startup
    */
   public HelixAggregatedViewClusterInfo initialize() throws Exception {
-    // We can assume that Helix Aggregated view cluster will be present in same zookeeper hosting regular Ambry cluster
-    // information. Get the HelixManager to talk to the local zk service.
-    DcZkInfo localDcZkInfo = dataCenterToZkAddress.get(clusterMapConfig.clusterMapDatacenterName);
+    // We will have Helix Aggregated view cluster in each data center. Connect to helix aggregated view cluster in local
+    // DC.
+    String localDcName = clusterMapConfig.clusterMapDatacenterName;
+    String aggregatedViewClusterName = clusterMapConfig.clusterMapAggregatedViewClusterName;
+    DcZkInfo localDcZkInfo = dataCenterToZkAddress.get(localDcName);
 
-    // For now, the first ZK endpoint (if there are more than one endpoints) will be adopted by default for initialization.
-    // Note that, Ambry currently doesn't support multiple spectators, because there should be only one source of truth.
+    // The first ZK endpoint (if there are more than one endpoints) will be adopted by default for initialization since
+    // Ambry doesn't support multiple spectators and uses only one source of truth.
     String localZkConnectStr = localDcZkInfo.getZkConnectStrs().get(0);
     HelixManager helixManager =
-        helixFactory.getZkHelixManagerAndConnect(clusterMapConfig.clusterMapAggregatedViewClusterName, selfInstanceName,
-            InstanceType.SPECTATOR, localZkConnectStr);
+        helixFactory.getZkHelixManagerAndConnect(aggregatedViewClusterName, selfInstanceName, InstanceType.SPECTATOR,
+            localZkConnectStr);
     logger.info("Helix cluster name {}", helixManager.getClusterName());
 
-    HelixClusterChangeHandler clusterChangeHandler =
-        helixClusterManager.new HelixClusterChangeHandler(clusterMapConfig.clusterMapClusterName, ex -> exception = ex,
+    clusterChangeHandler =
+        helixClusterManager.new HelixClusterChangeHandler(localDcName, aggregatedViewClusterName, ex -> exception = ex,
             true);
 
-    // Helix aggregated view cluster currently aggregates the following:
-    // 1. External view (which tells the current state of the cluster like replicas and their states).
-    // 2. Instance configs (These mostly contain fields set and used by Helix like host name and port).
-    // 3. Live instances (List of live hosts in cluster).
+    // Ambry needs below information from Helix:
+    // 1. Topology information list of hosts, disks in each host, partitions on each disk, etc. This is stored in helix
+    //    "PROPERTYSTORE/DataNodeConfigs" znodes.
+    // 2. External view: This tells the current states of various replicas in the cluster. For ex, list of replicas in
+    //    leader state in a given partition.
+    // 3. Live instances: This tells the list of live hosts in cluster so that we can mark the hosts as down.
 
-    // Ambry currently needs and listens to following changes in Helix/ZKs in all datacenters:
-    // 1. External view (indirectly via using RoutingTableProvider)
-    // 2. Live instances (List of live hosts in cluster)
-    // 3. HelixPropertyStore. This is where Ambry data node configuration like disk information, disk to replica mapping,
-    //    replica sealed states, etc are stored.
-    // 4. Helix ideal states. This is needed to keep track of Helix Resource (Helix terminology) to Ambry partitions
-    //    (Multiple Ambry partitions are grouped under one helix resource).
+    // Currently, Helix only provides aggregated view of External view and Live instances. So, we will have to
+    // fetch data in Helix Property store from all colos ourselves.
 
-    // As we can see above, since #3 and #4 are not aggregated by Helix currently, we get these information by talking
-    // to all ZK servers ourselves.
+    // 1. Fetch Data node configs from each Data center and wait until the initialization is complete before registering
+    // for changes from Aggregated helix view.
+    List<Thread> dcInitThreads = new ArrayList<>();
+    for (String dcName : dataCenterToZkAddress.keySet()) {
+      DcZkInfo dcZkInfo = dataCenterToZkAddress.get(dcName);
+      if (dcZkInfo.getReplicaType() != ReplicaType.DISK_BACKED) {
+        // There could be old configs which have CLOUD_BACKED replica information. Keep this until CLOUD_BACKED replicas
+        // are completely deprecated.
+        continue;
+      }
+      Thread thread = Utils.newThread("helix-aggregated-view-datanode-config-init-dc-" + dcName, () -> {
+        try {
+          registerForDataNodeConfigsChanges(dcName);
+        } catch (Exception e) {
+          exception = e;
+        }
+      }, false);
+      thread.start();
+      dcInitThreads.add(thread);
+    }
+    for (Thread thread : dcInitThreads) {
+      thread.join();
+    }
 
-    // 1. Create Helix RoutingTableProvider class which provides APIs to get information from external view.
+    // 2. Fetch External view. Helix provides a helper class RoutingTableProvider to get information in external view in
+    // a convenient way.
     logger.info("Creating routing table provider for entire cluster associated with Helix manager at {}",
         localZkConnectStr);
     // There are two ways to instantiate a RoutingTable. 1. EXTERNAL_VIEW based, 2. CURRENT_STATES based. In the former
@@ -139,33 +163,6 @@ class HelixAggregatedViewClusterInitializer {
     logger.info("Routing table provider is created for entire cluster");
     routingTableProvider.addRoutingTableChangeListener(clusterChangeHandler, null);
     logger.info("Registered routing table change listeners for entire cluster");
-
-    // 2. Since helix property store and ideal states are not aggregated as mentioned above, we get/subscribe to them by
-    // talking to ZKs in all colos.
-    List<DataNodeConfigSource> dataNodeConfigSources = new ArrayList<>();
-    for (DcZkInfo dcZkInfo : dataCenterToZkAddress.values()) {
-      String zkConnectStr = dcZkInfo.getZkConnectStrs().get(0);
-      // Register Data node configs listener.
-      DataNodeConfigSource dataNodeConfigSource =
-          helixFactory.getDataNodeConfigSource(clusterMapConfig, zkConnectStr, dataNodeConfigSourceMetrics);
-      dataNodeConfigSource.addDataNodeConfigChangeListener(clusterChangeHandler);
-      dataNodeConfigSources.add(dataNodeConfigSource);
-      logger.info("Registered data node config change listeners for data center {} via Helix manager at {}",
-          dcZkInfo.getDcName(), zkConnectStr);
-      // Register ideal state listener.
-      HelixManager manager =
-          helixFactory.getZkHelixManagerAndConnect(clusterMapConfig.clusterMapClusterName, selfInstanceName,
-              InstanceType.SPECTATOR, zkConnectStr);
-      manager.addIdealStateChangeListener(clusterChangeHandler);
-      logger.info("Registered ideal state change listeners for data center {} via Helix manager at {}",
-          dcZkInfo.getDcName(), zkConnectStr);
-    }
-
-    // 3. Register aggregate cluster change handler to get notified on live instance changes in entire cluster.
-    helixManager.addLiveInstanceChangeListener(clusterChangeHandler);
-    logger.info("Registered live instance change listeners for entire cluster via Helix manager at {}",
-        localZkConnectStr);
-
     // Since it is possible that initial event occurs before adding routing table listener, we explicitly set snapshot in
     // HelixClusterManager. The reason is, if listener missed initial event, snapshot inside routing table
     // provider should be already populated.
@@ -179,6 +176,36 @@ class HelixAggregatedViewClusterInitializer {
       clusterChangeHandler.waitForInitNotification();
     }
 
+    // 3. Fetch live instance changes in entire cluster
+    // When adding a listener, current live instances are fetched from Helix using blocking call and notified to the
+    // listener (Please follow below method to
+    // https://github.com/apache/helix/blob/fb773839117ee0689451fab7c8b949115f555100/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java#L393).
+    // I.e. by the time we return from below method, initial notification of live instances states would have been
+    // arrived. So, we don't need separate latch to wait for notification of live instances.
+    helixManager.addLiveInstanceChangeListener(clusterChangeHandler);
+    logger.info("Registered live instance change listeners for entire cluster via Helix manager at {}",
+        localZkConnectStr);
+
     return new HelixAggregatedViewClusterInfo(helixManager, clusterChangeHandler, dataNodeConfigSources);
+  }
+
+  /**
+   * Register for data node configs from Helix Property store.
+   * @param dcName data center for which we are interested in data node configs.
+   */
+  private void registerForDataNodeConfigsChanges(String dcName) throws Exception {
+    DcZkInfo dcZkInfo = dataCenterToZkAddress.get(dcName);
+    String zkConnectStr = dcZkInfo.getZkConnectStrs().get(0);
+    DataNodeConfigSource dataNodeConfigSource =
+        helixFactory.getDataNodeConfigSource(clusterMapConfig, zkConnectStr, dataNodeConfigSourceMetrics);
+    // When attaching a listener, current data is fetched from Helix using blocking call and notified to the listener
+    // (Please see PropertyStoreToDataNodeConfigAdapter.Subscription#start() method). I.e. by the time we return from
+    // below method, initial notification of data node configs would have been arrived. So, we don't need separate latch
+    // to wait for notification of data node configs.
+    dataNodeConfigSource.addDataNodeConfigChangeListener(
+        configs -> clusterChangeHandler.handleDataNodeConfigChange(configs, dcName));
+    dataNodeConfigSources.add(dataNodeConfigSource);
+    logger.info("Registered data node config change listeners for data center {} via Helix manager at {}",
+        dcZkInfo.getDcName(), zkConnectStr);
   }
 }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixAggregatedViewClusterInitializer.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixAggregatedViewClusterInitializer.java
@@ -182,12 +182,13 @@ class HelixAggregatedViewClusterInitializer {
     // listener (Please follow below method to
     // https://github.com/apache/helix/blob/fb773839117ee0689451fab7c8b949115f555100/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java#L393).
     // I.e. by the time we return from below method, initial notification of live instances states would have been
-    // arrived. So, we don't need separate latch to wait for notification of live instances.
+    // arrived. So, we don't need to separate latch to wait for notification of live instances.
     helixManager.addLiveInstanceChangeListener(clusterChangeHandler);
     logger.info("Registered live instance change listeners for cluster {} via Helix manager at {}",
         aggregatedViewClusterName, localZkConnectStr);
 
-    return new HelixAggregatedViewClusterInfo(helixManager, clusterChangeHandler, dataNodeConfigSources);
+    return new HelixAggregatedViewClusterInfo(helixManager, clusterChangeHandler, dataNodeConfigSources,
+        routingTableProvider);
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
@@ -32,6 +32,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -45,8 +46,8 @@ import org.apache.helix.NotificationContext;
 import org.apache.helix.api.listeners.IdealStateChangeListener;
 import org.apache.helix.api.listeners.LiveInstanceChangeListener;
 import org.apache.helix.api.listeners.RoutingTableChangeListener;
+import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
-import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.LiveInstance;
 import org.apache.helix.spectator.RoutingTableSnapshot;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
@@ -86,6 +87,9 @@ public class HelixClusterManager implements ClusterMap {
   private final Map<String, ConcurrentHashMap<String, String>> partitionToResourceNameByDc = new ConcurrentHashMap<>();
   private final Map<String, AtomicReference<RoutingTableSnapshot>> dcToRoutingTableSnapshotRef =
       new ConcurrentHashMap<>();
+  // A map of partition to resource names used in aggregated cluster view.
+  private final ConcurrentHashMap<String, List<String>> globalPartitionToResourceNames = new ConcurrentHashMap<>();
+  // Routing table snapshot reference used in aggregated cluster view.
   private final AtomicReference<RoutingTableSnapshot> globalRoutingTableSnapshotRef = new AtomicReference<>();
   private final ConcurrentHashMap<String, AmbryDataNode> instanceNameToAmbryDataNode = new ConcurrentHashMap<>();
   private final AtomicLong errorCount = new AtomicLong(0);
@@ -492,7 +496,7 @@ public class HelixClusterManager implements ClusterMap {
     }
     dcToDcInfo.clear();
 
-    if (clusterMapConfig.clusterMapUseAggregatedView) {
+    if (clusterMapConfig.clusterMapUseAggregatedView && helixAggregatedViewClusterInfo != null) {
       helixAggregatedViewClusterInfo.close();
     }
   }
@@ -527,8 +531,16 @@ public class HelixClusterManager implements ClusterMap {
    * Exposed for testing
    * @return a map of partition to its corresponding resource grouped by data center
    */
-  Map<String, Map<String, String>> getPartitionToResourceMap() {
+  Map<String, Map<String, String>> getPartitionToResourceMapByDC() {
     return Collections.unmodifiableMap(partitionToResourceNameByDc);
+  }
+
+  /**
+   * Exposed for testing
+   * @return a map of partition to its corresponding resources in all data centers.
+   */
+  Map<String, List<String>> getGlobalPartitionToResourceMap(){
+    return Collections.unmodifiableMap(globalPartitionToResourceNames);
   }
 
   /**
@@ -680,7 +692,7 @@ public class HelixClusterManager implements ClusterMap {
 
     /**
      * {@inheritDoc}
-     * If dcOrClusterName is null, then get replicas by given state from all datacenters.
+     * If dcName is null, then get replicas by given state from all datacenters.
      * If no routing table snapshot is found for dc name, or no resource name found for given partition, return empty list.
      */
     @Override
@@ -688,38 +700,35 @@ public class HelixClusterManager implements ClusterMap {
       Timer.Context operationTimer = helixClusterManagerMetrics.routingTableQueryTime.time();
       long startTime = SystemTime.getInstance().milliseconds();
       Set<AmbryReplica> replicas = new HashSet<>();
-      for (DcInfo dcInfo : dcToDcInfo.values()) {
-        String dc = dcInfo.dcName;
-        if (dcName == null || dcName.equals(dc)) {
-          // Note: When querying replicasByState from all DCs (i.e. input parameter "dcName" is null), Helix API
-          // "RoutingTableSnapshot#getInstancesForResource(resourceName, partition, replica state)" should ideally
-          // give instances from all DCs in one call when "Aggregated View" is enabled. But, we still query multiple
-          // times (with for-loop above) because the "resource -> partition" mapping can be different in each DC.
-          // For example, partition 1 can be under "resource 1" in "DC1" and under "resource 2" in "DC2". Hence,
-          // routingTableSnapshot.getInstancesForResource(resource1, partition1, standby) would give replicas of DC1
-          // routingTableSnapshot.getInstancesForResource(resource2, partition1, standby) would give replicas of DC2
+      if (clusterMapConfig.clusterMapUseAggregatedView) {
+        String partitionPath = partition.toPathString();
+        // A partition can be under different resources in different data centers. Due to that, when using aggregated
+        // view, get replicas from all {Resource, partition}s.
+        List<String> resourceNames = globalPartitionToResourceNames.get(partitionPath);
+        RoutingTableSnapshot globalRoutingTableSnapshot = globalRoutingTableSnapshotRef.get();
+        for (String resourceName : resourceNames) {
+          globalRoutingTableSnapshot.getInstancesForResource(resourceName, partitionPath, state.name())
+              .stream()
+              .map(instanceConfig -> instanceNameToAmbryDataNode.get(instanceConfig.getInstanceName()))
+              .filter(dataNode -> dcName == null || dataNode.getDatacenterName().equals(dcName))
+              .map(dataNode -> ambryDataNodeToAmbryReplicas.get(dataNode).get(partition.toPathString()))
+              .filter(Objects::nonNull)
+              .forEach(replicas::add);
+        }
+      } else {
+        List<String> dcs = dcName != null ? Collections.singletonList(dcName)
+            : dcToDcInfo.values().stream().map(dcInfo -> dcInfo.dcName).collect(Collectors.toList());
+        for(String dc : dcs){
+          // Get the resource that contains this partition in this data center.
           String resourceName = partitionToResourceNameByDc.get(dc).get(partition.toPathString());
-          RoutingTableSnapshot routingTableSnapshot =
-              clusterMapConfig.clusterMapUseAggregatedView ? globalRoutingTableSnapshotRef.get()
-                  : dcToRoutingTableSnapshotRef.get(dc).get();
+          RoutingTableSnapshot routingTableSnapshot = dcToRoutingTableSnapshotRef.get(dc).get();
           String partitionPath = partition.toPathString();
-          long helixQueryStartTime = SystemTime.getInstance().milliseconds();
-          List<String> instances =
-              routingTableSnapshot.getInstancesForResource(resourceName, partitionPath, state.name())
-                  .stream()
-                  .map(InstanceConfig::getInstanceName)
-                  .collect(Collectors.toList());
-          logger.debug(
-              "Helix returned instances for resourceName {}, partitionPath {}, state {} are {}. Query time in Ms {}",
-              resourceName, partitionPath, state.name(), instances,
-              SystemTime.getInstance().milliseconds() - helixQueryStartTime);
-          for (String instance : instances) {
-            AmbryDataNode dataNode = instanceNameToAmbryDataNode.get(instance);
-            AmbryReplica ambryReplica = ambryDataNodeToAmbryReplicas.get(dataNode).get(partition.toPathString());
-            if (ambryReplica != null) {
-              replicas.add(ambryReplica);
-            }
-          }
+          routingTableSnapshot.getInstancesForResource(resourceName, partitionPath, state.name())
+              .stream()
+              .map(instanceConfig -> instanceNameToAmbryDataNode.get(instanceConfig.getInstanceName()))
+              .map(dataNode -> ambryDataNodeToAmbryReplicas.get(dataNode).get(partition.toPathString()))
+              .filter(Objects::nonNull)
+              .forEach(replicas::add);
         }
       }
       logger.debug("Replicas for partition {} with state {} in dc {} are {}. Query time in Ms {}",
@@ -887,9 +896,10 @@ public class HelixClusterManager implements ClusterMap {
   class HelixClusterChangeHandler
       implements DataNodeConfigChangeListener, LiveInstanceChangeListener, IdealStateChangeListener,
                  RoutingTableChangeListener {
-    // When using Helix aggregated view, this variable contains to the cluster name (like ambry-prod, ambry-video, etc).
-    // Otherwise, it contains the actual data center name like prod-lor1, prod-ltx1, etc.
-    private final String dcOrClusterName;
+    // Data center for which the callback events correspond to.
+    private final String dcName;
+    // Helix cluster name which keeps track of Ambry topology information.
+    private final String helixClusterName;
     private final Object notificationLock = new Object();
     private final Consumer<Exception> onInitializationFailure;
     private final CountDownLatch routingTableInitLatch = new CountDownLatch(1);
@@ -903,16 +913,37 @@ public class HelixClusterManager implements ClusterMap {
     private final boolean isAggregatedViewHandler;
 
     /**
-     * @param dcOrClusterName the name of data center or the cluster this handler is associated with.
+     * @param dcName the name of data center or the cluster this handler is associated with.
+     * @param helixClusterName the name of helix cluster which hosts the Ambry topology information.
      * @param onInitializationFailure callback to be called if initialization fails in a listener call.
      * @param isAggregatedViewHandler indicates if this clusterChangeHandler is a listener for changes in the entire
-     *                                cluster via helix aggregated view.
      */
-    HelixClusterChangeHandler(String dcOrClusterName, Consumer<Exception> onInitializationFailure,
+    HelixClusterChangeHandler(String dcName, String helixClusterName, Consumer<Exception> onInitializationFailure,
         boolean isAggregatedViewHandler) {
-      this.dcOrClusterName = dcOrClusterName;
+      this.dcName = dcName;
+      this.helixClusterName = helixClusterName;
       this.onInitializationFailure = onInitializationFailure;
       this.isAggregatedViewHandler = isAggregatedViewHandler;
+    }
+
+    @Override
+    public void onDataNodeConfigChange(Iterable<DataNodeConfig> configs) {
+      handleDataNodeConfigChange(configs, dcName);
+    }
+
+    @Override
+    public void onIdealStateChange(List<IdealState> idealState, NotificationContext changeContext) {
+      handleIdealStateChange(idealState, dcName);
+    }
+
+    @Override
+    public void onRoutingTableChange(RoutingTableSnapshot routingTableSnapshot, Object context) {
+      handleRoutingTableChange(routingTableSnapshot);
+    }
+
+    @Override
+    public void onLiveInstanceChange(List<LiveInstance> liveInstances, NotificationContext changeContext) {
+      handleLiveInstanceChange(liveInstances);
     }
 
     /**
@@ -923,35 +954,39 @@ public class HelixClusterManager implements ClusterMap {
      * (The ZNode path of instance config in Helix is [AmbryClusterName]/CONFIGS/PARTICIPANT/[hostname_port])
      * @param configs all the {@link DataNodeConfig}(s) in current data center. (Note that PreFetch is enabled by default
      *                in Helix, which means all instance configs under "participants" ZNode will be sent to this method)
+     * @param dcName data center name.
      */
-    @Override
-    public void onDataNodeConfigChange(Iterable<DataNodeConfig> configs) {
+    void handleDataNodeConfigChange(Iterable<DataNodeConfig> configs, String dcName) {
       try {
         synchronized (notificationLock) {
           if (!instanceConfigInitialized) {
-            logger.info("Received initial notification for instance config change from {}", dcOrClusterName);
+            logger.info("Received initial notification for instance config change from helix cluster {} in dc {}",
+                helixClusterName, dcName);
           } else {
-            logger.info("Instance config change triggered from {}", dcOrClusterName);
+            logger.info("Instance config change triggered from helix cluster {} in dc {}", helixClusterName, dcName);
           }
           if (logger.isDebugEnabled()) {
-            configs.forEach(config -> logger.debug("Detailed data node config in {} is: {}", dcOrClusterName, config));
+            logger.debug("Detailed data node config from helix cluster {} in dc {} is: {}", helixClusterName, dcName,
+                configs);
           }
           try {
-            addOrUpdateInstanceInfos(configs);
+            addOrUpdateInstanceInfos(configs, dcName);
           } catch (Exception e) {
             if (!instanceConfigInitialized) {
-              logger.error("Exception occurred when initializing instances in {}: ", dcOrClusterName, e);
+              logger.error("Exception occurred when initializing instances from helix cluster {} in {}: ",
+                  helixClusterName, dcName, e);
               onInitializationFailure.accept(e);
             } else {
-              logger.error("Exception occurred at runtime when handling instance config changes in {}: ",
-                  dcOrClusterName, e);
+              logger.error(
+                  "Exception occurred at runtime when handling instance config changes from helix cluster {} in {}: ",
+                  helixClusterName, dcName, e);
               helixClusterManagerMetrics.instanceConfigChangeErrorCount.inc();
             }
           } finally {
             instanceConfigInitialized = true;
           }
           long counter = sealedStateChangeCounter.incrementAndGet();
-          logger.trace("SealedStateChangeCounter increase to {}", counter);
+          logger.info("SealedStateChangeCounter increase to {}", counter);
           helixClusterManagerMetrics.instanceConfigChangeTriggerCount.inc();
         }
       } catch (Throwable t) {
@@ -963,56 +998,39 @@ public class HelixClusterManager implements ClusterMap {
     /**
      * Triggered whenever the IdealState in current data center has changed (for now, it is usually updated by Helix
      * Bootstrap tool).
-     * @param idealState a list of {@link IdealState} that specifies ideal location of replicas.
-     * @param changeContext the {@link NotificationContext} associated.
+     * @param idealStates a list of {@link IdealState} that specifies ideal location of replicas.
+     * @param dcName data center name.
      */
-    @Override
-    public void onIdealStateChange(List<IdealState> idealState, NotificationContext changeContext) {
+    void handleIdealStateChange(List<IdealState> idealStates, String dcName) {
       if (!idealStateInitialized) {
-        logger.info("Received initial notification for IdealState change from {}", dcOrClusterName);
+        logger.info("Received initial notification for IdealState change from helix cluster {} in dc {}",
+            helixClusterName, dcName);
         idealStateInitialized = true;
       } else {
-        logger.info("IdealState change triggered from {}", dcOrClusterName);
+        logger.info("IdealState change triggered from helix cluster {} in dc {}", helixClusterName, dcName);
       }
-      logger.debug("Detailed ideal states in {} are: {}", dcOrClusterName, idealState);
+      logger.debug("Detailed ideal states from helix cluster {} in dc {} are: {}", helixClusterName, dcName,
+          idealStates);
       // rebuild the entire partition-to-resource map in current dc
-      ConcurrentHashMap<String, String> partitionToResourceMap = new ConcurrentHashMap<>();
-      for (IdealState state : idealState) {
-        String resourceName = state.getResourceName();
-        state.getPartitionSet().forEach(partitionName -> partitionToResourceMap.put(partitionName, resourceName));
-      }
-      String dcName;
-      if (isAggregatedViewHandler) {
-        // Since helix aggregated view service doesn't aggregate ideal states across colos, we register ideal state
-        // change listener with helix service in each colo separately. So, this callback would be invoked for each
-        // data center separately. In order to know which data center, this callback corresponds to, we try to get one
-        // of the host names from Ideal state and get its data center name.
-        IdealState state = idealState.iterator().next();
-        String partition = state.getPartitionSet().iterator().next();
-        String instanceName = state.getInstanceSet(partition).iterator().next();
-        dcName = instanceNameToAmbryDataNode.get(instanceName).getDatacenterName();
-      } else {
-        dcName = dcOrClusterName;
-      }
-      partitionToResourceNameByDc.put(dcName, partitionToResourceMap);
+      updatePartitionResourceMappingFromIdealStates(idealStates, dcName);
       helixClusterManagerMetrics.idealStateChangeTriggerCount.inc();
     }
 
     /**
      * Triggered whenever there is a change in the list of live instances.
      * @param liveInstances the list of all live instances (not a change set) at the time of this call.
-     * @param changeContext the {@link NotificationContext} associated.
      */
-    @Override
-    public void onLiveInstanceChange(List<LiveInstance> liveInstances, NotificationContext changeContext) {
+    private void handleLiveInstanceChange(List<LiveInstance> liveInstances) {
       try {
         if (!liveStateInitialized) {
-          logger.info("Received initial notification for live instance change from {}", dcOrClusterName);
+          logger.info("Received initial notification for live instance change from helix cluster {} in dc {}",
+              helixClusterName, dcName);
           liveStateInitialized = true;
         } else {
-          logger.info("Live instance change triggered from {}", dcOrClusterName);
+          logger.info("Live instance change triggered from helix cluster {} in dc {}", helixClusterName, dcName);
         }
-        logger.debug("Detailed live instances in {} are: {}", dcOrClusterName, liveInstances);
+        logger.debug("Detailed live instances from helix cluster {} in dc {} are: {}", helixClusterName, dcName,
+            liveInstances);
         synchronized (notificationLock) {
           updateInstanceLiveness(liveInstances);
           helixClusterManagerMetrics.liveInstanceChangeTriggerCount.inc();
@@ -1027,21 +1045,20 @@ public class HelixClusterManager implements ClusterMap {
      * Triggered whenever the state of replica in cluster has changed. The snapshot contains up-to-date state of all
      * resources(replicas) in this data center.
      * @param routingTableSnapshot a snapshot of routing table for this data center.
-     * @param context additional context associated with this change.
      */
-    @Override
-    public void onRoutingTableChange(RoutingTableSnapshot routingTableSnapshot, Object context) {
+    private void handleRoutingTableChange(RoutingTableSnapshot routingTableSnapshot) {
       if (isAggregatedViewHandler) {
-        globalRoutingTableSnapshotRef.getAndSet(routingTableSnapshot);
-      } else {
-        dcToRoutingTableSnapshotRef.computeIfAbsent(dcOrClusterName, k -> new AtomicReference<>())
-            .getAndSet(routingTableSnapshot);
+        // When using aggregated view, we create EXTERNAL_VIEW based RoutingTableProvider. We can update
+        // partition-to-resources map from this external view.
+        updatePartitionResourcesMappingFromExternalView(routingTableSnapshot.getExternalViews(), null);
       }
+      setRoutingTableSnapshot(routingTableSnapshot);
       if (routingTableInitLatch.getCount() == 1) {
-        logger.info("Received initial notification for routing table change from {}", dcOrClusterName);
+        logger.info("Received initial notification for routing table change from helix cluster {} in dc {}",
+            helixClusterName, dcName);
         routingTableInitLatch.countDown();
       } else {
-        logger.info("Routing table change triggered from {}", dcOrClusterName);
+        logger.info("Routing table change triggered from helix cluster {} in dc {}", helixClusterName, dcName);
       }
 
       // We should notify routing table change indication to different cluster map change listeners like replication
@@ -1061,7 +1078,7 @@ public class HelixClusterManager implements ClusterMap {
       if (isAggregatedViewHandler) {
         globalRoutingTableSnapshotRef.getAndSet(routingTableSnapshot);
       } else {
-        dcToRoutingTableSnapshotRef.computeIfAbsent(dcOrClusterName, k -> new AtomicReference<>())
+        dcToRoutingTableSnapshotRef.computeIfAbsent(dcName, k -> new AtomicReference<>())
             .getAndSet(routingTableSnapshot);
       }
     }
@@ -1085,7 +1102,8 @@ public class HelixClusterManager implements ClusterMap {
       // wait slightly more than 5 mins to ensure routerUpdater refreshes the snapshot.
       if (!routingTableInitLatch.await(320, TimeUnit.SECONDS)) {
         throw new IllegalStateException(
-            "Initial routing table change from " + dcOrClusterName + " didn't come within 5 mins");
+            "Initial routing table change from helix cluster " + helixClusterName + "in dc " + dcName
+                + " didn't come within 5 mins");
       }
     }
 
@@ -1094,19 +1112,67 @@ public class HelixClusterManager implements ClusterMap {
     }
 
     /**
+     * Update partition to resource mapping from Ideal states.
+     * @param idealStates list of ideal states for various resources.
+     * @param dcName data center for which this mapping corresponds to. If it is null, the mapping is for resources in
+     */
+    private void updatePartitionResourceMappingFromIdealStates(Collection<IdealState> idealStates, String dcName) {
+      // rebuild the entire partition-to-resource map in current dc
+      for (IdealState state : idealStates) {
+        String resourceName = state.getResourceName();
+        for (String partition : state.getPartitionSet()) {
+          if (dcName != null) {
+            ConcurrentHashMap<String, String> partitionToResourceName =
+                partitionToResourceNameByDc.computeIfAbsent(dcName, k -> new ConcurrentHashMap<>());
+            partitionToResourceName.put(partition, resourceName);
+          } else {
+            List<String> resourceNames =
+                globalPartitionToResourceNames.computeIfAbsent(partition, k -> new CopyOnWriteArrayList<>());
+            resourceNames.add(resourceName);
+          }
+        }
+      }
+    }
+
+    /**
+     * Update partition to resource mapping from External view.
+     * @param externalViews list of external view for various resources.
+     * @param dcName data center for which this mapping corresponds to. If it is null, the mapping is for resources in
+     */
+    private void updatePartitionResourcesMappingFromExternalView(Collection<ExternalView> externalViews,
+        String dcName) {
+      // rebuild the entire partition-to-resource map in current dc
+      for (ExternalView externalView : externalViews) {
+        String resourceName = externalView.getResourceName();
+        for (String partition : externalView.getPartitionSet()) {
+          if (dcName != null) {
+            ConcurrentHashMap<String, String> partitionToResourceName =
+                partitionToResourceNameByDc.computeIfAbsent(dcName, k -> new ConcurrentHashMap<>());
+            partitionToResourceName.put(partition, resourceName);
+          } else {
+            List<String> resourceNames =
+                globalPartitionToResourceNames.computeIfAbsent(partition, k -> new CopyOnWriteArrayList<>());
+            resourceNames.add(resourceName);
+          }
+        }
+      }
+    }
+
+    /**
      * Add new instances or update existing instances based on {@link DataNodeConfig}(s). This may also invoke callbacks
      * in some clustermap change listeners (i.e. {@link PartitionSelectionHelper}, ReplicationManager)
      * @param dataNodeConfigs the {@link DataNodeConfig}(s) used to update in-mem cluster map.
+     * @param dcName data center name.
      */
-    private void addOrUpdateInstanceInfos(Iterable<DataNodeConfig> dataNodeConfigs) throws Exception {
+    private void addOrUpdateInstanceInfos(Iterable<DataNodeConfig> dataNodeConfigs, String dcName) throws Exception {
       List<ReplicaId> totalAddedReplicas = new ArrayList<>();
       List<ReplicaId> totalRemovedReplicas = new ArrayList<>();
       for (DataNodeConfig dataNodeConfig : dataNodeConfigs) {
         Pair<List<ReplicaId>, List<ReplicaId>> addedAndRemovedReplicas;
         if (instanceNameToAmbryDataNode.containsKey(dataNodeConfig.getInstanceName())) {
-          addedAndRemovedReplicas = updateInstanceInfo(dataNodeConfig);
+          addedAndRemovedReplicas = updateInstanceInfo(dataNodeConfig, dcName);
         } else {
-          addedAndRemovedReplicas = new Pair<>(createNewInstance(dataNodeConfig), new ArrayList<>());
+          addedAndRemovedReplicas = new Pair<>(createNewInstance(dataNodeConfig, dcName), new ArrayList<>());
         }
         totalAddedReplicas.addAll(addedAndRemovedReplicas.getFirst());
         totalRemovedReplicas.addAll(addedAndRemovedReplicas.getSecond());
@@ -1127,9 +1193,11 @@ public class HelixClusterManager implements ClusterMap {
      * Update info of an existing instance. This may happen in following cases: (1) new replica is added; (2) old replica
      * is removed; (3) replica's state has changed (i.e. becomes seal/unseal).
      * @param dataNodeConfig the {@link DataNodeConfig} used to update info of instance.
+     * @param dcName
      * @return a pair of lists: (1) new added replicas; (2) removed old replicas, during this update.
      */
-    private Pair<List<ReplicaId>, List<ReplicaId>> updateInstanceInfo(DataNodeConfig dataNodeConfig) throws Exception {
+    private Pair<List<ReplicaId>, List<ReplicaId>> updateInstanceInfo(DataNodeConfig dataNodeConfig, String dcName)
+        throws Exception {
       final List<ReplicaId> addedReplicas = new ArrayList<>();
       final List<ReplicaId> removedReplicas = new ArrayList<>();
       String instanceName = dataNodeConfig.getInstanceName();
@@ -1174,8 +1242,7 @@ public class HelixClusterManager implements ClusterMap {
             updateReplicaStateAndOverrideIfNeeded(existingReplica, sealedReplicas, stoppedReplicas);
           } else {
             // if this is a new replica and doesn't exist on node
-            logger.info("Adding new replica {} to existing node {} in {}", partitionName, instanceName,
-                dcOrClusterName);
+            logger.info("Adding new replica {} to existing node {} in {}", partitionName, instanceName, dcName);
             // this can be a brand new partition that is added to an existing node
             AmbryPartition mappedPartition =
                 new AmbryPartition(Long.parseLong(partitionName), replicaConfig.getPartitionClass(),
@@ -1255,12 +1322,13 @@ public class HelixClusterManager implements ClusterMap {
     /**
      * Create a new instance(node) and initialize disks/replicas on it.
      * @param dataNodeConfig the {@link DataNodeConfig} to create new instance
+     * @param dcName data center name.
      * @return a list of newly added replicas;
      * @throws Exception if there is an exception in instantiating the {@link ResourceStatePolicy}
      */
-    private List<ReplicaId> createNewInstance(DataNodeConfig dataNodeConfig) throws Exception {
+    private List<ReplicaId> createNewInstance(DataNodeConfig dataNodeConfig, String dcName) throws Exception {
       String instanceName = dataNodeConfig.getInstanceName();
-      logger.info("Adding node {} and its disks and replicas in {}", instanceName, dcOrClusterName);
+      logger.info("Adding node {} and its disks and replicas in {}", instanceName, dcName);
       AmbryDataNode datanode =
           new AmbryServerDataNode(dataNodeConfig.getDatacenterName(), clusterMapConfig, dataNodeConfig.getHostName(),
               dataNodeConfig.getPort(), dataNodeConfig.getRackId(), dataNodeConfig.getSslPort(),

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
@@ -499,6 +499,10 @@ public class HelixClusterManager implements ClusterMap {
     if (clusterMapConfig.clusterMapUseAggregatedView && helixAggregatedViewClusterInfo != null) {
       helixAggregatedViewClusterInfo.close();
     }
+
+    if(helixPropertyStoreInLocalDc != null){
+      helixPropertyStoreInLocalDc.stop();
+    }
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixDatacenterInitializer.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixDatacenterInitializer.java
@@ -133,7 +133,8 @@ class HelixDatacenterInitializer {
           InstanceType.SPECTATOR, zkConnectStr);
     }
     HelixClusterChangeHandler clusterChangeHandler =
-        helixClusterManager.new HelixClusterChangeHandler(dcName, this::onInitializationFailure, false);
+        helixClusterManager.new HelixClusterChangeHandler(dcName, clusterMapConfig.clusterMapClusterName,
+            this::onInitializationFailure, false);
     // Create Helix RoutingTableProvider of each DC to keep track of partition(replicas) state. Here, we use CURRENT
     // STATES based RoutingTableProvider to remove dependency on Helix's pipeline and reduce notification latency.
     // To elaborate more, there are two ways to instantiate a RoutingTable. 1. EXTERNAL_VIEW based, 2. CURRENT_STATES

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixDatacenterInitializer.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixDatacenterInitializer.java
@@ -184,6 +184,6 @@ class HelixDatacenterInitializer {
       logger.info("Stopped listening to cross colo ZK server {}", zkConnectStr);
     }
 
-    return new HelixDcInfo(dcName, dcZkInfo, manager, clusterChangeHandler, dataNodeConfigSource);
+    return new HelixDcInfo(dcName, dcZkInfo, manager, clusterChangeHandler, dataNodeConfigSource, routingTableProvider);
   }
 }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixDcInfo.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixDcInfo.java
@@ -17,6 +17,7 @@ package com.github.ambry.clustermap;
 
 import com.github.ambry.clustermap.HelixClusterManager.HelixClusterChangeHandler;
 import org.apache.helix.HelixManager;
+import org.apache.helix.spectator.RoutingTableProvider;
 
 
 /**
@@ -26,21 +27,26 @@ import org.apache.helix.HelixManager;
 class HelixDcInfo extends DcInfo {
   final HelixManager helixManager;
   private final DataNodeConfigSource dataNodeConfigSource;
+  private RoutingTableProvider routingTableProvider;
 
   /**
    * Construct a HelixDcInfo object with the given parameters.
-   * @param dcName the associated datacenter name.
-   * @param dcZkInfo the {@link ClusterMapUtils.DcZkInfo} associated with the DC.
-   * @param helixManager the associated {@link HelixManager} for this datacenter. This can be null if the datacenter is
-   *                     not managed by helix.
+   *
+   * @param dcName               the associated datacenter name.
+   * @param dcZkInfo             the {@link ClusterMapUtils.DcZkInfo} associated with the DC.
+   * @param helixManager         the associated {@link HelixManager} for this datacenter. This can be null if the
+   *                             datacenter is not managed by helix.
    * @param clusterChangeHandler the associated {@link HelixClusterChangeHandler} for this datacenter.
    * @param dataNodeConfigSource the {@link DataNodeConfigSource} for this datacenter.
+   * @param routingTableProvider a helix helper class to provide snapshot of the cluster.
    */
   HelixDcInfo(String dcName, ClusterMapUtils.DcZkInfo dcZkInfo, HelixManager helixManager,
-      HelixClusterChangeHandler clusterChangeHandler, DataNodeConfigSource dataNodeConfigSource) {
+      HelixClusterChangeHandler clusterChangeHandler, DataNodeConfigSource dataNodeConfigSource,
+      RoutingTableProvider routingTableProvider) {
     super(dcName, dcZkInfo, clusterChangeHandler);
     this.helixManager = helixManager;
     this.dataNodeConfigSource = dataNodeConfigSource;
+    this.routingTableProvider = routingTableProvider;
   }
 
   @Override
@@ -51,6 +57,7 @@ class HelixDcInfo extends DcInfo {
       }
     } finally {
       dataNodeConfigSource.close();
+      routingTableProvider.shutdown();
     }
   }
 }

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/ClusterChangeHandlerTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/ClusterChangeHandlerTest.java
@@ -368,7 +368,7 @@ public class ClusterChangeHandlerTest {
     // verify all partitions are able to get their resource name
     helixClusterManager.getAllPartitionIds(DEFAULT_PARTITION_CLASS)
         .forEach(partitionId -> assertEquals("Resource name is not expected",
-            partitionNameToResource.get(partitionId.toPathString()), partitionId.getResourceName()));
+            partitionNameToResource.get(partitionId.toPathString()), partitionId.getResourceNames().get(0)));
     helixClusterManager.close();
   }
 

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/ClusterChangeHandlerTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/ClusterChangeHandlerTest.java
@@ -125,7 +125,8 @@ public class ClusterChangeHandlerTest {
     props.setProperty("clustermap.enable.partition.override", Boolean.toString(overrideEnabled));
     props.setProperty("clustermap.listen.cross.colo", Boolean.toString(true));
     helixCluster =
-        new MockHelixCluster(clusterNamePrefixInHelix, hardwareLayoutPath, partitionLayoutPath, zkLayoutPath);
+        new MockHelixCluster(clusterNamePrefixInHelix, hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, localDc,
+            false);
     helixManagerFactory = new HelixClusterManagerTest.MockHelixManagerFactory(helixCluster, znRecordMap, null);
   }
 
@@ -223,7 +224,8 @@ public class ClusterChangeHandlerTest {
 
     Counter initFailureCount = new Counter();
     HelixClusterChangeHandler helixClusterChangeHandler =
-        helixClusterManager.new HelixClusterChangeHandler(localDc, e -> initFailureCount.inc(), false);
+        helixClusterManager.new HelixClusterChangeHandler(localDc, clusterMapConfig.clusterMapClusterName,
+            e -> initFailureCount.inc(), false);
     // create an InstanceConfig with invalid entry that mocks error info added by Helix controller
     PartitionId selectedPartition = testPartitionLayout.getPartitionLayout().getPartitions(null).get(0);
     Replica testReplica = (Replica) selectedPartition.getReplicaIds().get(0);
@@ -357,7 +359,7 @@ public class ClusterChangeHandlerTest {
     }
     // trigger IdealState change and refresh partition-to-resource mapping (bring in the new partition in resource map)
     helixCluster.refreshIdealState();
-    Map<String, String> partitionNameToResource = helixClusterManager.getPartitionToResourceMap().get(localDc);
+    Map<String, String> partitionNameToResource = helixClusterManager.getPartitionToResourceMapByDC().get(localDc);
     List<PartitionId> partitionIds = testPartitionLayout.getPartitionLayout().getPartitions(null);
     // verify all partitions (including the new added one) are present in partition-to-resource map
     Set<String> partitionNames = partitionIds.stream().map(PartitionId::toPathString).collect(Collectors.toSet());

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/InstanceConfigToDataNodeConfigAdapterTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/InstanceConfigToDataNodeConfigAdapterTest.java
@@ -58,7 +58,7 @@ public class InstanceConfigToDataNodeConfigAdapterTest extends DataNodeConfigSou
     clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
     helixManager =
         new MockHelixManager(selfInstanceName, InstanceType.SPECTATOR, "localhost:" + zkInfo.getPort(), clusterName,
-            new MockHelixAdmin(), null, null);
+            new MockHelixAdmin(), null, null, null, false);
     helixManager.connect();
   }
 

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixDataAccessor.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixDataAccessor.java
@@ -15,14 +15,18 @@ package com.github.ambry.clustermap;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.helix.BaseDataAccessor;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixProperty;
 import org.apache.helix.PropertyKey;
 import org.apache.helix.model.CurrentState;
+import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.LiveInstance;
 import org.apache.helix.model.MaintenanceSignal;
@@ -43,17 +47,24 @@ public class MockHelixDataAccessor implements HelixDataAccessor {
   private static final long SESSION_ID = 1024L;
   private final String LIVEINSTANCE_PATH;
   private final String INSTANCECONFIG_PATH;
+  private final String EXTERNALVIEW_PATH;
+  private final boolean isAggregatedViewCluster;
   private final String clusterName;
   private final PropertyKey.Builder propertyKeyBuilder;
-  private final MockHelixAdmin mockHelixAdmin;
+  private final MockHelixAdmin mockLocalHelixAdmin;
+  private final List<MockHelixAdmin> mockHelixAdminList;
   private Map<PropertyKey, HelixProperty> properties = new ConcurrentHashMap<>();
 
-  MockHelixDataAccessor(String clusterName, MockHelixAdmin mockHelixAdmin) {
+  MockHelixDataAccessor(String clusterName, MockHelixAdmin mockLocalHelixAdmin, List<MockHelixAdmin> mockHelixAdminList,
+      boolean isAggregatedViewCluster) {
     this.clusterName = clusterName;
-    this.mockHelixAdmin = mockHelixAdmin;
+    this.mockLocalHelixAdmin = mockLocalHelixAdmin;
     propertyKeyBuilder = new PropertyKey.Builder(clusterName);
     LIVEINSTANCE_PATH = "/" + clusterName + "/LIVEINSTANCES";
     INSTANCECONFIG_PATH = "/" + clusterName + "/CONFIGS/PARTICIPANT";
+    EXTERNALVIEW_PATH = "/" + clusterName + "/EXTERNALVIEW";
+    this.mockHelixAdminList = mockHelixAdminList;
+    this.isAggregatedViewCluster = isAggregatedViewCluster;
   }
 
   @Override
@@ -117,7 +128,7 @@ public class MockHelixDataAccessor implements HelixDataAccessor {
         String instanceName = segments[3];
         String resourceName = segments[6];
         Map<String, Map<String, String>> partitionStateMap =
-            mockHelixAdmin.getPartitionStateMapForInstance(instanceName);
+            mockLocalHelixAdmin.getPartitionStateMapForInstance(instanceName);
         ZNRecord record = new ZNRecord(resourceName);
         record.setMapFields(partitionStateMap);
         result.add((T) (new CurrentState(record)));
@@ -130,12 +141,38 @@ public class MockHelixDataAccessor implements HelixDataAccessor {
       } else if (key.toString().matches("/Ambry-/CONFIGS/PARTICIPANT/.*_\\d+")) {
         String[] segments = key.toString().split("/");
         String instanceName = segments[4];
-        InstanceConfig instanceConfig = mockHelixAdmin.getInstanceConfigs(clusterName)
+        InstanceConfig instanceConfig = mockLocalHelixAdmin.getInstanceConfigs(clusterName)
             .stream()
             .filter(config -> config.getInstanceName().equals(instanceName))
             .findFirst()
             .get();
         result.add((T) instanceConfig);
+      } else if (key.toString().matches("/Ambry-/EXTERNALVIEW/\\d+")) {
+        // Add external view for the asked resource
+        String[] segments = key.toString().split("/");
+        String resourceName = segments[3];
+        ZNRecord record = new ZNRecord(resourceName);
+        if (isAggregatedViewCluster) {
+          // If aggregated view is being used, go through all mock helix clusters and calculate the aggregated mapping
+          Map<String, Map<String, String>> aggregatedPartitionToReplicasMap = new HashMap<>();
+          for (MockHelixAdmin mockHelixAdmin : mockHelixAdminList) {
+            Map<String, Map<String, String>> partitionToReplicasMap =
+                mockHelixAdmin.getPartitionToReplicasMapForResource(resourceName);
+            for (Map.Entry<String, Map<String, String>> entry : partitionToReplicasMap.entrySet()) {
+              String partition = entry.getKey();
+              Map<String, String> replicaToState = entry.getValue();
+              Map<String, String> aggregatedReplicaToState =
+                  aggregatedPartitionToReplicasMap.computeIfAbsent(partition, k -> new HashMap<>());
+              aggregatedReplicaToState.putAll(replicaToState);
+            }
+          }
+          record.setMapFields(aggregatedPartitionToReplicasMap);
+        } else {
+          Map<String, Map<String, String>> partitionToReplicasMap =
+              mockLocalHelixAdmin.getPartitionToReplicasMapForResource(resourceName);
+          record.setMapFields(partitionToReplicasMap);
+        }
+        result.add((T) new ExternalView(record));
       } else {
         result.add((T) properties.get(key));
       }
@@ -168,12 +205,29 @@ public class MockHelixDataAccessor implements HelixDataAccessor {
     List<String> result = new ArrayList<>();
     if (key.toString().endsWith("/CURRENTSTATES/" + Long.toHexString(SESSION_ID))) {
       // Add resource name into result. Note that, in current test setup, all partitions within same dc are under same resource.
-      result.add(mockHelixAdmin.getResourcesInCluster(clusterName).get(0));
+      result.add(mockLocalHelixAdmin.getResourcesInCluster(clusterName).get(0));
     } else if (key.toString().equals(LIVEINSTANCE_PATH)) {
-      result = mockHelixAdmin.getUpInstances();
+      if (isAggregatedViewCluster) {
+        for (MockHelixAdmin mockHelixAdmin : mockHelixAdminList) {
+          result.addAll(mockHelixAdmin.getUpInstances());
+        }
+      } else {
+        result.addAll(mockLocalHelixAdmin.getUpInstances());
+      }
     } else if (key.toString().equals(INSTANCECONFIG_PATH)) {
-      for (InstanceConfig config : mockHelixAdmin.getInstanceConfigs(clusterName)) {
+      for (InstanceConfig config : mockLocalHelixAdmin.getInstanceConfigs(clusterName)) {
         result.add(config.getInstanceName());
+      }
+    } else if (key.toString().equals(EXTERNALVIEW_PATH)) {
+      if (isAggregatedViewCluster) {
+        // return resources from all DCs. But use set to avoid adding resources twice.
+        Set<String> resources = new HashSet<>();
+        for (MockHelixAdmin mockHelixAdmin : mockHelixAdminList) {
+          resources.addAll(mockHelixAdmin.getResourcesInCluster(clusterName));
+        }
+        result.addAll(resources);
+      } else {
+        result.addAll(mockLocalHelixAdmin.getResourcesInCluster(clusterName));
       }
     }
     return result;

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixManager.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixManager.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
 import org.apache.helix.AccessOption;
 import org.apache.helix.ClusterMessagingService;
 import org.apache.helix.ConfigAccessor;
@@ -74,11 +75,13 @@ class MockHelixManager implements HelixManager {
   private final List<InstanceConfigChangeListener> instanceConfigChangeListeners = new CopyOnWriteArrayList<>();
   private IdealStateChangeListener idealStateChangeListener;
   private RoutingTableProvider routingTableProvider;
-  private final MockHelixAdmin mockAdmin;
+  private final MockHelixAdmin localHelixAdmin;
   private final MockHelixDataAccessor dataAccessor;
   private final Exception beBadException;
   private final Map<String, ZNRecord> znRecordMap;
   private ZkHelixPropertyStore<ZNRecord> helixPropertyStore;
+  private boolean isAggregatedViewCluster;
+  private final List<MockHelixAdmin> helixAdminList;
 
   /**
    * Instantiate a MockHelixManager.
@@ -88,11 +91,16 @@ class MockHelixManager implements HelixManager {
    * @param helixCluster the {@link MockHelixCluster} associated with this manager.
    * @param znRecordMap a map that contains ZNode path and its {@link ZNRecord} associated with HelixPropertyStore in this manager.
    * @param beBadException the {@link Exception} that this manager will throw on listener registrations.
+   * @param zkAddrs
+   * @param isAggregatedViewCluster
    */
   MockHelixManager(String instanceName, InstanceType instanceType, String zkAddr, MockHelixCluster helixCluster,
-      Map<String, ZNRecord> znRecordMap, Exception beBadException) {
+      Map<String, ZNRecord> znRecordMap, Exception beBadException, List<String> zkAddrs,
+      boolean isAggregatedViewCluster) {
     this(instanceName, instanceType, zkAddr, helixCluster.getClusterName(),
-        helixCluster.getHelixAdminFactory().getHelixAdmin(zkAddr), znRecordMap, beBadException);
+        helixCluster.getHelixAdminFactory().getHelixAdmin(zkAddr), znRecordMap, beBadException,
+        zkAddrs.stream().map(s -> helixCluster.getHelixAdminFactory().getHelixAdmin(s)).collect(Collectors.toList()),
+        isAggregatedViewCluster);
   }
 
   /**
@@ -101,18 +109,23 @@ class MockHelixManager implements HelixManager {
    * @param instanceType the {@link InstanceType} of the requester.
    * @param zkAddr the address identifying the zk service to which this request is to be made.
    * @param clusterName the cluster name for this manager.
-   * @param helixAdmin the {@link HelixAdmin} that can be used to change configs.
+   * @param localHelixAdmin the {@link HelixAdmin} that can be used to change configs.
    * @param znRecordMap a map that contains ZNode path and its {@link ZNRecord} associated with HelixPropertyStore in this manager.
    * @param beBadException the {@link Exception} that this manager will throw on listener registrations.
+   * @param helixAdminList
+   * @param isAggregatedViewCluster
    */
   MockHelixManager(String instanceName, InstanceType instanceType, String zkAddr, String clusterName,
-      MockHelixAdmin helixAdmin, Map<String, ZNRecord> znRecordMap, Exception beBadException) {
+      MockHelixAdmin localHelixAdmin, Map<String, ZNRecord> znRecordMap, Exception beBadException,
+      List<MockHelixAdmin> helixAdminList, boolean isAggregatedViewCluster) {
     this.instanceName = instanceName;
     this.instanceType = instanceType;
     this.clusterName = clusterName;
-    mockAdmin = helixAdmin;
-    mockAdmin.addHelixManager(this);
-    dataAccessor = new MockHelixDataAccessor(clusterName, mockAdmin);
+    this.localHelixAdmin = localHelixAdmin;
+    this.helixAdminList = helixAdminList;
+    this.localHelixAdmin.addHelixManager(this);
+    dataAccessor =
+        new MockHelixDataAccessor(clusterName, this.localHelixAdmin, helixAdminList, isAggregatedViewCluster);
     this.beBadException = beBadException;
     this.znRecordMap = znRecordMap;
     Properties storeProps = new Properties();
@@ -127,6 +140,7 @@ class MockHelixManager implements HelixManager {
         helixPropertyStore.set(znodePathAndRecord.getKey(), znodePathAndRecord.getValue(), AccessOption.PERSISTENT);
       }
     }
+    this.isAggregatedViewCluster = isAggregatedViewCluster;
   }
 
   @Override
@@ -179,7 +193,7 @@ class MockHelixManager implements HelixManager {
 
   @Override
   public HelixAdmin getClusterManagmentTool() {
-    return mockAdmin;
+    return localHelixAdmin;
   }
 
   @Override
@@ -197,10 +211,18 @@ class MockHelixManager implements HelixManager {
    */
   void triggerLiveInstanceNotification(boolean init) {
     List<LiveInstance> liveInstances = new ArrayList<>();
-    ListIterator<String> it = mockAdmin.getUpInstances().listIterator();
-    while (it.hasNext()) {
-      ZNRecord znRecord = new ZNRecord(it.next());
-      znRecord.setEphemeralOwner(it.nextIndex()+1);
+    List<String> instances = new ArrayList<>();
+    if (isAggregatedViewCluster) {
+      for (MockHelixAdmin mockHelixAdmin : helixAdminList) {
+        instances.addAll(mockHelixAdmin.getUpInstances());
+      }
+    } else {
+      instances.addAll(localHelixAdmin.getUpInstances());
+    }
+    int count = 0;
+    for (String instance : instances) {
+      ZNRecord znRecord = new ZNRecord(instance);
+      znRecord.setEphemeralOwner(++count);
       liveInstances.add(new LiveInstance(znRecord));
     }
     NotificationContext notificationContext = new NotificationContext(this);
@@ -219,7 +241,8 @@ class MockHelixManager implements HelixManager {
       notificationContext.setType(NotificationContext.Type.INIT);
     }
     instanceConfigChangeListeners.forEach(
-        listener -> listener.onInstanceConfigChange(mockAdmin.getInstanceConfigs(clusterName), notificationContext));
+        listener -> listener.onInstanceConfigChange(localHelixAdmin.getInstanceConfigs(clusterName),
+            notificationContext));
   }
 
   void triggerIdealStateNotification(boolean init) throws InterruptedException {
@@ -227,12 +250,16 @@ class MockHelixManager implements HelixManager {
     if (init) {
       notificationContext.setType(NotificationContext.Type.INIT);
     }
-    idealStateChangeListener.onIdealStateChange(mockAdmin.getIdealStates(), notificationContext);
+    idealStateChangeListener.onIdealStateChange(localHelixAdmin.getIdealStates(), notificationContext);
   }
 
   void triggerRoutingTableNotification() {
     NotificationContext notificationContext = new NotificationContext(this);
-    routingTableProvider.onStateChange(instanceName, Collections.emptyList(), notificationContext);
+    if (isAggregatedViewCluster) {
+      routingTableProvider.onExternalViewChange(Collections.emptyList(), notificationContext);
+    } else {
+      routingTableProvider.onStateChange(instanceName, Collections.emptyList(), notificationContext);
+    }
   }
 
   //****************************
@@ -254,6 +281,10 @@ class MockHelixManager implements HelixManager {
 
   @Override
   public void addLiveInstanceChangeListener(LiveInstanceChangeListener liveInstanceChangeListener) throws Exception {
+    if (!(liveInstanceChangeListener instanceof RoutingTableProvider) && beBadException != null) {
+      // Throw exception when HelixClusterManager tries to add listener if beBadException is set
+      throw beBadException;
+    }
     this.liveInstanceChangeListener = liveInstanceChangeListener;
     triggerLiveInstanceNotification(false);
   }
@@ -336,9 +367,8 @@ class MockHelixManager implements HelixManager {
 
   @Override
   public void addExternalViewChangeListener(ExternalViewChangeListener externalViewChangeListener) throws Exception {
-    if (beBadException != null) {
-      throw beBadException;
-    }
+    // Note: routingTableProvider implements external view change listener
+    this.routingTableProvider = (RoutingTableProvider) externalViewChangeListener;
     this.externalViewChangeListener = externalViewChangeListener;
     NotificationContext notificationContext = new NotificationContext(this);
     notificationContext.setType(NotificationContext.Type.INIT);

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixManager.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixManager.java
@@ -161,6 +161,8 @@ class MockHelixManager implements HelixManager {
         helixPropertyStore.remove(znodePath, AccessOption.PERSISTENT);
       }
     }
+    helixPropertyStore.stop();
+    helixPropertyStore.close();
   }
 
   @Override
@@ -419,7 +421,7 @@ class MockHelixManager implements HelixManager {
 
   @Override
   public boolean removeListener(PropertyKey key, Object listener) {
-    throw new IllegalStateException("Not implemented");
+    return true;
   }
 
   @Override

--- a/ambry-commons/src/test/java/com/github/ambry/commons/CommonUtilsTest.java
+++ b/ambry-commons/src/test/java/com/github/ambry/commons/CommonUtilsTest.java
@@ -85,6 +85,7 @@ public class CommonUtilsTest {
     // Verify record
     ZNRecord result = propertyStore.get(path, null, AccessOption.PERSISTENT);
     assertEquals("Mismatch in list content", new HashSet<>(list), new HashSet<>(result.getListField("AmbryList")));
+    propertyStore.stop();
     zkInfo.shutdown();
   }
 }

--- a/ambry-router/src/main/java/com/github/ambry/router/SimpleOperationTracker.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/SimpleOperationTracker.java
@@ -783,8 +783,8 @@ class SimpleOperationTracker implements OperationTracker {
         .append(partitionId)
         .append(", partition class is ")
         .append(partitionId.getPartitionClass())
-        .append(" and associated resource is ")
-        .append(partitionId.getResourceName())
+        .append(" and associated resources are ")
+        .append(partitionId.getResourceNames())
         .append(". examinedReplicas: ");
     for (ReplicaId replicaId : examinedReplicas) {
       errMsg.append(replicaId.getDataNodeId()).append(":").append(replicaId.isDown()).append(" ");


### PR DESCRIPTION
This PR contains following changes for aggregated view:
1. Fix getReplicaIdsByState(dcName) to return only replicas in the asked data center.
2. Fetch data node configs (stored in Helix Property store) from all DCs in parallel to speed up initialization.
3. Use external view (instead of ideal states) to get partition-to-Resource mapping.
4. Add unit tests for Helix aggregated view.