### PR TITLE
Advertise DR partitions as they DR partitions

### DIFF
--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -823,6 +823,15 @@ public class ReplicaThread implements Runnable {
   }
 
   /**
+   * Returns local replica mount path of the partition
+   * @param remoteReplicaInfo Info about remote replica
+   * @return Local replica mount path of the partition
+   */
+  protected String getLocalReplicaPath(RemoteReplicaInfo remoteReplicaInfo) {
+    return remoteReplicaInfo.getLocalReplicaId().getReplicaPath();
+  }
+
+  /**
    * Create a {@link ReplicaMetadataRequest} for given list of replicas in the {@code replicasToReplicaPerNode}.
    * @param replicasToReplicatePerNode The list of {@link RemoteReplicaInfo} that contains the remote replica ids and their tokens.
    * @param remoteNode The remote {@link DataNodeId}.
@@ -835,7 +844,7 @@ public class ReplicaThread implements Runnable {
       ReplicaMetadataRequestInfo replicaMetadataRequestInfo =
           new ReplicaMetadataRequestInfo(remoteReplicaInfo.getReplicaId().getPartitionId(),
               remoteReplicaInfo.getToken(), dataNodeId.getHostname(),
-              remoteReplicaInfo.getLocalReplicaId().getReplicaPath(), remoteReplicaInfo.getReplicaId().getReplicaType(),
+              getLocalReplicaPath(remoteReplicaInfo), remoteReplicaInfo.getReplicaId().getReplicaType(),
               replicationConfig.replicaMetadataRequestVersion);
       replicaMetadataRequestInfoList.add(replicaMetadataRequestInfo);
       logger.trace("Remote node: {} Thread name: {} Remote replica: {} Token going to be sent to remote: {} ",

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
@@ -252,7 +252,8 @@ public abstract class ReplicationEngine implements ReplicationAPI {
         break;
       }
     }
-    if (foundRemoteReplicaInfo == null && !replicaPath.startsWith(Cloud_Replica_Keyword)) {
+    if (foundRemoteReplicaInfo == null && !replicaPath.startsWith(Cloud_Replica_Keyword) &&
+        !replicaPath.startsWith(BackupCheckerThread.DR_Verifier_Keyword)) {
       replicationMetrics.unknownRemoteReplicaRequestCount.inc();
       logger.error("ReplicaMetaDataRequest from unknown Replica {}, with path {}", hostName, replicaPath);
     }


### PR DESCRIPTION
When DR tries to replicate from servers, the servers reject the requests because they do not recognize DR as a peer. 