### PR TITLE
[DR] Use static map to discover VCR nodes

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/ReplicationConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/ReplicationConfig.java
@@ -300,8 +300,14 @@ public class ReplicationConfig {
   @Config(BACKUP_CHECKER_REPORT_DIR)
   public final int maxBackupCheckerReportFd;
 
+  public static final String STATIC_VCR_CLUSTERMAP_FILE = "static.vcr.clustermap.file";
+  public static final String DEFAULT_STATIC_VCR_CLUSTERMAP_FILE = "";
+  @Config(STATIC_VCR_CLUSTERMAP_FILE)
+  public final String staticVcrClustermapFile;
+
   public ReplicationConfig(VerifiableProperties verifiableProperties) {
 
+    staticVcrClustermapFile = verifiableProperties.getString(STATIC_VCR_CLUSTERMAP_FILE, DEFAULT_STATIC_VCR_CLUSTERMAP_FILE);
     maxBackupCheckerReportFd =
         verifiableProperties.getInt(MAX_BACKUP_CHECKER_REPORT_FD, DEFAULT_MAX_BACKUP_CHECKER_REPORT_FD);
     backupCheckerReportDir =

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/CloudDataNode.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/CloudDataNode.java
@@ -172,6 +172,6 @@ public class CloudDataNode implements DataNodeId {
 
   @Override
   public String toString() {
-    return "CloudDataNode[" + getHostname() + ":" + getPort() + "]";
+    return "CloudDataNode[" + getHostname() + ":" + plainTextPort.toString() + ":" + http2Port.toString() + ":" + sslPort.toString() + "]";
   }
 }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/StaticVcrClustermap.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/StaticVcrClustermap.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2023 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.clustermap;
+
+import com.github.ambry.config.ClusterMapConfig;
+import com.github.ambry.network.Port;
+import com.github.ambry.network.PortType;
+import java.util.List;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Class to parse and store static vcr clustermap, useful for debugging vcr node issues.
+ * {
+ *   datacenter: [
+ *    {
+ *      datacenter_name: "ei4",
+ *      vcr_nodes: [
+ *        {
+ *          hostname: "..",
+ *          plaintext_port: "..",
+ *          ssl_port: "..",
+ *          http2_port: ".."
+ *        },
+ *        {
+ *          ...
+ *        }
+ *      ]
+ *    }
+ *   ]
+ * }
+ */
+public class StaticVcrClustermap {
+  public static final String HOSTNAME = "hostname";
+  public static final String PLAINTEXT_PORT = "plaintext_port";
+  public static final String SSL_PORT = "ssl_port";
+  public static final String HTTP2_PORT = "http2_port";
+  public static final String DATACENTER = "datacenter";
+  public static final String DATACENTER_NAME = "datacenter_name";
+  public static final String VCR_NODES = "vcr_nodes";
+  private static final Logger logger = LoggerFactory.getLogger(StaticVcrClustermap.class);
+  protected List<CloudDataNode> cloudDataNodes;
+
+  public StaticVcrClustermap(JSONObject jsonObject, ClusterMapConfig clusterMapConfig) {
+    this.cloudDataNodes = null;
+    JSONArray datacenters = jsonObject.getJSONArray(DATACENTER);
+    for (int i = 0; i < datacenters.length(); ++i) {
+      String datacenter = jsonObject.getString(DATACENTER_NAME);
+      JSONArray vcrNodes = jsonObject.getJSONArray(VCR_NODES);
+      for (int j = 0; j < vcrNodes.length(); ++j) {
+        JSONObject vcrNode = vcrNodes.getJSONObject(j);
+        CloudDataNode cloudDataNode = new CloudDataNode(vcrNode.getString(HOSTNAME),
+            new Port(vcrNode.getInt(PLAINTEXT_PORT), PortType.PLAINTEXT),
+            new Port(vcrNode.getInt(SSL_PORT), PortType.SSL),
+            new Port(vcrNode.getInt(HTTP2_PORT), PortType.HTTP2),
+            datacenter, clusterMapConfig);
+        cloudDataNodes.add(cloudDataNode);
+        logger.info("Read vcr node info {}", cloudDataNode);
+      }
+      logger.info("Done reading static vcr clustermap");
+    }
+  }
+
+  /**
+   * Returns cloud data nodes (vcr nodes)
+   * @return Returns cloud data nodes (vcr nodes)
+   */
+  public List<CloudDataNode> getCloudDataNodes() {
+    return cloudDataNodes;
+  }
+
+}

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/StaticVcrClustermap.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/StaticVcrClustermap.java
@@ -25,9 +25,9 @@ import org.slf4j.LoggerFactory;
 /**
  * Class to parse and store static vcr clustermap, useful for debugging vcr node issues.
  * {
- *   datacenter: [
+ *   datacenters: [
  *    {
- *      datacenter_name: "ei4",
+ *      datacenter: "ei4",
  *      vcr_nodes: [
  *        {
  *          hostname: "..",
@@ -48,17 +48,17 @@ public class StaticVcrClustermap {
   public static final String PLAINTEXT_PORT = "plaintext_port";
   public static final String SSL_PORT = "ssl_port";
   public static final String HTTP2_PORT = "http2_port";
+  public static final String DATACENTERS = "datacenters";
   public static final String DATACENTER = "datacenter";
-  public static final String DATACENTER_NAME = "datacenter_name";
   public static final String VCR_NODES = "vcr_nodes";
   private static final Logger logger = LoggerFactory.getLogger(StaticVcrClustermap.class);
   protected List<CloudDataNode> cloudDataNodes;
 
   public StaticVcrClustermap(JSONObject jsonObject, ClusterMapConfig clusterMapConfig) {
     this.cloudDataNodes = null;
-    JSONArray datacenters = jsonObject.getJSONArray(DATACENTER);
+    JSONArray datacenters = jsonObject.getJSONArray(DATACENTERS);
     for (int i = 0; i < datacenters.length(); ++i) {
-      String datacenter = jsonObject.getString(DATACENTER_NAME);
+      String datacenter = jsonObject.getString(DATACENTER);
       JSONArray vcrNodes = jsonObject.getJSONArray(VCR_NODES);
       for (int j = 0; j < vcrNodes.length(); ++j) {
         JSONObject vcrNode = vcrNodes.getJSONObject(j);

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/StaticVcrClustermap.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/StaticVcrClustermap.java
@@ -16,6 +16,7 @@ package com.github.ambry.clustermap;
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.network.Port;
 import com.github.ambry.network.PortType;
+import java.util.ArrayList;
 import java.util.List;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -55,22 +56,23 @@ public class StaticVcrClustermap {
   protected List<CloudDataNode> cloudDataNodes;
 
   public StaticVcrClustermap(JSONObject jsonObject, ClusterMapConfig clusterMapConfig) {
-    this.cloudDataNodes = null;
+    this.cloudDataNodes = new ArrayList<>();
     JSONArray datacenters = jsonObject.getJSONArray(DATACENTERS);
     for (int i = 0; i < datacenters.length(); ++i) {
-      String datacenter = jsonObject.getString(DATACENTER);
-      JSONArray vcrNodes = jsonObject.getJSONArray(VCR_NODES);
+      JSONObject datacenter = datacenters.getJSONObject(i);
+      String datacenterName = datacenter.getString(DATACENTER);
+      JSONArray vcrNodes = datacenter.getJSONArray(VCR_NODES);
       for (int j = 0; j < vcrNodes.length(); ++j) {
         JSONObject vcrNode = vcrNodes.getJSONObject(j);
         CloudDataNode cloudDataNode = new CloudDataNode(vcrNode.getString(HOSTNAME),
             new Port(vcrNode.getInt(PLAINTEXT_PORT), PortType.PLAINTEXT),
             new Port(vcrNode.getInt(SSL_PORT), PortType.SSL),
             new Port(vcrNode.getInt(HTTP2_PORT), PortType.HTTP2),
-            datacenter, clusterMapConfig);
+            datacenterName, clusterMapConfig);
         cloudDataNodes.add(cloudDataNode);
         logger.info("Read vcr node info {}", cloudDataNode);
       }
-      logger.info("Done reading static vcr clustermap");
+      logger.info("Done reading static vcr cluster-map");
     }
   }
 

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/StaticVcrClustermap.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/StaticVcrClustermap.java
@@ -13,9 +13,12 @@
  */
 package com.github.ambry.clustermap;
 
+import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.network.Port;
 import com.github.ambry.network.PortType;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import org.json.JSONArray;
@@ -44,7 +47,7 @@ import org.slf4j.LoggerFactory;
  *   ]
  * }
  */
-public class StaticVcrClustermap {
+public class StaticVcrClustermap implements ClusterMap {
   public static final String HOSTNAME = "hostname";
   public static final String PLAINTEXT_PORT = "plaintext_port";
   public static final String SSL_PORT = "ssl_port";
@@ -84,4 +87,88 @@ public class StaticVcrClustermap {
     return cloudDataNodes;
   }
 
+  @Override
+  public PartitionId getPartitionIdFromStream(InputStream stream) throws IOException {
+    return null;
+  }
+
+  @Override
+  public PartitionId getPartitionIdByName(String partitionIdStr) {
+    return null;
+  }
+
+  @Override
+  public List<? extends PartitionId> getWritablePartitionIds(String partitionClass) {
+    return null;
+  }
+
+  @Override
+  public PartitionId getRandomWritablePartition(String partitionClass, List<PartitionId> partitionsToExclude) {
+    return null;
+  }
+
+  @Override
+  public List<? extends PartitionId> getAllPartitionIds(String partitionClass) {
+    return null;
+  }
+
+  @Override
+  public boolean hasDatacenter(String datacenterName) {
+    return false;
+  }
+
+  @Override
+  public byte getLocalDatacenterId() {
+    return 0;
+  }
+
+  @Override
+  public String getDatacenterName(byte id) {
+    return null;
+  }
+
+  @Override
+  public DataNodeId getDataNodeId(String hostname, int port) {
+    return null;
+  }
+
+  @Override
+  public List<? extends ReplicaId> getReplicaIds(DataNodeId dataNodeId) {
+    return null;
+  }
+
+  @Override
+  public List<? extends DataNodeId> getDataNodeIds() {
+    return null;
+  }
+
+  @Override
+  public MetricRegistry getMetricRegistry() {
+    return null;
+  }
+
+  @Override
+  public void onReplicaEvent(ReplicaId replicaId, ReplicaEventType event) {
+
+  }
+
+  @Override
+  public JSONObject getSnapshot() {
+    return null;
+  }
+
+  @Override
+  public ReplicaId getBootstrapReplica(String partitionIdStr, DataNodeId dataNodeId) {
+    return null;
+  }
+
+  @Override
+  public void registerClusterMapListener(ClusterMapChangeListener clusterMapChangeListener) {
+
+  }
+
+  @Override
+  public void close() {
+
+  }
 }

--- a/ambry-replication/src/main/java/com/github/ambry/replication/CloudToStoreReplicationManager.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/CloudToStoreReplicationManager.java
@@ -128,8 +128,8 @@ public class CloudToStoreReplicationManager extends ReplicationEngine {
       // vcrClusterSpectator is null when vcrClusterAgentsFactory is set to StaticVcrClusterAgentsFactory
       // Static VCR cluster-map
       try {
-        StaticVcrClustermap staticVcrClustermap = new StaticVcrClustermap(new JSONObject(readStringFromFile(replicationConfig.staticVcrClustermapFile)),
-            clusterMapConfig);
+        StaticVcrClustermap staticVcrClustermap = new StaticVcrClustermap(
+            new JSONObject(readStringFromFile(replicationConfig.staticVcrClustermapFile)), clusterMapConfig);
         // Get vcr nodes
         vcrNodes.set(staticVcrClustermap.getCloudDataNodes());
         for (String partition : replicationConfig.replicationVcrRecoveryPartitions) {

--- a/ambry-replication/src/main/java/com/github/ambry/replication/CloudToStoreReplicationManager.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/CloudToStoreReplicationManager.java
@@ -138,6 +138,7 @@ public class CloudToStoreReplicationManager extends ReplicationEngine {
         }
       } catch (IOException e) {
         logger.error("Failed to read {} due to {}", replicationConfig.staticVcrClustermapFile, e.toString());
+        throw new RuntimeException(e);
       } catch (ReplicationException e) {
         logger.error("Failed to add cloud replica due to {}", e.toString());
         throw new RuntimeException(e);


### PR DESCRIPTION
It's becoming difficult to debug VCR issues because the current setup uses HelixVcrCluster to dynamically discover vcr nodes and then randomly picks a node to talk to. It is also difficult to play around with VCR configs and understand what works because one has to change configs in all VCR nodes and we don't know which VCR node will picked up next time we start a DR node.

This patch adds a support for reading files to discover vcr nodes and allows us to fix a vcr node for an experiment or debugging.