### PR TITLE
[FULL_AUTO] ClusterMap: Add a method to return if a data node is on FULL_AUTO

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/clustermap/ClusterMap.java
+++ b/ambry-api/src/main/java/com/github/ambry/clustermap/ClusterMap.java
@@ -102,6 +102,18 @@ public interface ClusterMap extends AutoCloseable {
   DataNodeId getDataNodeId(String hostname, int port);
 
   /**
+   * Return true if the given host is in the clustermap and all resources this host is given to have already turned
+   * on FULL_AUTO mode. This is a Helix specific method that requires Helix specific data. All the other implementations
+   * should just return false.
+   * @param hostname of the DataNodeId
+   * @param port of the DataNodeId
+   * @return True if all the resources for the given host has turned on FULL_AUTO.
+   */
+  default boolean isDataNodeInFullAutoMode(String hostname, int port) {
+    return false;
+  }
+
+  /**
    * Gets the ReplicaIds stored on the specified DataNodeId.
    *
    * @param dataNodeId the {@link DataNodeId} whose replicas are to be returned.

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
@@ -1610,6 +1610,9 @@ public class HelixClusterManager implements ClusterMap {
     }
   }
 
+  /**
+   * Properties for Resource.
+   */
   static class ResourceProperty {
     final String name;
     final IdealState.RebalanceMode rebalanceMode;

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
@@ -517,7 +517,7 @@ public class HelixClusterManager implements ClusterMap {
     }
     // Make sure all the resources turned on FULL_AUTO mode
     String resourceName = resourceNames.iterator().next();
-    ResourceProperty property = dcToResourceNameToResourceProperty.get(dcName).get(resourceNames);
+    ResourceProperty property = dcToResourceNameToResourceProperty.get(dcName).get(resourceName);
     if (property == null || !property.rebalanceMode.equals(IdealState.RebalanceMode.FULL_AUTO)) {
       return false;
     }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
@@ -93,6 +93,10 @@ public class HelixClusterManager implements ClusterMap {
   // Routing table snapshot reference used in aggregated cluster view.
   private final AtomicReference<RoutingTableSnapshot> globalRoutingTableSnapshotRef = new AtomicReference<>();
   private final ConcurrentHashMap<String, AmbryDataNode> instanceNameToAmbryDataNode = new ConcurrentHashMap<>();
+  private final Map<String, ConcurrentHashMap<String, Set<String>>> dcToInstanceNameToResources =
+      new ConcurrentHashMap<>();
+  private final Map<String, ConcurrentHashMap<String, ResourceProperty>> dcToResourceNameToResourceProperty =
+      new ConcurrentHashMap<>();
   private final AtomicLong errorCount = new AtomicLong(0);
   private final AtomicLong clusterWideRawCapacityBytes = new AtomicLong(0);
   private final AtomicLong clusterWideAllocatedRawCapacityBytes = new AtomicLong(0);
@@ -105,8 +109,8 @@ public class HelixClusterManager implements ClusterMap {
   private final Map<String, ReplicaId> bootstrapReplicas = new ConcurrentHashMap<>();
   private ZkHelixPropertyStore<ZNRecord> helixPropertyStoreInLocalDc = null;
   // The current xid currently does not change after instantiation. This can change in the future, allowing the cluster
-// manager to dynamically incorporate newer changes in the cluster. This variable is atomic so that the gauge metric
-// reflects the current value.
+  // manager to dynamically incorporate newer changes in the cluster. This variable is atomic so that the gauge metric
+  // reflects the current value.
   private final AtomicLong currentXid;
   final HelixClusterManagerMetrics helixClusterManagerMetrics;
   private HelixAggregatedViewClusterInfo helixAggregatedViewClusterInfo = null;
@@ -487,6 +491,38 @@ public class HelixClusterManager implements ClusterMap {
         helixDcInfo.clusterChangeHandler.registerClusterMapListener(clusterMapChangeListener);
       }
     }
+  }
+
+  @Override
+  public boolean isDataNodeInFullAutoMode(String hostname, int port) {
+    if (clusterMapConfig.clusterMapUseAggregatedView) {
+      // Aggregated view don't include IdealState now, we are not getting IdealState from Helix, just return false.
+      // TODO: Pulling IdealState from helix managers in all datacenters
+      return false;
+    }
+    String instanceName = getInstanceName(hostname, port);
+    DataNodeId dataNodeId = instanceNameToAmbryDataNode.get(instanceName);
+    if (dataNodeId == null) {
+      throw new IllegalArgumentException("Host " + hostname + " Port " + port + " doesn't exist");
+    }
+    String dcName = dataNodeId.getDatacenterName();
+    Set<String> resourceNames = dcToInstanceNameToResources.get(dcName).get(instanceName);
+    if (resourceNames == null || resourceNames.isEmpty()) {
+      logger.trace("DataNode {} doesn't have any resources", instanceName);
+      return false;
+    }
+    // Before turn on FULL_AUTO, we have to make sure each host only stores partitions from one resource
+    if (resourceNames.size() != 1) {
+      return false;
+    }
+    // Make sure all the resources turned on FULL_AUTO mode
+    for (String resourceName : resourceNames) {
+      ResourceProperty property = dcToResourceNameToResourceProperty.get(dcName).get(resourceName);
+      if (property == null || !property.rebalanceMode.equals(IdealState.RebalanceMode.FULL_AUTO)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   /**
@@ -1193,12 +1229,26 @@ public class HelixClusterManager implements ClusterMap {
       if (dcName != null) {
         // Rebuild the entire partition-to-resource map in current dc
         ConcurrentHashMap<String, String> partitionToResourceMap = new ConcurrentHashMap<>();
+        ConcurrentHashMap<String, Set<String>> instanceNameToResourceNames = new ConcurrentHashMap<>();
+        ConcurrentHashMap<String, ResourceProperty> resourceNameToProperty = new ConcurrentHashMap<>();
         for (IdealState state : idealStates) {
           String resourceName = state.getResourceName();
-          state.getPartitionSet()
-              .forEach(partitionName -> partitionToResourceMap.compute(partitionName,
-                  resourceNameReplaceFunc(resourceName)));
+          for (String partitionName : state.getPartitionSet()) {
+            String mappedResourceName =
+                partitionToResourceMap.compute(partitionName, resourceNameReplaceFunc(resourceName));
+            if (mappedResourceName.equals(resourceName)) {
+              ResourceProperty resourceProperty = new ResourceProperty(resourceName, state.getRebalanceMode());
+              resourceNameToProperty.put(resourceName, resourceProperty);
+
+              for (String instanceName : state.getInstanceSet(partitionName)) {
+                instanceNameToResourceNames.computeIfAbsent(instanceName, k -> ConcurrentHashMap.newKeySet())
+                    .add(resourceName);
+              }
+            }
+          }
         }
+        dcToResourceNameToResourceProperty.put(dcName, resourceNameToProperty);
+        dcToInstanceNameToResources.put(dcName, instanceNameToResourceNames);
         partitionToResourceNameByDc.put(dcName, partitionToResourceMap);
       } else {
         logger.warn("Partition to resource mapping for aggregated cluster view would be built from external view");
@@ -1543,13 +1593,13 @@ public class HelixClusterManager implements ClusterMap {
     private ReplicaSealStatus resolveReplicaSealStatus(String partitionName, Collection<String> sealedReplicas,
         Collection<String> partiallySealedReplicas) {
       if (clusterMapConfig.clusterMapEnablePartitionOverride && partitionOverrideInfoMap.containsKey(partitionName)) {
-        if(partitionOverrideInfoMap.get(partitionName)
+        if (partitionOverrideInfoMap.get(partitionName)
             .get(ClusterMapUtils.PARTITION_STATE)
             .equals(ClusterMapUtils.READ_ONLY_STR)) {
           return ReplicaSealStatus.SEALED;
         }
       } else {
-        if(sealedReplicas.contains(partitionName)) {
+        if (sealedReplicas.contains(partitionName)) {
           return ReplicaSealStatus.SEALED;
         }
       }
@@ -1557,6 +1607,16 @@ public class HelixClusterManager implements ClusterMap {
         return ReplicaSealStatus.PARTIALLY_SEALED;
       }
       return ReplicaSealStatus.NOT_SEALED;
+    }
+  }
+
+  static class ResourceProperty {
+    final String name;
+    final IdealState.RebalanceMode rebalanceMode;
+
+    ResourceProperty(String name, IdealState.RebalanceMode rebalanceMode) {
+      this.name = name;
+      this.rebalanceMode = rebalanceMode;
     }
   }
 }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
@@ -516,11 +516,10 @@ public class HelixClusterManager implements ClusterMap {
       return false;
     }
     // Make sure all the resources turned on FULL_AUTO mode
-    for (String resourceName : resourceNames) {
-      ResourceProperty property = dcToResourceNameToResourceProperty.get(dcName).get(resourceName);
-      if (property == null || !property.rebalanceMode.equals(IdealState.RebalanceMode.FULL_AUTO)) {
-        return false;
-      }
+    String resourceName = resourceNames.iterator().next();
+    ResourceProperty property = dcToResourceNameToResourceProperty.get(dcName).get(resourceNames);
+    if (property == null || !property.rebalanceMode.equals(IdealState.RebalanceMode.FULL_AUTO)) {
+      return false;
     }
     return true;
   }

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixClusterManagerTest.java
@@ -810,7 +810,6 @@ public class HelixClusterManagerTest {
 
     // Now return old resource in local dc, and nothing should change
     localHelixAdmin.removeResourceIdealState("", resourceName);
-    localHelixAdmin.triggerRoutingTableNotification();
     Thread.sleep(1000);
 
     // Nothing should change

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixClusterManagerTest.java
@@ -852,6 +852,82 @@ public class HelixClusterManagerTest {
   }
 
   /**
+   * Test {@link ClusterMap#isDataNodeInFullAutoMode}.
+   * @throws Exception
+   */
+  @Test
+  public void testHostFullAuto() throws Exception {
+    // For aggregated view, it will always return false
+    assumeTrue(!useComposite && !useAggregatedView);
+    HelixClusterManager helixClusterManager = (HelixClusterManager) clusterManager;
+    verifyInitialClusterChanges(helixClusterManager, helixCluster, helixDcs);
+
+    // By default, all the hosts are not in FULL_AUTO mode.
+    List<DataNode> allLocalDcDataNodes = testHardwareLayout.getAllDataNodesFromDc(localDc);
+    for (DataNode dataNode : allLocalDcDataNodes) {
+      assertFalse("By default, local node should not on FULL_AUTO",
+          helixClusterManager.isDataNodeInFullAutoMode(dataNode.getHostname(), dataNode.getPort()));
+    }
+    List<DataNode> allRemoteDcDataNodes = testHardwareLayout.getAllDataNodesFromDc(remoteDc);
+    for (DataNode dataNode : allRemoteDcDataNodes) {
+      assertFalse("By default, remote node should not on FULL_AUTO",
+          helixClusterManager.isDataNodeInFullAutoMode(dataNode.getHostname(), dataNode.getPort()));
+    }
+
+    // Should have only one Resource when bootup
+    List<String> resourceNames = helixCluster.getResources(localDc);
+    assertEquals("Should only have one resource when bootup", 1, resourceNames.size());
+
+    // Update the IdealState to CUSTOMIZED mode, this would keep all local data node as they were.
+    String resourceName = resourceNames.get(0);
+    IdealState idealState = helixCluster.getResourceIdealState(resourceName, localDc);
+    // Update idealState here would impact the IdealState in the helixCluster since they reference to the same object
+    idealState.setRebalanceMode(IdealState.RebalanceMode.CUSTOMIZED);
+    helixCluster.refreshIdealState();
+    allLocalDcDataNodes = testHardwareLayout.getAllDataNodesFromDc(localDc);
+    for (DataNode dataNode : allLocalDcDataNodes) {
+      assertFalse("Customized mode, local node should not on FULL_AUTO",
+          helixClusterManager.isDataNodeInFullAutoMode(dataNode.getHostname(), dataNode.getPort()));
+    }
+
+    // Now update resource to FULL_AUTO
+    idealState.setRebalanceMode(IdealState.RebalanceMode.FULL_AUTO);
+    helixCluster.refreshIdealState();
+    for (DataNode dataNode : allLocalDcDataNodes) {
+      assertTrue("FULL_AUTO mode, local node should be on FULL_AUTO",
+          helixClusterManager.isDataNodeInFullAutoMode(dataNode.getHostname(), dataNode.getPort()));
+    }
+    // Remote data nodes should not be impacted
+    for (DataNode dataNode : allRemoteDcDataNodes) {
+      assertFalse("Local DC change, remote node should not on FULL_AUTO",
+          helixClusterManager.isDataNodeInFullAutoMode(dataNode.getHostname(), dataNode.getPort()));
+    }
+
+    // Now add new resource to the local dc, it will make hosts back to off FULL_AUTO.
+    // User MockHelixAdmin::addResource to add resource and external view
+    MockHelixAdmin localHelixAdmin = helixCluster.getHelixAdminFromDc(localDc);
+    // 1. add new resource
+    // 2. update partition to resource map
+    // 3. generate different states for different instances for again
+    String newResourceName = String.valueOf(Integer.valueOf(resourceName) + 1000);
+    localHelixAdmin.addResource("", newResourceName, cloneIdealState(idealState, newResourceName));
+    helixCluster.refreshIdealState();
+
+    resourceNames = helixCluster.getResources(localDc);
+    assertEquals("Should have two resources after adding a new resource", 2, resourceNames.size());
+    for (DataNode dataNode : allLocalDcDataNodes) {
+      assertFalse("More than one resources, local node should not on FULL_AUTO",
+          helixClusterManager.isDataNodeInFullAutoMode(dataNode.getHostname(), dataNode.getPort()));
+    }
+
+    helixCluster.removeResourceIdealState(newResourceName, localDc);
+    for (DataNode dataNode : allLocalDcDataNodes) {
+      assertTrue("Back to one resource, local node should on FULL_AUTO",
+          helixClusterManager.isDataNodeInFullAutoMode(dataNode.getHostname(), dataNode.getPort()));
+    }
+  }
+
+  /**
    * Test that routing table change reflects correct state of each replica and {@link HelixClusterManager} is able to get
    * replica in required state.
    */

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixAdmin.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixAdmin.java
@@ -292,9 +292,10 @@ public class MockHelixAdmin implements HelixAdmin {
     triggerInstanceConfigChangeNotification(tagAsInit);
   }
 
-  void removeResourceIdealState(String clusterName, String resourceName) {
+  void removeResourceIdealState(String clusterName, String resourceName) throws Exception {
     resourcesToIdealStates.remove(resourceName);
     resourceToResourceInfoMap.remove(resourceName);
+    triggerIdealStateChangeNotification();
   }
 
   /**

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixAdmin.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixAdmin.java
@@ -292,6 +292,13 @@ public class MockHelixAdmin implements HelixAdmin {
     triggerInstanceConfigChangeNotification(tagAsInit);
   }
 
+  /**
+   * Remove ideal state for the given resource name. The {@code clusterName} is not used. It will trigger ideal state
+   * change notification.
+   * @param clusterName The name of the helix cluster, not used.
+   * @param resourceName The name of the resource.
+   * @throws Exception
+   */
   void removeResourceIdealState(String clusterName, String resourceName) throws Exception {
     resourcesToIdealStates.remove(resourceName);
     resourceToResourceInfoMap.remove(resourceName);

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixManager.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixManager.java
@@ -247,11 +247,13 @@ class MockHelixManager implements HelixManager {
   }
 
   void triggerIdealStateNotification(boolean init) throws InterruptedException {
-    NotificationContext notificationContext = new NotificationContext(this);
-    if (init) {
-      notificationContext.setType(NotificationContext.Type.INIT);
+    if (idealStateChangeListener != null) {
+      NotificationContext notificationContext = new NotificationContext(this);
+      if (init) {
+        notificationContext.setType(NotificationContext.Type.INIT);
+      }
+      idealStateChangeListener.onIdealStateChange(localHelixAdmin.getIdealStates(), notificationContext);
     }
-    idealStateChangeListener.onIdealStateChange(localHelixAdmin.getIdealStates(), notificationContext);
   }
 
   void triggerRoutingTableNotification() {


### PR DESCRIPTION
This PR adds a method in clustermap interface and HelixClusterManager implementation to indicate a data node is on FULL_AUTO or not by returning true or false.

When turning on FULL_AUTO, we would first reconstruct resource so that a data node can have partitions from only one resource. Then we update the resource's ideal state to change the RebalanceMode to FULL_AUTO. In this way, a data node would know if all the partitions assigned to it are on FULL_AUTO mode or not.