### PR TITLE
[Efficient Metadata Operations] Add functionality to get partially sealed partitions in ClusterMap.

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/clustermap/ClusterMap.java
+++ b/ambry-api/src/main/java/com/github/ambry/clustermap/ClusterMap.java
@@ -54,12 +54,29 @@ public interface ClusterMap extends AutoCloseable {
   List<? extends PartitionId> getWritablePartitionIds(String partitionClass);
 
   /**
+   * Gets a list of partitions that are available for writes. Gets a mutable shallow copy of the list of the partitions
+   * that are available for writes
+   * @param partitionClass the partition class whose writable partitions are required. Can be {@code null}
+   * @return a list of all writable partitions belonging to the partition class (or all writable partitions if
+   * {@code partitionClass} is {@code null})
+   */
+  List<? extends PartitionId> getFullyWritablePartitionIds(String partitionClass);
+
+  /**
    * Get a writable partition chosen at random that belongs to given partition class.
    * @param partitionClass the partition class whose writable partitions are required. Can be {@code null}
    * @param partitionsToExclude list of partitions that shouldn't be considered as a possible partition returned
    * @return chosen random partition. Can be {@code null}
    */
   PartitionId getRandomWritablePartition(String partitionClass, List<PartitionId> partitionsToExclude);
+
+  /**
+   * Get a fully writable partition chosen at random that belongs to given partition class.
+   * @param partitionClass the partition class whose fully writable partitions are required. Can be {@code null}
+   * @param partitionsToExclude list of partitions that shouldn't be considered as a possible partition returned
+   * @return chosen random partition. Can be {@code null}.
+   */
+  PartitionId getRandomFullyWritablePartition(String partitionClass, List<PartitionId> partitionsToExclude);
 
   /**
    * Gets a list of all partitions in the cluster.  Gets a mutable shallow copy of the list of all partitions.

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
@@ -46,7 +46,6 @@ import org.apache.helix.NotificationContext;
 import org.apache.helix.api.listeners.IdealStateChangeListener;
 import org.apache.helix.api.listeners.LiveInstanceChangeListener;
 import org.apache.helix.api.listeners.RoutingTableChangeListener;
-import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.LiveInstance;
 import org.apache.helix.spectator.RoutingTableSnapshot;
@@ -379,8 +378,18 @@ public class HelixClusterManager implements ClusterMap {
   }
 
   @Override
+  public List<PartitionId> getFullyWritablePartitionIds(String partitionClass) {
+    return partitionSelectionHelper.getFullyWritablePartitions(partitionClass);
+  }
+
+  @Override
   public PartitionId getRandomWritablePartition(String partitionClass, List<PartitionId> partitionsToExclude) {
     return partitionSelectionHelper.getRandomWritablePartition(partitionClass, partitionsToExclude);
+  }
+
+  @Override
+  public PartitionId getRandomFullyWritablePartition(String partitionClass, List<PartitionId> partitionsToExclude) {
+    return partitionSelectionHelper.getRandomFullyWritablePartition(partitionClass, partitionsToExclude);
   }
 
   @Override

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PartitionLayout.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PartitionLayout.java
@@ -134,6 +134,10 @@ public class PartitionLayout {
     return partitionSelectionHelper.getWritablePartitions(partitionClass);
   }
 
+  public List<PartitionId> getFullyWritablePartitions(String partitionClass) {
+    return partitionSelectionHelper.getFullyWritablePartitions(partitionClass);
+  }
+
   public PartitionId getRandomWritablePartition(String partitionClass, List<PartitionId> toExclude) {
     return partitionSelectionHelper.getRandomWritablePartition(partitionClass, toExclude);
   }
@@ -144,6 +148,9 @@ public class PartitionLayout {
         checkLocalDcOnly);
   }
 
+  public PartitionId getRandomFullyWritablePartition(String partitionClass, List<PartitionId> toExclude) {
+    return partitionSelectionHelper.getRandomFullyWritablePartition(partitionClass, toExclude);
+  }
 
   public long getAllocatedRawCapacityInBytes() {
     return allocatedRawCapacityInBytes;

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/RecoveryTestClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/RecoveryTestClusterManager.java
@@ -81,8 +81,18 @@ public class RecoveryTestClusterManager implements ClusterMap {
   }
 
   @Override
+  public List<? extends PartitionId> getFullyWritablePartitionIds(String partitionClass) {
+    throw new UnsupportedOperationException(String.format("getFullyWritablePartitionIds method is not supported"));
+  }
+
+  @Override
   public PartitionId getRandomWritablePartition(String partitionClass, List<PartitionId> partitionsToExclude) {
     throw new UnsupportedOperationException(String.format("getRandomWritablePartition method is not supported"));
+  }
+
+  @Override
+  public PartitionId getRandomFullyWritablePartition(String partitionClass, List<PartitionId> partitionsToExclude) {
+    throw new UnsupportedOperationException(String.format("getRandomFullyWritablePartition method is not supported"));
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/StaticClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/StaticClusterManager.java
@@ -82,8 +82,18 @@ class StaticClusterManager implements ClusterMap {
   }
 
   @Override
+  public List<PartitionId> getFullyWritablePartitionIds(String partitionClass) {
+    return partitionLayout.getFullyWritablePartitions(partitionClass);
+  }
+
+  @Override
   public PartitionId getRandomWritablePartition(String partitionClass, List<PartitionId> partitionsToExclude) {
     return partitionLayout.getRandomWritablePartition(partitionClass, partitionsToExclude);
+  }
+
+  @Override
+  public PartitionId getRandomFullyWritablePartition(String partitionClass, List<PartitionId> partitionsToExclude) {
+    return partitionLayout.getRandomFullyWritablePartition(partitionClass, partitionsToExclude);
   }
 
   @Override

--- a/ambry-commons/src/test/java/com/github/ambry/commons/ResponseHandlerTest.java
+++ b/ambry-commons/src/test/java/com/github/ambry/commons/ResponseHandlerTest.java
@@ -71,7 +71,17 @@ public class ResponseHandlerTest {
     }
 
     @Override
+    public List<? extends PartitionId> getFullyWritablePartitionIds(String partitionClass) {
+      return null;
+    }
+
+    @Override
     public PartitionId getRandomWritablePartition(String partitionClass, List<PartitionId> partitionsToExclude) {
+      return null;
+    }
+
+    @Override
+    public PartitionId getRandomFullyWritablePartition(String partitionClass, List<PartitionId> partitionsToExclude) {
       return null;
     }
 

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/GetPeersHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/GetPeersHandlerTest.java
@@ -322,7 +322,17 @@ class TailoredPeersClusterMap implements ClusterMap {
   }
 
   @Override
+  public List<? extends PartitionId> getFullyWritablePartitionIds(String partitionClass) {
+    throw new IllegalStateException();
+  }
+
+  @Override
   public PartitionId getRandomWritablePartition(String partitionClass, List<PartitionId> partitionsToExclude) {
+    throw new IllegalStateException();
+  }
+
+  @Override
+  public PartitionId getRandomFullyWritablePartition(String partitionClass, List<PartitionId> partitionsToExclude) {
     throw new IllegalStateException();
   }
 

--- a/ambry-replication/src/test/java/com/github/ambry/replication/BlobIdTransformerTest.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/BlobIdTransformerTest.java
@@ -639,7 +639,17 @@ public class BlobIdTransformerTest {
       return null;
     }
 
+    @Override
+    public List<? extends PartitionId> getFullyWritablePartitionIds(String partitionClass) {
+      return null;
+    }
+
     public PartitionId getRandomWritablePartition(String partitionClass, List<PartitionId> partitionsToExclude) {
+      return null;
+    }
+
+    @Override
+    public PartitionId getRandomFullyWritablePartition(String partitionClass, List<PartitionId> partitionsToExclude) {
       return null;
     }
 

--- a/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockClusterMap.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockClusterMap.java
@@ -417,10 +417,29 @@ public class MockClusterMap implements ClusterMap {
   }
 
   @Override
+  public List<? extends PartitionId> getFullyWritablePartitionIds(String partitionClass) {
+    lastRequestedPartitionClasses.add(partitionClass);
+    List<PartitionId> partitionIdList = Collections.emptyList();
+    if (!partitionsUnavailable) {
+      partitionIdList = partitionSelectionHelper.getFullyWritablePartitions(partitionClass);
+    }
+    return partitionIdList;
+  }
+
+  @Override
   public PartitionId getRandomWritablePartition(String partitionClass, List<PartitionId> partitionsToExclude) {
     lastRequestedPartitionClasses.add(partitionClass);
     if (!partitionsUnavailable) {
       return partitionSelectionHelper.getRandomWritablePartition(partitionClass, partitionsToExclude);
+    }
+    return null;
+  }
+
+  @Override
+  public PartitionId getRandomFullyWritablePartition(String partitionClass, List<PartitionId> partitionsToExclude) {
+    lastRequestedPartitionClasses.add(partitionClass);
+    if (!partitionsUnavailable) {
+      return partitionSelectionHelper.getRandomFullyWritablePartition(partitionClass, partitionsToExclude);
     }
     return null;
   }


### PR DESCRIPTION
Adds methods to getFullyWritablePartitions and getRandomFullyWritablePartition in the ClusterMap. This method will be used by the PutManager to determine which partition a metadata chunk should go to.
Note that for efficient metadata operations, metadata chunks needs to go a partition that is "fully writable" i.e, in READ_WRITE state only. The data chunks can goto a partition that can be in "READ_WRITE" or "PARTIAL_READ_WRITE" state.