### PR TITLE
Listen to Helix Ideal states in Aggregated view as well

### DIFF
--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/ClusterChangeHandlerTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/ClusterChangeHandlerTest.java
@@ -394,35 +394,17 @@ public class ClusterChangeHandlerTest {
           helixClusterManager.getReplicaForPartitionOnNode(ambryNode, "0"));
     }
     // trigger IdealState change and refresh partition-to-resource mapping (bring in the new partition in resource map)
-    if (!useAggregatedView) {
-      helixCluster.refreshIdealState();
-      Map<String, String> partitionNameToResource = helixClusterManager.getPartitionToResourceMapByDC().get(localDc);
-      List<PartitionId> partitionIds = testPartitionLayout.getPartitionLayout().getPartitions(null);
-      // verify all partitions (including the new added one) are present in partition-to-resource map
-      Set<String> partitionNames = partitionIds.stream().map(PartitionId::toPathString).collect(Collectors.toSet());
-      assertEquals("Some partitions are not present in partition-to-resource map", partitionNames,
-          partitionNameToResource.keySet());
-      // verify all partitions are able to get their resource name
-      helixClusterManager.getAllPartitionIds(DEFAULT_PARTITION_CLASS)
-          .forEach(partitionId -> assertEquals("Resource name is not expected",
-              partitionNameToResource.get(partitionId.toPathString()), partitionId.getResourceNames().get(0)));
-    } else {
-      helixCluster.getHelixAdminFromDc(localDc).triggerRoutingTableNotification();
-      // Wait for some time to get the routing table notification
-      Thread.sleep(1000);
-      Map<String, Set<String>> globalPartitionNameToResourcesMap =
-          helixClusterManager.getGlobalPartitionToResourceMap();
-      List<PartitionId> partitionIds = testPartitionLayout.getPartitionLayout().getPartitions(null);
-      // verify all partitions (including the new added one) are present in partition-to-resource map
-      Set<String> partitionNames = partitionIds.stream().map(PartitionId::toPathString).collect(Collectors.toSet());
-      assertEquals("Some partitions are not present in partition-to-resource map", partitionNames,
-          globalPartitionNameToResourcesMap.keySet());
-      // verify all partitions are able to get their resource name
-      helixClusterManager.getAllPartitionIds(DEFAULT_PARTITION_CLASS)
-          .forEach(partitionId -> assertEquals("Resource name is not expected",
-              globalPartitionNameToResourcesMap.get(partitionId.toPathString()).iterator().next(),
-              partitionId.getResourceNames().get(0)));
-    }
+    helixCluster.refreshIdealState();
+    Map<String, String> partitionNameToResource = helixClusterManager.getPartitionToResourceMapByDC().get(localDc);
+    List<PartitionId> partitionIds = testPartitionLayout.getPartitionLayout().getPartitions(null);
+    // verify all partitions (including the new added one) are present in partition-to-resource map
+    Set<String> partitionNames = partitionIds.stream().map(PartitionId::toPathString).collect(Collectors.toSet());
+    assertEquals("Some partitions are not present in partition-to-resource map", partitionNames,
+        partitionNameToResource.keySet());
+    // verify all partitions are able to get their resource name
+    helixClusterManager.getAllPartitionIds(DEFAULT_PARTITION_CLASS)
+        .forEach(partitionId -> assertEquals("Resource name is not expected",
+            partitionNameToResource.get(partitionId.toPathString()), partitionId.getResourceNames().get(0)));
     helixClusterManager.close();
   }
 


### PR DESCRIPTION
When we move Ambry to Full auto, we need to Helix Ideal states for getting the assigned Partition to Replica mapping. In addition, we also need it for getting the Resource configs to know if a resource is in full-auto or semi-auto mode. 

This PR has following changes:

1. Currently we are only listening to Ideal states when using Non-aggregated view. Add changes to listen to helix ideal state in aggregated view as well.
2. Use Ideal states to get the Resource to Partition mapping in both aggregated and non-aggregated views.
