### PR TITLE
Record replication lag in seconds for the originating dc

### DIFF
--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationMetrics.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationMetrics.java
@@ -818,7 +818,7 @@ public class ReplicationMetrics {
    * @param timeInSeconds The replication lag in seconds
    */
   public void updateReplicationLagInSecondsForBlob(String datacenter, long timeInSeconds) {
-    if (dcToReplicaLagInSecondsForBlob.containsKey(datacenter)) {
+    if (datacenter != null && dcToReplicaLagInSecondsForBlob.containsKey(datacenter)) {
       dcToReplicaLagInSecondsForBlob.get(datacenter).update(timeInSeconds);
     }
   }


### PR DESCRIPTION
This PR changes the way we record replication lag in seconds metrics. Before this PR, whenever we get a blob from a remote peer, we just record the replication lag in seconds against this peer's datacenter. However, this peer might get this blob from other datacenter. This would skew the replication lag in seconds metric.

This PR fixes this issue. 