### PR TITLE
Support retentionCount for dataset version database

### DIFF
--- a/ambry-account/src/main/java/com/github/ambry/account/MySqlAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/MySqlAccountService.java
@@ -483,6 +483,24 @@ public class MySqlAccountService extends AbstractAccountService {
   }
 
   @Override
+  public List<DatasetVersionRecord> getAllValidVersionsOutOfRetentionCount(String accountName,
+      String containerName, String datasetName) throws AccountServiceException {
+    try {
+      Container container = getContainerByName(accountName, containerName);
+      if (container == null) {
+        throw new AccountServiceException("Can't find the container: " + containerName + " in account: " + accountName,
+            AccountServiceErrorCode.BadRequest);
+      }
+      short accountId = container.getParentAccountId();
+      short containerId = container.getId();
+      return mySqlAccountStore.getAllValidVersionsOutOfRetentionCount(accountId, containerId, accountName,
+          containerName, datasetName);
+    } catch (SQLException e) {
+      throw translateSQLException(e);
+    }
+  }
+
+  @Override
   protected void updateResolvedContainers(Account account, Collection<Container> resolvedContainers)
       throws AccountServiceException {
     try {

--- a/ambry-account/src/main/java/com/github/ambry/account/mysql/AccountDao.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/mysql/AccountDao.java
@@ -98,6 +98,7 @@ public class AccountDao {
   private final String updateDatasetVersionIfExpiredSql;
   private final String listVersionSql;
   private final String listValidVersionSql;
+  private final String listVersionByModifiedTimeSql;
 
   // Dataset table query strings
   private final String insertDatasetSql;
@@ -176,6 +177,10 @@ public class AccountDao {
     listValidVersionSql =
         String.format("select %s, %s from %s " + "where (%s IS NULL or %s > now(3)) and %s = ? and %s = ? and %s = ?",
             VERSION, DELETE_TS, DATASET_VERSION_TABLE, DELETE_TS, DELETE_TS, ACCOUNT_ID, CONTAINER_ID, DATASET_NAME);
+    listVersionByModifiedTimeSql = String.format(
+        "select %s, %s from %s " + "where (%s IS NULL or %s > now(3)) and %s = ? and %s = ? and %s = ? ORDER BY %s DESC",
+        VERSION, DELETE_TS, DATASET_VERSION_TABLE, DELETE_TS, DELETE_TS, ACCOUNT_ID, CONTAINER_ID, DATASET_NAME,
+        LAST_MODIFIED_TIME);
     getDatasetVersionByNameSql =
         String.format("select %s, %s from %s where %s = ? and %s = ? and %s = ? and %s = ?", LAST_MODIFIED_TIME,
             DELETE_TS, DATASET_VERSION_TABLE, ACCOUNT_ID, CONTAINER_ID, DATASET_NAME, VERSION);
@@ -701,6 +706,116 @@ public class AccountDao {
     } catch (SQLException e) {
       dataAccessor.onException(e, Read);
       throw e;
+    }
+  }
+
+  /**
+   * Get all versions from a dataset which has not expired and out of retentionCount by checking the last modified time.
+   * @param accountId the id for the parent account.
+   * @param containerId the id of the container.
+   * @param accountName the name for the parent account.
+   * @param containerName the name for the container.
+   * @param datasetName the name of the dataset.
+   * @return a list of {@link DatasetVersionRecord}
+   */
+  public synchronized List<DatasetVersionRecord> getAllValidVersionsOutOfRetentionCount(short accountId,
+      short containerId, String accountName, String containerName, String datasetName)
+      throws SQLException, AccountServiceException {
+    long startTimeMs = System.currentTimeMillis();
+    Integer retentionCount;
+    Dataset.VersionSchema versionSchema;
+    try {
+      //if dataset is deleted, we should not be able to get any dataset version.
+      Dataset dataset = getDataset(accountId, containerId, accountName, containerName, datasetName);
+      retentionCount = dataset.getRetentionCount();
+      versionSchema = dataset.getVersionSchema();
+    } catch (SQLException | AccountServiceException e) {
+      dataAccessor.onException(e, Read);
+      throw e;
+    }
+    if (retentionCount != null) {
+      try {
+        dataAccessor.getDatabaseConnection(false);
+        PreparedStatement listAllValidVersionsOrderedByLastModifiedTimeStatement =
+            dataAccessor.getPreparedStatement(listVersionByModifiedTimeSql, false);
+        List<DatasetVersionRecord> datasetVersionRecordList =
+            executeListAllValidVersionsOrderedByLastModifiedTimeStatement(
+                listAllValidVersionsOrderedByLastModifiedTimeStatement, accountId, containerId, datasetName, retentionCount, versionSchema);
+        dataAccessor.onSuccess(Read, System.currentTimeMillis() - startTimeMs);
+        return datasetVersionRecordList;
+      } catch (SQLException e) {
+        dataAccessor.onException(e, Read);
+        throw e;
+      }
+    } else {
+      return new ArrayList<>();
+    }
+  }
+
+  /**
+   * Execute the listAllValidVersionsOrderedByLastModifiedTimeStatement and fileter all versions out of retentionCount.
+   * @param statement the listVersionByModifiedTimeSql statement.
+   * @param accountId the id for the parent account.
+   * @param containerId the id of the container.
+   * @param datasetName the name of the dataset.
+   * @param retentionCount the retention count of dataset.
+   * @param versionSchema the {@link com.github.ambry.account.Dataset.VersionSchema} of the datset.
+   * @return a list of versions from a dataset which has not expired and out of retentionCount by checking the last modified time.
+   * @throws SQLException
+   */
+  private List<DatasetVersionRecord> executeListAllValidVersionsOrderedByLastModifiedTimeStatement(
+      PreparedStatement statement, int accountId, int containerId, String datasetName, int retentionCount,
+      Dataset.VersionSchema versionSchema) throws SQLException {
+    ResultSet resultSet = null;
+    List<DatasetVersionRecord> datasetVersionRecordList = new ArrayList<>();
+    try {
+      statement.setInt(1, accountId);
+      statement.setInt(2, containerId);
+      statement.setString(3, datasetName);
+      resultSet = statement.executeQuery();
+      int idx = 0;
+      while (resultSet.next()) {
+        idx++;
+        if (idx > retentionCount) {
+          long versionValue = resultSet.getLong(VERSION);
+          Timestamp deletionTime = resultSet.getTimestamp(DELETE_TS);
+          String version = convertVersionValueToVersion(versionValue, versionSchema);
+          datasetVersionRecordList.add(
+              new DatasetVersionRecord(accountId, containerId, datasetName, version, timestampToMs(deletionTime)));
+        }
+      }
+      return datasetVersionRecordList;
+    } finally {
+      closeQuietly(resultSet);
+    }
+  }
+
+  /**
+   * Convert version value from DB to string version.
+   * @param versionValue the value of the version from DB.
+   * @param versionSchema the {@link com.github.ambry.account.Dataset.VersionSchema} from dataset level.
+   * @return the converted string format version.
+   */
+  private String convertVersionValueToVersion(long versionValue, Dataset.VersionSchema versionSchema) {
+    String version;
+    switch (versionSchema) {
+      case TIMESTAMP:
+      case MONOTONIC:
+        version = Long.toString(versionValue);
+        return version;
+      case SEMANTIC:
+        //Given a version number MAJOR.MINOR.PATCH, increment the:
+        //1.MAJOR version when you make incompatible API changes
+        //2.MINOR version when you add functionality in a backwards compatible manner
+        //3.PATCH version when you make backwards compatible bug fixes
+        //The MAJOR,MINOR and PATCH version are non-negative value.
+        long major = versionValue / 1000000L;
+        long minor = (versionValue % 1000000L) / 1000L;
+        long patch = versionValue % 1000L;
+        version = String.format("%d.%d.%d", major, minor, patch);
+        return version;
+      default:
+        throw new IllegalArgumentException("Unsupported version schema: " + versionSchema);
     }
   }
 

--- a/ambry-account/src/main/java/com/github/ambry/account/mysql/MySqlAccountStore.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/mysql/MySqlAccountStore.java
@@ -251,6 +251,21 @@ public class MySqlAccountStore {
   }
 
   /**
+   * Get all versions from a dataset which has not expired and out of retentionCount by checking the last modified time.
+   * @param accountId the id for the parent account.
+   * @param containerId the id of the container.
+   * @param accountName the name for the parent account.
+   * @param containerName the name for the container.
+   * @param datasetName the name of the dataset.
+   * @return a list of {@link DatasetVersionRecord}
+   * @throws SQLException
+   */
+  public List<DatasetVersionRecord> getAllValidVersionsOutOfRetentionCount(short accountId, short containerId,
+      String accountName, String containerName, String datasetName) throws SQLException, AccountServiceException {
+     return accountDao.getAllValidVersionsOutOfRetentionCount(accountId, containerId, accountName, containerName, datasetName);
+  }
+
+  /**
    * Helper method to close the active connection, if there is one.
    */
   public void closeConnection() {

--- a/ambry-api/src/main/java/com/github/ambry/account/AccountService.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/AccountService.java
@@ -251,6 +251,19 @@ public interface AccountService extends Closeable {
     throw new UnsupportedOperationException("This method is not supported");
   }
 
+  /**
+   * Get all versions from a dataset which has not expired and out of retentionCount by checking the last modified time.
+   * @param accountName The name for the parent account.
+   * @param containerName The name for the container.
+   * @param datasetName The name of the dataset.
+   * @return a list of {@link DatasetVersionRecord}
+   * @throws AccountServiceException
+   */
+  default List<DatasetVersionRecord> getAllValidVersionsOutOfRetentionCount(String accountName,
+      String containerName, String datasetName) throws AccountServiceException {
+    throw new UnsupportedOperationException("This method is not supported");
+  }
+
   default void selectInactiveContainersAndMarkInStore(AggregatedAccountStorageStats aggregatedAccountStorageStats) {
     throw new UnsupportedOperationException("This method is not supported");
   }

--- a/ambry-api/src/main/java/com/github/ambry/commons/CallbackUtils.java
+++ b/ambry-api/src/main/java/com/github/ambry/commons/CallbackUtils.java
@@ -46,14 +46,14 @@ public class CallbackUtils {
     return (result, exception) -> {
       try {
         asyncOperationTracker.markOperationEnd();
-        if (exception == null) {
+        if (exception == null && successAction != null) {
           successAction.accept(result);
         }
       } catch (Exception e) {
         asyncOperationTracker.markCallbackProcessingError();
         exception = e;
       } finally {
-        if (exception != null) {
+        if (exception != null && failureCallback != null) {
           failureCallback.onCompletion(null, exception);
         }
         asyncOperationTracker.markCallbackProcessingEnd();

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/DeleteBlobHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/DeleteBlobHandler.java
@@ -179,6 +179,8 @@ public class DeleteBlobHandler {
         //do not process response when the delete request is coming caused by putting dataset version request.
         if (restRequest.getRestMethod() != RestMethod.PUT) {
           securityService.processResponse(restRequest, restResponseChannel, null, securityProcessResponseCallback());
+        } else {
+          securityProcessResponseCallback().onCompletion(null, null);
         }
       }, restRequest.getUri(), LOGGER, (r, e) -> {
         // Even we failed in router operations, we already used some of the resources in router,

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/DeleteBlobHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/DeleteBlobHandler.java
@@ -176,12 +176,17 @@ public class DeleteBlobHandler {
           restResponseChannel.setHeader(RestUtils.Headers.DATE, new GregorianCalendar().getTime());
           restResponseChannel.setHeader(RestUtils.Headers.CONTENT_LENGTH, 0);
         }
-        securityService.processResponse(restRequest, restResponseChannel, null, securityProcessResponseCallback());
+        //do not process response when the delete request is coming caused by putting dataset version request.
+        if (restRequest.getRestMethod() != RestMethod.PUT) {
+          securityService.processResponse(restRequest, restResponseChannel, null, securityProcessResponseCallback());
+        }
       }, restRequest.getUri(), LOGGER, (r, e) -> {
         // Even we failed in router operations, we already used some of the resources in router,
         // so let's record the charges for this request.
         securityService.processRequestCharges(restRequest, restResponseChannel, null);
-        finalCallback.onCompletion(null, e);
+        if (finalCallback != null) {
+          finalCallback.onCompletion(null, e);
+        }
       });
     }
 

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestService.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestService.java
@@ -196,7 +196,7 @@ class FrontendRestRequestService implements RestRequestService {
         new NamedBlobListHandler(securityService, namedBlobDb, accountAndContainerInjector, frontendMetrics);
     namedBlobPutHandler =
         new NamedBlobPutHandler(securityService, namedBlobDb, idConverter, idSigningService, router, accountAndContainerInjector,
-            frontendConfig, frontendMetrics, clusterName, quotaManager, accountService);
+            frontendConfig, frontendMetrics, clusterName, quotaManager, accountService, deleteBlobHandler);
 
     getClusterMapSnapshotHandler = new GetClusterMapSnapshotHandler(securityService, frontendMetrics, clusterMap);
     getAccountsHandler = new GetAccountsHandler(securityService, accountService, frontendMetrics);

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
@@ -59,6 +59,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static com.github.ambry.frontend.FrontendUtils.*;
+import static com.github.ambry.rest.RestUtils.*;
 import static com.github.ambry.rest.RestUtils.InternalKeys.*;
 import static com.github.ambry.router.RouterErrorCode.*;
 
@@ -98,6 +99,7 @@ public class NamedBlobPutHandler {
   private final RetryExecutor retryExecutor = new RetryExecutor(Executors.newScheduledThreadPool(2));
   private final Set<RouterErrorCode> retriableRouterError =
       EnumSet.of(AmbryUnavailable, ChannelClosed, UnexpectedInternalError, OperationTimedOut);
+  private final DeleteBlobHandler deleteBlobHandler;
 
   /**
    * Constructs a handler for handling requests for uploading or stitching blobs.
@@ -112,11 +114,12 @@ public class NamedBlobPutHandler {
    * @param clusterName the name of the storage cluster that the router communicates with
    * @param quotaManager The {@link QuotaManager} class to account for quota usage in serving requests.
    * @param accountService The {@link AccountService} to get the account and container id based on names.
+   * @param deleteBlobHandler
    */
   NamedBlobPutHandler(SecurityService securityService, NamedBlobDb namedBlobDb, IdConverter idConverter,
       IdSigningService idSigningService, Router router, AccountAndContainerInjector accountAndContainerInjector,
       FrontendConfig frontendConfig, FrontendMetrics frontendMetrics, String clusterName, QuotaManager quotaManager,
-      AccountService accountService) {
+      AccountService accountService, DeleteBlobHandler deleteBlobHandler) {
     this.securityService = securityService;
     this.namedBlobDb = namedBlobDb;
     this.idConverter = idConverter;
@@ -128,6 +131,7 @@ public class NamedBlobPutHandler {
     this.clusterName = clusterName;
     this.quotaManager = quotaManager;
     this.accountService = accountService;
+    this.deleteBlobHandler = deleteBlobHandler;
   }
 
   /**
@@ -275,6 +279,7 @@ public class NamedBlobPutHandler {
                   QuotaUtils.buildQuotaChargeCallback(restRequest, quotaManager, false)), this::isRetriable,
               routerTtlUpdateCallback(blobInfo, blobId));
         } else {
+          deleteDatasetVersionOutOfRetentionCount();
           securityService.processResponse(restRequest, restResponseChannel, blobInfo,
               securityProcessResponseCallback());
         }
@@ -301,9 +306,8 @@ public class NamedBlobPutHandler {
       return buildCallback(frontendMetrics.updateBlobTtlRouterMetrics, convertedBlobId -> {
         // Set the named blob state to be 'READY' after the Ttl update succeed
         if (!restRequest.getArgs().containsKey(RestUtils.InternalKeys.NAMED_BLOB_VERSION)) {
-          throw new RestServiceException(
-              "Internal key " + RestUtils.InternalKeys.NAMED_BLOB_VERSION + " is required in Named Blob TTL update callback!",
-              RestServiceErrorCode.InternalServerError);
+          throw new RestServiceException("Internal key " + RestUtils.InternalKeys.NAMED_BLOB_VERSION
+              + " is required in Named Blob TTL update callback!", RestServiceErrorCode.InternalServerError);
         }
         long namedBlobVersion = (long) restRequest.getArgs().get(NAMED_BLOB_VERSION);
         String blobIdClean = RestUtils.stripSlashAndExtensionFromId(blobId);
@@ -311,7 +315,7 @@ public class NamedBlobPutHandler {
         NamedBlobRecord record = new NamedBlobRecord(namedBlobPath.getAccountName(), namedBlobPath.getContainerName(),
             namedBlobPath.getBlobName(), blobIdClean, Utils.Infinite_Time, namedBlobVersion);
         namedBlobDb.updateBlobStateToReady(record).get();
-
+        deleteDatasetVersionOutOfRetentionCount();
         securityService.processResponse(restRequest, restResponseChannel, blobInfo, securityProcessResponseCallback());
       }, uri, LOGGER, finalCallback);
     }
@@ -506,8 +510,7 @@ public class NamedBlobPutHandler {
      * @return the {@link Dataset}
      * @throws RestServiceException
      */
-    private void addDatasetVersion(BlobProperties blobProperties, RestRequest restRequest)
-        throws RestServiceException {
+    private void addDatasetVersion(BlobProperties blobProperties, RestRequest restRequest) throws RestServiceException {
       long startAddDatasetVersionTime = System.currentTimeMillis();
       String accountName = null;
       String containerName = null;
@@ -525,7 +528,8 @@ public class NamedBlobPutHandler {
             Utils.addSecondsToEpochTime(blobProperties.getCreationTimeInMs(), blobProperties.getTimeToLiveInSeconds());
         DatasetVersionRecord datasetVersionRecord =
             accountService.addDatasetVersion(accountName, containerName, datasetName, version,
-                blobProperties.getTimeToLiveInSeconds(), blobProperties.getCreationTimeInMs(), datasetVersionTtlEnabled);
+                blobProperties.getTimeToLiveInSeconds(), blobProperties.getCreationTimeInMs(),
+                datasetVersionTtlEnabled);
         FrontendUtils.replaceRequestPathWithNewOperationOrBlobIdIfNeeded(restRequest, datasetVersionRecord, version);
         restResponseChannel.setHeader(RestUtils.Headers.TARGET_ACCOUNT_NAME, accountName);
         restResponseChannel.setHeader(RestUtils.Headers.TARGET_CONTAINER_NAME, containerName);
@@ -546,6 +550,42 @@ public class NamedBlobPutHandler {
                 + " datasetName: " + datasetName + " version: " + version);
         throw new RestServiceException(ex.getMessage(),
             RestServiceErrorCode.getRestServiceErrorCode(ex.getErrorCode()));
+      }
+    }
+
+    /**
+     * Support delete the dataset version out of retentionCount
+     */
+    private void deleteDatasetVersionOutOfRetentionCount() {
+      Dataset dataset = (Dataset) restRequest.getArgs().get(RestUtils.InternalKeys.TARGET_DATASET);
+      try {
+        if (RestUtils.isDatasetVersionQueryEnabled(restRequest.getArgs())) {
+          String accountName = dataset.getAccountName();
+          String containerName = dataset.getContainerName();
+          String datasetName = dataset.getDatasetName();
+          List<DatasetVersionRecord> datasetVersionRecordList =
+              accountService.getAllValidVersionsOutOfRetentionCount(accountName, containerName, datasetName);
+          for (DatasetVersionRecord record : datasetVersionRecordList) {
+            String version = record.getVersion();
+            RequestPath requestPath = getRequestPath(restRequest);
+            RequestPath newRequestPath = new RequestPath(requestPath.getPrefix(), requestPath.getClusterName(),
+                requestPath.getPathAfterPrefixes(),
+                NAMED_BLOB_PREFIX + SLASH + accountName + SLASH + containerName + SLASH + datasetName + SLASH + version,
+                requestPath.getSubResource(), requestPath.getBlobSegmentIdx());
+            // Replace RequestPath in the RestRequest and call DeleteBlobHandler.handle.
+            restRequest.setArg(InternalKeys.REQUEST_PATH, newRequestPath);
+            restRequest.setArg(InternalKeys.TARGET_ACCOUNT_KEY, null);
+            restRequest.setArg(InternalKeys.TARGET_CONTAINER_KEY, null);
+            try {
+              deleteBlobHandler.handle(restRequest, restResponseChannel, null);
+            } catch (Exception e) {
+              //do not throw the exception or handle it since we don't care if it has been deleted successfully.
+              LOGGER.error("Failed to delete the datasetVersionRecord :" + record);
+            }
+          }
+        }
+      } catch (Exception e) {
+        LOGGER.error("Failed to delete dataset version out of retention count for this dataset: " + dataset.toString());
       }
     }
   }

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
@@ -519,6 +519,123 @@ public class FrontendRestRequestServiceTest {
   }
 
   /**
+   * Test deleting dataset version out of retention logic when issue put request.
+   * @throws Exception
+   */
+  @Test
+  public void testRetentionCountLogic() throws Exception {
+    //Add dataset
+    Account testAccount = new ArrayList<>(accountService.getAllAccounts()).get(1);
+    Container testContainer = new ArrayList<>(testAccount.getAllContainers()).get(1);
+    Dataset.VersionSchema versionSchema = Dataset.VersionSchema.TIMESTAMP;
+    long datasetTtl = 3600;
+    Dataset dataset =
+        new DatasetBuilder(testAccount.getName(), testContainer.getName(), DATASET_NAME).setVersionSchema(versionSchema)
+            .setRetentionTimeInSeconds(datasetTtl)
+            .setRetentionCount(1)
+            .build();
+    byte[] datasetsUpdateJson = AccountCollectionSerde.serializeDatasetsInJson(dataset);
+    List<ByteBuffer> body = new LinkedList<>();
+    body.add(ByteBuffer.wrap(datasetsUpdateJson));
+    body.add(null);
+    JSONObject headers = new JSONObject().put(RestUtils.Headers.TARGET_ACCOUNT_NAME, testAccount.getName())
+        .put(RestUtils.Headers.TARGET_CONTAINER_NAME, testContainer.getName());
+    RestRequest restRequest =
+        createRestRequest(RestMethod.POST, Operations.ACCOUNTS_CONTAINERS_DATASETS, headers, body);
+    MockRestResponseChannel restResponseChannel = new MockRestResponseChannel();
+    doOperation(restRequest, restResponseChannel);
+
+
+    // add first dataset version
+    long version = 0;
+    String blobName = DATASET_NAME + SLASH + version;
+    String namedBlobPathUri =
+        NAMED_BLOB_PREFIX + SLASH + testAccount.getName() + SLASH + testContainer.getName() + SLASH + blobName;
+    ByteBuffer content = ByteBuffer.wrap(TestUtils.getRandomBytes(10));
+    body = new LinkedList<>();
+    body.add(content);
+    body.add(null);
+    headers = new JSONObject();
+    setAmbryHeadersForPut(headers, 7200, testContainer.isCacheable(), "test", "application/octet-stream", "owner", null, null,
+        null);
+    headers.put(RestUtils.Headers.DATASET_VERSION_QUERY_ENABLED, true);
+    restRequest = createRestRequest(RestMethod.PUT, namedBlobPathUri, headers, body);
+    restResponseChannel = new MockRestResponseChannel();
+
+    BlobProperties blobProperties =
+        new BlobProperties(0, testAccount.getName(), "owner", "image/gif", false, 7200, testAccount.getId(),
+            testContainer.getId(), false, null, null, null);
+    ReadableStreamChannel byteBufferContent = new ByteBufferReadableStreamChannel(ByteBuffer.allocate(10));
+    String blobIdFromRouter =
+        router.putBlobWithIdVersion(blobProperties, new byte[0], byteBufferContent, BlobId.BLOB_ID_V6).get();
+    reset(namedBlobDb);
+    NamedBlobRecord namedBlobRecord = new NamedBlobRecord(testAccount.getName(), testContainer.getName(), blobName,
+        blobIdFromRouter, Utils.Infinite_Time);
+    when(namedBlobDb.put(any(), any(), any())).thenReturn(
+        CompletableFuture.completedFuture(new PutResult(namedBlobRecord)));
+    when(namedBlobDb.delete(namedBlobRecord.getAccountName(), namedBlobRecord.getContainerName(),
+        blobName)).thenReturn(
+        CompletableFuture.completedFuture(new DeleteResult(blobIdFromRouter, false)));
+    when(namedBlobDb.get(namedBlobRecord.getAccountName(), namedBlobRecord.getContainerName(),
+        blobName, GetOption.None)).thenReturn(CompletableFuture.completedFuture(namedBlobRecord));
+    when(namedBlobDb.updateBlobStateToReady(any())).thenReturn(
+        CompletableFuture.completedFuture(new PutResult(namedBlobRecord)));
+
+    doOperation(restRequest, restResponseChannel);
+
+
+    //add second dataset version
+    long version1 = 1;
+    String blobName1 = DATASET_NAME + SLASH + version1;
+    String namedBlobPathUri1 =
+        NAMED_BLOB_PREFIX + SLASH + testAccount.getName() + SLASH + testContainer.getName() + SLASH + blobName1;
+    content = ByteBuffer.wrap(TestUtils.getRandomBytes(10));
+    body = new LinkedList<>();
+    body.add(content);
+    body.add(null);
+    headers = new JSONObject();
+    setAmbryHeadersForPut(headers, 7200, testContainer.isCacheable(), "test", "application/octet-stream", "owner", null, null,
+        null);
+    headers.put(RestUtils.Headers.DATASET_VERSION_QUERY_ENABLED, true);
+    restRequest = createRestRequest(RestMethod.PUT, namedBlobPathUri1, headers, body);
+    restResponseChannel = new MockRestResponseChannel();
+
+    byteBufferContent = new ByteBufferReadableStreamChannel(ByteBuffer.allocate(10));
+    String blobIdFromRouter1 =
+        router.putBlobWithIdVersion(blobProperties, new byte[0], byteBufferContent, BlobId.BLOB_ID_V6).get();
+    NamedBlobRecord namedBlobRecord1 = new NamedBlobRecord(testAccount.getName(), testContainer.getName(), blobName1,
+        blobIdFromRouter1, Utils.Infinite_Time);
+    when(namedBlobDb.put(any(), any(), any())).thenReturn(
+        CompletableFuture.completedFuture(new PutResult(namedBlobRecord1)));
+    when(namedBlobDb.delete(namedBlobRecord1.getAccountName(), namedBlobRecord1.getContainerName(),
+        blobName1)).thenReturn(
+        CompletableFuture.completedFuture(new DeleteResult(blobIdFromRouter1, false)));
+    when(namedBlobDb.get(namedBlobRecord1.getAccountName(), namedBlobRecord1.getContainerName(),
+        blobName1, GetOption.None)).thenReturn(CompletableFuture.completedFuture(namedBlobRecord1));
+    when(namedBlobDb.updateBlobStateToReady(any())).thenReturn(
+        CompletableFuture.completedFuture(new PutResult(namedBlobRecord1)));
+
+    doOperation(restRequest, restResponseChannel);
+
+    //get the 1st dataset version under the dataset, should be deleted.
+    headers = new JSONObject();
+    headers.put(RestUtils.Headers.DATASET_VERSION_QUERY_ENABLED, true);
+    restRequest = createRestRequest(RestMethod.GET, namedBlobPathUri, headers, null);
+    verifyOperationFailure(restRequest, RestServiceErrorCode.Deleted);
+
+    //get the 2nd dataset version, should exist
+    headers = new JSONObject();
+    headers.put(RestUtils.Headers.DATASET_VERSION_QUERY_ENABLED, true);
+    restRequest = createRestRequest(RestMethod.GET, namedBlobPathUri1, headers, null);
+    restResponseChannel = new MockRestResponseChannel();
+
+    //Issue get dataset version request
+    doOperation(restRequest, restResponseChannel);
+    assertEquals("Unexpected GET /DatasetVersions response content length", 10,
+        restResponseChannel.getResponseBody().length);
+  }
+
+  /**
    * Test add and get dataset version.
    * @throws Exception
    */

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/NamedBlobPutHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/NamedBlobPutHandlerTest.java
@@ -22,7 +22,6 @@ import com.github.ambry.account.Container;
 import com.github.ambry.account.ContainerBuilder;
 import com.github.ambry.account.DatasetBuilder;
 import com.github.ambry.account.InMemAccountService;
-import com.github.ambry.account.InMemAccountServiceFactory;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.commons.ByteBufferReadableStreamChannel;
@@ -563,7 +562,7 @@ public class NamedBlobPutHandlerTest {
     frontendConfig = new FrontendConfig(verifiableProperties);
     namedBlobPutHandler = new NamedBlobPutHandler(securityServiceFactory.getSecurityService(), namedBlobDb,
         idConverterFactory.getIdConverter(), idSigningService, router, injector, frontendConfig, metrics, CLUSTER_NAME,
-        QuotaTestUtils.createDummyQuotaManager(), ACCOUNT_SERVICE);
+        QuotaTestUtils.createDummyQuotaManager(), ACCOUNT_SERVICE, null);
   }
 
   /**


### PR DESCRIPTION
This pr supported the retentionCount logic for our dataset version db.
When user issue a put request to put a new version of dataset, we will check if the number of existing dataset version of this dataset is out of the retention count number which has been set at dataset level.
And we will issue a delete to try to delete the dataset version out of the retention count. 
And since it happened to every request, we will handle it async and only log the error messaged if delete failed. And retry with next put. So it won't affect the availability of put.