### PR TITLE
[Efficient Metadata Operations] Add logic in BlobStore to mark a replica as partially sealed when it crosses threshold.

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/clustermap/ReplicaId.java
+++ b/ambry-api/src/main/java/com/github/ambry/clustermap/ReplicaId.java
@@ -96,6 +96,13 @@ public interface ReplicaId extends Resource {
   boolean isPartiallySealed();
 
   /**
+   * @return true if this replica's {@link ReplicaSealStatus} is {@link ReplicaSealStatus#NOT_SEALED}.
+   */
+  default boolean isUnsealed() {
+    return !(isSealed() || isPartiallySealed());
+  }
+
+  /**
    * @return the {@code ReplicaType} for this replica.
    */
   ReplicaType getReplicaType();

--- a/ambry-api/src/main/java/com/github/ambry/clustermap/ReplicaStatusDelegate.java
+++ b/ambry-api/src/main/java/com/github/ambry/clustermap/ReplicaStatusDelegate.java
@@ -44,8 +44,8 @@ public class ReplicaStatusDelegate {
    * @return {@code true} if replica is successfully partial-sealed. {@code false} if not.
    */
   public boolean partialSeal(ReplicaId replicaId) {
-    // TODO Under implementation.
-    return false;
+    // TODO Once the partial seal logic is complete end to end, this should set the partial seal state.
+    return clusterParticipant.setReplicaSealedState(replicaId, false);
   }
 
   /**
@@ -55,16 +55,6 @@ public class ReplicaStatusDelegate {
    */
   public boolean unseal(ReplicaId replicaId) {
     return clusterParticipant.setReplicaSealedState(replicaId, false);
-  }
-
-  /**
-   * Sets replicaId to partial-unsealed status. Unsealed replicas are READ_WRITE for all blobs.
-   * @param replicaId the {@link ReplicaId} whose status would be set to read write.
-   * @return {@code true} if replica is successfully unsealed. {@code false} if not.
-   */
-  public boolean partialUnseal(ReplicaId replicaId) {
-    // TODO Under implementation.
-    return false;
   }
 
   /**

--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -324,7 +324,7 @@ public class StoreConfig {
    * partially writable from RW.
    */
   @Config(storePartialWriteEnableSizeThresholdPercentageName)
-  @Default("50")
+  @Default("95")
   public final int storePartialWriteEnableSizeThresholdPercentage;
   public static final String storePartialWriteEnableSizeThresholdPercentageName =
       "store.partial.write.enable.size.threshold.percentage";

--- a/ambry-store/src/main/java/com/github/ambry/store/StoreMetrics.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StoreMetrics.java
@@ -53,8 +53,10 @@ public class StoreMetrics {
   public final Counter overflowReadError;
   public final Counter sealSetError;
   public final Counter unsealSetError;
+  public final Counter partialSealSetError;
   public final Counter sealDoneCount;
   public final Counter unsealDoneCount;
+  public final Counter partialSealDoneCount;
   public final Counter indexBasedTokenResetCount;
   public final Counter journalBasedTokenResetCount;
   public final Counter resetKeyFoundInCurrentIndex;
@@ -155,8 +157,10 @@ public class StoreMetrics {
     overflowReadError = registry.counter(MetricRegistry.name(Log.class, name + "OverflowReadError"));
     sealSetError = registry.counter(MetricRegistry.name(BlobStore.class, name + "SealSetError"));
     unsealSetError = registry.counter(MetricRegistry.name(BlobStore.class, name + "UnsealSetError"));
+    partialSealSetError = registry.counter(MetricRegistry.name(BlobStore.class, name + "PartialSealSetError"));
     sealDoneCount = registry.counter(MetricRegistry.name(BlobStore.class, name + "SealDoneCount"));
     unsealDoneCount = registry.counter(MetricRegistry.name(BlobStore.class, name + "UnsealDoneCount"));
+    partialSealDoneCount = registry.counter(MetricRegistry.name(BlobStore.class, name + "PartialSealDoneCount"));
     indexBasedTokenResetCount =
         registry.counter(MetricRegistry.name(PersistentIndex.class, name + "IndexBasedTokenResetCount"));
     journalBasedTokenResetCount =


### PR DESCRIPTION
This PR implements the logic in BlobStore to mark a replica as partially sealed when it crosses the threshold. Do note that ReplicaStatusDelegate still doesn't do the partial update in HelixPartiticipant, so this doesn't change the end to end logic yet.