### PR TITLE
Update clustermap and state transition factory to deal with duplicate partition ids

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/clustermap/StateTransitionException.java
+++ b/ambry-api/src/main/java/com/github/ambry/clustermap/StateTransitionException.java
@@ -25,6 +25,12 @@ public class StateTransitionException extends RuntimeException {
     this.error = error;
   }
 
+  public StateTransitionException(String s, TransitionErrorCode error, Throwable throwable) {
+    super(s, throwable);
+    this.error = error;
+  }
+
+
   public TransitionErrorCode getErrorCode() {
     return error;
   }
@@ -62,6 +68,11 @@ public class StateTransitionException extends RuntimeException {
     /**
      * If updating cluster info in Helix fails at some point for specific replica.
      */
-    HelixUpdateFailure
+    HelixUpdateFailure,
+
+    /**
+     * If the resource name is not a numeric number.
+     */
+    InvalidResourceName
   }
 }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryPartitionStateModel.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryPartitionStateModel.java
@@ -15,6 +15,7 @@ package com.github.ambry.clustermap;
 
 import com.github.ambry.config.ClusterMapConfig;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentMap;
 import org.apache.helix.NotificationContext;
 import org.apache.helix.model.Message;
 import org.apache.helix.participant.statemachine.StateModel;
@@ -32,97 +33,147 @@ public class AmbryPartitionStateModel extends StateModel {
   private final String partitionName;
   private final PartitionStateChangeListener partitionStateChangeListener;
   private final ClusterMapConfig clusterMapConfig;
+  private final ConcurrentMap<String, String> partitionNameToResourceName;
 
   AmbryPartitionStateModel(String resourceName, String partitionName,
-      PartitionStateChangeListener partitionStateChangeListener, ClusterMapConfig clusterMapConfig) {
+      PartitionStateChangeListener partitionStateChangeListener, ClusterMapConfig clusterMapConfig,
+      ConcurrentMap<String, String> partitionNameToResourceName) {
     this.resourceName = resourceName;
     this.partitionName = partitionName;
     this.partitionStateChangeListener = Objects.requireNonNull(partitionStateChangeListener);
     this.clusterMapConfig = Objects.requireNonNull(clusterMapConfig);
     StateModelParser parser = new StateModelParser();
     _currentState = parser.getInitialState(AmbryPartitionStateModel.class);
+    this.partitionNameToResourceName = partitionNameToResourceName;
   }
 
   @Transition(to = "BOOTSTRAP", from = "OFFLINE")
   public void onBecomeBootstrapFromOffline(Message message, NotificationContext context) {
-    logger.info("Partition {} in resource {} is becoming BOOTSTRAP from OFFLINE", message.getPartitionName(),
-        message.getResourceName());
-    if (clusterMapConfig.clustermapEnableStateModelListener) {
-      partitionStateChangeListener.onPartitionBecomeBootstrapFromOffline(message.getPartitionName());
+    boolean shouldTransition = shouldTransition(message);
+    String partitionName = message.getPartitionName();
+    logger.info("Partition {} in resource {} is becoming BOOTSTRAP from OFFLINE, Should Transition? {}",
+        message.getPartitionName(), message.getResourceName(), shouldTransition);
+    if (clusterMapConfig.clustermapEnableStateModelListener && shouldTransition) {
+      partitionStateChangeListener.onPartitionBecomeBootstrapFromOffline(partitionName);
     }
   }
 
   @Transition(to = "STANDBY", from = "BOOTSTRAP")
   public void onBecomeStandbyFromBootstrap(Message message, NotificationContext context) {
+    boolean shouldTransition = shouldTransition(message);
     String partitionName = message.getPartitionName();
-    logger.info("Partition {} in resource {} is becoming STANDBY from BOOTSTRAP", partitionName,
-        message.getResourceName());
-    if (clusterMapConfig.clustermapEnableStateModelListener) {
+    logger.info("Partition {} in resource {} is becoming STANDBY from BOOTSTRAP, Should Transition? {}", partitionName,
+        message.getResourceName(), shouldTransition);
+    if (clusterMapConfig.clustermapEnableStateModelListener && shouldTransition) {
       partitionStateChangeListener.onPartitionBecomeStandbyFromBootstrap(partitionName);
     }
   }
 
   @Transition(to = "LEADER", from = "STANDBY")
   public void onBecomeLeaderFromStandby(Message message, NotificationContext context) {
-    logger.info("Partition {} in resource {} is becoming LEADER from STANDBY", message.getPartitionName(),
-        message.getResourceName());
-    partitionStateChangeListener.onPartitionBecomeLeaderFromStandby(message.getPartitionName());
+    boolean shouldTransition = shouldTransition(message);
+    String partitionName = message.getPartitionName();
+    logger.info("Partition {} in resource {} is becoming LEADER from STANDBY, Should Transition? {}", partitionName,
+        message.getResourceName(), shouldTransition);
+    if (shouldTransition) {
+      partitionStateChangeListener.onPartitionBecomeLeaderFromStandby(partitionName);
+    }
   }
 
   @Transition(to = "STANDBY", from = "LEADER")
   public void onBecomeStandbyFromLeader(Message message, NotificationContext context) {
-    logger.info("Partition {} in resource {} is becoming STANDBY from LEADER", message.getPartitionName(),
-        message.getResourceName());
-    partitionStateChangeListener.onPartitionBecomeStandbyFromLeader(message.getPartitionName());
+    boolean shouldTransition = shouldTransition(message);
+    String partitionName = message.getPartitionName();
+    logger.info("Partition {} in resource {} is becoming STANDBY from LEADER, Should Transition? {}", partitionName,
+        message.getResourceName(), shouldTransition);
+    if (shouldTransition) {
+      partitionStateChangeListener.onPartitionBecomeStandbyFromLeader(partitionName);
+    }
   }
 
   @Transition(to = "INACTIVE", from = "STANDBY")
   public void onBecomeInactiveFromStandby(Message message, NotificationContext context) {
+    boolean shouldTransition = shouldTransition(message);
     String partitionName = message.getPartitionName();
-    logger.info("Partition {} in resource {} is becoming INACTIVE from STANDBY", partitionName,
-        message.getResourceName());
-    if (clusterMapConfig.clustermapEnableStateModelListener) {
+    logger.info("Partition {} in resource {} is becoming INACTIVE from STANDBY, Should Transition? {}", partitionName,
+        message.getResourceName(), shouldTransition);
+    if (clusterMapConfig.clustermapEnableStateModelListener && shouldTransition) {
       partitionStateChangeListener.onPartitionBecomeInactiveFromStandby(partitionName);
     }
   }
 
   @Transition(to = "OFFLINE", from = "INACTIVE")
   public void onBecomeOfflineFromInactive(Message message, NotificationContext context) {
+    boolean shouldTransition = shouldTransition(message);
     String partitionName = message.getPartitionName();
-    logger.info("Partition {} in resource {} is becoming OFFLINE from INACTIVE", partitionName,
-        message.getResourceName());
-    if (clusterMapConfig.clustermapEnableStateModelListener) {
+    logger.info("Partition {} in resource {} is becoming OFFLINE from INACTIVE, Should Transition? {}", partitionName,
+        message.getResourceName(), shouldTransition);
+    if (clusterMapConfig.clustermapEnableStateModelListener && shouldTransition) {
       partitionStateChangeListener.onPartitionBecomeOfflineFromInactive(partitionName);
     }
   }
 
   @Transition(to = "DROPPED", from = "OFFLINE")
   public void onBecomeDroppedFromOffline(Message message, NotificationContext context) {
+    boolean shouldTransition = shouldTransition(message);
     String partitionName = message.getPartitionName();
-    logger.info("Partition {} in resource {} is becoming DROPPED from OFFLINE", partitionName,
-        message.getResourceName());
-    if (clusterMapConfig.clustermapEnableStateModelListener) {
+    logger.info("Partition {} in resource {} is becoming DROPPED from OFFLINE, Should Transition? {}", partitionName,
+        message.getResourceName(), shouldTransition);
+    if (clusterMapConfig.clustermapEnableStateModelListener && shouldTransition) {
       partitionStateChangeListener.onPartitionBecomeDroppedFromOffline(partitionName);
     }
   }
 
   @Transition(to = "DROPPED", from = "ERROR")
   public void onBecomeDroppedFromError(Message message, NotificationContext context) {
-    logger.info("Partition {} in resource {} is becoming DROPPED from ERROR", message.getPartitionName(),
-        message.getResourceName());
-    partitionStateChangeListener.onPartitionBecomeDroppedFromError(message.getPartitionName());
+    boolean shouldTransition = shouldTransition(message);
+    String partitionName = message.getPartitionName();
+    logger.info("Partition {} in resource {} is becoming DROPPED from ERROR, Should Transition? {}", partitionName,
+        message.getResourceName(), shouldTransition);
+    if (shouldTransition) {
+      partitionStateChangeListener.onPartitionBecomeDroppedFromError(partitionName);
+    }
   }
 
   @Transition(to = "OFFLINE", from = "ERROR")
   public void onBecomeOfflineFromError(Message message, NotificationContext context) {
-    logger.info("Partition {} in resource {} is becoming OFFLINE from ERROR", message.getPartitionName(),
-        message.getResourceName());
-    partitionStateChangeListener.onPartitionBecomeOfflineFromError(message.getPartitionName());
+    boolean shouldTransition = shouldTransition(message);
+    String partitionName = message.getPartitionName();
+    logger.info("Partition {} in resource {} is becoming OFFLINE from ERROR, Should Transition? {}", partitionName,
+        message.getResourceName(), shouldTransition);
+    if (shouldTransition) {
+      partitionStateChangeListener.onPartitionBecomeOfflineFromError(partitionName);
+    }
   }
 
   @Override
   public void reset() {
     logger.info("Reset method invoked. Partition {} in resource {} is reset to OFFLINE", partitionName, resourceName);
     partitionStateChangeListener.onReset(partitionName);
+  }
+
+  /**
+   * Return true if we should transition the state from the message. Ambry is undergoing resource reconstruction. Same
+   * partition will be added to different resources. Resource that has higher id should be considered as the primary
+   * resource.
+   * @param message Message that carry partition information.
+   * @return True if a state transition should happen.
+   */
+  boolean shouldTransition(Message message) {
+    String resourceName = message.getResourceName();
+    String partitionName = message.getPartitionName();
+    String mappedResourceName = partitionNameToResourceName.compute(partitionName, (k, v) -> {
+      if (v == null || v.equals(resourceName)) {
+        return resourceName;
+      }
+      try {
+        int oldResourceId = Integer.valueOf(v);
+        int newResourceId = Integer.valueOf(resourceName);
+        return newResourceId > oldResourceId ? resourceName : v;
+      } catch (Exception e) {
+        return resourceName;
+      }
+    });
+    return mappedResourceName.equals(resourceName);
   }
 }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryPartitionStateModel.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryPartitionStateModel.java
@@ -55,7 +55,7 @@ import org.slf4j.LoggerFactory;
  * transition multiple times and generate the same result, except for ReplicationManager. When transitioning from standby
  * to leader and from leader to standby, replication manager would change the leader pair. If different replicas are chosen
  * to be leader in different transition, then we would have multiple leaders. But this is fine, since replication manager
- * use this leader pair information for cross-col replication. The worst case is that we have more than one replicas doing
+ * use this leader pair information for cross-colo replication. The worst case is that we have more than one replicas doing
  * cross-colo data replication.
  */
 @StateModelInfo(initialState = "OFFLINE", states = {"BOOTSTRAP", "LEADER", "STANDBY", "INACTIVE"})
@@ -83,8 +83,8 @@ public class AmbryPartitionStateModel extends StateModel {
   public void onBecomeBootstrapFromOffline(Message message, NotificationContext context) {
     boolean shouldTransition = shouldTransition(message);
     String partitionName = message.getPartitionName();
-    logger.info("Partition {} in resource {} is becoming BOOTSTRAP from OFFLINE, Should Transition? {}",
-        message.getPartitionName(), message.getResourceName(), shouldTransition);
+    logger.info("Partition {} in resource {} is becoming BOOTSTRAP from OFFLINE, Should Transition? {}", partitionName,
+        message.getResourceName(), shouldTransition);
     if (clusterMapConfig.clustermapEnableStateModelListener && shouldTransition) {
       partitionStateChangeListener.onPartitionBecomeBootstrapFromOffline(partitionName);
     }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryStateModelFactory.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryStateModelFactory.java
@@ -14,6 +14,7 @@
 package com.github.ambry.clustermap;
 
 import com.github.ambry.config.ClusterMapConfig;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.helix.model.LeaderStandbySMD;
 import org.apache.helix.participant.statemachine.StateModel;
 import org.apache.helix.participant.statemachine.StateModelFactory;
@@ -25,6 +26,7 @@ import org.apache.helix.participant.statemachine.StateModelFactory;
 class AmbryStateModelFactory extends StateModelFactory<StateModel> {
   private final ClusterMapConfig clustermapConfig;
   private final PartitionStateChangeListener partitionStateChangeListener;
+  private final ConcurrentHashMap<String, String> partitionNameToResourceName = new ConcurrentHashMap<>();
 
   AmbryStateModelFactory(ClusterMapConfig clusterMapConfig, PartitionStateChangeListener partitionStateChangeListener) {
     this.clustermapConfig = clusterMapConfig;
@@ -43,7 +45,8 @@ class AmbryStateModelFactory extends StateModelFactory<StateModel> {
     switch (clustermapConfig.clustermapStateModelDefinition) {
       case AmbryStateModelDefinition.AMBRY_LEADER_STANDBY_MODEL:
         stateModelToReturn =
-            new AmbryPartitionStateModel(resourceName, partitionName, partitionStateChangeListener, clustermapConfig);
+            new AmbryPartitionStateModel(resourceName, partitionName, partitionStateChangeListener, clustermapConfig,
+                partitionNameToResourceName);
         break;
       case LeaderStandbySMD.name:
         stateModelToReturn = new DefaultLeaderStandbyStateModel();

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
@@ -36,6 +36,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.apache.helix.AccessOption;
@@ -104,8 +105,8 @@ public class HelixClusterManager implements ClusterMap {
   private final Map<String, ReplicaId> bootstrapReplicas = new ConcurrentHashMap<>();
   private ZkHelixPropertyStore<ZNRecord> helixPropertyStoreInLocalDc = null;
   // The current xid currently does not change after instantiation. This can change in the future, allowing the cluster
-  // manager to dynamically incorporate newer changes in the cluster. This variable is atomic so that the gauge metric
-  // reflects the current value.
+// manager to dynamically incorporate newer changes in the cluster. This variable is atomic so that the gauge metric
+// reflects the current value.
   private final AtomicLong currentXid;
   final HelixClusterManagerMetrics helixClusterManagerMetrics;
   private HelixAggregatedViewClusterInfo helixAggregatedViewClusterInfo = null;
@@ -1132,7 +1133,9 @@ public class HelixClusterManager implements ClusterMap {
         ConcurrentHashMap<String, String> partitionToResourceMap = new ConcurrentHashMap<>();
         for (IdealState state : idealStates) {
           String resourceName = state.getResourceName();
-          state.getPartitionSet().forEach(partitionName -> partitionToResourceMap.put(partitionName, resourceName));
+          state.getPartitionSet()
+              .forEach(partitionName -> partitionToResourceMap.compute(partitionName,
+                  resourceNameReplaceFunc(resourceName)));
         }
         partitionToResourceNameByDc.put(dcName, partitionToResourceMap);
       } else {
@@ -1152,17 +1155,44 @@ public class HelixClusterManager implements ClusterMap {
         logger.warn(
             "Partition to resource mapping for individual dc (non-aggregated view) would be built from ideal states");
       } else {
+        Map<String, Map<String, String>> partitionToDCToResourceNames = new HashMap<>();
         // Rebuild the partition-to-resource map across all data centers
-        ConcurrentHashMap<String, Set<String>> partitionToResourceNames = new ConcurrentHashMap<>();
         for (ExternalView externalView : externalViews) {
           String resourceName = externalView.getResourceName();
-          externalView.getPartitionSet().forEach(partitionName -> {
-            Set<String> resourceNames = partitionToResourceNames.computeIfAbsent(partitionName, k -> new HashSet<>());
-            resourceNames.add(resourceName);
-          });
+          for (String partitionId : externalView.getPartitionSet()) {
+            // This is a map from instanceName to state
+            Map<String, String> stateMap = externalView.getStateMap(partitionId);
+            for (String instanceName : stateMap.keySet()) {
+              AmbryDataNode dataNode = instanceNameToAmbryDataNode.get(instanceName);
+              if (dataNode != null) {
+                String dc = dataNode.getDatacenterName();
+                partitionToDCToResourceNames.computeIfAbsent(partitionId, k -> new HashMap<>())
+                    .compute(dc, resourceNameReplaceFunc(resourceName));
+              }
+            }
+          }
+        }
+        ConcurrentHashMap<String, Set<String>> partitionToResourceNames = new ConcurrentHashMap<>();
+        for (Map.Entry<String, Map<String, String>> entry : partitionToDCToResourceNames.entrySet()) {
+          partitionToResourceNames.put(entry.getKey(), new HashSet<>(entry.getValue().values()));
         }
         globalPartitionToResourceNamesRef.set(partitionToResourceNames);
       }
+    }
+
+    private <K> BiFunction<K, String, String> resourceNameReplaceFunc(String resourceName) {
+      return (k, s) -> {
+        if (s == null || s.equals(resourceName)) {
+          return resourceName;
+        }
+        try {
+          int newId = Integer.valueOf(resourceName);
+          int oldId = Integer.valueOf(s);
+          return newId > oldId ? resourceName : s;
+        } catch (Exception e) {
+          return resourceName;
+        }
+      };
     }
 
     /**

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
@@ -1180,6 +1180,12 @@ public class HelixClusterManager implements ClusterMap {
       }
     }
 
+    /**
+     * Return a BiFunction to replace resource name for partition.
+     * @param resourceName The new resource name.
+     * @param <K> The Key of the map.
+     * @return A BiFunction to replace resource name for partition.
+     */
     private <K> BiFunction<K, String, String> resourceNameReplaceFunc(String resourceName) {
       return (k, s) -> {
         if (s == null || s.equals(resourceName)) {
@@ -1190,7 +1196,8 @@ public class HelixClusterManager implements ClusterMap {
           int oldId = Integer.valueOf(s);
           return newId > oldId ? resourceName : s;
         } catch (Exception e) {
-          return resourceName;
+          logger.error("Failed to parse resource name to an integer", e);
+          throw new IllegalArgumentException("Failed to parse resource name to an integer", e);
         }
       };
     }

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/AmbryReplicaSyncUpManagerTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/AmbryReplicaSyncUpManagerTest.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -83,7 +84,8 @@ public class AmbryReplicaSyncUpManagerTest {
     mockHelixParticipant.currentReplica = currentReplica;
     mockHelixParticipant.replicaSyncUpService = replicaSyncUpService;
     stateModel =
-        new AmbryPartitionStateModel(RESOURCE_NAME, partition.toPathString(), mockHelixParticipant, clusterMapConfig);
+        new AmbryPartitionStateModel(RESOURCE_NAME, partition.toPathString(), mockHelixParticipant, clusterMapConfig,
+            new ConcurrentHashMap<>());
     mockMessage = Mockito.mock(Message.class);
     when(mockMessage.getPartitionName()).thenReturn(partition.toPathString());
     when(mockMessage.getResourceName()).thenReturn(RESOURCE_NAME);

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixAdmin.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixAdmin.java
@@ -292,6 +292,11 @@ public class MockHelixAdmin implements HelixAdmin {
     triggerInstanceConfigChangeNotification(tagAsInit);
   }
 
+  void removeResourceIdealState(String clusterName, String resourceName) {
+    resourcesToIdealStates.remove(resourceName);
+    resourceToResourceInfoMap.remove(resourceName);
+  }
+
   /**
    * Add new resource and its associated ideal state into cluster (Note that, each dc has its own HelixAdmin so resource
    * is actually added into dc where current HelixAdmin sits). This would trigger ideal state change which should be captured

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixCluster.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixCluster.java
@@ -20,7 +20,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.apache.helix.HelixAdmin;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.InstanceConfig;
 
@@ -282,6 +281,21 @@ public class MockHelixCluster {
   void addNewResource(String resourceName, IdealState idealState, String dcName) throws Exception {
     MockHelixAdmin helixAdmin = helixAdmins.get(dataCenterToZkAddress.get(dcName).getZkConnectStrs().get(0));
     helixAdmin.addNewResource(resourceName, idealState);
+  }
+
+  List<String> getResources(String dcName) throws Exception {
+    MockHelixAdmin helixAdmin = helixAdmins.get(dataCenterToZkAddress.get(dcName).getZkConnectStrs().get(0));
+    return helixAdmin.getResourcesInCluster("");
+  }
+
+  IdealState getResourceIdealState(String resourceName, String dcName) throws Exception {
+    MockHelixAdmin helixAdmin = helixAdmins.get(dataCenterToZkAddress.get(dcName).getZkConnectStrs().get(0));
+    return helixAdmin.getResourceIdealState("", resourceName);
+  }
+
+  void removeResourceIdealState(String resourceName, String dcName) throws Exception {
+    MockHelixAdmin helixAdmin = helixAdmins.get(dataCenterToZkAddress.get(dcName).getZkConnectStrs().get(0));
+    helixAdmin.removeResourceIdealState("", resourceName);
   }
 
   Map<String, String> getPartitionToLeaderReplica(String dcName) {

--- a/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
@@ -582,7 +582,11 @@ public class StorageManager implements StoreManager {
         // Only update store state if this is a state transition for primary participant. Since replication Manager
         // which eventually moves this state to STANDBY/LEADER only listens to primary participant, store state gets
         // stuck in BOOTSTRAP if this is updated by second participant listener too
-        store.setCurrentState(ReplicaState.BOOTSTRAP);
+        ReplicaState currentState = store.getCurrentState();
+        if (currentState != ReplicaState.LEADER && currentState != ReplicaState.STANDBY) {
+          // Only set the current state to BOOTSTRAP when it's not LEADER or STANDBY
+          store.setCurrentState(ReplicaState.BOOTSTRAP);
+        }
       }
     }
 

--- a/ambry-test-utils/src/main/java/com/github/ambry/utils/TestUtils.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/utils/TestUtils.java
@@ -301,7 +301,7 @@ public class TestUtils {
         nioFactory.configure(new InetSocketAddress(port), maxClientConnections);
         nioFactory.startup(zk);
       } catch (IOException e) {
-        throw new ZkException("Unable to start single ZooKeeper server.", e);
+        throw new ZkException("Unable to start single ZooKeeper server at port " + port, e);
       } catch (InterruptedException e) {
         throw new ZkInterruptedException(e);
       }


### PR DESCRIPTION
Ambry is currently going through the process of reconstructing resource names. We used to assign partition ids to several resources, even if those partition ids belong to the same clique. Now we are trying to gather all the partition ids of the same clique to one resource.

Since in server we honor new resource over the old resource, we have to do the same thing in frontend. This is easy since we can compare the resource names and know that higher number resource name would win.
