### PR TITLE
[vcr] Reduce noise in logging exceptions

### DIFF
--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobStore.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobStore.java
@@ -75,6 +75,7 @@ class CloudBlobStore implements Store {
   private static final int cacheInitialCapacity = 1000;
   private static final float cacheLoadFactor = 0.75f;
   static final int STATUS_NOT_FOUND = 404;
+  static final int TOO_MANY_REQUESTS = 429;
   private static final short IGNORE_LIFE_VERSION = -2;
   private final PartitionId partitionId;
   private final CloudDestination cloudDestination;
@@ -637,6 +638,11 @@ class CloudBlobStore implements Store {
             "Delete", partitionId.toPathString());
       }
     } catch (CloudStorageException ex) {
+      if (ex.getStatusCode() == TOO_MANY_REQUESTS) {
+        // Throw no exception for throttling errors
+        logger.debug(ex.toString());
+        return;
+      }
       if (ex.getCause() instanceof StoreException) {
         throw (StoreException) ex.getCause();
       }

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobStore.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobStore.java
@@ -75,7 +75,6 @@ class CloudBlobStore implements Store {
   private static final int cacheInitialCapacity = 1000;
   private static final float cacheLoadFactor = 0.75f;
   static final int STATUS_NOT_FOUND = 404;
-  static final int TOO_MANY_REQUESTS = 429;
   private static final short IGNORE_LIFE_VERSION = -2;
   private final PartitionId partitionId;
   private final CloudDestination cloudDestination;
@@ -638,11 +637,6 @@ class CloudBlobStore implements Store {
             "Delete", partitionId.toPathString());
       }
     } catch (CloudStorageException ex) {
-      if (ex.getStatusCode() == TOO_MANY_REQUESTS) {
-        // Throw no exception for throttling errors
-        logger.debug(ex.toString());
-        return;
-      }
       if (ex.getCause() instanceof StoreException) {
         throw (StoreException) ex.getCause();
       }

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/StorageClient.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/StorageClient.java
@@ -426,9 +426,7 @@ public abstract class StorageClient implements AzureStorageClient {
     if (T instanceof BlobStorageException
         && ((BlobStorageException) T).getErrorCode() == BlobErrorCode.BLOB_ALREADY_EXISTS) {
       // Common case first
-      if (logger.isDebugEnabled()) {
         logger.debug("Blob store operation failed due to exception: " + T);
-      }
     } else {
       logger.error("Blob store operation failed due to exception: " + T.toString());
       azureMetrics.storageClientOperationExceptionCount.inc();

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/StorageClient.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/StorageClient.java
@@ -432,12 +432,12 @@ public abstract class StorageClient implements AzureStorageClient {
     }
     if (logError) {
       logger.error("Blob store operation failed due to exception: " + throwable.toString());
+      azureMetrics.storageClientOperationExceptionCount.inc();
+      // All retries must have been completed internally by now.
+      azureMetrics.storageClientFailureAfterRetryCount.inc();
     } else {
       logger.debug("Blob store operation failed due to exception: " + throwable);
     }
-    azureMetrics.storageClientOperationExceptionCount.inc();
-    // All retries must have been completed internally by now.
-    azureMetrics.storageClientFailureAfterRetryCount.inc();
   }
 
   /**

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/StorageClient.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/StorageClient.java
@@ -426,7 +426,7 @@ public abstract class StorageClient implements AzureStorageClient {
     if (T instanceof BlobStorageException
         && ((BlobStorageException) T).getErrorCode() == BlobErrorCode.BLOB_ALREADY_EXISTS) {
       // Common case first
-        logger.debug("Blob store operation failed due to exception: " + T);
+      logger.debug("Blob store operation failed due to exception: " + T);
     } else {
       logger.error("Blob store operation failed due to exception: " + T.toString());
       azureMetrics.storageClientOperationExceptionCount.inc();

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/StorageClient.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/StorageClient.java
@@ -418,7 +418,6 @@ public abstract class StorageClient implements AzureStorageClient {
    */
   protected abstract boolean handleExceptionAndHintRetry(BlobStorageException blobStorageException);
 
-
   /**
    * Handle any errors. For now, we update the error metrics.
    * @param T associated with this error.

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/StorageClient.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/StorageClient.java
@@ -58,7 +58,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
-import java.util.logging.Level;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/StorageClient.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/StorageClient.java
@@ -420,15 +420,15 @@ public abstract class StorageClient implements AzureStorageClient {
 
   /**
    * Handle any errors. For now, we update the error metrics.
-   * @param T associated with this error.
+   * @param t associated with this error.
    */
-  private void onError(Throwable T) {
-    if (T instanceof BlobStorageException
-        && ((BlobStorageException) T).getErrorCode() == BlobErrorCode.BLOB_ALREADY_EXISTS) {
+  private void onError(Throwable t) {
+    if (t instanceof BlobStorageException
+        && ((BlobStorageException) t).getErrorCode() == BlobErrorCode.BLOB_ALREADY_EXISTS) {
       // Common case first
-      logger.debug("Blob store operation failed due to exception: " + T);
+      logger.debug("Blob store operation failed due to exception: " + t);
     } else {
-      logger.error("Blob store operation failed due to exception: " + T.toString());
+      logger.error("Blob store operation failed due to exception: " + t);
       azureMetrics.storageClientOperationExceptionCount.inc();
       // All retries must have been completed internally by now.
       azureMetrics.storageClientFailureAfterRetryCount.inc();


### PR DESCRIPTION
We have been getting many tickets from VCR for errors including throttling errors and blob-already-exists cases. We get tickets because we log these errors. This just causes a lot of noise. This patch converts those log messages to debug messages.