### PR TITLE
Support retentionTime at dataset level

### DIFF
--- a/ambry-account/src/integration-test/java/com/github/ambry/account/MySqlAccountServiceIntegrationTest.java
+++ b/ambry-account/src/integration-test/java/com/github/ambry/account/MySqlAccountServiceIntegrationTest.java
@@ -39,7 +39,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import org.json.JSONArray;
@@ -733,7 +732,7 @@ public class MySqlAccountServiceIntegrationTest {
     //add dataset with must provide info
     Dataset dataset =
         new DatasetBuilder(testAccount.getName(), testContainer.getName(), DATASET_NAME_BASIC).setVersionSchema(
-            Dataset.VersionSchema.MONOTONIC).setExpirationTimeMs(-1).build();
+            Dataset.VersionSchema.MONOTONIC).setRetentionTime(-1).build();
     mySqlAccountStore.addDataset(testAccount.getId(), testContainer.getId(), dataset);
     Dataset datasetFromMysql =
         mySqlAccountStore.getDataset(testAccount.getId(), testContainer.getId(), testAccount.getName(),
@@ -745,7 +744,7 @@ public class MySqlAccountServiceIntegrationTest {
     int retentionCount = 5;
     dataset = new DatasetBuilder(testAccount.getName(), testContainer.getName(), DATASET_NAME).setVersionSchema(
             Dataset.VersionSchema.TIMESTAMP)
-        .setExpirationTimeMs(-1)
+        .setRetentionTime(-1)
         .setUserTags(userTags)
         .setRetentionCount(retentionCount)
         .build();
@@ -777,15 +776,14 @@ public class MySqlAccountServiceIntegrationTest {
         datasetFromMysql.getRetentionCount());
 
     //update the expiration time.
-    long expirationTimeInMs = Utils.addSecondsToEpochTime(System.currentTimeMillis(), 30);
+    long datasetTtl = 30;
     datasetForUpdate =
-        new DatasetBuilder(testAccount.getName(), testContainer.getName(), DATASET_NAME).setExpirationTimeMs(
-            expirationTimeInMs).build();
+        new DatasetBuilder(testAccount.getName(), testContainer.getName(), DATASET_NAME).setRetentionTime(datasetTtl)
+            .build();
     mySqlAccountStore.updateDataset(testAccount.getId(), testContainer.getId(), datasetForUpdate);
     datasetFromMysql = mySqlAccountStore.getDataset(testAccount.getId(), testContainer.getId(), testAccount.getName(),
         testContainer.getName(), DATASET_NAME);
-    assertEquals("Mismatch in updated expirationTimeInMst", (Long) expirationTimeInMs,
-        datasetFromMysql.getExpirationTimeMs());
+    assertEquals("Mismatch in updated dataset ttl", (Long) datasetTtl, datasetFromMysql.getRetentionTime());
 
     //update the user tags
     userTags.clear();
@@ -809,41 +807,26 @@ public class MySqlAccountServiceIntegrationTest {
     }
 
     //Add a dataset with limited ttl
-    expirationTimeInMs = Utils.addSecondsToEpochTime(System.currentTimeMillis(), 30);
     dataset =
         new DatasetBuilder(testAccount.getName(), testContainer.getName(), DATASET_NAME_WITH_TTL).setVersionSchema(
                 Dataset.VersionSchema.TIMESTAMP)
-            .setExpirationTimeMs(expirationTimeInMs)
+            .setRetentionTime(datasetTtl)
             .setUserTags(userTags)
             .setRetentionCount(retentionCount)
             .build();
     mySqlAccountStore.addDataset(testAccount.getId(), testContainer.getId(), dataset);
 
     //update expiration to permanent.
-    expirationTimeInMs = -1;
+    datasetTtl = -1;
     datasetForUpdate =
-        new DatasetBuilder(testAccount.getName(), testContainer.getName(), DATASET_NAME_WITH_TTL).setExpirationTimeMs(
-            expirationTimeInMs).build();
+        new DatasetBuilder(testAccount.getName(), testContainer.getName(), DATASET_NAME_WITH_TTL).setRetentionTime(
+            datasetTtl).build();
     mySqlAccountStore.updateDataset(testAccount.getId(), testContainer.getId(), datasetForUpdate);
     datasetFromMysql = mySqlAccountStore.getDataset(testAccount.getId(), testContainer.getId(), testAccount.getName(),
         testContainer.getName(), DATASET_NAME_WITH_TTL);
-    assertEquals("Mismatch in updated expirationTimeInMst", (Long) expirationTimeInMs,
-        datasetFromMysql.getExpirationTimeMs());
+    assertEquals("Mismatch in updated dataset ttl", (Long) datasetTtl, datasetFromMysql.getRetentionTime());
 
-    //delete a permanent dataset.
-    mySqlAccountStore.deleteDataset(testAccount.getId(), testContainer.getId(), DATASET_NAME_WITH_TTL);
-    try {
-      mySqlAccountStore.getDataset(testAccount.getId(), testContainer.getId(), testAccount.getName(),
-          testContainer.getName(), DATASET_NAME_WITH_TTL);
-      fail("Should fail due to the dataset already expired");
-    } catch (AccountServiceException e) {
-      assertEquals("Mistmatch on error code", AccountServiceErrorCode.Deleted, e.getErrorCode());
-    }
-
-    //delete a dataset with future expirationTimeMs
-    long oldExpirationTime =
-        mySqlAccountStore.getDataset(testAccount.getId(), testContainer.getId(), testAccount.getName(),
-            testContainer.getName(), DATASET_NAME).getExpirationTimeMs();
+    //delete a dataset
     mySqlAccountStore.deleteDataset(testAccount.getId(), testContainer.getId(), DATASET_NAME);
     try {
       mySqlAccountStore.getDataset(testAccount.getId(), testContainer.getId(), testAccount.getName(),
@@ -853,26 +836,9 @@ public class MySqlAccountServiceIntegrationTest {
       assertEquals("Mistmatch on error code", AccountServiceErrorCode.Deleted, e.getErrorCode());
     }
 
-    //delete a dataset which already expired, should fail.
-    expirationTimeInMs = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(1);
-    dataset = new DatasetBuilder(testAccount.getName(), testContainer.getName(), DATASET_NAME_EXPIRED).setVersionSchema(
-            Dataset.VersionSchema.TIMESTAMP)
-        .setExpirationTimeMs(expirationTimeInMs)
-        .setUserTags(userTags)
-        .setRetentionCount(retentionCount)
-        .build();
-    // Add dataset to db
-    mySqlAccountStore.addDataset(testAccount.getId(), testContainer.getId(), dataset);
-    try {
-      mySqlAccountStore.deleteDataset(testAccount.getId(), testContainer.getId(), DATASET_NAME_EXPIRED);
-      fail("Should fail due to the dataset already expired");
-    } catch (AccountServiceException e) {
-      assertEquals("Mistmatch on error code", AccountServiceErrorCode.NotFound, e.getErrorCode());
-    }
-
     //add new dataset with same primary key after it has been deleted.
     dataset = new DatasetBuilder(testAccount.getName(), testContainer.getName(), DATASET_NAME_EXPIRED).setVersionSchema(
-        Dataset.VersionSchema.TIMESTAMP).setExpirationTimeMs(-1).setRetentionCount(retentionCount).build();
+        Dataset.VersionSchema.TIMESTAMP).setRetentionTime(-1).setRetentionCount(retentionCount).build();
     mySqlAccountStore.addDataset(testAccount.getId(), testContainer.getId(), dataset);
   }
 
@@ -886,9 +852,9 @@ public class MySqlAccountServiceIntegrationTest {
     Map<String, String> userTags = new HashMap<>();
     List<Long> versions = new ArrayList<>();
     userTags.put("userTag", "tagValue");
-    long expirationTimeMs1 = Utils.addSecondsToEpochTime(SystemTime.getInstance().milliseconds(), 3600L);
+    long datasetTtl = 3600L;
     Dataset dataset = new DatasetBuilder(testAccount.getName(), testContainer.getName(), DATASET_NAME).setVersionSchema(
-        Dataset.VersionSchema.MONOTONIC).setExpirationTimeMs(expirationTimeMs1).setUserTags(userTags).build();
+        Dataset.VersionSchema.MONOTONIC).setRetentionTime(datasetTtl).setUserTags(userTags).build();
 
     // Add a dataset to db
     mySqlAccountStore.addDataset(testAccount.getId(), testContainer.getId(), dataset);
@@ -897,59 +863,70 @@ public class MySqlAccountServiceIntegrationTest {
     long versionNumber = 1;
     String version = String.valueOf(versionNumber);
     versions.add(versionNumber);
+    long creationTimeInMs = System.currentTimeMillis();
     DatasetVersionRecord expectedDatasetVersionRecord =
-        new DatasetVersionRecord(testAccount.getId(), testContainer.getId(), DATASET_NAME, version, expirationTimeMs1);
+        new DatasetVersionRecord(testAccount.getId(), testContainer.getId(), DATASET_NAME, version,
+            Utils.addSecondsToEpochTime(creationTimeInMs, datasetTtl));
     DatasetVersionRecord datasetVersionRecordFromMysql =
         mySqlAccountStore.addDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
-            testContainer.getName(), DATASET_NAME, version, -1);
-    assertEquals("Mismatch in dataset read from db", expectedDatasetVersionRecord, datasetVersionRecordFromMysql);
+            testContainer.getName(), DATASET_NAME, version, -1, creationTimeInMs, false);
+    assertEquals("Mismatch in dataset", expectedDatasetVersionRecord, datasetVersionRecordFromMysql);
 
     // Get the dataset version
     datasetVersionRecordFromMysql =
-        mySqlAccountStore.getDatasetVersion(testAccount.getId(), testContainer.getId(), DATASET_NAME, version);
+        mySqlAccountStore.getDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
+            testContainer.getName(), DATASET_NAME, version);
     assertEquals("Mismatch in dataset version read from db", expectedDatasetVersionRecord,
         datasetVersionRecordFromMysql);
 
-    // Add a valid dataset version with ttl and get from DB, dataset version ttl < dataset ttl.
+    // Enable datasetVersionTtlEnable and add a valid dataset version with ttl and get from DB, should use the dataset
+    // version level ttl.
     versionNumber = 2;
     version = String.valueOf(versionNumber);
     versions.add(versionNumber);
-    long expirationTimeMs = Utils.addSecondsToEpochTime(SystemTime.getInstance().milliseconds(), 360L);
+    creationTimeInMs = System.currentTimeMillis();
+    long datasetVersionTtl = 360L;
+    boolean datasetVersionTtlEnable = true;
     expectedDatasetVersionRecord =
-        new DatasetVersionRecord(testAccount.getId(), testContainer.getId(), DATASET_NAME, version, expirationTimeMs);
+        new DatasetVersionRecord(testAccount.getId(), testContainer.getId(), DATASET_NAME, version,
+            Utils.addSecondsToEpochTime(creationTimeInMs, datasetVersionTtl));
     mySqlAccountStore.addDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
-        testContainer.getName(), DATASET_NAME, version, expirationTimeMs);
+        testContainer.getName(), DATASET_NAME, version, datasetVersionTtl, creationTimeInMs, datasetVersionTtlEnable);
     datasetVersionRecordFromMysql =
-        mySqlAccountStore.getDatasetVersion(testAccount.getId(), testContainer.getId(), DATASET_NAME, version);
+        mySqlAccountStore.getDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
+            testContainer.getName(), DATASET_NAME, version);
     assertEquals("Mismatch in dataset version read from db", expectedDatasetVersionRecord,
         datasetVersionRecordFromMysql);
 
-    // Add a dataset with ttl (set to a past timestamp) and add a dataset version with current ttl, expect to be failed
-    // due to dataset already expired.
-    expirationTimeMs = System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(10);
-    Dataset datasetWithTtl =
-        new DatasetBuilder(testAccount.getName(), testContainer.getName(), DATASET_NAME_WITH_TTL).setVersionSchema(
-            Dataset.VersionSchema.TIMESTAMP).setExpirationTimeMs(expirationTimeMs).setUserTags(userTags).build();
-    mySqlAccountStore.addDataset(testAccount.getId(), testContainer.getId(), datasetWithTtl);
-    version = "3";
-    expirationTimeMs = System.currentTimeMillis();
-    try {
-      mySqlAccountStore.addDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
-          testContainer.getName(), DATASET_NAME_WITH_TTL, version, expirationTimeMs);
-      fail("Add dataset version should fail with ttl larger than dataset level");
-    } catch (AccountServiceException e) {
-      assertEquals("Unexpected ErrorCode", AccountServiceErrorCode.Deleted, e.getErrorCode());
-    }
+    // Disable datasetVersionTtlEnable and add a valid dataset version with ttl and get from DB, should use the dataset
+    // level ttl.
+    versionNumber = 3;
+    datasetVersionTtlEnable = false;
+    version = String.valueOf(versionNumber);
+    versions.add(versionNumber);
+    expectedDatasetVersionRecord =
+        new DatasetVersionRecord(testAccount.getId(), testContainer.getId(), DATASET_NAME, version,
+            Utils.addSecondsToEpochTime(creationTimeInMs, datasetTtl));
+    mySqlAccountStore.addDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
+        testContainer.getName(), DATASET_NAME, version, datasetVersionTtl, creationTimeInMs, datasetVersionTtlEnable);
+    datasetVersionRecordFromMysql =
+        mySqlAccountStore.getDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
+            testContainer.getName(), DATASET_NAME, version);
+    assertEquals("Mismatch in dataset version read from db", expectedDatasetVersionRecord,
+        datasetVersionRecordFromMysql);
+
     // Add a permanent dataset version, it should inherit from dataset level ttl.
     versionNumber = 4;
     version = String.valueOf(versionNumber);
     versions.add(versionNumber);
+    creationTimeInMs = System.currentTimeMillis();
     mySqlAccountStore.addDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
-        testContainer.getName(), DATASET_NAME, version, -1);
+        testContainer.getName(), DATASET_NAME, version, -1, creationTimeInMs, false);
     DatasetVersionRecord datasetVersionRecordWithTtl =
-        mySqlAccountStore.getDatasetVersion(testAccount.getId(), testContainer.getId(), DATASET_NAME, version);
-    assertEquals("Mismatch in dataset expirationTimeMs", (long) dataset.getExpirationTimeMs(),
-        datasetVersionRecordWithTtl.getExpirationTimeMs());
+        mySqlAccountStore.getDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
+            testContainer.getName(), DATASET_NAME, version);
+    assertEquals("Mismatch in dataset expirationTimeMs", (long) dataset.getRetentionTime(),
+        TimeUnit.MILLISECONDS.toSeconds(datasetVersionRecordWithTtl.getExpirationTimeMs() - creationTimeInMs));
 
     Collections.reverse(versions);
     long expectedLatestVersion = versions.get(0);
@@ -960,21 +937,21 @@ public class MySqlAccountServiceIntegrationTest {
     //Test semantic version.
     dataset =
         new DatasetBuilder(testAccount.getName(), testContainer.getName(), DATASET_NAME_WITH_SEMANTIC).setVersionSchema(
-            Dataset.VersionSchema.SEMANTIC).setExpirationTimeMs(-1).setUserTags(userTags).build();
+            Dataset.VersionSchema.SEMANTIC).setRetentionTime(-1).setUserTags(userTags).build();
     // Add a dataset to db
     mySqlAccountStore.addDataset(testAccount.getId(), testContainer.getId(), dataset);
     version = "1.2.4";
     mySqlAccountStore.addDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
-        testContainer.getName(), DATASET_NAME_WITH_SEMANTIC, version, -1);
+        testContainer.getName(), DATASET_NAME_WITH_SEMANTIC, version, -1, System.currentTimeMillis(), false);
     DatasetVersionRecord datasetVersionRecordWithSemanticVersion =
-        mySqlAccountStore.getDatasetVersion(testAccount.getId(), testContainer.getId(), DATASET_NAME_WITH_SEMANTIC,
-            version);
+        mySqlAccountStore.getDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
+            testContainer.getName(), DATASET_NAME_WITH_SEMANTIC, version);
     assertEquals("Mismatch in dataset version", version, datasetVersionRecordWithSemanticVersion.getVersion());
 
     // Add dataset version for non-existing dataset.
     try {
       mySqlAccountStore.addDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
-          testContainer.getName(), "NonExistingDataset", version, -1);
+          testContainer.getName(), "NonExistingDataset", version, -1, System.currentTimeMillis(), false);
       fail("Add dataset version should fail without dataset");
     } catch (AccountServiceException e) {
       assertEquals("Unexpected ErrorCode", AccountServiceErrorCode.NotFound, e.getErrorCode());
@@ -983,7 +960,7 @@ public class MySqlAccountServiceIntegrationTest {
     //add same dataset version, should fail
     try {
       mySqlAccountStore.addDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
-          testContainer.getName(), DATASET_NAME_WITH_SEMANTIC, version, -1);
+          testContainer.getName(), DATASET_NAME_WITH_SEMANTIC, version, -1, 0, false);
       fail("Should fail due to dataset version already exist");
     } catch (AccountServiceException e) {
       assertEquals("Unexpected error code", AccountServiceErrorCode.ResourceConflict, e.getErrorCode());
@@ -995,16 +972,35 @@ public class MySqlAccountServiceIntegrationTest {
 
     //add dataset version again, should succeed.
     mySqlAccountStore.addDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
-        testContainer.getName(), DATASET_NAME_WITH_SEMANTIC, version, -1);
+        testContainer.getName(), DATASET_NAME_WITH_SEMANTIC, version, -1, System.currentTimeMillis(), false);
 
     // Add dataset version which didn't follow the semantic format.
     version = "1.2";
     try {
       mySqlAccountStore.addDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
-          testContainer.getName(), DATASET_NAME_WITH_SEMANTIC, version, -1);
+          testContainer.getName(), DATASET_NAME_WITH_SEMANTIC, version, -1, System.currentTimeMillis(), false);
       fail("Add dataset version should fail with wrong format of semantic version");
     } catch (IllegalArgumentException e) {
       // do nothing
+    }
+
+    //delete the dataset, and can't add or get any dataset version.
+    mySqlAccountStore.deleteDataset(testAccount.getId(), testContainer.getId(), DATASET_NAME);
+    version = "1";
+    try {
+      mySqlAccountStore.addDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
+          testContainer.getName(), DATASET_NAME, version, -1, System.currentTimeMillis(), false);
+      fail("Should fail due to the dataset already gone");
+    } catch (AccountServiceException e) {
+      assertEquals("Unexpected error code", AccountServiceErrorCode.Deleted, e.getErrorCode());
+    }
+
+    try {
+      mySqlAccountStore.getDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
+          testContainer.getName(), DATASET_NAME, version);
+      fail("Should fail due to the dataset already gone");
+    } catch (AccountServiceException e) {
+      assertEquals("Unexpected error code", AccountServiceErrorCode.Deleted, e.getErrorCode());
     }
   }
 

--- a/ambry-account/src/integration-test/java/com/github/ambry/account/MySqlAccountServiceIntegrationTest.java
+++ b/ambry-account/src/integration-test/java/com/github/ambry/account/MySqlAccountServiceIntegrationTest.java
@@ -732,7 +732,7 @@ public class MySqlAccountServiceIntegrationTest {
     //add dataset with must provide info
     Dataset dataset =
         new DatasetBuilder(testAccount.getName(), testContainer.getName(), DATASET_NAME_BASIC).setVersionSchema(
-            Dataset.VersionSchema.MONOTONIC).setRetentionTime(-1).build();
+            Dataset.VersionSchema.MONOTONIC).setRetentionTimeInSeconds(-1).build();
     mySqlAccountStore.addDataset(testAccount.getId(), testContainer.getId(), dataset);
     Dataset datasetFromMysql =
         mySqlAccountStore.getDataset(testAccount.getId(), testContainer.getId(), testAccount.getName(),
@@ -744,7 +744,7 @@ public class MySqlAccountServiceIntegrationTest {
     int retentionCount = 5;
     dataset = new DatasetBuilder(testAccount.getName(), testContainer.getName(), DATASET_NAME).setVersionSchema(
             Dataset.VersionSchema.TIMESTAMP)
-        .setRetentionTime(-1)
+        .setRetentionTimeInSeconds(-1)
         .setUserTags(userTags)
         .setRetentionCount(retentionCount)
         .build();
@@ -778,12 +778,12 @@ public class MySqlAccountServiceIntegrationTest {
     //update the expiration time.
     long datasetTtl = 30;
     datasetForUpdate =
-        new DatasetBuilder(testAccount.getName(), testContainer.getName(), DATASET_NAME).setRetentionTime(datasetTtl)
+        new DatasetBuilder(testAccount.getName(), testContainer.getName(), DATASET_NAME).setRetentionTimeInSeconds(datasetTtl)
             .build();
     mySqlAccountStore.updateDataset(testAccount.getId(), testContainer.getId(), datasetForUpdate);
     datasetFromMysql = mySqlAccountStore.getDataset(testAccount.getId(), testContainer.getId(), testAccount.getName(),
         testContainer.getName(), DATASET_NAME);
-    assertEquals("Mismatch in updated dataset ttl", (Long) datasetTtl, datasetFromMysql.getRetentionTime());
+    assertEquals("Mismatch in updated dataset ttl", (Long) datasetTtl, datasetFromMysql.getRetentionTimeInSeconds());
 
     //update the user tags
     userTags.clear();
@@ -810,7 +810,7 @@ public class MySqlAccountServiceIntegrationTest {
     dataset =
         new DatasetBuilder(testAccount.getName(), testContainer.getName(), DATASET_NAME_WITH_TTL).setVersionSchema(
                 Dataset.VersionSchema.TIMESTAMP)
-            .setRetentionTime(datasetTtl)
+            .setRetentionTimeInSeconds(datasetTtl)
             .setUserTags(userTags)
             .setRetentionCount(retentionCount)
             .build();
@@ -819,12 +819,12 @@ public class MySqlAccountServiceIntegrationTest {
     //update expiration to permanent.
     datasetTtl = -1;
     datasetForUpdate =
-        new DatasetBuilder(testAccount.getName(), testContainer.getName(), DATASET_NAME_WITH_TTL).setRetentionTime(
+        new DatasetBuilder(testAccount.getName(), testContainer.getName(), DATASET_NAME_WITH_TTL).setRetentionTimeInSeconds(
             datasetTtl).build();
     mySqlAccountStore.updateDataset(testAccount.getId(), testContainer.getId(), datasetForUpdate);
     datasetFromMysql = mySqlAccountStore.getDataset(testAccount.getId(), testContainer.getId(), testAccount.getName(),
         testContainer.getName(), DATASET_NAME_WITH_TTL);
-    assertEquals("Mismatch in updated dataset ttl", (Long) datasetTtl, datasetFromMysql.getRetentionTime());
+    assertEquals("Mismatch in updated dataset ttl", (Long) datasetTtl, datasetFromMysql.getRetentionTimeInSeconds());
 
     //delete a dataset
     mySqlAccountStore.deleteDataset(testAccount.getId(), testContainer.getId(), DATASET_NAME);
@@ -838,7 +838,7 @@ public class MySqlAccountServiceIntegrationTest {
 
     //add new dataset with same primary key after it has been deleted.
     dataset = new DatasetBuilder(testAccount.getName(), testContainer.getName(), DATASET_NAME_EXPIRED).setVersionSchema(
-        Dataset.VersionSchema.TIMESTAMP).setRetentionTime(-1).setRetentionCount(retentionCount).build();
+        Dataset.VersionSchema.TIMESTAMP).setRetentionTimeInSeconds(-1).setRetentionCount(retentionCount).build();
     mySqlAccountStore.addDataset(testAccount.getId(), testContainer.getId(), dataset);
   }
 
@@ -854,7 +854,7 @@ public class MySqlAccountServiceIntegrationTest {
     userTags.put("userTag", "tagValue");
     long datasetTtl = 3600L;
     Dataset dataset = new DatasetBuilder(testAccount.getName(), testContainer.getName(), DATASET_NAME).setVersionSchema(
-        Dataset.VersionSchema.MONOTONIC).setRetentionTime(datasetTtl).setUserTags(userTags).build();
+        Dataset.VersionSchema.MONOTONIC).setRetentionTimeInSeconds(datasetTtl).setUserTags(userTags).build();
 
     // Add a dataset to db
     mySqlAccountStore.addDataset(testAccount.getId(), testContainer.getId(), dataset);
@@ -925,7 +925,7 @@ public class MySqlAccountServiceIntegrationTest {
     DatasetVersionRecord datasetVersionRecordWithTtl =
         mySqlAccountStore.getDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
             testContainer.getName(), DATASET_NAME, version);
-    assertEquals("Mismatch in dataset expirationTimeMs", (long) dataset.getRetentionTime(),
+    assertEquals("Mismatch in dataset expirationTimeMs", (long) dataset.getRetentionTimeInSeconds(),
         TimeUnit.MILLISECONDS.toSeconds(datasetVersionRecordWithTtl.getExpirationTimeMs() - creationTimeInMs));
 
     Collections.reverse(versions);
@@ -937,7 +937,7 @@ public class MySqlAccountServiceIntegrationTest {
     //Test semantic version.
     dataset =
         new DatasetBuilder(testAccount.getName(), testContainer.getName(), DATASET_NAME_WITH_SEMANTIC).setVersionSchema(
-            Dataset.VersionSchema.SEMANTIC).setRetentionTime(-1).setUserTags(userTags).build();
+            Dataset.VersionSchema.SEMANTIC).setRetentionTimeInSeconds(-1).setUserTags(userTags).build();
     // Add a dataset to db
     mySqlAccountStore.addDataset(testAccount.getId(), testContainer.getId(), dataset);
     version = "1.2.4";

--- a/ambry-account/src/main/java/com/github/ambry/account/MySqlAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/MySqlAccountService.java
@@ -413,8 +413,8 @@ public class MySqlAccountService extends AbstractAccountService {
   }
 
   @Override
-  public DatasetVersionRecord addDatasetVersion(String accountName, String containerName, String datasetName, String version,
-      long expirationTimeMs) throws AccountServiceException {
+  public DatasetVersionRecord addDatasetVersion(String accountName, String containerName, String datasetName,
+      String version, long timeToLiveInSeconds, long creationTimeInMs, boolean datasetVersionTtlEnabled) throws AccountServiceException {
     try {
       Container container = getContainerByName(accountName, containerName);
       if (container == null) {
@@ -424,7 +424,7 @@ public class MySqlAccountService extends AbstractAccountService {
       short accountId = container.getParentAccountId();
       short containerId = container.getId();
       return mySqlAccountStore.addDatasetVersion(accountId, containerId, accountName, containerName, datasetName,
-          version, expirationTimeMs);
+          version, timeToLiveInSeconds, creationTimeInMs, datasetVersionTtlEnabled);
     } catch (SQLException e) {
       throw translateSQLException(e);
     }
@@ -441,7 +441,8 @@ public class MySqlAccountService extends AbstractAccountService {
       }
       short accountId = container.getParentAccountId();
       short containerId = container.getId();
-      return mySqlAccountStore.getDatasetVersion(accountId, containerId, datasetName, version);
+      return mySqlAccountStore.getDatasetVersion(accountId, containerId, accountName, containerName, datasetName,
+          version);
     } catch (SQLException e) {
       throw translateSQLException(e);
     }

--- a/ambry-account/src/main/java/com/github/ambry/account/mysql/AccountDao.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/mysql/AccountDao.java
@@ -66,6 +66,7 @@ public class AccountDao {
   public static final String DATASET_NAME = "datasetName";
   public static final String VERSION_SCHEMA = "versionSchema";
   public static final String RETENTION_COUNT = "retentionCount";
+  public static final String RETENTION_TIME = "retentionTime";
   public static final String USER_TAGS = "userTags";
   public static final String DELETE_TS = "delete_ts";
 
@@ -144,23 +145,22 @@ public class AccountDao {
     insertDatasetSql =
         String.format("insert into %s (%s, %s, %s, %s, %s, %s, %s, %s) values (?, ?, ?, ?, now(3), ?, ?, ?)",
             DATASET_TABLE, ACCOUNT_ID, CONTAINER_ID, DATASET_NAME, VERSION_SCHEMA, LAST_MODIFIED_TIME, RETENTION_COUNT,
-            USER_TAGS, DELETE_TS);
+            RETENTION_TIME, USER_TAGS);
     updateDatasetIfExpiredSql = String.format(
         "update %s set %s = ?, %s = now(3), %s = ?, %s = ?, %s = ? where %s = ? and %s = ? and %s = ? and delete_ts < now(3)",
-        DATASET_TABLE, VERSION_SCHEMA, LAST_MODIFIED_TIME, RETENTION_COUNT, USER_TAGS, DELETE_TS, ACCOUNT_ID,
+        DATASET_TABLE, VERSION_SCHEMA, LAST_MODIFIED_TIME, RETENTION_COUNT, RETENTION_TIME, USER_TAGS, ACCOUNT_ID,
         CONTAINER_ID, DATASET_NAME);
     //update the dataset field, in order to support partial update, if one parameter is null, keep the original value.
     //if the delete_ts parameter from input equals to Utils.Infinite_Time(-1), set the delete_ts to null.
     updateDatasetSql = String.format(
         "update %1$s set %2$s = now(3)," + "`retentionCount` = IFNULL(?, `retentionCount`), "
-            + "`userTags` = IFNULL(?, `userTags`),"
-            + "`delete_ts` = CASE WHEN ? = '-1' THEN NULL ELSE IFNULL(?, `delete_ts`) END"
+            + "`retentionTime` = IFNULL(?, `retentionTime`)," + "`userTags` = IFNULL(?, `userTags`)"
             + " where %6$s = ? and %7$s = ? and %8$s = ?", DATASET_TABLE, LAST_MODIFIED_TIME, RETENTION_COUNT,
-        USER_TAGS, DELETE_TS, ACCOUNT_ID, CONTAINER_ID, DATASET_NAME);
+        RETENTION_TIME, USER_TAGS, ACCOUNT_ID, CONTAINER_ID, DATASET_NAME);
     getDatasetByNameSql =
-        String.format("select %s, %s, %s, %s, %s, %s from %s where %s = ? and %s = ? and %s = ?", DATASET_NAME,
-            VERSION_SCHEMA, LAST_MODIFIED_TIME, RETENTION_COUNT, USER_TAGS, DELETE_TS, DATASET_TABLE, ACCOUNT_ID,
-            CONTAINER_ID, DATASET_NAME);
+        String.format("select %s, %s, %s, %s, %s, %s , %s from %s where %s = ? and %s = ? and %s = ?", DATASET_NAME,
+            VERSION_SCHEMA, LAST_MODIFIED_TIME, RETENTION_COUNT, RETENTION_TIME, USER_TAGS, DELETE_TS, DATASET_TABLE,
+            ACCOUNT_ID, CONTAINER_ID, DATASET_NAME);
     deleteDatasetByIdSql = String.format(
         "update %s set %s = now(3), %s = now(3) where (%s IS NULL or %s > now(3)) and %s = ? and %s = ? and %s = ?",
         DATASET_TABLE, DELETE_TS, LAST_MODIFIED_TIME, DELETE_TS, DELETE_TS, ACCOUNT_ID, CONTAINER_ID, DATASET_NAME);
@@ -342,12 +342,15 @@ public class AccountDao {
    * @param containerName the name for the container.
    * @param datasetName the name of the dataset.
    * @param version the version of the dataset.
-   * @param expirationTimeMs the expiration time of the version of the dataset.
+   * @param timeToLiveInSeconds The dataset version level ttl.
+   * @param creationTimeInMs the creation time of the dataset.
+   * @param datasetVersionTtlEnabled set to true if dataset version ttl want to override the dataset level default ttl.
    * @return the {@link DatasetVersionRecord}.
    * @throws SQLException
    */
   public synchronized DatasetVersionRecord addDatasetVersions(int accountId, int containerId, String accountName,
-      String containerName, String datasetName, String version, long expirationTimeMs)
+      String containerName, String datasetName, String version, long timeToLiveInSeconds, long creationTimeInMs,
+      boolean datasetVersionTtlEnabled)
       throws SQLException, AccountServiceException {
     long startTimeMs = System.currentTimeMillis();
     long versionNumber = 0;
@@ -361,7 +364,7 @@ public class AccountDao {
       versionNumber = getVersionBasedOnSchema(version, dataset.getVersionSchema());
       long newExpirationTimeMs =
           executeAddDatasetVersionStatement(insertDatasetVersionStatement, accountId, containerId, datasetName,
-              versionNumber, expirationTimeMs, dataset);
+              versionNumber, timeToLiveInSeconds, creationTimeInMs, dataset, datasetVersionTtlEnabled);
       dataAccessor.onSuccess(Write, System.currentTimeMillis() - startTimeMs);
       return new DatasetVersionRecord(accountId, containerId, datasetName, version, newExpirationTimeMs);
     } catch (SQLException | AccountServiceException e) {
@@ -371,7 +374,8 @@ public class AccountDao {
         try {
           long newExpirationTimeMs =
               executeUpdateDatasetVersionIfExpiredSqlStatement(updateDatasetSqlIfExpiredStatement, accountId,
-                  containerId, datasetName, versionNumber, expirationTimeMs, dataset);
+                  containerId, datasetName, versionNumber, timeToLiveInSeconds, creationTimeInMs, dataset,
+                  datasetVersionTtlEnabled);
           dataAccessor.onSuccess(Write, System.currentTimeMillis() - startTimeMs);
           return new DatasetVersionRecord(accountId, containerId, datasetName, version, newExpirationTimeMs);
         } catch (SQLException | AccountServiceException ex) {
@@ -388,18 +392,20 @@ public class AccountDao {
    * Get a version of {@link Dataset} based on supplied properties.
    * @param accountId the id for the parent account.
    * @param containerId the id of the container.
+   * @param accountName the name for the parent account.
+   * @param containerName the name for the container.
    * @param datasetName the name of the dataset.
    * @param version the version of the dataset.
    * @return the {@link DatasetVersionRecord}
    * @throws SQLException
    */
-  public synchronized DatasetVersionRecord getDatasetVersions(short accountId, short containerId, String datasetName,
-      String version) throws SQLException, AccountServiceException {
+  public synchronized DatasetVersionRecord getDatasetVersions(short accountId, short containerId, String accountName,
+      String containerName, String datasetName, String version) throws SQLException, AccountServiceException {
     try {
       long startTimeMs = System.currentTimeMillis();
-      PreparedStatement getVersionSchemaStatement = dataAccessor.getPreparedStatement(getVersionSchemaSql, false);
-      Dataset.VersionSchema versionSchema =
-          executeGetVersionSchema(getVersionSchemaStatement, accountId, containerId, datasetName);
+      //if dataset is deleted, we should not be able to get any dataset version.
+      Dataset dataset = getDataset(accountId, containerId, accountName, containerName, datasetName);
+      Dataset.VersionSchema versionSchema = dataset.getVersionSchema();
       dataAccessor.getDatabaseConnection(false);
       PreparedStatement getDatasetVersionStatement =
           dataAccessor.getPreparedStatement(getDatasetVersionByNameSql, false);
@@ -450,24 +456,28 @@ public class AccountDao {
    * @param containerId the id of the container.
    * @param datasetName the name of the dataset.
    * @param version the version of the dataset.
-   * @param expirationTimeMs the expiration time in milliseconds.
+   * @param timeToLiveInSeconds The dataset version level ttl.
+   * @param creationTimeInMs The time at which the blob is created.
    * @param dataset the {@link Dataset} including the metadata.
+   * @param datasetVersionTtlEnabled set to true if dataset version ttl want to override the dataset level default ttl.
    * @throws SQLException
    */
-  private long executeAddDatasetVersionStatement(PreparedStatement statement, int accountId,
-      int containerId, String datasetName, long version, long expirationTimeMs, Dataset dataset) throws SQLException {
+  private long executeAddDatasetVersionStatement(PreparedStatement statement, int accountId, int containerId,
+      String datasetName, long version, long timeToLiveInSeconds, long creationTimeInMs, Dataset dataset,
+      boolean datasetVersionTtlEnabled) throws SQLException {
     statement.setInt(1, accountId);
     statement.setInt(2, containerId);
     statement.setString(3, datasetName);
     statement.setLong(4, version);
-    long updatedExpirationTimeMs = expirationTimeMs;
-    if (expirationTimeMs == Infinite_Time && dataset.getExpirationTimeMs() == Infinite_Time) {
-      statement.setTimestamp(5, null);
-    } else if (expirationTimeMs == Infinite_Time || dataset.getExpirationTimeMs() == Infinite_Time) {
-      updatedExpirationTimeMs = expirationTimeMs == Infinite_Time ? dataset.getExpirationTimeMs() : expirationTimeMs;
-      statement.setTimestamp(5, new Timestamp(updatedExpirationTimeMs));
+    long updatedExpirationTimeMs;
+    if (datasetVersionTtlEnabled || dataset.getRetentionTime() == null) {
+      updatedExpirationTimeMs = Utils.addSecondsToEpochTime(creationTimeInMs, timeToLiveInSeconds);
     } else {
-      updatedExpirationTimeMs = Math.min(dataset.getExpirationTimeMs(), expirationTimeMs);
+      updatedExpirationTimeMs = Utils.addSecondsToEpochTime(creationTimeInMs, dataset.getRetentionTime());
+    }
+    if (updatedExpirationTimeMs == Infinite_Time) {
+      statement.setTimestamp(5, null);
+    } else {
       statement.setTimestamp(5, new Timestamp(updatedExpirationTimeMs));
     }
     statement.executeUpdate();
@@ -505,24 +515,27 @@ public class AccountDao {
    * @param containerId the id of the container.
    * @param datasetName the name of the dataset.
    * @param version the version value of the dataset.
-   * @param expirationTimeMs the expiration time in milliseconds.
+   * @param timeToLiveInSeconds The dataset version level ttl.
+   * @param creationTimeInMs the creation time of the dataset version.
    * @param dataset the {@link Dataset} including the metadata.
-   * @return
+   * @param datasetVersionTtlEnabled set to true if dataset version ttl want to override the dataset level default ttl.
+   * @return the updated expiration time.
    * @throws SQLException
    * @throws AccountServiceException
    */
-  private long executeUpdateDatasetVersionIfExpiredSqlStatement(PreparedStatement statement,
-      int accountId, int containerId, String datasetName, long version, long expirationTimeMs, Dataset dataset)
-      throws SQLException, AccountServiceException {
+  private long executeUpdateDatasetVersionIfExpiredSqlStatement(PreparedStatement statement, int accountId,
+      int containerId, String datasetName, long version, long timeToLiveInSeconds, long creationTimeInMs,
+      Dataset dataset, boolean datasetVersionTtlEnabled) throws SQLException, AccountServiceException {
     statement.setLong(1, version);
-    long updatedExpirationTimeMs = expirationTimeMs;
-    if (expirationTimeMs == Infinite_Time && dataset.getExpirationTimeMs() == Infinite_Time) {
-      statement.setTimestamp(2, null);
-    } else if (expirationTimeMs == Infinite_Time || dataset.getExpirationTimeMs() == Infinite_Time) {
-      updatedExpirationTimeMs = expirationTimeMs == Infinite_Time ? dataset.getExpirationTimeMs() : expirationTimeMs;
-      statement.setTimestamp(2, new Timestamp(updatedExpirationTimeMs));
+    long updatedExpirationTimeMs;
+    if (datasetVersionTtlEnabled || dataset.getRetentionTime() == null) {
+      updatedExpirationTimeMs = Utils.addSecondsToEpochTime(creationTimeInMs, timeToLiveInSeconds);
     } else {
-      updatedExpirationTimeMs = Math.min(dataset.getExpirationTimeMs(), expirationTimeMs);
+      updatedExpirationTimeMs = Utils.addSecondsToEpochTime(creationTimeInMs, dataset.getRetentionTime());
+    }
+    if (updatedExpirationTimeMs == Infinite_Time) {
+      statement.setTimestamp(2, null);
+    } else {
       statement.setTimestamp(2, new Timestamp(updatedExpirationTimeMs));
     }
     statement.setInt(3, accountId);
@@ -871,13 +884,9 @@ public class AccountDao {
       throw new AccountServiceException("Must set the version schema info during dataset creation",
           AccountServiceErrorCode.BadRequest);
     }
-    Long expirationTimeMs = dataset.getExpirationTimeMs();
-    if (expirationTimeMs == null) {
-      throw new AccountServiceException("Must set the expiration time info during dataset creation",
-          AccountServiceErrorCode.BadRequest);
-    }
     int schemaVersionOrdinal = dataset.getVersionSchema().ordinal();
     Integer retentionCount = dataset.getRetentionCount();
+    Long retentionTime = dataset.getRetentionTime();
     Map<String, String> userTags = dataset.getUserTags();
     String userTagsInJson;
     try {
@@ -895,15 +904,15 @@ public class AccountDao {
     } else {
       statement.setObject(5, null);
     }
-    if (userTags != null) {
-      statement.setString(6, userTagsInJson);
+    if (retentionTime != null) {
+      statement.setLong(6, retentionTime);
     } else {
-      statement.setString(6, null);
+      statement.setObject(6, null);
     }
-    if (dataset.getExpirationTimeMs() != Utils.Infinite_Time) {
-      statement.setTimestamp(7, new Timestamp(dataset.getExpirationTimeMs()));
+    if (userTags != null) {
+      statement.setString(7, userTagsInJson);
     } else {
-      statement.setTimestamp(7, null);
+      statement.setString(7, null);
     }
     statement.executeUpdate();
   }
@@ -925,13 +934,9 @@ public class AccountDao {
       throw new AccountServiceException("Must set the version schema info during dataset creation",
           AccountServiceErrorCode.BadRequest);
     }
-    Long expirationTimeMs = dataset.getExpirationTimeMs();
-    if (expirationTimeMs == null) {
-      throw new AccountServiceException("Must set the expiration time info during dataset creation",
-          AccountServiceErrorCode.BadRequest);
-    }
     int schemaVersionOrdinal = dataset.getVersionSchema().ordinal();
     Integer retentionCount = dataset.getRetentionCount();
+    Long retentionTime = dataset.getRetentionTime();
     Map<String, String> userTags = dataset.getUserTags();
     String userTagsInJson;
     try {
@@ -946,15 +951,15 @@ public class AccountDao {
     } else {
       statement.setObject(2, null);
     }
-    if (userTags != null) {
-      statement.setString(3, userTagsInJson);
+    if (retentionTime != null) {
+      statement.setLong(3, retentionTime);
     } else {
-      statement.setString(3, null);
+      statement.setObject(3, null);
     }
-    if (dataset.getExpirationTimeMs() != Utils.Infinite_Time) {
-      statement.setTimestamp(4, new Timestamp(dataset.getExpirationTimeMs()));
+    if (userTags != null) {
+      statement.setString(4, userTagsInJson);
     } else {
-      statement.setTimestamp(4, null);
+      statement.setString(4, null);
     }
     statement.setInt(5, accountId);
     statement.setInt(6, containerId);
@@ -994,21 +999,16 @@ public class AccountDao {
     } else {
       statement.setObject(1, null);
     }
-    statement.setString(2, userTagsInJson);
-    Long expirationTimeMs = dataset.getExpirationTimeMs();
-    if (expirationTimeMs == null) {
-      statement.setTimestamp(3, null);
-      statement.setTimestamp(4, null);
-    } else if (expirationTimeMs == -1) {
-      statement.setString(3, "-1");
-      statement.setString(4, "-1");
+    Long retentionTime = dataset.getRetentionTime();
+    if (retentionTime != null) {
+      statement.setLong(2, retentionTime);
     } else {
-      statement.setTimestamp(3, new Timestamp(expirationTimeMs));
-      statement.setTimestamp(4, new Timestamp(expirationTimeMs));
+      statement.setObject(2, null);
     }
-    statement.setInt(5, accountId);
-    statement.setInt(6, containerId);
-    statement.setString(7, dataset.getDatasetName());
+    statement.setString(3, userTagsInJson);
+    statement.setInt(4, accountId);
+    statement.setInt(5, containerId);
+    statement.setString(6, dataset.getDatasetName());
     return statement.executeUpdate();
   }
 
@@ -1027,6 +1027,7 @@ public class AccountDao {
       String accountName, String containerName, String datasetName) throws SQLException, AccountServiceException {
     Dataset.VersionSchema versionSchema;
     Integer retentionCount;
+    Long retentionTime;
     Timestamp deletionTime;
     Map<String, String> userTags = null;
     ResultSet resultSet = null;
@@ -1049,6 +1050,7 @@ public class AccountDao {
       }
       versionSchema = Dataset.VersionSchema.values()[resultSet.getInt(VERSION_SCHEMA)];
       retentionCount = resultSet.getObject(RETENTION_COUNT, Integer.class);
+      retentionTime = resultSet.getObject(RETENTION_TIME, Long.class);
       String userTagsInJson = resultSet.getString(USER_TAGS);
       if (userTagsInJson != null) {
         try {
@@ -1062,8 +1064,7 @@ public class AccountDao {
       //If result set is not created in a try-with-resources block, it needs to be closed in a finally block.
       closeQuietly(resultSet);
     }
-    return new Dataset(accountName, containerName, datasetName, versionSchema, timestampToMs(deletionTime),
-        retentionCount, userTags);
+    return new Dataset(accountName, containerName, datasetName, versionSchema, retentionCount, retentionTime, userTags);
   }
 
   /**

--- a/ambry-account/src/main/java/com/github/ambry/account/mysql/MySqlAccountStore.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/mysql/MySqlAccountStore.java
@@ -181,28 +181,33 @@ public class MySqlAccountStore {
    * @param containerName the name for the container.
    * @param datasetName the name of the dataset.
    * @param version the version of the dataset.
-   * @param expirationTimeMs the expiration time of the version of the dataset.
+   * @param timeToLiveInSeconds The dataset version level ttl.
+   * @param creationTimeInMs the creation time of the dataset.
+   * @param datasetVersionTtlEnabled set to true if dataset version ttl want to override the dataset level default ttl.
    * @return the corresponding {@link Dataset}
    * @throws SQLException
    */
-  public DatasetVersionRecord addDatasetVersion(int accountId, int containerId, String accountName, String containerName,
-      String datasetName, String version, long expirationTimeMs) throws SQLException, AccountServiceException {
+  public DatasetVersionRecord addDatasetVersion(int accountId, int containerId, String accountName,
+      String containerName, String datasetName, String version, long timeToLiveInSeconds, long creationTimeInMs,
+      boolean datasetVersionTtlEnabled) throws SQLException, AccountServiceException {
     return accountDao.addDatasetVersions(accountId, containerId, accountName, containerName, datasetName, version,
-        expirationTimeMs);
+        timeToLiveInSeconds, creationTimeInMs, datasetVersionTtlEnabled);
   }
 
   /**
    * Get a version of {@link Dataset}
    * @param accountId the id for the parent account.
    * @param containerId the id of the container.
+   * @param accountName the name for the parent account.
+   * @param containerName the name for the container.
    * @param datasetName the name of the dataset.
    * @param version the version of the dataset.
    * @return the {@link DatasetVersionRecord}
    * @throws SQLException
    */
-  public DatasetVersionRecord getDatasetVersion(short accountId, short containerId, String datasetName,
-      String version) throws SQLException, AccountServiceException {
-    return accountDao.getDatasetVersions(accountId, containerId, datasetName, version);
+  public DatasetVersionRecord getDatasetVersion(short accountId, short containerId, String accountName,
+      String containerName, String datasetName, String version) throws SQLException, AccountServiceException {
+    return accountDao.getDatasetVersions(accountId, containerId, accountName, containerName, datasetName, version);
   }
 
   /**

--- a/ambry-account/src/main/resources/AccountSchema.ddl
+++ b/ambry-account/src/main/resources/AccountSchema.ddl
@@ -51,7 +51,7 @@ CREATE TABLE IF NOT EXISTS Datasets (
     datasetName VARCHAR(235) NOT NULL,
     versionSchema INT NOT NULL,
     retentionCount INT DEFAULT NULL,
-    retentionTime BIGINT NOT NULL,
+    retentionTimeInSeconds BIGINT NOT NULL,
     userTags JSON DEFAULT NULL,
     lastModifiedTime DATETIME(3) NOT NULL,
     delete_ts DATETIME(6) DEFAULT NULL,

--- a/ambry-account/src/main/resources/AccountSchema.ddl
+++ b/ambry-account/src/main/resources/AccountSchema.ddl
@@ -51,6 +51,7 @@ CREATE TABLE IF NOT EXISTS Datasets (
     datasetName VARCHAR(235) NOT NULL,
     versionSchema INT NOT NULL,
     retentionCount INT DEFAULT NULL,
+    retentionTime BIGINT NOT NULL,
     userTags JSON DEFAULT NULL,
     lastModifiedTime DATETIME(3) NOT NULL,
     delete_ts DATETIME(6) DEFAULT NULL,

--- a/ambry-api/src/main/java/com/github/ambry/account/AccountService.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/AccountService.java
@@ -181,12 +181,15 @@ public interface AccountService extends Closeable {
    * @param containerName The name for the container.
    * @param datasetName The name of the dataset.
    * @param version The version of the dataset.
-   * @param expirationTimeMs the expiration time of the version of the dataset.
+   * @param timeToLiveInSeconds The dataset version level ttl.
+   * @param creationTimeInMs the creationTime of the dataset version.
+   * @param datasetVersionTtlEnabled set to true if dataset version ttl want to override the dataset level default ttl.
    * @return the {@link DatasetVersionRecord}.
    * @throws AccountServiceException
    */
   default DatasetVersionRecord addDatasetVersion(String accountName, String containerName, String datasetName,
-      String version, long expirationTimeMs) throws AccountServiceException {
+      String version, long timeToLiveInSeconds, long creationTimeInMs, boolean datasetVersionTtlEnabled)
+      throws AccountServiceException {
     throw new UnsupportedOperationException("This method is not supported");
   }
 

--- a/ambry-api/src/main/java/com/github/ambry/account/Dataset.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/Dataset.java
@@ -42,7 +42,7 @@ import java.util.regex.Pattern;
  *    "versionSchema": "TIMESTAMP",
  *    "expirationTimeMs": -1,
  *    "retentionCount": 10,
- *    "retentionTime": 3600,
+ *    "retentionTimeInSeconds": 3600,
  *    "userTags": "{userTag1:tagValue1}"
  *  } * </code></pre>
  */
@@ -62,7 +62,7 @@ public class Dataset {
   static final String DATASET_NAME_KEY = "datasetName";
   static final String JSON_VERSION_SCHEMA_KEY = "versionSchema";
   static final String JSON_RETENTION_COUNT_KEY = "retentionCount";
-  static final String JSON_RETENTION_TIME_KEY = "retentionTime";
+  static final String JSON_RETENTION_TIME_KEY = "retentionTimeInSeconds";
   static final String JSON_USER_TAGS_KEY = "userTags";
 
   @JsonProperty(ACCOUNT_NAME_KEY)
@@ -78,7 +78,7 @@ public class Dataset {
   private final Integer retentionCount;
   @JsonProperty(JSON_RETENTION_TIME_KEY)
   @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-  private final Long retentionTime;
+  private final Long retentionTimeInSeconds;
   @JsonProperty(JSON_USER_TAGS_KEY)
   private final Map<String, String> userTags;
 
@@ -89,18 +89,18 @@ public class Dataset {
    * @param datasetName The name of the dataset. Cannot be null.
    * @param versionSchema The schema of the version. Cannot be null.
    * @param retentionCount The retention of dataset by count. The older versions will be deprecated. Can be null.
-   * @param retentionTime The time-to-live for versions of this dataset. Numbers equals to -1 indicate an unlimited retention.
+   * @param retentionTimeInSeconds The time-to-live for versions of this dataset. Numbers equals to -1 indicate an unlimited retention.
    * @param userTags The user defined metadata. Can be null.
    */
   public Dataset(String accountName, String containerName, String datasetName, VersionSchema versionSchema,
-      Integer retentionCount, Long retentionTime, Map<String, String> userTags) {
+      Integer retentionCount, Long retentionTimeInSeconds, Map<String, String> userTags) {
     checkPreconditions(accountName, containerName, datasetName);
     this.accountName = accountName;
     this.containerName = containerName;
     this.datasetName = datasetName;
     this.versionSchema = versionSchema;
     this.retentionCount = retentionCount;
-    this.retentionTime = retentionTime;
+    this.retentionTimeInSeconds = retentionTimeInSeconds;
     this.userTags = userTags;
   }
 
@@ -147,7 +147,7 @@ public class Dataset {
   /**
    * @return the time-to-live for versions of this dataset.
    */
-  public Long getRetentionTime() {return retentionTime; }
+  public Long getRetentionTimeInSeconds() {return retentionTimeInSeconds; }
 
   /**
    * @return the user defined metadata.
@@ -195,7 +195,7 @@ public class Dataset {
         && Objects.equals(datasetName, dataset.datasetName)
         && versionSchema == dataset.versionSchema
         && Objects.equals(retentionCount, dataset.retentionCount)
-        && Objects.equals(retentionTime, dataset.retentionTime)
+        && Objects.equals(retentionTimeInSeconds, dataset.retentionTimeInSeconds)
         && Objects.equals(userTags, dataset.userTags);
   }
 

--- a/ambry-api/src/main/java/com/github/ambry/account/Dataset.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/Dataset.java
@@ -16,7 +16,6 @@ package com.github.ambry.account;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Pattern;
@@ -43,6 +42,7 @@ import java.util.regex.Pattern;
  *    "versionSchema": "TIMESTAMP",
  *    "expirationTimeMs": -1,
  *    "retentionCount": 10,
+ *    "retentionTime": 3600,
  *    "userTags": "{userTag1:tagValue1}"
  *  } * </code></pre>
  */
@@ -61,8 +61,8 @@ public class Dataset {
   static final String CONTAINER_NAME_KEY = "containerName";
   static final String DATASET_NAME_KEY = "datasetName";
   static final String JSON_VERSION_SCHEMA_KEY = "versionSchema";
-  static final String JSON_EXPIRATION_TIME_KEY = "expirationTimeMs";
   static final String JSON_RETENTION_COUNT_KEY = "retentionCount";
+  static final String JSON_RETENTION_TIME_KEY = "retentionTime";
   static final String JSON_USER_TAGS_KEY = "userTags";
 
   @JsonProperty(ACCOUNT_NAME_KEY)
@@ -73,11 +73,12 @@ public class Dataset {
   private final String datasetName;
   @JsonProperty(JSON_VERSION_SCHEMA_KEY)
   private final VersionSchema versionSchema;
-  @JsonProperty(JSON_EXPIRATION_TIME_KEY)
-  private final Long expirationTimeMs;
   @JsonProperty(JSON_RETENTION_COUNT_KEY)
   @JsonInclude(JsonInclude.Include.NON_DEFAULT)
   private final Integer retentionCount;
+  @JsonProperty(JSON_RETENTION_TIME_KEY)
+  @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+  private final Long retentionTime;
   @JsonProperty(JSON_USER_TAGS_KEY)
   private final Map<String, String> userTags;
 
@@ -87,19 +88,19 @@ public class Dataset {
    * @param containerName The name of the container. Cannot be null.
    * @param datasetName The name of the dataset. Cannot be null.
    * @param versionSchema The schema of the version. Cannot be null.
-   * @param expirationTimeMs The expiration time in milliseconds since epoch, or -1 if the dataset should be permanent. Cannot be null.
    * @param retentionCount The retention of dataset by count. The older versions will be deprecated. Can be null.
+   * @param retentionTime The time-to-live for versions of this dataset. Numbers equals to -1 indicate an unlimited retention.
    * @param userTags The user defined metadata. Can be null.
    */
   public Dataset(String accountName, String containerName, String datasetName, VersionSchema versionSchema,
-      Long expirationTimeMs, Integer retentionCount, Map<String, String> userTags) {
+      Integer retentionCount, Long retentionTime, Map<String, String> userTags) {
     checkPreconditions(accountName, containerName, datasetName);
     this.accountName = accountName;
     this.containerName = containerName;
     this.datasetName = datasetName;
     this.versionSchema = versionSchema;
-    this.expirationTimeMs = expirationTimeMs;
     this.retentionCount = retentionCount;
+    this.retentionTime = retentionTime;
     this.userTags = userTags;
   }
 
@@ -137,18 +138,16 @@ public class Dataset {
   }
 
   /**
-   * @return the expiration time in milliseconds since epoch, or -1 if the dataset should be permanent.
-   */
-  public Long getExpirationTimeMs() {
-    return expirationTimeMs;
-  }
-
-  /**
    * @return the retention of dataset by count. The older versions will be deprecated.
    */
   public Integer getRetentionCount() {
     return retentionCount;
   }
+
+  /**
+   * @return the time-to-live for versions of this dataset.
+   */
+  public Long getRetentionTime() {return retentionTime; }
 
   /**
    * @return the user defined metadata.
@@ -195,8 +194,8 @@ public class Dataset {
         && Objects.equals(containerName, dataset.containerName)
         && Objects.equals(datasetName, dataset.datasetName)
         && versionSchema == dataset.versionSchema
-        && Objects.equals(expirationTimeMs, dataset.expirationTimeMs)
         && Objects.equals(retentionCount, dataset.retentionCount)
+        && Objects.equals(retentionTime, dataset.retentionTime)
         && Objects.equals(userTags, dataset.userTags);
   }
 

--- a/ambry-api/src/main/java/com/github/ambry/account/DatasetBuilder.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/DatasetBuilder.java
@@ -32,8 +32,8 @@ public class DatasetBuilder {
   // necessary for insert, not update.
   private Dataset.VersionSchema versionSchema;
   //optional
-  private Long expirationTimeMs = null;
   private Integer retentionCount = null;
+  private Long retentionTime = null;
   private Map<String, String> userTags = null;
 
   /**
@@ -56,8 +56,8 @@ public class DatasetBuilder {
     containerName = origin.getContainerName();
     datasetName = origin.getDatasetName();
     versionSchema = origin.getVersionSchema();
-    expirationTimeMs = origin.getExpirationTimeMs();
     retentionCount = origin.getRetentionCount();
+    retentionTime = origin.getRetentionTime();
     userTags = origin.getUserTags();
   }
 
@@ -118,17 +118,6 @@ public class DatasetBuilder {
   }
 
   /**
-   * Set the expiration time in milliseconds of the {@link Dataset} to build.
-   * @param expirationTimeMs the expirationTime in milliseconds to set.
-   * @return the builder.
-   */
-  @JsonProperty(JSON_EXPIRATION_TIME_KEY)
-  public DatasetBuilder setExpirationTimeMs(long expirationTimeMs) {
-    this.expirationTimeMs = expirationTimeMs;
-    return this;
-  }
-
-  /**
    * Set the retention count of the {@link Dataset} to build.
    * @param retentionCount the retention count to set.
    * @return the builder.
@@ -136,6 +125,17 @@ public class DatasetBuilder {
   @JsonProperty(JSON_RETENTION_COUNT_KEY)
   public DatasetBuilder setRetentionCount(int retentionCount) {
     this.retentionCount = retentionCount;
+    return this;
+  }
+
+  /**
+   * Set the retention time of the {@link Dataset} to build.
+   * @param retentionTime the retention count to set.
+   * @return the builder.
+   */
+  @JsonProperty(JSON_RETENTION_TIME_KEY)
+  public DatasetBuilder setRetentionTime(long retentionTime) {
+    this.retentionTime = retentionTime;
     return this;
   }
 
@@ -156,7 +156,6 @@ public class DatasetBuilder {
    * @return a {@link Dataset} object.
    */
   public Dataset build() {
-    return new Dataset(accountName, containerName, datasetName, versionSchema, expirationTimeMs, retentionCount,
-        userTags);
+    return new Dataset(accountName, containerName, datasetName, versionSchema, retentionCount, retentionTime, userTags);
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/account/DatasetBuilder.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/DatasetBuilder.java
@@ -33,7 +33,7 @@ public class DatasetBuilder {
   private Dataset.VersionSchema versionSchema;
   //optional
   private Integer retentionCount = null;
-  private Long retentionTime = null;
+  private Long retentionTimeInSeconds = null;
   private Map<String, String> userTags = null;
 
   /**
@@ -57,7 +57,7 @@ public class DatasetBuilder {
     datasetName = origin.getDatasetName();
     versionSchema = origin.getVersionSchema();
     retentionCount = origin.getRetentionCount();
-    retentionTime = origin.getRetentionTime();
+    retentionTimeInSeconds = origin.getRetentionTimeInSeconds();
     userTags = origin.getUserTags();
   }
 
@@ -130,12 +130,12 @@ public class DatasetBuilder {
 
   /**
    * Set the retention time of the {@link Dataset} to build.
-   * @param retentionTime the retention count to set.
+   * @param retentionTimeInSeconds the retention count to set.
    * @return the builder.
    */
   @JsonProperty(JSON_RETENTION_TIME_KEY)
-  public DatasetBuilder setRetentionTime(long retentionTime) {
-    this.retentionTime = retentionTime;
+  public DatasetBuilder setRetentionTimeInSeconds(long retentionTimeInSeconds) {
+    this.retentionTimeInSeconds = retentionTimeInSeconds;
     return this;
   }
 
@@ -156,6 +156,6 @@ public class DatasetBuilder {
    * @return a {@link Dataset} object.
    */
   public Dataset build() {
-    return new Dataset(accountName, containerName, datasetName, versionSchema, retentionCount, retentionTime, userTags);
+    return new Dataset(accountName, containerName, datasetName, versionSchema, retentionCount, retentionTimeInSeconds, userTags);
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com/github/ambry/rest/RestUtils.java
@@ -247,6 +247,10 @@ public class RestUtils {
      */
     public static final String DATASET_VERSION_QUERY_ENABLED = "x-ambry-dataset-version-query-enabled";
     /**
+     * Boolean field set to "true" to enable dataset version level ttl.
+     */
+    public static final String DATASET_VERSION_TTL_ENABLED = "x-ambry-dataset-version-ttl-enabled";
+    /**
      * Boolean field set to "true" to update dataset.
      */
     public static final String DATASET_UPDATE = "x-ambry-dataset-update";

--- a/ambry-api/src/test/java/com/github/ambry/account/AccountContainerTest.java
+++ b/ambry-api/src/test/java/com/github/ambry/account/AccountContainerTest.java
@@ -91,7 +91,7 @@ public class AccountContainerTest {
   private List<Dataset> refDatasets;
   private List<String> refDatasetNames;
   private List<Dataset.VersionSchema> refDatasetVersionSchemas;
-  private List<Long> refDatasetRetentionTime;
+  private List<Long> refDatasetRetentionTimeInSeconds;
   private List<Integer> refDatasetRetentionCounts;
   private List<Map<String, String>> refDatasetUserTags;
 
@@ -309,7 +309,7 @@ public class AccountContainerTest {
       Dataset datasetFromBuilder = buildDatasetWithOtherFields(
           new DatasetBuilder(refAccountName, refContainers.get(0).getName(), refDatasetNames.get(i))
               .setVersionSchema(refDatasetVersionSchemas.get(i))
-              .setRetentionTime(refDatasetRetentionTime.get(i))
+              .setRetentionTimeInSeconds(refDatasetRetentionTimeInSeconds.get(i))
               .setRetentionCount(refDatasetRetentionCounts.get(i))
               .setUserTags(refDatasetUserTags.get(i)), refDatasets.get(i));
       assertDataset(datasetFromBuilder, i);
@@ -842,7 +842,7 @@ public class AccountContainerTest {
     assertEquals("Wrong dataset name", refDatasetNames.get(index), dataset.getDatasetName());
     assertEquals("Wrong version schema", refDatasetVersionSchemas.get(index), dataset.getVersionSchema());
     assertEquals("Wrong retention count", refDatasetRetentionCounts.get(index), dataset.getRetentionCount());
-    assertEquals("Wrong retention time", refDatasetRetentionTime.get(index), dataset.getRetentionTime());
+    assertEquals("Wrong retention time", refDatasetRetentionTimeInSeconds.get(index), dataset.getRetentionTimeInSeconds());
     assertEquals("Wrong user tage", refDatasetUserTags.get(index), dataset.getUserTags());
   }
 
@@ -1072,7 +1072,7 @@ public class AccountContainerTest {
   private void initializeRefDatasets() {
     refDatasetNames = new ArrayList<>();
     refDatasetVersionSchemas = new ArrayList<>();
-    refDatasetRetentionTime = new ArrayList<>();
+    refDatasetRetentionTimeInSeconds = new ArrayList<>();
     refDatasetRetentionCounts = new ArrayList<>();
     refDatasetUserTags = new ArrayList<>();
     refDatasets = new ArrayList<>();
@@ -1082,15 +1082,15 @@ public class AccountContainerTest {
       refDatasetNames.add(datasetName);
       refDatasetVersionSchemas.add(
           random.nextBoolean() ? Dataset.VersionSchema.MONOTONIC : Dataset.VersionSchema.TIMESTAMP);
-      long retentionTime = random.nextBoolean() ? -1 : Utils.getRandomLong(random, Long.MAX_VALUE);
-      refDatasetRetentionTime.add(retentionTime);
+      long retentionTimeInSeconds = random.nextBoolean() ? -1 : Utils.getRandomLong(random, Long.MAX_VALUE);
+      refDatasetRetentionTimeInSeconds.add(retentionTimeInSeconds);
       int retentionCount = Utils.getRandomShort(random);
       refDatasetRetentionCounts.add(retentionCount);
       Map<String, String> userTags = new HashMap<>();
       userTags.put(UUID.randomUUID().toString(), UUID.randomUUID().toString());
       refDatasetUserTags.add(userTags);
       refDatasets.add(new Dataset(refAccountName, refContainers.get(0).getName(), refDatasetNames.get(i),
-          refDatasetVersionSchemas.get(i), refDatasetRetentionCounts.get(i), refDatasetRetentionTime.get(i),
+          refDatasetVersionSchemas.get(i), refDatasetRetentionCounts.get(i), refDatasetRetentionTimeInSeconds.get(i),
           refDatasetUserTags.get(i)));
     }
   }

--- a/ambry-api/src/test/java/com/github/ambry/account/AccountContainerTest.java
+++ b/ambry-api/src/test/java/com/github/ambry/account/AccountContainerTest.java
@@ -91,7 +91,7 @@ public class AccountContainerTest {
   private List<Dataset> refDatasets;
   private List<String> refDatasetNames;
   private List<Dataset.VersionSchema> refDatasetVersionSchemas;
-  private List<Long> refDatasetExpirationTimeMs;
+  private List<Long> refDatasetRetentionTime;
   private List<Integer> refDatasetRetentionCounts;
   private List<Map<String, String>> refDatasetUserTags;
 
@@ -309,7 +309,7 @@ public class AccountContainerTest {
       Dataset datasetFromBuilder = buildDatasetWithOtherFields(
           new DatasetBuilder(refAccountName, refContainers.get(0).getName(), refDatasetNames.get(i))
               .setVersionSchema(refDatasetVersionSchemas.get(i))
-              .setExpirationTimeMs(refDatasetExpirationTimeMs.get(i))
+              .setRetentionTime(refDatasetRetentionTime.get(i))
               .setRetentionCount(refDatasetRetentionCounts.get(i))
               .setUserTags(refDatasetUserTags.get(i)), refDatasets.get(i));
       assertDataset(datasetFromBuilder, i);
@@ -828,7 +828,6 @@ public class AccountContainerTest {
     return builder.setAccountName(dataset.getAccountName())
         .setContainerName(dataset.getContainerName())
         .setVersionSchema(dataset.getVersionSchema())
-        .setExpirationTimeMs(dataset.getExpirationTimeMs())
         .build();
   }
 
@@ -842,8 +841,8 @@ public class AccountContainerTest {
     assertEquals("Wrong container name", refContainers.get(0).getName(), dataset.getContainerName());
     assertEquals("Wrong dataset name", refDatasetNames.get(index), dataset.getDatasetName());
     assertEquals("Wrong version schema", refDatasetVersionSchemas.get(index), dataset.getVersionSchema());
-    assertEquals("Wrong expiration time", refDatasetExpirationTimeMs.get(index), dataset.getExpirationTimeMs());
     assertEquals("Wrong retention count", refDatasetRetentionCounts.get(index), dataset.getRetentionCount());
+    assertEquals("Wrong retention time", refDatasetRetentionTime.get(index), dataset.getRetentionTime());
     assertEquals("Wrong user tage", refDatasetUserTags.get(index), dataset.getUserTags());
   }
 
@@ -1073,7 +1072,7 @@ public class AccountContainerTest {
   private void initializeRefDatasets() {
     refDatasetNames = new ArrayList<>();
     refDatasetVersionSchemas = new ArrayList<>();
-    refDatasetExpirationTimeMs = new ArrayList<>();
+    refDatasetRetentionTime = new ArrayList<>();
     refDatasetRetentionCounts = new ArrayList<>();
     refDatasetUserTags = new ArrayList<>();
     refDatasets = new ArrayList<>();
@@ -1083,15 +1082,15 @@ public class AccountContainerTest {
       refDatasetNames.add(datasetName);
       refDatasetVersionSchemas.add(
           random.nextBoolean() ? Dataset.VersionSchema.MONOTONIC : Dataset.VersionSchema.TIMESTAMP);
-      long expirationTimeMs = random.nextBoolean() ? -1 : Utils.getRandomLong(random, Long.MAX_VALUE);
-      refDatasetExpirationTimeMs.add(expirationTimeMs);
+      long retentionTime = random.nextBoolean() ? -1 : Utils.getRandomLong(random, Long.MAX_VALUE);
+      refDatasetRetentionTime.add(retentionTime);
       int retentionCount = Utils.getRandomShort(random);
       refDatasetRetentionCounts.add(retentionCount);
       Map<String, String> userTags = new HashMap<>();
       userTags.put(UUID.randomUUID().toString(), UUID.randomUUID().toString());
       refDatasetUserTags.add(userTags);
       refDatasets.add(new Dataset(refAccountName, refContainers.get(0).getName(), refDatasetNames.get(i),
-          refDatasetVersionSchemas.get(i), refDatasetExpirationTimeMs.get(i), refDatasetRetentionCounts.get(i),
+          refDatasetVersionSchemas.get(i), refDatasetRetentionCounts.get(i), refDatasetRetentionTime.get(i),
           refDatasetUserTags.get(i)));
     }
   }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/DeleteDatasetHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/DeleteDatasetHandler.java
@@ -136,6 +136,7 @@ public class DeleteDatasetHandler {
         accountName = RestUtils.getHeader(restRequest.getArgs(), RestUtils.Headers.TARGET_ACCOUNT_NAME, true);
         containerName = RestUtils.getHeader(restRequest.getArgs(), RestUtils.Headers.TARGET_CONTAINER_NAME, true);
         datasetName = RestUtils.getHeader(restRequest.getArgs(), RestUtils.Headers.TARGET_DATASET_NAME, true);
+        //TODO: delete all the dataset version under the dataset.
         accountService.deleteDataset(accountName, containerName, datasetName);
         restResponseChannel.setStatus(ResponseStatus.Accepted);
         restResponseChannel.setHeader(RestUtils.Headers.DATE, new GregorianCalendar().getTime());

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
@@ -516,10 +516,13 @@ public class NamedBlobPutHandler {
         containerName = dataset.getContainerName();
         datasetName = dataset.getDatasetName();
         version = (String) restRequest.getArgs().get(TARGET_DATASET_VERSION);
+        boolean datasetVersionTtlEnabled =
+            RestUtils.getBooleanHeader(restRequest.getArgs(), RestUtils.Headers.DATASET_VERSION_TTL_ENABLED, false);
         long expirationTimeMs =
             Utils.addSecondsToEpochTime(blobProperties.getCreationTimeInMs(), blobProperties.getTimeToLiveInSeconds());
         DatasetVersionRecord datasetVersionRecord =
-            accountService.addDatasetVersion(accountName, containerName, datasetName, version, expirationTimeMs);
+            accountService.addDatasetVersion(accountName, containerName, datasetName, version,
+                blobProperties.getTimeToLiveInSeconds(), blobProperties.getCreationTimeInMs(), datasetVersionTtlEnabled);
         FrontendUtils.replaceRequestPathWithNewOperationOrBlobIdIfNeeded(restRequest, datasetVersionRecord, version);
         restResponseChannel.setHeader(RestUtils.Headers.TARGET_ACCOUNT_NAME, accountName);
         restResponseChannel.setHeader(RestUtils.Headers.TARGET_CONTAINER_NAME, containerName);

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/PostDatasetsHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/PostDatasetsHandler.java
@@ -177,10 +177,6 @@ public class PostDatasetsHandler {
             throw new RestServiceException("Version schema can't be null for dataset creation",
                 RestServiceErrorCode.BadRequest);
           }
-          if (datasetToUpdate.getExpirationTimeMs() == null) {
-            throw new RestServiceException("ExpirationTimeMs can't be null for dataset creation",
-                RestServiceErrorCode.BadRequest);
-          }
         }
         datasetName = datasetToUpdate.getDatasetName();
         accountName = datasetToUpdate.getAccountName();

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
@@ -530,11 +530,11 @@ public class FrontendRestRequestServiceTest {
     Map<String, String> userTags = new HashMap<>();
     String userTagKey = "tagKey";
     userTags.put(userTagKey, "tagValues");
-    long expirationTimeInMs = Utils.addSecondsToEpochTime(System.currentTimeMillis(), 3600);
+    long datasetTtl = 3600;
 
     Dataset dataset =
         new DatasetBuilder(testAccount.getName(), testContainer.getName(), DATASET_NAME).setVersionSchema(versionSchema)
-            .setExpirationTimeMs(expirationTimeInMs)
+            .setRetentionTime(datasetTtl)
             .setUserTags(userTags)
             .build();
     byte[] datasetsUpdateJson = AccountCollectionSerde.serializeDatasetsInJson(dataset);
@@ -595,7 +595,8 @@ public class FrontendRestRequestServiceTest {
     assertEquals("Unexpected PUT /DatasetVersions response", blobId, blobIdFromResponse);
     assertEquals("Unexpected userMetadata", userTags.get(userTagKey),
         userMetadataFromRouter.get(USER_META_DATA_HEADER_PREFIX + userTagKey));
-    assertNotEquals("Ttl should be updated", blobTtl, expectedBlobProperties.getTimeToLiveInSeconds());
+    assertEquals("Ttl should be the dataset level ttl", (long) dataset.getRetentionTime(),
+        expectedBlobProperties.getTimeToLiveInSeconds());
 
     // Add a dataset version without version specified.
     namedBlobPathUri =
@@ -636,7 +637,7 @@ public class FrontendRestRequestServiceTest {
     versionSchema = Dataset.VersionSchema.MONOTONIC;
 
     dataset = new DatasetBuilder(testAccount.getName(), testContainer.getName(),
-        DATASET_NAME_WITHOUT_USER_TAGS).setVersionSchema(versionSchema).setExpirationTimeMs(-1).build();
+        DATASET_NAME_WITHOUT_USER_TAGS).setVersionSchema(versionSchema).setRetentionTime(-1).build();
     datasetsUpdateJson = AccountCollectionSerde.serializeDatasetsInJson(dataset);
     body = new LinkedList<>();
     body.add(ByteBuffer.wrap(datasetsUpdateJson));
@@ -1211,7 +1212,6 @@ public class FrontendRestRequestServiceTest {
     Dataset.VersionSchema versionSchema = Dataset.VersionSchema.TIMESTAMP;
     Dataset dataset =
         new DatasetBuilder(testAccount.getName(), testContainer.getName(), DATASET_NAME).setVersionSchema(versionSchema)
-            .setExpirationTimeMs(-1)
             .build();
     byte[] datasetsUpdateJson = AccountCollectionSerde.serializeDatasetsInJson(dataset);
     List<ByteBuffer> body = new LinkedList<>();

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
@@ -534,7 +534,7 @@ public class FrontendRestRequestServiceTest {
 
     Dataset dataset =
         new DatasetBuilder(testAccount.getName(), testContainer.getName(), DATASET_NAME).setVersionSchema(versionSchema)
-            .setRetentionTime(datasetTtl)
+            .setRetentionTimeInSeconds(datasetTtl)
             .setUserTags(userTags)
             .build();
     byte[] datasetsUpdateJson = AccountCollectionSerde.serializeDatasetsInJson(dataset);
@@ -595,7 +595,7 @@ public class FrontendRestRequestServiceTest {
     assertEquals("Unexpected PUT /DatasetVersions response", blobId, blobIdFromResponse);
     assertEquals("Unexpected userMetadata", userTags.get(userTagKey),
         userMetadataFromRouter.get(USER_META_DATA_HEADER_PREFIX + userTagKey));
-    assertEquals("Ttl should be the dataset level ttl", (long) dataset.getRetentionTime(),
+    assertEquals("Ttl should be the dataset level ttl", (long) dataset.getRetentionTimeInSeconds(),
         expectedBlobProperties.getTimeToLiveInSeconds());
 
     // Add a dataset version without version specified.
@@ -637,7 +637,7 @@ public class FrontendRestRequestServiceTest {
     versionSchema = Dataset.VersionSchema.MONOTONIC;
 
     dataset = new DatasetBuilder(testAccount.getName(), testContainer.getName(),
-        DATASET_NAME_WITHOUT_USER_TAGS).setVersionSchema(versionSchema).setRetentionTime(-1).build();
+        DATASET_NAME_WITHOUT_USER_TAGS).setVersionSchema(versionSchema).setRetentionTimeInSeconds(-1).build();
     datasetsUpdateJson = AccountCollectionSerde.serializeDatasetsInJson(dataset);
     body = new LinkedList<>();
     body.add(ByteBuffer.wrap(datasetsUpdateJson));

--- a/ambry-test-utils/src/main/java/com/github/ambry/account/InMemAccountService.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/account/InMemAccountService.java
@@ -132,17 +132,17 @@ public class InMemAccountService implements AccountService {
 
   @Override
   public synchronized DatasetVersionRecord addDatasetVersion(String accountName, String containerName,
-      String datasetName, String version, long expirationTimeMs) throws AccountServiceException {
+      String datasetName, String version, long timeToLiveInSeconds, long creationTimeInMs,
+      boolean datasetVersionTtlEnabled)
+      throws AccountServiceException {
     Account account = nameToAccountMap.get(accountName);
     short accountId = account.getId();
     short containerId = account.getContainerByName(containerName).getId();
     idToDatasetVersionMap.putIfAbsent(new Pair<>(accountId, containerId), new HashMap<>());
     Dataset dataset = getDataset(accountName, containerName, datasetName);
-    long updatedExpirationTimeMs = expirationTimeMs;
-    if (expirationTimeMs == Infinite_Time || dataset.getExpirationTimeMs() == Infinite_Time) {
-      updatedExpirationTimeMs = expirationTimeMs == Infinite_Time ? dataset.getExpirationTimeMs() : expirationTimeMs;
-    } else if (dataset.getExpirationTimeMs() <= expirationTimeMs) {
-      updatedExpirationTimeMs = dataset.getExpirationTimeMs();
+    long updatedExpirationTimeMs = Utils.addSecondsToEpochTime(creationTimeInMs, dataset.getRetentionTime());
+    if (datasetVersionTtlEnabled) {
+      updatedExpirationTimeMs = Utils.addSecondsToEpochTime(creationTimeInMs, timeToLiveInSeconds);
     }
     DatasetVersionRecord datasetVersionRecord =
         new DatasetVersionRecord(accountId, containerId, datasetName, version, updatedExpirationTimeMs);

--- a/ambry-test-utils/src/main/java/com/github/ambry/account/InMemAccountService.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/account/InMemAccountService.java
@@ -31,8 +31,6 @@ import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
 
-import static com.github.ambry.utils.Utils.*;
-
 
 /**
  * Implementation of {@link AccountService} for test. This implementation synchronizes on all methods.
@@ -140,7 +138,7 @@ public class InMemAccountService implements AccountService {
     short containerId = account.getContainerByName(containerName).getId();
     idToDatasetVersionMap.putIfAbsent(new Pair<>(accountId, containerId), new HashMap<>());
     Dataset dataset = getDataset(accountName, containerName, datasetName);
-    long updatedExpirationTimeMs = Utils.addSecondsToEpochTime(creationTimeInMs, dataset.getRetentionTime());
+    long updatedExpirationTimeMs = Utils.addSecondsToEpochTime(creationTimeInMs, dataset.getRetentionTimeInSeconds());
     if (datasetVersionTtlEnabled) {
       updatedExpirationTimeMs = Utils.addSecondsToEpochTime(creationTimeInMs, timeToLiveInSeconds);
     }


### PR DESCRIPTION
Previously I treat expiration time of dataset as the dataset life span as well as the default dataset version life span. But after a second thought, I feel like treat expiration time(retention time) of dataset as the default ttl which all dataset version can be inherited from is better. And due to for all blobs we will provide ttl value or -1, it's hard for use to determine if user provided dataset version ttl or not, so I've added this header x-ambry-dataset-version-ttl-enabled to help identify if user want the dataset version ttl override the default dataset level ttl. By default it will be disabled and all the dataset version ttl are inherited from the default dataset level ttl.