### PR TITLE
Fix statsManager config names

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/StatsManagerConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StatsManagerConfig.java
@@ -37,14 +37,14 @@ public class StatsManagerConfig {
    */
   @Config(STATS_OUTPUT_FILE_PATH)
   @Default("/tmp/stats_output.json")
-  public final String outputFilePath;
+  public final String statsOutputFilePath;
 
   /**
    * The time period in seconds that configures how often stats are published.
    */
   @Config(STATS_PUBLISH_PERIOD_IN_SECS)
   @Default("7200")
-  public final long publishPeriodInSecs;
+  public final long statsPublishPeriodInSecs;
 
   /**
    * The upper bound for the initial delay in seconds before the first stats collection is triggered. The delay is a
@@ -52,21 +52,21 @@ public class StatsManagerConfig {
    */
   @Config(STATS_INITIAL_DELAY_UPPER_BOUND_IN_SECS)
   @Default("600")
-  public final int initialDelayUpperBoundInSecs;
+  public final int statsInitialDelayUpperBoundInSecs;
 
   /**
    * True to enable publishing stats to mysql database
    */
   @Config(STATS_ENABLE_MYSQL_REPORT)
   @Default("false")
-  public final boolean enableMysqlReport;
+  public final boolean statsEnableMysqlReport;
 
   /**
    * The account names to exclude from the health report. Multiple account names should be separated with ",".
    */
   @Config(STATS_HEALTH_REPORT_EXCLUDE_ACCOUNT_NAMES)
   @Default("")
-  public final List<String> healthReportExcludeAccountNames;
+  public final List<String> statsHealthReportExcludeAccountNames;
 
   /**
    * The account names to exclude from publishing to local disk and mysql database. Multiple account names should be
@@ -74,7 +74,7 @@ public class StatsManagerConfig {
    */
   @Config(STATS_PUBLISH_EXCLUDE_ACCOUNT_NAMES)
   @Default("")
-  public final List<String> publishExcludeAccountNames;
+  public final List<String> statsPublishExcludeAccountNames;
 
   /**
    * The time period in seconds that configures how often partition class stats are published to mysql. Set it to 0 to
@@ -82,25 +82,25 @@ public class StatsManagerConfig {
    */
   @Config(STATS_PUBLISH_PARTITION_CLASS_REPORT_PERIOD_IN_SECS)
   @Default("0")
-  public final long publishPartitionClassReportPeriodInSecs;
+  public final long statsPublishPartitionClassReportPeriodInSecs;
 
   public StatsManagerConfig(VerifiableProperties verifiableProperties) {
-    outputFilePath = verifiableProperties.getString(STATS_OUTPUT_FILE_PATH, "/tmp/stats_output.json");
-    publishPeriodInSecs = verifiableProperties.getLongInRange(STATS_PUBLISH_PERIOD_IN_SECS, 7200, 0, Long.MAX_VALUE);
-    initialDelayUpperBoundInSecs =
+    statsOutputFilePath = verifiableProperties.getString(STATS_OUTPUT_FILE_PATH, "/tmp/stats_output.json");
+    statsPublishPeriodInSecs = verifiableProperties.getLongInRange(STATS_PUBLISH_PERIOD_IN_SECS, 7200, 0, Long.MAX_VALUE);
+    statsInitialDelayUpperBoundInSecs =
         verifiableProperties.getIntInRange(STATS_INITIAL_DELAY_UPPER_BOUND_IN_SECS, 600, 0, Integer.MAX_VALUE);
-    enableMysqlReport = verifiableProperties.getBoolean(STATS_ENABLE_MYSQL_REPORT, false);
+    statsEnableMysqlReport = verifiableProperties.getBoolean(STATS_ENABLE_MYSQL_REPORT, false);
     String excludeNames = verifiableProperties.getString(STATS_HEALTH_REPORT_EXCLUDE_ACCOUNT_NAMES, "").trim();
-    healthReportExcludeAccountNames =
+    statsHealthReportExcludeAccountNames =
         excludeNames.isEmpty() ? Collections.EMPTY_LIST : Arrays.asList(excludeNames.split(","));
     excludeNames = verifiableProperties.getString(STATS_PUBLISH_EXCLUDE_ACCOUNT_NAMES, "").trim();
-    publishExcludeAccountNames =
+    statsPublishExcludeAccountNames =
         excludeNames.isEmpty() ? Collections.EMPTY_LIST : Arrays.asList(excludeNames.split(","));
-    publishPartitionClassReportPeriodInSecs =
+    statsPublishPartitionClassReportPeriodInSecs =
         verifiableProperties.getLongInRange(STATS_PUBLISH_PARTITION_CLASS_REPORT_PERIOD_IN_SECS, 0, 0, Long.MAX_VALUE);
-    if (publishPartitionClassReportPeriodInSecs != 0 && !enableMysqlReport) {
+    if (statsPublishPartitionClassReportPeriodInSecs != 0 && !statsEnableMysqlReport) {
       throw new IllegalStateException(
-          "Bad configuration, you have to enableMysqlReport if you set a non-zero value for publishPartitionClassReportPeriodInSecs");
+          "Bad configuration, you have to statsEnableMysqlReport if you set a non-zero value for statsPublishPartitionClassReportPeriodInSecs");
     }
   }
 }

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryServer.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryServer.java
@@ -267,7 +267,7 @@ public class AmbryServer {
       logger.info("Creating StatsManager to publish stats");
 
       accountStatsMySqlStore =
-          statsConfig.enableMysqlReport ? (AccountStatsMySqlStore) new AccountStatsMySqlStoreFactory(properties,
+          statsConfig.statsEnableMysqlReport ? (AccountStatsMySqlStore) new AccountStatsMySqlStoreFactory(properties,
               clusterMapConfig, registry).getAccountStatsStore() : null;
       statsManager = new StatsManager(storageManager, clusterMap.getReplicaIds(nodeId), registry, statsConfig, time,
           clusterParticipants.get(0), accountStatsMySqlStore, accountService);

--- a/ambry-server/src/main/java/com/github/ambry/server/StatsManager.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/StatsManager.java
@@ -104,7 +104,7 @@ class StatsManager {
       AccountService accountService) {
     this.storageManager = storageManager;
     this.config = config;
-    statsOutputFile = new File(config.outputFilePath);
+    statsOutputFile = new File(config.statsOutputFilePath);
     metrics = new StatsManagerMetrics(registry, aggregatedDeleteTombstoneStats);
     partitionToReplicaMap =
         replicaIds.stream().collect(Collectors.toConcurrentMap(ReplicaId::getPartitionId, Function.identity()));
@@ -120,8 +120,8 @@ class StatsManager {
         .filter(Objects::nonNull)
         .map(Account::getId)
         .collect(Collectors.toList());
-    this.healthReportExcludeAccountIds = convertAccountNamesToIds.apply(config.healthReportExcludeAccountNames);
-    this.publishExcludeAccountIds = convertAccountNamesToIds.apply(config.publishExcludeAccountNames);
+    this.healthReportExcludeAccountIds = convertAccountNamesToIds.apply(config.statsHealthReportExcludeAccountNames);
+    this.publishExcludeAccountIds = convertAccountNamesToIds.apply(config.statsPublishExcludeAccountNames);
   }
 
   /**
@@ -131,19 +131,19 @@ class StatsManager {
     scheduler = Utils.newScheduler(1, false);
     if (accountStatsStore != null) {
       accountsStatsPublisher = new AccountStatsPublisher(accountStatsStore);
-      int actualDelay = config.initialDelayUpperBoundInSecs > 0 ? ThreadLocalRandom.current()
-          .nextInt(config.initialDelayUpperBoundInSecs) : 0;
+      int actualDelay = config.statsInitialDelayUpperBoundInSecs > 0 ? ThreadLocalRandom.current()
+          .nextInt(config.statsInitialDelayUpperBoundInSecs) : 0;
       logger.info("Scheduling account stats publishing job with an initial delay of {} secs", actualDelay);
-      scheduler.scheduleAtFixedRate(accountsStatsPublisher, actualDelay, config.publishPeriodInSecs, TimeUnit.SECONDS);
+      scheduler.scheduleAtFixedRate(accountsStatsPublisher, actualDelay, config.statsPublishPeriodInSecs, TimeUnit.SECONDS);
     }
 
-    if (config.publishPartitionClassReportPeriodInSecs != 0) {
+    if (config.statsPublishPartitionClassReportPeriodInSecs != 0) {
       partitionClassStatsPublisher = new PartitionClassStatsPublisher(accountStatsStore);
-      long initialDelay = ThreadLocalRandom.current().nextLong(config.publishPartitionClassReportPeriodInSecs / 2)
-          + config.publishPartitionClassReportPeriodInSecs / 2;
+      long initialDelay = ThreadLocalRandom.current().nextLong(config.statsPublishPartitionClassReportPeriodInSecs / 2)
+          + config.statsPublishPartitionClassReportPeriodInSecs / 2;
       logger.info("Scheduling partition class stats publishing job with an initial delay of {} secs", initialDelay);
       scheduler.scheduleAtFixedRate(partitionClassStatsPublisher, initialDelay,
-          config.publishPartitionClassReportPeriodInSecs, TimeUnit.SECONDS);
+          config.statsPublishPartitionClassReportPeriodInSecs, TimeUnit.SECONDS);
     }
   }
 


### PR DESCRIPTION
Caused by: java.lang.NoSuchFieldError: outputFilePath
        at com.github.ambry.server.StatsManager.<init>(StatsManager.java:107) ~[ambry-server-0.3.962.jar:?]
        at com.github.ambry.server.AmbryServer.startup(AmbryServer.java:274) ~[ambry-server-0.3.962.jar:?]
        ... 28 more

Encountered this error during testing. Not sure how the server has been deployed so far. But the config variables in open source code do not match the closed-source version. This patch fixes that.