### PR TITLE
Fix thread leak in unit tests

### DIFF
--- a/ambry-account/src/main/java/com/github/ambry/account/HelixAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/HelixAccountService.java
@@ -313,7 +313,9 @@ public class HelixAccountService extends AbstractAccountService {
       if (baseDataAccessor != null) {
         baseDataAccessor.close();
       }
-      notifier.close();
+      if (notifier != null) {
+        notifier.close();
+      }
     }
   }
 

--- a/ambry-account/src/test/java/com/github/ambry/account/HelixAccountServiceTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/HelixAccountServiceTest.java
@@ -1310,6 +1310,7 @@ public class HelixAccountServiceTest {
     if (shouldNotify) {
       notifier.publish(ACCOUNT_METADATA_CHANGE_TOPIC, FULL_ACCOUNT_METADATA_CHANGE_MESSAGE);
     }
+    storeOperator.close();
   }
 
   /**
@@ -1328,6 +1329,7 @@ public class HelixAccountServiceTest {
     if (shouldNotify) {
       notifier.publish(ACCOUNT_METADATA_CHANGE_TOPIC, FULL_ACCOUNT_METADATA_CHANGE_MESSAGE);
     }
+    storeOperator.close();
   }
 
   /**
@@ -1392,6 +1394,7 @@ public class HelixAccountServiceTest {
     if (storeOperator.exist("/")) {
       storeOperator.delete("/");
     }
+    storeOperator.close();
   }
 
   /**

--- a/ambry-account/src/test/java/com/github/ambry/account/MockHelixAccountServiceFactory.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/MockHelixAccountServiceFactory.java
@@ -59,7 +59,7 @@ public class MockHelixAccountServiceFactory extends HelixAccountServiceFactory {
       ScheduledExecutorService scheduler =
           accountServiceConfig.updaterPollingIntervalMs > 0 ? Utils.newScheduler(1, updaterThreadPrefix, false) : null;
       HelixAccountService accountService =
-          new HelixAccountService(getHelixStore(accountServiceConfig.zkClientConnectString, storeConfig),
+          new HelixAccountService(getHelixStore(accountServiceConfig.zkClientConnectString, storeConfig), null,
               accountServiceMetrics, notifier, scheduler, accountServiceConfig);
       if (useNewZNodePath) {
         accountService.setupRouter(router);

--- a/ambry-account/src/test/java/com/github/ambry/account/RouterStoreTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/RouterStoreTest.java
@@ -100,6 +100,7 @@ public class RouterStoreTest {
     if (operator.exist("/")) {
       operator.delete("/");
     }
+    operator.close();
     if (Files.exists(accountBackupDir)) {
       Utils.deleteFileOrDirectory(accountBackupDir.toFile());
     }

--- a/ambry-api/src/main/java/com/github/ambry/commons/Notifier.java
+++ b/ambry-api/src/main/java/com/github/ambry/commons/Notifier.java
@@ -47,4 +47,10 @@ public interface Notifier<T> {
    * @param listener The {@link TopicListener} who unsubscribes the topic.
    */
   public void unsubscribe(String topic, TopicListener<T> listener);
+
+  /**
+   * Close this notifier.
+   */
+  default void close() {
+  }
 }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
@@ -491,6 +491,9 @@ public class HelixClusterManager implements ClusterMap {
    */
   @Override
   public void close() {
+    if(helixPropertyStoreInLocalDc != null){
+      helixPropertyStoreInLocalDc.stop();
+    }
     for (DcInfo dcInfo : dcToDcInfo.values()) {
       dcInfo.close();
     }
@@ -498,10 +501,6 @@ public class HelixClusterManager implements ClusterMap {
 
     if (clusterMapConfig.clusterMapUseAggregatedView && helixAggregatedViewClusterInfo != null) {
       helixAggregatedViewClusterInfo.close();
-    }
-
-    if(helixPropertyStoreInLocalDc != null){
-      helixPropertyStoreInLocalDc.stop();
     }
   }
 

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixClusterManagerTest.java
@@ -139,9 +139,11 @@ public class HelixClusterManagerTest {
     tempDir.deleteOnExit();
     int port = 2200;
     byte dcId = (byte) 0;
+
     for (String dcName : helixDcs) {
       dcsToZkInfo.put(dcName, new com.github.ambry.utils.TestUtils.ZkInfo(tempDirPath, dcName, dcId++, port++, true));
     }
+
     hardwareLayoutPath = tempDirPath + File.separator + "hardwareLayoutTest.json";
     partitionLayoutPath = tempDirPath + File.separator + "partitionLayoutTest.json";
     String zkLayoutPath = tempDirPath + File.separator + "zkLayoutPath.json";
@@ -191,6 +193,7 @@ public class HelixClusterManagerTest {
     helixCluster =
         new MockHelixCluster(clusterNamePrefixInHelix, hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, localDc,
             useAggregatedView);
+
     for (PartitionId partitionId : testPartitionLayout.getPartitionLayout().getPartitions(null)) {
       if (partitionId.getPartitionState().equals(PartitionState.READ_ONLY)) {
         String helixPartitionName = partitionId.toPathString();

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixCluster.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixCluster.java
@@ -20,7 +20,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.apache.helix.HelixAdmin;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.InstanceConfig;
 

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/PropertyStoreToDataNodeConfigAdapterTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/PropertyStoreToDataNodeConfigAdapterTest.java
@@ -104,7 +104,7 @@ public class PropertyStoreToDataNodeConfigAdapterTest extends DataNodeConfigSour
     reset(listener2);
     String rootPath = PropertyPathBuilder.propertyStore(clusterMapConfig.clusterMapClusterName);
     HelixPropertyStore<ZNRecord> propertyStore =
-        CommonUtils.createHelixPropertyStore(zkAddress, rootPath, Collections.emptyList());
+        CommonUtils.createHelixPropertyStore(zkAddress, rootPath, Collections.emptyList()).getFirst();
     try {
       assertTrue("Remove did not succeed",
           propertyStore.remove(PropertyStoreToDataNodeConfigAdapter.CONFIG_PATH + "/" + updatedConfig.getInstanceName(),

--- a/ambry-commons/src/main/java/com/github/ambry/commons/CommonUtils.java
+++ b/ambry-commons/src/main/java/com/github/ambry/commons/CommonUtils.java
@@ -15,50 +15,60 @@
 package com.github.ambry.commons;
 
 import com.github.ambry.config.HelixPropertyStoreConfig;
+import com.github.ambry.utils.Pair;
 import java.util.List;
-import org.apache.helix.manager.zk.ZNRecordSerializer;
 import org.apache.helix.manager.zk.ZkBaseDataAccessor;
-import org.apache.helix.manager.zk.ZkClient;
 import org.apache.helix.store.HelixPropertyStore;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.apache.helix.zookeeper.api.client.ZkClientType;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.helix.zookeeper.datamodel.serializer.ZNRecordSerializer;
 
 
 public class CommonUtils {
   /**
-   * Create a instance of {@link HelixPropertyStore} based on given {@link HelixPropertyStoreConfig}.
+   * Create an instance of {@link HelixPropertyStore} and {@link ZkBaseDataAccessor} based on given {@link HelixPropertyStoreConfig}.
+   * Close {@link ZkBaseDataAccessor} after stopping {@link HelixPropertyStore}.
    * @param zkServers the ZooKeeper server address.
    * @param propertyStoreConfig the config for {@link HelixPropertyStore}.
    * @param subscribedPaths a list of paths to which the PropertyStore subscribes.
-   * @return the instance of {@link HelixPropertyStore}.
+   * @return A pair of an instance of {@link HelixPropertyStore} and an instance of {@link ZkBaseDataAccessor}.
    */
-  public static HelixPropertyStore<ZNRecord> createHelixPropertyStore(String zkServers,
-      HelixPropertyStoreConfig propertyStoreConfig, List<String> subscribedPaths) {
+  public static Pair<HelixPropertyStore<ZNRecord>, ZkBaseDataAccessor<ZNRecord>> createHelixPropertyStore(
+      String zkServers, HelixPropertyStoreConfig propertyStoreConfig, List<String> subscribedPaths) {
     if (zkServers == null || zkServers.isEmpty() || propertyStoreConfig == null) {
       throw new IllegalArgumentException("Invalid arguments, cannot create HelixPropertyStore");
     }
-    ZkClient zkClient = new ZkClient(zkServers, propertyStoreConfig.zkClientSessionTimeoutMs,
-        propertyStoreConfig.zkClientConnectionTimeoutMs, new ZNRecordSerializer());
-    return new ZkHelixPropertyStore<>(new ZkBaseDataAccessor<>(zkClient), propertyStoreConfig.rootPath,
-        subscribedPaths);
+    ZkBaseDataAccessor<ZNRecord> baseDataAccessor =
+        new ZkBaseDataAccessor.Builder<ZNRecord>().setZkClientType(ZkClientType.DEDICATED)
+            .setZkAddress(zkServers)
+            .setRealmAwareZkClientConfig(new RealmAwareZkClient.RealmAwareZkClientConfig().setConnectInitTimeout(
+                propertyStoreConfig.zkClientConnectionTimeoutMs).setZkSerializer(new ZNRecordSerializer()))
+            .setRealmAwareZkConnectionConfig(
+                new RealmAwareZkClient.RealmAwareZkConnectionConfig.Builder().setSessionTimeout(
+                    propertyStoreConfig.zkClientSessionTimeoutMs).build())
+            .build();
+    return new Pair<>(new ZkHelixPropertyStore<>(baseDataAccessor, propertyStoreConfig.rootPath, subscribedPaths),
+        baseDataAccessor);
   }
 
   /**
-   * Create an instance of {@link HelixPropertyStore}, using non-deprecated APIs.
+   * Create an instance of {@link HelixPropertyStore} and {@link ZkBaseDataAccessor}, using non-deprecated APIs.
+   * Close {@link ZkBaseDataAccessor} after stopping {@link HelixPropertyStore}.
    * TODO replace usages of the other method with this one once verified to be stable.
    * @param zkAddress the ZooKeeper server address.
    * @param rootPath the root path for this {@link HelixPropertyStore}.
    * @param subscribedPaths the paths to subscribe to for change notification. Note that these should be absolute paths,
    *                        not relative paths under {@code rootPath}.
-   * @return the instance of {@link HelixPropertyStore}.
+   * @return A pair of an instance of {@link HelixPropertyStore} and an instance of {@link ZkBaseDataAccessor}.
    */
-  public static HelixPropertyStore<ZNRecord> createHelixPropertyStore(String zkAddress, String rootPath,
-      List<String> subscribedPaths) {
+  public static Pair<HelixPropertyStore<ZNRecord>, ZkBaseDataAccessor<ZNRecord>> createHelixPropertyStore(
+      String zkAddress, String rootPath, List<String> subscribedPaths) {
     ZkBaseDataAccessor<ZNRecord> baseDataAccessor =
         new ZkBaseDataAccessor.Builder<ZNRecord>().setZkClientType(ZkClientType.DEDICATED)
             .setZkAddress(zkAddress)
             .build();
-    return new ZkHelixPropertyStore<>(baseDataAccessor, rootPath, subscribedPaths);
+    return new Pair<>(new ZkHelixPropertyStore<>(baseDataAccessor, rootPath, subscribedPaths), baseDataAccessor);
   }
 }

--- a/ambry-commons/src/test/java/com/github/ambry/commons/CommonUtilsTest.java
+++ b/ambry-commons/src/test/java/com/github/ambry/commons/CommonUtilsTest.java
@@ -17,6 +17,7 @@ package com.github.ambry.commons;
 import com.github.ambry.clustermap.ClusterMapUtils;
 import com.github.ambry.config.HelixPropertyStoreConfig;
 import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.utils.Pair;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -24,6 +25,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
 import org.apache.helix.AccessOption;
+import org.apache.helix.manager.zk.ZkBaseDataAccessor;
 import org.apache.helix.store.HelixPropertyStore;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.junit.Test;
@@ -67,10 +69,13 @@ public class CommonUtilsTest {
       //expected
     }
 
-    HelixPropertyStore<ZNRecord> propertyStore =
+    Pair<HelixPropertyStore<ZNRecord>, ZkBaseDataAccessor<ZNRecord>> pair =
         CommonUtils.createHelixPropertyStore("localhost:" + zkInfo.getPort(), propertyStoreConfig,
             Collections.singletonList(propertyStoreConfig.rootPath));
+    HelixPropertyStore<ZNRecord> propertyStore = pair.getFirst();
+    ZkBaseDataAccessor<ZNRecord> baseDataAccessor = pair.getSecond();
     assertNotNull(propertyStore);
+    assertNotNull(baseDataAccessor);
 
     // Ensure the HelixPropertyStore works correctly
     List<String> list = Arrays.asList("first", "second", "third");
@@ -86,6 +91,7 @@ public class CommonUtilsTest {
     ZNRecord result = propertyStore.get(path, null, AccessOption.PERSISTENT);
     assertEquals("Mismatch in list content", new HashSet<>(list), new HashSet<>(result.getListField("AmbryList")));
     propertyStore.stop();
+    baseDataAccessor.close();
     zkInfo.shutdown();
   }
 }

--- a/ambry-commons/src/test/java/com/github/ambry/commons/HelixNotifierTest.java
+++ b/ambry-commons/src/test/java/com/github/ambry/commons/HelixNotifierTest.java
@@ -424,6 +424,7 @@ public class HelixNotifierTest {
     if (storeOperator.exist("/")) {
       storeOperator.delete("/");
     }
+    storeOperator.close();
   }
 
   /**

--- a/ambry-tools/src/integration-test/java/com/github/ambry/account/AccountUpdateToolTest.java
+++ b/ambry-tools/src/integration-test/java/com/github/ambry/account/AccountUpdateToolTest.java
@@ -137,6 +137,8 @@ public class AccountUpdateToolTest {
       accountService.removeAccountUpdateConsumer(accountUpdateConsumer);
       accountService.close();
     }
+    storeOperator.close();
+    notifier.close();
   }
 
   @AfterClass


### PR DESCRIPTION
There are some thread leak in our unit tests. Most of them are coming from zookeeper client. The reason why zookeeper client leaks threads is that we are not closing zookeeper client every time we create a PropertyStore with methods in CommonUtils class. 

In these methods, we create a ZkBaseDataAccessor and then pass this accessor to HelixPropertyStore. When we stop HelixPropertyStore, it doesn't close the ZkBaseDataAccessor since HelixPropertyStore thinks that ZkBaseDataAccessor is owned by something else. 

We have to return both HelixPropertyStore and ZkBaseDataAccessor to the caller of these methods and let the caller close both objects.