### PR TITLE
[Efficient Metadata Operations] Refactor metrics related to reserved metadata ids to a separate class.

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/frontend/ReservedMetadataIdMetrics.java
+++ b/ambry-api/src/main/java/com/github/ambry/frontend/ReservedMetadataIdMetrics.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.frontend;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.MetricRegistry;
+import java.util.HashMap;
+import java.util.Map;
+
+
+/**
+ * Metrics related to reserved metadata blob id.
+ */
+public class ReservedMetadataIdMetrics {
+  static final Map<MetricRegistry, ReservedMetadataIdMetrics> METRIC_MAP = new HashMap<>();
+  public final Counter numFailedPartitionReserveAttempts;
+  public final Counter numUnexpectedReservedPartitionClassCount;
+  public final Counter numReservedPartitionFoundReadOnlyCount;
+  public final Counter numReservedPartitionFoundUnavailableInLocalDcCount;
+  public final Counter numReservedPartitionFoundUnavailableInAllDcCount;
+
+  /**
+   * Constructor for {@link ReservedMetadataIdMetrics}.
+   * @param metricRegistry {@link MetricRegistry} object.
+   */
+  private ReservedMetadataIdMetrics(MetricRegistry metricRegistry) {
+    numUnexpectedReservedPartitionClassCount = metricRegistry.counter(
+        MetricRegistry.name(ReservedMetadataIdMetrics.class, "NumUnexpectedReservedPartitionClassCount"));
+    numFailedPartitionReserveAttempts = metricRegistry.counter(
+        MetricRegistry.name(ReservedMetadataIdMetrics.class, "NumFailedPartitionReserveAttempts"));
+    numReservedPartitionFoundReadOnlyCount = metricRegistry.counter(
+        MetricRegistry.name(ReservedMetadataIdMetrics.class, "NumReservedPartitionFoundReadOnlyCount"));
+    numReservedPartitionFoundUnavailableInLocalDcCount = metricRegistry.counter(
+        MetricRegistry.name(ReservedMetadataIdMetrics.class, "NumReservedPartitionFoundUnavailableInLocalDcCount"));
+    numReservedPartitionFoundUnavailableInAllDcCount = metricRegistry.counter(
+        MetricRegistry.name(ReservedMetadataIdMetrics.class, "NumReservedPartitionFoundUnavailableInAllDcCount"));
+  }
+
+  /**
+   * Return {@link ReservedMetadataIdMetrics} associated with the specified {@link MetricRegistry} object. If no
+   * {@link ReservedMetadataIdMetrics} is associated with the specified {@link MetricRegistry} object, then create one
+   * and return the created object.
+   * @param metricRegistry {@link MetricRegistry} object.
+   * @return ReservedMetadataIdMetrics object.
+   */
+  public static ReservedMetadataIdMetrics getReservedMetadataIdMetrics(MetricRegistry metricRegistry) {
+    synchronized (ReservedMetadataIdMetrics.class) {
+      if (!METRIC_MAP.containsKey(metricRegistry)) {
+        METRIC_MAP.put(metricRegistry, new ReservedMetadataIdMetrics(metricRegistry));
+      }
+      return METRIC_MAP.get(metricRegistry);
+    }
+  }
+}

--- a/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterMetrics.java
@@ -215,13 +215,6 @@ public class NonBlockingRouterMetrics {
   public final Counter compositeBlobGetCount;
   public final Counter rawBlobGetCount;
 
-  // Metrics for Reserving partitions and blobid for metadata chunk.
-  public final Counter numFailedPartitionReserveAttempts;
-  public final Counter numUnexpectedReservedPartitionClassCount;
-  public final Counter numReservedPartitionFoundReadOnlyCount;
-  public final Counter numReservedPartitionFoundUnavailableInLocalDcCount;
-  public final Counter numReservedPartitionFoundUnavailableInAllDcCount;
-
   // SimpleOperationTracker and AdaptiveOperationTracker metrics
   public final CachedHistogram getBlobLocalDcLatencyMs;
   public final CachedHistogram getBlobCrossDcLatencyMs;
@@ -519,16 +512,6 @@ public class NonBlockingRouterMetrics {
         metricRegistry.counter(MetricRegistry.name(GetBlobOperation.class, "CompositeBlobSizeMismatchCount"));
     unknownPartitionClassCount =
         metricRegistry.counter(MetricRegistry.name(PutOperation.class, "UnknownPartitionClassCount"));
-    numUnexpectedReservedPartitionClassCount = metricRegistry.counter(MetricRegistry.name(PutOperation.class,
-        "NumUnexpectedReservedPartitionClassCount"));
-    numFailedPartitionReserveAttempts = metricRegistry.counter(MetricRegistry.name(PutOperation.class,
-        "NumFailedPartitionReserveAttempts"));
-    numReservedPartitionFoundReadOnlyCount = metricRegistry.counter(MetricRegistry.name(PutOperation.class,
-        "NumReservedPartitionFoundReadOnlyCount"));
-    numReservedPartitionFoundUnavailableInLocalDcCount = metricRegistry.counter(MetricRegistry.name(PutOperation.class,
-        "NumReservedPartitionFoundUnavailableInLocalDcCount"));
-    numReservedPartitionFoundUnavailableInAllDcCount = metricRegistry.counter(MetricRegistry.name(PutOperation.class,
-        "NumReservedPartitionFoundUnavailableInAllDcCount"));
     updateOptimizedCount =
         metricRegistry.counter(MetricRegistry.name(OperationController.class, "UpdateOptimizedCount"));
     updateUnOptimizedCount =


### PR DESCRIPTION
The metrics related to reserved metadata ids will also be used in other classes (e.g, AmbryUrlSigningService). So, refactoring them into a separate class to make shared access easy. 