### PR TITLE
Update logic for sending 404 and 503

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
@@ -127,6 +127,8 @@ public class RouterConfig {
   public static final String ROUTER_UNAVAILABLE_DUE_TO_SUCCESS_COUNT_IS_NON_ZERO_FOR_DELETE =
       "router.unavailable.due.to.success.count.is.non.zero.for.delete";
   public static final String ROUTER_REPAIR_WITH_REPLICATE_BLOB_ENABLED = "router.repair.with.replicate.blob.enabled";
+  public static final String ROUTER_OPERATION_TRACKER_CHECK_ALL_ORIGINATING_REPLICAS_FOR_NOT_FOUND =
+      "router.operation.tracker.check.all.originating.replicas.for.not.found";
 
   /**
    * Number of independent scaling units for the router.
@@ -672,6 +674,16 @@ public class RouterConfig {
   public static final String ROUTER_GET_BLOB_RETRY_LIMIT_COUNT = "router.get.blob.retry.limit.count";
   public static final int ROUTER_GET_BLOB_RETRY_LIMIT_COUNT_MAX = 100;
 
+  /*
+   * If this config is set to {@code true} the operation tracker would make sure all replicas in originating data center
+   * are up and respond with BLOB_NOT_FOUND before concluding that blob is not present. Else, it would check in
+   * total_originating_dc_replicas - put_success_target + 1 replicas.
+   */
+  @Config(ROUTER_OPERATION_TRACKER_CHECK_ALL_ORIGINATING_REPLICAS_FOR_NOT_FOUND)
+  @Default("true")
+  public final boolean routerOperationTrackerCheckAllOriginatingReplicasForNotFound;
+
+
   // Group compression-related configs in the CompressConfig class.
   private final CompressionConfig compressionConfig;
 
@@ -825,6 +837,8 @@ public class RouterConfig {
         ROUTER_GET_BLOB_RETRY_LIMIT_COUNT_MAX);
 
     compressionConfig = new CompressionConfig(verifiableProperties);
+    routerOperationTrackerCheckAllOriginatingReplicasForNotFound =
+        verifiableProperties.getBoolean(ROUTER_OPERATION_TRACKER_CHECK_ALL_ORIGINATING_REPLICAS_FOR_NOT_FOUND, true);
   }
 
   /**

--- a/ambry-router/src/main/java/com/github/ambry/router/GetBlobInfoOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/GetBlobInfoOperation.java
@@ -493,9 +493,15 @@ class GetBlobInfoOperation extends GetOperation {
     if (progressTracker.isDone()) {
       if (progressTracker.hasSucceeded()) {
         operationException.set(null);
-      } else if (operationTracker.hasFailedOnNotFound()) {
-        operationException.set(new RouterException("GetBlobInfoOperation failed because of BlobNotFound",
-            RouterErrorCode.BlobDoesNotExist));
+      } else {
+        if (operationTracker.hasFailedOnNotFound()) {
+          operationException.set(new RouterException("GetBlobInfoOperation failed because of BlobNotFound",
+              RouterErrorCode.BlobDoesNotExist));
+        } else if (operationTracker.hasSomeUnavailability()) {
+          setOperationException(
+              new RouterException("GetBlobInfoOperation failed possibly because some replicas are unavailable",
+                  RouterErrorCode.AmbryUnavailable));
+        }
       }
       operationCompleted = true;
     }

--- a/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
@@ -1056,12 +1056,14 @@ class GetBlobOperation extends GetOperation {
       if (progressTracker.isDone()) {
         if (progressTracker.hasSucceeded() && !retainChunkExceptionOnSuccess) {
           chunkException = null;
-        } else if (chunkOperationTracker.maybeFailedDueToOfflineReplicas()) {
-          chunkException =
-              buildChunkException("Get Chunk failed because of offline replicas", RouterErrorCode.AmbryUnavailable);
-        } else if (chunkOperationTracker.hasFailedOnNotFound()) {
-          chunkException =
-              buildChunkException("Get Chunk failed because of BlobNotFound", RouterErrorCode.BlobDoesNotExist);
+        } else {
+          if (chunkOperationTracker.hasFailedOnNotFound()) {
+            chunkException =
+                buildChunkException("Get Chunk failed because of BlobNotFound", RouterErrorCode.BlobDoesNotExist);
+          } else if (chunkOperationTracker.hasSomeUnavailability()) {
+            setChunkException(chunkException =
+                buildChunkException("Get Chunk failed because of offline replicas", RouterErrorCode.AmbryUnavailable));
+          }
         }
         if (shouldRetry(chunkException)) {
           resetForRetry();

--- a/ambry-router/src/main/java/com/github/ambry/router/OperationTracker.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/OperationTracker.java
@@ -55,21 +55,18 @@ interface OperationTracker {
   boolean hasSucceeded();
 
   /**
-   * Return {@code true} if the blob is not found in available replicas, and there are offline replicas where blob might
-   * have existed.
-   *
-   * @return {@code true} if the operation failed because of eligible replicas' {@link TrackedRequestFinalState#NOT_FOUND} and
-   * some replicas being offline.
-   */
-  boolean maybeFailedDueToOfflineReplicas();
-
-  /**
-   * Return {@code true} only if the number of NOT_FOUND responses from originating DC passes the threshold.
-   * It also means hasSucceeded would return {@code false}.
+   * Return {@code true} only if the number of NOT_FOUND responses from originating DC passes the threshold. It also
+   * means hasSucceeded would return {@code false}.
    *
    * @return {@code true} if the operation failed because of {@link TrackedRequestFinalState#NOT_FOUND}.
    */
   boolean hasFailedOnNotFound();
+
+  /**
+   * @return {@code true} if any of replicas are not up in originating DC. This method can be used to check if there
+   * are any unavailable replicas when a operation has failed.
+   */
+  boolean hasSomeUnavailability();
 
   /**
    * Check if any replica returned NOT_FOUND response.

--- a/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateOperation.java
@@ -369,8 +369,8 @@ class TtlUpdateOperation {
     // 4. and error code precedence is over AmbryUnavailable. If we have one success and one delete, shouldn't do retry.
     RouterErrorCode errorCode = ((RouterException) operationException.get()).getErrorCode();
     return (routerConfig.routerRepairWithReplicateBlobEnabled && operationTracker.hasNotFound()
-        && operationTracker.getSuccessCount() > 0
-        && getPrecedenceLevel(errorCode) >= getPrecedenceLevel(RouterErrorCode.AmbryUnavailable));
+        && operationTracker.getSuccessCount() > 0 && getPrecedenceLevel(errorCode) >= getPrecedenceLevel(
+        RouterErrorCode.AmbryUnavailable));
   }
 
   /**
@@ -391,26 +391,12 @@ class TtlUpdateOperation {
             return;
           }
         }
-
-        if (operationTracker.maybeFailedDueToOfflineReplicas()) {
-          operationException.set(new RouterException("TtlUpdateOperation failed possibly because of offline replicas",
+        if (operationTracker.hasFailedOnNotFound()) {
+          operationException.set(new RouterException("TtlUpdateOperation failed because of BlobNotFound",
+              RouterErrorCode.BlobDoesNotExist));
+        } else if (operationTracker.hasSomeUnavailability()) {
+          setOperationException(new RouterException("TtlUpdateOperation failed possibly because of offline replicas",
               RouterErrorCode.AmbryUnavailable));
-        } else if (operationTracker.hasFailedOnNotFound()) {
-          /*
-            We are relying on the fact that at least one replica has the blob. Scenarios like below are rare, so that we don’t need to handle them for now.
-            1. put parallelism is 3 && all three replicas of originating dc are down && remote replication is not caught up
-            2. put parallelism is 2 && 2 replicas are down (note that 2 replicas down happen all the time) && replication has not caught up such that blob doesn’t exist in at least one other replica.
-                i.e, its very rare for 2 replicas to be down simultaneously and immediately after taking a POST (with parallelism 2)
-          */
-          if (operationTracker.getSuccessCount() > 0) {
-            routerMetrics.failedMaybeDueToUnavailableReplicasCount.inc();
-            operationException.set(
-                new RouterException("TtlUpdateOperation failed possibly because of unavailable replicas",
-                    RouterErrorCode.AmbryUnavailable));
-          } else {
-            operationException.set(new RouterException("TtlUpdateOperation failed because of BlobNotFound",
-                RouterErrorCode.BlobDoesNotExist));
-          }
         }
       }
 

--- a/ambry-router/src/main/java/com/github/ambry/router/UndeleteOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/UndeleteOperation.java
@@ -378,9 +378,15 @@ public class UndeleteOperation {
     if (operationTracker.isDone() || operationCompleted) {
       if (operationTracker.hasSucceeded()) {
         operationException.set(null);
-      } else if (operationTracker.hasFailedOnNotFound()) {
-        operationException.set(
-            new RouterException("UndeleteOperation failed because of BlobNotFound", RouterErrorCode.BlobDoesNotExist));
+      } else {
+        if (operationTracker.hasFailedOnNotFound()) {
+          operationException.set(new RouterException("UndeleteOperation failed because of BlobNotFound",
+              RouterErrorCode.BlobDoesNotExist));
+        } else if (operationTracker.hasSomeUnavailability()) {
+          setOperationException(
+              new RouterException("UndeleteOperation failed possibly because some replicas are unavailable",
+                  RouterErrorCode.AmbryUnavailable));
+        }
       }
       if (QuotaUtils.postProcessCharge(quotaChargeCallback)) {
         try {

--- a/ambry-router/src/test/java/com/github/ambry/router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/GetBlobOperationTest.java
@@ -1331,7 +1331,7 @@ public class GetBlobOperationTest {
 
   /**
    * Test the case where originating dc returns 2 Disk_Unavailable and 1 Not_Found and rest replicas return Not_Found.
-   * In this case, result of GET operation will be Not_Found.
+   * In this case, result of GET operation will be AmbryUnavailable.
    * @throws Exception
    */
   @Test
@@ -1353,7 +1353,7 @@ public class GetBlobOperationTest {
         localDcServers.get(i).setServerErrorForAllRequests(ServerErrorCode.Blob_Not_Found);
       }
     }
-    getErrorCodeChecker.testAndAssert(RouterErrorCode.BlobDoesNotExist);
+    getErrorCodeChecker.testAndAssert(RouterErrorCode.AmbryUnavailable);
     mockServerLayout.getMockServers().forEach(MockServer::resetServerErrors);
   }
 
@@ -1454,12 +1454,10 @@ public class GetBlobOperationTest {
       RouterErrorCode expectedRouterError;
       switch (serverErrorCode) {
         case Replica_Unavailable:
-          expectedRouterError = RouterErrorCode.AmbryUnavailable;
-          break;
         case Disk_Unavailable:
-          // if all the disks are unavailable (which should be extremely rare), after replacing these disks, the blob is
-          // definitely not present.
-          expectedRouterError = RouterErrorCode.BlobDoesNotExist;
+          // Even if all the disks are unavailable (which should be extremely rare), we will return AmbryUnavailable.
+          // Once the disks are back up, we will return BlobNotFound.
+          expectedRouterError = RouterErrorCode.AmbryUnavailable;
           break;
         default:
           expectedRouterError = RouterErrorCode.UnexpectedInternalError;

--- a/ambry-router/src/test/java/com/github/ambry/router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/GetBlobOperationTest.java
@@ -853,7 +853,7 @@ public class GetBlobOperationTest {
     }
 
     RouterException routerException = (RouterException) op.getOperationException();
-    // error code should be OperationTimedOut because it precedes BlobDoesNotExist
+    // error code should be BlobDoesNotExist
     Assert.assertEquals(RouterErrorCode.BlobDoesNotExist, routerException.getErrorCode());
 
     props = getDefaultNonBlockingRouterProperties(true);
@@ -861,6 +861,141 @@ public class GetBlobOperationTest {
     props.setProperty("router.get.request.parallelism", "2");
     props.setProperty("router.operation.tracker.max.inflight.requests", "2");
     routerConfig = new RouterConfig(new VerifiableProperties(props));
+  }
+
+  /**
+   * Test the case when some of the replicas in originating DC are unavailable, we should return AmbryUnavailable.
+   * @throws Exception
+   */
+  @Test
+  public void testOrigDcUnavailability() throws Exception {
+    doPut();
+
+    // Default all replicas to return not found.
+    int serverCount = mockServerLayout.getMockServers().size();
+    List<ServerErrorCode> serverErrorCodes = Collections.nCopies(serverCount, ServerErrorCode.Blob_Not_Found);
+    setServerErrorCodes(serverErrorCodes, mockServerLayout);
+
+    // Set 1 not found from bootstrap, 2 not found from standby in originating dc
+    List<MockServer> serversInLocalDc = new ArrayList<>();
+    mockServerLayout.getMockServers().forEach(mockServer -> {
+      if (mockServer.getDataCenter().equals(localDcName)) {
+        serversInLocalDc.add(mockServer);
+      }
+    });
+    MockPartitionId partitionId = (MockPartitionId) blobId.getPartition();
+    ReplicaId boostrapReplica = partitionId.replicaIds.stream()
+        .filter(replicaId -> replicaId.getDataNodeId().getDatacenterName().equals(localDcName))
+        .filter(replicaId -> replicaId.getDataNodeId().getHostname().equals(serversInLocalDc.get(0).getHostName()))
+        .findFirst()
+        .get();
+    partitionId.setReplicaState(boostrapReplica, ReplicaState.BOOTSTRAP);
+    serversInLocalDc.get(0).setServerErrorForAllRequests(ServerErrorCode.Blob_Not_Found);
+    serversInLocalDc.get(1).setServerErrorForAllRequests(ServerErrorCode.Blob_Not_Found);
+    serversInLocalDc.get(2).setServerErrorForAllRequests(ServerErrorCode.Blob_Not_Found);
+
+    getErrorCodeChecker.testAndAssert(RouterErrorCode.AmbryUnavailable);
+  }
+
+  /**
+   * Test the case when all of the replicas in originating DC return NotFound, we should return BlobNotFound.
+   * @throws Exception
+   */
+  @Test
+  public void testOrigDcNotFound() throws Exception {
+    doPut();
+
+    // Default all replicas to return not found.
+    int serverCount = mockServerLayout.getMockServers().size();
+    List<ServerErrorCode> serverErrorCodes = Collections.nCopies(serverCount, ServerErrorCode.IO_Error);
+    setServerErrorCodes(serverErrorCodes, mockServerLayout);
+
+    // Set 3 not found from standby in originating dc
+    List<MockServer> serversInLocalDc = new ArrayList<>();
+    mockServerLayout.getMockServers().forEach(mockServer -> {
+      if (mockServer.getDataCenter().equals(localDcName)) {
+        serversInLocalDc.add(mockServer);
+      }
+    });
+    serversInLocalDc.get(0).setServerErrorForAllRequests(ServerErrorCode.Blob_Not_Found);
+    serversInLocalDc.get(1).setServerErrorForAllRequests(ServerErrorCode.Blob_Not_Found);
+    serversInLocalDc.get(2).setServerErrorForAllRequests(ServerErrorCode.Blob_Not_Found);
+
+    getErrorCodeChecker.testAndAssert(RouterErrorCode.BlobDoesNotExist);
+  }
+
+  /**
+   * Test the case when error precedence is maintained with unavailability in originating DC.
+   * @throws Exception
+   */
+  @Test
+  public void testErrorPrecedenceWithOrigDcUnavailability() throws Exception {
+    doPut();
+
+    // Default all replicas to return not found.
+    int serverCount = mockServerLayout.getMockServers().size();
+    List<ServerErrorCode> serverErrorCodes = Collections.nCopies(serverCount, ServerErrorCode.Blob_Not_Found);
+    setServerErrorCodes(serverErrorCodes, mockServerLayout);
+
+    // Set 1 not found from bootstrap, 2 not found from standby in originating dc
+    List<MockServer> serversInLocalDc = new ArrayList<>();
+    mockServerLayout.getMockServers().forEach(mockServer -> {
+      if (mockServer.getDataCenter().equals(localDcName)) {
+        serversInLocalDc.add(mockServer);
+      }
+    });
+    MockPartitionId partitionId = (MockPartitionId) blobId.getPartition();
+    ReplicaId boostrapReplica = partitionId.replicaIds.stream()
+        .filter(replicaId -> replicaId.getDataNodeId().getDatacenterName().equals(localDcName))
+        .filter(replicaId -> replicaId.getDataNodeId().getHostname().equals(serversInLocalDc.get(0).getHostName()))
+        .findFirst()
+        .get();
+    partitionId.setReplicaState(boostrapReplica, ReplicaState.BOOTSTRAP);
+    serversInLocalDc.get(0).setServerErrorForAllRequests(ServerErrorCode.Blob_Not_Found);
+    serversInLocalDc.get(1).setServerErrorForAllRequests(ServerErrorCode.Blob_Not_Found);
+    serversInLocalDc.get(2).setServerErrorForAllRequests(ServerErrorCode.Blob_Not_Found);
+
+    // Set two remote servers to return BlobExpired
+    List<MockServer> serversInRemoteDc = new ArrayList<>(mockServerLayout.getMockServers());
+    serversInRemoteDc.removeAll(serversInLocalDc);
+    serversInRemoteDc.get(0).setServerErrorForAllRequests(ServerErrorCode.Blob_Expired);
+    serversInRemoteDc.get(1).setServerErrorForAllRequests(ServerErrorCode.Blob_Expired);
+
+    getErrorCodeChecker.testAndAssert(RouterErrorCode.BlobExpired);
+  }
+
+  /**
+   * Test the case when there is 1 success in originating data center, we should return success.
+   * @throws Exception
+   */
+  @Test
+  public void testOrigDcSuccess() throws Exception {
+    doPut();
+
+    // Default all replicas to return not found.
+    int serverCount = mockServerLayout.getMockServers().size();
+    List<ServerErrorCode> serverErrorCodes = Collections.nCopies(serverCount, ServerErrorCode.Blob_Not_Found);
+    setServerErrorCodes(serverErrorCodes, mockServerLayout);
+
+    // Set 1 success and rest not found in originating dc
+    List<MockServer> serversInLocalDc = new ArrayList<>();
+    mockServerLayout.getMockServers().forEach(mockServer -> {
+      if (mockServer.getDataCenter().equals(localDcName)) {
+        serversInLocalDc.add(mockServer);
+      }
+    });
+    MockPartitionId partitionId = (MockPartitionId) blobId.getPartition();
+    ReplicaId boostrapReplica = partitionId.replicaIds.stream()
+        .filter(replicaId -> replicaId.getDataNodeId().getDatacenterName().equals(localDcName))
+        .filter(replicaId -> replicaId.getDataNodeId().getHostname().equals(serversInLocalDc.get(0).getHostName()))
+        .findFirst()
+        .get();
+    partitionId.setReplicaState(boostrapReplica, ReplicaState.BOOTSTRAP);
+    serversInLocalDc.get(0).setServerErrorForAllRequests(ServerErrorCode.Blob_Not_Found);
+    serversInLocalDc.get(1).setServerErrorForAllRequests(ServerErrorCode.Blob_Not_Found);
+    serversInLocalDc.get(2).setServerErrorForAllRequests(ServerErrorCode.No_Error);
+
+    getErrorCodeChecker.testAndAssert(null);
   }
 
   /**

--- a/ambry-router/src/test/java/com/github/ambry/router/TtlUpdateManagerTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/TtlUpdateManagerTest.java
@@ -75,7 +75,7 @@ public class TtlUpdateManagerTest {
   private static final byte[] PUT_CONTENT = new byte[1000];
   private static final int BLOBS_COUNT = 5;
   private static final String UPDATE_SERVICE_ID = "update-service-id";
-  private static final String LOCAL_DC = "DC1";
+  private String localDc;
   private final NonBlockingRouter router;
   private final TtlUpdateManager ttlUpdateManager;
   private final SocketNetworkClient networkClient;
@@ -96,6 +96,7 @@ public class TtlUpdateManagerTest {
    */
   public TtlUpdateManagerTest() throws Exception {
     assertTrue("Server count has to be at least 9", serverCount >= 9);
+    localDc = clusterMap.getDatacenterName(clusterMap.getLocalDatacenterId());
     VerifiableProperties vProps =
         new VerifiableProperties(getNonBlockingRouterProperties(DEFAULT_SUCCESS_TARGET, DEFAULT_PARALLELISM));
     RouterConfig routerConfig = new RouterConfig(vProps);
@@ -226,7 +227,11 @@ public class TtlUpdateManagerTest {
     Map<ServerErrorCode, RouterErrorCode> errorCodeMap = new HashMap<>();
     errorCodeMap.put(ServerErrorCode.Blob_Deleted, RouterErrorCode.BlobDeleted);
     errorCodeMap.put(ServerErrorCode.Blob_Expired, RouterErrorCode.BlobExpired);
-    errorCodeMap.put(ServerErrorCode.Blob_Not_Found, RouterErrorCode.BlobDoesNotExist);
+    // In production, disk_unavailable usually means disk is bad with I/O errors. For now, the only way to fix this is
+    // to replace disk and relies on replication to restore data. If all replicas return disk unavailable (should be
+    // extremely rare in real world), it means blob is no long present and it's should be ok to return BlobDoesNotExist.
+    // But for simplicity, we will return AmbryUnavailable. Once disks are replaced, we will begin to return
+    // BlobDoesNotExist.
     errorCodeMap.put(ServerErrorCode.Disk_Unavailable, RouterErrorCode.AmbryUnavailable);
     errorCodeMap.put(ServerErrorCode.Replica_Unavailable, RouterErrorCode.AmbryUnavailable);
     errorCodeMap.put(ServerErrorCode.Blob_Update_Not_Allowed, RouterErrorCode.BlobUpdateNotAllowed);
@@ -236,17 +241,13 @@ public class TtlUpdateManagerTest {
         continue;
       }
       ArrayList<ServerErrorCode> serverErrorCodes =
-          new ArrayList<>(Collections.nCopies(serverCount, ServerErrorCode.Blob_Not_Found));
+          new ArrayList<>(Collections.nCopies(serverCount, ServerErrorCode.IO_Error));
       // has to be repeated because the op tracker returns failure if it sees 8/9 failures and the success target is 2
       serverErrorCodes.set(3, errorCode);
       serverErrorCodes.set(5, errorCode);
       Collections.shuffle(serverErrorCodes);
       setServerErrorCodes(serverErrorCodes, serverLayout);
-      // In production, disk_unavailable usually means disk is bad with I/O errors. For now, the only way to fix this is
-      // to replace disk and relies on replication to restore data. If all replicas return disk unavailable (should be
-      // extremely rare in real world), it means blob is no long present and it's ok to return BlobDoesNotExist.
-      RouterErrorCode expected = errorCode == ServerErrorCode.Disk_Unavailable ? RouterErrorCode.BlobDoesNotExist
-          : errorCodeMap.getOrDefault(errorCode, RouterErrorCode.UnexpectedInternalError);
+      RouterErrorCode expected = errorCodeMap.getOrDefault(errorCode, RouterErrorCode.UnexpectedInternalError);
       executeOpAndVerify(blobIds, expected, false, true, true, false, false);
     }
     serverLayout.getMockServers().forEach(MockServer::resetServerErrors);
@@ -353,6 +354,7 @@ public class TtlUpdateManagerTest {
     notificationSystem.reset();
     List<String> chunkIds = new ArrayList<>(ids);
     router.currentOperationsCount.addAndGet(ids.size() == 1 ? 1 : ids.size() - 1);
+    ttlUpdateManager.close();
     ttlUpdateManager.submitTtlUpdateOperation(chunkIds.get(0), chunkIds.subList(1, chunkIds.size()), UPDATE_SERVICE_ID,
         Utils.Infinite_Time, future, callback, quotaChargeCallback);
     sendRequestsGetResponses(future, ttlUpdateManager, advanceTime, ignoreUnrecognizedRequests, isQuotaRejected);
@@ -473,7 +475,7 @@ public class TtlUpdateManagerTest {
   private Properties getNonBlockingRouterProperties(int successTarget, int parallelism) {
     Properties properties = new Properties();
     properties.setProperty("router.hostname", "localhost");
-    properties.setProperty("router.datacenter.name", LOCAL_DC);
+    properties.setProperty("router.datacenter.name", localDc);
     properties.setProperty("router.ttl.update.success.target", Integer.toString(successTarget));
     properties.setProperty("router.ttl.update.request.parallelism", Integer.toString(parallelism));
     return properties;
@@ -490,7 +492,7 @@ public class TtlUpdateManagerTest {
       ServerErrorCode errorCodeToReturn) throws Exception {
     List<MockServer> serversInLocalDc = new ArrayList<>();
     serverLayout.getMockServers().forEach(mockServer -> {
-      if (mockServer.getDataCenter().equals(LOCAL_DC)) {
+      if (mockServer.getDataCenter().equals(localDc)) {
         serversInLocalDc.add(mockServer);
       }
     });
@@ -499,8 +501,15 @@ public class TtlUpdateManagerTest {
     }
     List<ServerErrorCode> serverErrorCodes = Collections.nCopies(serverCount, ServerErrorCode.Blob_Not_Found);
     setServerErrorCodes(serverErrorCodes, serverLayout);
-    for (int i = 0; i < successfulResponsesCount; i++) {
-      serversInLocalDc.get(i).setServerErrorForAllRequests(errorCodeToReturn);
+    if (successfulResponsesCount > 0) {
+      for (int i = 0; i < successfulResponsesCount; i++) {
+        serversInLocalDc.get(i).setServerErrorForAllRequests(errorCodeToReturn);
+      }
+      // Set error code from other local dc servers as Disk_Unavailable since it is not practical that we get 1 found
+      // and 2 not found from healthy local dc servers.
+      for (int i = successfulResponsesCount; i < serversInLocalDc.size(); i++) {
+        serversInLocalDc.get(i).setServerErrorForAllRequests(ServerErrorCode.Disk_Unavailable);
+      }
     }
     RouterErrorCode expectedErrorCode =
         (successfulResponsesCount > 0) ? RouterErrorCode.AmbryUnavailable : RouterErrorCode.BlobDoesNotExist;
@@ -522,7 +531,7 @@ public class TtlUpdateManagerTest {
       throw new IllegalStateException("Cannot run test because there aren't enough servers for the given codes");
     }
     List<ServerErrorCode> serverErrorCodes =
-        new ArrayList<>(Collections.nCopies(serverCount, ServerErrorCode.Blob_Not_Found));
+        new ArrayList<>(Collections.nCopies(serverCount, ServerErrorCode.IO_Error));
     List<RouterErrorCode> expected = new ArrayList<>(codesToSetAndTest.size());
     // fill in the array with all the error codes that need resolution and knock them off one by one
     // has to be repeated because the op tracker returns failure if it sees 8/9 failures and the success target is 2
@@ -533,49 +542,20 @@ public class TtlUpdateManagerTest {
       expected.add(entry.getValue());
       serverIdx += 2;
     }
-    expected.add(RouterErrorCode.BlobDoesNotExist);
+    expected.add(RouterErrorCode.UnexpectedInternalError);
     for (int i = 0; i < expected.size(); i++) {
       List<ServerErrorCode> shuffled = new ArrayList<>(serverErrorCodes);
       Collections.shuffle(shuffled);
       setServerErrorCodes(shuffled, serverLayout);
-      RouterErrorCode expectedRouterError = resolveRouterErrorCode(serverErrorCodes, expected.get(i));
-      executeOpAndVerify(blobIds, expectedRouterError, false, true, true, false, false);
+      executeOpAndVerify(blobIds, expected.get(i), false, true, true, false, false);
       if (i * 2 + 1 < serverErrorCodes.size()) {
-        serverErrorCodes.set(i * 2, ServerErrorCode.Blob_Not_Found);
-        serverErrorCodes.set(i * 2 + 1, ServerErrorCode.Blob_Not_Found);
+        serverErrorCodes.set(i * 2, ServerErrorCode.IO_Error);
+        serverErrorCodes.set(i * 2 + 1, ServerErrorCode.IO_Error);
       }
     }
     serverLayout.getMockServers().forEach(MockServer::resetServerErrors);
     assertTtl(router, blobIds, TTL_SECS);
   }
-
-  /**
-   * Helper method to resolve router error code. This accounts for combined disk_unavailable and not_found situation.
-   * @param serverErrorCodes a list of error code which servers will return.
-   * @param routerErrorCode the router error code solely decided by getPrecedenceLevel() method (which might be overridden)
-   * @return the resolved router error code.
-   */
-  private RouterErrorCode resolveRouterErrorCode(List<ServerErrorCode> serverErrorCodes,
-      RouterErrorCode routerErrorCode) {
-    RouterErrorCode resolvedErrorCode = routerErrorCode;
-    if (routerErrorCode == RouterErrorCode.AmbryUnavailable) {
-      int diskDownCount = 0;
-      int notFoundCount = 0;
-      for (ServerErrorCode errorCode : serverErrorCodes) {
-        if (errorCode == ServerErrorCode.Disk_Unavailable) {
-          diskDownCount++;
-        } else if (errorCode == ServerErrorCode.Blob_Not_Found) {
-          notFoundCount++;
-        }
-      }
-      if (diskDownCount + notFoundCount > serverCount - 2) {
-        resolvedErrorCode = RouterErrorCode.BlobDoesNotExist;
-      }
-    }
-    return resolvedErrorCode;
-  }
-
-  // routerErrorCodeResolutionTest() helpers
 
   static {
     TestUtils.RANDOM.nextBytes(PUT_CONTENT);


### PR DESCRIPTION
This PR refactors OperationTracker code to use originating data center as the source of truth when sending 404 responses. 

1. If all the replicas in originating data center are up and return that blob is not present, we send 404. Config `routerOperationTrackerTerminateOnNotFoundEnabled` is used to terminate the operation immediately. 
2. If any of the originating DC replicas are not up (i.e. in leader or standby state) and the success count doesn't meet the quorum, we send 503 if there are no other errors with higher precedence (such as Authorization failure, Blob deleted, etc).

