### PR TITLE
Revert "Add a new FindMissingKey implementation to make it faster (#2213)"

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -339,7 +339,6 @@ public class StoreConfig {
   public static final String storePartialWriteToReadWriteEnableSizeThresholdPercentageDeltaName =
       "store.partial.write.to.read.write.enable.size.threshold.percentage.delta";
 
-
   /**
    * Specifies the minimum number of seconds before a blob's current expiry time (creation time + TTL) that the current
    * time has to be in order for a TTL update operation on the blob to succeed.
@@ -484,27 +483,6 @@ public class StoreConfig {
   public final int storeDiskIoReservoirTimeWindowMs;
 
   /**
-   * True to enable batch mode in findMissingKeys.
-   * @TODO: There is a bug in the implementation that ignores some keys
-   */
-  @Config(storeEnableFindMissingKeysInBatchModeName)
-  @Default("false")
-  public final boolean storeEnableFindMissingKeysInBatchMode;
-  public static final String storeEnableFindMissingKeysInBatchModeName = "store.enable.find.missing.keys.in.batch.mode";
-
-  @Config(storeCacheSizeForFindMissingKeysInBatchModeName)
-  @Default("3")
-  public final int storeCacheSizeForFindMissingKeysInBatchMode;
-  public static final String storeCacheSizeForFindMissingKeysInBatchModeName =
-      "store.cache.size.for.find.missing.keys.in.batch.mode";
-
-  @Config(storeNumOfCacheMissForFindMissingKeysInBatchModeName)
-  @Default("5")
-  public final int storeNumOfCacheMissForFindMissingKeysInBatchMode;
-  public static final String storeNumOfCacheMissForFindMissingKeysInBatchModeName =
-      "store.num.of.cache.miss.for.find.missing.keys.in.batch.mode";
-
-  /**
    * How many days of compactionlogs we have to read from disk to build the compaction history
    */
   @Config(storeCompactionHistoryInDayName)
@@ -645,12 +623,6 @@ public class StoreConfig {
             Integer.MAX_VALUE);
     storeDiskIoReservoirTimeWindowMs =
         verifiableProperties.getIntInRange("store.disk.io.reservoir.time.window.ms", 200, 0, Integer.MAX_VALUE);
-    storeEnableFindMissingKeysInBatchMode =
-        verifiableProperties.getBoolean(storeEnableFindMissingKeysInBatchModeName, false);
-    storeCacheSizeForFindMissingKeysInBatchMode =
-        verifiableProperties.getIntInRange(storeCacheSizeForFindMissingKeysInBatchModeName, 3, 1, 100);
-    storeNumOfCacheMissForFindMissingKeysInBatchMode =
-        verifiableProperties.getIntInRange(storeNumOfCacheMissForFindMissingKeysInBatchModeName, 5, 3, 100);
     storeCompactionHistoryInDay = verifiableProperties.getIntInRange(storeCompactionHistoryInDayName, 21, 1, 365);
     storeRebuildTokenBasedOnCompactionHistory =
         verifiableProperties.getBoolean(storeRebuildTokenBasedOnCompactionHistoryName, false);

--- a/ambry-api/src/main/java/com/github/ambry/store/Store.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/Store.java
@@ -13,7 +13,6 @@
  */
 package com.github.ambry.store;
 
-import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.ReplicaState;
 import com.github.ambry.replication.FindToken;
 import java.util.EnumSet;
@@ -95,22 +94,10 @@ public interface Store {
   /**
    * Finds all the keys that are not present in the store from the input keys
    * @param keys The list of keys that need to be checked for existence
-   * @param sourceDataNodeId The {@link DataNodeId} that we are replicating from, that calls this method. Set to null if
-   *                         this is not called from a replication thread.
    * @return The list of keys that are not present in the store
    * @throws StoreException
    */
-  Set<StoreKey> findMissingKeys(List<StoreKey> keys, DataNodeId sourceDataNodeId) throws StoreException;
-
-  /**
-   * Finds all the keys that are not present in the store from the input keys
-   * @param keys The list of keys that need to be checked for existence
-   * @return The list of keys that are not present in the store
-   * @throws StoreException
-   */
-  default Set<StoreKey> findMissingKeys(List<StoreKey> keys) throws StoreException {
-    return findMissingKeys(keys, null);
-  }
+  Set<StoreKey> findMissingKeys(List<StoreKey> keys) throws StoreException;
 
   /**
    * Return {@link MessageInfo} of given key. This method will only be used in replication thread.

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobStore.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobStore.java
@@ -15,7 +15,6 @@ package com.github.ambry.cloud;
 
 import com.codahale.metrics.Timer;
 import com.github.ambry.clustermap.ClusterMap;
-import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.clustermap.ReplicaState;
 import com.github.ambry.commons.BlobId;
@@ -1255,7 +1254,7 @@ class CloudBlobStore implements Store {
   }
 
   @Override
-  public Set<StoreKey> findMissingKeys(List<StoreKey> keys, DataNodeId sourceDataNodeId) throws StoreException {
+  public Set<StoreKey> findMissingKeys(List<StoreKey> keys) throws StoreException {
     checkStarted();
     // Check existence of keys in cloud metadata
     // Note that it is ok to refer cache here, because all we are doing is eliminating blobs that were seen before and

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -52,6 +52,7 @@ import com.github.ambry.protocol.ReplicaMetadataResponseInfo;
 import com.github.ambry.protocol.RequestOrResponse;
 import com.github.ambry.protocol.RequestOrResponseType;
 import com.github.ambry.server.ServerErrorCode;
+import com.github.ambry.store.BlobStore;
 import com.github.ambry.store.MessageInfo;
 import com.github.ambry.store.StoreErrorCodes;
 import com.github.ambry.store.StoreException;
@@ -938,9 +939,8 @@ public class ReplicaThread implements Runnable {
         remoteMessageToConvertedKeyNonNull.put(messageInfo, convertedKey);
       }
     }
-    Set<StoreKey> convertedMissingStoreKeys = remoteReplicaInfo.getLocalStore()
-        .findMissingKeys(new ArrayList<>(remoteMessageToConvertedKeyNonNull.values()),
-            remoteReplicaInfo.getReplicaId().getDataNodeId());
+    Set<StoreKey> convertedMissingStoreKeys =
+        remoteReplicaInfo.getLocalStore().findMissingKeys(new ArrayList<>(remoteMessageToConvertedKeyNonNull.values()));
     Set<MessageInfo> missingRemoteMessages = new HashSet<>();
     remoteMessageToConvertedKeyNonNull.forEach((messageInfo, convertedKey) -> {
       if (convertedMissingStoreKeys.contains(convertedKey)) {
@@ -1610,8 +1610,7 @@ public class ReplicaThread implements Runnable {
 
         // Find the set of store keys that are still missing in the store
         Set<StoreKey> convertedMissingStoreKeys = remoteReplicaInfo.getLocalStore()
-            .findMissingKeys(new ArrayList<>(remoteMessageToConvertedKeyNonNull.values()),
-                remoteReplicaInfo.getReplicaId().getDataNodeId());
+            .findMissingKeys(new ArrayList<>(remoteMessageToConvertedKeyNonNull.values()));
 
         // Filter the remote messages whose keys are now found in store, i.e. not present in convertedMissingStoreKeys set.
         remoteMessageToConvertedKeyNonNull.forEach((messageInfo, convertedKey) -> {

--- a/ambry-replication/src/test/java/com/github/ambry/replication/InMemoryStore.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/InMemoryStore.java
@@ -13,7 +13,6 @@
  */
 package com.github.ambry.replication;
 
-import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.clustermap.ReplicaState;
 import com.github.ambry.commons.Callback;
@@ -390,7 +389,7 @@ class InMemoryStore implements Store {
   }
 
   @Override
-  public Set<StoreKey> findMissingKeys(List<StoreKey> keys, DataNodeId sourceDataNodeId) throws StoreException {
+  public Set<StoreKey> findMissingKeys(List<StoreKey> keys) throws StoreException {
     Set<StoreKey> keysMissing = new HashSet<>();
     for (StoreKey key : keys) {
       boolean found = false;

--- a/ambry-server/src/test/java/com/github/ambry/server/StatsManagerTest.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/StatsManagerTest.java
@@ -615,7 +615,7 @@ public class StatsManagerTest {
     }
 
     @Override
-    public Set<StoreKey> findMissingKeys(List<StoreKey> keys, DataNodeId sourceDataNodeId) throws StoreException {
+    public Set<StoreKey> findMissingKeys(List<StoreKey> keys) throws StoreException {
       throw new IllegalStateException("Not implemented");
     }
 

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -913,7 +913,7 @@ public class BlobStore implements Store {
         remoteTokenTracker.updateTokenFromPeerReplica(token, hostname, remoteReplicaPath);
       }
       FindInfo findInfo = index.findEntriesSince(token, maxTotalSizeOfEntries);
-      // We don't call onSuccess here because findEntries only involvs reading index entries from the index
+      // We don't call onSuccess here because findEntries only involves reading index entries from the index
       // files, which have already been loaded to memory, thus there is no disk operations.
       return findInfo;
     } catch (StoreException e) {

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -15,7 +15,6 @@ package com.github.ambry.store;
 
 import com.codahale.metrics.Timer;
 import com.github.ambry.account.AccountService;
-import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.clustermap.ReplicaState;
 import com.github.ambry.clustermap.ReplicaStatusDelegate;
@@ -914,7 +913,7 @@ public class BlobStore implements Store {
         remoteTokenTracker.updateTokenFromPeerReplica(token, hostname, remoteReplicaPath);
       }
       FindInfo findInfo = index.findEntriesSince(token, maxTotalSizeOfEntries);
-      // We don't call onSuccess here because findEntries only involves reading index entries from the index
+      // We don't call onSuccess here because findEntries only involvs reading index entries from the index
       // files, which have already been loaded to memory, thus there is no disk operations.
       return findInfo;
     } catch (StoreException e) {
@@ -928,13 +927,11 @@ public class BlobStore implements Store {
   }
 
   @Override
-  public Set<StoreKey> findMissingKeys(List<StoreKey> keys, DataNodeId sourceDataNodeId) throws StoreException {
+  public Set<StoreKey> findMissingKeys(List<StoreKey> keys) throws StoreException {
     checkStarted();
     final Timer.Context context = metrics.findMissingKeysResponse.time();
     try {
-      Set<StoreKey> missingKeys =
-          config.storeEnableFindMissingKeysInBatchMode && sourceDataNodeId != null ? index.findMissingKeysInBatch(keys,
-              sourceDataNodeId.toString()) : index.findMissingKeys(keys);
+      Set<StoreKey> missingKeys = index.findMissingKeys(keys);
       return missingKeys;
     } catch (StoreException e) {
       if (e.getErrorCode() == StoreErrorCodes.IOError) {

--- a/ambry-store/src/main/java/com/github/ambry/store/IndexSegment.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/IndexSegment.java
@@ -461,29 +461,6 @@ class IndexSegment implements Iterable<IndexEntry> {
   }
 
   /**
-   * Return all the keys in the IndexSegment in a set.
-   * @return
-   */
-  Set<StoreKey> getAllStoreKeys() throws StoreException {
-    Set<StoreKey> keys = new HashSet<>();
-    rwLock.readLock().lock();
-    boolean isSealed = sealed.get();
-    NavigableMap<StoreKey, ConcurrentSkipListSet<IndexValue>> indexCopy = index;
-    ByteBuffer buffer = serEntries;
-    rwLock.readLock().unlock();
-    if (isSealed) {
-      buffer = buffer.duplicate();
-      int numOfIndexEntries = numberOfEntries(buffer);
-      for (int i = 0; i < numOfIndexEntries; i++) {
-        keys.add(getKeyAt(buffer, i));
-      }
-    } else {
-      keys.addAll(indexCopy.keySet());
-    }
-    return keys;
-  }
-
-  /**
    * According to config, get the {@link ByteBuffer} of {@link StoreKey} for bloom filter. The store config specifies
    * whether to populate bloom filter with key's UUID only.
    * @param key the store key to use in bloom filter.

--- a/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
@@ -17,7 +17,6 @@ import com.codahale.metrics.Timer;
 import com.github.ambry.config.StoreConfig;
 import com.github.ambry.replication.FindToken;
 import com.github.ambry.replication.FindTokenType;
-import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
 import java.io.File;
@@ -34,7 +33,6 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
@@ -44,7 +42,6 @@ import java.util.Random;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ScheduledExecutorService;
@@ -161,7 +158,6 @@ class PersistentIndex {
   // If getBlobReadInfo happens after compaction's step 3, then the IndexValue returned by findKey method would reflect
   // the result of the compaction already, it will not point to any old log segment.
   private final ReadWriteLock rwLock = new ReentrantReadWriteLock();
-  private Runnable getBlobReadInfoTestCallback = null;
 
   private volatile boolean shouldRebuildTokenBasedOnCompactionHistory = false;
   private volatile boolean sanityCheckFailed = false;
@@ -172,8 +168,7 @@ class PersistentIndex {
   // A map from the compaction start timestamp to the set of offsets in the before and after compaction index segment
   // offset map. This map will only be accessed in the compaction thread after startup.
   private final TreeMap<Long, Set<Offset>> compactionTimestampToIndexSegmentOffsets = new TreeMap<>();
-
-  private ConcurrentHashMap<String, LinkedList<Pair<Offset, Set<StoreKey>>>> cachedKeys = new ConcurrentHashMap<>();
+  private Runnable getBlobReadInfoTestCallback = null;
 
   /**
    * Creates a new persistent index
@@ -1451,273 +1446,8 @@ class PersistentIndex {
   }
 
   /**
-   * Returns the list of keys that are not found in the index from the given input keys. This is the same interface as
-   * {@link #findMissingKeys}, however, the implementation is slightly different. In this method, we leverage the locality
-   * of the input keys to make search faster.
-   *
-   * This method is primarily used in replication thread to find the keys that exist in remote peer, but not in the local
-   * store. There are several unique characteristics about this usage, that would make this method much faster than
-   * {@link #findMissingKeys}
-   * 1. The input keys are basically from the same index segment from remote peer, if they already exist locally, they are
-   *    likely to exist in the same index segment as well.
-   * 2. We don't need to deserialize the entire IndexValue from IndexSegment, we only need to check if the key exists or not.
-   * 3. Input keys are scanned from the beginning of the log in remote peer, so when we try to find they in local store,
-   *    we should do the same, not backwards.
-   *
-   * These three characteristics inspire the new implementation.
-   * 1. This method would keep a cache of several index segment's keys. For each key, we first search it in the cache.
-   * 2. If we can't find the key in the cache, this method would locate the next segment and try to find the key in it.
-   * 3. If we find the key in the next segment, then it will be cached. If not, we fall back to use findKey method. The
-   *    index segment returned by findKey method would then be cached.
-   * 4. We only keep limited amount of index segments in the cache.
-   *
-   * One thing we have to figure out with the cache is when to stop using it. The locality of the input keys only exist
-   * when we already replicated them before but somehow get reset due to compaction, or due to replication from a different
-   * host. We should stop using cache
-   * 1. We stop using cache when we hit unsealed index segment.
-   * 2. We stop using cached when we have more than enough misses from the cache.
-   * @param keys The list of keys that needs to be tested against the index
-   * @param dataNode The data node that we are replicating from, that calls this method.
-   * @return The list of keys that are not found in the index
-   * @throws StoreException
-   */
-  Set<StoreKey> findMissingKeysInBatch(List<StoreKey> keys, String dataNode) throws StoreException {
-    long startTime = System.currentTimeMillis();
-    Set<StoreKey> missingKeys = new HashSet<>();
-    LinkedList<Pair<Offset, Set<StoreKey>>> cachedKeysForDataNode =
-        cachedKeys.computeIfAbsent(dataNode, k -> new LinkedList<>());
-
-    FindMissingKeysCacheStats stats = new FindMissingKeysCacheStats();
-    stats.numberOfKeys = keys.size();
-    logger.trace("Index {}: in findMissingKeysInBatch for {}, starting find {} keys", dataDir, dataNode, keys.size());
-
-    int continuousMissingKeyFromCacheCount = 0;
-    int idx = 0;
-    for (; idx < keys.size(); idx++) {
-      StoreKey key = keys.get(idx);
-      // For each Key, we try these index segments first. We only care about if the key exists or not, we don't care
-      // about the final state of the key.
-      // What about compaction that removes this index segment? It's fine to keep these keys, because findMissingKeys
-      // should find the keys that never exist in the store. Key existing in the cache means it did exist in the store
-      // before the compaction.
-      if (cachedKeysForDataNode.stream().anyMatch(p -> p.getSecond().contains(key))) {
-        stats.numberOfCacheHit++;
-        continuousMissingKeyFromCacheCount = 0;
-        continue;
-      }
-
-      // Missing keys from cache
-      logger.trace("Index {}: In findMissingKeysInBatch for {}, can't find key {} in cache. Size of Cache: {}", dataDir,
-          dataNode, key, cachedKeysForDataNode.size());
-      continuousMissingKeyFromCacheCount++;
-      stats.numberOfCacheMiss++;
-      if (continuousMissingKeyFromCacheCount >= config.storeNumOfCacheMissForFindMissingKeysInBatchMode) {
-        logger.trace(
-            "Index {}: In findMissingKeysInBatch for {}, cache miss is more than the threshold. stop using cache",
-            dataDir, dataNode);
-        cachedKeysForDataNode.clear();
-        // Retry this key without cache
-        break;
-      }
-      boolean shouldUseCachedKeys;
-      if (cachedKeysForDataNode.size() > 0) {
-        shouldUseCachedKeys = findKeyInNextSegment(key, missingKeys, cachedKeysForDataNode, dataNode, stats);
-      } else {
-        shouldUseCachedKeys =
-            findKeyAndAddIndexSegmentToCache(key, missingKeys, cachedKeysForDataNode, dataNode, stats);
-      }
-
-      if (!shouldUseCachedKeys) {
-        logger.trace("Index {}: In findMissingKeyInBatch for {}, stop using cache after {}th key {}", dataDir, dataNode,
-            idx, key);
-        cachedKeysForDataNode.clear();
-        // We are breaking out here, but we should move to next key
-        idx++;
-        break;
-      }
-    }
-    if (idx < keys.size()) {
-      stats.cachedDisabled = true;
-      for (; idx < keys.size(); idx++) {
-        stats.numberOfFindKeyMethodCall++;
-        StoreKey key = keys.get(idx);
-        if (findKey(key) == null) {
-          missingKeys.add(key);
-        }
-      }
-    }
-    stats.numberOfMissingKeys = missingKeys.size();
-    stats.processingTimeInMs = System.currentTimeMillis() - startTime;
-    logger.trace("Index {}: In findMissingKeysInBatch for {}, The final stats: {}", dataDir, dataNode, stats);
-    return missingKeys;
-  }
-
-  /**
-   * Find the given {@code key} in by calling {@link #findKey} and try to add the IndexSegment that contains this key to
-   * the cache.
-   * @param key The input key
-   * @param missingKeys Set of missing keys. If we can't find the input key, add the input key to this set.
-   * @param cachedKeysForDataNode The cache that contains keys from index segments.
-   * @param dataNode The source data node
-   * @param stats The {@link FindMissingKeysCacheStats} object to keep track of stats.
-   * @return A boolean value to indicate if we should keep use cache anymore. False means clear cache and don't use it again.
-   * @throws StoreException
-   */
-  private boolean findKeyAndAddIndexSegmentToCache(StoreKey key, Set<StoreKey> missingKeys,
-      LinkedList<Pair<Offset, Set<StoreKey>>> cachedKeysForDataNode, String dataNode, FindMissingKeysCacheStats stats)
-      throws StoreException {
-    boolean shouldUseCachedKeys = true;
-    stats.numberOfFindKeyMethodCall++;
-    IndexValue value = findKey(key);
-    if (value != null) {
-      // Find the index segment for this value
-      Map.Entry<Offset, IndexSegment> entry = validIndexSegments.floorEntry(value.getOffset());
-      if (entry == null) {
-        // This could happen. Between calling findKey and floorEntry, we have a compaction just finished that removes
-        // the index segment for this value. If this is the case, don't cache and just return.
-        // This is not an error.
-        logger.info(
-            "Index {}: In findMissingKeysInBatch for {}, can't find the index segment that contains the value {}",
-            dataDir, dataNode, value);
-        return true;
-      }
-      IndexSegment segment = entry.getValue();
-      if (segment.isSealed()) {
-        Set<StoreKey> allStoreKeys = segment.getAllStoreKeys();
-        // Adding this index segment to the front of the list
-        logger.trace("Index {}: In findMissingKeysInbBatch for {}, adding new segment : {}", dataDir, dataNode,
-            segment.getStartOffset());
-        cachedKeysForDataNode.addFirst(new Pair<>(entry.getKey(), allStoreKeys));
-        if (cachedKeysForDataNode.size() > config.storeCacheSizeForFindMissingKeysInBatchMode) {
-          cachedKeysForDataNode.removeLast();
-        }
-      } else {
-        logger.trace(
-            "Index {}: In findMissingKeysInbBatch for {}, hitting unsealed index segment, stop using cache : {}",
-            dataDir, dataNode, segment.getStartOffset());
-        // We are hitting unsealed index segment, there is no need to cache keys anymore
-        shouldUseCachedKeys = false;
-      }
-    } else {
-      missingKeys.add(key);
-    }
-    return shouldUseCachedKeys;
-  }
-
-  /**
-   * Find the input key by searching it in latest cached index segment's next segment. If the next segment exists and it
-   * contains the input key, then add the next segment to the cache. Otherwise, use {@link #findKey} to find the input
-   * key.
-   * @param key The input key
-   * @paoram missingKeys Set of missing keys. If we can't find the input key, add the input key to this set.
-   * @param cachedKeysForDataNode The cache that contains keys from index segments.
-   * @param dataNode The source data node
-   * @param stats The {@link FindMissingKeysCacheStats} object to keep track of stats.
-   * @return A boolean value to indicate if we should keep use cache anymore. False means clear cache and don't use it again.
-   * @throws StoreException
-   */
-  private boolean findKeyInNextSegment(StoreKey key, Set<StoreKey> missingKeys,
-      LinkedList<Pair<Offset, Set<StoreKey>>> cachedKeysForDataNode, String dataNode, FindMissingKeysCacheStats stats)
-      throws StoreException {
-    boolean shouldUseCachedKeys = true;
-    Offset latestIndexSegmentOffset = cachedKeysForDataNode.get(0).getFirst();
-    Map.Entry<Offset, IndexSegment> entryAfter = validIndexSegments.higherEntry(latestIndexSegmentOffset);
-    if (entryAfter == null) {
-      // Sanity checking, this shouldn't happen
-      // We only cache sealed index segment, which means all cached index segment can't be the last one
-      logger.error(
-          "Index {}: In findMissingKeysInbBatch for {}, searching for next index segment returns null for offset: {}",
-          dataDir, dataNode, latestIndexSegmentOffset);
-      stats.numberOfFindKeyMethodCall++;
-      if (findKey(key) == null) {
-        missingKeys.add(key);
-      }
-    } else {
-      if (cachedKeysForDataNode.stream().map(Pair::getFirst).anyMatch(offset -> offset.equals(entryAfter.getKey()))) {
-        // if next index segment already in the cache, don't bother to search key in next index segment
-        logger.trace("Index {}: In findMissingKeysInBatch for {}, next segment {} already in the cache, skip searching",
-            dataDir, dataNode, entryAfter.getKey());
-        return findKeyAndAddIndexSegmentToCache(key, missingKeys, cachedKeysForDataNode, dataNode, stats);
-      }
-      stats.numberOfNextSegment++;
-      IndexSegment nextSegment = entryAfter.getValue();
-      NavigableSet<IndexValue> values = nextSegment.find(key);
-      if (values == null || values.isEmpty()) {
-        logger.trace("Index {}: In findMissingKeysInBatch for {}, can't find key {} in next segment {}", dataDir,
-            dataNode, key, nextSegment.getStartOffset());
-        shouldUseCachedKeys =
-            findKeyAndAddIndexSegmentToCache(key, missingKeys, cachedKeysForDataNode, dataNode, stats);
-      } else {
-        stats.numberOfNextSegmentHit++;
-        if (nextSegment.isSealed()) {
-          Set<StoreKey> allStoreKeys = nextSegment.getAllStoreKeys();
-          // Adding this index segment to the front of the list
-          logger.info("Index {}: In findMissingKeyInbBatch for {}, adding next segment : {}", dataDir, dataNode,
-              nextSegment.getStartOffset());
-          cachedKeysForDataNode.addFirst(new Pair<>(nextSegment.getStartOffset(), allStoreKeys));
-          if (cachedKeysForDataNode.size() > config.storeCacheSizeForFindMissingKeysInBatchMode) {
-            cachedKeysForDataNode.removeLast();
-          }
-        } else {
-          logger.trace(
-              "Index {}: In findMissingKeyInbBatch for {}, hitting unsealed index segment, stop using cache : {}",
-              dataDir, dataNode, nextSegment.getStartOffset());
-          // We are hitting unsealed index segment, there is no need to cache keys anymore
-          shouldUseCachedKeys = false;
-        }
-      }
-    }
-    return shouldUseCachedKeys;
-  }
-
-  private static class FindMissingKeysCacheStats {
-    int numberOfKeys = 0;
-    int numberOfFindKeyMethodCall = 0;
-    int numberOfCacheMiss = 0;
-    int numberOfCacheHit = 0;
-    int numberOfMissingKeys = 0;
-    int numberOfNextSegment = 0;
-    int numberOfNextSegmentHit = 0;
-    boolean cachedDisabled = false;
-    long processingTimeInMs = 0;
-
-    @Override
-    public String toString() {
-      StringBuilder sb = new StringBuilder();
-      sb.append("Stats[")
-          .append("numberOfKeys=")
-          .append(numberOfKeys)
-          .append(",numberOfFindKeyMethodCall=")
-          .append(numberOfFindKeyMethodCall)
-          .append(",numberOfCacheMiss=")
-          .append(numberOfCacheMiss)
-          .append(",numberOfCacheHit=")
-          .append(numberOfCacheHit)
-          .append(",numberOfMissingKeys=")
-          .append(numberOfMissingKeys)
-          .append(",numberOfNextSegment=")
-          .append(numberOfNextSegment)
-          .append(",numberOfNextSegmentHit=")
-          .append(numberOfNextSegmentHit)
-          .append(",cachedDisabled=")
-          .append(cachedDisabled)
-          .append(",processingTimeInMs=")
-          .append(processingTimeInMs)
-          .append("]");
-      return sb.toString();
-    }
-  }
-
-  /**
-   * @return CachedKeys, only used in test.
-   */
-  ConcurrentHashMap<String, LinkedList<Pair<Offset, Set<StoreKey>>>> getCachedKeys() {
-    return cachedKeys;
-  }
-
-  /**
    * Finds all the entries from the given start token(inclusive). The token defines the start position in the index from
-   * where entries need to be fetched
+   * where entries needs to be fetched
    * @param token The token that signifies the start position in the index from where entries need to be retrieved
    * @param maxTotalSizeOfEntries The maximum total size of entries that needs to be returned. The api will try to
    *                              return a list of entries whose total size is close to this value.

--- a/ambry-store/src/test/java/com/github/ambry/store/CuratedLogIndexState.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CuratedLogIndexState.java
@@ -145,6 +145,7 @@ class CuratedLogIndexState {
   private final Set<MockId> generatedKeys = new HashSet<>();
 
   private StoreMetrics metrics;
+  StoreConfig config;
 
   /**
    * Creates state in order to make sure all cases are represented and log-index tests don't need to do any setup
@@ -1050,7 +1051,7 @@ class CuratedLogIndexState {
    * @throws StoreException
    */
   void initIndex(ScheduledExecutorService newScheduler) throws StoreException {
-    StoreConfig config = new StoreConfig(new VerifiableProperties(properties));
+    config = new StoreConfig(new VerifiableProperties(properties));
     sessionId = UUID.randomUUID();
     metricRegistry = new MetricRegistry();
     metrics = new StoreMetrics(metricRegistry);

--- a/ambry-store/src/test/java/com/github/ambry/store/CuratedLogIndexState.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CuratedLogIndexState.java
@@ -80,8 +80,6 @@ class CuratedLogIndexState {
   static final long TTL_UPDATE_RECORD_SIZE = 37;
   static final long UNDELETE_RECORD_SIZE = 29;
 
-  static final int DEFAULT_NUMBER_CACHE_MISS_IN_FIND_MISSING_KEY_IN_BATCH_MODE = 3;
-
   static final int deleteRetentionHour = 1;
 
   static {
@@ -126,10 +124,6 @@ class CuratedLogIndexState {
   MessageStoreRecovery recovery = new DummyMessageStoreRecovery();
   // The MessageStoreHardDelete that is used with the index
   MessageStoreHardDelete hardDelete = new MockMessageStoreHardDelete();
-  // The metrics
-  StoreMetrics metrics;
-  // The StoreConfig
-  StoreConfig config;
   // The Log which has the data
   Log log;
   // The index of the log
@@ -149,6 +143,8 @@ class CuratedLogIndexState {
   private final String tempDirStr;
   // used by getUniqueId() to make sure keys are never regenerated in a single test run.
   private final Set<MockId> generatedKeys = new HashSet<>();
+
+  private StoreMetrics metrics;
 
   /**
    * Creates state in order to make sure all cases are represented and log-index tests don't need to do any setup
@@ -212,8 +208,6 @@ class CuratedLogIndexState {
     properties.put("store.deleted.message.retention.hours", Integer.toString(CuratedLogIndexState.deleteRetentionHour));
     properties.put("store.rebuild.token.based.on.reset.key", Boolean.toString(enableResetKey));
     properties.put("store.auto.close.last.log.segment.enabled", Boolean.toString(enableAutoCloseLastLogSegment));
-    properties.put(StoreConfig.storeNumOfCacheMissForFindMissingKeysInBatchModeName,
-        String.valueOf(DEFAULT_NUMBER_CACHE_MISS_IN_FIND_MISSING_KEY_IN_BATCH_MODE));
     if (addUndeletes) {
       // If we have undelete, than we need undelete filter
       properties.put("store.compaction.filter",
@@ -1056,7 +1050,7 @@ class CuratedLogIndexState {
    * @throws StoreException
    */
   void initIndex(ScheduledExecutorService newScheduler) throws StoreException {
-    config = new StoreConfig(new VerifiableProperties(properties));
+    StoreConfig config = new StoreConfig(new VerifiableProperties(properties));
     sessionId = UUID.randomUUID();
     metricRegistry = new MetricRegistry();
     metrics = new StoreMetrics(metricRegistry);

--- a/ambry-store/src/test/java/com/github/ambry/store/IndexTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/IndexTest.java
@@ -35,7 +35,6 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -83,7 +82,7 @@ public class IndexTest {
   private final boolean isLogSegmented;
   private final File tempDir;
   private final File tokenTestDir;
-  private CuratedLogIndexState state;
+  private final CuratedLogIndexState state;
   private final CuratedLogIndexState stateForTokenTest;
   private final short persistentIndexVersion;
   private final boolean addUndeletes;
@@ -359,7 +358,7 @@ public class IndexTest {
    */
   @Test
   public void findMissingKeysTest() throws StoreException {
-    List<StoreKey> idsToProvide = new ArrayList<>(state.allKeys.keySet());
+    List<StoreKey> idsToProvide = new ArrayList<StoreKey>(state.allKeys.keySet());
     Set<StoreKey> nonExistentIds = new HashSet<>();
     for (int i = 0; i < 10; i++) {
       nonExistentIds.add(state.getUniqueId());
@@ -368,95 +367,6 @@ public class IndexTest {
     Collections.shuffle(idsToProvide);
     Set<StoreKey> missingKeys = state.index.findMissingKeys(idsToProvide);
     assertEquals("Set of missing keys not as expected", nonExistentIds, missingKeys);
-  }
-
-  @Test
-  public void findMissingKeysInBatchTest() throws Exception {
-    Assume.assumeTrue(isLogSegmented);
-    Assume.assumeFalse(addUndeletes);
-    Assume.assumeTrue(persistentIndexVersion >= VERSION_3);
-    if (state != null) {
-      state.destroy();
-    }
-    state = new CuratedLogIndexState(true, tempDir, false, false, true, false, false, false);
-
-    final String dataNode = "remotedatanode1";
-    final int maxEntriesInOneIndexSegment = DEFAULT_MAX_IN_MEM_ELEMENTS;
-    final int numberOfIndexSegments = 10;
-    // Let's deal with DELETEs for now
-    List<StoreKey> deletedStoreKeys = new ArrayList<>(maxEntriesInOneIndexSegment * numberOfIndexSegments);
-    for (int i = 0; i < numberOfIndexSegments * maxEntriesInOneIndexSegment; i++) {
-      MockId p = state.getUniqueId();
-      state.addDeleteEntry(p, new MessageInfo(p, DELETE_RECORD_SIZE, true, false, p.getAccountId(), p.getContainerId(),
-          state.time.milliseconds()), (short) 0);
-      deletedStoreKeys.add(p);
-    }
-
-    // Make sure we persist the index and seal the index segments.
-    state.index.persistIndex();
-    List<Offset> indexSegmentOffsets = new ArrayList<>();
-    // referenceIndex is a tree map, it returns keys in order
-    state.referenceIndex.keySet().forEach(offset -> indexSegmentOffsets.add(offset));
-
-    // FindMissingKeysInBatch should only call findKey for the first key in first index segment
-    LinkedList<Offset> cachedKeysOffsets = new LinkedList<>();
-    Offset indexSegmentOffset = state.referenceIndex.firstKey();
-    boolean isFirst = true;
-    for (int i = 0; i < state.config.storeCacheSizeForFindMissingKeysInBatchMode; i++) {
-      cachedKeysOffsets.addFirst(indexSegmentOffset);
-      findMissingKeysInBatchForIndexSegmentAndVerify(indexSegmentOffset, isFirst ? 1L : 0, cachedKeysOffsets, dataNode);
-      indexSegmentOffset = state.referenceIndex.higherKey(indexSegmentOffset);
-      isFirst = false;
-    }
-
-    // Back to first index segment, it shouldn't call find key here
-    findMissingKeysInBatchForIndexSegmentAndVerify(state.referenceIndex.firstKey(), 0, cachedKeysOffsets, dataNode);
-    // Move on to fourth index segment, the first index segment would be removed from the cache
-    cachedKeysOffsets.removeLast();
-    cachedKeysOffsets.addFirst(indexSegmentOffset);
-    findMissingKeysInBatchForIndexSegmentAndVerify(indexSegmentOffset, 0, cachedKeysOffsets, dataNode);
-
-    Offset lastIndexSegmentOffset = state.referenceIndex.lastKey();
-    // Last index segment is not sealed, find missing keys in the last index segment would clear the cache.
-    StoreKey cacheClearKey = state.referenceIndex.get(lastIndexSegmentOffset).keySet().iterator().next();
-    Assert.assertEquals(0,
-        state.index.findMissingKeysInBatch(Collections.singletonList(cacheClearKey), dataNode).size());
-    Assert.assertEquals(0, state.index.getCachedKeys().get(dataNode).size());
-
-    // First key is in second index segment, and second key is in first index segment
-    List<StoreKey> keys = getRandomKeyFromIndexSegment(1, 0);
-    Assert.assertEquals(0, state.index.findMissingKeysInBatch(keys, dataNode).size());
-    LinkedList<Pair<Offset, Set<StoreKey>>> cachedKeys = state.index.getCachedKeys().get(dataNode);
-    Assert.assertEquals(2, cachedKeys.size());
-    Assert.assertEquals(indexSegmentOffsets.get(0), cachedKeys.get(0).getFirst());
-    Assert.assertEquals(indexSegmentOffsets.get(1), cachedKeys.get(1).getFirst());
-
-    // missing one key won't clear the cache
-    keys = Collections.singletonList(state.getUniqueId());
-    Assert.assertEquals(1, state.index.findMissingKeysInBatch(keys, dataNode).size());
-    Assert.assertEquals(2, state.index.getCachedKeys().get(dataNode).size());
-
-    // Trying a different datanode, it should not interfere with the existing datanode's cache
-    final String anotherDataNode = "anotherDataNode";
-    findMissingKeysInBatchForIndexSegmentAndVerify(indexSegmentOffsets.get(0), 1,
-        Collections.singletonList(indexSegmentOffsets.get(0)), anotherDataNode);
-    cachedKeys = state.index.getCachedKeys().get(dataNode);
-    Assert.assertEquals(2, cachedKeys.size());
-    Assert.assertEquals(indexSegmentOffsets.get(0), cachedKeys.get(0).getFirst());
-    Assert.assertEquals(indexSegmentOffsets.get(1), cachedKeys.get(1).getFirst());
-
-    // Back to first dataNode, missing several keys would clear the cache
-    int numKeys = DEFAULT_NUMBER_CACHE_MISS_IN_FIND_MISSING_KEY_IN_BATCH_MODE;
-    keys = new ArrayList<>(numKeys);
-    for (int i = 0; i < numKeys + 1; i++) {
-      keys.add(state.getUniqueId());
-    }
-    keys.addAll(getRandomKeyFromIndexSegment(0, 1));
-    long findKeyCallCountBefore = state.metrics.findTime.getCount();
-    Assert.assertEquals(numKeys + 1, state.index.findMissingKeysInBatch(keys, dataNode).size());
-    long findKeyCallCountAfter = state.metrics.findTime.getCount();
-    Assert.assertEquals(keys.size(), findKeyCallCountAfter - findKeyCallCountBefore);
-    Assert.assertEquals(0, state.index.getCachedKeys().get(dataNode).size());
   }
 
   /**
@@ -3999,47 +3909,5 @@ public class IndexTest {
       assertEquals("ContainerId mismatch for " + entry.getKey(), expectedValue.getContainerId(),
           value.getContainerId());
     }
-  }
-
-  /**
-   * Call {@link PersistentIndex#findMissingKeysInBatch} on all the keys from {@link IndexSegment} referenced by the given
-   * {@code offset}.
-   * @param offset The given offset referencing the IndexSegment.
-   * @param expectedFindKeyCallCount Expected findKey call count.
-   * @param expectedCachedKeysOffsets Expected cached keys offsets.
-   * @throws StoreException
-   */
-  private void findMissingKeysInBatchForIndexSegmentAndVerify(Offset offset, long expectedFindKeyCallCount,
-      List<Offset> expectedCachedKeysOffsets, String dataNode) throws StoreException {
-    List<StoreKey> indexSegmentKeys = new LinkedList<>(state.referenceIndex.get(offset).keySet());
-    long findKeyCallCountBefore = state.metrics.findTime.getCount();
-    Assert.assertEquals(0, state.index.findMissingKeysInBatch(indexSegmentKeys, dataNode).size());
-    long findKeyCallCountAfter = state.metrics.findTime.getCount();
-    Assert.assertEquals(expectedFindKeyCallCount, findKeyCallCountAfter - findKeyCallCountBefore);
-    if (expectedCachedKeysOffsets != null) {
-      LinkedList<Pair<Offset, Set<StoreKey>>> cachedKeys = state.index.getCachedKeys().get(dataNode);
-      Assert.assertEquals(expectedCachedKeysOffsets.size(), cachedKeys.size());
-      for (int j = 0; j < expectedCachedKeysOffsets.size(); j++) {
-        Assert.assertEquals(expectedCachedKeysOffsets.get(j), cachedKeys.get(j).getFirst());
-      }
-    }
-  }
-
-  /**
-   * Return random keys from the referenceIndex in curated log index state. the given indexes are the indexes of index
-   * segments, it starts with 0.
-   * @param indexes the list of indexes.
-   * @return A list of store keys.
-   */
-  private List<StoreKey> getRandomKeyFromIndexSegment(int... indexes) {
-    List<Offset> offsets = new ArrayList<>();
-    state.referenceIndex.keySet().forEach(offset -> offsets.add(offset));
-
-    List<StoreKey> results = new ArrayList<>(indexes.length);
-    for (int index : indexes) {
-      Offset offset = offsets.get(index);
-      results.add(state.referenceIndex.get(offset).keySet().iterator().next());
-    }
-    return results;
   }
 }


### PR DESCRIPTION
This reverts commit 36bc2f10f7298e3726ebe7f8e2072fe4db72fd10.

We've found some bugs in this PR that the new implementation of FindMissingKeys didn't return the correct missing keys. Now that the nonblocking network client would fix the slowness in cross-colo replication, we might as well just disable this feature by removing the code all together.