### PR TITLE
Mute ReplicationException for RetryAfterBackoff

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/replication/ReplicationException.java
+++ b/ambry-api/src/main/java/com/github/ambry/replication/ReplicationException.java
@@ -13,18 +13,34 @@
  */
 package com.github.ambry.replication;
 
+import com.github.ambry.server.ServerErrorCode;
+
+
 public class ReplicationException extends Exception {
   private static final long serialVersionUID = 1;
+  private final ServerErrorCode serverErrorCode;
 
   public ReplicationException(String message) {
     super(message);
+    serverErrorCode = null;
   }
 
   public ReplicationException(String message, Throwable e) {
     super(message, e);
+    serverErrorCode = null;
   }
 
   public ReplicationException(Throwable e) {
     super(e);
+    serverErrorCode = null;
+  }
+
+  public ReplicationException(String message, ServerErrorCode errorCode) {
+    super(message);
+    serverErrorCode = errorCode;
+  }
+
+  public ServerErrorCode getServerErrorCode() {
+    return serverErrorCode;
   }
 }

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationMetrics.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationMetrics.java
@@ -155,6 +155,8 @@ public class ReplicationMetrics {
   private final Counter intraColoTimeoutRequestErrorCount;
   private final Map<String, Counter> dcToRequestNetworkError = new ConcurrentHashMap<>();
   private final Counter intraColoRequestNetworkErrorCount;
+  private final Map<String, Counter> dcToRetryAfterBackoffError = new ConcurrentHashMap<>();
+  private final Counter intraColoRetryAfterBackoffErrorCount;
   private final Map<String, Counter> dcToResponseError = new ConcurrentHashMap<>();
   private final Counter intraColoResponseErrorCount;
 
@@ -285,6 +287,8 @@ public class ReplicationMetrics {
         registry.counter(MetricRegistry.name(ReplicaThread.class, "IntraColoTimeoutRequestErrorCount"));
     intraColoRequestNetworkErrorCount =
         registry.counter(MetricRegistry.name(ReplicaThread.class, "IntraColoRequestNetworkErrorCount"));
+    intraColoRetryAfterBackoffErrorCount =
+        registry.counter(MetricRegistry.name(ReplicaThread.class, "IntraColoRetryAfterBackoffErrorCount"));
     intraColoResponseErrorCount =
         registry.counter(MetricRegistry.name(ReplicaThread.class, "IntraColoResponseErrorCount"));
     this.registry = registry;
@@ -421,6 +425,9 @@ public class ReplicationMetrics {
     Counter requestNetworkError =
         registry.counter(MetricRegistry.name(ReplicaThread.class, "Inter-" + datacenter + "-RequestNetworkErrorCount"));
     dcToRequestNetworkError.put(datacenter, requestNetworkError);
+    Counter retryAfterBackoffError = registry.counter(
+        MetricRegistry.name(ReplicaThread.class, "Inter-" + datacenter + "-RetryAfterBackoffErrorCount"));
+    dcToRetryAfterBackoffError.put(datacenter, retryAfterBackoffError);
     Counter responseError =
         registry.counter(MetricRegistry.name(ReplicaThread.class, "Inter-" + datacenter + "-ResponseErrorCount"));
     dcToResponseError.put(datacenter, responseError);
@@ -658,6 +665,16 @@ public class ReplicationMetrics {
       dcToReplicationError.get(datacenter).inc();
     } else {
       intraColoRequestNetworkErrorCount.inc();
+      intraColoReplicationErrorCount.inc();
+    }
+  }
+
+  public void incrementRetryAfterBackoffErrorCount(boolean remoteColo, String datacenter) {
+    if (remoteColo) {
+      dcToRetryAfterBackoffError.get(datacenter).inc();
+      dcToReplicationError.get(datacenter).inc();
+    } else {
+      intraColoRetryAfterBackoffErrorCount.inc();
       intraColoReplicationErrorCount.inc();
     }
   }


### PR DESCRIPTION
Mute RetryAfterBackoff replication exception and use a metric to record the occurrence of this exception.