### PR TITLE
Support replication with nonblocking network client

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/ReplicationConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/ReplicationConfig.java
@@ -224,22 +224,35 @@ public class ReplicationConfig {
   @Default("120")
   public final int replicationStandbyWaitTimeoutToTriggerCrossColoFetchSeconds;
 
-  @Config(REPLICATION_REQUEST_NETWORK_TIMEOUT_MS)
-  @Default("10 * 1000")
-  public final long replicationRequestNetworkTimeoutMs;
-  public final static String REPLICATION_REQUEST_NETWORK_TIMEOUT_MS = "replication.request.network.timeout.ms";
-
-  @Config(REPLICATION_REQUEST_NETWORK_POLL_TIMEOUT_MS)
-  @Default("40")
-  public final long replicationRequestNetworkPollTimeoutMs;
-  public final static String REPLICATION_REQUEST_NETWORK_POLL_TIMEOUT_MS =
-      "replication.request.network.poll.timeout.ms";
-
+  /**
+   * True to start using nonblocking network client for remote colo replication. The remote colo replication is a lot
+   * slower than the intra-colo replication so using a nonblocking network client should greatly improve the speed of
+   * replication. When doing so, also set the number of inter-colo replication thread to 1 since we only need one thread
+   * when using a nonblocking network client.
+   */
   @Config(REPLICATION_USING_NONBLOCKING_NETWORK_CLIENT_FOR_REMOTE_COLO)
   @Default("false")
   public final boolean replicationUsingNonblockingNetworkClientForRemoteColo;
   public final static String REPLICATION_USING_NONBLOCKING_NETWORK_CLIENT_FOR_REMOTE_COLO =
       "replication.using.nonblocking.network.client.for.remote.colo";
+  /**
+   * Timeout in milliseconds for requests in nonblocking network client. This configuration is only useful when the
+   * nonblocking network client is enabled.
+   */
+  @Config(REPLICATION_REQUEST_NETWORK_TIMEOUT_MS)
+  @Default("10 * 1000")
+  public final long replicationRequestNetworkTimeoutMs;
+  public final static String REPLICATION_REQUEST_NETWORK_TIMEOUT_MS = "replication.request.network.timeout.ms";
+
+  /**
+   * Timeout in milliseconds for polling the nonblocking network client to fetch more responses from remote hosts. This
+   * configuration is only useful when the nonblocking network client is enabled.
+   */
+  @Config(REPLICATION_REQUEST_NETWORK_POLL_TIMEOUT_MS)
+  @Default("40")
+  public final long replicationRequestNetworkPollTimeoutMs;
+  public final static String REPLICATION_REQUEST_NETWORK_POLL_TIMEOUT_MS =
+      "replication.request.network.poll.timeout.ms";
 
   public ReplicationConfig(VerifiableProperties verifiableProperties) {
 

--- a/ambry-api/src/main/java/com/github/ambry/config/ReplicationConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/ReplicationConfig.java
@@ -224,6 +224,23 @@ public class ReplicationConfig {
   @Default("120")
   public final int replicationStandbyWaitTimeoutToTriggerCrossColoFetchSeconds;
 
+  @Config(REPLICATION_REQUEST_NETWORK_TIMEOUT_MS)
+  @Default("10 * 1000")
+  public final long replicationRequestNetworkTimeoutMs;
+  public final static String REPLICATION_REQUEST_NETWORK_TIMEOUT_MS = "replication.request.network.timeout.ms";
+
+  @Config(REPLICATION_REQUEST_NETWORK_POLL_TIMEOUT_MS)
+  @Default("40")
+  public final long replicationRequestNetworkPollTimeoutMs;
+  public final static String REPLICATION_REQUEST_NETWORK_POLL_TIMEOUT_MS =
+      "replication.request.network.poll.timeout.ms";
+
+  @Config(REPLICATION_USING_NONBLOCKING_NETWORK_CLIENT_FOR_REMOTE_COLO)
+  @Default("false")
+  public final boolean replicationUsingNonblockingNetworkClientForRemoteColo;
+  public final static String REPLICATION_USING_NONBLOCKING_NETWORK_CLIENT_FOR_REMOTE_COLO =
+      "replication.using.nonblocking.network.client.for.remote.colo";
+
   public ReplicationConfig(VerifiableProperties verifiableProperties) {
 
     replicationStoreTokenFactory =
@@ -275,5 +292,10 @@ public class ReplicationConfig {
     replicationStandbyWaitTimeoutToTriggerCrossColoFetchSeconds =
         verifiableProperties.getIntInRange(REPLICATION_STANDBY_WAIT_TIMEOUT_TO_TRIGGER_CROSS_COLO_FETCH_SECONDS, 120,
             -1, Integer.MAX_VALUE);
+    replicationRequestNetworkTimeoutMs = verifiableProperties.getLong(REPLICATION_REQUEST_NETWORK_TIMEOUT_MS, 10000);
+    replicationRequestNetworkPollTimeoutMs =
+        verifiableProperties.getLong(REPLICATION_REQUEST_NETWORK_POLL_TIMEOUT_MS, 40);
+    replicationUsingNonblockingNetworkClientForRemoteColo =
+        verifiableProperties.getBoolean(REPLICATION_USING_NONBLOCKING_NETWORK_CLIENT_FOR_REMOTE_COLO, false);
   }
 }

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -2182,7 +2182,7 @@ public class ReplicaThread implements Runnable {
               group.getRemoteDataNode(), threadName, group.getId(), entry.getKey(), requestInfo.getRequestCreateTime());
         } else {
           // This shouldn't happen
-          logger.trace("Thread name: {} Request {} timed out", threadName, group.getId(), entry.getKey());
+          logger.trace("Thread name: {} RemoteReplicaGroup {} Request {} timed out", threadName, group.getId(), entry.getKey());
         }
       } else {
         // The correlationIdToRequest should be a LinkedHashMap that has a predictable iteration order based on insertion.
@@ -2216,7 +2216,7 @@ public class ReplicaThread implements Runnable {
         // back from the network client.
         if (remoteReplicaGroup != null) {
           RequestOrResponseType type = ((RequestOrResponse) requestInfo.getRequest()).getRequestType();
-          logger.debug("Remote node: {} Thread name: RemoteReplicaGroup {} Handling response of type {} for {}",
+          logger.debug("Remote node: {} Thread name: {} RemoteReplicaGroup {} Handling response of type {} for {}",
               remoteReplicaGroup.getRemoteDataNode(), threadName, remoteReplicaGroup.getId(), type, correlationId);
           switch (type) {
             case ReplicaMetadataRequest:
@@ -2232,7 +2232,7 @@ public class ReplicaThread implements Runnable {
           }
         } else {
           logger.trace("Thread Name: {} No RemoteReplicaGroup found for correlation Id {}, it might already time out",
-              correlationId);
+              threadName, correlationId);
         }
       }
     }

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -33,6 +33,10 @@ import com.github.ambry.network.ChannelOutput;
 import com.github.ambry.network.ConnectedChannel;
 import com.github.ambry.network.ConnectionPool;
 import com.github.ambry.network.NetworkClient;
+import com.github.ambry.network.NetworkClientErrorCode;
+import com.github.ambry.network.Port;
+import com.github.ambry.network.RequestInfo;
+import com.github.ambry.network.ResponseInfo;
 import com.github.ambry.notification.BlobReplicaSourceType;
 import com.github.ambry.notification.NotificationSystem;
 import com.github.ambry.notification.UpdateType;
@@ -45,6 +49,8 @@ import com.github.ambry.protocol.ReplicaMetadataRequest;
 import com.github.ambry.protocol.ReplicaMetadataRequestInfo;
 import com.github.ambry.protocol.ReplicaMetadataResponse;
 import com.github.ambry.protocol.ReplicaMetadataResponseInfo;
+import com.github.ambry.protocol.RequestOrResponse;
+import com.github.ambry.protocol.RequestOrResponseType;
 import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.store.MessageInfo;
 import com.github.ambry.store.StoreErrorCodes;
@@ -55,12 +61,16 @@ import com.github.ambry.store.Transformer;
 import com.github.ambry.utils.NettyByteBufDataInputStream;
 import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
+import java.io.DataInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -119,6 +129,8 @@ public class ReplicaThread implements Runnable {
 
   private final Timer replicationLatencyTimer;
   private final Timer portTypeBasedReplicationLatencyTimer;
+
+  private Map<DataNodeId, List<ExchangeMetadataResponse>> exchangeMetadataResponsesInEachCycle = null;
 
   public ReplicaThread(String threadName, FindTokenHelper findTokenHelper, ClusterMap clusterMap,
       AtomicInteger correlationIdGenerator, DataNodeId dataNodeId, ConnectionPool connectionPool,
@@ -288,7 +300,8 @@ public class ReplicaThread implements Runnable {
     try {
       allReplicatedPartitions.add(remoteReplicaInfo.getReplicaId().getPartitionId());
       DataNodeId dataNodeId = remoteReplicaInfo.getReplicaId().getDataNodeId();
-      if (!replicasToReplicateGroupedByNode.computeIfAbsent(dataNodeId, key -> new HashSet<>())
+      // Use a linked hash set to make sure that we maintain a predictable order based on the insertion
+      if (!replicasToReplicateGroupedByNode.computeIfAbsent(dataNodeId, key -> new LinkedHashSet<>())
           .add(remoteReplicaInfo)) {
         replicationMetrics.remoteReplicaInfoAddError.inc();
         // Since VCR is also listening Ambry Clustermap change, this may happen if events happens in following order:
@@ -342,9 +355,23 @@ public class ReplicaThread implements Runnable {
    *
    */
   public void replicate() {
+    if (networkClient == null) {
+      replicateWithBlockingChannel();
+    } else {
+      replicateWithNetworkClient();
+    }
+  }
+
+  /**
+   * Do replication for replicas grouped by {@link DataNodeId} with blocking channel.
+   */
+  public void replicateWithBlockingChannel() {
+    exchangeMetadataResponsesInEachCycle = new HashMap<>();
     boolean allCaughtUp = true;
+    long oneRoundStartTimeMs = time.milliseconds();
     Map<DataNodeId, List<RemoteReplicaInfo>> dataNodeToRemoteReplicaInfo = getRemoteReplicaInfos();
 
+    storeKeyConverter.dropCache();
     logger.trace("Replicating from {} DataNodes.", replicasToReplicateGroupedByNode.size());
     for (Map.Entry<DataNodeId, List<RemoteReplicaInfo>> entry : dataNodeToRemoteReplicaInfo.entrySet()) {
       if (!running) {
@@ -391,6 +418,8 @@ public class ReplicaThread implements Runnable {
             List<ExchangeMetadataResponse> exchangeMetadataResponseList =
                 exchangeMetadata(connectedChannel, replicaSubList);
             exchangeMetadataTimeInMs = time.milliseconds() - startTimeInMs;
+            exchangeMetadataResponsesInEachCycle.computeIfAbsent(remoteNode, k -> new ArrayList<>())
+                .addAll(exchangeMetadataResponseList);
 
             if (replicatingFromRemoteColo && leaderBasedReplicationAdmin != null) {
               // If leader based replication is enabled, we are replicating from remote colo, fetch the missing blobs
@@ -448,7 +477,7 @@ public class ReplicaThread implements Runnable {
                 .map(ExchangeMetadataResponse::getMissingStoreKeys)
                 .flatMap(Collection::stream)
                 .collect(Collectors.toList());
-            convertStoreKeys(storeKeysToConvert);
+            storeKeyConverter.convert(storeKeysToConvert);
 
             exchangeMetadataTimeInMs = 0;
             fixMissingStoreKeysTimeInMs = -1;
@@ -494,7 +523,17 @@ public class ReplicaThread implements Runnable {
         portTypeBasedContext.stop();
       }
     }
+    replicationMetrics.updateOneCycleReplicationTime(time.milliseconds() - oneRoundStartTimeMs,
+        replicatingFromRemoteColo, datacenterName);
+    maybeSleepAfterReplication(allCaughtUp);
+  }
 
+  /**
+   * Maybe sleep for a while after one round of replication. If all the replicas are caught up and the configuration
+   * shows we should sleep, then sleep for a while so we can save some CPU.
+   * @param allCaughtUp True when all replicas are caught up.
+   */
+  private void maybeSleepAfterReplication(boolean allCaughtUp) {
     long sleepDurationMs = 0;
     if (allCaughtUp && replicationConfig.replicationReplicaThreadIdleSleepDurationMs > 0) {
       sleepDurationMs = replicationConfig.replicationReplicaThreadIdleSleepDurationMs;
@@ -504,7 +543,7 @@ public class ReplicaThread implements Runnable {
       throttleCount.inc();
     }
 
-    if (sleepDurationMs > 0) {
+    if (running && sleepDurationMs > 0) {
       try {
         long currentTime = time.milliseconds();
         time.sleep(sleepDurationMs);
@@ -567,7 +606,7 @@ public class ReplicaThread implements Runnable {
    * @throws ReplicationException Any other exception that will be wrapped
    */
   List<ExchangeMetadataResponse> exchangeMetadata(ConnectedChannel connectedChannel,
-      List<RemoteReplicaInfo> replicasToReplicatePerNode) throws IOException, ReplicationException {
+      List<RemoteReplicaInfo> replicasToReplicatePerNode) throws ReplicationException {
     long exchangeMetadataStartTimeInMs = time.milliseconds();
     if (replicasToReplicatePerNode.isEmpty()) {
       return Collections.emptyList();
@@ -577,6 +616,11 @@ public class ReplicaThread implements Runnable {
       ReplicaMetadataResponse response =
           getReplicaMetadataResponse(replicasToReplicatePerNode, connectedChannel, remoteNode);
       return handleReplicaMetadataResponse(response, replicasToReplicatePerNode, remoteNode);
+    } catch (Exception e) {
+      if (e instanceof ReplicationException) {
+        throw (ReplicationException) e;
+      }
+      throw new ReplicationException(e);
     } finally {
       long exchangeMetadataTime = time.milliseconds() - exchangeMetadataStartTimeInMs;
       replicationMetrics.updateExchangeMetadataTime(exchangeMetadataTime, replicatingFromRemoteColo, replicatingOverSsl,
@@ -595,7 +639,7 @@ public class ReplicaThread implements Runnable {
    * @throws IOException
    */
   List<ExchangeMetadataResponse> handleReplicaMetadataResponse(ReplicaMetadataResponse response,
-      List<RemoteReplicaInfo> replicasToReplicatePerNode, DataNodeId remoteNode) throws IOException {
+      List<RemoteReplicaInfo> replicasToReplicatePerNode, DataNodeId remoteNode) throws Exception {
     long startTimeInMs = time.milliseconds();
     List<ExchangeMetadataResponse> exchangeMetadataResponseList = new ArrayList<>();
     Map<StoreKey, StoreKey> remoteKeyToLocalKeyMap = batchConvertReplicaMetadataResponseKeys(response);
@@ -1031,7 +1075,7 @@ public class ReplicaThread implements Runnable {
    * @return the map from the {@link StoreKeyConverter#convert(Collection)} call
    * @throws IOException thrown if {@link StoreKeyConverter#convert(Collection)} fails
    */
-  Map<StoreKey, StoreKey> batchConvertReplicaMetadataResponseKeys(ReplicaMetadataResponse response) throws IOException {
+  Map<StoreKey, StoreKey> batchConvertReplicaMetadataResponseKeys(ReplicaMetadataResponse response) throws Exception {
     List<StoreKey> storeKeysToConvert = new ArrayList<>();
     for (ReplicaMetadataResponseInfo replicaMetadataResponseInfo : response.getReplicaMetadataResponseInfoList()) {
       if ((replicaMetadataResponseInfo.getError() == ServerErrorCode.No_Error) && (
@@ -1041,22 +1085,7 @@ public class ReplicaThread implements Runnable {
         }
       }
     }
-    return convertStoreKeys(storeKeysToConvert);
-  }
-
-  /**
-   * Converts all input remote store keys to local keys using {@link StoreKeyConverter}
-   * @param storeKeysToConvert the {@link List<StoreKey>} list of keys to be converted
-   * @return the map from the {@link StoreKeyConverter#convert(Collection)} call
-   * @throws IOException thrown if {@link StoreKeyConverter#convert(Collection)} fails
-   */
-  Map<StoreKey, StoreKey> convertStoreKeys(List<StoreKey> storeKeysToConvert) throws IOException {
-    try {
-      storeKeyConverter.dropCache();
-      return storeKeyConverter.convert(storeKeysToConvert);
-    } catch (Exception e) {
-      throw new IOException("Problem with store key conversion", e);
-    }
+    return storeKeyConverter.convert(storeKeysToConvert);
   }
 
   /**
@@ -1564,6 +1593,10 @@ public class ReplicaThread implements Runnable {
     return replicationMetrics;
   }
 
+  Map<DataNodeId, List<ExchangeMetadataResponse>> getExchangeMetadataResponsesInEachCycle() {
+    return exchangeMetadataResponsesInEachCycle;
+  }
+
   static class ExchangeMetadataResponse {
     // Set of messages from remote replica missing in the local store.
     final Set<MessageInfo> missingStoreMessages;
@@ -1721,6 +1754,482 @@ public class ReplicaThread implements Runnable {
     } finally {
       lock.unlock();
     }
+    if (networkClient != null) {
+      networkClient.close();
+    }
     shutdownLatch.await();
+  }
+
+  /**
+   * ReplicaGroupState indicates different state of RemoteReplicaGroup in one replication cycle.
+   * Each replication cycle, we will break all the replicas in order different groups and each group
+   * has to go through these states to finish replication with nonblocking network client.
+   */
+  enum ReplicaGroupState {
+    /**
+     * The group is ready to start replication.
+     */
+    STARTED,
+    /**
+     * The group has sent the ReplicaMetadataRequest.
+     */
+    REPLICA_METADATA_REQUEST_SENT,
+    /**
+     * The group has handled the ReplicaMetadataResponse.
+     */
+    REPLICA_METADATA_RESPONSE_HANDLED,
+    /**
+     * The group has sent the GetRequest.
+     */
+    GET_REQUEST_SENT,
+    /**
+     * The group has handled the GetResponse and the process is marked as Done.
+     */
+    DONE
+  }
+
+  /**
+   * A group of remote replicas to replicate. This group of replicas belongs to the same data node, so we can create one
+   * ReplicaMetadatRequest to exchange replication metadata and one GetRequest to copy all the missing blobs if there is
+   * any.
+   *
+   * For replication, this group has to go through several state in sequence.
+   * <ol>
+   *   <li>Send ReplicaMetadataRequest to remote data node</li>
+   *   <li>Wait for ReplicaMetadataResponse to come back and handle the ReplicaMetadataResponse</li>
+   *   <li>Send GetRequest to remote data node</li>
+   *   <li>Wait for GetResponse to come back and handle the GetResponse</li>
+   * </ol>
+   * Since network requests will be done through a nonblocking network client, we have to keep track of which state
+   * this group is currently in. A group is in STARTED state when created. In STARTED state, it can send out one
+   * {@link ReplicaMetadataRequest} and enter REPLICA_METADATA_REQUEST_SENT state. In this state, it will wait for
+   * {@link ReplicaMetadataResponse} from network client. After getting the response from the network client, it
+   * handles the response and moves to REPLICA_METADATA_RESPONSE_HANDLED state. in this state, it can send out one
+   * {@link GetRequest} and enter GET_REQUEST_SENT state. In this state, it will wait for {@link GetResponse} from
+   * network client. After getting the response from tne network client, it handles the response and moves to DONE
+   * state. Any error happens in the middle of processing would force group to DONE state.
+   */
+  private class RemoteReplicaGroup {
+    private final List<RemoteReplicaInfo> remoteReplicaInfos;
+    private final DataNodeId remoteDataNode;
+    private final boolean standbyCatchingUp;
+    private final int id;
+    private List<ExchangeMetadataResponse> exchangeMetadataResponseList;
+    private ReplicaGroupState state;
+    private Exception exception = null;
+    private long replicaMetadataRequestStartTimeMs;
+    private long getRequestStartTimeMs;
+    private long exchangeMetadataStartTimeInMs;
+    private long fixMissingStoreKeysStartTimeInMs;
+
+    /**
+     * Constructor of {@link RemoteReplicaGroup}.
+     * @param remoteReplicaInfos The list {@link RemoteReplicaInfo} that point to the list of replicas.
+     * @param dataNodeId The remote data no
+     * @param standbyCatchingUp True if this is standby replicas trying to catch up with the missing blob content. If true,
+     *                          this group should start with REPLICA_METADATA_RESPONSE_HANDLED, since it already exchanged
+     *                          ReplicaMetadata before and now wants to download missing blobs.
+     * @param id The id of this RemoteReplicaGroup. This id should be unique at each cycle.
+     */
+    public RemoteReplicaGroup(List<RemoteReplicaInfo> remoteReplicaInfos, DataNodeId dataNodeId,
+        boolean standbyCatchingUp, int id) {
+      this.remoteReplicaInfos = remoteReplicaInfos;
+      this.remoteDataNode = dataNodeId;
+      this.standbyCatchingUp = standbyCatchingUp;
+      this.id = id;
+      if (standbyCatchingUp) {
+        exchangeMetadataResponseList = remoteReplicaInfos.stream()
+            .map(remoteReplicaInfo -> new ExchangeMetadataResponse(remoteReplicaInfo.getExchangeMetadataResponse()))
+            .collect(Collectors.toList());
+        List<StoreKey> storeKeysToConvert = exchangeMetadataResponseList.stream()
+            .map(ExchangeMetadataResponse::getMissingStoreKeys)
+            .flatMap(Collection::stream)
+            .collect(Collectors.toList());
+        try {
+          storeKeyConverter.convert(storeKeysToConvert);
+          state = ReplicaGroupState.REPLICA_METADATA_RESPONSE_HANDLED;
+        } catch (Exception e) {
+          setException(e, "Failed to convert storeKeys");
+        }
+      } else {
+        state = ReplicaGroupState.STARTED;
+      }
+      logger.trace(
+          "Remote node: {} Thread name: {} Adding a new RemoteReplicaGroup {}, ReplicaInfos {}, State {} isStandbyCatchingup {}",
+          dataNodeId, threadName, id, remoteReplicaInfos, state, standbyCatchingUp);
+    }
+
+    public List<RemoteReplicaInfo> getRemoteReplicaInfos() {
+      return remoteReplicaInfos;
+    }
+
+    public DataNodeId getRemoteDataNode() {
+      return remoteDataNode;
+    }
+
+    public boolean isDone() {
+      return state == ReplicaGroupState.DONE;
+    }
+
+    public int getId() {
+      return id;
+    }
+
+    public List<ExchangeMetadataResponse> getExchangeMetadataResponseList() {
+      return exchangeMetadataResponseList;
+    }
+
+    /**
+     * Polling the {@link RequestInfo} from this group to send out. Each group has two requests to send out, one is
+     * ReplicaMetadataRequest the other is GetRequest. Group only sends ReplicaMetadataRequest when it's in STARTED
+     * state. And it only sends GetRequest when it's in REPLICA_METADATA_RESPONSE_HANDLED state. When group is not in
+     * those states, this method would return null.
+     *
+     * @return {@link RequestInfo} to send out. A null might be returned when there is nothing to send.
+     */
+    public RequestInfo poll() {
+      Port port = remoteReplicaInfos.get(0).getPort();
+      long timeout = replicationConfig.replicationRequestNetworkTimeoutMs;
+      if (state == ReplicaGroupState.STARTED) {
+        // When the state is STARTED, we will send the ReplicaMetadataRequest out.
+        replicaMetadataRequestStartTimeMs = time.milliseconds();
+        exchangeMetadataStartTimeInMs = replicaMetadataRequestStartTimeMs;
+        ReplicaMetadataRequest request = createReplicaMetadataRequest(remoteReplicaInfos, remoteDataNode);
+        RequestInfo requestInfo =
+            new RequestInfo(remoteDataNode.getHostname(), port, request, remoteReplicaInfos.get(0).getReplicaId(), null,
+                time.milliseconds(), timeout, timeout);
+        logger.trace(
+            "Remote node: {} Thread name: {} RemoteReplicaGroup {} Create ReplicaMetadataRequest, correlation id {}, state {}",
+            dataNodeId, threadName, id, requestInfo.getRequest().getCorrelationId(), state);
+        state = ReplicaGroupState.REPLICA_METADATA_REQUEST_SENT;
+        return requestInfo;
+      } else if (state == ReplicaGroupState.REPLICA_METADATA_RESPONSE_HANDLED) {
+        // When the state is REPLICA_METADATA_RESPONSE_HANDLED, we will send the GetRequest out if needed.
+        List<RemoteReplicaInfo> remoteReplicaInfosToSendGet = remoteReplicaInfos;
+        if (!standbyCatchingUp && replicatingFromRemoteColo && leaderBasedReplicationAdmin != null) {
+          // If this is not standby replicas trying to catch up, and this is cross-colo replication, and we enable
+          // leader based replication, then filter out remote replicas that is not leader to leader.
+          List<RemoteReplicaInfo> leaderReplicaList = new ArrayList<>();
+          List<ExchangeMetadataResponse> exchangeMetadataResponseListForLeaderReplicas = new ArrayList<>();
+          getLeaderReplicaList(remoteReplicaInfos, exchangeMetadataResponseList, leaderReplicaList,
+              exchangeMetadataResponseListForLeaderReplicas);
+          remoteReplicaInfosToSendGet = leaderReplicaList;
+          exchangeMetadataResponseList = exchangeMetadataResponseListForLeaderReplicas;
+        }
+        if (!remoteReplicaInfosToSendGet.isEmpty()) {
+          GetRequest request = createGetRequest(remoteReplicaInfos, exchangeMetadataResponseList, remoteDataNode);
+          if (request != null) {
+            // Only when we still have RemoteReplicaInfos and when the GetRequest is not null
+            // we send the GetRequest out
+            getRequestStartTimeMs = time.milliseconds();
+            fixMissingStoreKeysStartTimeInMs = getRequestStartTimeMs;
+            RequestInfo requestInfo = new RequestInfo(remoteDataNode.getHostname(), port, request,
+                remoteReplicaInfosToSendGet.get(0).getReplicaId(), null, time.milliseconds(), timeout, timeout);
+            logger.trace(
+                "Remote node: {} Thread name: {} RemoteReplicaGroup {} Create GetRequest, correlation id {}, state {}",
+                dataNodeId, threadName, id, requestInfo.getRequest().getCorrelationId(), state);
+            state = ReplicaGroupState.GET_REQUEST_SENT;
+            return requestInfo;
+          }
+        }
+        logger.trace("Remote node: {} Thread name: {} RemoteReplicaGroup {} No GetRequest needed, set state to Done",
+            dataNodeId, threadName, id);
+        state = ReplicaGroupState.DONE;
+      }
+      return null;
+    }
+
+    /**
+     * Handle the {@link ReplicaMetadataResponse} returned in {@link ResponseInfo} by nonblocking network client.
+     * @param responseInfo The {@link ResponseInfo} that carries a {@link ReplicaMetadataResponse}.
+     */
+    public void handleReplicaMetadataResponse(ResponseInfo responseInfo) {
+      if (state != ReplicaGroupState.REPLICA_METADATA_REQUEST_SENT) {
+        logger.error("Remote node: {} Thread name: {} ReplicaMetadataResponse comes back after wrong state {}",
+            remoteDataNode, threadName, state);
+        return;
+      }
+
+      NetworkClientErrorCode networkClientErrorCode = responseInfo.getError();
+      logger.trace(
+          "Remote node: {} Thread name: {} RemoteReplicaGroup {} ReplicaMetadataResponse come back for correlation id {}, NetworkClientError {}",
+          dataNodeId, threadName, id, responseInfo.getRequestInfo().getRequest().getCorrelationId(),
+          networkClientErrorCode);
+      if (networkClientErrorCode == null) {
+        replicationMetrics.updateMetadataRequestTime(time.milliseconds() - replicaMetadataRequestStartTimeMs,
+            replicatingFromRemoteColo, replicatingOverSsl, datacenterName);
+        try {
+          // Deserialize the request from the given ResponseInfo
+          DataInputStream dis = new NettyByteBufDataInputStream(responseInfo.content());
+          ReplicaMetadataResponse response = ReplicaMetadataResponse.readFrom(dis, findTokenHelper, clusterMap);
+          exchangeMetadataResponseList =
+              ReplicaThread.this.handleReplicaMetadataResponse(response, remoteReplicaInfos, remoteDataNode);
+          state = ReplicaGroupState.REPLICA_METADATA_RESPONSE_HANDLED;
+          logger.trace(
+              "Remote node: {} Thread name: {} RemoteReplicaGroup {} Handled ReplicaMetadataResponse for correlation id {}, set state to {}",
+              dataNodeId, threadName, id, responseInfo.getRequestInfo().getRequest().getCorrelationId(), state);
+          long exchangeMetadataTimeInMs = time.milliseconds() - exchangeMetadataStartTimeInMs;
+          replicationMetrics.updateExchangeMetadataTime(exchangeMetadataTimeInMs, replicatingFromRemoteColo,
+              replicatingOverSsl, datacenterName);
+        } catch (Exception e) {
+          setException(e, "ReplicaMetadataResponse deserialization received unexpected error");
+        }
+      } else {
+        // We have a network client error here, mark all the replicas int request with this error.
+        remoteReplicaInfos.forEach(r -> responseHandler.onEvent(r.getReplicaId(), networkClientErrorCode));
+        setException(new IOException("NetworkClientErrorCode: " + networkClientErrorCode),
+            "Failed to send ReplicaMetadataRequest");
+      }
+    }
+
+    /**
+     * Handle the {@link GetResponse} returned in {@link ResponseInfo} by nonblocking network client.
+     * @param responseInfo The {@link ResponseInfo} that carries a {@link GetResponse}.
+     */
+    public void handleGetResponse(ResponseInfo responseInfo) {
+      if (state != ReplicaGroupState.GET_REQUEST_SENT) {
+        logger.error("Remote node: {} Thread name: {} GetResponse comes back after wrong state {}", remoteDataNode,
+            threadName, state);
+        return;
+      }
+      NetworkClientErrorCode networkClientErrorCode = responseInfo.getError();
+      logger.trace(
+          "Remote node: {} Thread name: {} RemoteReplicaGroup {} GetResponse come back for correlation id {}, NetworkClientError {}",
+          dataNodeId, threadName, id, responseInfo.getRequestInfo().getRequest().getCorrelationId(),
+          networkClientErrorCode);
+      if (networkClientErrorCode == null) {
+        replicationMetrics.updateGetRequestTime(time.milliseconds() - getRequestStartTimeMs, replicatingFromRemoteColo,
+            replicatingOverSsl, datacenterName, standbyCatchingUp);
+        try {
+          // Deserialize the request from the given ResponseInfo
+          DataInputStream dis = new NettyByteBufDataInputStream(responseInfo.content());
+          GetResponse response = GetResponse.readFrom(dis, clusterMap);
+          ReplicaThread.this.handleGetResponse(response, remoteReplicaInfos, exchangeMetadataResponseList,
+              remoteDataNode, standbyCatchingUp);
+          logger.trace(
+              "Remote node: {} Thread name: {} RemoteReplicaGroup {} Handled GetResponse for correlation id {}",
+              dataNodeId, threadName, id, responseInfo.getRequestInfo().getRequest().getCorrelationId());
+          long fixMissingStoreKeysTime = time.milliseconds() - fixMissingStoreKeysStartTimeInMs;
+          replicationMetrics.updateFixMissingStoreKeysTime(fixMissingStoreKeysTime, replicatingFromRemoteColo,
+              replicatingOverSsl, datacenterName);
+        } catch (Exception e) {
+          setException(e, "GetResponse deserialization received unexpected error");
+        }
+      } else {
+        remoteReplicaInfos.forEach(r -> responseHandler.onEvent(r.getReplicaId(), networkClientErrorCode));
+        setException(new IOException("NetworkClientErrorCode: " + networkClientErrorCode), "Failed to send GetRequest");
+      }
+      state = ReplicaGroupState.DONE;
+    }
+
+    /**
+     * Set exception for the group and change the state to DONE and log the message out.
+     * @param e The exception to set
+     * @param message The message to log out
+     */
+    private void setException(Exception e, String message) {
+      logger.error("Remote node: {} Thread name: {} RemoteReplicaGroup {} {}", remoteDataNode, threadName, id, message,
+          e);
+      exception = e;
+      state = ReplicaGroupState.DONE;
+    }
+
+    /**
+     * @return The exception.
+     */
+    public Exception getException() {
+      return exception;
+    }
+  }
+
+  /**
+   * Do replication for replicas grouped by {@link DataNodeId} with nonblocking network client.
+   */
+  public void replicateWithNetworkClient() {
+    exchangeMetadataResponsesInEachCycle = new HashMap<>();
+    long oneRoundStartTimeMs = time.milliseconds();
+    logger.trace("Thread name: {} Start RemoteReplicaGroup replication", threadName);
+    List<RemoteReplicaGroup> remoteReplicaGroups = new ArrayList<>();
+    int remoteReplicaGroupId = 0;
+
+    // Before each cycle of replication, we clean up the cache in key converter.
+    storeKeyConverter.dropCache();
+    Map<DataNodeId, List<RemoteReplicaInfo>> dataNodeToRemoteReplicaInfo = getRemoteReplicaInfos();
+    for (Map.Entry<DataNodeId, List<RemoteReplicaInfo>> entry : dataNodeToRemoteReplicaInfo.entrySet()) {
+      DataNodeId remoteNode = entry.getKey();
+      List<RemoteReplicaInfo> replicasToReplicatePerNode = entry.getValue();
+      List<RemoteReplicaInfo> activeReplicasPerNode = new ArrayList<>();
+      List<RemoteReplicaInfo> standbyReplicasWithNoProgress = new ArrayList<>();
+      filterRemoteReplicasToReplicate(replicasToReplicatePerNode, activeReplicasPerNode, standbyReplicasWithNoProgress);
+
+      if (activeReplicasPerNode.size() > 0) {
+        List<List<RemoteReplicaInfo>> activeReplicaSubLists =
+            maxReplicaCountPerRequest > 0 ? Utils.partitionList(activeReplicasPerNode, maxReplicaCountPerRequest)
+                : Collections.singletonList(activeReplicasPerNode);
+        for (List<RemoteReplicaInfo> replicaSubList : activeReplicaSubLists) {
+          RemoteReplicaGroup group = new RemoteReplicaGroup(replicaSubList, remoteNode, false, remoteReplicaGroupId++);
+          remoteReplicaGroups.add(group);
+        }
+      }
+      if (standbyReplicasWithNoProgress.size() > 0) {
+        List<RemoteReplicaInfo> standbyReplicasTimedOutOnNoProgress =
+            getRemoteStandbyReplicasTimedOutOnNoProgress(standbyReplicasWithNoProgress);
+        RemoteReplicaGroup group =
+            new RemoteReplicaGroup(standbyReplicasTimedOutOnNoProgress, remoteNode, true, remoteReplicaGroupId++);
+        remoteReplicaGroups.add(group);
+      }
+    }
+    // A map from correlation id to RemoteReplicaGroup. This is used to find the group when response comes back.
+    Map<Integer, RemoteReplicaGroup> correlationIdToReplicaGroup = new HashMap<>();
+    // A map from correlation id to RequestInfo. This is used to find timed out RequestInfos.
+    Map<Integer, RequestInfo> correlationIdToRequestInfo = new LinkedHashMap<>();
+    while (!remoteReplicaGroups.stream().allMatch(RemoteReplicaGroup::isDone)) {
+      if (!running) {
+        break;
+      }
+      List<RequestInfo> requestInfos =
+          pollRemoteReplicaGroups(remoteReplicaGroups, correlationIdToRequestInfo, correlationIdToReplicaGroup);
+      List<ResponseInfo> timedOutResponses =
+          filterTimedOutRequests(correlationIdToRequestInfo, correlationIdToReplicaGroup);
+      Set<Integer> requestsToDrop = timedOutResponses.stream()
+          .map(resp -> resp.getRequestInfo().getRequest().getCorrelationId())
+          .collect(Collectors.toSet());
+
+      final int pollTimeoutMs = (int) replicationConfig.replicationRequestNetworkPollTimeoutMs;
+      List<ResponseInfo> responseInfos = networkClient.sendAndPoll(requestInfos, requestsToDrop, pollTimeoutMs);
+      // Adding the timed out responses after network client, since a timed out request might have its response coming
+      // back in the sendAndPoll call. We want to handle the responses from the network client first if they are present.
+      responseInfos.addAll(timedOutResponses);
+      onResponses(responseInfos, correlationIdToReplicaGroup);
+    }
+    logger.trace("Thread name: {} Finish all RemoteReplicaGroup replication", threadName);
+    remoteReplicaGroups.stream()
+        .forEach(
+            g -> exchangeMetadataResponsesInEachCycle.computeIfAbsent(g.getRemoteDataNode(), k -> new ArrayList<>())
+                .addAll(g.getExchangeMetadataResponseList()));
+
+    // Print out the exceptions.
+    remoteReplicaGroups.stream().filter(g -> g.isDone() && g.getException() != null).forEach(g -> {
+      logger.error("Remote node: {} Thread name: {} RemoteReplicaGroup {} has exception {}", g.getRemoteDataNode(),
+          threadName, g.getRemoteReplicaInfos(), g.getException());
+    });
+
+    replicationMetrics.updateOneCycleReplicationTime(time.milliseconds() - oneRoundStartTimeMs,
+        replicatingFromRemoteColo, datacenterName);
+    maybeSleepAfterReplication(remoteReplicaGroups.isEmpty());
+  }
+
+  /**
+   * Polling the request from each {@link RemoteReplicaGroup}. Adding new requests to the {@code correlationIdToRequestInfo}
+   * map and the {@code correlationIdToRemoteReplicaGroup} map.
+   * @param remoteReplicaGroups The list of the {@link RemoteReplicaGroup} to poll requests from.
+   * @param correlationIdToRequestInfo The map from correlation id to request info, new request would be added to this map.
+   * @param correlationIdToRemoteReplicaGroup The map from correlation id to remote replica group, new request would be
+   *                                          added to this map.
+   * @return A list of {@link RequestInfo}s.
+   */
+  private List<RequestInfo> pollRemoteReplicaGroups(List<RemoteReplicaGroup> remoteReplicaGroups,
+      Map<Integer, RequestInfo> correlationIdToRequestInfo,
+      Map<Integer, RemoteReplicaGroup> correlationIdToRemoteReplicaGroup) {
+    logger.trace("Thread Name: {} Polling {} RemoteReplicaGroups for requests", threadName, remoteReplicaGroups.size());
+    List<RequestInfo> requestInfos = new ArrayList<>();
+    for (RemoteReplicaGroup group : remoteReplicaGroups) {
+      if (group.isDone()) {
+        logger.trace("Remote Node: {} Thread Name: {} RemoteReplicaGroup {} is Done", group.getRemoteDataNode(),
+            threadName, group.getId());
+        continue;
+      }
+      RequestInfo requestInfo = group.poll();
+      if (requestInfo != null) {
+        requestInfos.add(requestInfo);
+        correlationIdToRemoteReplicaGroup.put(requestInfo.getRequest().getCorrelationId(), group);
+        correlationIdToRequestInfo.put(requestInfo.getRequest().getCorrelationId(), requestInfo);
+      }
+    }
+    logger.trace("Thread Name: {} There are {} requests polled from RemoteReplicaGroups", threadName,
+        requestInfos.size());
+    return requestInfos;
+  }
+
+  /**
+   * Filter requests that are timed out and return corresponding ResponseInfos for them. This method would also remove
+   * the timed out request form the map.
+   * @param correlationIdToRequest The map from correlation id to request.
+   * @param correlationIdToRemoteReplicaGroup The map from correlation id to RemoteReplicaGroup
+   * @return A list of ResponseInfo for the timed out requests.
+   */
+  private List<ResponseInfo> filterTimedOutRequests(Map<Integer, RequestInfo> correlationIdToRequest,
+      Map<Integer, RemoteReplicaGroup> correlationIdToRemoteReplicaGroup) {
+    logger.trace("Thread Name: {} Trying to filter out timed out requests", threadName);
+    List<ResponseInfo> responseInfos = new ArrayList<>();
+    Iterator<Map.Entry<Integer, RequestInfo>> inFlightRequestIterator = correlationIdToRequest.entrySet().iterator();
+    while (inFlightRequestIterator.hasNext()) {
+      Map.Entry<Integer, RequestInfo> entry = inFlightRequestIterator.next();
+      RequestInfo requestInfo = entry.getValue();
+      long currentTimeInMs = time.milliseconds();
+      if (currentTimeInMs > requestInfo.getRequestCreateTime() + replicationConfig.replicationRequestNetworkTimeoutMs) {
+        inFlightRequestIterator.remove();
+        responseInfos.add(new ResponseInfo(requestInfo, NetworkClientErrorCode.TimeoutError, null));
+        RemoteReplicaGroup group = correlationIdToRemoteReplicaGroup.remove(entry.getKey());
+        if (group != null) {
+          logger.trace(
+              "Remote node: {} Thread name: {} RemoteReplicaGroup {} Request {} timed out, it was issued at {}",
+              group.getRemoteDataNode(), threadName, group.getId(), entry.getKey(), requestInfo.getRequestCreateTime());
+        } else {
+          // This shouldn't happen
+          logger.trace("Thread name: {} Request {} timed out", threadName, group.getId(), entry.getKey());
+        }
+      } else {
+        // The correlationIdToRequest should be a LinkedHashMap that has a predictable iteration order based on insertion.
+        // The correlation id increases as we insert it to the map. So if current request is not timed out, then all the
+        // requests after are not timed out.
+        break;
+      }
+    }
+    logger.trace("Thread Name: {} There are {} requests timedout", threadName, responseInfos.size());
+    return responseInfos;
+  }
+
+  /**
+   * Handle the response from the nonblocking network client.
+   * @param responseInfos The list of {@link ResponseInfo}s.
+   * @param correlationIdToReplicaGroup The map from correlation id to remote replica group.
+   */
+  private void onResponses(List<ResponseInfo> responseInfos,
+      Map<Integer, RemoteReplicaGroup> correlationIdToReplicaGroup) {
+    logger.trace("Thread Name: {} There are {} Responses to handle", threadName, responseInfos.size());
+    for (ResponseInfo responseInfo : responseInfos) {
+      RequestInfo requestInfo = responseInfo.getRequestInfo();
+      if (requestInfo == null) {
+        // Only possible when warming up the network client
+        DataNodeId dataNodeId = responseInfo.getDataNode();
+        responseHandler.onConnectionTimeout(dataNodeId);
+      } else {
+        RemoteReplicaGroup remoteReplicaGroup =
+            correlationIdToReplicaGroup.remove(requestInfo.getRequest().getCorrelationId());
+        // This correlation id might be removed because the corresponding request timed out. But later we get the response
+        // back from the network client.
+        if (remoteReplicaGroup != null) {
+          RequestOrResponseType type = ((RequestOrResponse) requestInfo.getRequest()).getRequestType();
+          logger.debug("Remote node: {} Thread name: RemoteReplicaGroup {} Handling response of type {} for {}",
+              remoteReplicaGroup.getRemoteDataNode(), threadName, remoteReplicaGroup.getId(), type,
+              requestInfo.getRequest().getCorrelationId());
+          switch (type) {
+            case ReplicaMetadataRequest:
+              remoteReplicaGroup.handleReplicaMetadataResponse(responseInfo);
+              break;
+            case GetRequest:
+              remoteReplicaGroup.handleGetResponse(responseInfo);
+              break;
+            default:
+              logger.error(
+                  "Remote node: {} Thread name: {} RemoteReplicaGroup {} Unexpected type: {} received, discarding",
+                  remoteReplicaGroup.getRemoteDataNode(), threadName, remoteReplicaGroup.getId(), type);
+          }
+        }
+      }
+    }
+    // Release all the ResponseInfo
+    responseInfos.forEach(ResponseInfo::release);
   }
 }

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
@@ -370,7 +370,11 @@ public abstract class ReplicationEngine implements ReplicationAPI {
         StoreKeyConverter threadSpecificKeyConverter = storeKeyConverterFactory.getStoreKeyConverter();
         Transformer threadSpecificTransformer =
             Utils.getObj(transformerClassName, storeKeyFactory, threadSpecificKeyConverter);
-        NetworkClient networkClient = networkClientFactory != null ? networkClientFactory.getNetworkClient() : null;
+        NetworkClient networkClient = null;
+        if (!dataNodeId.getDatacenterName().equals(datacenter)
+            && replicationConfig.replicationUsingNonblockingNetworkClientForRemoteColo) {
+          networkClient = networkClientFactory != null ? networkClientFactory.getNetworkClient() : null;
+        }
         ReplicaThread replicaThread =
             new ReplicaThread(threadIdentity, tokenHelper, clusterMap, correlationIdGenerator, dataNodeId,
                 connectionPool, networkClient, replicationConfig, replicationMetrics, notification,

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationMetrics.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationMetrics.java
@@ -242,7 +242,7 @@ public class ReplicationMetrics {
     intraColoTotalReplicationTime =
         registry.histogram(MetricRegistry.name(ReplicaThread.class, "IntraColoTotalReplicationTime"));
     intraColoOneCycleReplicationTime =
-        registry.histogram(MetricRegistry.name(ReplicaThread.class, "IntraColoOneRoundReplicationTime"));
+        registry.histogram(MetricRegistry.name(ReplicaThread.class, "IntraColoOneCycleReplicationTime"));
     plainTextIntraColoTotalReplicationTime =
         registry.histogram(MetricRegistry.name(ReplicaThread.class, "PlainTextIntraColoTotalReplicationTime"));
     sslIntraColoTotalReplicationTime =
@@ -373,9 +373,9 @@ public class ReplicationMetrics {
     Histogram interColoTotalReplicationTimePerDC =
         registry.histogram(MetricRegistry.name(ReplicaThread.class, "Inter-" + datacenter + "-TotalReplicationTime"));
     interColoTotalReplicationTime.put(datacenter, interColoTotalReplicationTimePerDC);
-    Histogram interColoOneRoundReplicationTimePerDC = registry.histogram(
-        MetricRegistry.name(ReplicaThread.class, "Inter-" + datacenter + "-OneRoundReplicationTime"));
-    interColoOneCycleReplicationTime.put(datacenter, interColoOneRoundReplicationTimePerDC);
+    Histogram interColoOneCycleReplicationTimePerDC = registry.histogram(
+        MetricRegistry.name(ReplicaThread.class, "Inter-" + datacenter + "-OneCycleReplicationTime"));
+    interColoOneCycleReplicationTime.put(datacenter, interColoOneCycleReplicationTimePerDC);
     Histogram plainTextInterColoTotalReplicationTimePerDC = registry.histogram(
         MetricRegistry.name(ReplicaThread.class, "PlainTextInter-" + datacenter + "-TotalReplicationTime"));
     plainTextInterColoTotalReplicationTime.put(datacenter, plainTextInterColoTotalReplicationTimePerDC);

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationMetrics.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationMetrics.java
@@ -111,8 +111,10 @@ public class ReplicationMetrics {
   public final Histogram plainTextIntraColoBatchStoreWriteTime;
   public final Map<String, Histogram> sslInterColoBatchStoreWriteTime = new HashMap<String, Histogram>();
   public final Histogram sslIntraColoBatchStoreWriteTime;
-  public final Map<String, Histogram> interColoTotalReplicationTime = new HashMap<String, Histogram>();
+  public final Map<String, Histogram> interColoTotalReplicationTime = new HashMap<>();
+  public final Map<String, Histogram> interColoOneCycleReplicationTime = new HashMap<>();
   public final Histogram intraColoTotalReplicationTime;
+  public final Histogram intraColoOneCycleReplicationTime;
   public final Map<String, Histogram> plainTextInterColoTotalReplicationTime = new HashMap<String, Histogram>();
   public final Histogram plainTextIntraColoTotalReplicationTime;
   public final Map<String, Histogram> sslInterColoTotalReplicationTime = new HashMap<String, Histogram>();
@@ -239,6 +241,8 @@ public class ReplicationMetrics {
         registry.histogram(MetricRegistry.name(ReplicaThread.class, "SslIntraColoBatchStoreWriteTime"));
     intraColoTotalReplicationTime =
         registry.histogram(MetricRegistry.name(ReplicaThread.class, "IntraColoTotalReplicationTime"));
+    intraColoOneCycleReplicationTime =
+        registry.histogram(MetricRegistry.name(ReplicaThread.class, "IntraColoOneRoundReplicationTime"));
     plainTextIntraColoTotalReplicationTime =
         registry.histogram(MetricRegistry.name(ReplicaThread.class, "PlainTextIntraColoTotalReplicationTime"));
     sslIntraColoTotalReplicationTime =
@@ -369,6 +373,9 @@ public class ReplicationMetrics {
     Histogram interColoTotalReplicationTimePerDC =
         registry.histogram(MetricRegistry.name(ReplicaThread.class, "Inter-" + datacenter + "-TotalReplicationTime"));
     interColoTotalReplicationTime.put(datacenter, interColoTotalReplicationTimePerDC);
+    Histogram interColoOneRoundReplicationTimePerDC = registry.histogram(
+        MetricRegistry.name(ReplicaThread.class, "Inter-" + datacenter + "-OneRoundReplicationTime"));
+    interColoOneCycleReplicationTime.put(datacenter, interColoOneRoundReplicationTimePerDC);
     Histogram plainTextInterColoTotalReplicationTimePerDC = registry.histogram(
         MetricRegistry.name(ReplicaThread.class, "PlainTextInter-" + datacenter + "-TotalReplicationTime"));
     plainTextInterColoTotalReplicationTime.put(datacenter, plainTextInterColoTotalReplicationTimePerDC);
@@ -603,6 +610,14 @@ public class ReplicationMetrics {
       sslReplicationErrors.inc();
     } else {
       plainTextReplicationErrors.inc();
+    }
+  }
+
+  public void updateOneCycleReplicationTime(long replicationTime, boolean remoteColo, String datacenter) {
+    if (remoteColo) {
+      interColoOneCycleReplicationTime.get(datacenter).update(replicationTime);
+    } else {
+      intraColoOneCycleReplicationTime.update(replicationTime);
     }
   }
 

--- a/ambry-replication/src/test/java/com/github/ambry/replication/LeaderBasedReplicationTest.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/LeaderBasedReplicationTest.java
@@ -28,6 +28,8 @@ import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.ReplicationConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.network.ConnectionPool;
+import com.github.ambry.protocol.ReplicaMetadataRequest;
+import com.github.ambry.protocol.ReplicaMetadataResponse;
 import com.github.ambry.store.StorageManager;
 import com.github.ambry.store.Store;
 import com.github.ambry.store.StoreKey;
@@ -71,8 +73,24 @@ public class LeaderBasedReplicationTest extends ReplicationTestHelper {
    * Constructor to set the configs
    */
   public LeaderBasedReplicationTest(short requestVersion, short responseVersion) throws IOException {
-    super(requestVersion, responseVersion);
+    super(requestVersion, responseVersion, false);
     setUp();
+  }
+
+  /**
+   * Running for the two sets of compatible ReplicaMetadataRequest and ReplicaMetadataResponse,
+   * viz {{@code ReplicaMetadataRequest#Replica_Metadata_Request_Version_V1}, {@code ReplicaMetadataResponse#REPLICA_METADATA_RESPONSE_VERSION_V_5}}
+   * & {{@code ReplicaMetadataRequest#Replica_Metadata_Request_Version_V2}, {@code ReplicaMetadataResponse#REPLICA_METADATA_RESPONSE_VERSION_V_6}}
+   * @return an array with both pairs of compatible request and response.
+   */
+  @Parameterized.Parameters
+  public static List<Object[]> data() {
+    //@formatter:off
+    return Arrays.asList(new Object[][]{
+        {ReplicaMetadataRequest.Replica_Metadata_Request_Version_V1, ReplicaMetadataResponse.REPLICA_METADATA_RESPONSE_VERSION_V_5},
+        {ReplicaMetadataRequest.Replica_Metadata_Request_Version_V2, ReplicaMetadataResponse.REPLICA_METADATA_RESPONSE_VERSION_V_6},
+    });
+    //@formatter:on
   }
 
   public void setUp() throws IOException {

--- a/ambry-replication/src/test/java/com/github/ambry/replication/MockConnectionPool.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/MockConnectionPool.java
@@ -16,7 +16,6 @@ package com.github.ambry.replication;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.PartitionId;
-import com.github.ambry.network.PortType;
 import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.messageformat.MessageMetadata;
 import com.github.ambry.network.ChannelOutput;
@@ -70,7 +69,7 @@ public class MockConnectionPool implements ConnectionPool {
     this.hosts = hosts;
     this.clusterMap = clusterMap;
     this.maxEntriesToReturn = maxEntriesToReturn;
-    this.connections = new HashMap<DataNodeId, MockConnection>();
+    this.connections = new HashMap<>();
   }
 
   @Override

--- a/ambry-replication/src/test/java/com/github/ambry/replication/MockFindToken.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/MockFindToken.java
@@ -77,4 +77,18 @@ public class MockFindToken implements FindToken {
   public long getBytesRead() {
     return this.bytesRead;
   }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("Version:")
+        .append(version)
+        .append(" Type:")
+        .append(type.name())
+        .append(" Index:")
+        .append(index)
+        .append(" BytesRead:")
+        .append(bytesRead);
+    return sb.toString();
+  }
 }

--- a/ambry-replication/src/test/java/com/github/ambry/replication/MockNetworkClient.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/MockNetworkClient.java
@@ -1,0 +1,106 @@
+package com.github.ambry.replication;
+
+import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.clustermap.DataNodeId;
+import com.github.ambry.network.ChannelOutput;
+import com.github.ambry.network.NetworkClient;
+import com.github.ambry.network.NetworkClientErrorCode;
+import com.github.ambry.network.Port;
+import com.github.ambry.network.RequestInfo;
+import com.github.ambry.network.ResponseInfo;
+import com.github.ambry.store.StoreKey;
+import com.github.ambry.utils.Utils;
+import io.netty.buffer.Unpooled;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+
+/**
+ * A mock of {@link NetworkClient} implementation
+ */
+public class MockNetworkClient implements NetworkClient {
+  private final Map<DataNodeId, MockHost> hosts;
+  private final Map<DataNodeId, MockConnectionPool.MockConnection> connections;
+  private final ClusterMap clusterMap;
+  private final int batchSize;
+  private final Map<StoreKey, StoreKey> conversionMap;
+
+  private final Map<Integer, RequestInfo> correlationIdToRequestInfos = new HashMap<>();
+
+  public MockNetworkClient(Map<DataNodeId, MockHost> hosts, ClusterMap clusterMap, int batchSize,
+      Map<StoreKey, StoreKey> conversionMap) {
+    this.hosts = hosts;
+    this.clusterMap = clusterMap;
+    this.batchSize = batchSize;
+    this.connections = new HashMap<>();
+    this.conversionMap = conversionMap;
+  }
+
+  @Override
+  public List<ResponseInfo> sendAndPoll(List<RequestInfo> requestsToSend, Set<Integer> requestsToDrop,
+      int pollTimeoutMs) {
+    List<ResponseInfo> responseInfos = new ArrayList<>();
+    // first drop requests
+    for (Integer correlationId : requestsToDrop) {
+      NetworkClientErrorCode errorCode = NetworkClientErrorCode.TimeoutError;
+      RequestInfo requestInfo = correlationIdToRequestInfos.remove(correlationId);
+      if (requestInfo != null) {
+        responseInfos.add(new ResponseInfo(requestInfo, errorCode, null));
+      }
+    }
+
+    // Now return what the request submitted last time
+    for (RequestInfo requestInfo : correlationIdToRequestInfos.values()) {
+      String host = requestInfo.getHost();
+      Port port = requestInfo.getPort();
+      DataNodeId dataNodeId = clusterMap.getDataNodeId(host, port.getPort());
+      try {
+        connections.get(dataNodeId).send(requestInfo.getRequest());
+        ChannelOutput channelOutput = connections.get(dataNodeId).receive();
+        byte[] bytes = Utils.readBytesFromStream(channelOutput.getInputStream(), (int) channelOutput.getStreamSize());
+        responseInfos.add(new ResponseInfo(requestInfo, null, Unpooled.wrappedBuffer(bytes)));
+      } catch (IOException e) {
+        responseInfos.add(new ResponseInfo(requestInfo, NetworkClientErrorCode.NetworkError, null));
+      }
+    }
+
+    correlationIdToRequestInfos.clear();
+    // Now adding new requests to the map so we can return next time
+    for (RequestInfo requestInfo : requestsToSend) {
+      int correlationId = requestInfo.getRequest().getCorrelationId();
+      String host = requestInfo.getHost();
+      Port port = requestInfo.getPort();
+      DataNodeId dataNodeId = clusterMap.getDataNodeId(host, port.getPort());
+      if (!hosts.containsKey(dataNodeId)) {
+        responseInfos.add(new ResponseInfo(requestInfo, NetworkClientErrorCode.NetworkError, null));
+      } else {
+        if (!connections.containsKey(dataNodeId)) {
+          connections.put(dataNodeId, new MockConnectionPool.MockConnection(hosts.get(dataNodeId), batchSize));
+        }
+        correlationIdToRequestInfos.put(correlationId, requestInfo);
+      }
+    }
+
+    return responseInfos;
+  }
+
+  @Override
+  public int warmUpConnections(List<DataNodeId> dataNodeIds, int connectionWarmUpPercentagePerDataNode,
+      long timeForWarmUp, List<ResponseInfo> responseInfoList) {
+    return 0;
+  }
+
+  @Override
+  public void wakeup() {
+
+  }
+
+  @Override
+  public void close() {
+
+  }
+}

--- a/ambry-replication/src/test/java/com/github/ambry/replication/MockNetworkClient.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/MockNetworkClient.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2023 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
 package com.github.ambry.replication;
 
 import com.github.ambry.clustermap.ClusterMap;
@@ -20,7 +33,7 @@ import java.util.Set;
 
 
 /**
- * A mock of {@link NetworkClient} implementation
+ * A mock implementation of {@link NetworkClient}.
  */
 public class MockNetworkClient implements NetworkClient {
   private final Map<DataNodeId, MockHost> hosts;

--- a/ambry-replication/src/test/java/com/github/ambry/replication/MockNetworkClient.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/MockNetworkClient.java
@@ -40,17 +40,14 @@ public class MockNetworkClient implements NetworkClient {
   private final Map<DataNodeId, MockConnectionPool.MockConnection> connections;
   private final ClusterMap clusterMap;
   private final int batchSize;
-  private final Map<StoreKey, StoreKey> conversionMap;
 
   private final Map<Integer, RequestInfo> correlationIdToRequestInfos = new HashMap<>();
 
-  public MockNetworkClient(Map<DataNodeId, MockHost> hosts, ClusterMap clusterMap, int batchSize,
-      Map<StoreKey, StoreKey> conversionMap) {
+  public MockNetworkClient(Map<DataNodeId, MockHost> hosts, ClusterMap clusterMap, int batchSize) {
     this.hosts = hosts;
     this.clusterMap = clusterMap;
     this.batchSize = batchSize;
     this.connections = new HashMap<>();
-    this.conversionMap = conversionMap;
   }
 
   @Override

--- a/ambry-replication/src/test/java/com/github/ambry/replication/ReplicationTestHelper.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/ReplicationTestHelper.java
@@ -329,10 +329,9 @@ public class ReplicationTestHelper {
       replicasToReplicate.put(remoteHost.dataNodeId, remoteReplicaInfoList);
       hosts.put(remoteHost.dataNodeId, remoteHost);
     }
-    Map<StoreKey, StoreKey> conversionMap = new HashMap<>();
     MockConnectionPool connectionPool = new MockConnectionPool(hosts, clusterMap, batchSize);
     MockNetworkClient networkClient =
-        shouldUseNetworkClient ? new MockNetworkClient(hosts, clusterMap, batchSize, conversionMap) : null;
+        shouldUseNetworkClient ? new MockNetworkClient(hosts, clusterMap, batchSize) : null;
     ReplicaThread replicaThread =
         new ReplicaThread("threadtest", new MockFindTokenHelper(storeKeyFactory, replicationConfig), clusterMap,
             new AtomicInteger(0), localHost.dataNodeId, connectionPool, networkClient, replicationConfig,

--- a/ambry-replication/src/test/java/com/github/ambry/replication/ReplicationTestHelper.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/ReplicationTestHelper.java
@@ -45,8 +45,6 @@ import com.github.ambry.messageformat.PutMessageFormatInputStream;
 import com.github.ambry.messageformat.TtlUpdateMessageFormatInputStream;
 import com.github.ambry.messageformat.UndeleteMessageFormatInputStream;
 import com.github.ambry.network.ConnectionPool;
-import com.github.ambry.protocol.ReplicaMetadataRequest;
-import com.github.ambry.protocol.ReplicaMetadataResponse;
 import com.github.ambry.store.Message;
 import com.github.ambry.store.MessageInfo;
 import com.github.ambry.store.MockStoreKeyConverterFactory;
@@ -80,7 +78,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import org.json.JSONObject;
-import org.junit.runners.Parameterized;
 import org.mockito.Mockito;
 
 import static com.github.ambry.clustermap.TestUtils.*;
@@ -99,8 +96,11 @@ public class ReplicationTestHelper {
   protected VerifiableProperties verifiableProperties;
   protected ReplicationConfig replicationConfig;
   protected final AccountService accountService;
+  protected final boolean shouldUseNetworkClient;
 
-  public ReplicationTestHelper(short requestVersion, short responseVersion) {
+  public ReplicationTestHelper(short requestVersion, short responseVersion, boolean shouldUseNetworkClient) {
+    System.out.println("The request version: " + requestVersion + " ResponseVersion: " + responseVersion);
+    this.shouldUseNetworkClient = shouldUseNetworkClient;
     List<TestUtils.ZkInfo> zkInfoList = new ArrayList<>();
     zkInfoList.add(new com.github.ambry.utils.TestUtils.ZkInfo(null, "DC1", (byte) 0, 2199, false));
     JSONObject zkJson = constructZkLayoutJSON(zkInfoList);
@@ -123,20 +123,7 @@ public class ReplicationTestHelper {
     verifiableProperties = new VerifiableProperties(properties);
     replicationConfig = new ReplicationConfig(verifiableProperties);
     accountService = Mockito.mock(AccountService.class);
-  }
-
-  /**
-   * Running for the two sets of compatible ReplicaMetadataRequest and ReplicaMetadataResponse,
-   * viz {{@code ReplicaMetadataRequest#Replica_Metadata_Request_Version_V1}, {@code ReplicaMetadataResponse#REPLICA_METADATA_RESPONSE_VERSION_V_5}}
-   * & {{@code ReplicaMetadataRequest#Replica_Metadata_Request_Version_V2}, {@code ReplicaMetadataResponse#REPLICA_METADATA_RESPONSE_VERSION_V_6}}
-   * @return an array with both pairs of compatible request and response.
-   */
-  @Parameterized.Parameters
-  public static List<Object[]> data() {
-    return Arrays.asList(new Object[][]{{ReplicaMetadataRequest.Replica_Metadata_Request_Version_V1,
-        ReplicaMetadataResponse.REPLICA_METADATA_RESPONSE_VERSION_V_5},
-        {ReplicaMetadataRequest.Replica_Metadata_Request_Version_V2,
-            ReplicaMetadataResponse.REPLICA_METADATA_RESPONSE_VERSION_V_6}});
+    time.setCurrentMilliseconds(System.currentTimeMillis());
   }
 
   // helpers
@@ -159,7 +146,7 @@ public class ReplicationTestHelper {
   }
 
   /**
-   * Helepr function to test when the local lifeVersion is greater than the remote lifeVersion.
+   * Helper function to test when the local lifeVersion is greater than the remote lifeVersion.
    * @param localTtlUpdated
    * @param remoteTtlUpdated
    * @throws Exception
@@ -213,15 +200,15 @@ public class ReplicationTestHelper {
 
     int batchSize = 4;
     Pair<Map<DataNodeId, List<RemoteReplicaInfo>>, ReplicaThread> replicasAndThread =
-        getRemoteReplicasAndReplicaThread(batchSize, clusterMap, localHost, remoteHost, storeKeyConverter, null, null,
-            null);
+        getRemoteReplicasAndReplicaThread(batchSize, clusterMap, localHost, storeKeyConverter, null, null, null,
+            remoteHost);
     List<RemoteReplicaInfo> remoteReplicaInfos = replicasAndThread.getFirst().get(remoteHost.dataNodeId);
     ReplicaThread replicaThread = replicasAndThread.getSecond();
 
     // Do the replica metadata exchange.
+    replicaThread.replicate();
     List<ReplicaThread.ExchangeMetadataResponse> response =
-        replicaThread.exchangeMetadata(new MockConnectionPool.MockConnection(remoteHost, batchSize),
-            remoteReplicaInfos);
+        replicaThread.getExchangeMetadataResponsesInEachCycle().get(remoteHost.dataNodeId);
 
     assertEquals("Response should contain a response for each replica", remoteReplicaInfos.size(), response.size());
     for (int i = 0; i < response.size(); i++) {
@@ -320,35 +307,42 @@ public class ReplicationTestHelper {
    * @param batchSize the number of messages to be returned in each iteration of replication
    * @param clusterMap the {@link ClusterMap} to use
    * @param localHost the local {@link MockHost} (the one running the replica thread)
-   * @param remoteHost the remote {@link MockHost} (the target of replication)
    * @param storeKeyConverter the {@link StoreKeyConverter} to be used in {@link ReplicaThread}
    * @param transformer the {@link Transformer} to be used in {@link ReplicaThread}
    * @param listener the {@link StoreEventListener} to use.
    * @param replicaSyncUpManager the {@link ReplicaSyncUpManager} to help create replica thread
+   * @param remoteHosts the list of remote {@link MockHost} (the target of replication)
    * @return a pair whose first element is the set of remote replicas and the second element is the {@link ReplicaThread}
    */
   protected Pair<Map<DataNodeId, List<RemoteReplicaInfo>>, ReplicaThread> getRemoteReplicasAndReplicaThread(
-      int batchSize, ClusterMap clusterMap, MockHost localHost, MockHost remoteHost,
-      StoreKeyConverter storeKeyConverter, Transformer transformer, StoreEventListener listener,
-      ReplicaSyncUpManager replicaSyncUpManager) throws ReflectiveOperationException {
+      int batchSize, ClusterMap clusterMap, MockHost localHost, StoreKeyConverter storeKeyConverter,
+      Transformer transformer, StoreEventListener listener, ReplicaSyncUpManager replicaSyncUpManager,
+      MockHost... remoteHosts) throws ReflectiveOperationException {
     ReplicationMetrics replicationMetrics =
         new ReplicationMetrics(new MetricRegistry(), clusterMap.getReplicaIds(localHost.dataNodeId));
-    replicationMetrics.populateSingleColoMetrics(remoteHost.dataNodeId.getDatacenterName());
-    List<RemoteReplicaInfo> remoteReplicaInfoList = localHost.getRemoteReplicaInfos(remoteHost, listener);
-    Map<DataNodeId, List<RemoteReplicaInfo>> replicasToReplicate =
-        Collections.singletonMap(remoteHost.dataNodeId, remoteReplicaInfoList);
     StoreKeyFactory storeKeyFactory = Utils.getObj("com.github.ambry.commons.BlobIdFactory", clusterMap);
     Map<DataNodeId, MockHost> hosts = new HashMap<>();
-    hosts.put(remoteHost.dataNodeId, remoteHost);
+    Map<DataNodeId, List<RemoteReplicaInfo>> replicasToReplicate = new HashMap<>();
+    for (MockHost remoteHost : remoteHosts) {
+      replicationMetrics.populateSingleColoMetrics(remoteHost.dataNodeId.getDatacenterName());
+      List<RemoteReplicaInfo> remoteReplicaInfoList = localHost.getRemoteReplicaInfos(remoteHost, listener);
+      replicasToReplicate.put(remoteHost.dataNodeId, remoteReplicaInfoList);
+      hosts.put(remoteHost.dataNodeId, remoteHost);
+    }
+    Map<StoreKey, StoreKey> conversionMap = new HashMap<>();
     MockConnectionPool connectionPool = new MockConnectionPool(hosts, clusterMap, batchSize);
+    MockNetworkClient networkClient =
+        shouldUseNetworkClient ? new MockNetworkClient(hosts, clusterMap, batchSize, conversionMap) : null;
     ReplicaThread replicaThread =
         new ReplicaThread("threadtest", new MockFindTokenHelper(storeKeyFactory, replicationConfig), clusterMap,
-            new AtomicInteger(0), localHost.dataNodeId, connectionPool, null, replicationConfig, replicationMetrics,
-            null, storeKeyConverter, transformer, clusterMap.getMetricRegistry(), false,
+            new AtomicInteger(0), localHost.dataNodeId, connectionPool, networkClient, replicationConfig,
+            replicationMetrics, null, storeKeyConverter, transformer, clusterMap.getMetricRegistry(), false,
             localHost.dataNodeId.getDatacenterName(), new ResponseHandler(clusterMap), time, replicaSyncUpManager, null,
             null);
-    for (RemoteReplicaInfo remoteReplicaInfo : remoteReplicaInfoList) {
-      replicaThread.addRemoteReplicaInfo(remoteReplicaInfo);
+    for (MockHost remoteHost : remoteHosts) {
+      for (RemoteReplicaInfo remoteReplicaInfo : replicasToReplicate.get(remoteHost.dataNodeId)) {
+        replicaThread.addRemoteReplicaInfo(remoteReplicaInfo);
+      }
     }
     for (PartitionId partitionId : clusterMap.getAllPartitionIds(null)) {
       replicationMetrics.addLagMetricForPartition(partitionId, true);
@@ -369,11 +363,11 @@ public class ReplicationTestHelper {
    * @return expectedIndex + expectedIndexInc
    * @throws Exception
    */
-  protected int assertMissingKeysAndFixMissingStoreKeys(int expectedIndex, int expectedIndexInc, int batchSize,
-      int expectedMissingKeysSum, ReplicaThread replicaThread, MockHost remoteHost,
+  protected int assertMissingKeysAndFixMissingStoreKeys(int expectedIndex, int expectedIndexInc,
+      int expectedMissingKeysSum, ReplicaThread replicaThread,
       Map<DataNodeId, List<RemoteReplicaInfo>> replicasToReplicate) throws Exception {
-    return assertMissingKeysAndFixMissingStoreKeys(expectedIndex, expectedIndex, expectedIndexInc, batchSize,
-        expectedMissingKeysSum, replicaThread, remoteHost, replicasToReplicate);
+    return assertMissingKeysAndFixMissingStoreKeys(expectedIndex, expectedIndex, expectedIndexInc,
+        expectedMissingKeysSum, replicaThread, replicasToReplicate);
   }
 
   /**
@@ -381,35 +375,30 @@ public class ReplicationTestHelper {
    * @param expectedIndex initial expected index for even numbered partitions
    * @param expectedIndexOdd initial expected index for odd numbered partitions
    * @param expectedIndexInc increment level for the expected index (how much the findToken index is expected to increment)
-   * @param batchSize how large of a batch size the internal MockConnection will use for fixing missing store keys
    * @param expectedMissingKeysSum the number of missing keys expected
    * @param replicaThread replicaThread that will be performing replication
-   * @param remoteHost the remote host that keys are being pulled from
    * @param replicasToReplicate list of replicas to replicate between
    * @return expectedIndex + expectedIndexInc
    * @throws Exception
    */
   protected int assertMissingKeysAndFixMissingStoreKeys(int expectedIndex, int expectedIndexOdd, int expectedIndexInc,
-      int batchSize, int expectedMissingKeysSum, ReplicaThread replicaThread, MockHost remoteHost,
+      int expectedMissingKeysSum, ReplicaThread replicaThread,
       Map<DataNodeId, List<RemoteReplicaInfo>> replicasToReplicate) throws Exception {
     expectedIndex += expectedIndexInc;
     expectedIndexOdd += expectedIndexInc;
-    List<ReplicaThread.ExchangeMetadataResponse> response =
-        replicaThread.exchangeMetadata(new MockConnectionPool.MockConnection(remoteHost, batchSize),
-            replicasToReplicate.get(remoteHost.dataNodeId));
-    assertEquals("Response should contain a response for each replica",
-        replicasToReplicate.get(remoteHost.dataNodeId).size(), response.size());
-    for (int i = 0; i < response.size(); i++) {
-      assertEquals(expectedMissingKeysSum, response.get(i).missingStoreMessages.size());
-      assertEquals(i % 2 == 0 ? expectedIndex : expectedIndexOdd,
-          ((MockFindToken) response.get(i).remoteToken).getIndex());
-      replicasToReplicate.get(remoteHost.dataNodeId).get(i).setToken(response.get(i).remoteToken);
-    }
-    replicaThread.fixMissingStoreKeys(new MockConnectionPool.MockConnection(remoteHost, batchSize),
-        replicasToReplicate.get(remoteHost.dataNodeId), response, false);
-    for (int i = 0; i < response.size(); i++) {
-      assertEquals("Token should have been set correctly in fixMissingStoreKeys()", response.get(i).remoteToken,
-          replicasToReplicate.get(remoteHost.dataNodeId).get(i).getToken());
+    replicaThread.replicate();
+    for (DataNodeId dataNodeId : replicasToReplicate.keySet()) {
+      List<ReplicaThread.ExchangeMetadataResponse> response =
+          replicaThread.getExchangeMetadataResponsesInEachCycle().get(dataNodeId);
+      assertEquals("Response should contain a response for each replica", replicasToReplicate.get(dataNodeId).size(),
+          response.size());
+      for (int i = 0; i < response.size(); i++) {
+        assertEquals(expectedMissingKeysSum, response.get(i).missingStoreMessages.size());
+        assertEquals(i % 2 == 0 ? expectedIndex : expectedIndexOdd,
+            ((MockFindToken) response.get(i).remoteToken).getIndex());
+        assertEquals("Token should have been set correctly in fixMissingStoreKeys()", response.get(i).remoteToken,
+            replicasToReplicate.get(dataNodeId).get(i).getToken());
+      }
     }
     return expectedIndex;
   }
@@ -455,8 +444,7 @@ public class ReplicationTestHelper {
       int expectedIndex, int expectedIndexOdd, int expectedMissingBuffers) throws Exception {
     // no more missing keys
     List<ReplicaThread.ExchangeMetadataResponse> response =
-        replicaThread.exchangeMetadata(new MockConnectionPool.MockConnection(remoteHost, 4),
-            replicasToReplicate.get(remoteHost.dataNodeId));
+        replicaThread.getExchangeMetadataResponsesInEachCycle().get(remoteHost.dataNodeId);
     assertEquals("Response should contain a response for each replica",
         replicasToReplicate.get(remoteHost.dataNodeId).size(), response.size());
     for (int i = 0; i < response.size(); i++) {
@@ -1118,8 +1106,8 @@ public class ReplicationTestHelper {
       Transformer transformer = new BlobIdTransformer(storeKeyFactory, storeKeyConverter);
 
       Pair<Map<DataNodeId, List<RemoteReplicaInfo>>, ReplicaThread> replicasAndThread =
-          getRemoteReplicasAndReplicaThread(batchSize, clusterMap, localHost, remoteHost, storeKeyConverter,
-              transformer, null, null);
+          getRemoteReplicasAndReplicaThread(batchSize, clusterMap, localHost, storeKeyConverter, transformer, null,
+              null, remoteHost);
       replicasToReplicate = replicasAndThread.getFirst();
       replicaThread = replicasAndThread.getSecond();
     }

--- a/ambry-server/src/test/java/com/github/ambry/server/AmbryServerRequestsTest.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/AmbryServerRequestsTest.java
@@ -170,7 +170,7 @@ public class AmbryServerRequestsTest extends ReplicationTestHelper {
   public AmbryServerRequestsTest(boolean validateRequestOnStoreState)
       throws IOException, ReplicationException, StoreException, InterruptedException, ReflectiveOperationException {
     super(ReplicaMetadataRequest.Replica_Metadata_Request_Version_V2,
-        ReplicaMetadataResponse.REPLICA_METADATA_RESPONSE_VERSION_V_6);
+        ReplicaMetadataResponse.REPLICA_METADATA_RESPONSE_VERSION_V_6, false);
     this.validateRequestOnStoreState = validateRequestOnStoreState;
     clusterMap = new MockClusterMap();
     localDc = clusterMap.getDatacenterName(clusterMap.getLocalDatacenterId());


### PR DESCRIPTION
Start using nonblocking network client in replica thread to boost up replication speed for cross-colo replication.

This PR adds nonblocking network client support in ReplicaThread. It mimics the logic/code in OperationControllers in router package. It first divides replicas to replicate into several groups and for each group, it sends the request to the remote servers and feed the response back to the group.

This PR also adds nonblocking network client to the existing test cases., and add a new test case to test replication for multiple remote hosts at the same time.