### PR TITLE
[Efficient Metadata Operations] Add method in ClusterMap to check if partition has enough eligible replicas for put operation.

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/clustermap/ClusterMap.java
+++ b/ambry-api/src/main/java/com/github/ambry/clustermap/ClusterMap.java
@@ -163,6 +163,18 @@ public interface ClusterMap extends AutoCloseable {
   void registerClusterMapListener(ClusterMapChangeListener clusterMapChangeListener);
 
   /**
+   * Check if there are at least requiredEligibleReplicaCount of replicas eligible for Put operation for the specified
+   * partition. If the specified checkLocalDcOnly is set to {@code true} then the check happens only for local datacenter.
+   * Otherwise, the check happens for all the datacenters.
+   * @param partitionId {@link PartitionId} whose replicas are checked for eligibility.
+   * @param requiredEligibleReplicaCount required number of replicas which should be eligible for put.
+   * @param checkLocalDcOnly if set to {@code true} then only local datacenter is checked. Otherwise, all the datacenters are checked.
+   * @return {@code true} if there are enough replicas. {@code false} otherwise.
+   */
+   boolean hasEnoughEligibleReplicasAvailableForPut(PartitionId partitionId, int requiredEligibleReplicaCount,
+       boolean checkLocalDcOnly);
+
+  /**
    * Close the cluster map. Any cleanups should be done in this call.
    */
   @Override

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/CompositeClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/CompositeClusterManager.java
@@ -306,6 +306,24 @@ class CompositeClusterManager implements ClusterMap {
   }
 
   @Override
+  public boolean hasEnoughEligibleReplicasAvailableForPut(PartitionId partitionId, int requiredEligibleReplicaCount,
+      boolean checkLocalDcOnly) {
+    boolean staticHasEnoughEligible =
+        staticClusterManager.hasEnoughEligibleReplicasAvailableForPut(partitionId, requiredEligibleReplicaCount,
+            checkLocalDcOnly);
+    if (helixClusterManager.hasEnoughEligibleReplicasAvailableForPut(partitionId, requiredEligibleReplicaCount,
+        checkLocalDcOnly) != staticHasEnoughEligible) {
+      String staticLogStr = staticHasEnoughEligible ? "has" : "doesn't have";
+      String helixLogStr = staticHasEnoughEligible ? "doesn't have" : "has";
+      logger.warn(
+          "Partition {} {} enough eligible replicas for put in static cluster map, but {} enough eligible replicas for put in helix cluster map.",
+          partitionId, staticLogStr, helixLogStr);
+    }
+    return staticHasEnoughEligible;
+  }
+
+
+  @Override
   public void close() {
     staticClusterManager.close();
     if (helixClusterManager != null) {

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
@@ -513,6 +513,14 @@ public class HelixClusterManager implements ClusterMap {
     return property != null && property.rebalanceMode.equals(IdealState.RebalanceMode.FULL_AUTO);
   }
 
+  @Override
+  public boolean hasEnoughEligibleReplicasAvailableForPut(PartitionId partitionId, int requiredEligibleReplicaCount,
+      boolean checkLocalDcOnly) {
+    return partitionSelectionHelper.hasEnoughEligibleReplicasAvailableForPut(partitionId, requiredEligibleReplicaCount,
+        checkLocalDcOnly);
+  }
+
+
   /**
    * Disconnect from the HelixManagers associated with each and every datacenter.
    */

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PartitionLayout.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PartitionLayout.java
@@ -138,6 +138,13 @@ public class PartitionLayout {
     return partitionSelectionHelper.getRandomWritablePartition(partitionClass, toExclude);
   }
 
+  public boolean hasEnoughEligibleReplicasAvailableForPut(PartitionId partitionId, int requiredEligibleReplicaCount,
+      boolean checkLocalDcOnly) {
+    return partitionSelectionHelper.hasEnoughEligibleReplicasAvailableForPut(partitionId, requiredEligibleReplicaCount,
+        checkLocalDcOnly);
+  }
+
+
   public long getAllocatedRawCapacityInBytes() {
     return allocatedRawCapacityInBytes;
   }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/RecoveryTestClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/RecoveryTestClusterManager.java
@@ -222,6 +222,14 @@ public class RecoveryTestClusterManager implements ClusterMap {
   }
 
   @Override
+  public boolean hasEnoughEligibleReplicasAvailableForPut(PartitionId partitionId, int requiredEligibleReplicaCount,
+      boolean checkLocalDcOnly) {
+    return helixClusterManager.hasEnoughEligibleReplicasAvailableForPut(partitionId, requiredEligibleReplicaCount,
+        checkLocalDcOnly);
+  }
+
+
+  @Override
   public void close() {
     staticClusterManager.close();
     if (helixClusterManager != null) {

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/StaticClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/StaticClusterManager.java
@@ -163,6 +163,14 @@ class StaticClusterManager implements ClusterMap {
     // no op for static cluster manager
   }
 
+  @Override
+  public boolean hasEnoughEligibleReplicasAvailableForPut(PartitionId partitionId, int requiredEligibleReplicaCount,
+      boolean checkLocalDcOnly) {
+    return partitionLayout.hasEnoughEligibleReplicasAvailableForPut(partitionId, requiredEligibleReplicaCount,
+        checkLocalDcOnly);
+  }
+
+
   // Administrative API
   // -----------------------
 

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixAdmin.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixAdmin.java
@@ -253,6 +253,20 @@ public class MockHelixAdmin implements HelixAdmin {
   }
 
   /**
+   * Set the replica state of the specified replica of the specified partition to the specified state.
+   * @param partition the partition whose leader replica should be changed.
+   * @param instance the instance of the replica for which state needs to be changed.
+   * @param newReplicaState The new state of the replica.
+   */
+  void setReplicaStateForPartition(String partition, String instance, ReplicaState newReplicaState) {
+    instanceToReplicaStateInfos.get(instance).setReplicaState(partition, newReplicaState.name());
+    // Update external view maps
+    String resource = partitionToResourceMap.get(partition);
+    ResourceInfo resourceInfo = resourceToResourceInfoMap.get(resource);
+    resourceInfo.setReplicasState(partition, instance, newReplicaState.name());
+  }
+
+  /**
    * Set or reset the sealed state of the replica for the given partition on the given instance.
    * @param partition the {@link AmbryPartition}
    * @param instance the instance name.

--- a/ambry-commons/src/test/java/com/github/ambry/commons/ResponseHandlerTest.java
+++ b/ambry-commons/src/test/java/com/github/ambry/commons/ResponseHandlerTest.java
@@ -136,6 +136,12 @@ public class ResponseHandlerTest {
     }
 
     @Override
+    public boolean hasEnoughEligibleReplicasAvailableForPut(PartitionId partitionId, int requiredEligibleReplicaCount,
+        boolean checkLocalDcOnly) {
+      return false;
+    }
+
+    @Override
     public void close() {
     }
 

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/GetPeersHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/GetPeersHandlerTest.java
@@ -397,6 +397,12 @@ class TailoredPeersClusterMap implements ClusterMap {
   }
 
   @Override
+  public boolean hasEnoughEligibleReplicasAvailableForPut(PartitionId partitionId, int requiredEligibleReplicaCount,
+      boolean checkLocalDcOnly) {
+    throw new IllegalStateException();
+  }
+
+  @Override
   public void close() {
   }
 

--- a/ambry-replication/src/test/java/com/github/ambry/replication/BlobIdTransformerTest.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/BlobIdTransformerTest.java
@@ -692,6 +692,12 @@ public class BlobIdTransformerTest {
     public void registerClusterMapListener(ClusterMapChangeListener clusterMapChangeListener) {
     }
 
+    @Override
+    public boolean hasEnoughEligibleReplicasAvailableForPut(PartitionId partitionId, int requiredEligibleReplicaCount,
+        boolean checkLocalDcOnly) {
+      return false;
+    }
+
     public void close() {
     }
   }

--- a/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockClusterMap.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockClusterMap.java
@@ -631,6 +631,16 @@ public class MockClusterMap implements ClusterMap {
   }
 
   @Override
+  public boolean hasEnoughEligibleReplicasAvailableForPut(PartitionId partitionId, int requiredEligibleReplicaCount,
+      boolean checkLocalDcOnly) {
+    if (!partitionsUnavailable) {
+      return partitionSelectionHelper.hasEnoughEligibleReplicasAvailableForPut(partitionId,
+          requiredEligibleReplicaCount, checkLocalDcOnly);
+    }
+    return false;
+  }
+
+  @Override
   public void close() {
     // No-op.
   }


### PR DESCRIPTION
This method will be used in PutOperation to check if the reserved partition for MetadataChunk is available when metadata chunk is ready to be written.