### PR TITLE
[DR] Create RecoveryThread

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/ReplicationConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/ReplicationConfig.java
@@ -266,6 +266,17 @@ public class ReplicationConfig {
   public final String replicationThreadType;
 
   /**
+   * The replication manager used to restore backups from cloud
+   * DEFAULT_REPLICATION_THREAD as the name suggests is the current one.
+   * BACKUP_CHECKER_THREAD is the one that checks for missing blobs in backup by comparing blobs from on-prem servers.
+   */
+  public static final String RECOVERY_THREAD_TYPE = "recovery.thread.type";
+  public static final String DEFAULT_RECOVERY_THREAD = "com.github.ambry.replication.ReplicaThread";
+  public static final String CUSTOM_RECOVERY_THREAD = "com.github.ambry.replication.RecoveryThread";
+  @Config(RECOVERY_THREAD_TYPE)
+  public final String recoveryThreadType;
+
+  /**
    * Config for file manager class for backup checker
    */
   public static final String BACKUP_CHECKER_FILE_MANAGER_TYPE = "backup.checker.file.manager.type";
@@ -297,6 +308,7 @@ public class ReplicationConfig {
         DEFAULT_BACKUP_CHECKER_REPORT_DIR);
     backupCheckFileManagerType = verifiableProperties.getString(BACKUP_CHECKER_FILE_MANAGER_TYPE,
         DEFAULT_BACKUP_CHECKER_FILE_MANAGER);
+    recoveryThreadType = verifiableProperties.getString(RECOVERY_THREAD_TYPE, DEFAULT_RECOVERY_THREAD);
     replicationThreadType = verifiableProperties.getString(REPLICATION_THREAD_TYPE, DEFAULT_REPLICATION_THREAD);
     replicationStoreTokenFactory =
         verifiableProperties.getString("replication.token.factory", "com.github.ambry.store.StoreFindTokenFactory");

--- a/ambry-api/src/main/java/com/github/ambry/config/ReplicationConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/ReplicationConfig.java
@@ -267,8 +267,8 @@ public class ReplicationConfig {
 
   /**
    * The replication manager used to restore backups from cloud
-   * DEFAULT_REPLICATION_THREAD as the name suggests is the current one.
-   * BACKUP_CHECKER_THREAD is the one that checks for missing blobs in backup by comparing blobs from on-prem servers.
+   * DEFAULT_RECOVERY_THREAD as the name suggests is the current one.
+   * CUSTOM_RECOVERY_THREAD reports the progress of recovery in addition to other things that replicaThread does.
    */
   public static final String RECOVERY_THREAD_TYPE = "recovery.thread.type";
   public static final String DEFAULT_RECOVERY_THREAD = "com.github.ambry.replication.ReplicaThread";

--- a/ambry-replication/src/main/java/com/github/ambry/replication/BackupCheckerFileManager.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/BackupCheckerFileManager.java
@@ -15,8 +15,6 @@ package com.github.ambry.replication;
 
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.config.ReplicationConfig;
-import java.nio.file.StandardOpenOption;
-import java.util.EnumSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,7 +24,8 @@ import org.slf4j.LoggerFactory;
 public class BackupCheckerFileManager {
   private final Logger logger = LoggerFactory.getLogger(BackupCheckerFileManager.class);
 
-  public BackupCheckerFileManager(ReplicationConfig replicationConfig, MetricRegistry metricRegistry) {
+  public BackupCheckerFileManager(String fileManagerId, ReplicationConfig replicationConfig,
+      MetricRegistry metricRegistry) {
   }
 
   /**

--- a/ambry-replication/src/main/java/com/github/ambry/replication/BackupCheckerThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/BackupCheckerThread.java
@@ -75,8 +75,9 @@ public class BackupCheckerThread extends ReplicaThread {
         replicatingOverSsl, datacenterName, responseHandler, time, replicaSyncUpManager, skipPredicate,
         leaderBasedReplicationAdmin);
     try {
-      // TODO: Move the fileManager up the hierarchy so that we have a single file mgr and a singe fd-cache
+      // TODO: Move the fileManager up the hierarchy so that we have a single file mgr and a single fd-cache
       // TODO: Or disable emitting metrics in the cache. One concern is we could be emitting too many metrics.
+      // TODO: ReplicaThreads do not operate on the same set of files so a shared fd-cache or individual one doesn't matter.
       fileManager = Utils.getObj(replicationConfig.backupCheckFileManagerType,
           "BackupCheckerThread" + threadName, replicationConfig, metricRegistry);
     } catch (ReflectiveOperationException e) {

--- a/ambry-replication/src/main/java/com/github/ambry/replication/BackupCheckerThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/BackupCheckerThread.java
@@ -34,7 +34,6 @@ import com.github.ambry.store.Transformer;
 import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
 import java.io.File;
-import java.nio.file.StandardOpenOption;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
@@ -54,13 +53,12 @@ import org.slf4j.LoggerFactory;
  * 2> The backup may be ahead of the replica. This can happen if the replica is lagging behind its peers. If we recover
  * from such a backup, we'd still be consistent from the user's point of view. The lagging replica must catch up with
  * its peers and this checker will detect such lagging replicas as well.
- * TODO: Redirect to a different file
- * TODO: Testing on sample partitions
  */
 public class BackupCheckerThread extends ReplicaThread {
 
   private final Logger logger = LoggerFactory.getLogger(BackupCheckerThread.class);
   protected final BackupCheckerFileManager fileManager;
+  protected final ReplicationConfig _replicationConfig;
   public static final String DR_Verifier_Keyword = "dr";
   public static final String MISSING_KEYS_FILE = "missingKeys";
   public static final String REPLICA_STATUS_FILE = "replicaCheckStatus";
@@ -82,6 +80,7 @@ public class BackupCheckerThread extends ReplicaThread {
       logger.error("Failed to create file manager. ", e.toString());
       throw new RuntimeException(e);
     }
+    this._replicationConfig = replicationConfig;
     logger.info("Created BackupCheckerThread {}", threadName);
   }
 
@@ -268,7 +267,7 @@ public class BackupCheckerThread extends ReplicaThread {
    * @return Returns a concatenated file path
    */
   protected String getFilePath(RemoteReplicaInfo remoteReplicaInfo, String fileName) {
-    return String.join(File.separator,
+    return String.join(File.separator, this._replicationConfig.backupCheckerReportDir,
         Long.toString(remoteReplicaInfo.getReplicaId().getPartitionId().getId()),
         remoteReplicaInfo.getReplicaId().getDataNodeId().getHostname(),
         fileName);

--- a/ambry-replication/src/main/java/com/github/ambry/replication/BackupCheckerThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/BackupCheckerThread.java
@@ -75,7 +75,8 @@ public class BackupCheckerThread extends ReplicaThread {
         replicatingOverSsl, datacenterName, responseHandler, time, replicaSyncUpManager, skipPredicate,
         leaderBasedReplicationAdmin);
     try {
-      fileManager = Utils.getObj(replicationConfig.backupCheckFileManagerType, replicationConfig, metricRegistry);
+      fileManager = Utils.getObj(replicationConfig.backupCheckFileManagerType,
+          "BackupCheckerThread" + threadName, replicationConfig, metricRegistry);
     } catch (ReflectiveOperationException e) {
       logger.error("Failed to create file manager. ", e.toString());
       throw new RuntimeException(e);

--- a/ambry-replication/src/main/java/com/github/ambry/replication/BackupCheckerThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/BackupCheckerThread.java
@@ -75,6 +75,8 @@ public class BackupCheckerThread extends ReplicaThread {
         replicatingOverSsl, datacenterName, responseHandler, time, replicaSyncUpManager, skipPredicate,
         leaderBasedReplicationAdmin);
     try {
+      // TODO: Move the fileManager up the hierarchy so that we have a single file mgr and a singe fd-cache
+      // TODO: Or disable emitting metrics in the cache. One concern is we could be emitting too many metrics.
       fileManager = Utils.getObj(replicationConfig.backupCheckFileManagerType,
           "BackupCheckerThread" + threadName, replicationConfig, metricRegistry);
     } catch (ReflectiveOperationException e) {

--- a/ambry-replication/src/main/java/com/github/ambry/replication/RecoveryThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/RecoveryThread.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2023 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.replication;
+
+import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.clustermap.DataNodeId;
+import com.github.ambry.clustermap.ReplicaSyncUpManager;
+import com.github.ambry.commons.ResponseHandler;
+import com.github.ambry.config.ReplicationConfig;
+import com.github.ambry.network.ConnectionPool;
+import com.github.ambry.network.NetworkClient;
+import com.github.ambry.notification.NotificationSystem;
+import com.github.ambry.store.MessageInfo;
+import com.github.ambry.store.StoreKeyConverter;
+import com.github.ambry.store.Transformer;
+import com.github.ambry.utils.Time;
+import com.github.ambry.utils.Utils;
+import java.io.File;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Recovery thread restores backup from cloud and reports its status
+ */
+public class RecoveryThread extends ReplicaThread {
+  private final Logger logger = LoggerFactory.getLogger(RecoveryThread.class);
+  protected final BackupCheckerFileManager fileManager;
+  protected final ReplicationConfig _replicationConfig;
+  public static final String RECOVERY_STATUS_FILE = "recoveryStatusFile";
+
+  public RecoveryThread(String threadName, FindTokenHelper findTokenHelper, ClusterMap clusterMap,
+      AtomicInteger correlationIdGenerator, DataNodeId dataNodeId, ConnectionPool connectionPool, NetworkClient networkClient,
+      ReplicationConfig replicationConfig, ReplicationMetrics replicationMetrics, NotificationSystem notification,
+      StoreKeyConverter storeKeyConverter, Transformer transformer, MetricRegistry metricRegistry,
+      boolean replicatingOverSsl, String datacenterName, ResponseHandler responseHandler, Time time,
+      ReplicaSyncUpManager replicaSyncUpManager, Predicate<MessageInfo> skipPredicate,
+      ReplicationManager.LeaderBasedReplicationAdmin leaderBasedReplicationAdmin) {
+    super(threadName, findTokenHelper, clusterMap, correlationIdGenerator, dataNodeId, connectionPool, networkClient,
+        replicationConfig, replicationMetrics, notification, storeKeyConverter, transformer, metricRegistry,
+        replicatingOverSsl, datacenterName, responseHandler, time, replicaSyncUpManager, skipPredicate,
+        leaderBasedReplicationAdmin);
+    try {
+      fileManager = Utils.getObj(replicationConfig.backupCheckFileManagerType, replicationConfig, metricRegistry);
+    } catch (ReflectiveOperationException e) {
+      logger.error("Failed to create file manager. ", e.toString());
+      throw new RuntimeException(e);
+    }
+    this._replicationConfig = replicationConfig;
+    logger.info("Created RecoveryThread {}", threadName);
+  }
+
+  /**
+   * Prints recovery progress when recovering from cloud
+   * @param remoteReplicaInfo Info about remote replica
+   * @param exchangeMetadataResponse Metadata response object
+   */
+  @Override
+  protected void logReplicationStatus(RemoteReplicaInfo remoteReplicaInfo,
+      ExchangeMetadataResponse exchangeMetadataResponse) {
+    // This will help us know when to stop recovery process
+    String text = String.format("%s | ReplicaType = %s | Token = %s | localLagFromRemoteInBytes = %s \n",
+        remoteReplicaInfo, remoteReplicaInfo.getLocalReplicaId().getReplicaType(),
+        remoteReplicaInfo.getToken().toString(),
+        exchangeMetadataResponse.localLagFromRemoteInBytes);
+    fileManager.truncateAndWriteToFile(getFilePath(remoteReplicaInfo, RECOVERY_STATUS_FILE), text);
+  }
+
+  /**
+   * Returns a concatenated file path
+   * @param remoteReplicaInfo Info about remote replica
+   * @param fileName Name of file to write text to
+   * @return Returns a concatenated file path
+   */
+  protected String getFilePath(RemoteReplicaInfo remoteReplicaInfo, String fileName) {
+    return String.join(File.separator, this._replicationConfig.backupCheckerReportDir,
+        Long.toString(remoteReplicaInfo.getReplicaId().getPartitionId().getId()),
+        fileName);
+  }
+}

--- a/ambry-replication/src/main/java/com/github/ambry/replication/RecoveryThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/RecoveryThread.java
@@ -41,7 +41,7 @@ public class RecoveryThread extends ReplicaThread {
   private final Logger logger = LoggerFactory.getLogger(RecoveryThread.class);
   protected final BackupCheckerFileManager fileManager;
   protected final ReplicationConfig _replicationConfig;
-  public static final String RECOVERY_STATUS_FILE = "recoveryStatusFile";
+  public static final String RECOVERY_STATUS_FILE = "cloudReplicaRecoveryStatusFile";
 
   public RecoveryThread(String threadName, FindTokenHelper findTokenHelper, ClusterMap clusterMap,
       AtomicInteger correlationIdGenerator, DataNodeId dataNodeId, ConnectionPool connectionPool, NetworkClient networkClient,

--- a/ambry-replication/src/main/java/com/github/ambry/replication/RecoveryThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/RecoveryThread.java
@@ -55,7 +55,8 @@ public class RecoveryThread extends ReplicaThread {
         replicatingOverSsl, datacenterName, responseHandler, time, replicaSyncUpManager, skipPredicate,
         leaderBasedReplicationAdmin);
     try {
-      fileManager = Utils.getObj(replicationConfig.backupCheckFileManagerType, replicationConfig, metricRegistry);
+      fileManager = Utils.getObj(replicationConfig.backupCheckFileManagerType,
+          "RecoveryThread" + threadName, replicationConfig, metricRegistry);
     } catch (ReflectiveOperationException e) {
       logger.error("Failed to create file manager. ", e.toString());
       throw new RuntimeException(e);

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -250,6 +250,7 @@ public class ReplicaThread implements Runnable {
   /**
    * Logs replication progress of local node against some remote node
    * @param remoteReplicaInfo remote replica information
+   * @param exchangeMetadataResponse metadata response object
    */
   protected void logReplicationStatus(RemoteReplicaInfo remoteReplicaInfo,
       ExchangeMetadataResponse exchangeMetadataResponse) {

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
@@ -361,7 +361,7 @@ public abstract class ReplicationEngine implements ReplicationAPI {
       NotificationSystem notification, StoreKeyConverter storeKeyConverter, Transformer transformer,
       MetricRegistry metricRegistry, boolean replicatingOverSsl, String datacenterName, ResponseHandler responseHandler,
       Time time, ReplicaSyncUpManager replicaSyncUpManager, Predicate<MessageInfo> skipPredicate,
-      ReplicationManager.LeaderBasedReplicationAdmin leaderBasedReplicationAdmin) {
+      LeaderBasedReplicationAdmin leaderBasedReplicationAdmin) {
       return new ReplicaThread(threadName, tokenHelper, clusterMap, correlationIdGenerator, dataNodeId,
           connectionPool, networkClient, replicationConfig, replicationMetrics, notification,
           storeKeyConverter, transformer, metricRegistry, replicatingOverSsl, datacenterName,
@@ -574,7 +574,7 @@ public abstract class ReplicationEngine implements ReplicationAPI {
   /**
    * To co-ordinate replication between leader and standby replicas of a partition during leader based replication.
    */
-  class LeaderBasedReplicationAdmin {
+  protected class LeaderBasedReplicationAdmin {
 
     //Maintains the list of leader partitions on local node and their corresponding peer leaders in remote data centers
     private final Map<String, Set<ReplicaId>> leaderPartitionToPeerLeaderReplicas = new HashMap<>();

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationManager.java
@@ -124,7 +124,7 @@ public class ReplicationManager extends ReplicationEngine {
       NotificationSystem notification, StoreKeyConverter storeKeyConverter, Transformer transformer,
       MetricRegistry metricRegistry, boolean replicatingOverSsl, String datacenterName, ResponseHandler responseHandler,
       Time time, ReplicaSyncUpManager replicaSyncUpManager, Predicate<MessageInfo> skipPredicate,
-      ReplicationManager.LeaderBasedReplicationAdmin leaderBasedReplicationAdmin) {
+      LeaderBasedReplicationAdmin leaderBasedReplicationAdmin) {
     switch(replicationConfig.replicationThreadType) {
       case ReplicationConfig.BACKUP_CHECKER_THREAD:
         return new BackupCheckerThread(threadName, tokenHelper, clusterMap, correlationIdGenerator, dataNodeId,


### PR DESCRIPTION
RecoveryThread is a thin extension of ReplicaThread. It just reports the status of recovery from cloud. This can help us know when to pause recovery.