### PR TITLE
Add Dataset and Dataset Version table in Account metadata DB

### DIFF
--- a/ambry-account/src/main/resources/AccountSchema.ddl
+++ b/ambry-account/src/main/resources/AccountSchema.ddl
@@ -44,3 +44,27 @@ CREATE TABLE IF NOT EXISTS Containers
     INDEX statusIndex (status)
 )
 CHARACTER SET utf8 COLLATE utf8_bin;
+
+CREATE TABLE IF NOT EXISTS Datasets (
+    accountId INT NOT NULL,
+    containerId INT NOT NULL,
+    datasetName VARCHAR(255) NOT NULL,
+    versionSchema INT NOT NULL,
+    retentionCount INT DEFAULT NULL,
+    userTags JSON DEFAULT NULL,
+    lastModifiedTime DATETIME(3) NOT NULL,
+    delete_ts datetime(6) DEFAULT NULL,
+    PRIMARY KEY (accountId, containerId, datasetName)
+)
+CHARACTER SET utf8 COLLATE utf8_bin;
+
+CREATE TABLE IF NOT EXISTS DatasetVersions (
+    accountId INT NOT NULL,
+    containerId INT NOT NULL,
+    datasetName VARCHAR(255) NOT NULL,
+    version bigint NOT NULL,
+    lastModifiedTime DATETIME(3) NOT NULL,
+    delete_ts datetime(6) DEFAULT NULL,
+    PRIMARY KEY (accountId, containerId, datasetName, version)
+)
+CHARACTER SET utf8 COLLATE utf8_bin;

--- a/ambry-account/src/main/resources/AccountSchema.ddl
+++ b/ambry-account/src/main/resources/AccountSchema.ddl
@@ -48,12 +48,12 @@ CHARACTER SET utf8 COLLATE utf8_bin;
 CREATE TABLE IF NOT EXISTS Datasets (
     accountId INT NOT NULL,
     containerId INT NOT NULL,
-    datasetName VARCHAR(255) NOT NULL,
+    datasetName VARCHAR(235) NOT NULL,
     versionSchema INT NOT NULL,
     retentionCount INT DEFAULT NULL,
     userTags JSON DEFAULT NULL,
     lastModifiedTime DATETIME(3) NOT NULL,
-    delete_ts datetime(6) DEFAULT NULL,
+    delete_ts DATETIME(6) DEFAULT NULL,
     PRIMARY KEY (accountId, containerId, datasetName)
 )
 CHARACTER SET utf8 COLLATE utf8_bin;
@@ -61,10 +61,10 @@ CHARACTER SET utf8 COLLATE utf8_bin;
 CREATE TABLE IF NOT EXISTS DatasetVersions (
     accountId INT NOT NULL,
     containerId INT NOT NULL,
-    datasetName VARCHAR(255) NOT NULL,
-    version bigint NOT NULL,
+    datasetName VARCHAR(235) NOT NULL,
+    version BIGINT NOT NULL,
     lastModifiedTime DATETIME(3) NOT NULL,
-    delete_ts datetime(6) DEFAULT NULL,
+    delete_ts DATETIME(6) DEFAULT NULL,
     PRIMARY KEY (accountId, containerId, datasetName, version)
 )
 CHARACTER SET utf8 COLLATE utf8_bin;


### PR DESCRIPTION
Adding Datasets and DatasetVersions table in order to support PROML migration.
Will ask MYSQL team to review it again before it gets merged.
In order to support auto purge, the naming convention for delete_ts has to follow this exact format with "_"
And to keep consistent with other table, for non auto-purge related field, I follow what we have in Accounts and Containers table.