### PR TITLE
[Efficient Metadata Operations] Introduce partially sealed state in ReplicaId interface.

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/clustermap/PartitionState.java
+++ b/ambry-api/src/main/java/com/github/ambry/clustermap/PartitionState.java
@@ -14,8 +14,17 @@
 package com.github.ambry.clustermap;
 
 /**
- * The valid states for a {@link PartitionId}.
+ * The valid states for a {@link PartitionId}. The state of a partition is resolved via the {@link ReplicaSealStatus}es
+ * of the partition's replicas. See ClusterMapUtils
+ *
+ * The state transition of a partition's state will always follow the following order:
+ * READ_WRITE <-> PARTIAL_READ_WRITE <-> READ_ONLY
  */
 public enum PartitionState {
-  READ_WRITE, READ_ONLY
+  /** The partition is available for all reads and writes */
+  READ_WRITE,
+  /** The partition is available for all reads but limited writes */
+  PARTIAL_READ_WRITE,
+  /** The partition is available for reads only. */
+  READ_ONLY
 }

--- a/ambry-api/src/main/java/com/github/ambry/clustermap/ReplicaId.java
+++ b/ambry-api/src/main/java/com/github/ambry/clustermap/ReplicaId.java
@@ -86,9 +86,14 @@ public interface ReplicaId extends Resource {
   boolean isDown();
 
   /**
-   * @return true if this replica is in sealed state.
+   * @return true if this replica's {@link ReplicaSealStatus} is {@link ReplicaSealStatus#SEALED}.
    */
   boolean isSealed();
+
+  /**
+   * @return true if this replica's {@link ReplicaSealStatus} is {@link ReplicaSealStatus#PARTIALLY_SEALED}.
+   */
+  boolean isPartiallySealed();
 
   /**
    * @return the {@code ReplicaType} for this replica.

--- a/ambry-api/src/main/java/com/github/ambry/clustermap/ReplicaSealStatus.java
+++ b/ambry-api/src/main/java/com/github/ambry/clustermap/ReplicaSealStatus.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.clustermap;
+
+/**
+ * Valid sealed status of a {@link ReplicaId}.
+ * Sealed status of a replica is determined by the percentage of replica's size compared to its capacity.
+ * See {@link com.github.ambry.config.StoreConfig} for the thresholds.
+ *
+ * The state transition of a replica's seal status due to size will always follow the following order:
+ * NOT_SEALED <-> PARTIALLY_SEALED <-> SEALED
+ */
+public enum ReplicaSealStatus {
+  NOT_SEALED,
+  PARTIALLY_SEALED,
+  SEALED
+}

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryServerReplica.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryServerReplica.java
@@ -35,11 +35,11 @@ class AmbryServerReplica extends AmbryReplica {
    * @param disk the {@link AmbryDisk} on which this replica resides.
    * @param isReplicaStopped whether this replica is stopped or not.
    * @param capacityBytes the capacity in bytes for this replica.
-   * @param isSealed whether this replica is in sealed state.
+   * @param replicaSealStatus {@link ReplicaSealStatus} of the replica.
    */
   AmbryServerReplica(ClusterMapConfig clusterMapConfig, AmbryPartition partition, AmbryDisk disk,
-      boolean isReplicaStopped, long capacityBytes, boolean isSealed) throws Exception {
-    super(clusterMapConfig, partition, isReplicaStopped, capacityBytes, isSealed);
+      boolean isReplicaStopped, long capacityBytes, ReplicaSealStatus replicaSealStatus) throws Exception {
+    super(clusterMapConfig, partition, isReplicaStopped, capacityBytes, replicaSealStatus);
     this.disk = Objects.requireNonNull(disk, "null disk");
   }
 
@@ -78,7 +78,7 @@ class AmbryServerReplica extends AmbryReplica {
     snapshot.put(REPLICA_DISK, getDiskId().getMountPath());
     snapshot.put(REPLICA_PATH, getReplicaPath());
     snapshot.put(CAPACITY_BYTES, getCapacityInBytes());
-    snapshot.put(REPLICA_WRITE_STATE, isSealed() ? PartitionState.READ_ONLY.name() : PartitionState.READ_WRITE.name());
+    snapshot.put(REPLICA_WRITE_STATE, ClusterMapUtils.convertReplicaSealStatusToPartitionState(getSealedStatus()));
     String replicaLiveness = UP;
     if (dataNodeId.getState() == HardwareState.UNAVAILABLE) {
       replicaLiveness = NODE_DOWN;

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/CloudReplica.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/CloudReplica.java
@@ -79,6 +79,11 @@ public class CloudReplica implements ReplicaId {
   }
 
   @Override
+  public boolean isPartiallySealed() {
+    return partitionId.getPartitionState().equals(PartitionState.PARTIAL_READ_WRITE);
+  }
+
+  @Override
   public JSONObject getSnapshot() {
     JSONObject snapshot = new JSONObject();
     snapshot.put(REPLICA_NODE, dataNodeId.getHostname() + ":" + dataNodeId.getPort());

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/CloudServiceReplica.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/CloudServiceReplica.java
@@ -39,7 +39,7 @@ class CloudServiceReplica extends AmbryReplica {
    */
   CloudServiceReplica(ClusterMapConfig clusterMapConfig, CloudServiceDataNode dataNode, AmbryPartition partition,
       long capacityBytes) throws Exception {
-    super(clusterMapConfig, partition, false, capacityBytes, false);
+    super(clusterMapConfig, partition, false, capacityBytes, ReplicaSealStatus.NOT_SEALED);
     this.dataNode = dataNode;
   }
 

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
@@ -174,6 +174,48 @@ public class ClusterMapUtils {
   }
 
   /**
+   * Returns the replica's {@link PartitionState} based on the specified {@link ReplicaSealStatus}.
+   * @param replicaSealStatus {@link ReplicaSealStatus} of the replica.
+   * @return PartitionState object.
+   */
+  public static PartitionState convertReplicaSealStatusToPartitionState(ReplicaSealStatus replicaSealStatus) {
+    PartitionState partitionState = null;
+    switch (replicaSealStatus) {
+      case SEALED:
+        partitionState = PartitionState.READ_ONLY;
+        break;
+      case PARTIALLY_SEALED:
+        partitionState = PartitionState.PARTIAL_READ_WRITE;
+        break;
+      case NOT_SEALED:
+        partitionState = PartitionState.READ_WRITE;
+        break;
+    }
+    return partitionState;
+  }
+
+  /**
+   * Returns the replica's {@link ReplicaSealStatus} based on the specified {@link PartitionState}.
+   * @param partitionState {@link PartitionState} object.
+   * @return ReplicaSealStatus object.
+   */
+  public static ReplicaSealStatus convertPartitionStateToReplicaSealSatus(PartitionState partitionState) {
+    ReplicaSealStatus replicaSealStatus = null;
+    switch (partitionState) {
+      case READ_ONLY:
+        replicaSealStatus = ReplicaSealStatus.SEALED;
+        break;
+      case PARTIAL_READ_WRITE:
+        replicaSealStatus = ReplicaSealStatus.PARTIALLY_SEALED;
+        break;
+      case READ_WRITE:
+        replicaSealStatus = ReplicaSealStatus.NOT_SEALED;
+        break;
+    }
+    return replicaSealStatus;
+  }
+
+  /**
    * Get the schema version associated with the given instance (if any).
    * @param instanceConfig the {@link InstanceConfig} associated with the interested instance.
    * @return the schema version of the information stored. If the field is absent in the InstanceConfig, the version

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
@@ -453,8 +453,9 @@ public class HelixClusterManager implements ClusterMap {
           // update disk capacity if bootstrap replica info contains disk capacity in bytes.
           targetDisk.setDiskCapacityInBytes(Long.parseLong(diskCapacityStr));
         }
-        bootstrapReplica =
-            new AmbryServerReplica(clusterMapConfig, currentPartition, targetDisk, true, replicaCapacity, false);
+        // A bootstrap replica is always ReplicaSealedStatus#NOT_SEALED.
+        bootstrapReplica = new AmbryServerReplica(clusterMapConfig, currentPartition, targetDisk, true, replicaCapacity,
+            ReplicaSealStatus.NOT_SEALED);
       } catch (Exception e) {
         logger.error("Failed to create bootstrap replica for partition {} on {} due to exception: ", partitionIdStr,
             instanceName, e);
@@ -1247,6 +1248,7 @@ public class HelixClusterManager implements ClusterMap {
       String instanceName = dataNodeConfig.getInstanceName();
       logger.info("Updating replicas info for existing node {}", instanceName);
       Set<String> sealedReplicas = dataNodeConfig.getSealedReplicas();
+      Set<String> partiallySealedReplicas = dataNodeConfig.getPartiallySealedReplicas();
       Set<String> stoppedReplicas = dataNodeConfig.getStoppedReplicas();
       AmbryDataNode dataNode = instanceNameToAmbryDataNode.get(instanceName);
       ConcurrentHashMap<String, AmbryReplica> currentReplicasOnNode = ambryDataNodeToAmbryReplicas.get(dataNode);
@@ -1283,7 +1285,8 @@ public class HelixClusterManager implements ClusterMap {
             // 1. directly add it into "replicasFromInstanceConfig" map
             replicasFromInstanceConfig.put(partitionName, existingReplica);
             // 2. update replica seal/stop state
-            updateReplicaStateAndOverrideIfNeeded(existingReplica, sealedReplicas, stoppedReplicas);
+            updateReplicaStateAndOverrideIfNeeded(existingReplica, sealedReplicas, partiallySealedReplicas,
+                stoppedReplicas);
           } else {
             // if this is a new replica and doesn't exist on node
             logger.info("Adding new replica {} to existing node {} in {}", partitionName, instanceName, dcName);
@@ -1308,9 +1311,9 @@ public class HelixClusterManager implements ClusterMap {
             } else {
               replica = new AmbryServerReplica(clusterMapConfig, mappedPartition, disk,
                   stoppedReplicas.contains(partitionName), replicaConfig.getReplicaCapacityInBytes(),
-                  sealedReplicas.contains(partitionName));
+                  resolveReplicaSealStatus(partitionName, sealedReplicas, partiallySealedReplicas));
             }
-            updateReplicaStateAndOverrideIfNeeded(replica, sealedReplicas, stoppedReplicas);
+            updateReplicaStateAndOverrideIfNeeded(replica, sealedReplicas, partiallySealedReplicas, stoppedReplicas);
             // add new created replica to "replicasFromInstanceConfig" map
             replicasFromInstanceConfig.put(partitionName, replica);
             // Put new replica into partition-to-replica map temporarily (this is to avoid any exception thrown within the
@@ -1342,24 +1345,17 @@ public class HelixClusterManager implements ClusterMap {
     }
 
     /**
-     * If partition override is enabled, we override replica SEAL/UNSEAL state based on partitionOverrideMap. If disabled,
-     * update replica state according to the info from {@link DataNodeConfig}.
+     * If partition override is enabled, we override replica's {@link ReplicaSealStatus} based on partitionOverrideMap.
+     * If disabled, update replica state according to the info from {@link DataNodeConfig}.
      * @param replica the {@link ReplicaId} whose states (seal,stop) should be updated.
      * @param sealedReplicas a collection of {@link ReplicaId}(s) that are in SEALED state.
+     * @param partiallySealedReplicas a collection of {@link ReplicaId}(s) that are in PARTIALLY_SEALED state.
      * @param stoppedReplicas a collection of {@link ReplicaId}(s) that are in STOPPED state.
      */
     private void updateReplicaStateAndOverrideIfNeeded(AmbryReplica replica, Collection<String> sealedReplicas,
-        Collection<String> stoppedReplicas) {
+        Collection<String> partiallySealedReplicas, Collection<String> stoppedReplicas) {
       String partitionName = replica.getPartitionId().toPathString();
-      boolean isSealed;
-      if (clusterMapConfig.clusterMapEnablePartitionOverride && partitionOverrideInfoMap.containsKey(partitionName)) {
-        isSealed = partitionOverrideInfoMap.get(partitionName)
-            .get(ClusterMapUtils.PARTITION_STATE)
-            .equals(ClusterMapUtils.READ_ONLY_STR);
-      } else {
-        isSealed = sealedReplicas.contains(partitionName);
-      }
-      replica.setSealedState(isSealed);
+      replica.setSealedStatus(resolveReplicaSealStatus(partitionName, sealedReplicas, partiallySealedReplicas));
       replica.setStoppedState(stoppedReplicas.contains(partitionName));
     }
 
@@ -1401,6 +1397,7 @@ public class HelixClusterManager implements ClusterMap {
         throws Exception {
       List<ReplicaId> addedReplicas = new ArrayList<>();
       Set<String> sealedReplicas = dataNodeConfig.getSealedReplicas();
+      Set<String> partiallySealedReplicas = dataNodeConfig.getPartiallySealedReplicas();
       Set<String> stoppedReplicas = dataNodeConfig.getStoppedReplicas();
       ambryDataNodeToAmbryReplicas.put(datanode, new ConcurrentHashMap<>());
       ambryDataNodeToAmbryDisks.put(datanode, ConcurrentHashMap.newKeySet());
@@ -1426,17 +1423,10 @@ public class HelixClusterManager implements ClusterMap {
           ensurePartitionAbsenceOnNodeAndValidateCapacity(mappedPartition, datanode,
               replicaConfig.getReplicaCapacityInBytes());
           // Create replica associated with this node and this partition
-          boolean isSealed = sealedReplicas.contains(partitionName);
-          if (clusterMapConfig.clusterMapEnablePartitionOverride && partitionOverrideInfoMap.containsKey(
-              partitionName)) {
-            // override sealed state if PartitionOverride is enabled.
-            isSealed = partitionOverrideInfoMap.get(partitionName)
-                .get(ClusterMapUtils.PARTITION_STATE)
-                .equals(ClusterMapUtils.READ_ONLY_STR);
-          }
           AmbryReplica replica =
               new AmbryServerReplica(clusterMapConfig, mappedPartition, disk, stoppedReplicas.contains(partitionName),
-                  replicaConfig.getReplicaCapacityInBytes(), isSealed);
+                  replicaConfig.getReplicaCapacityInBytes(),
+                  resolveReplicaSealStatus(partitionName, sealedReplicas, partiallySealedReplicas));
           ambryDataNodeToAmbryReplicas.get(datanode).put(mappedPartition.toPathString(), replica);
           addReplicasToPartition(mappedPartition, Collections.singletonList(replica));
           addedReplicas.add(replica);
@@ -1480,6 +1470,32 @@ public class HelixClusterManager implements ClusterMap {
               + "the capacity of an existing replica " + replica.getCapacityInBytes());
         }
       }
+    }
+
+    /**
+     * Resolve the {@link ReplicaSealStatus} of the replica belonging to the partition with the specified partitionName.
+     * @param partitionName Name of the partition.
+     * @param sealedReplicas {@link Collection} of partition names whose replicas are sealed.
+     * @param partiallySealedReplicas {@link Collection} of partition names whose replicas are partially sealed.
+     * @return ReplicaSealStatus object.
+     */
+    private ReplicaSealStatus resolveReplicaSealStatus(String partitionName, Collection<String> sealedReplicas,
+        Collection<String> partiallySealedReplicas) {
+      if (clusterMapConfig.clusterMapEnablePartitionOverride && partitionOverrideInfoMap.containsKey(partitionName)) {
+        if(partitionOverrideInfoMap.get(partitionName)
+            .get(ClusterMapUtils.PARTITION_STATE)
+            .equals(ClusterMapUtils.READ_ONLY_STR)) {
+          return ReplicaSealStatus.SEALED;
+        }
+      } else {
+        if(sealedReplicas.contains(partitionName)) {
+          return ReplicaSealStatus.SEALED;
+        }
+      }
+      if (partiallySealedReplicas.contains(partitionName)) {
+        return ReplicaSealStatus.PARTIALLY_SEALED;
+      }
+      return ReplicaSealStatus.NOT_SEALED;
     }
   }
 }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/Replica.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/Replica.java
@@ -121,6 +121,11 @@ class Replica implements ReplicaId {
   }
 
   @Override
+  public boolean isPartiallySealed() {
+    return partition.getPartitionState().equals(PartitionState.PARTIAL_READ_WRITE);
+  }
+
+  @Override
   public JSONObject getSnapshot() {
     JSONObject snapshot = new JSONObject();
     DataNodeId dataNodeId = getDataNodeId();
@@ -129,7 +134,8 @@ class Replica implements ReplicaId {
     snapshot.put(REPLICA_DISK, getDiskId().getMountPath());
     snapshot.put(REPLICA_PATH, getReplicaPath());
     snapshot.put(CAPACITY_BYTES, getCapacityInBytes());
-    snapshot.put(REPLICA_WRITE_STATE, isSealed() ? PartitionState.READ_ONLY.name() : PartitionState.READ_WRITE.name());
+    snapshot.put(REPLICA_WRITE_STATE,
+        ClusterMapUtils.convertPartitionStateToReplicaSealSatus(partition.partitionState));
     String replicaLiveness = UP;
     if (dataNodeId.getState() == HardwareState.UNAVAILABLE) {
       replicaLiveness = NODE_DOWN;

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/ClusterMapUtilsTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/ClusterMapUtilsTest.java
@@ -220,7 +220,7 @@ public class ClusterMapUtilsTest {
     for (MockPartitionId partitionId : toReset) {
       for (ReplicaId replicaId : partitionId.getReplicaIds()) {
         ((MockReplicaId) replicaId).markReplicaDownStatus(false);
-        ((MockReplicaId) replicaId).setSealedState(false);
+        ((MockReplicaId) replicaId).setReplicaSealStatus(ReplicaSealStatus.NOT_SEALED);
       }
     }
   }
@@ -381,7 +381,7 @@ public class ClusterMapUtilsTest {
     allPartitionIds.add(testedPart2);
 
     // one partition of "classBeingTested" is READ_ONLY
-    ((MockReplicaId) testedPart1.getReplicaIds().get(0)).setSealedState(true);
+    ((MockReplicaId) testedPart1.getReplicaIds().get(0)).setReplicaSealStatus(ReplicaSealStatus.SEALED);
     allPartitionIds.remove(testedPart1);
     expectedReturnForClassBeingTested.remove(testedPart1);
     verifyGetWritablePartition(psh, allPartitionIds, classBeingTested, expectedReturnForClassBeingTested, localDc);
@@ -389,7 +389,7 @@ public class ClusterMapUtilsTest {
         localDc);
 
     // all READ_ONLY
-    ((MockReplicaId) testedPart2.getReplicaIds().get(0)).setSealedState(true);
+    ((MockReplicaId) testedPart2.getReplicaIds().get(0)).setReplicaSealStatus(ReplicaSealStatus.SEALED);
     allPartitionIds.remove(testedPart2);
     expectedReturnForClassBeingTested.remove(testedPart2);
     verifyGetWritablePartition(psh, allPartitionIds, classBeingTested, expectedReturnForClassBeingTested, localDc);
@@ -401,8 +401,8 @@ public class ClusterMapUtilsTest {
     }
 
     //cleanup the cluster map
-    ((MockReplicaId) testedPart1.getReplicaIds().get(0)).setSealedState(false);
-    ((MockReplicaId) testedPart2.getReplicaIds().get(0)).setSealedState(false);
+    ((MockReplicaId) testedPart1.getReplicaIds().get(0)).setReplicaSealStatus(ReplicaSealStatus.NOT_SEALED);
+    ((MockReplicaId) testedPart2.getReplicaIds().get(0)).setReplicaSealStatus(ReplicaSealStatus.NOT_SEALED);
     allPartitionIds.add(testedPart1);
     allPartitionIds.add(testedPart2);
     expectedReturnForClassBeingTested.add(testedPart1);

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/DynamicClusterManagerComponentsTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/DynamicClusterManagerComponentsTest.java
@@ -178,21 +178,24 @@ public class DynamicClusterManagerComponentsTest {
 
     // AmbryReplica tests
     try {
-      new AmbryServerReplica(clusterMapConfig1, null, disk1, false, MAX_REPLICA_CAPACITY_IN_BYTES, false);
+      new AmbryServerReplica(clusterMapConfig1, null, disk1, false, MAX_REPLICA_CAPACITY_IN_BYTES,
+          ReplicaSealStatus.NOT_SEALED);
       fail("Replica initialization should fail with invalid arguments");
     } catch (NullPointerException e) {
       // OK
     }
 
     try {
-      new AmbryServerReplica(clusterMapConfig1, partition1, null, false, MAX_REPLICA_CAPACITY_IN_BYTES, false);
+      new AmbryServerReplica(clusterMapConfig1, partition1, null, false, MAX_REPLICA_CAPACITY_IN_BYTES,
+          ReplicaSealStatus.NOT_SEALED);
       fail("Replica initialization should fail with invalid arguments");
     } catch (NullPointerException e) {
       // OK
     }
 
     try {
-      new AmbryServerReplica(clusterMapConfig1, partition1, disk1, false, MAX_REPLICA_CAPACITY_IN_BYTES + 1, false);
+      new AmbryServerReplica(clusterMapConfig1, partition1, disk1, false, MAX_REPLICA_CAPACITY_IN_BYTES + 1,
+          ReplicaSealStatus.NOT_SEALED);
       fail("Replica initialization should fail with invalid arguments");
     } catch (IllegalStateException e) {
       // OK
@@ -200,19 +203,24 @@ public class DynamicClusterManagerComponentsTest {
 
     // Create a few replicas and make the mockClusterManagerCallback aware of the association.
     AmbryReplica replica1 =
-        new AmbryServerReplica(clusterMapConfig1, partition1, disk1, false, MAX_REPLICA_CAPACITY_IN_BYTES, false);
+        new AmbryServerReplica(clusterMapConfig1, partition1, disk1, false, MAX_REPLICA_CAPACITY_IN_BYTES,
+            ReplicaSealStatus.NOT_SEALED);
     mockClusterManagerCallback.addReplicaToPartition(partition1, replica1);
     AmbryReplica replica2 =
-        new AmbryServerReplica(clusterMapConfig1, partition2, disk1, false, MIN_REPLICA_CAPACITY_IN_BYTES, false);
+        new AmbryServerReplica(clusterMapConfig1, partition2, disk1, false, MIN_REPLICA_CAPACITY_IN_BYTES,
+            ReplicaSealStatus.NOT_SEALED);
     mockClusterManagerCallback.addReplicaToPartition(partition2, replica2);
     AmbryReplica replica3 =
-        new AmbryServerReplica(clusterMapConfig2, partition1, disk2, false, MIN_REPLICA_CAPACITY_IN_BYTES, false);
+        new AmbryServerReplica(clusterMapConfig2, partition1, disk2, false, MIN_REPLICA_CAPACITY_IN_BYTES,
+            ReplicaSealStatus.NOT_SEALED);
     mockClusterManagerCallback.addReplicaToPartition(partition1, replica3);
     AmbryReplica replica4 =
-        new AmbryServerReplica(clusterMapConfig2, partition2, disk2, false, MIN_REPLICA_CAPACITY_IN_BYTES, true);
+        new AmbryServerReplica(clusterMapConfig2, partition2, disk2, false, MIN_REPLICA_CAPACITY_IN_BYTES,
+            ReplicaSealStatus.SEALED);
     mockClusterManagerCallback.addReplicaToPartition(partition2, replica4);
     AmbryReplica replica5 =
-        new AmbryServerReplica(clusterMapConfig1, partition1, disk1, true, MIN_REPLICA_CAPACITY_IN_BYTES, false);
+        new AmbryServerReplica(clusterMapConfig1, partition1, disk1, true, MIN_REPLICA_CAPACITY_IN_BYTES,
+            ReplicaSealStatus.NOT_SEALED);
     mockClusterManagerCallback.addReplicaToPartition(partition1, replica5);
 
     sealedStateChangeCounter.incrementAndGet();
@@ -237,19 +245,19 @@ public class DynamicClusterManagerComponentsTest {
 
     assertEquals(partition1.getPartitionState(), PartitionState.READ_WRITE);
     assertEquals(partition2.getPartitionState(), PartitionState.READ_ONLY);
-    replica1.setSealedState(true);
+    replica1.setSealedStatus(ReplicaSealStatus.SEALED);
     sealedStateChangeCounter.incrementAndGet();
     assertEquals(partition1.getPartitionState(), PartitionState.READ_ONLY);
-    replica3.setSealedState(true);
+    replica3.setSealedStatus(ReplicaSealStatus.SEALED);
     sealedStateChangeCounter.incrementAndGet();
     assertEquals(partition1.getPartitionState(), PartitionState.READ_ONLY);
-    replica1.setSealedState(false);
+    replica1.setSealedStatus(ReplicaSealStatus.NOT_SEALED);
     sealedStateChangeCounter.incrementAndGet();
     assertEquals(partition1.getPartitionState(), PartitionState.READ_ONLY);
-    replica3.setSealedState(false);
+    replica3.setSealedStatus(ReplicaSealStatus.NOT_SEALED);
     sealedStateChangeCounter.incrementAndGet();
     assertEquals(partition1.getPartitionState(), PartitionState.READ_WRITE);
-    replica4.setSealedState(false);
+    replica4.setSealedStatus(ReplicaSealStatus.NOT_SEALED);
     sealedStateChangeCounter.incrementAndGet();
     assertEquals(partition2.getPartitionState(), PartitionState.READ_WRITE);
 

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockClusterAgentsFactory.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockClusterAgentsFactory.java
@@ -105,7 +105,7 @@ public class MockClusterAgentsFactory implements ClusterAgentsFactory {
             throw new IllegalArgumentException("Not MockReplicaId");
           }
           MockReplicaId mockReplicaId = (MockReplicaId) replicaId;
-          mockReplicaId.setSealedState(isSealed);
+          mockReplicaId.setReplicaSealStatus(isSealed ? ReplicaSealStatus.SEALED : ReplicaSealStatus.NOT_SEALED);
           return true;
         }
 

--- a/ambry-server/src/test/java/com/github/ambry/server/AmbryServerRequestsTest.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/AmbryServerRequestsTest.java
@@ -24,6 +24,7 @@ import com.github.ambry.clustermap.MockReplicaId;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.clustermap.ReplicaEventType;
 import com.github.ambry.clustermap.ReplicaId;
+import com.github.ambry.clustermap.ReplicaSealStatus;
 import com.github.ambry.clustermap.ReplicaState;
 import com.github.ambry.clustermap.ReplicaStatusDelegate;
 import com.github.ambry.clustermap.ReplicaType;
@@ -1508,7 +1509,7 @@ public class AmbryServerRequestsTest extends ReplicationTestHelper {
    */
   private void changePartitionState(PartitionId id, boolean seal) {
     MockReplicaId replicaId = (MockReplicaId) findReplica(id);
-    replicaId.setSealedState(seal);
+    replicaId.setReplicaSealStatus(seal ? ReplicaSealStatus.SEALED : ReplicaSealStatus.NOT_SEALED);
     ((MockPartitionId) id).resolvePartitionStatus();
   }
 

--- a/ambry-store/src/test/java/com/github/ambry/store/StoreTestUtils.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/StoreTestUtils.java
@@ -20,6 +20,7 @@ import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.DiskId;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.clustermap.ReplicaId;
+import com.github.ambry.clustermap.ReplicaSealStatus;
 import com.github.ambry.clustermap.ReplicaType;
 import com.github.ambry.config.StoreConfig;
 import com.github.ambry.config.VerifiableProperties;
@@ -79,7 +80,7 @@ class StoreTestUtils {
     private long capacity;
     private String filePath;
     private PartitionId partitionId;
-    private boolean isSealed = false;
+    private ReplicaSealStatus replicaSealStatus = ReplicaSealStatus.NOT_SEALED;
 
     MockReplicaId(String storeId, long capacity, String filePath) {
       this.capacity = capacity;
@@ -131,7 +132,12 @@ class StoreTestUtils {
 
     @Override
     public boolean isSealed() {
-      return isSealed;
+      return replicaSealStatus == ReplicaSealStatus.SEALED;
+    }
+
+    @Override
+    public boolean isPartiallySealed() {
+      return replicaSealStatus == ReplicaSealStatus.PARTIALLY_SEALED;
     }
 
     @Override
@@ -154,8 +160,12 @@ class StoreTestUtils {
       return ReplicaType.DISK_BACKED;
     }
 
-    public void setSealedState(boolean isSealed) {
-      this.isSealed = isSealed;
+    /**
+     * Set the {@link ReplicaSealStatus} for this replica.
+     * @param replicaSealStatus {@link ReplicaSealStatus} to set.
+     */
+    public void setSealedState(ReplicaSealStatus replicaSealStatus) {
+      this.replicaSealStatus = replicaSealStatus;
     }
   }
 


### PR DESCRIPTION
Introducing a partially sealed state in ReplicaID will enable BlobStore implementations to make replicas partially sealed. 
In order to manage three possible states of a replica this PR also introduces the ReplicaSealStatus enum.
