### PR TITLE
Fix zk client thread leak in unit test

### DIFF
--- a/ambry-account/src/main/java/com/github/ambry/account/AbstractAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/AbstractAccountService.java
@@ -102,6 +102,7 @@ public abstract class AbstractAccountService implements AccountService {
   protected void maybeUnsubscribeChangeTopic() {
     if (notifier != null) {
       notifier.unsubscribe(ACCOUNT_METADATA_CHANGE_TOPIC, changeTopicListener);
+      notifier.close();
     }
   }
 

--- a/ambry-account/src/main/java/com/github/ambry/account/HelixAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/HelixAccountService.java
@@ -306,6 +306,9 @@ public class HelixAccountService extends AbstractAccountService {
         shutDownExecutorService(scheduler, config.updaterShutDownTimeoutMs, TimeUnit.MILLISECONDS);
       }
       helixStore.stop();
+      if (notifier != null) {
+        notifier.close();
+      }
     }
   }
 

--- a/ambry-api/src/main/java/com/github/ambry/commons/Notifier.java
+++ b/ambry-api/src/main/java/com/github/ambry/commons/Notifier.java
@@ -30,7 +30,7 @@ public interface Notifier<T> {
    * @param message The message to send for the topic.
    * @return {@code true} if the message has been sent out successfully, {@code false} otherwise.
    */
-  public boolean publish(String topic, T message);
+  boolean publish(String topic, T message);
 
   /**
    * Let a {@link TopicListener} subscribe to a topic. After subscription, it will receive the messages
@@ -38,7 +38,7 @@ public interface Notifier<T> {
    * @param topic The topic to subscribe.
    * @param listener The {@link TopicListener} who subscribes the topic.
    */
-  public void subscribe(String topic, TopicListener<T> listener);
+  void subscribe(String topic, TopicListener<T> listener);
 
   /**
    * Let a {@link TopicListener} unsubscribe from a topic, so it will no longer receive the messages for
@@ -46,5 +46,11 @@ public interface Notifier<T> {
    * @param topic The topic to unsubscribe.
    * @param listener The {@link TopicListener} who unsubscribes the topic.
    */
-  public void unsubscribe(String topic, TopicListener<T> listener);
+  void unsubscribe(String topic, TopicListener<T> listener);
+
+  /**
+   * Close all the underlying data structures.
+   */
+  default void close() {
+  }
 }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
@@ -499,8 +499,7 @@ public class HelixClusterManager implements ClusterMap {
     if (clusterMapConfig.clusterMapUseAggregatedView && helixAggregatedViewClusterInfo != null) {
       helixAggregatedViewClusterInfo.close();
     }
-
-    if(helixPropertyStoreInLocalDc != null){
+    if (helixPropertyStoreInLocalDc != null) {
       helixPropertyStoreInLocalDc.stop();
     }
   }

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixManager.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixManager.java
@@ -19,7 +19,6 @@ import com.github.ambry.config.VerifiableProperties;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.ListIterator;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -58,6 +57,7 @@ import org.apache.helix.model.HelixConfigScope;
 import org.apache.helix.model.LiveInstance;
 import org.apache.helix.participant.StateMachineEngine;
 import org.apache.helix.spectator.RoutingTableProvider;
+import org.apache.helix.store.HelixPropertyStore;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 
@@ -79,7 +79,7 @@ class MockHelixManager implements HelixManager {
   private final MockHelixDataAccessor dataAccessor;
   private final Exception beBadException;
   private final Map<String, ZNRecord> znRecordMap;
-  private ZkHelixPropertyStore<ZNRecord> helixPropertyStore;
+  private HelixPropertyStore<ZNRecord> helixPropertyStore;
   private boolean isAggregatedViewCluster;
   private final List<MockHelixAdmin> helixAdminList;
 
@@ -132,9 +132,8 @@ class MockHelixManager implements HelixManager {
     storeProps.setProperty("helix.property.store.root.path",
         "/" + clusterName + "/" + ClusterMapUtils.PROPERTYSTORE_STR);
     HelixPropertyStoreConfig propertyStoreConfig = new HelixPropertyStoreConfig(new VerifiableProperties(storeProps));
-    helixPropertyStore =
-        (ZkHelixPropertyStore<ZNRecord>) CommonUtils.createHelixPropertyStore(zkAddr, propertyStoreConfig,
-            Collections.singletonList(propertyStoreConfig.rootPath));
+    helixPropertyStore = CommonUtils.createHelixPropertyStore(zkAddr, propertyStoreConfig,
+        Collections.singletonList(propertyStoreConfig.rootPath));
     if (znRecordMap != null) {
       for (Map.Entry<String, ZNRecord> znodePathAndRecord : znRecordMap.entrySet()) {
         helixPropertyStore.set(znodePathAndRecord.getKey(), znodePathAndRecord.getValue(), AccessOption.PERSISTENT);
@@ -205,7 +204,7 @@ class MockHelixManager implements HelixManager {
 
   @Override
   public ZkHelixPropertyStore<ZNRecord> getHelixPropertyStore() {
-    return helixPropertyStore;
+    return (ZkHelixPropertyStore<ZNRecord>) helixPropertyStore;
   }
 
   /**

--- a/ambry-commons/src/main/java/com/github/ambry/commons/CommonUtils.java
+++ b/ambry-commons/src/main/java/com/github/ambry/commons/CommonUtils.java
@@ -35,13 +35,11 @@ public class CommonUtils {
     if (zkServers == null || zkServers.isEmpty() || propertyStoreConfig == null) {
       throw new IllegalArgumentException("Invalid arguments, cannot create HelixPropertyStore");
     }
-    return new ZkHelixPropertyStore<ZNRecord>(zkServers, new ZNRecordSerializer(), propertyStoreConfig.rootPath,
-        subscribedPaths);
+    return createHelixPropertyStore(zkServers, propertyStoreConfig.rootPath, subscribedPaths);
   }
 
   /**
    * Create an instance of {@link HelixPropertyStore}, using non-deprecated APIs.
-   * TODO replace usages of the other method with this one once verified to be stable.
    * @param zkAddress the ZooKeeper server address.
    * @param rootPath the root path for this {@link HelixPropertyStore}.
    * @param subscribedPaths the paths to subscribe to for change notification. Note that these should be absolute paths,

--- a/ambry-commons/src/main/java/com/github/ambry/commons/CommonUtils.java
+++ b/ambry-commons/src/main/java/com/github/ambry/commons/CommonUtils.java
@@ -16,13 +16,10 @@ package com.github.ambry.commons;
 
 import com.github.ambry.config.HelixPropertyStoreConfig;
 import java.util.List;
-import org.apache.helix.manager.zk.ZNRecordSerializer;
-import org.apache.helix.manager.zk.ZkBaseDataAccessor;
-import org.apache.helix.manager.zk.ZkClient;
 import org.apache.helix.store.HelixPropertyStore;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
-import org.apache.helix.zookeeper.api.client.ZkClientType;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.helix.zookeeper.datamodel.serializer.ZNRecordSerializer;
 
 
 public class CommonUtils {
@@ -38,9 +35,7 @@ public class CommonUtils {
     if (zkServers == null || zkServers.isEmpty() || propertyStoreConfig == null) {
       throw new IllegalArgumentException("Invalid arguments, cannot create HelixPropertyStore");
     }
-    ZkClient zkClient = new ZkClient(zkServers, propertyStoreConfig.zkClientSessionTimeoutMs,
-        propertyStoreConfig.zkClientConnectionTimeoutMs, new ZNRecordSerializer());
-    return new ZkHelixPropertyStore<>(new ZkBaseDataAccessor<>(zkClient), propertyStoreConfig.rootPath,
+    return new ZkHelixPropertyStore<ZNRecord>(zkServers, new ZNRecordSerializer(), propertyStoreConfig.rootPath,
         subscribedPaths);
   }
 
@@ -55,10 +50,6 @@ public class CommonUtils {
    */
   public static HelixPropertyStore<ZNRecord> createHelixPropertyStore(String zkAddress, String rootPath,
       List<String> subscribedPaths) {
-    ZkBaseDataAccessor<ZNRecord> baseDataAccessor =
-        new ZkBaseDataAccessor.Builder<ZNRecord>().setZkClientType(ZkClientType.DEDICATED)
-            .setZkAddress(zkAddress)
-            .build();
-    return new ZkHelixPropertyStore<>(baseDataAccessor, rootPath, subscribedPaths);
+    return new ZkHelixPropertyStore<ZNRecord>(zkAddress, new ZNRecordSerializer(), rootPath, subscribedPaths);
   }
 }

--- a/ambry-commons/src/main/java/com/github/ambry/commons/HelixNotifier.java
+++ b/ambry-commons/src/main/java/com/github/ambry/commons/HelixNotifier.java
@@ -161,6 +161,13 @@ public class HelixNotifier implements Notifier<String> {
     logger.trace("TopicListener={} has been unsubscribed from topic={}", topicListener, topic);
   }
 
+  @Override
+  public void close() {
+    if (helixStore != null) {
+      helixStore.stop();
+    }
+  }
+
   /**
    * Sends a message to local {@link TopicListener} that subscribed topics through this {@code HelixNotifier}.
    * @param topicListener The {@link TopicListener} to send the message.

--- a/ambry-tools/src/integration-test/java/com/github/ambry/account/AccountUpdateToolTest.java
+++ b/ambry-tools/src/integration-test/java/com/github/ambry/account/AccountUpdateToolTest.java
@@ -58,7 +58,7 @@ import static org.junit.Assert.*;
 public class AccountUpdateToolTest {
   private static final int NUM_REF_ACCOUNT = 10 + (int) (Math.random() * 50);
   private static final int NUM_CONTAINER_PER_ACCOUNT = 4;
-  private static final int ZK_SERVER_PORT = 2200;
+  private static final int ZK_SERVER_PORT = 2600;
   private static final String DC_NAME = "testDc";
   private static final byte DC_ID = (byte) 1;
   private static final String ZK_SERVER_ADDRESS = "localhost:" + ZK_SERVER_PORT;


### PR DESCRIPTION
There are some thread leak in our unit tests. Most of them are coming from zookeeper client. The reason why zookeeper client leaks threads is that we are not closing zookeeper client every time we create a ZkHelixPropertyStore with methods in CommonUtils class.

In these methods, we create a ZkBaseDataAccessor and then pass this accessor to HelixPropertyStore. When we stop HelixPropertyStore, it doesn't close the ZkBaseDataAccessor since HelixPropertyStore thinks that ZkBaseDataAccessor is owned by something else.

We have use different constructors from ZkHelixPropertyStore so that the zk client is created internally in the PropertyStore, so that when we call ZkHelixPropertyStore.stop, it will close the zk client for us.

However, by doing so, we are choosing to create this zk client with a shared connection, instead of a dedicated connection. A shared connection would potentially damage our zk client's performance but it should be fine. Since we only use this shared connection in HelixNotifier and PropertyStoreDataNodeConfigAdapter. We are not using it much.
