### PR TITLE
[Efficient Metadata Operations] Enable replicas to be marked as partially sealed in DataNodeConfig.

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/clustermap/ReplicaStatusDelegate.java
+++ b/ambry-api/src/main/java/com/github/ambry/clustermap/ReplicaStatusDelegate.java
@@ -44,9 +44,7 @@ public class ReplicaStatusDelegate {
    * @return {@code true} if replica is successfully partial-sealed. {@code false} if not.
    */
   public boolean partialSeal(ReplicaId replicaId) {
-    // TODO Efficient_Metadata_Operations_TODO Once the partial seal logic is complete end to end, this should set the
-    //  partial seal state.
-    return clusterParticipant.setReplicaSealedState(replicaId, ReplicaSealStatus.NOT_SEALED);
+    return clusterParticipant.setReplicaSealedState(replicaId, ReplicaSealStatus.PARTIALLY_SEALED);
   }
 
   /**

--- a/ambry-api/src/test/java/com/github/ambry/clustermap/ReplicaStatusDelegateTest.java
+++ b/ambry-api/src/test/java/com/github/ambry/clustermap/ReplicaStatusDelegateTest.java
@@ -43,7 +43,7 @@ public class ReplicaStatusDelegateTest {
     verify(clusterParticipant).setReplicaSealedState(replicaId, ReplicaSealStatus.NOT_SEALED);
     verifyNoMoreInteractions(clusterParticipant);
     delegate.partialSeal(replicaId);
-    verify(clusterParticipant, times(2)).setReplicaSealedState(replicaId, ReplicaSealStatus.NOT_SEALED);
+    verify(clusterParticipant).setReplicaSealedState(replicaId, ReplicaSealStatus.PARTIALLY_SEALED);
     verifyNoMoreInteractions(clusterParticipant);
     delegate.markStopped(replicaIds);
     verify(clusterParticipant).setReplicaStoppedState(replicaIds, true);


### PR DESCRIPTION
Before this change, the BlobStore was marking replicas that met partial seal conditions, as Unsealed. This PR changes ReplicaStatusDelegate to mark partially sealed partitions in Helix DatanodeConfig.