### PR TITLE
Reducing the Number of StoreExceptions for checking mount path

### DIFF
--- a/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
@@ -531,14 +531,17 @@ public class DiskManager {
 
   /**
    * @throws StoreException if the disk's mount path is inaccessible.
+   *
+   * @return bool - True if mount is accessible otherwise False
    */
-  private void checkMountPathAccessible() throws StoreException {
+  private boolean checkMountPathAccessible() throws StoreException {
     File mountPath = new File(disk.getMountPath());
     if (!mountPath.exists() && diskHealthStatus != DiskHealthStatus.MOUNT_NOT_ACCESSIBLE) {
       metrics.diskMountPathFailures.inc();
       throw new StoreException("Mount path does not exist: " + mountPath + " ; cannot start stores on this disk",
           StoreErrorCodes.Initialization_Error);
     }
+    return mountPath.exists();
   }
 
   /**
@@ -677,7 +680,9 @@ public class DiskManager {
      */
     private AsynchronousFileChannel createFileChannel() {
       try {
-        checkMountPathAccessible();
+        if (!checkMountPathAccessible()) {
+          return null;
+        }
         Path path = Paths.get(disk.getMountPath(), "temp");
         AsynchronousFileChannel fileChannel =
             AsynchronousFileChannel.open(path, StandardOpenOption.WRITE, StandardOpenOption.READ,

--- a/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
@@ -84,7 +84,7 @@ public class DiskManager {
   private final AccountService accountService;
   private final DiskManagerConfig diskManagerConfig;
   private boolean running = false;
-  private DiskHealthStatus diskHealthStatus = DiskHealthStatus.MOUNT_NOT_ACCESSIBLE;
+  private DiskHealthStatus diskHealthStatus;
   private final DiskHealthCheck diskHealthCheck;
 
   private static final Logger logger = LoggerFactory.getLogger(DiskManager.class);
@@ -534,7 +534,7 @@ public class DiskManager {
    */
   private void checkMountPathAccessible() throws StoreException {
     File mountPath = new File(disk.getMountPath());
-    if (!mountPath.exists()) {
+    if (!mountPath.exists() && diskHealthStatus != DiskHealthStatus.MOUNT_NOT_ACCESSIBLE) {
       metrics.diskMountPathFailures.inc();
       throw new StoreException("Mount path does not exist: " + mountPath + " ; cannot start stores on this disk",
           StoreErrorCodes.Initialization_Error);


### PR DESCRIPTION
The disk healthchecker will check if the mount is accessible every 60s, so if a mount is inaccessible, the logs will be crowded with repeated exceptions of disks being inaccessible. With this change, we reduce the number of exceptions. So, we only throw an exception, if the previous state wasn't MOUNT_NOT_ACCESSIBLE.The initial state for diskHealthStatus will be null to trigger that initial Store Exception, if the mount isn't accessible. Build was successful