### PR TITLE
Revert "Replication Optimization: Treating deleted put record's size same as delete  (#2297)"

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -531,19 +531,6 @@ public class StoreConfig {
   public static final String storeRebuildTokenBasedOnCompactionHistoryName =
       "store.rebuild.token.based.on.compaction.history";
 
-  /**
-   * If true, then in findEntriesSince method, use Delete entry's size for a deleted Put entry. This is useful for replication.
-   * In replication, when handling ReplicaMetadataRequest, server would scan through index segments. One Put entry could be
-   * as big as 4MB, but if this Put entry is already deleted, then in the requester server side it will do nothing. This is bad
-   * because we are using one roundtrip to bypass on blob id.
-   * Set this to true would help mitigate this issue. We know the put's final state is delete and the requester server won't
-   * do anything, then we just move on to scan more entries.
-   * @TODO: there is a but in the implementation that returns too many blob ids in one request.
-   */
-  @Config(storeDeletedPutAsDeleteInFindEntriesName)
-  public final boolean storeDeletedPutAsDeleteInFindEntries;
-  public static final String storeDeletedPutAsDeleteInFindEntriesName = "store.deleted.put.as.delete.in.find.entries";
-
   public StoreConfig(VerifiableProperties verifiableProperties) {
 
     storeKeyFactory = verifiableProperties.getString("store.key.factory", "com.github.ambry.commons.BlobIdFactory");
@@ -675,8 +662,5 @@ public class StoreConfig {
       storePartitionsToRebuildTokenBasedOnCompactionHistory =
           Stream.of(partitions.split(",")).map(Long::parseLong).collect(Collectors.toList());
     }
-
-    storeDeletedPutAsDeleteInFindEntries =
-        verifiableProperties.getBoolean(storeDeletedPutAsDeleteInFindEntriesName, false);
   }
 }

--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/DeleteMessageFormatInputStream.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/DeleteMessageFormatInputStream.java
@@ -67,19 +67,4 @@ public class DeleteMessageFormatInputStream extends MessageFormatInputStream {
     messageLength = buffer.capacity();
     buffer.flip();
   }
-
-  /**
-   * Only used in test. Return the {@link DeleteMessageFormatInputStream} size for the given {@code key}.
-   * @param key The {@link StoreKey}
-   * @return The size of {@link DeleteMessageFormatInputStream}
-   */
-  public static long getDeleteMessageFormatInputStreamSize(StoreKey key) {
-    try {
-      int headerSize = MessageFormatRecord.getHeaderSizeForVersion(MessageFormatRecord.headerVersionToUse);
-      int deleteRecordSize = MessageFormatRecord.Update_Format_V3.getRecordSize(SubRecord.Type.DELETE);
-      return headerSize + key.sizeInBytes() + deleteRecordSize;
-    } catch (MessageFormatException e) {
-      throw new IllegalArgumentException("Failed to get DeleteMessageFormatInputStreamSize for key " + key, e);
-    }
-  }
 }

--- a/ambry-store/src/test/java/com/github/ambry/store/CuratedLogIndexState.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CuratedLogIndexState.java
@@ -75,8 +75,8 @@ class CuratedLogIndexState {
   static final long DELAY_BETWEEN_LAST_MODIFIED_TIMES_MS = 10 * Time.MsPerSec;
   static final StoreKeyFactory STORE_KEY_FACTORY;
   // deliberately do not divide the capacities perfectly.
-  static long PUT_RECORD_SIZE = 53;
-  static long DELETE_RECORD_SIZE = 29;
+  static final long PUT_RECORD_SIZE = 53;
+  static final long DELETE_RECORD_SIZE = 29;
   static final long TTL_UPDATE_RECORD_SIZE = 37;
   static final long UNDELETE_RECORD_SIZE = 29;
 


### PR DESCRIPTION
This reverts commit dc51de39d882cc2a6d2c9c65166535a99d3cd91e.

We've found some bugs in this PR that makes GetRequests extremely huge and it breaks the server in replication. Now that the nonblocking network client would fix the slowness in cross-colo replication, we might as well just disable this feature by removing the code all together.
