### PR TITLE
Update the dataset version API to include version info

### DIFF
--- a/ambry-account/src/integration-test/java/com/github/ambry/account/MySqlAccountServiceIntegrationTest.java
+++ b/ambry-account/src/integration-test/java/com/github/ambry/account/MySqlAccountServiceIntegrationTest.java
@@ -764,13 +764,13 @@ public class MySqlAccountServiceIntegrationTest {
     versions.add(versionNumber);
     DatasetVersionRecord expectedDatasetVersionRecord =
         new DatasetVersionRecord(testAccount.getId(), testContainer.getId(), DATASET_NAME, version, -1);
-    Dataset datasetFromMysql =
+    DatasetVersionRecord datasetVersionRecordFromMysql =
         mySqlAccountStore.addDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
             testContainer.getName(), DATASET_NAME, version, -1);
-    assertEquals("Mismatch in dataset read from db", dataset, datasetFromMysql);
+    assertEquals("Mismatch in dataset read from db", expectedDatasetVersionRecord, datasetVersionRecordFromMysql);
 
     // Get the dataset version
-    DatasetVersionRecord datasetVersionRecordFromMysql =
+    datasetVersionRecordFromMysql =
         mySqlAccountStore.getDatasetVersion(testAccount.getId(), testContainer.getId(), DATASET_NAME, version);
     assertEquals("Mismatch in dataset version read from db", expectedDatasetVersionRecord,
         datasetVersionRecordFromMysql);

--- a/ambry-account/src/main/java/com/github/ambry/account/MySqlAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/MySqlAccountService.java
@@ -413,7 +413,7 @@ public class MySqlAccountService extends AbstractAccountService {
   }
 
   @Override
-  public Dataset addDatasetVersion(String accountName, String containerName, String datasetName, String version,
+  public DatasetVersionRecord addDatasetVersion(String accountName, String containerName, String datasetName, String version,
       long expirationTimeMs) throws AccountServiceException {
     try {
       Container container = getContainerByName(accountName, containerName);

--- a/ambry-account/src/main/java/com/github/ambry/account/mysql/AccountDao.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/mysql/AccountDao.java
@@ -314,10 +314,10 @@ public class AccountDao {
    * @param datasetName the name of the dataset.
    * @param version the version of the dataset.
    * @param expirationTimeMs the expiration time of the version of the dataset.
-   * @return the {@link Dataset} which contains the metadata.
+   * @return the {@link DatasetVersionRecord}.
    * @throws SQLException
    */
-  public synchronized Dataset addDatasetVersions(int accountId, int containerId, String accountName,
+  public synchronized DatasetVersionRecord addDatasetVersions(int accountId, int containerId, String accountName,
       String containerName, String datasetName, String version, long expirationTimeMs) throws SQLException {
     try {
       long startTimeMs = System.currentTimeMillis();
@@ -331,7 +331,7 @@ public class AccountDao {
       executeAddDatasetVersionStatement(insertDatasetVersionStatement, accountId, containerId, datasetName,
           versionNumber, expirationTimeMs, dataset);
       dataAccessor.onSuccess(Write, System.currentTimeMillis() - startTimeMs);
-      return dataset;
+      return new DatasetVersionRecord(accountId, containerId, datasetName, version, expirationTimeMs);
     } catch (SQLException e) {
       dataAccessor.onException(e, Write);
       throw e;

--- a/ambry-account/src/main/java/com/github/ambry/account/mysql/MySqlAccountStore.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/mysql/MySqlAccountStore.java
@@ -158,7 +158,7 @@ public class MySqlAccountStore {
    * @return the corresponding {@link Dataset}
    * @throws SQLException
    */
-  public Dataset addDatasetVersion(int accountId, int containerId, String accountName, String containerName,
+  public DatasetVersionRecord addDatasetVersion(int accountId, int containerId, String accountName, String containerName,
       String datasetName, String version, long expirationTimeMs) throws SQLException {
     return accountDao.addDatasetVersions(accountId, containerId, accountName, containerName, datasetName, version,
         expirationTimeMs);

--- a/ambry-api/src/main/java/com/github/ambry/account/AccountService.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/AccountService.java
@@ -173,11 +173,11 @@ public interface AccountService extends Closeable {
    * @param datasetName The name of the dataset.
    * @param version The version of the dataset.
    * @param expirationTimeMs the expiration time of the version of the dataset.
-   * @return the {@link Dataset} which contains the metadata.
+   * @return the {@link DatasetVersionRecord}.
    * @throws AccountServiceException
    */
-  default Dataset addDatasetVersion(String accountName, String containerName, String datasetName, String version,
-      long expirationTimeMs) throws AccountServiceException {
+  default DatasetVersionRecord addDatasetVersion(String accountName, String containerName, String datasetName,
+      String version, long expirationTimeMs) throws AccountServiceException {
     throw new UnsupportedOperationException("This method is not supported");
   }
 

--- a/ambry-api/src/main/java/com/github/ambry/account/Dataset.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/Dataset.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
+import java.util.regex.Pattern;
 
 
 /**
@@ -48,6 +49,13 @@ import java.util.Objects;
 @JsonDeserialize(builder = DatasetBuilder.class)
 public class Dataset {
   //constant
+
+  /**
+   * The pattern defining valid Dataset names in Ambry. Names must begin with an alphanumeric character, followed
+   * by up to 100 characters that are alphanumeric, {@code _} , {@code .} , or {@code -} (underscore, period,
+   * or hyphen).
+   */
+  private static final Pattern AMBRY_VALID_DATASET_NAME_PATTERN = Pattern.compile("[a-zA-Z0-9][a-zA-Z0-9_.-]{0,100}");
 
   static final String ACCOUNT_NAME_KEY = "accountName";
   static final String CONTAINER_NAME_KEY = "containerName";
@@ -165,15 +173,20 @@ public class Dataset {
       VersionSchema versionSchema, Long expirationTimeMs) {
     if (accountName == null || containerName == null || datasetName == null || versionSchema == null
         || expirationTimeMs == null) {
-      throw new IllegalStateException(
+      throw new IllegalArgumentException(
           "At lease one of required fields accountName=" + accountName + " or containerName=" + containerName
               + " or datasetName=" + datasetName + " or versionSchema=" + versionSchema + " or expirationTimeMs="
               + expirationTimeMs + " is null");
     }
     if (accountName.isEmpty() || containerName.isEmpty() || datasetName.isEmpty()) {
-      throw new IllegalStateException(
+      throw new IllegalArgumentException(
           "At lease one of required fields accountName=" + accountName + " or containerName=" + containerName
               + " or datasetName=" + datasetName + " is empty");
+    }
+    if (!AMBRY_VALID_DATASET_NAME_PATTERN.matcher(datasetName).matches()) {
+      throw new IllegalArgumentException("Invalid name for an Ambry dataset: " + datasetName
+          + ". Valid names should only include alphanumeric characters, periods, underscores, and hyphens. The exact regex you must match is: "
+          + AMBRY_VALID_DATASET_NAME_PATTERN);
     }
   }
 

--- a/ambry-api/src/main/java/com/github/ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com/github/ambry/rest/RestUtils.java
@@ -59,7 +59,6 @@ public class RestUtils {
    * The default extension to add to blob id returned back to client.
    */
   public static final String DEFAULT_EXTENSION = "bin";
-
   /**
    * Ambry specific HTTP headers.
    */
@@ -376,6 +375,10 @@ public class RestUtils {
      */
     public static final String TARGET_DATASET_KEY = KEY_PREFIX + "target-dataset";
 
+    /**
+     * The key for the target dataset version indicated by the request.
+     */
+    public static final String TARGET_DATASET_VERSION_KEY = KEY_PREFIX + "target-dataset-version-key";
 
     /**
      * The key for the metadata {@code Map<String, String>} to include in a signed ID. This argument should be non-null
@@ -855,7 +858,7 @@ public class RestUtils {
    * @return {@code true} if {@link Headers#DATASET_VERSION_UPLOAD} is set.
    * @throws RestServiceException
    */
-  public static boolean isDatasetUpload(Map<String, Object> args) throws RestServiceException {
+  public static boolean isDatasetVersionUpload(Map<String, Object> args) throws RestServiceException {
     return getBooleanHeader(args, Headers.DATASET_VERSION_UPLOAD, false);
   }
 

--- a/ambry-api/src/main/java/com/github/ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com/github/ambry/rest/RestUtils.java
@@ -59,6 +59,7 @@ public class RestUtils {
    * The default extension to add to blob id returned back to client.
    */
   public static final String DEFAULT_EXTENSION = "bin";
+  public static final String PATH_SEPARATOR_STRING = "/";
   /**
    * Ambry specific HTTP headers.
    */
@@ -373,12 +374,12 @@ public class RestUtils {
     /**
      * The key for the target {@link com.github.ambry.account.Dataset} indicated by the request.
      */
-    public static final String TARGET_DATASET_KEY = KEY_PREFIX + "target-dataset";
+    public static final String TARGET_DATASET = KEY_PREFIX + "target-dataset";
 
     /**
      * The key for the target dataset version indicated by the request.
      */
-    public static final String TARGET_DATASET_VERSION_KEY = KEY_PREFIX + "target-dataset-version-key";
+    public static final String TARGET_DATASET_VERSION = KEY_PREFIX + "target-dataset-version-key";
 
     /**
      * The key for the metadata {@code Map<String, String>} to include in a signed ID. This argument should be non-null

--- a/ambry-api/src/main/java/com/github/ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com/github/ambry/rest/RestUtils.java
@@ -379,7 +379,7 @@ public class RestUtils {
     /**
      * The key for the target dataset version indicated by the request.
      */
-    public static final String TARGET_DATASET_VERSION = KEY_PREFIX + "target-dataset-version-key";
+    public static final String TARGET_DATASET_VERSION = KEY_PREFIX + "target-dataset-version";
 
     /**
      * The key for the metadata {@code Map<String, String>} to include in a signed ID. This argument should be non-null

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/AccountAndContainerInjector.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/AccountAndContainerInjector.java
@@ -45,7 +45,6 @@ public class AccountAndContainerInjector {
   private static final Set<String> requiredAmbryHeadersForPutWithAccountAndContainerName = Collections.unmodifiableSet(
       new HashSet<>(Arrays.asList(Headers.TARGET_ACCOUNT_NAME, Headers.TARGET_CONTAINER_NAME)));
   private static final Logger logger = LoggerFactory.getLogger(AccountAndContainerInjector.class);
-  private static final String PATH_SEPARATOR_STRING = "/";
 
   private final AccountService accountService;
   private final FrontendMetrics frontendMetrics;
@@ -336,7 +335,7 @@ public class AccountAndContainerInjector {
   }
 
   /**
-   * Set target {@link Dataset} objects and it's version in the {@link RestRequest}.
+   * Set target {@link Dataset} objects and its version in the {@link RestRequest}.
    * @param restRequest The {@link RestRequest} to set.
    * @param namedBlobPath the {@link NamedBlobPath} to get account, container and dataset name.
    * @throws RestServiceException
@@ -360,8 +359,8 @@ public class AccountAndContainerInjector {
       String version = splitName[1];
       try {
         Dataset dataset = accountService.getDataset(accountName, containerName, datasetName);
-        restRequest.setArg(InternalKeys.TARGET_DATASET_KEY, dataset);
-        restRequest.setArg(InternalKeys.TARGET_DATASET_VERSION_KEY, version);
+        restRequest.setArg(InternalKeys.TARGET_DATASET, dataset);
+        restRequest.setArg(InternalKeys.TARGET_DATASET_VERSION, version);
       } catch (AccountServiceException e) {
         frontendMetrics.unrecognizedDatasetNameCount.inc();
         throw new RestServiceException(

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendUtils.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendUtils.java
@@ -40,6 +40,7 @@ import org.json.JSONObject;
 import org.json.JSONTokener;
 import org.slf4j.Logger;
 
+import static com.github.ambry.rest.RestUtils.*;
 import static com.github.ambry.rest.RestUtils.InternalKeys.*;
 
 
@@ -47,10 +48,6 @@ import static com.github.ambry.rest.RestUtils.InternalKeys.*;
  * Common utility functions that will be used across frontend package
  */
 class FrontendUtils {
-  /**
-   * Path separator character for named blob uri.
-   */
-  private static final char PATH_SEPARATOR_CHAR = '/';
 
   /**
    * Fetches {@link BlobId} from the given string representation of BlobId
@@ -154,11 +151,11 @@ class FrontendUtils {
     if (version.equals("LATEST") || version.equals("MAJOR") || version.equals("MINOR") || version.equals("PATCH")) {
       RequestPath originalRequestPath = (RequestPath) restRequest.getArgs().get(REQUEST_PATH);
       String originalOperationOrBlobId = originalRequestPath.getOperationOrBlobId(false);
-      int index = originalOperationOrBlobId.lastIndexOf(PATH_SEPARATOR_CHAR);
+      int index = originalOperationOrBlobId.lastIndexOf(PATH_SEPARATOR_STRING);
       String latestOperationOrBlobId;
       if (index != -1) {
         latestOperationOrBlobId =
-            originalOperationOrBlobId.substring(0, index) + PATH_SEPARATOR_CHAR + datasetVersionRecord.getVersion();
+            originalOperationOrBlobId.substring(0, index) + PATH_SEPARATOR_STRING + datasetVersionRecord.getVersion();
       } else {
         throw new RestServiceException("Failed to parse the originalOperationOrBlobId: " + originalOperationOrBlobId,
             RestServiceErrorCode.BadRequest);

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendUtils.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendUtils.java
@@ -149,7 +149,7 @@ class FrontendUtils {
    * @param datasetVersionRecord the {@link DatasetVersionRecord} which include the version info.
    * @throws RestServiceException
    */
-  static void refreshRequestPathWithNewOperationOrBlobIdIfNeeded(RestRequest restRequest,
+  static void replaceRequestPathWithNewOperationOrBlobIdIfNeeded(RestRequest restRequest,
       DatasetVersionRecord datasetVersionRecord, String version) throws RestServiceException {
     if (version.equals("LATEST") || version.equals("MAJOR") || version.equals("MINOR") || version.equals("PATCH")) {
       RequestPath originalRequestPath = (RequestPath) restRequest.getArgs().get(REQUEST_PATH);
@@ -168,7 +168,6 @@ class FrontendUtils {
               originalRequestPath.getPathAfterPrefixes(), latestOperationOrBlobId, originalRequestPath.getSubResource(),
               originalRequestPath.getBlobSegmentIdx());
       restRequest.setArg(RestUtils.InternalKeys.REQUEST_PATH, newRequestPath);
-      restRequest.setArg(RestUtils.InternalKeys.FILENAME_HINT, newRequestPath.getOperationOrBlobId(true));
     }
   }
 }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/GetBlobHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/GetBlobHandler.java
@@ -329,14 +329,14 @@ public class GetBlobHandler {
       String datasetName = null;
       String version = null;
       try {
-        Dataset dataset = (Dataset) restRequest.getArgs().get(InternalKeys.TARGET_DATASET_KEY);
+        Dataset dataset = (Dataset) restRequest.getArgs().get(InternalKeys.TARGET_DATASET);
         accountName = dataset.getAccountName();
         containerName = dataset.getContainerName();
         datasetName = dataset.getDatasetName();
-        version = (String) restRequest.getArgs().get(TARGET_DATASET_VERSION_KEY);
+        version = (String) restRequest.getArgs().get(TARGET_DATASET_VERSION);
         DatasetVersionRecord datasetVersionRecord =
             accountService.getDatasetVersion(accountName, containerName, datasetName, version);
-        FrontendUtils.refreshRequestPathWithNewOperationOrBlobIdIfNeeded(restRequest, datasetVersionRecord, version);
+        FrontendUtils.replaceRequestPathWithNewOperationOrBlobIdIfNeeded(restRequest, datasetVersionRecord, version);
         restResponseChannel.setHeader(RestUtils.Headers.TARGET_ACCOUNT_NAME, accountName);
         restResponseChannel.setHeader(RestUtils.Headers.TARGET_CONTAINER_NAME, containerName);
         restResponseChannel.setHeader(RestUtils.Headers.TARGET_DATASET_NAME, datasetName);

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/GetBlobHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/GetBlobHandler.java
@@ -145,7 +145,7 @@ public class GetBlobHandler {
     private Callback<Void> securityProcessRequestCallback() {
       return buildCallback(metrics.getBlobSecurityProcessRequestMetrics, result -> {
         String blobIdStr;
-        if (RestUtils.isDatasetUpload(restRequest.getArgs())) {
+        if (RestUtils.isDatasetVersionUpload(restRequest.getArgs())) {
           try {
             metrics.getDatasetVersionRate.mark();
             blobIdStr = getDatasetVersion(restRequest);
@@ -333,9 +333,10 @@ public class GetBlobHandler {
         accountName = dataset.getAccountName();
         containerName = dataset.getContainerName();
         datasetName = dataset.getDatasetName();
-        version = RestUtils.getHeader(restRequest.getArgs(), RestUtils.Headers.TARGET_DATASET_VERSION, false);
+        version = (String) restRequest.getArgs().get(TARGET_DATASET_VERSION_KEY);
         DatasetVersionRecord datasetVersionRecord =
             accountService.getDatasetVersion(accountName, containerName, datasetName, version);
+        FrontendUtils.refreshRequestPathWithNewOperationOrBlobIdIfNeeded(restRequest, datasetVersionRecord, version);
         restResponseChannel.setHeader(RestUtils.Headers.TARGET_ACCOUNT_NAME, accountName);
         restResponseChannel.setHeader(RestUtils.Headers.TARGET_CONTAINER_NAME, containerName);
         restResponseChannel.setHeader(RestUtils.Headers.TARGET_DATASET_NAME, datasetName);

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
@@ -376,7 +376,7 @@ public class NamedBlobPutHandler {
     private Map<String, String> getDatasetUserTags(RestRequest restRequest) throws RestServiceException {
       Map<String, String> userTags = null;
       if (RestUtils.isDatasetVersionUpload(restRequest.getArgs())) {
-        Dataset dataset = (Dataset) restRequest.getArgs().get(RestUtils.InternalKeys.TARGET_DATASET_KEY);
+        Dataset dataset = (Dataset) restRequest.getArgs().get(RestUtils.InternalKeys.TARGET_DATASET);
         userTags = dataset.getUserTags();
       }
       return userTags;
@@ -500,16 +500,16 @@ public class NamedBlobPutHandler {
       String datasetName = null;
       String version = null;
       try {
-        Dataset dataset = (Dataset) restRequest.getArgs().get(RestUtils.InternalKeys.TARGET_DATASET_KEY);
+        Dataset dataset = (Dataset) restRequest.getArgs().get(RestUtils.InternalKeys.TARGET_DATASET);
         accountName = dataset.getAccountName();
         containerName = dataset.getContainerName();
         datasetName = dataset.getDatasetName();
-        version = (String) restRequest.getArgs().get(TARGET_DATASET_VERSION_KEY);
+        version = (String) restRequest.getArgs().get(TARGET_DATASET_VERSION);
         long expirationTimeMs =
             Utils.addSecondsToEpochTime(blobProperties.getCreationTimeInMs(), blobProperties.getTimeToLiveInSeconds());
         DatasetVersionRecord datasetVersionRecord =
             accountService.addDatasetVersion(accountName, containerName, datasetName, version, expirationTimeMs);
-        FrontendUtils.refreshRequestPathWithNewOperationOrBlobIdIfNeeded(restRequest, datasetVersionRecord, version);
+        FrontendUtils.replaceRequestPathWithNewOperationOrBlobIdIfNeeded(restRequest, datasetVersionRecord, version);
         restResponseChannel.setHeader(RestUtils.Headers.TARGET_ACCOUNT_NAME, accountName);
         restResponseChannel.setHeader(RestUtils.Headers.TARGET_CONTAINER_NAME, containerName);
         restResponseChannel.setHeader(RestUtils.Headers.TARGET_DATASET_NAME, datasetName);

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
@@ -17,6 +17,7 @@ import com.github.ambry.account.AccountService;
 import com.github.ambry.account.AccountServiceException;
 import com.github.ambry.account.Container;
 import com.github.ambry.account.Dataset;
+import com.github.ambry.account.DatasetVersionRecord;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.Callback;
 import com.github.ambry.commons.RetainingAsyncWritableChannel;
@@ -202,7 +203,7 @@ public class NamedBlobPutHandler {
               new RetainingAsyncWritableChannel(frontendConfig.maxJsonRequestSizeBytes);
           restRequest.readInto(channel, fetchStitchRequestBodyCallback(channel, blobInfo));
         } else {
-          if (RestUtils.isDatasetUpload(restRequest.getArgs())) {
+          if (RestUtils.isDatasetVersionUpload(restRequest.getArgs())) {
             addDatasetVersion(blobInfo.getBlobProperties(), restRequest);
           }
           PutBlobOptions options = getPutBlobOptionsFromRequest();
@@ -236,9 +237,8 @@ public class NamedBlobPutHandler {
       return buildCallback(frontendMetrics.putReadStitchRequestMetrics,
           bytesRead -> router.stitchBlob(getPropertiesForRouterUpload(blobInfo), blobInfo.getUserMetadata(),
               getChunksToStitch(blobInfo.getBlobProperties(), readJsonFromChannel(channel)),
-              routerStitchBlobCallback(blobInfo),
-              QuotaUtils.buildQuotaChargeCallback(restRequest, quotaManager, true)), uri, LOGGER,
-          finalCallback);
+              routerStitchBlobCallback(blobInfo), QuotaUtils.buildQuotaChargeCallback(restRequest, quotaManager, true)),
+          uri, LOGGER, finalCallback);
     }
 
     /**
@@ -352,8 +352,8 @@ public class NamedBlobPutHandler {
         restRequest.getMetricsTracker()
             .injectMetrics(frontendMetrics.putBlobMetricsGroup.getRestRequestMetrics(restRequest.isSslUsed(), true));
       }
-      Map <String, Object> userMetadataFromRequest = restRequest.getArgs();
-      Map <String, String> userTags = getDatasetUserTags(restRequest);
+      Map<String, Object> userMetadataFromRequest = restRequest.getArgs();
+      Map<String, String> userTags = getDatasetUserTags(restRequest);
       if (userTags != null) {
         userTags.forEach((key, value) -> {
           if (!userMetadataFromRequest.containsKey(key)) {
@@ -375,7 +375,7 @@ public class NamedBlobPutHandler {
      */
     private Map<String, String> getDatasetUserTags(RestRequest restRequest) throws RestServiceException {
       Map<String, String> userTags = null;
-      if (RestUtils.isDatasetUpload(restRequest.getArgs())) {
+      if (RestUtils.isDatasetVersionUpload(restRequest.getArgs())) {
         Dataset dataset = (Dataset) restRequest.getArgs().get(RestUtils.InternalKeys.TARGET_DATASET_KEY);
         userTags = dataset.getUserTags();
       }
@@ -492,7 +492,8 @@ public class NamedBlobPutHandler {
      * @return the {@link Dataset}
      * @throws RestServiceException
      */
-    private Dataset addDatasetVersion(BlobProperties blobProperties, RestRequest restRequest) throws RestServiceException {
+    private void addDatasetVersion(BlobProperties blobProperties, RestRequest restRequest)
+        throws RestServiceException {
       long startAddDatasetVersionTime = System.currentTimeMillis();
       String accountName = null;
       String containerName = null;
@@ -503,18 +504,18 @@ public class NamedBlobPutHandler {
         accountName = dataset.getAccountName();
         containerName = dataset.getContainerName();
         datasetName = dataset.getDatasetName();
-        version = RestUtils.getHeader(restRequest.getArgs(), RestUtils.Headers.TARGET_DATASET_VERSION, false);
+        version = (String) restRequest.getArgs().get(TARGET_DATASET_VERSION_KEY);
         long expirationTimeMs =
             Utils.addSecondsToEpochTime(blobProperties.getCreationTimeInMs(), blobProperties.getTimeToLiveInSeconds());
-        accountService.addDatasetVersion(accountName, containerName, datasetName, version, expirationTimeMs);
+        DatasetVersionRecord datasetVersionRecord =
+            accountService.addDatasetVersion(accountName, containerName, datasetName, version, expirationTimeMs);
+        FrontendUtils.refreshRequestPathWithNewOperationOrBlobIdIfNeeded(restRequest, datasetVersionRecord, version);
         restResponseChannel.setHeader(RestUtils.Headers.TARGET_ACCOUNT_NAME, accountName);
         restResponseChannel.setHeader(RestUtils.Headers.TARGET_CONTAINER_NAME, containerName);
         restResponseChannel.setHeader(RestUtils.Headers.TARGET_DATASET_NAME, datasetName);
-        // TODO: support version is null.
-        restResponseChannel.setHeader(RestUtils.Headers.TARGET_DATASET_VERSION, version);
+        restResponseChannel.setHeader(RestUtils.Headers.TARGET_DATASET_VERSION, datasetVersionRecord.getVersion());
         frontendMetrics.addDatasetVersionProcessingTimeInMs.update(
             System.currentTimeMillis() - startAddDatasetVersionTime);
-        return dataset;
       } catch (AccountServiceException ex) {
         throw new RestServiceException(
             "Dataset version create failed for accountName: " + accountName + " containerName: " + containerName

--- a/ambry-test-utils/src/main/java/com/github/ambry/account/InMemAccountService.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/account/InMemAccountService.java
@@ -129,21 +129,16 @@ public class InMemAccountService implements AccountService {
   }
 
   @Override
-  public synchronized Dataset addDatasetVersion(String accountName, String containerName, String datasetName,
-      String version, long expirationTimeMs) {
+  public synchronized DatasetVersionRecord addDatasetVersion(String accountName, String containerName,
+      String datasetName, String version, long expirationTimeMs) {
     Account account = nameToAccountMap.get(accountName);
     short accountId = account.getId();
     short containerId = account.getContainerByName(containerName).getId();
     idToDatasetVersionMap.putIfAbsent(new Pair<>(accountId, containerId), new HashMap<>());
-    idToDatasetVersionMap.get(new Pair<>(accountId, containerId))
-        .put(datasetName + version,
-            new DatasetVersionRecord(accountId, containerId, datasetName, version, expirationTimeMs));
-    Dataset dataset =
-        new DatasetBuilder(accountName, containerName, datasetName, Dataset.VersionSchema.TIMESTAMP, -1).setUserTags(
-            userTags).build();
-    idToDatasetMap.putIfAbsent(new Pair<>(accountId, containerId), new HashMap<>());
-    idToDatasetMap.get(new Pair<>(accountId, containerId)).put(dataset.getDatasetName(), dataset);
-    return dataset;
+    DatasetVersionRecord datasetVersionRecord =
+        new DatasetVersionRecord(accountId, containerId, datasetName, version, expirationTimeMs);
+    idToDatasetVersionMap.get(new Pair<>(accountId, containerId)).put(datasetName + version, datasetVersionRecord);
+    return datasetVersionRecord;
   }
 
   @Override


### PR DESCRIPTION
Follow up pr for #2341. In order to make the API easier to understand, instead of supporting version through header, this pr support put the version info in the request url. so the format of the request will be something like:
PUT(GET) named/accountName/containerName/datasetName/version.
This pr will not include the whole latest version support. only for specific versions support.