### PR TITLE
On-demand replication ignore the failures from the Background deleter.

### DIFF
--- a/ambry-router/src/main/java/com/github/ambry/router/DeleteOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/DeleteOperation.java
@@ -374,7 +374,7 @@ class DeleteOperation {
     return (routerConfig.routerRepairWithReplicateBlobOnDeleteEnabled && operationTracker.hasNotFound()
         && operationTracker.getSuccessCount() > 0
         && getPrecedenceLevel(errorCode) >= getPrecedenceLevel(RouterErrorCode.AmbryUnavailable)
-        && serviceId.indexOf(BackgroundDeleteRequest.SERVICE_ID_PREFIX) != 0);
+        && !serviceId.startsWith(BackgroundDeleteRequest.SERVICE_ID_PREFIX));
   }
 
   /**

--- a/ambry-router/src/main/java/com/github/ambry/router/DeleteOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/DeleteOperation.java
@@ -369,10 +369,12 @@ class DeleteOperation {
     // 2. and at least one replica returned NOT_FOUND status.
     // 3. and at least one replica returned successful status.
     // 4. and error code precedence is over AmbryUnavailable. We don't do replication if there BlobExpired or TooManyRequests.
+    // 5. It's not a delete request from the BackgroundDeleter. We don't do on-demand replication for background deleter.
     RouterErrorCode errorCode = ((RouterException) operationException.get()).getErrorCode();
     return (routerConfig.routerRepairWithReplicateBlobOnDeleteEnabled && operationTracker.hasNotFound()
-        && operationTracker.getSuccessCount() > 0 && getPrecedenceLevel(errorCode) >= getPrecedenceLevel(
-        RouterErrorCode.AmbryUnavailable));
+        && operationTracker.getSuccessCount() > 0
+        && getPrecedenceLevel(errorCode) >= getPrecedenceLevel(RouterErrorCode.AmbryUnavailable)
+        && serviceId.indexOf(BackgroundDeleteRequest.SERVICE_ID_PREFIX) != 0);
   }
 
   /**

--- a/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockReplicaId.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockReplicaId.java
@@ -156,7 +156,7 @@ public class MockReplicaId implements ReplicaId {
 
   @Override
   public String toString() {
-    return "Mount Path " + mountPath + " Replica Path " + replicaPath;
+    return dataNodeId.toString();
   }
 
   @Override


### PR DESCRIPTION
If background deleter fails, on-demand replication will ignore it and won't trigger replication and retry.