### PR TITLE
FE: Add retry logic to router for get blob

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
@@ -656,6 +656,25 @@ public class RouterConfig {
   @Default("false")
   public final boolean routerRepairWithReplicateBlobEnabled;
 
+  /**
+   * The maximum duration in seconds to retry. If the get blob operation takes more than this duration, we would not retry.
+   */
+  @Config(ROUTER_GET_BLOB_RETRY_LIMIT_IN_SEC)
+  @Default("0")
+  public final int routerGetBlobRetryLimitInSec;
+  public static final String ROUTER_GET_BLOB_RETRY_LIMIT_IN_SEC = "router.get.blob.retry.limit.in.sec";
+  public static final int ROUTER_GET_BLOB_RETRY_LIMIT_IN_SEC_MAX = 30;
+
+  /**
+   * The maximum number of retries for get blob. The default value is 0, which means no retry for get blob.
+   * The maximum number for this is 10. We don't want to retry more than 10 times.
+   */
+  @Config(ROUTER_GET_BLOB_RETRY_LIMIT_COUNT)
+  @Default("0")
+  public final int routerGetBlobRetryLimitCount;
+  public static final String ROUTER_GET_BLOB_RETRY_LIMIT_COUNT = "router.get.blob.retry.limit.count";
+  public static final int ROUTER_GET_BLOB_RETRY_LIMIT_COUNT_MAX = 10;
+
   // Group compression-related configs in the CompressConfig class.
   private final CompressionConfig compressionConfig;
 
@@ -798,10 +817,15 @@ public class RouterConfig {
         verifiableProperties.getBoolean(ROUTER_UNAVAILABLE_DUE_TO_SUCCESS_COUNT_IS_NON_ZERO_FOR_DELETE, true);
     routerNotFoundCacheTtlInMs = verifiableProperties.getLongInRange(ROUTER_NOT_FOUND_CACHE_TTL_IN_MS, 15 * 1000L, 0,
         ROUTER_NOT_FOUND_CACHE_MAX_TTL_IN_MS);
-    routerUpdateOpMetadataRelianceTimestampInMs = verifiableProperties.getLong(
-        ROUTER_UPDATE_OP_METADATA_RELIANCE_TIMESTAMP_IN_MS, DEFAULT_ROUTER_UPDATE_OP_METADATA_RELIANCE_TIMESTAMP_IN_MS);
+    routerUpdateOpMetadataRelianceTimestampInMs =
+        verifiableProperties.getLong(ROUTER_UPDATE_OP_METADATA_RELIANCE_TIMESTAMP_IN_MS,
+            DEFAULT_ROUTER_UPDATE_OP_METADATA_RELIANCE_TIMESTAMP_IN_MS);
     routerRepairWithReplicateBlobEnabled =
         verifiableProperties.getBoolean(ROUTER_REPAIR_WITH_REPLICATE_BLOB_ENABLED, false);
+    routerGetBlobRetryLimitInSec = verifiableProperties.getIntInRange(ROUTER_GET_BLOB_RETRY_LIMIT_IN_SEC, 0, 0,
+        ROUTER_GET_BLOB_RETRY_LIMIT_IN_SEC_MAX);
+    routerGetBlobRetryLimitCount = verifiableProperties.getIntInRange(ROUTER_GET_BLOB_RETRY_LIMIT_COUNT, 0, 0,
+        ROUTER_GET_BLOB_RETRY_LIMIT_COUNT_MAX);
 
     compressionConfig = new CompressionConfig(verifiableProperties);
   }

--- a/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
@@ -663,17 +663,16 @@ public class RouterConfig {
   @Default("0")
   public final int routerGetBlobRetryLimitInSec;
   public static final String ROUTER_GET_BLOB_RETRY_LIMIT_IN_SEC = "router.get.blob.retry.limit.in.sec";
-  public static final int ROUTER_GET_BLOB_RETRY_LIMIT_IN_SEC_MAX = 30;
+  public static final int ROUTER_GET_BLOB_RETRY_LIMIT_IN_SEC_MAX = 300;
 
   /**
    * The maximum number of retries for get blob. The default value is 0, which means no retry for get blob.
-   * The maximum number for this is 10. We don't want to retry more than 10 times.
    */
   @Config(ROUTER_GET_BLOB_RETRY_LIMIT_COUNT)
   @Default("0")
   public final int routerGetBlobRetryLimitCount;
   public static final String ROUTER_GET_BLOB_RETRY_LIMIT_COUNT = "router.get.blob.retry.limit.count";
-  public static final int ROUTER_GET_BLOB_RETRY_LIMIT_COUNT_MAX = 10;
+  public static final int ROUTER_GET_BLOB_RETRY_LIMIT_COUNT_MAX = 100;
 
   // Group compression-related configs in the CompressConfig class.
   private final CompressionConfig compressionConfig;

--- a/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
@@ -660,7 +660,6 @@ public class RouterConfig {
    * The maximum duration in seconds to retry. If the get blob operation takes more than this duration, we would not retry.
    */
   @Config(ROUTER_GET_BLOB_RETRY_LIMIT_IN_SEC)
-  @Default("0")
   public final int routerGetBlobRetryLimitInSec;
   public static final String ROUTER_GET_BLOB_RETRY_LIMIT_IN_SEC = "router.get.blob.retry.limit.in.sec";
   public static final int ROUTER_GET_BLOB_RETRY_LIMIT_IN_SEC_MAX = 300;
@@ -669,7 +668,6 @@ public class RouterConfig {
    * The maximum number of retries for get blob. The default value is 0, which means no retry for get blob.
    */
   @Config(ROUTER_GET_BLOB_RETRY_LIMIT_COUNT)
-  @Default("0")
   public final int routerGetBlobRetryLimitCount;
   public static final String ROUTER_GET_BLOB_RETRY_LIMIT_COUNT = "router.get.blob.retry.limit.count";
   public static final int ROUTER_GET_BLOB_RETRY_LIMIT_COUNT_MAX = 100;

--- a/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
@@ -65,6 +65,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -717,6 +718,7 @@ class GetBlobOperation extends GetOperation {
     // Tracks quota charging for this chunk.
     private OperationQuotaCharger operationQuotaCharger;
     protected long initializedTimeMs;
+    private int failedAttempts;
     protected boolean isChunkCompressed;
 
     /**
@@ -775,6 +777,7 @@ class GetBlobOperation extends GetOperation {
       operationQuotaCharger =
           new OperationQuotaCharger(quotaChargeCallback, GetBlobOperation.class.getSimpleName(), routerMetrics);
       initializedTimeMs = -1;
+      failedAttempts = 0;
     }
 
     /**
@@ -792,7 +795,22 @@ class GetBlobOperation extends GetOperation {
           RouterOperation.GetBlobOperation, chunkBlobId);
       progressTracker = new ProgressTracker(chunkOperationTracker);
       state = ChunkState.Ready;
-      initializedTimeMs = System.currentTimeMillis();
+      initializedTimeMs = time.milliseconds();
+    }
+
+    /**
+     * Reset some variables for retry.
+     */
+    void resetForRetry() {
+      logger.trace("BlobId {}: Retry for chunk Id: {}, failed attempts: {}, initializedTime: {}", blobId, chunkBlobId,
+          failedAttempts, initializedTimeMs);
+      chunkException = null;
+      chunkOperationTracker = getOperationTracker(chunkBlobId.getPartition(), chunkBlobId.getDatacenterId(),
+          RouterOperation.GetBlobOperation, chunkBlobId);
+      progressTracker = new ProgressTracker(chunkOperationTracker);
+      state = ChunkState.Ready;
+      failedAttempts++;
+      routerMetrics.getBlobRetryCount.inc();
     }
 
     /**
@@ -1001,6 +1019,35 @@ class GetBlobOperation extends GetOperation {
     }
 
     /**
+     * Return a boolean value to indicate whether we should retry on fetching this chunk based on the given exception.
+     * To Retry on a Get failure, these conditions have to be met at the same time
+     * <p>
+     *   <ol>
+     *     <li>Exception is AmbryUnavailable, or OperationTimeout, or UnexpectedInternalError. The errors that return 503</li>
+     *     <li>Failed attempts is less than the maximum retry count</li>
+     *     <li>Operation duration is less than maximum retry duration</li>
+     *   </ol>
+     * </p>
+     * @param exception The exception for this chunk operation.
+     * @return {@code True} to retry this chunk. otherwise, return false.
+     */
+    boolean shouldRetry(RouterException exception) {
+      if (exception == null) {
+        return false;
+      }
+      switch (exception.getErrorCode()) {
+        case AmbryUnavailable:
+        case OperationTimedOut:
+        case UnexpectedInternalError:
+          return failedAttempts < routerConfig.routerGetBlobRetryLimitCount
+              && time.milliseconds() < initializedTimeMs + TimeUnit.SECONDS.toMillis(
+              routerConfig.routerGetBlobRetryLimitInSec);
+        default:
+          return false;
+      }
+    }
+
+    /**
      * Check if the operation on the chunk is eligible for completion, if so complete it.
      */
     void checkAndMaybeComplete() {
@@ -1010,11 +1057,15 @@ class GetBlobOperation extends GetOperation {
         } else if (chunkOperationTracker.maybeFailedDueToOfflineReplicas()) {
           chunkException =
               buildChunkException("Get Chunk failed because of offline replicas", RouterErrorCode.AmbryUnavailable);
-        } else if (chunkOperationTracker.hasFailedOnNotFound()){
+        } else if (chunkOperationTracker.hasFailedOnNotFound()) {
           chunkException =
               buildChunkException("Get Chunk failed because of BlobNotFound", RouterErrorCode.BlobDoesNotExist);
         }
-        chunkCompleted = true;
+        if (shouldRetry(chunkException)) {
+          resetForRetry();
+        } else {
+          chunkCompleted = true;
+        }
       }
       if (chunkCompleted) {
         if (state != ChunkState.Complete && QuotaUtils.postProcessCharge(quotaChargeCallback)

--- a/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterMetrics.java
@@ -196,6 +196,7 @@ public class NonBlockingRouterMetrics {
   public final Counter skippedGetBlobCount;
   public Gauge<Long> chunkFillerThreadRunning;
   public Gauge<Long> requestResponseHandlerThreadRunning;
+  public final Counter getBlobRetryCount;
 
   // metrics for tracking blob sizes and chunking.
   public final Histogram putBlobSizeBytes;
@@ -502,6 +503,7 @@ public class NonBlockingRouterMetrics {
         metricRegistry.counter(MetricRegistry.name(OperationController.class, "UpdateOptimizedCount"));
     updateUnOptimizedCount =
         metricRegistry.counter(MetricRegistry.name(OperationController.class, "UpdateUnOptimizedCount"));
+    getBlobRetryCount = metricRegistry.counter(MetricRegistry.name(GetBlobOperation.class, "GetBlobRetryCount"));
 
     // metrics to track blob sizes and chunking.
     putBlobSizeBytes = metricRegistry.histogram(MetricRegistry.name(PutManager.class, "PutBlobSizeBytes"));

--- a/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
@@ -1221,7 +1221,6 @@ class PutOperation {
             passedInBlobProperties.getExternalAssetTag(), passedInBlobProperties.getContentEncoding(),
             passedInBlobProperties.getFilename());
         operationTracker = getOperationTracker();
-        chunkException = null;
         correlationIdToChunkPutRequestInfo.clear();
         logger.trace("{}: Chunk {} is ready for sending out to server", loggingContext, chunkIndex);
         state = ChunkState.Ready;
@@ -1434,6 +1433,7 @@ class PutOperation {
             logger.trace("{}: Attempt to put chunk with id: {} failed, attempting slipped put ", loggingContext,
                 chunkBlobId);
             routerMetrics.slippedPutAttemptCount.inc();
+            chunkException = null;
             prepareForSending();
           } else {
             // this chunk could not be successfully put. The whole operation has to fail.

--- a/ambry-router/src/test/java/com/github/ambry/router/MockServer.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/MockServer.java
@@ -386,6 +386,12 @@ class MockServer {
         }
         byteBuffer = ByteBuffer.allocate(0);
         byteBufferSize = 0;
+      } else if (processedError == ServerErrorCode.Replica_Unavailable) {
+        if (partitionError == ServerErrorCode.No_Error) {
+          partitionError = ServerErrorCode.Replica_Unavailable;
+        }
+        byteBuffer = ByteBuffer.allocate(0);
+        byteBufferSize = 0;
       } else {
         if (partitionError == ServerErrorCode.No_Error) {
           partitionError = ServerErrorCode.Blob_Not_Found;


### PR DESCRIPTION
This PR adds retry logic for GetBlobOperation in router.

Why are we doing this:
Router might fail client's get requests due to temporary network error, or server being overloaded. If frontend returns 503 right away, client would would probably retry the entire blob. However, if this is a composite blob made of hundreds of chunks, then client resending get request would end up wasting lots of resources to refetch those already fetched blob in router.

This PR adds retry logic to prevent resource from wasting. It will retry on GetBlobOperation. But there is a limit to which an GetBlobOperation can retry. This limit is based on both count and duration. We can configure the maximum number of retries and the longest duration for retries. A retry can't exceed either limit.