### PR TITLE
[Efficient Metadata Operations] Add methods to send message to partially seal and unseal replicas to HelixParticipant.

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/clustermap/ClusterParticipant.java
+++ b/ambry-api/src/main/java/com/github/ambry/clustermap/ClusterParticipant.java
@@ -19,6 +19,7 @@ import com.github.ambry.commons.Callback;
 import com.github.ambry.server.AmbryStatsReport;
 import com.github.ambry.server.storagestats.AggregatedAccountStorageStats;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -49,6 +50,18 @@ public interface ClusterParticipant extends AutoCloseable {
   boolean setReplicaSealedState(ReplicaId replicaId, boolean isSealed);
 
   /**
+   * Set or reset the partial-sealed state of the given replica.
+   * @param replicaId the {@link ReplicaId} whose sealed state will be updated.
+   * @param isPartiallySealed if {@code true}, the replica will be marked as partially sealed. if {@code false} the
+   *                          replica will become unsealed.
+   * @return {@code true} if set replica partial sealed state was successful. {@code false} if not.
+   */
+  default boolean setReplicaPartialSealedState(ReplicaId replicaId, boolean isPartiallySealed) {
+    // TODO add implementation.
+    return false;
+  }
+
+  /**
    * Set or reset the stopped state of the given replica.
    * @param replicaIds a list of replicas whose stopped state will be updated
    * @param markStop if true, the replica will be marked as stopped; otherwise it will be marked as started.
@@ -68,6 +81,15 @@ public interface ClusterParticipant extends AutoCloseable {
    * @return a list of all sealed replicas.
    */
   List<String> getSealedReplicas();
+
+  /**
+   * Get a list of replicas that are marked as partially sealed.
+   * @return a list of all partially sealed replicas.
+   */
+  default List<String> getPartiallySealedReplicas() {
+    // TODO Add implementations.
+    return new ArrayList<>();
+  }
 
   /**
    * Get a list of replicas that are marked as stopped.


### PR DESCRIPTION
Add methods to send messages to partially seal and unseal replicas to HelixParticipant.
This will enable BlobStore implementations to make replicas partially sealed.