### PR TITLE
Add configuration to enable nonblocking network client in local colo replication

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/ReplicationConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/ReplicationConfig.java
@@ -235,6 +235,16 @@ public class ReplicationConfig {
   public final boolean replicationUsingNonblockingNetworkClientForRemoteColo;
   public final static String REPLICATION_USING_NONBLOCKING_NETWORK_CLIENT_FOR_REMOTE_COLO =
       "replication.using.nonblocking.network.client.for.remote.colo";
+
+  /**
+   * True to start using nonblocking network client for local colo replication.
+   */
+  @Config(REPLICATION_USING_NONBLOCKING_NETWORK_CLIENT_FOR_LOCAL_COLO)
+  @Default("false")
+  public final boolean replicationUsingNonblockingNetworkClientForLocalColo;
+  public final static String REPLICATION_USING_NONBLOCKING_NETWORK_CLIENT_FOR_LOCAL_COLO =
+      "replication.using.nonblocking.network.client.for.local.colo";
+
   /**
    * Timeout in milliseconds for requests in nonblocking network client. This configuration is only useful when the
    * nonblocking network client is enabled.
@@ -269,7 +279,8 @@ public class ReplicationConfig {
    * Config for file manager class for backup checker
    */
   public static final String BACKUP_CHECKER_FILE_MANAGER_TYPE = "backup.checker.file.manager.type";
-  public static final String DEFAULT_BACKUP_CHECKER_FILE_MANAGER = "com.github.ambry.replication.BackupCheckerFileManager";
+  public static final String DEFAULT_BACKUP_CHECKER_FILE_MANAGER =
+      "com.github.ambry.replication.BackupCheckerFileManager";
   @Config(BACKUP_CHECKER_FILE_MANAGER_TYPE)
   public final String backupCheckFileManagerType;
 
@@ -291,12 +302,12 @@ public class ReplicationConfig {
 
   public ReplicationConfig(VerifiableProperties verifiableProperties) {
 
-    maxBackupCheckerReportFd = verifiableProperties.getInt(MAX_BACKUP_CHECKER_REPORT_FD,
-        DEFAULT_MAX_BACKUP_CHECKER_REPORT_FD);
-    backupCheckerReportDir = verifiableProperties.getString(BACKUP_CHECKER_REPORT_DIR,
-        DEFAULT_BACKUP_CHECKER_REPORT_DIR);
-    backupCheckFileManagerType = verifiableProperties.getString(BACKUP_CHECKER_FILE_MANAGER_TYPE,
-        DEFAULT_BACKUP_CHECKER_FILE_MANAGER);
+    maxBackupCheckerReportFd =
+        verifiableProperties.getInt(MAX_BACKUP_CHECKER_REPORT_FD, DEFAULT_MAX_BACKUP_CHECKER_REPORT_FD);
+    backupCheckerReportDir =
+        verifiableProperties.getString(BACKUP_CHECKER_REPORT_DIR, DEFAULT_BACKUP_CHECKER_REPORT_DIR);
+    backupCheckFileManagerType =
+        verifiableProperties.getString(BACKUP_CHECKER_FILE_MANAGER_TYPE, DEFAULT_BACKUP_CHECKER_FILE_MANAGER);
     replicationThreadType = verifiableProperties.getString(REPLICATION_THREAD_TYPE, DEFAULT_REPLICATION_THREAD);
     replicationStoreTokenFactory =
         verifiableProperties.getString("replication.token.factory", "com.github.ambry.store.StoreFindTokenFactory");
@@ -352,5 +363,7 @@ public class ReplicationConfig {
         verifiableProperties.getLong(REPLICATION_REQUEST_NETWORK_POLL_TIMEOUT_MS, 40);
     replicationUsingNonblockingNetworkClientForRemoteColo =
         verifiableProperties.getBoolean(REPLICATION_USING_NONBLOCKING_NETWORK_CLIENT_FOR_REMOTE_COLO, false);
+    replicationUsingNonblockingNetworkClientForLocalColo =
+        verifiableProperties.getBoolean(REPLICATION_USING_NONBLOCKING_NETWORK_CLIENT_FOR_LOCAL_COLO, false);
   }
 }

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
@@ -252,8 +252,8 @@ public abstract class ReplicationEngine implements ReplicationAPI {
         break;
       }
     }
-    if (foundRemoteReplicaInfo == null && !replicaPath.startsWith(Cloud_Replica_Keyword) &&
-        !replicaPath.startsWith(BackupCheckerThread.DR_Verifier_Keyword)) {
+    if (foundRemoteReplicaInfo == null && !replicaPath.startsWith(Cloud_Replica_Keyword) && !replicaPath.startsWith(
+        BackupCheckerThread.DR_Verifier_Keyword)) {
       replicationMetrics.unknownRemoteReplicaRequestCount.inc();
       logger.error("ReplicaMetaDataRequest from unknown Replica {}, with path {}", hostName, replicaPath);
     }
@@ -362,10 +362,10 @@ public abstract class ReplicationEngine implements ReplicationAPI {
       MetricRegistry metricRegistry, boolean replicatingOverSsl, String datacenterName, ResponseHandler responseHandler,
       Time time, ReplicaSyncUpManager replicaSyncUpManager, Predicate<MessageInfo> skipPredicate,
       ReplicationManager.LeaderBasedReplicationAdmin leaderBasedReplicationAdmin) {
-      return new ReplicaThread(threadName, tokenHelper, clusterMap, correlationIdGenerator, dataNodeId,
-          connectionPool, networkClient, replicationConfig, replicationMetrics, notification,
-          storeKeyConverter, transformer, metricRegistry, replicatingOverSsl, datacenterName,
-          responseHandler, time, replicaSyncUpManager, skipPredicate, leaderBasedReplicationAdmin);
+    return new ReplicaThread(threadName, tokenHelper, clusterMap, correlationIdGenerator, dataNodeId, connectionPool,
+        networkClient, replicationConfig, replicationMetrics, notification, storeKeyConverter, transformer,
+        metricRegistry, replicatingOverSsl, datacenterName, responseHandler, time, replicaSyncUpManager, skipPredicate,
+        leaderBasedReplicationAdmin);
   }
 
   /**
@@ -388,9 +388,16 @@ public abstract class ReplicationEngine implements ReplicationAPI {
         Transformer threadSpecificTransformer =
             Utils.getObj(transformerClassName, storeKeyFactory, threadSpecificKeyConverter);
         NetworkClient networkClient = null;
-        if (!dataNodeId.getDatacenterName().equals(datacenter)
-            && replicationConfig.replicationUsingNonblockingNetworkClientForRemoteColo) {
-          networkClient = networkClientFactory != null ? networkClientFactory.getNetworkClient() : null;
+        if (!dataNodeId.getDatacenterName().equals(datacenter)) {
+          // Inter-DC replication
+          if (replicationConfig.replicationUsingNonblockingNetworkClientForRemoteColo) {
+            networkClient = networkClientFactory != null ? networkClientFactory.getNetworkClient() : null;
+          }
+        } else {
+          // Intra-DC replication
+          if (replicationConfig.replicationUsingNonblockingNetworkClientForLocalColo) {
+            networkClient = networkClientFactory != null ? networkClientFactory.getNetworkClient() : null;
+          }
         }
         ReplicaThread replicaThread =
             getReplicaThread(threadIdentity, tokenHelper, clusterMap, correlationIdGenerator, dataNodeId,


### PR DESCRIPTION
This PR adds a configuration to add nonblocking network client for intra-colo replication.

Intra-colo replication is much faster than inter-colo replication since it has less data to replicate and faster connection to replicate data with. That's why a blocking channel usually works just fine for intra-colo replication. But this change would still be beneficial for intra-colo replication especially when it comes to bootstrapping. 
