### PR TITLE
Fix typo in GetBlobOperation so we dont force set unavailability error when blob is deleted

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/FrontendConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/FrontendConfig.java
@@ -59,7 +59,7 @@ public class FrontendConfig {
   private static final String DEFAULT_CONTAINER_METRICS_ENABLED_GET_REQUEST_TYPES = "GetBlob,GetBlobInfo,GetSignedUrl";
 
 
-  /**
+  /**u
    * Cache validity in seconds for non-private blobs for GET.
    */
   @Config("frontend.cache.validity.seconds")

--- a/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
@@ -808,6 +808,7 @@ class GetBlobOperation extends GetOperation {
       logger.trace("BlobId {}: Retry for chunk Id: {}, failed attempts: {}, initializedTime: {}", blobId, chunkBlobId,
           failedAttempts, initializedTimeMs);
       chunkException = null;
+      chunkCompleted = false;
       chunkOperationTracker = getOperationTracker(chunkBlobId.getPartition(), chunkBlobId.getDatacenterId(),
           RouterOperation.GetBlobOperation, chunkBlobId);
       progressTracker = new ProgressTracker(chunkOperationTracker);
@@ -1062,7 +1063,7 @@ class GetBlobOperation extends GetOperation {
             chunkException =
                 buildChunkException("Get Chunk failed because of BlobNotFound", RouterErrorCode.BlobDoesNotExist);
           } else if (chunkOperationTracker.hasSomeUnavailability()) {
-            setChunkException(chunkException =
+            setChunkException(
                 buildChunkException("Get Chunk failed because of offline replicas", RouterErrorCode.AmbryUnavailable));
           }
         }


### PR DESCRIPTION
There is a typo in GetBlobOperation that would mistakenly set the the chunkException to AmbryUnavailable when the exception should be either BlobDeleted or BlobExpired. This PR fix that typo and also adds some test cases.