### PR TITLE
Support getting bootstrap replica in Helix Full auto mode

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/clustermap/ClusterMap.java
+++ b/ambry-api/src/main/java/com/github/ambry/clustermap/ClusterMap.java
@@ -119,14 +119,14 @@ public interface ClusterMap extends AutoCloseable {
   DataNodeId getDataNodeId(String hostname, int port);
 
   /**
-   * Return true if the given host is in the clustermap and all resources this host is given to have already turned
+   * Return true if the given host is in the cluster map and all resources this host is given to have already turned
    * on FULL_AUTO mode. This is a Helix specific method that requires Helix specific data. All the other implementations
    * should just return false.
-   * @param hostname of the DataNodeId
-   * @param port of the DataNodeId
+   *
+   * @param dataNodeId the {@link DataNodeId} to check.
    * @return True if all the resources for the given host has turned on FULL_AUTO.
    */
-  default boolean isDataNodeInFullAutoMode(String hostname, int port) {
+  default boolean isDataNodeInFullAutoMode(DataNodeId dataNodeId) {
     return false;
   }
 

--- a/ambry-api/src/main/java/com/github/ambry/clustermap/DiskId.java
+++ b/ambry-api/src/main/java/com/github/ambry/clustermap/DiskId.java
@@ -41,6 +41,27 @@ public interface DiskId extends Resource {
   long getRawCapacityInBytes();
 
   /**
+   * Decrease available space in bytes for this DiskId
+   *
+   * @param delta amount of bytes to decrease.
+   */
+  void decreaseAvailableSpaceInBytes(long delta);
+
+  /**
+   * Increase available space in bytes for this DiskId
+   *
+   * @param delta amount of bytes to increase.
+   */
+  void increaseAvailableSpaceInBytes(long delta);
+
+  /**
+   * Get available capacity in bytes for this DiskId
+   *
+   * @return the available capacity in bytes
+   */
+  long getAvailableSpaceInBytes();
+
+  /**
    * Gets the data node of this disk.
    *
    * @return {@link DataNodeId} hosting this disk.

--- a/ambry-api/src/main/java/com/github/ambry/server/StoreManager.java
+++ b/ambry-api/src/main/java/com/github/ambry/server/StoreManager.java
@@ -16,6 +16,8 @@ package com.github.ambry.server;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.store.Store;
+import com.github.ambry.store.StoreException;
+import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 
@@ -37,7 +39,7 @@ public interface StoreManager {
    * @param id the {@link PartitionId} associated with store
    * @return {@code true} if removal succeeds. {@code false} otherwise.
    */
-  boolean removeBlobStore(PartitionId id);
+  boolean removeBlobStore(PartitionId id) throws IOException, StoreException;
 
   /**
    * Start BlobStore with given {@link PartitionId} {@code id}.

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicationManager.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicationManager.java
@@ -36,10 +36,12 @@ import com.github.ambry.replication.ReplicationEngine;
 import com.github.ambry.replication.ReplicationException;
 import com.github.ambry.server.StoreManager;
 import com.github.ambry.store.Store;
+import com.github.ambry.store.StoreException;
 import com.github.ambry.store.StoreKeyConverterFactory;
 import com.github.ambry.store.StoreKeyFactory;
 import com.github.ambry.utils.SystemTime;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -298,7 +300,7 @@ public class VcrReplicationManager extends ReplicationEngine {
    * Remove a replica of given {@link PartitionId} and its {@link RemoteReplicaInfo}s from the backup list.
    * @param partitionId the {@link PartitionId} of the replica to removed.
    */
-  void removeReplica(PartitionId partitionId) {
+  void removeReplica(PartitionId partitionId) throws IOException, StoreException {
     rwLock.writeLock().lock();
     try {
       stopPartitionReplication(partitionId);

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
@@ -97,6 +97,9 @@ public class ClusterMapUtils {
   static final long MIN_REPLICA_CAPACITY_IN_BYTES = 1024 * 1024 * 1024L;
   static final long MAX_REPLICA_CAPACITY_IN_BYTES = 10L * 1024 * 1024 * 1024 * 1024;
   static final long MIN_DISK_CAPACITY_IN_BYTES = 10L * 1024 * 1024 * 1024;
+  // TODO: Temporary defaults to be used when adding replicas in helix FULL_AUTO mode. These replica configs will need
+  //  to stored in configs or helix for each cluster.
+  static final long DEFAULT_REPLICA_CAPACITY_IN_BYTES = 100L * 1024 * 1024 * 1024;
   static final int CURRENT_SCHEMA_VERSION = 0;
   static final String WRITABLE_LOG_STR = "writable";
   static final String FULLY_WRITABLE_LOG_STR = "fully writable";

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
@@ -397,95 +398,28 @@ public class HelixClusterManager implements ClusterMap {
     return partitionSelectionHelper.getPartitions(partitionClass);
   }
 
-  /**
-   * {@inheritDoc}
-   * To create bootstrap replica, {@link HelixClusterManager} needs to fetch replica info (i.e. capacity, mount path)
-   * from Helix PropertyStore. This method looks up the ZNode in local datacenter and does some validation. Right now,
-   * {@link HelixClusterManager} supports getting bootstrap replica of new partition but it doesn't support getting replica
-   * residing on hosts that are not present in clustermap.
-   * The ZNRecord of REPLICA_ADDITION_ZNODE has following format in mapFields.
-   * <pre>
-   * "mapFields": {
-   *     "1": {
-   *         "replicaCapacityInBytes": 107374182400,
-   *         "partitionClass": "max-replicas-all-datacenters",
-   *         "localhost1_17088": "/tmp/c/1",
-   *         "localhost2_17088": "/tmp/d/1"
-   *     },
-   *     "2": {
-   *         "replicaCapacityInBytes": 107374182400,
-   *         "partitionClass": "max-replicas-all-datacenters",
-   *         "localhost3_17088": "/tmp/e/1"
-   *     }
-   * }
-   * </pre>
-   * In above example, two bootstrap replicas of partition[1] will be added to localhost1 and localhost2 respectively.
-   * The host name is followed by mount path on which the bootstrap replica should be placed.
-   */
   @Override
   public ReplicaId getBootstrapReplica(String partitionIdStr, DataNodeId dataNodeId) {
-    ReplicaId bootstrapReplica = null;
-    logger.info("Getting ReplicaAddition ZNRecord from HelixPropertyStore in local DC.");
-    ZNRecord zNRecord = helixPropertyStoreInLocalDc.get(REPLICA_ADDITION_ZNODE_PATH, null, AccessOption.PERSISTENT);
-    if (zNRecord == null) {
-      logger.warn("ZNRecord from HelixPropertyStore is NULL, partition to replicaInfo map doesn't exist.");
-      return null;
-    }
     String instanceName = getInstanceName(dataNodeId.getHostname(), dataNodeId.getPort());
-    Map<String, Map<String, String>> partitionToReplicas = zNRecord.getMapFields();
-    Map<String, String> replicaInfos = partitionToReplicas.get(partitionIdStr);
-    if (replicaInfos == null || !replicaInfos.containsKey(instanceName)) {
-      logger.warn("Partition {} or replica on host {} is not found in replica info map", partitionIdStr, instanceName);
+    try {
+      ReplicaId bootstrapReplica =
+          isDataNodeInFullAutoMode(dataNodeId) ? getBootstrapReplicaInFullAuto(partitionIdStr, dataNodeId)
+              : getBootstrapReplicaInSemiAuto(partitionIdStr, dataNodeId);
+      // For now this method is only called by server which new replica will be added to. So if datanode equals to current
+      // node, we temporarily add this into a map (because we don't know whether store addition in storage manager
+      // succeeds or not). After store addition succeeds, current node is supposed to update InstanceConfig and will
+      // receive notification from Helix afterwards. At that time, dynamic cluster change handler will move replica from
+      // this map to clustermap related data structures that can be queried by other components.
+      if (bootstrapReplica != null && instanceName.equals(selfInstanceName)) {
+        // Note that this method might be called by several state transition threads concurrently.
+        bootstrapReplicas.put(partitionIdStr, bootstrapReplica);
+      }
+      return bootstrapReplica;
+    } catch (Exception e) {
+      logger.error("Failed to create bootstrap replica for partition {} on {} due to exception: ", partitionIdStr,
+          instanceName, e);
       return null;
     }
-    long replicaCapacity = Long.parseLong(replicaInfos.get(REPLICAS_CAPACITY_STR));
-    String partitionClass = replicaInfos.get(PARTITION_CLASS_STR);
-    AmbryPartition mappedPartition =
-        new AmbryPartition(Long.parseLong(partitionIdStr), partitionClass, helixClusterManagerQueryHelper);
-    AmbryPartition currentPartition =
-        partitionNameToAmbryPartition.putIfAbsent(mappedPartition.toPathString(), mappedPartition);
-    if (currentPartition == null) {
-      logger.info("Partition {} is currently not present in cluster map, a new partition is created", partitionIdStr);
-      currentPartition = mappedPartition;
-    }
-    // Check if data node or disk is in current cluster map, if not, set bootstrapReplica to null.
-    AmbryDataNode dataNode = instanceNameToAmbryDataNode.get(instanceName);
-    String mountPathAndDiskCapacityFromHelix = replicaInfos.get(instanceName);
-    String[] segments = mountPathAndDiskCapacityFromHelix.split(DISK_CAPACITY_DELIM_STR);
-    String mountPath = segments[0];
-    String diskCapacityStr = segments.length >= 2 ? segments[1] : null;
-    Set<AmbryDisk> disks = dataNode != null ? ambryDataNodeToAmbryDisks.get(dataNode) : null;
-    Optional<AmbryDisk> potentialDisk =
-        disks != null ? disks.stream().filter(d -> d.getMountPath().equals(mountPath)).findAny() : Optional.empty();
-    if (potentialDisk.isPresent()) {
-      try {
-        AmbryDisk targetDisk = potentialDisk.get();
-        if (diskCapacityStr != null) {
-          // update disk capacity if bootstrap replica info contains disk capacity in bytes.
-          targetDisk.setDiskCapacityInBytes(Long.parseLong(diskCapacityStr));
-        }
-        // A bootstrap replica is always ReplicaSealedStatus#NOT_SEALED.
-        bootstrapReplica = new AmbryServerReplica(clusterMapConfig, currentPartition, targetDisk, true, replicaCapacity,
-            ReplicaSealStatus.NOT_SEALED);
-      } catch (Exception e) {
-        logger.error("Failed to create bootstrap replica for partition {} on {} due to exception: ", partitionIdStr,
-            instanceName, e);
-        bootstrapReplica = null;
-      }
-    } else {
-      logger.error(
-          "Either datanode or disk that associated with bootstrap replica is not found in cluster map. Cannot create the replica.");
-    }
-    // For now this method is only called by server which new replica will be added to. So if datanode equals to current
-    // node, we temporarily add this into a map (because we don't know whether store addition in storage manager
-    // succeeds or not). After store addition succeeds, current node is supposed to update InstanceConfig and will
-    // receive notification from Helix afterwards. At that time, dynamic cluster change handler will move replica from
-    // this map to clustermap related data structures that can be queried by other components.
-    if (bootstrapReplica != null && instanceName.equals(selfInstanceName)) {
-      // Note that this method might be called by several state transition threads concurrently.
-      bootstrapReplicas.put(currentPartition.toPathString(), bootstrapReplica);
-    }
-    return bootstrapReplica;
   }
 
   @Override
@@ -500,11 +434,10 @@ public class HelixClusterManager implements ClusterMap {
   }
 
   @Override
-  public boolean isDataNodeInFullAutoMode(String hostname, int port) {
-    String instanceName = getInstanceName(hostname, port);
-    DataNodeId dataNodeId = instanceNameToAmbryDataNode.get(instanceName);
-    if (dataNodeId == null) {
-      throw new IllegalArgumentException("Host " + hostname + " Port " + port + " doesn't exist");
+  public boolean isDataNodeInFullAutoMode(DataNodeId dataNodeId) {
+    String instanceName = getInstanceName(dataNodeId.getHostname(), dataNodeId.getPort());
+    if (instanceNameToAmbryDataNode.get(instanceName) == null) {
+      throw new IllegalArgumentException("Instance " + instanceName + " doesn't exist");
     }
     String dcName = dataNodeId.getDatacenterName();
     Set<String> resourceNames = dcToInstanceNameToResources.get(dcName).get(instanceName);
@@ -711,6 +644,152 @@ public class HelixClusterManager implements ClusterMap {
    */
   private AmbryReplica fetchBootstrapReplica(String partitionName) {
     return (AmbryReplica) bootstrapReplicas.remove(partitionName);
+  }
+
+  /**
+   * Get bootstrap replica in Helix semi auto mode.
+   * To create bootstrap replica, {@link HelixClusterManager} needs to fetch replica info (i.e. capacity, mount path)
+   * from Helix PropertyStore. This method looks up the ZNode in local datacenter and does some validation. Right now,
+   * {@link HelixClusterManager} supports getting bootstrap replica of new partition but it doesn't support getting replica
+   * residing on hosts that are not present in clustermap.
+   * The ZNRecord of REPLICA_ADDITION_ZNODE has following format in mapFields.
+   * <pre>
+   * "mapFields": {
+   *     "1": {
+   *         "replicaCapacityInBytes": 107374182400,
+   *         "partitionClass": "max-replicas-all-datacenters",
+   *         "localhost1_17088": "/tmp/c/1",
+   *         "localhost2_17088": "/tmp/d/1"
+   *     },
+   *     "2": {
+   *         "replicaCapacityInBytes": 107374182400,
+   *         "partitionClass": "max-replicas-all-datacenters",
+   *         "localhost3_17088": "/tmp/e/1"
+   *     }
+   * }
+   * </pre>
+   * In above example, two bootstrap replicas of partition[1] will be added to localhost1 and localhost2 respectively.
+   * The host name is followed by mount path on which the bootstrap replica should be placed.
+   */
+  private ReplicaId getBootstrapReplicaInSemiAuto(String partitionIdStr, DataNodeId dataNodeId) {
+    ReplicaId bootstrapReplica = null;
+    logger.info("Getting ReplicaAddition ZNRecord from HelixPropertyStore in local DC.");
+    ZNRecord zNRecord = helixPropertyStoreInLocalDc.get(REPLICA_ADDITION_ZNODE_PATH, null, AccessOption.PERSISTENT);
+    if (zNRecord == null) {
+      logger.warn("ZNRecord from HelixPropertyStore is NULL, partition to replicaInfo map doesn't exist.");
+      return null;
+    }
+    String instanceName = getInstanceName(dataNodeId.getHostname(), dataNodeId.getPort());
+    Map<String, Map<String, String>> partitionToReplicas = zNRecord.getMapFields();
+    Map<String, String> replicaInfos = partitionToReplicas.get(partitionIdStr);
+    if (replicaInfos == null || !replicaInfos.containsKey(instanceName)) {
+      logger.warn("Partition {} or replica on host {} is not found in replica info map", partitionIdStr, instanceName);
+      return null;
+    }
+    long replicaCapacity = Long.parseLong(replicaInfos.get(REPLICAS_CAPACITY_STR));
+    String partitionClass = replicaInfos.get(PARTITION_CLASS_STR);
+    AmbryPartition mappedPartition =
+        new AmbryPartition(Long.parseLong(partitionIdStr), partitionClass, helixClusterManagerQueryHelper);
+    AmbryPartition currentPartition =
+        partitionNameToAmbryPartition.putIfAbsent(mappedPartition.toPathString(), mappedPartition);
+    if (currentPartition == null) {
+      logger.info("Partition {} is currently not present in cluster map, a new partition is created", partitionIdStr);
+      currentPartition = mappedPartition;
+    }
+    // Check if data node or disk is in current cluster map, if not, set bootstrapReplica to null.
+    AmbryDataNode dataNode = instanceNameToAmbryDataNode.get(instanceName);
+    String mountPathAndDiskCapacityFromHelix = replicaInfos.get(instanceName);
+    String[] segments = mountPathAndDiskCapacityFromHelix.split(DISK_CAPACITY_DELIM_STR);
+    String mountPath = segments[0];
+    String diskCapacityStr = segments.length >= 2 ? segments[1] : null;
+    Set<AmbryDisk> disks = dataNode != null ? ambryDataNodeToAmbryDisks.get(dataNode) : null;
+    Optional<AmbryDisk> potentialDisk =
+        disks != null ? disks.stream().filter(d -> d.getMountPath().equals(mountPath)).findAny() : Optional.empty();
+    if (potentialDisk.isPresent()) {
+      try {
+        AmbryDisk targetDisk = potentialDisk.get();
+        if (diskCapacityStr != null) {
+          // update disk capacity if bootstrap replica info contains disk capacity in bytes.
+          targetDisk.setDiskCapacityInBytes(Long.parseLong(diskCapacityStr));
+        }
+        // A bootstrap replica is always ReplicaSealedStatus#NOT_SEALED.
+        bootstrapReplica = new AmbryServerReplica(clusterMapConfig, currentPartition, targetDisk, true, replicaCapacity,
+            ReplicaSealStatus.NOT_SEALED);
+      } catch (Exception e) {
+        logger.error("Failed to create bootstrap replica for partition {} on {} due to exception: ", partitionIdStr,
+            instanceName, e);
+        bootstrapReplica = null;
+      }
+    } else {
+      logger.error(
+          "Either datanode or disk that associated with bootstrap replica is not found in cluster map. Cannot create the replica.");
+    }
+    return bootstrapReplica;
+  }
+
+  /**
+   * Gets bootstrap replica in Helix full auto mode.
+   * @param partitionIdStr the partition id string
+   * @param dataNodeId the {@link DataNodeId} on which bootstrap replica is placed
+   * @return {@link ReplicaId} if there is a new replica satisfying given partition and data node. {@code null} otherwise.
+   */
+  private ReplicaId getBootstrapReplicaInFullAuto(String partitionIdStr, DataNodeId dataNodeId) {
+    try {
+      AmbryDisk disk = getDiskForBootstrapReplica((AmbryDataNode) dataNodeId);
+      if (disk == null) {
+        logger.error("No Disk is available to host bootstrap replica. Cannot create the replica.");
+        return null;
+      }
+      AmbryPartition mappedPartition =
+          new AmbryPartition(Long.parseLong(partitionIdStr), clusterMapConfig.clusterMapDefaultPartitionClass,
+              helixClusterManagerQueryHelper);
+      AmbryPartition currentPartition =
+          partitionNameToAmbryPartition.putIfAbsent(mappedPartition.toPathString(), mappedPartition);
+      if (currentPartition == null) {
+        logger.info("Partition {} is currently not present in cluster map, a new partition is created", partitionIdStr);
+        currentPartition = mappedPartition;
+      }
+      return new AmbryServerReplica(clusterMapConfig, currentPartition, disk, true, DEFAULT_REPLICA_CAPACITY_IN_BYTES,
+          ReplicaSealStatus.NOT_SEALED);
+    } catch (Exception e) {
+      logger.error("Failed to create bootstrap replica for partition {} on {} due to exception: ", partitionIdStr,
+          dataNodeId, e);
+      return null;
+    }
+  }
+
+  /**
+   * Get a disk with maximum available space for bootstrapping replica in Full auto mode. This method is synchronized
+   * since it can be queried concurrently when multiple replicas are bootstrapped.
+   * TODO Check for disk health as well (Will be added in next PR)
+   * @param dataNode the {@link DataNodeId} on which disk is needed
+   * @return {@link AmbryDisk} which has maximum available or free capacity. If none of the disks have free space,
+   * returns null.
+   */
+  synchronized private AmbryDisk getDiskForBootstrapReplica(AmbryDataNode dataNode) {
+    Set<AmbryDisk> disks = ambryDataNodeToAmbryDisks.get(dataNode);
+    List<AmbryDisk> potentialDisks = new ArrayList<>();
+    long maxAvailableDiskSpace = 0;
+    for (AmbryDisk disk : disks) {
+      if (disk.getAvailableSpaceInBytes() < DEFAULT_REPLICA_CAPACITY_IN_BYTES) {
+        logger.info("Disk {} doesn't have space to host new replica. Disk space left {}, replica capacity {}", disk,
+            disk.getAvailableSpaceInBytes(), DEFAULT_REPLICA_CAPACITY_IN_BYTES);
+        continue;
+      }
+      if (disk.getAvailableSpaceInBytes() == maxAvailableDiskSpace) {
+        potentialDisks.add(disk);
+      } else if (disk.getAvailableSpaceInBytes() > maxAvailableDiskSpace) {
+        potentialDisks.clear();
+        potentialDisks.add(disk);
+        maxAvailableDiskSpace = disk.getAvailableSpaceInBytes();
+      }
+    }
+    if (potentialDisks.isEmpty()) {
+      return null;
+    }
+    // Select a random disk to among all the ones with equal available space.
+    int index = new Random().nextInt(potentialDisks.size());
+    return potentialDisks.get(index);
   }
 
   /**

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryServerRequests.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryServerRequests.java
@@ -778,7 +778,6 @@ public class AmbryServerRequests extends AmbryRequests {
     Store store = ((StorageManager) storeManager).getStore(partitionId, true);
     // Attempt to remove store from storage manager.
     if (storeManager.removeBlobStore(partitionId) && store != null) {
-      ((BlobStore) store).deleteStoreFiles();
       for (ReplicaStatusDelegate replicaStatusDelegate : ((BlobStore) store).getReplicaStatusDelegates()) {
         // Remove store from sealed and stopped list (if present)
         logger.info("Removing store from sealed and stopped list(if present)");

--- a/ambry-server/src/test/java/com/github/ambry/server/MockStorageManager.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/MockStorageManager.java
@@ -60,6 +60,7 @@ import com.github.ambry.utils.MockTime;
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.Utils;
 import io.netty.buffer.ByteBuf;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.SequenceInputStream;
 import java.nio.channels.WritableByteChannel;
@@ -589,7 +590,10 @@ class MockStorageManager extends StorageManager {
   }
 
   @Override
-  public boolean removeBlobStore(PartitionId id) {
+  public boolean removeBlobStore(PartitionId id) throws IOException, StoreException {
+    // Delete store files to mock logic in StorageManager code.
+    Store store = getStore(id, false);
+    ((BlobStore)store).deleteStoreFiles();
     return returnValueOfRemoveBlobStore;
   }
 

--- a/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockDiskId.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockDiskId.java
@@ -23,6 +23,7 @@ public class MockDiskId implements DiskId {
   MockDataNodeId dataNode;
   HardwareState state = HardwareState.AVAILABLE;
   private boolean allowChangesThroughClustermap = true;
+  public long availableSpaceInBytes = 10000;
 
   public MockDiskId(MockDataNodeId dataNode, String mountPath) {
     this.mountPath = mountPath;
@@ -41,7 +42,22 @@ public class MockDiskId implements DiskId {
 
   @Override
   public long getRawCapacityInBytes() {
-    return 100000;
+    return availableSpaceInBytes;
+  }
+
+  @Override
+  public void decreaseAvailableSpaceInBytes(long delta) {
+    availableSpaceInBytes -= delta;
+  }
+
+  @Override
+  public void increaseAvailableSpaceInBytes(long delta) {
+    availableSpaceInBytes += delta;
+  }
+
+  @Override
+  public long getAvailableSpaceInBytes() {
+    return availableSpaceInBytes;
   }
 
   @Override


### PR DESCRIPTION
This PR adds changes to create a new AmbryReplica object dynamically during OFFLINE -> BOOTSTRAP instance in Full Auto mode. 

In Semi-auto mode, the new replica information such as mount path of the disk, size of the replica is decided before hand and stored to Helix (/PROPERTYSTORE/AdminConfigs/ReplicaAddition Znode).  But, in Full-auto mode, the decision of the disk to host the replica has to be made locally. This PR adds those changes.