### PR TITLE
Reduce Index Segment Size

### DIFF
--- a/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
@@ -741,7 +741,6 @@ class PersistentIndex {
   private boolean needToRollOverIndex(IndexEntry entry) {
     Offset offset = entry.getValue().getOffset();
     int thisValueSize = entry.getValue().getBytes().capacity();
-    int thisEntrySize = entry.getKey().sizeInBytes() + thisValueSize;
     if (validIndexSegments.size() == 0) {
       logger.info("Creating first segment with start offset {}", offset);
       return true;
@@ -768,12 +767,6 @@ class PersistentIndex {
       logger.info(
           "Index: {} Rolling over from {} to {} because the number of items in the last segment: {} >= maxInMemoryNumElements {}",
           dataDir, lastSegment.getStartOffset(), offset, lastSegment.getNumberOfItems(), maxInMemoryNumElements);
-      return true;
-    }
-    if (lastSegment.getPersistedEntrySize() < thisEntrySize) {
-      logger.info(
-          "Index: {} Rolling over from {} to {} because the segment persisted entry size: {} is less than the size of this entry: {}",
-          dataDir, lastSegment.getStartOffset(), offset, lastSegment.getPersistedEntrySize(), thisEntrySize);
       return true;
     }
     if (lastSegment.getValueSize() != thisValueSize) {


### PR DESCRIPTION
It's based on https://github.com/linkedin/ambry/pull/2376.
Instead of pre-config the entry size to 115, we monitor the IndexSegment Entry size with the maxEntrySize variable. When we write the IndexSegment, we pad each entry with the maxEntrySize.
There are three cases related to entry size,
1. Sealed Index Segment: The entry size is fixed. Renamed it to PersistedEntrySize.
2. Brand new index segment. maxEntrySize starts with 0. And we monitor the new entry size and update it.
3. Saved index segment but not sealed, after we read from the index segment size, we set the initial maxEntrySize to the entry size used in the file. Then we continue to change maxEntrySize if we have a new entry which is larger than that.

