### PR TITLE
[Efficient Metadata Operations] Add logic to handle partially sealed partition in ClusterParticipant.

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/clustermap/ClusterParticipant.java
+++ b/ambry-api/src/main/java/com/github/ambry/clustermap/ClusterParticipant.java
@@ -19,7 +19,6 @@ import com.github.ambry.commons.Callback;
 import com.github.ambry.server.AmbryStatsReport;
 import com.github.ambry.server.storagestats.AggregatedAccountStorageStats;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -74,10 +73,7 @@ public interface ClusterParticipant extends AutoCloseable {
    * Get a list of replicas that are marked as partially sealed.
    * @return a list of all partially sealed replicas.
    */
-  default List<String> getPartiallySealedReplicas() {
-    // TODO Add implementations.
-    return new ArrayList<>();
-  }
+  List<String> getPartiallySealedReplicas();
 
   /**
    * Get a list of replicas that are marked as stopped.

--- a/ambry-api/src/test/java/com/github/ambry/clustermap/ReplicaStatusDelegateTest.java
+++ b/ambry-api/src/test/java/com/github/ambry/clustermap/ReplicaStatusDelegateTest.java
@@ -42,6 +42,9 @@ public class ReplicaStatusDelegateTest {
     delegate.unseal(replicaId);
     verify(clusterParticipant).setReplicaSealedState(replicaId, ReplicaSealStatus.NOT_SEALED);
     verifyNoMoreInteractions(clusterParticipant);
+    delegate.partialSeal(replicaId);
+    verify(clusterParticipant, times(2)).setReplicaSealedState(replicaId, ReplicaSealStatus.NOT_SEALED);
+    verifyNoMoreInteractions(clusterParticipant);
     delegate.markStopped(replicaIds);
     verify(clusterParticipant).setReplicaStoppedState(replicaIds, true);
     verifyNoMoreInteractions(clusterParticipant);

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/RecoveryTestClusterAgentsFactory.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/RecoveryTestClusterAgentsFactory.java
@@ -111,6 +111,11 @@ public class RecoveryTestClusterAgentsFactory implements ClusterAgentsFactory {
         }
 
         @Override
+        public List<String> getPartiallySealedReplicas() {
+          return Collections.emptyList();
+        }
+
+        @Override
         public List<String> getStoppedReplicas() {
           return Collections.emptyList();
         }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/StaticClusterAgentsFactory.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/StaticClusterAgentsFactory.java
@@ -121,6 +121,11 @@ public class StaticClusterAgentsFactory implements ClusterAgentsFactory {
         }
 
         @Override
+        public List<String> getPartiallySealedReplicas() {
+          return Collections.emptyList();
+        }
+
+        @Override
         public List<String> getStoppedReplicas() {
           return Collections.emptyList();
         }

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockClusterAgentsFactory.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockClusterAgentsFactory.java
@@ -127,6 +127,11 @@ public class MockClusterAgentsFactory implements ClusterAgentsFactory {
         }
 
         @Override
+        public List<String> getPartiallySealedReplicas() {
+          return new ArrayList<>();
+        }
+
+        @Override
         public List<String> getStoppedReplicas() {
           return new ArrayList<>();
         }

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixParticipant.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixParticipant.java
@@ -44,6 +44,7 @@ public class MockHelixParticipant extends HelixParticipant {
   ReplicaId currentReplica = null;
   ReplicaSyncUpManager replicaSyncUpService = null;
   private Set<ReplicaId> sealedReplicas = new HashSet<>();
+  private Set<ReplicaId> partiallySealedReplicas = new HashSet<>();
   private Set<ReplicaId> stoppedReplicas = new HashSet<>();
   private Set<ReplicaId> disabledReplicas = new HashSet<>();
   private PartitionStateChangeListener mockReplicationManagerListener;
@@ -101,10 +102,19 @@ public class MockHelixParticipant extends HelixParticipant {
 
   @Override
   public boolean setReplicaSealedState(ReplicaId replicaId, ReplicaSealStatus replicaSealStatus) {
-    if (replicaSealStatus == ReplicaSealStatus.SEALED) {
-      sealedReplicas.add(replicaId);
-    } else {
-      sealedReplicas.remove(replicaId);
+    switch (replicaSealStatus) {
+      case SEALED:
+        sealedReplicas.add(replicaId);
+        partiallySealedReplicas.remove(replicaId);
+        break;
+      case PARTIALLY_SEALED:
+        partiallySealedReplicas.add(replicaId);
+        sealedReplicas.remove(replicaId);
+        break;
+      case NOT_SEALED:
+        partiallySealedReplicas.remove(replicaId);
+        sealedReplicas.remove(replicaId);
+        break;
     }
     return true;
   }
@@ -143,6 +153,11 @@ public class MockHelixParticipant extends HelixParticipant {
   @Override
   public List<String> getSealedReplicas() {
     return sealedReplicas.stream().map(r -> r.getPartitionId().toPathString()).collect(Collectors.toList());
+  }
+
+  @Override
+  public List<String> getPartiallySealedReplicas() {
+    return partiallySealedReplicas.stream().map(r -> r.getPartitionId().toPathString()).collect(Collectors.toList());
   }
 
   @Override

--- a/ambry-commons/src/main/java/com/github/ambry/commons/ServerMetrics.java
+++ b/ambry-commons/src/main/java/com/github/ambry/commons/ServerMetrics.java
@@ -266,6 +266,7 @@ public class ServerMetrics {
   public final Counter ttlUpdateRejectedError;
   public final Counter replicationResponseMessageSizeTooHigh;
   public Counter sealedReplicasMismatchCount = null;
+  public Counter partiallySealedReplicasMismatchCount = null;
   public Counter stoppedReplicasMismatchCount = null;
   // AmbryServerSecurityService
   public final Counter serverValidateConnectionSuccess;
@@ -628,6 +629,8 @@ public class ServerMetrics {
   public void registerParticipantsMismatchMetrics() {
     sealedReplicasMismatchCount =
         registry.counter(MetricRegistry.name(ServerMetrics.class, "SealedReplicasMismatchCount"));
+    partiallySealedReplicasMismatchCount =
+        registry.counter(MetricRegistry.name(ServerMetrics.class, "PartiallySealedReplicasMismatchCount"));
     stoppedReplicasMismatchCount =
         registry.counter(MetricRegistry.name(ServerMetrics.class, "StoppedReplicasMismatchCount"));
   }

--- a/ambry-server/src/main/java/com/github/ambry/server/ParticipantsConsistencyChecker.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/ParticipantsConsistencyChecker.java
@@ -45,6 +45,7 @@ public class ParticipantsConsistencyChecker implements Runnable {
       ClusterParticipant clusterParticipant = participants.get(0);
       Set<String> sealedReplicas1 = new HashSet<>(clusterParticipant.getSealedReplicas());
       Set<String> stoppedReplicas1 = new HashSet<>(clusterParticipant.getStoppedReplicas());
+      Set<String> partiallySealedReplicas1 = new HashSet<>(clusterParticipant.getPartiallySealedReplicas());
       for (int i = 1; i < participants.size(); ++i) {
         logger.debug("Checking sealed replica list");
         Set<String> sealedReplicas2 = new HashSet<>(participants.get(i).getSealedReplicas());
@@ -58,6 +59,13 @@ public class ParticipantsConsistencyChecker implements Runnable {
           logger.warn("Mismatch in stopped replicas. Set {} is different from set {}", stoppedReplicas1,
               stoppedReplicas2);
           metrics.stoppedReplicasMismatchCount.inc();
+        }
+        logger.debug("Checking partially sealed replica list");
+        Set<String> partiallySealedReplicas2 = new HashSet<>(participants.get(i).getPartiallySealedReplicas());
+        if (!partiallySealedReplicas1.equals(partiallySealedReplicas2)) {
+          logger.warn("Mismatch in partially sealed replicas. Set {} is different from set {}",
+              partiallySealedReplicas1, partiallySealedReplicas2);
+          metrics.partiallySealedReplicasMismatchCount.inc();
         }
       }
     } catch (Throwable t) {

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
@@ -329,7 +329,7 @@ public class BlobStoreTest {
     this.isLogSegmented = isLogSegmented;
     tempDir = StoreTestUtils.createTempDirectory("storeDir-" + storeId);
     tempDirStr = tempDir.getAbsolutePath();
-    StoreConfig config = new StoreConfig(new VerifiableProperties(properties));
+    StoreConfig config = new StoreConfig(new VerifiableProperties(new Properties()));
     long bufferTimeMs = TimeUnit.SECONDS.toMillis(config.storeTtlUpdateBufferTimeSeconds);
     expiresAtMs = time.milliseconds() + bufferTimeMs + TimeUnit.HOURS.toMillis(1);
     setupTestState(true, true);


### PR DESCRIPTION
Before this PR, the ClusterParticipant implementations were ignoring the PARTIALLY_SEALED state. This PR adds the logic so ClusterParticipant can handle the PARTIALLY_SEALED state and update the appropriate backend. 