### PR TITLE
[Efficient Metadata Operations] Introduce partially sealed replicas in DataNodeConfig.

### DIFF
--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
@@ -74,6 +74,7 @@ public class ClusterMapUtils {
   public static final String HTTP2_PORT_STR = "http2Port";
   static final String RACKID_STR = "rackId";
   static final String SEALED_STR = "SEALED";
+  static final String PARTIALLY_SEALED_STR = "PARTIALLY_SEALED";
   static final String STOPPED_REPLICAS_STR = "STOPPED";
   static final String DISABLED_REPLICAS_STR = "DISABLED";
   static final String AVAILABLE_STR = "AVAILABLE";
@@ -204,6 +205,17 @@ public class ClusterMapUtils {
   }
 
   /**
+   * Get the list of partially sealed replicas on a given instance.
+   * This is guaranteed to return a non-null list. It would return an empty list if there are no sealed replicas or if
+   * the field itself is absent for this instance.
+   * @param instanceConfig the {@link InstanceConfig} associated with the interested instance.
+   * @return the list of partially sealed replicas.
+   */
+  static List<String> getPartiallySealedReplicas(InstanceConfig instanceConfig) {
+    return getPartiallySealedReplicas(instanceConfig.getRecord());
+  }
+
+  /**
    * Get the list of sealed replicas on a given instance. This is guaranteed to return a non-null list. It would return
    * an empty list if there are no sealed replicas or if the field itself is absent for this instance.
    * @param znRecord the {@link ZNRecord} associated with the interested instance.
@@ -212,6 +224,18 @@ public class ClusterMapUtils {
   static List<String> getSealedReplicas(ZNRecord znRecord) {
     List<String> sealedReplicas = znRecord.getListField(ClusterMapUtils.SEALED_STR);
     return sealedReplicas == null ? new ArrayList<>() : sealedReplicas;
+  }
+
+  /**
+   * Get the list of partially sealed replicas on a given instance. This is guaranteed to return a non-null list. It
+   * would return an empty list if there are no partially sealed replicas or if the field itself is absent for this
+   * instance.
+   * @param znRecord the {@link ZNRecord} associated with the interested instance.
+   * @return the list of partially sealed replicas.
+   */
+  static List<String> getPartiallySealedReplicas(ZNRecord znRecord) {
+    List<String> partiallySealedReplicas = znRecord.getListField(ClusterMapUtils.PARTIALLY_SEALED_STR);
+    return partiallySealedReplicas == null ? new ArrayList<>() : partiallySealedReplicas;
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DataNodeConfig.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DataNodeConfig.java
@@ -36,6 +36,7 @@ class DataNodeConfig {
   private final String rackId;
   private final long xid;
   private final Set<String> sealedReplicas = new HashSet<>();
+  private final Set<String> partiallySealedReplicas = new HashSet<>();
   private final Set<String> stoppedReplicas = new HashSet<>();
   private final Set<String> disabledReplicas = new HashSet<>();
   private final Map<String, DiskConfig> diskConfigs = new TreeMap<>();
@@ -128,6 +129,13 @@ class DataNodeConfig {
   }
 
   /**
+   * @return the set of partially sealed replicas on this server. This set is mutable.
+   */
+  Set<String> getPartiallySealedReplicas() {
+    return partiallySealedReplicas;
+  }
+
+  /**
    * @return the set of stopped replicas on this server. This set is mutable.
    */
   Set<String> getStoppedReplicas() {
@@ -164,7 +172,7 @@ class DataNodeConfig {
         + port + ", datacenterName='" + datacenterName + '\'' + ", sslPort=" + sslPort + ", http2Port=" + http2Port
         + ", rackId='" + rackId + '\'' + ", xid=" + xid + ", sealedReplicas=" + sealedReplicas + ", stoppedReplicas="
         + stoppedReplicas + ", disabledReplicas=" + disabledReplicas + ", diskConfigs=" + diskConfigs
-        + ", extraMapFields=" + extraMapFields + '}';
+        + ", extraMapFields=" + extraMapFields + ", partiallySealedReplicas=" + partiallySealedReplicas + '}';
   }
 
   @Override
@@ -182,7 +190,8 @@ class DataNodeConfig {
         datacenterName, that.datacenterName) && port == that.port && Objects.equals(sslPort, that.sslPort)
         && Objects.equals(http2Port, that.http2Port) && Objects.equals(rackId, that.rackId) && sealedReplicas.equals(
         that.sealedReplicas) && stoppedReplicas.equals(that.stoppedReplicas) && disabledReplicas.equals(
-        that.disabledReplicas) && diskConfigs.equals(that.diskConfigs);
+        that.disabledReplicas) && diskConfigs.equals(that.diskConfigs)
+        && partiallySealedReplicas.equals(this.partiallySealedReplicas);
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeUtil.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeUtil.java
@@ -1387,6 +1387,7 @@ public class HelixBootstrapUpgradeUtil {
     instanceConfig.getRecord().setSimpleField(SCHEMA_VERSION_STR, Integer.toString(CURRENT_SCHEMA_VERSION));
 
     List<String> sealedPartitionsList = new ArrayList<>();
+    List<String> partiallySealedPartitionsList = new ArrayList<>();
     List<String> stoppedReplicasList = new ArrayList<>();
     List<String> disabledReplicasList = new ArrayList<>();
     if (instanceToDiskReplicasMap.containsKey(instanceName)) {
@@ -1425,10 +1426,12 @@ public class HelixBootstrapUpgradeUtil {
     // Set the fields that need to be preserved from the referenceInstanceConfig.
     if (referenceInstanceConfig != null) {
       sealedPartitionsList = ClusterMapUtils.getSealedReplicas(referenceInstanceConfig);
+      partiallySealedPartitionsList = ClusterMapUtils.getPartiallySealedReplicas(referenceInstanceConfig);
       stoppedReplicasList = ClusterMapUtils.getStoppedReplicas(referenceInstanceConfig);
       disabledReplicasList = ClusterMapUtils.getDisabledReplicas(referenceInstanceConfig);
     }
     instanceConfig.getRecord().setListField(SEALED_STR, sealedPartitionsList);
+    instanceConfig.getRecord().setListField(PARTIALLY_SEALED_STR, partiallySealedPartitionsList);
     instanceConfig.getRecord().setListField(STOPPED_REPLICAS_STR, stoppedReplicasList);
     instanceConfig.getRecord().setListField(DISABLED_REPLICAS_STR, disabledReplicasList);
     return instanceConfig;

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/InstanceConfigToDataNodeConfigAdapter.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/InstanceConfigToDataNodeConfigAdapter.java
@@ -101,6 +101,7 @@ public class InstanceConfigToDataNodeConfigAdapter implements DataNodeConfigSour
           Integer.parseInt(instanceConfig.getPort()), getDcName(instanceConfig), getSslPortStr(instanceConfig),
           getHttp2PortStr(instanceConfig), getRackId(instanceConfig), getXid(instanceConfig));
       dataNodeConfig.getSealedReplicas().addAll(getSealedReplicas(instanceConfig));
+      dataNodeConfig.getPartiallySealedReplicas().addAll(getPartiallySealedReplicas(instanceConfig));
       dataNodeConfig.getStoppedReplicas().addAll(getStoppedReplicas(instanceConfig));
       dataNodeConfig.getDisabledReplicas().addAll(getDisabledReplicas(instanceConfig));
       instanceConfig.getRecord().getMapFields().forEach((mountPath, diskProps) -> {
@@ -157,6 +158,8 @@ public class InstanceConfigToDataNodeConfigAdapter implements DataNodeConfigSour
       }
       instanceConfig.getRecord().setIntField(SCHEMA_VERSION_STR, CURRENT_SCHEMA_VERSION);
       instanceConfig.getRecord().setListField(SEALED_STR, new ArrayList<>(dataNodeConfig.getSealedReplicas()));
+      instanceConfig.getRecord().setListField(PARTIALLY_SEALED_STR,
+          new ArrayList<>(dataNodeConfig.getPartiallySealedReplicas()));
       instanceConfig.getRecord()
           .setListField(STOPPED_REPLICAS_STR, new ArrayList<>(dataNodeConfig.getStoppedReplicas()));
       instanceConfig.getRecord()

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PropertyStoreToDataNodeConfigAdapter.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PropertyStoreToDataNodeConfigAdapter.java
@@ -233,6 +233,7 @@ class PropertyStoreToDataNodeConfigAdapter implements DataNodeConfigSource {
           record.getIntField(PORT_FIELD, DataNodeId.UNKNOWN_PORT), getDcName(record), getSslPortStr(record),
           getHttp2PortStr(record), getRackId(record), DEFAULT_XID);
       dataNodeConfig.getSealedReplicas().addAll(getSealedReplicas(record));
+      dataNodeConfig.getPartiallySealedReplicas().addAll(getPartiallySealedReplicas(record));
       dataNodeConfig.getStoppedReplicas().addAll(getStoppedReplicas(record));
       dataNodeConfig.getDisabledReplicas().addAll(getDisabledReplicas(record));
       record.getMapFields().forEach((key, diskProps) -> {
@@ -278,6 +279,7 @@ class PropertyStoreToDataNodeConfigAdapter implements DataNodeConfigSource {
       }
       record.setSimpleField(RACKID_STR, dataNodeConfig.getRackId());
       record.setListField(SEALED_STR, new ArrayList<>(dataNodeConfig.getSealedReplicas()));
+      record.setListField(PARTIALLY_SEALED_STR, new ArrayList<>(dataNodeConfig.getPartiallySealedReplicas()));
       record.setListField(STOPPED_REPLICAS_STR, new ArrayList<>(dataNodeConfig.getStoppedReplicas()));
       record.setListField(DISABLED_REPLICAS_STR, new ArrayList<>(dataNodeConfig.getDisabledReplicas()));
       dataNodeConfig.getDiskConfigs().forEach((mountPath, diskConfig) -> {

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/ClusterChangeHandlerTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/ClusterChangeHandlerTest.java
@@ -272,6 +272,7 @@ public class ClusterChangeHandlerTest {
     instanceConfig.getRecord()
         .setSimpleField(ClusterMapUtils.SCHEMA_VERSION_STR, Integer.toString(ClusterMapUtils.CURRENT_SCHEMA_VERSION));
     instanceConfig.getRecord().setListField(ClusterMapUtils.SEALED_STR, Collections.emptyList());
+    instanceConfig.getRecord().setListField(PARTIALLY_SEALED_STR, Collections.emptyList());
     instanceConfig.getRecord().setListField(ClusterMapUtils.STOPPED_REPLICAS_STR, Collections.emptyList());
 
     Map<String, Map<String, String>> diskInfos = new HashMap<>();

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixParticipantTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixParticipantTest.java
@@ -545,6 +545,7 @@ public class HelixParticipantTest {
     }
     instanceConfig.getRecord().setMapFields(mountPathToDiskInfos);
     instanceConfig.getRecord().setListField(SEALED_STR, new ArrayList<>(dataNodeConfig.getSealedReplicas()));
+    instanceConfig.getRecord().setListField(PARTIALLY_SEALED_STR, new ArrayList<>(dataNodeConfig.getSealedReplicas()));
     instanceConfig.getRecord().setListField(STOPPED_REPLICAS_STR, new ArrayList<>(dataNodeConfig.getStoppedReplicas()));
     instanceConfig.getRecord()
         .setListField(DISABLED_REPLICAS_STR, new ArrayList<>(dataNodeConfig.getDisabledReplicas()));

--- a/ambry-tools/src/integration-test/java/com/github/ambry/clustermap/HelixBootstrapUpgradeToolTest.java
+++ b/ambry-tools/src/integration-test/java/com/github/ambry/clustermap/HelixBootstrapUpgradeToolTest.java
@@ -316,15 +316,24 @@ public class HelixBootstrapUpgradeToolTest {
     referenceInstanceConfig.getRecord().setListField(ClusterMapUtils.SEALED_STR, sealedList);
     // set the field to null. The created InstanceConfig should not have null fields.
     referenceInstanceConfig.getRecord().setListField(ClusterMapUtils.STOPPED_REPLICAS_STR, null);
+    referenceInstanceConfig.getRecord().setListField(PARTIALLY_SEALED_STR, null);
     instanceConfig = HelixBootstrapUpgradeUtil.createInstanceConfigFromStaticInfo(dataNode, partitionToInstances,
         new ConcurrentHashMap<>(), referenceInstanceConfig);
-    // Stopped replicas should be an empty list and not null, so set that in referenceInstanceConfig for comparison.
+    // Stopped replicas and partially sealed replicas should be an empty list and not null, so set that in referenceInstanceConfig for comparison.
     referenceInstanceConfig.getRecord().setListField(ClusterMapUtils.STOPPED_REPLICAS_STR, Collections.emptyList());
+    referenceInstanceConfig.getRecord().setListField(PARTIALLY_SEALED_STR, Collections.emptyList());
     assertEquals(instanceConfig.getRecord(), referenceInstanceConfig.getRecord());
 
     // Assert that stopped list being different does not affect equality
     List<String> stoppedReplicas = Arrays.asList("11", "15");
     referenceInstanceConfig.getRecord().setListField(ClusterMapUtils.STOPPED_REPLICAS_STR, stoppedReplicas);
+    instanceConfig = HelixBootstrapUpgradeUtil.createInstanceConfigFromStaticInfo(dataNode, partitionToInstances,
+        new ConcurrentHashMap<>(), referenceInstanceConfig);
+    assertEquals(instanceConfig.getRecord(), referenceInstanceConfig.getRecord());
+
+    // Assert that partially sealed list being different does not affect equality
+    List<String> partiallySealedReplicas = Arrays.asList("11", "15");
+    referenceInstanceConfig.getRecord().setListField(PARTIALLY_SEALED_STR, partiallySealedReplicas);
     instanceConfig = HelixBootstrapUpgradeUtil.createInstanceConfigFromStaticInfo(dataNode, partitionToInstances,
         new ConcurrentHashMap<>(), referenceInstanceConfig);
     assertEquals(instanceConfig.getRecord(), referenceInstanceConfig.getRecord());


### PR DESCRIPTION
Introduce partially sealed replicas in DataNodeConfig. Replicas marked as partially sealed will not be able to take writes for metadata chunks whose id is reserved at the start of the upload.