### PR TITLE
Handle QuotaReject error in operations, not SimpleOperationTracker

### DIFF
--- a/ambry-router/src/main/java/com/github/ambry/router/AdaptiveOperationTracker.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/AdaptiveOperationTracker.java
@@ -106,9 +106,6 @@ class AdaptiveOperationTracker extends SimpleOperationTracker {
   @Override
   public void onResponse(ReplicaId replicaId, TrackedRequestFinalState trackedRequestFinalState) {
     super.onResponse(replicaId, trackedRequestFinalState);
-    if (trackedRequestFinalState == TrackedRequestFinalState.QUOTA_REJECTED) {
-      return;
-    }
     long elapsedTime;
     if (unexpiredRequestSendTimes.containsKey(replicaId)) {
       elapsedTime = time.milliseconds() - unexpiredRequestSendTimes.remove(replicaId).getSecond();

--- a/ambry-router/src/main/java/com/github/ambry/router/DeleteOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/DeleteOperation.java
@@ -254,6 +254,7 @@ class DeleteOperation {
   private void processQuotaRejectedResponse(int correlationId, ReplicaId replicaId) {
     logger.trace("DeleteRequest with response correlationId {} was rejected because quota was exceeded.",
         correlationId);
+    operationCompleted = true;
     onErrorResponse(replicaId, new RouterException("QuotaExceeded", RouterErrorCode.TooManyRequests), false);
     checkAndMaybeComplete();
   }

--- a/ambry-router/src/main/java/com/github/ambry/router/GetBlobInfoOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/GetBlobInfoOperation.java
@@ -94,10 +94,10 @@ class GetBlobInfoOperation extends GetOperation {
    * @param nonBlockingRouter The non-blocking router object
    */
   GetBlobInfoOperation(RouterConfig routerConfig, NonBlockingRouterMetrics routerMetrics, ClusterMap clusterMap,
-      ResponseHandler responseHandler, BlobId blobId, GetBlobOptionsInternal options,
-      Callback<GetBlobResult> callback, RouterCallback routerCallback, KeyManagementService kms,
-      CryptoService cryptoService, CryptoJobHandler cryptoJobHandler, Time time, boolean isEncrypted,
-      QuotaChargeCallback quotaChargeCallback, NonBlockingRouter nonBlockingRouter) {
+      ResponseHandler responseHandler, BlobId blobId, GetBlobOptionsInternal options, Callback<GetBlobResult> callback,
+      RouterCallback routerCallback, KeyManagementService kms, CryptoService cryptoService,
+      CryptoJobHandler cryptoJobHandler, Time time, boolean isEncrypted, QuotaChargeCallback quotaChargeCallback,
+      NonBlockingRouter nonBlockingRouter) {
     super(routerConfig, routerMetrics, clusterMap, responseHandler, blobId, options, callback, kms, cryptoService,
         cryptoJobHandler, time, isEncrypted);
     this.routerCallback = routerCallback;
@@ -369,6 +369,7 @@ class GetBlobInfoOperation extends GetOperation {
   private void processQuotaRejectedResponse(int correlationId, ReplicaId replicaId) {
     logger.trace("GetBlobInfoRequest with response correlationId {} was rejected because quota was exceeded.",
         correlationId);
+    operationCompleted = true;
     onErrorResponse(replicaId, new RouterException("QuotaExceeded", RouterErrorCode.TooManyRequests), false);
     checkAndMaybeComplete();
   }
@@ -489,7 +490,7 @@ class GetBlobInfoOperation extends GetOperation {
    * Check whether the operation can be completed, if so complete it.
    */
   private void checkAndMaybeComplete() {
-    if (progressTracker.isDone()) {
+    if (progressTracker.isDone() || operationCompleted) {
       if (progressTracker.hasSucceeded()) {
         operationException.set(null);
       } else if (operationTracker.hasFailedOnNotFound()) {

--- a/ambry-router/src/main/java/com/github/ambry/router/GetBlobInfoOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/GetBlobInfoOperation.java
@@ -490,7 +490,7 @@ class GetBlobInfoOperation extends GetOperation {
    * Check whether the operation can be completed, if so complete it.
    */
   private void checkAndMaybeComplete() {
-    if (progressTracker.isDone() || operationCompleted) {
+    if (progressTracker.isDone()) {
       if (progressTracker.hasSucceeded()) {
         operationException.set(null);
       } else if (operationTracker.hasFailedOnNotFound()) {

--- a/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
@@ -1004,7 +1004,7 @@ class GetBlobOperation extends GetOperation {
      * Check if the operation on the chunk is eligible for completion, if so complete it.
      */
     void checkAndMaybeComplete() {
-      if (progressTracker.isDone()) {
+      if (progressTracker.isDone() || chunkCompleted) {
         if (progressTracker.hasSucceeded() && !retainChunkExceptionOnSuccess) {
           chunkException = null;
         } else if (chunkOperationTracker.maybeFailedDueToOfflineReplicas()) {

--- a/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
@@ -1004,7 +1004,7 @@ class GetBlobOperation extends GetOperation {
      * Check if the operation on the chunk is eligible for completion, if so complete it.
      */
     void checkAndMaybeComplete() {
-      if (progressTracker.isDone() || chunkCompleted) {
+      if (progressTracker.isDone()) {
         if (progressTracker.hasSucceeded() && !retainChunkExceptionOnSuccess) {
           chunkException = null;
         } else if (chunkOperationTracker.maybeFailedDueToOfflineReplicas()) {
@@ -1290,6 +1290,7 @@ class GetBlobOperation extends GetOperation {
     private void processQuotaRejectedResponse(int correlationId, ReplicaId replicaId) {
       logger.trace("GetBlobRequest with response correlationId {} rejected because it exceeded quota", correlationId);
       onErrorResponse(replicaId, new RouterException("QuotaExceeded", RouterErrorCode.TooManyRequests), false);
+      chunkCompleted = true;
       checkAndMaybeComplete();
     }
 

--- a/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
@@ -1221,6 +1221,7 @@ class PutOperation {
             passedInBlobProperties.getExternalAssetTag(), passedInBlobProperties.getContentEncoding(),
             passedInBlobProperties.getFilename());
         operationTracker = getOperationTracker();
+        chunkException = null;
         correlationIdToChunkPutRequestInfo.clear();
         logger.trace("{}: Chunk {} is ready for sending out to server", loggingContext, chunkIndex);
         state = ChunkState.Ready;
@@ -1424,7 +1425,8 @@ class PutOperation {
     void checkAndMaybeComplete() {
       boolean done = false;
       // Now, check if this chunk is done.
-      if (operationTracker.isDone()) {
+      if (operationTracker.isDone() || (chunkException != null
+          && chunkException.getErrorCode() == RouterErrorCode.TooManyRequests)) {
         if (!operationTracker.hasSucceeded()) {
           failedAttempts++;
           appendSlippedPutBlobId(chunkBlobId);
@@ -1695,7 +1697,7 @@ class PutOperation {
       logger.debug("{}: PutRequest with response correlationId {} was rejected because quota was exceeded.",
           loggingContext, correlationId);
       setChunkException(new RouterException("QuotaExceeded", RouterErrorCode.TooManyRequests));
-      onErrorResponse(replicaId, TrackedRequestFinalState.QUOTA_REJECTED, false);
+      onErrorResponse(replicaId, TrackedRequestFinalState.FAILURE, false);
       checkAndMaybeComplete();
     }
 

--- a/ambry-router/src/main/java/com/github/ambry/router/SimpleOperationTracker.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/SimpleOperationTracker.java
@@ -88,7 +88,6 @@ class SimpleOperationTracker implements OperationTracker {
   protected List<ReplicaId> successReplica = new ArrayList<>();
   protected int replicaInPoolOrFlightCount = 0;
   protected int failedCount = 0;
-  protected boolean quotaRejected = false;
   protected int disabledCount = 0;
   protected int originatingDcNotFoundCount = 0;
   protected int totalNotFoundCount = 0;
@@ -570,9 +569,6 @@ class SimpleOperationTracker implements OperationTracker {
       case REQUEST_DISABLED:
         disabledCount++;
         break;
-      case QUOTA_REJECTED:
-        quotaRejected = true;
-        break;
       default:
         failedCount++;
         // NOT_FOUND is a special error. When tracker sees >= numReplicasInOriginatingDc - 1 "NOT_FOUND" from the
@@ -674,9 +670,6 @@ class SimpleOperationTracker implements OperationTracker {
   }
 
   public boolean hasFailed() {
-    if (quotaRejected) {
-      return true;
-    }
     if (routerOperation == RouterOperation.PutOperation && routerConfig.routerPutUseDynamicSuccessTarget) {
       return totalReplicaCount - failedCount < Math.max(totalReplicaCount - 1,
           routerConfig.routerPutSuccessTarget + disabledCount);

--- a/ambry-router/src/main/java/com/github/ambry/router/TrackedRequestFinalState.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/TrackedRequestFinalState.java
@@ -19,7 +19,7 @@ package com.github.ambry.router;
  * consumed by operation tracker to change success/failure counter and determine whether to update Histograms.
  */
 public enum TrackedRequestFinalState {
-  SUCCESS, FAILURE, TIMED_OUT, NOT_FOUND, REQUEST_DISABLED, DISK_DOWN, QUOTA_REJECTED;
+  SUCCESS, FAILURE, TIMED_OUT, NOT_FOUND, REQUEST_DISABLED, DISK_DOWN;
 
   /**
    *  Return the corresponding {@link TrackedRequestFinalState}  for the given {@link RouterErrorCode}.
@@ -32,8 +32,6 @@ public enum TrackedRequestFinalState {
         return TIMED_OUT;
       case BlobDoesNotExist:
         return NOT_FOUND;
-      case TooManyRequests:
-        return QUOTA_REJECTED;
       default:
         return FAILURE;
     }

--- a/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateOperation.java
@@ -298,6 +298,7 @@ class TtlUpdateOperation {
   private void processQuotaRejectedResponse(int correlationId, ReplicaId replicaId) {
     LOGGER.debug("TtlUpdateRequest with response correlationId {} was rejected because quota was exceeded.",
         correlationId);
+    operationCompleted = true;
     onErrorResponse(replicaId, new RouterException("QuotaExceeded", RouterErrorCode.TooManyRequests), false);
     checkAndMaybeComplete();
   }

--- a/ambry-router/src/main/java/com/github/ambry/router/UndeleteOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/UndeleteOperation.java
@@ -265,6 +265,7 @@ public class UndeleteOperation {
   private void processQuotaRejectedResponse(int correlationId, ReplicaId replicaId) {
     LOGGER.trace("UndeleteRequest with response correlationId {} was rejected because quota was exceeded.",
         correlationId);
+    operationCompleted = true;
     onErrorResponse(replicaId, new RouterException("QuotaExceeded", RouterErrorCode.TooManyRequests), false);
     checkAndMaybeComplete();
   }

--- a/ambry-router/src/main/java/com/github/ambry/router/UndeleteOperationTracker.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/UndeleteOperationTracker.java
@@ -86,9 +86,6 @@ public class UndeleteOperationTracker extends SimpleOperationTracker {
 
   @Override
   public boolean hasFailed() {
-    if (quotaRejected) {
-      return true;
-    }
     return hasReachedAnyLocalQuorum(numReplicasInDcs, numFailureInDcs);
   }
 

--- a/ambry-router/src/test/java/com/github/ambry/router/OperationTrackerTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/OperationTrackerTest.java
@@ -163,15 +163,6 @@ public class OperationTrackerTest {
     // 0-0-1-2; 9-0-0-0
     assertFalse("Operation should not have succeeded", ot.hasSucceeded());
     assertTrue("Operation should be done", ot.isDone());
-
-    // test quota rejection failure.
-    initialize();
-    ot = getOperationTrackerForGetOrPut(false, 2, 3, RouterOperation.GetBlobOperation, true);
-    assertFalse("Operation should not have been done.", ot.isDone());
-    sendRequests(ot, 3, false);
-    ot.onResponse(inflightReplicas.poll(), TrackedRequestFinalState.QUOTA_REJECTED);
-    assertFalse("Operation should not have succeeded", ot.hasSucceeded());
-    assertTrue("Operation should be done", ot.isDone());
   }
 
   /**
@@ -182,17 +173,14 @@ public class OperationTrackerTest {
    *         for remaining 3 replicas:
    *         (1) two success and one failure (whole operation should succeed)
    *         (2) one success and two failure (whole operation should fail)
-   *         (3) one quota exception (whole operation should fail)
    * Case 3: 1 LEADER and 5 STANDBY replicas. Several combinations to discuss:
    *         (1) 3 REQUEST_DISABLED, 2 success and 1 failure (operation should succeed)
    *         (2) 2 REQUEST_DISABLED, 2 failure (operation should fail no matter what results are from remaining replicas)
    *         (3) 1 REQUEST_DISABLED, 1 failure, 4 success (operation should succeed)
    *         (4) 0 REQUEST_DISABLED, 2 failure, 4 success (operation should fail)
-   *         (5) one quota exception (operation should fail)
    * Case 4: 1 LEADER, 4 STANDBY, 1 INACTIVE  (this is to mock one replica has completed STANDBY -> INACTIVE)
    *         (1) 2 REQUEST_DISABLED, 1 failure and 2 success (operation should succeed)
    *         (2) 3 REQUEST_DISABLED, 1 failure (operation should fail no matter what result is from remaining replica)
-   *         (3) one quota exception (operation should fail)
    */
   @Test
   public void putOperationWithDynamicTargetTest() {
@@ -235,13 +223,6 @@ public class OperationTrackerTest {
       ot.onResponse(inflightReplicas.poll(), TrackedRequestFinalState.FAILURE);
     }
     assertFalse("Operation should fail", ot.hasSucceeded());
-    // Case 2.3
-    repetitionTracker.clear();
-    ot = getOperationTrackerForGetOrPut(true, 1, 4, RouterOperation.PutOperation, true);
-    sendRequests(ot, 4, false);
-    ot.onResponse(inflightReplicas.poll(), TrackedRequestFinalState.QUOTA_REJECTED);
-    assertFalse("Operation should fail", ot.hasSucceeded());
-    assertTrue("Operation should be done", ot.isDone());
     // Case 3.1
     populateReplicaList(2, ReplicaState.STANDBY);
     repetitionTracker.clear();
@@ -288,13 +269,6 @@ public class OperationTrackerTest {
       }
     }
     assertFalse("Operation should fail", ot.hasSucceeded());
-    // Case 3.5
-    repetitionTracker.clear();
-    ot = getOperationTrackerForGetOrPut(true, 1, 6, RouterOperation.PutOperation, true);
-    sendRequests(ot, 6, false);
-    ot.onResponse(inflightReplicas.poll(), TrackedRequestFinalState.QUOTA_REJECTED);
-    assertFalse("Operation should fail", ot.hasSucceeded());
-    assertTrue("Operation should be done", ot.isDone());
     // Case 4
     // re-populate replica list
     mockPartition.cleanUp();
@@ -322,13 +296,6 @@ public class OperationTrackerTest {
       ot.onResponse(inflightReplicas.poll(), TrackedRequestFinalState.REQUEST_DISABLED);
     }
     ot.onResponse(inflightReplicas.poll(), TrackedRequestFinalState.FAILURE);
-    assertTrue("Operation should be done", ot.isDone());
-    assertFalse("Operation should fail", ot.hasSucceeded());
-    // Case 4.3
-    repetitionTracker.clear();
-    ot = getOperationTrackerForGetOrPut(true, 1, 5, RouterOperation.PutOperation, true);
-    sendRequests(ot, 5, false);
-    ot.onResponse(inflightReplicas.poll(), TrackedRequestFinalState.QUOTA_REJECTED);
     assertTrue("Operation should be done", ot.isDone());
     assertFalse("Operation should fail", ot.hasSucceeded());
   }

--- a/ambry-router/src/test/java/com/github/ambry/router/TrackedRequestFinalStateTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/TrackedRequestFinalStateTest.java
@@ -34,8 +34,6 @@ public class TrackedRequestFinalStateTest {
         TrackedRequestFinalState.fromRouterErrorCodeToFinalState(RouterErrorCode.OperationTimedOut));
     Assert.assertEquals(TrackedRequestFinalState.NOT_FOUND,
         TrackedRequestFinalState.fromRouterErrorCodeToFinalState(RouterErrorCode.BlobDoesNotExist));
-    Assert.assertEquals(TrackedRequestFinalState.QUOTA_REJECTED,
-        TrackedRequestFinalState.fromRouterErrorCodeToFinalState(RouterErrorCode.TooManyRequests));
 
     Set<RouterErrorCode> checkedErrorCodes = new HashSet<>(
         Arrays.asList(RouterErrorCode.OperationTimedOut, RouterErrorCode.BlobDoesNotExist,


### PR DESCRIPTION
Simplify the SimpleOperationTracker to move the logic of handling QuotaRejection from it to different Operations.