### PR TITLE
[Efficient Metadata Operations] Refactor AmbryUrlSigningServiceFactory and AmbryUrlSigningService to get ClusterMap object

### DIFF
--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbryUrlSigningService.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbryUrlSigningService.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.frontend;
 
+import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.rest.RestMethod;
 import com.github.ambry.rest.RestRequest;
 import com.github.ambry.rest.RestServiceErrorCode;
@@ -51,6 +52,7 @@ public class AmbryUrlSigningService implements UrlSigningService {
   private final long chunkUploadMaxChunkSize;
   private final long maxUrlTtlSecs;
   private final Time time;
+  private final ClusterMap clusterMap;
 
   /**
    * Constructor
@@ -64,10 +66,11 @@ public class AmbryUrlSigningService implements UrlSigningService {
    *                                       will be made permanent once the blob is stitched together.
    * @param chunkUploadMaxChunkSize the preconfigured max size for chunks of a stitched upload.
    * @param time the {@link Time} instance to use.
+   * @param clusterMap the {@link ClusterMap} object.
    */
   AmbryUrlSigningService(String uploadEndpoint, String downloadEndpoint, long defaultUrlTtlSecs,
       long defaultMaxUploadSize, long maxUrlTtlSecs, long chunkUploadInitialChunkTtlSecs, long chunkUploadMaxChunkSize,
-      Time time) {
+      Time time, ClusterMap clusterMap) {
     if (!uploadEndpoint.endsWith(ENDPOINT_SUFFIX)) {
       uploadEndpoint = uploadEndpoint + ENDPOINT_SUFFIX;
     }
@@ -82,6 +85,7 @@ public class AmbryUrlSigningService implements UrlSigningService {
     this.chunkUploadMaxChunkSize = chunkUploadMaxChunkSize;
     this.maxUrlTtlSecs = maxUrlTtlSecs;
     this.time = time;
+    this.clusterMap = clusterMap;
   }
 
   @Override

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbryUrlSigningServiceFactory.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbryUrlSigningServiceFactory.java
@@ -13,7 +13,7 @@
  */
 package com.github.ambry.frontend;
 
-import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.config.FrontendConfig;
 import com.github.ambry.config.RouterConfig;
 import com.github.ambry.config.VerifiableProperties;
@@ -31,10 +31,12 @@ import org.json.JSONObject;
 public class AmbryUrlSigningServiceFactory implements UrlSigningServiceFactory {
   private final FrontendConfig config;
   private final int chunkUploadMaxChunkSize;
+  private final ClusterMap clusterMap;
 
-  public AmbryUrlSigningServiceFactory(VerifiableProperties verifiableProperties, MetricRegistry metricRegistry) {
+  public AmbryUrlSigningServiceFactory(VerifiableProperties verifiableProperties, ClusterMap clusterMap) {
     config = new FrontendConfig(verifiableProperties);
     chunkUploadMaxChunkSize = new RouterConfig(verifiableProperties).routerMaxPutChunkSizeBytes;
+    this.clusterMap = clusterMap;
   }
 
   @Override
@@ -52,6 +54,6 @@ public class AmbryUrlSigningServiceFactory implements UrlSigningServiceFactory {
 
     return new AmbryUrlSigningService(uploadEndpoint, downloadEndpoint, config.urlSignerDefaultUrlTtlSecs,
         config.urlSignerDefaultMaxUploadSizeBytes, config.urlSignerMaxUrlTtlSecs,
-        config.chunkUploadInitialChunkTtlSecs, chunkUploadMaxChunkSize, SystemTime.getInstance());
+        config.chunkUploadInitialChunkTtlSecs, chunkUploadMaxChunkSize, SystemTime.getInstance(), clusterMap);
   }
 }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestServiceFactory.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestServiceFactory.java
@@ -90,7 +90,7 @@ public class FrontendRestRequestServiceFactory implements RestRequestServiceFact
               idSigningService, namedBlobDb);
       UrlSigningService urlSigningService =
           Utils.<UrlSigningServiceFactory>getObj(frontendConfig.urlSigningServiceFactory, verifiableProperties,
-              clusterMap.getMetricRegistry()).getUrlSigningService();
+              clusterMap).getUrlSigningService();
       AccountAndContainerInjector accountAndContainerInjector =
           new AccountAndContainerInjector(accountService, frontendMetrics, frontendConfig);
       AccountStatsStore accountStatsStore =

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/AmbryUrlSigningServiceTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/AmbryUrlSigningServiceTest.java
@@ -14,6 +14,7 @@
 package com.github.ambry.frontend;
 
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.commons.CommonTestUtils;
 import com.github.ambry.config.FrontendConfig;
 import com.github.ambry.config.VerifiableProperties;
@@ -33,6 +34,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import org.json.JSONObject;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import static org.junit.Assert.*;
 
@@ -49,6 +51,7 @@ public class AmbryUrlSigningServiceTest {
   private static final long CHUNK_UPLOAD_INITIAL_CHUNK_TTL_SECS = 24 * 1024 * 1024;
   private static final long CHUNK_UPLOAD_MAX_CHUNK_SIZE = 4 * 1024 * 1024;
   private static final String RANDOM_AMBRY_HEADER = AmbryUrlSigningService.AMBRY_PARAMETERS_PREFIX + "random";
+  private static final ClusterMap MOCK_CLUSTER_MAP = Mockito.mock(ClusterMap.class);
 
   /**
    * Tests for {@link AmbryUrlSigningServiceFactory}.
@@ -66,7 +69,7 @@ public class AmbryUrlSigningServiceTest {
     CommonTestUtils.populateRequiredRouterProps(properties);
     properties.setProperty("router.max.put.chunk.size.bytes", Long.toString(CHUNK_UPLOAD_MAX_CHUNK_SIZE));
     UrlSigningService signer = new AmbryUrlSigningServiceFactory(new VerifiableProperties(properties),
-        new MetricRegistry()).getUrlSigningService();
+        MOCK_CLUSTER_MAP).getUrlSigningService();
     assertNotNull("UrlSigningService is null", signer);
     assertTrue("UrlSigningService is AmbryUrlSigningService", signer instanceof AmbryUrlSigningService);
     assertTrue(((AmbryUrlSigningService) signer).getUploadEndpoint().contains(UPLOAD_ENDPOINT));
@@ -85,7 +88,7 @@ public class AmbryUrlSigningServiceTest {
     properties.setProperty(FrontendConfig.URL_SIGNER_ENDPOINTS, jsonObject.toString());
     try {
       new AmbryUrlSigningServiceFactory(new VerifiableProperties(properties),
-          new MetricRegistry()).getUrlSigningService();
+          MOCK_CLUSTER_MAP).getUrlSigningService();
       fail("Expected exception");
     } catch (IllegalStateException ex) {
     }
@@ -94,7 +97,7 @@ public class AmbryUrlSigningServiceTest {
     properties.setProperty(FrontendConfig.URL_SIGNER_ENDPOINTS, jsonObject.toString());
     try {
       new AmbryUrlSigningServiceFactory(new VerifiableProperties(properties),
-          new MetricRegistry()).getUrlSigningService();
+          MOCK_CLUSTER_MAP).getUrlSigningService();
       fail("Expected exception");
     } catch (IllegalStateException ex) {
     }
@@ -102,7 +105,7 @@ public class AmbryUrlSigningServiceTest {
     properties.setProperty(FrontendConfig.URL_SIGNER_ENDPOINTS, "[Garbage string &%#123");
     try {
       new AmbryUrlSigningServiceFactory(new VerifiableProperties(properties),
-          new MetricRegistry()).getUrlSigningService();
+          MOCK_CLUSTER_MAP).getUrlSigningService();
       fail("Expected exception");
     } catch (IllegalStateException ex) {
     }
@@ -147,7 +150,8 @@ public class AmbryUrlSigningServiceTest {
    */
   private AmbryUrlSigningService getUrlSignerWithDefaults(Time time) {
     return new AmbryUrlSigningService(UPLOAD_ENDPOINT, DOWNLOAD_ENDPOINT, DEFAULT_URL_TTL_SECS, DEFAULT_MAX_UPLOAD_SIZE,
-        MAX_URL_TTL_SECS, CHUNK_UPLOAD_INITIAL_CHUNK_TTL_SECS, CHUNK_UPLOAD_MAX_CHUNK_SIZE, time);
+        MAX_URL_TTL_SECS, CHUNK_UPLOAD_INITIAL_CHUNK_TTL_SECS, CHUNK_UPLOAD_MAX_CHUNK_SIZE, time, Mockito.mock(
+        ClusterMap.class));
   }
 
   /**

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
@@ -211,7 +211,7 @@ public class FrontendRestRequestServiceTest {
     String endpoint = "http://localhost:1174";
     urlSigningService = new AmbryUrlSigningService(endpoint, endpoint, frontendConfig.urlSignerDefaultUrlTtlSecs,
         frontendConfig.urlSignerDefaultMaxUploadSizeBytes, frontendConfig.urlSignerMaxUrlTtlSecs,
-        frontendConfig.chunkUploadInitialChunkTtlSecs, 4 * 1024 * 1024, SystemTime.getInstance());
+        frontendConfig.chunkUploadInitialChunkTtlSecs, 4 * 1024 * 1024, SystemTime.getInstance(), clusterMap);
     idSigningService = new AmbryIdSigningService();
     namedBlobDb = mock(NamedBlobDb.class);
     idConverterFactory =


### PR DESCRIPTION
This will allow AmbryUrlSigningService to reserve the Metadata chunk id in the POST-signed-url request for stitched blobs.