### PR TITLE
ReplicateBlob on deletion: add the unit test for compacted blob.

### DIFF
--- a/ambry-router/src/main/java/com/github/ambry/router/ReplicateBlobOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/ReplicateBlobOperation.java
@@ -290,6 +290,8 @@ class ReplicateBlobOperation {
     switch (serverErrorCode) {
       case Blob_Authorization_Failure:
         return RouterErrorCode.BlobAuthorizationFailure;
+      case Blob_Deleted:
+        return RouterErrorCode.BlobDeleted;
       case Blob_Expired:
         return RouterErrorCode.BlobExpired;
       case Blob_Not_Found:
@@ -351,18 +353,20 @@ class ReplicateBlobOperation {
     switch (routerErrorCode) {
       case BlobAuthorizationFailure:
         return 1;
-      case BlobExpired:
+      case BlobDeleted:
         return 2;
-      case TooManyRequests:
+      case BlobExpired:
         return 3;
-      case AmbryUnavailable:
+      case TooManyRequests:
         return 4;
-      case UnexpectedInternalError:
+      case AmbryUnavailable:
         return 5;
-      case OperationTimedOut:
+      case UnexpectedInternalError:
         return 6;
-      case BlobDoesNotExist:
+      case OperationTimedOut:
         return 7;
+      case BlobDoesNotExist:
+        return 8;
       default:
         return Integer.MIN_VALUE;
     }

--- a/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTest.java
@@ -3158,7 +3158,7 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
     serverErrors.add(ServerErrorCode.Blob_Deleted); // source PutBlob is compacted, replication fails with Blob_Deleted.
     for (MockServer server : layout.getMockServers()) {
       if (server.getDataCenter().equals(localDcName)) {
-        // local DC, return NO_ERROR for one replica,
+        // local DC, return NO_ERROR for one replica. This replica will be the source replica of the ReplicateBlob.
         if (sourceDataNode == null) {
           sourceDataNode = mockClusterMap.getDataNodeId(server.getHostName(), server.getHostPort());
         } else {

--- a/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTest.java
@@ -3137,6 +3137,53 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
   }
 
   /**
+   * Test Deletion first hits Not_FOUND. Then run ReplicateBlob.
+   * If the PutBlob is compacted already, ReplicateBlob may fail with ID_Deleted.
+   * @throws Exception
+   */
+  @Test
+  public void testReplicateBlobOnDeleteButPutBlobCompacted() throws Exception {
+    String serviceID = "delete-service";
+    MockServerLayout layout = new MockServerLayout(mockClusterMap);
+    String localDcName = "DC3";
+    setRouter(getNonBlockingRouterProperties(localDcName), layout, new LoggingNotificationSystem());
+    setOperationParams();
+    String blobId = router.putBlob(putBlobProperties, putUserMetadata, putChannel, new PutBlobOptionsBuilder().build())
+        .get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+
+    // two local replicas are unavailable. Remote replica doesn't have the Blob.
+    DataNodeId sourceDataNode = null;
+    List<ServerErrorCode> serverErrors = new ArrayList<>();
+    serverErrors.add(ServerErrorCode.Blob_Not_Found); // return NOT_FOUND for the first Delete Request
+    serverErrors.add(ServerErrorCode.Blob_Deleted); // source PutBlob is compacted, replication fails with Blob_Deleted.
+    for (MockServer server : layout.getMockServers()) {
+      if (server.getDataCenter().equals(localDcName)) {
+        // local DC, return NO_ERROR for one replica,
+        if (sourceDataNode == null) {
+          sourceDataNode = mockClusterMap.getDataNodeId(server.getHostName(), server.getHostPort());
+        } else {
+          server.setServerErrorForAllRequests(ServerErrorCode.Replica_Unavailable);
+        }
+      } else {
+        server.setServerErrors(serverErrors);
+      }
+    }
+
+    // ReplicateBlob fails, it returns the error of the delete operation.
+    try {
+      router.deleteBlob(blobId, serviceID).get();
+      fail("deleteBlob should fail since ReplicateBlob fails.");
+    } catch (Exception e) {
+      RouterException r = (RouterException) e.getCause();
+      Assert.assertEquals("AmbryUnavailable error is expected", RouterErrorCode.AmbryUnavailable, r.getErrorCode());
+    } finally {
+      layout.getMockServers().forEach(mockServer -> mockServer.setServerErrorForAllRequests(null));
+      router.getNotFoundCache().invalidateAll();
+      router.close();
+    }
+  }
+
+  /**
    * When a composite blob put fails, background deleter will kick off and delete all the data chunks.
    * Test On-Demand replication won't get triggered for the background deleter.
    */

--- a/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
@@ -1394,7 +1394,7 @@ class PersistentIndex {
               putValue.getAccountId(), putValue.getContainerId(), putValue.getOperationTimeInMs(),
               value.getLifeVersion()));
     } else {
-      // PUT record no longer available.
+      // PUT record no longer available. When the PutBlob is compacted, it throws the ID_Deleted exception.
       throw new StoreException("Did not find PUT index entry for key [" + key
           + "] and the the original offset in value of the DELETE entry was [" + value.getOriginalMessageOffset() + "]",
           StoreErrorCodes.ID_Deleted);


### PR DESCRIPTION
Add the unit test that the source blob is deleted and compacted.
ReplicateBlob will fail with Blob deleted.
The DeleteOperation fails with its original error.