### PR TITLE
Add changes to bootstrap tool for migrating helix resources to Full auto

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/clustermap/RebalanceMode.java
+++ b/ambry-api/src/main/java/com/github/ambry/clustermap/RebalanceMode.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.clustermap;
+
+/**
+ * Re-balancing mode used for Helix based cluster manager.
+ */
+public enum RebalanceMode {
+  /**
+   * Helix will automatically determine the location and state of each replica
+   */
+  SEMI_AUTO,
+  /**
+   * Helix will take the location of each replica and automatically determine the state
+   */
+  FULL_AUTO
+}

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeUtil.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeUtil.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -49,7 +48,6 @@ import org.apache.helix.manager.zk.ZNRecordSerializer;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.LeaderStandbySMD;
-import org.apache.helix.model.ResourceConfig;
 import org.apache.helix.model.StateModelDefinition;
 import org.apache.helix.store.HelixPropertyStore;
 import org.apache.helix.zookeeper.api.client.HelixZkClient;
@@ -106,52 +104,52 @@ import static com.github.ambry.utils.Utils.*;
  *  }
  *}
  */
-public class HelixBootstrapUpgradeUtil {
+public abstract class HelixBootstrapUpgradeUtil {
   static final int DEFAULT_MAX_PARTITIONS_PER_RESOURCE = 100;
   static final String HELIX_DISABLED_PARTITION_STR =
       InstanceConfig.InstanceConfigProperty.HELIX_DISABLED_PARTITION.name();
   // blockRemovingNodeLatch is for testing purpose
   static CountDownLatch blockRemovingNodeLatch = null;
   static CountDownLatch disablePartitionLatch = null;
-  private final StaticClusterManager staticClusterMap;
-  private final String zkLayoutPath;
-  private final String stateModelDef;
-  private final Map<String, HelixAdmin> adminForDc = new HashMap<>();
-  private final Map<String, RealmAwareZkClient> zkClientForDc = new HashMap<>();
+  protected final StaticClusterManager staticClusterMap;
+  protected final String zkLayoutPath;
+  protected final String stateModelDef;
+  protected final Map<String, HelixAdmin> adminForDc = new HashMap<>();
+  protected final Map<String, RealmAwareZkClient> zkClientForDc = new HashMap<>();
   // These two maps should be concurrent map because they are accessed in multi-threaded context (see addUpdateInstances
   // method).
   // For now, the inner map doesn't need to be concurrent map because it is within a certain dc which means there should
   // be only one thread that updates it.
-  private final ConcurrentHashMap<String, Map<DiskId, SortedSet<Replica>>> instanceToDiskReplicasMap =
+  protected final ConcurrentHashMap<String, Map<DiskId, SortedSet<Replica>>> instanceToDiskReplicasMap =
       new ConcurrentHashMap<>();
-  private final ConcurrentHashMap<String, Map<String, DataNodeId>> dcToInstanceNameToDataNodeId =
+  protected final ConcurrentHashMap<String, Map<String, DataNodeId>> dcToInstanceNameToDataNodeId =
       new ConcurrentHashMap<>();
-  private final int maxPartitionsInOneResource;
-  private final boolean dryRun;
-  private final boolean forceRemove;
-  private final String clusterName;
-  private final String hostName;
-  private final Integer portNum;
-  private final String partitionName;
-  private final HelixAdminOperation helixAdminOperation;
-  private final DataNodeConfigSourceType dataNodeConfigSourceType;
-  private final boolean overrideReplicaStatus;
-  private boolean expectMoreInHelixDuringValidate = false;
-  private ConcurrentHashMap<String, Set<String>> instancesNotForceRemovedByDc = new ConcurrentHashMap<>();
-  private ConcurrentHashMap<String, Set<String>> partitionsNotForceRemovedByDc = new ConcurrentHashMap<>();
-  private final AtomicInteger instancesAdded = new AtomicInteger();
-  private final AtomicInteger instancesUpdated = new AtomicInteger();
-  private final AtomicInteger instancesDropped = new AtomicInteger();
-  private final AtomicInteger resourcesAdded = new AtomicInteger();
-  private final AtomicInteger resourcesUpdated = new AtomicInteger();
-  private final AtomicInteger resourcesDropped = new AtomicInteger();
-  private final AtomicInteger partitionsDisabled = new AtomicInteger();
-  private final AtomicInteger partitionsEnabled = new AtomicInteger();
-  private final AtomicInteger partitionsReset = new AtomicInteger();
-  private Map<String, ClusterMapUtils.DcZkInfo> dataCenterToZkAddress;
-  private HelixClusterManager validatingHelixClusterManager;
-  private static final Logger logger = LoggerFactory.getLogger("Helix bootstrap tool");
-  private static final String ALL = "all";
+  protected final int maxPartitionsInOneResource;
+  protected final boolean dryRun;
+  protected final boolean forceRemove;
+  protected final String clusterName;
+  protected final String hostName;
+  protected final Integer portNum;
+  protected final String partitionName;
+  protected final HelixAdminOperation helixAdminOperation;
+  protected final DataNodeConfigSourceType dataNodeConfigSourceType;
+  protected final boolean overrideReplicaStatus;
+  protected boolean expectMoreInHelixDuringValidate = false;
+  protected ConcurrentHashMap<String, Set<String>> instancesNotForceRemovedByDc = new ConcurrentHashMap<>();
+  protected ConcurrentHashMap<String, Set<String>> partitionsNotForceRemovedByDc = new ConcurrentHashMap<>();
+  protected final AtomicInteger instancesAdded = new AtomicInteger();
+  protected final AtomicInteger instancesUpdated = new AtomicInteger();
+  protected final AtomicInteger instancesDropped = new AtomicInteger();
+  protected final AtomicInteger resourcesAdded = new AtomicInteger();
+  protected final AtomicInteger resourcesUpdated = new AtomicInteger();
+  protected final AtomicInteger resourcesDropped = new AtomicInteger();
+  protected final AtomicInteger partitionsDisabled = new AtomicInteger();
+  protected final AtomicInteger partitionsEnabled = new AtomicInteger();
+  protected final AtomicInteger partitionsReset = new AtomicInteger();
+  protected Map<String, ClusterMapUtils.DcZkInfo> dataCenterToZkAddress;
+  protected HelixClusterManager validatingHelixClusterManager;
+  protected static final Logger logger = LoggerFactory.getLogger("Helix bootstrap tool");
+  protected static final String ALL = "all";
 
   public enum HelixAdminOperation {
     BootstrapCluster,
@@ -161,7 +159,8 @@ public class HelixBootstrapUpgradeUtil {
     EnablePartition,
     ResetPartition,
     ListSealedPartition,
-    MigrateToPropertyStore
+    MigrateToPropertyStore,
+    MigrateToFullAuto
   }
 
   /**
@@ -215,6 +214,7 @@ public class HelixBootstrapUpgradeUtil {
    *                           InstanceConfig will be updated by nodes themselves.
    * @param dataNodeConfigSourceType the {@link DataNodeConfigSourceType} to use when bootstrapping cluster.
    * @param overrideReplicaStatus whether to override sealed/stopped/disabled replica status lists.
+   * @param rebalanceMode the {@link RebalanceMode} used in Helix.
    * @throws IOException if there is an error reading a file.
    * @throws JSONException if there is an error parsing the JSON content in any of the files.
    */
@@ -222,15 +222,20 @@ public class HelixBootstrapUpgradeUtil {
       String clusterNamePrefix, String dcs, int maxPartitionsInOneResource, boolean dryRun, boolean forceRemove,
       HelixAdminFactory helixAdminFactory, boolean startValidatingClusterManager, String stateModelDef,
       HelixAdminOperation helixAdminOperation, DataNodeConfigSourceType dataNodeConfigSourceType,
-      boolean overrideReplicaStatus) throws Exception {
+      boolean overrideReplicaStatus, RebalanceMode rebalanceMode) throws Exception {
     if (dryRun) {
       info("==== This is a dry run ====");
       info("No changes will be made to the information in Helix (except adding the cluster if it does not exist.");
     }
-    HelixBootstrapUpgradeUtil clusterMapToHelixMapper =
-        new HelixBootstrapUpgradeUtil(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterNamePrefix, dcs,
-            maxPartitionsInOneResource, dryRun, forceRemove, helixAdminFactory, stateModelDef, null, null, null,
-            helixAdminOperation, dataNodeConfigSourceType, overrideReplicaStatus);
+    HelixBootstrapUpgradeUtil clusterMapToHelixMapper;
+    if (rebalanceMode == RebalanceMode.SEMI_AUTO) {
+      clusterMapToHelixMapper =
+          new HelixBootstrapUpgradeUtilSemiAuto(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
+              clusterNamePrefix, dcs, maxPartitionsInOneResource, dryRun, forceRemove, helixAdminFactory, stateModelDef,
+              null, null, null, helixAdminOperation, dataNodeConfigSourceType, overrideReplicaStatus);
+    } else {
+      throw new IllegalArgumentException("Unsupported rebalance mode " + rebalanceMode);
+    }
     if (dryRun) {
       info("To drop the cluster, run this tool again with the '--dropCluster {}' argument.",
           clusterMapToHelixMapper.clusterName);
@@ -264,9 +269,9 @@ public class HelixBootstrapUpgradeUtil {
       String clusterNamePrefix, String dcs, boolean forceRemove, String[] adminTypes, String adminConfigFilePath)
       throws Exception {
     HelixBootstrapUpgradeUtil clusterMapToHelixMapper =
-        new HelixBootstrapUpgradeUtil(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterNamePrefix, dcs,
-            DEFAULT_MAX_PARTITIONS_PER_RESOURCE, false, forceRemove, null, ClusterMapConfig.DEFAULT_STATE_MODEL_DEF,
-            null, null, null, null, null, false);
+        new HelixBootstrapUpgradeUtilSemiAuto(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterNamePrefix,
+            dcs, DEFAULT_MAX_PARTITIONS_PER_RESOURCE, false, forceRemove, null,
+            ClusterMapConfig.DEFAULT_STATE_MODEL_DEF, null, null, null, null, null, false);
     if (forceRemove) {
       for (String adminType : adminTypes) {
         removeAdminInfosFromCluster(clusterMapToHelixMapper, adminType);
@@ -284,8 +289,9 @@ public class HelixBootstrapUpgradeUtil {
   static void addStateModelDef(String hardwareLayoutPath, String partitionLayoutPath, String zkLayoutPath,
       String clusterNamePrefix, String dcs, String stateModelDef) throws Exception {
     HelixBootstrapUpgradeUtil clusterMapToHelixMapper =
-        new HelixBootstrapUpgradeUtil(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterNamePrefix, dcs,
-            DEFAULT_MAX_PARTITIONS_PER_RESOURCE, false, false, null, stateModelDef, null, null, null, null, null, false);
+        new HelixBootstrapUpgradeUtilSemiAuto(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterNamePrefix,
+            dcs, DEFAULT_MAX_PARTITIONS_PER_RESOURCE, false, false, null, stateModelDef, null, null, null, null, null,
+            false);
     clusterMapToHelixMapper.addStateModelDef();
     info("State model def is successfully added");
   }
@@ -305,10 +311,11 @@ public class HelixBootstrapUpgradeUtil {
    * @throws JSONException if there is an error parsing the JSON content in any of the files.
    */
   static void validate(String hardwareLayoutPath, String partitionLayoutPath, String zkLayoutPath,
-      String clusterNamePrefix, String dcs, String stateModelDef, DataNodeConfigSourceType dataNodeConfigSourceType) throws Exception {
+      String clusterNamePrefix, String dcs, String stateModelDef, DataNodeConfigSourceType dataNodeConfigSourceType)
+      throws Exception {
     HelixBootstrapUpgradeUtil clusterMapToHelixMapper =
-        new HelixBootstrapUpgradeUtil(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterNamePrefix, dcs,
-            DEFAULT_MAX_PARTITIONS_PER_RESOURCE, false, false, null, stateModelDef, null, null, null,
+        new HelixBootstrapUpgradeUtilSemiAuto(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterNamePrefix,
+            dcs, DEFAULT_MAX_PARTITIONS_PER_RESOURCE, false, false, null, stateModelDef, null, null, null,
             HelixAdminOperation.ValidateCluster, dataNodeConfigSourceType, false);
     clusterMapToHelixMapper.validateAndClose();
     clusterMapToHelixMapper.logSummary();
@@ -329,9 +336,9 @@ public class HelixBootstrapUpgradeUtil {
   static Set<String> listSealedPartition(String hardwareLayoutPath, String partitionLayoutPath, String zkLayoutPath,
       String clusterNamePrefix, String dcs, DataNodeConfigSourceType dataNodeConfigSourceType) throws Exception {
     HelixBootstrapUpgradeUtil helixBootstrapUpgradeUtil =
-        new HelixBootstrapUpgradeUtil(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterNamePrefix, dcs,
-            DEFAULT_MAX_PARTITIONS_PER_RESOURCE, false, false, null, ClusterMapConfig.DEFAULT_STATE_MODEL_DEF, null,
-            null, null, HelixAdminOperation.ListSealedPartition, dataNodeConfigSourceType, false);
+        new HelixBootstrapUpgradeUtilSemiAuto(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterNamePrefix,
+            dcs, DEFAULT_MAX_PARTITIONS_PER_RESOURCE, false, false, null, ClusterMapConfig.DEFAULT_STATE_MODEL_DEF,
+            null, null, null, HelixAdminOperation.ListSealedPartition, dataNodeConfigSourceType, false);
     return helixBootstrapUpgradeUtil.getSealedPartitionsInHelixCluster();
   }
 
@@ -354,9 +361,9 @@ public class HelixBootstrapUpgradeUtil {
       String partitionName) throws Exception {
 
     HelixBootstrapUpgradeUtil helixBootstrapUpgradeUtil =
-        new HelixBootstrapUpgradeUtil(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterNamePrefix, dcs,
-            DEFAULT_MAX_PARTITIONS_PER_RESOURCE, false, false, null, null, Objects.requireNonNull(hostname), portNum,
-            Objects.requireNonNull(partitionName), operation, null, false);
+        new HelixBootstrapUpgradeUtilSemiAuto(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterNamePrefix,
+            dcs, DEFAULT_MAX_PARTITIONS_PER_RESOURCE, false, false, null, null, Objects.requireNonNull(hostname),
+            portNum, Objects.requireNonNull(partitionName), operation, null, false);
     if (operation == HelixAdminOperation.ResetPartition) {
       helixBootstrapUpgradeUtil.resetPartition();
     } else {
@@ -379,10 +386,31 @@ public class HelixBootstrapUpgradeUtil {
       String clusterNamePrefix, String dcs) throws Exception {
 
     HelixBootstrapUpgradeUtil helixBootstrapUpgradeUtil =
-        new HelixBootstrapUpgradeUtil(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterNamePrefix, dcs,
-            DEFAULT_MAX_PARTITIONS_PER_RESOURCE, false, false, null, null, null, null, null,
+        new HelixBootstrapUpgradeUtilSemiAuto(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterNamePrefix,
+            dcs, DEFAULT_MAX_PARTITIONS_PER_RESOURCE, false, false, null, null, null, null, null,
             HelixAdminOperation.MigrateToPropertyStore, PROPERTY_STORE, false);
     helixBootstrapUpgradeUtil.migrateToPropertyStore();
+  }
+
+  /**
+   * Migrate resources from semi-auto to full-auto.
+   * @param hardwareLayoutPath the path to the hardware layout file.
+   * @param partitionLayoutPath the path to the partition layout file.
+   * @param zkLayoutPath the path to the zookeeper layout file.
+   * @param clusterNamePrefix the prefix that when combined with the cluster name in the static cluster map files
+   *                          will give the cluster name in Helix to bootstrap or upgrade.
+   * @param dcs the comma-separated list of data centers that needs to be migrated
+   * @param resources the comma-separated list of resources that needs to be migrated
+   * @param dryRun
+   * @throws Exception
+   */
+  static void migrateToFullAuto(String hardwareLayoutPath, String partitionLayoutPath, String zkLayoutPath,
+      String clusterNamePrefix, String dcs, String resources, boolean dryRun) throws Exception {
+    HelixBootstrapUpgradeUtilFullAuto helixBootstrapUpgradeUtilFullAuto =
+        new HelixBootstrapUpgradeUtilFullAuto(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterNamePrefix,
+            dcs, DEFAULT_MAX_PARTITIONS_PER_RESOURCE, dryRun, false, null, null, null, null, null,
+            HelixAdminOperation.MigrateToFullAuto, PROPERTY_STORE, false);
+    helixBootstrapUpgradeUtilFullAuto.migrateToFullAuto(resources);
   }
 
   /**
@@ -415,7 +443,7 @@ public class HelixBootstrapUpgradeUtil {
    * @param adminType the type of admin operation.
    * @param adminConfigFilePath if not null, use this file to generate admin config infos to upload to Helix.
    */
-  private static void generateAdminInfosAndUpload(HelixBootstrapUpgradeUtil clusterMapToHelixMapper, String adminType,
+  protected static void generateAdminInfosAndUpload(HelixBootstrapUpgradeUtil clusterMapToHelixMapper, String adminType,
       String adminConfigFilePath) throws IOException {
     switch (adminType) {
       case PARTITION_OVERRIDE_STR:
@@ -444,7 +472,7 @@ public class HelixBootstrapUpgradeUtil {
    * @param helixBootstrapUpgradeUtil the {@link HelixBootstrapUpgradeUtil} to use
    * @param adminType the name of admin config
    */
-  private static void removeAdminInfosFromCluster(HelixBootstrapUpgradeUtil helixBootstrapUpgradeUtil,
+  protected static void removeAdminInfosFromCluster(HelixBootstrapUpgradeUtil helixBootstrapUpgradeUtil,
       String adminType) {
     switch (adminType) {
       case PARTITION_OVERRIDE_STR:
@@ -482,7 +510,7 @@ public class HelixBootstrapUpgradeUtil {
    * @throws IOException if there is an error reading a file.
    * @throws JSONException if there is an error parsing the JSON content in any of the files.
    */
-  private HelixBootstrapUpgradeUtil(String hardwareLayoutPath, String partitionLayoutPath, String zkLayoutPath,
+  public HelixBootstrapUpgradeUtil(String hardwareLayoutPath, String partitionLayoutPath, String zkLayoutPath,
       String clusterNamePrefix, String dcs, int maxPartitionsInOneResource, boolean dryRun, boolean forceRemove,
       HelixAdminFactory helixAdminFactory, String stateModelDef, String hostname, Integer portNum, String partitionName,
       HelixAdminOperation helixAdminOperation, DataNodeConfigSourceType dataNodeConfigSourceType,
@@ -559,7 +587,7 @@ public class HelixBootstrapUpgradeUtil {
    *    }
    * }
    */
-  private Map<String, Map<String, Map<String, String>>> generatePartitionOverrideFromClusterMap() {
+  protected Map<String, Map<String, Map<String, String>>> generatePartitionOverrideFromClusterMap() {
     Map<String, Map<String, String>> partitionOverrideInfos = new HashMap<>();
     for (PartitionId partitionId : staticClusterMap.getAllPartitionIds(null)) {
       String partitionName = partitionId.toPathString();
@@ -589,7 +617,7 @@ public class HelixBootstrapUpgradeUtil {
    * }
    * @throws IOException
    */
-  private Map<String, Map<String, Map<String, String>>> generatePartitionOverrideFromConfigFile(
+  protected Map<String, Map<String, Map<String, String>>> generatePartitionOverrideFromConfigFile(
       String adminConfigFilePath) throws IOException {
     Map<String, Map<String, String>> partitionOverrideInfos = new HashMap<>();
     long maxPartitionId = staticClusterMap.getAllPartitionIds(null)
@@ -640,7 +668,7 @@ public class HelixBootstrapUpgradeUtil {
    * placed.
    * @return a map that contains detailed replica info.
    */
-  private Map<String, Map<String, Map<String, String>>> generateReplicaAdditionMap() {
+  protected Map<String, Map<String, Map<String, String>>> generateReplicaAdditionMap() {
     //populate dcToInstanceNameToDataNodeId and instanceToDiskReplicasMap
     populateInstancesAndPartitionsMap();
     Map<String, Map<String, Map<String, String>>> newAddedReplicasByDc = new HashMap<>();
@@ -707,7 +735,7 @@ public class HelixBootstrapUpgradeUtil {
    * @param clusterAdminType the type of cluster admin that would be uploaded (i.e. PartitionOverride, ReplicaAddition)
    * @param adminConfigZNodePath ZNode path of admin config associated with clusterAdminType.
    */
-  private void uploadClusterAdminInfos(Map<String, Map<String, Map<String, String>>> adminInfosByDc,
+  protected void uploadClusterAdminInfos(Map<String, Map<String, Map<String, String>>> adminInfosByDc,
       String clusterAdminType, String adminConfigZNodePath) {
     for (String dcName : dataCenterToZkAddress.keySet()) {
       info("Uploading {} infos for datacenter {}.", clusterAdminType, dcName);
@@ -729,7 +757,7 @@ public class HelixBootstrapUpgradeUtil {
    * @param clusterAdminType the name of admin config.
    * @param adminConfigZNodePath the znode path of admin config.
    */
-  private void deleteClusterAdminInfos(String clusterAdminType, String adminConfigZNodePath) {
+  protected void deleteClusterAdminInfos(String clusterAdminType, String adminConfigZNodePath) {
     for (Map.Entry<String, ClusterMapUtils.DcZkInfo> entry : dataCenterToZkAddress.entrySet()) {
       info("Deleting {} infos for datacenter {}.", clusterAdminType, entry.getKey());
       HelixPropertyStore<ZNRecord> helixPropertyStore = createHelixPropertyStore(entry.getKey());
@@ -743,7 +771,7 @@ public class HelixBootstrapUpgradeUtil {
   /**
    * Convert instance configs to the new DataNodeConfig format and persist them in the property store.
    */
-  private void migrateToPropertyStore() throws InterruptedException {
+  protected void migrateToPropertyStore() throws InterruptedException {
     CountDownLatch migrationComplete = new CountDownLatch(adminForDc.size());
     // different DCs can be migrated in parallel
     adminForDc.forEach((dcName, helixAdmin) -> Utils.newThread(() -> {
@@ -781,7 +809,7 @@ public class HelixBootstrapUpgradeUtil {
   /**
    * Read from the static cluster map and populate a map of {@link DataNodeId} -> list of its {@link ReplicaId}.
    */
-  private void populateInstancesAndPartitionsMap() {
+  protected void populateInstancesAndPartitionsMap() {
     for (DataNodeId dataNodeId : staticClusterMap.getDataNodeIds()) {
       dcToInstanceNameToDataNodeId.computeIfAbsent(dataNodeId.getDatacenterName(), k -> new HashMap<>())
           .put(getInstanceName(dataNodeId), dataNodeId);
@@ -802,7 +830,7 @@ public class HelixBootstrapUpgradeUtil {
   /**
    * Control state of partition on certain node. (i.e. DisablePartition, EnablePartition)
    */
-  private void controlPartitionState() {
+  protected void controlPartitionState() {
     // for now, we only support controlling state of single partition on certain node. Hence, there should be only 1 dc
     // in adminForDc map.
     if (adminForDc.size() != 1) {
@@ -846,7 +874,7 @@ public class HelixBootstrapUpgradeUtil {
   /**
    * Reset the partition on specific node.
    */
-  private void resetPartition() {
+  protected void resetPartition() {
     if (adminForDc.size() != 1) {
       throw new IllegalStateException("The dc count is not 1 for resetting partition operation");
     }
@@ -872,70 +900,9 @@ public class HelixBootstrapUpgradeUtil {
   /**
    * Map the information in the layout files to Helix. Calling this method multiple times has no effect if the
    * information in the static files do not change. This tool is therefore safe to use for upgrades.
-   *
-   * Instead of defining the entire cluster under a single resource, or defining a resource for every partition, the
-   * tool groups together partitions under resources, with a limit to the number of partitions that will be grouped
-   * under a single resource.
-   *
-   * The logic is as follows to optimize a single setInstanceConfig() all for any node:
-   *
-   * for each datacenter/admin:
-   *   for each instance in datacenter present in both static clustermap and Helix:
-   *     get replicas it hosts with their sealed state and capacity from static.
-   *     newInstanceConfig = create one with the replicas and other information for the instance.
-   *     existingInstanceConfig = get InstanceConfig from helix;
-   *     if (newInstanceConfig.equals(existingInstanceConfig)):
-   *         continue;
-   *     else:
-   *       setInstanceConfig(newInstanceConfig);
-   *     endif
-   *   endfor
-   *
-   *   for each instance in datacenter present in static clustermap but not in Helix:
-   *     get replicas it hosts with their sealed state and capacity from static.
-   *     newInstanceConfig = create one with the replicas and other information for the instance.
-   *     addNewInstanceInHelix(newInstanceConfig);
-   *   endfor
-   *
-   *   // Optional:
-   *   for each instance in Helix not present in static:
-   *     dropInstanceFromHelix()
-   *   endfor
-   * endfor
-   *
    * @param startValidatingClusterManager whether validation should include staring up a {@link HelixClusterManager}
    */
-  private void updateClusterMapInHelix(boolean startValidatingClusterManager) throws Exception {
-    info("Initializing admins and possibly adding cluster in Helix (if non-existent)");
-    maybeAddCluster();
-    info("Validating cluster manager is {}", startValidatingClusterManager ? "ENABLED" : "DISABLED");
-    if (startValidatingClusterManager) {
-      startClusterManager();
-    }
-    info("Populating resources and partitions set");
-    populateInstancesAndPartitionsMap();
-    info("Populated resources and partitions set");
-    final CountDownLatch bootstrapLatch = new CountDownLatch(adminForDc.size());
-    for (Datacenter dc : staticClusterMap.hardwareLayout.getDatacenters()) {
-      if (adminForDc.containsKey(dc.getName())) {
-        Utils.newThread(() -> {
-          info("\n=======Starting datacenter: {}=========\n", dc.getName());
-          Map<String, Set<String>> partitionsToInstancesInDc = new HashMap<>();
-          addUpdateInstances(dc.getName(), partitionsToInstancesInDc);
-          // Process those partitions that are already under resources. Just update their instance sets if that has changed.
-          info(
-              "[{}] Done adding all instances in {}, now scanning resources in Helix and ensuring instance set for partitions are the same.",
-              dc.getName().toUpperCase(), dc.getName());
-          addUpdateResources(dc.getName(), partitionsToInstancesInDc);
-          bootstrapLatch.countDown();
-        }, false).start();
-      } else {
-        info("\n========Skipping datacenter: {}==========\n", dc.getName());
-      }
-    }
-    // make sure bootstrap has completed in all dcs (can extend timeout if amount of resources in each datacenter is really large)
-    bootstrapLatch.await(15, TimeUnit.MINUTES);
-  }
+  protected abstract void updateClusterMapInHelix(boolean startValidatingClusterManager) throws Exception;
 
   /**
    * Add and/or update instances in Helix based on the information in the static cluster map.
@@ -943,103 +910,9 @@ public class HelixBootstrapUpgradeUtil {
    * @param partitionsToInstancesInDc a map to be filled with the mapping of partitions to their instance sets in the
    *                                  given datacenter.
    */
-  private void addUpdateInstances(String dcName, Map<String, Set<String>> partitionsToInstancesInDc) {
-    ClusterMapConfig config = getClusterMapConfig(clusterName, dcName, null);
-    String zkConnectStr = dataCenterToZkAddress.get(dcName).getZkConnectStrs().get(0);
-    try (PropertyStoreToDataNodeConfigAdapter propertyStoreAdapter = new PropertyStoreToDataNodeConfigAdapter(
-        zkConnectStr, config)) {
-      InstanceConfigToDataNodeConfigAdapter.Converter instanceConfigConverter =
-          new InstanceConfigToDataNodeConfigAdapter.Converter(config);
-      info("[{}] Getting list of instances in {}", dcName.toUpperCase(), dcName);
-      Set<String> instancesInHelix = new HashSet<>(getInstanceNamesInHelix(dcName, propertyStoreAdapter));
-      Set<String> instancesInStatic = dcToInstanceNameToDataNodeId.get(dcName) == null ? new HashSet<>()
-          : new HashSet<>(dcToInstanceNameToDataNodeId.get(dcName).keySet());
-      Set<String> instancesInBoth = new HashSet<>(instancesInHelix);
-      // set instances in both correctly.
-      instancesInBoth.retainAll(instancesInStatic);
-      // set instances in Helix only correctly.
-      instancesInHelix.removeAll(instancesInBoth);
-      // set instances in Static only correctly.
-      instancesInStatic.removeAll(instancesInBoth);
-      int totalInstances = instancesInBoth.size() + instancesInHelix.size() + instancesInStatic.size();
-      for (String instanceName : instancesInBoth) {
-        DataNodeConfig nodeConfigFromHelix =
-            getDataNodeConfigFromHelix(dcName, instanceName, propertyStoreAdapter, instanceConfigConverter);
-        DataNodeConfig nodeConfigFromStatic =
-            createDataNodeConfigFromStatic(dcName, instanceName, nodeConfigFromHelix, partitionsToInstancesInDc,
-                instanceConfigConverter);
-        if (!nodeConfigFromStatic.equals(nodeConfigFromHelix, !overrideReplicaStatus)) {
-          if (helixAdminOperation == HelixAdminOperation.BootstrapCluster) {
-            if (!dryRun) {
-              info(
-                  "[{}] Instance {} already present in Helix {}, but config has changed, updating. Remaining instances: {}",
-                  dcName.toUpperCase(), instanceName, dataNodeConfigSourceType.name(), --totalInstances);
-              // Continuing on the note above, if there is indeed a change, we must make a call on whether RO/RW, replica
-              // availability and so on should be updated at all (if not, nodeConfigFromStatic should be replaced with
-              // the appropriate dataNodeConfig that is constructed with the correct values from both).
-              // For now, only bootstrapping cluster is allowed to directly change DataNodeConfig
-              setDataNodeConfigInHelix(dcName, instanceName, nodeConfigFromStatic, propertyStoreAdapter,
-                  instanceConfigConverter);
-            } else {
-              info(
-                  "[{}] Instance {} already present in Helix {}, but config has changed, no action as dry run. Remaining instances: {}",
-                  dcName.toUpperCase(), instanceName, dataNodeConfigSourceType.name(), --totalInstances);
-              logger.debug("[{}] Previous config: {} \n New config: {}", dcName.toUpperCase(), nodeConfigFromHelix,
-                  nodeConfigFromStatic);
-            }
-            // for dryRun, we update counter but don't really change the DataNodeConfig in Helix
-            instancesUpdated.getAndIncrement();
-          }
-        } else {
-          if (!dryRun) {
-            info("[{}] Instance {} already present in Helix {}, with same Data, skipping. Remaining instances: {}",
-                dcName.toUpperCase(), instanceName, dataNodeConfigSourceType.name(), --totalInstances);
-          }
-        }
-      }
+  protected abstract void addUpdateInstances(String dcName, Map<String, Set<String>> partitionsToInstancesInDc);
 
-      for (String instanceName : instancesInStatic) {
-        DataNodeConfig nodeConfigFromStatic =
-            createDataNodeConfigFromStatic(dcName, instanceName, null, partitionsToInstancesInDc,
-                instanceConfigConverter);
-        info("[{}] Instance {} is new, {}. Remaining instances: {}", dcName.toUpperCase(), instanceName,
-            dryRun ? "no action as dry run" : "adding to Helix " + dataNodeConfigSourceType.name(), --totalInstances);
-        // Note: if we want to move replica to new instance (not present in cluster yet), we can prepare a transient
-        // clustermap in which we keep existing replicas and add new replicas/instances. We should be able to upgrade cluster
-        // normally (update both datanode configs and IdealState). Helix controller will notify new instance to perform
-        // replica addition.
-        if (helixAdminOperation == HelixAdminOperation.BootstrapCluster) {
-          if (!dryRun) {
-            addDataNodeConfigToHelix(dcName, nodeConfigFromStatic, propertyStoreAdapter, instanceConfigConverter);
-          }
-          instancesAdded.getAndIncrement();
-        }
-      }
-
-      for (String instanceName : instancesInHelix) {
-        if (forceRemove) {
-          info("[{}] Instance {} is in Helix {}, but not in static. {}. Remaining instances: {}", dcName.toUpperCase(),
-              instanceName, dataNodeConfigSourceType.name(), dryRun ? "No action as dry run" : "Forcefully removing",
-              --totalInstances);
-          if (helixAdminOperation == HelixAdminOperation.BootstrapCluster) {
-            if (!dryRun) {
-              removeDataNodeConfigFromHelix(dcName, instanceName, propertyStoreAdapter);
-            }
-            instancesDropped.getAndIncrement();
-          }
-        } else {
-          info(
-              "[{}] Instance {} is in Helix {}, but not in static. Ignoring for now (use --forceRemove to forcefully remove). "
-                  + "Remaining instances: {}", dcName.toUpperCase(), instanceName, dataNodeConfigSourceType.name(),
-              --totalInstances);
-          expectMoreInHelixDuringValidate = true;
-          instancesNotForceRemovedByDc.computeIfAbsent(dcName, k -> ConcurrentHashMap.newKeySet()).add(instanceName);
-        }
-      }
-    }
-  }
-
-  private List<String> getInstanceNamesInHelix(String dcName, PropertyStoreToDataNodeConfigAdapter adapter) {
+  protected List<String> getInstanceNamesInHelix(String dcName, PropertyStoreToDataNodeConfigAdapter adapter) {
     List<String> instanceNames;
     if (dataNodeConfigSourceType == PROPERTY_STORE) {
       instanceNames = adapter.getAllDataNodeNames();
@@ -1049,7 +922,7 @@ public class HelixBootstrapUpgradeUtil {
     return instanceNames;
   }
 
-  private DataNodeConfig createDataNodeConfigFromStatic(String dcName, String instanceName,
+  protected DataNodeConfig createDataNodeConfigFromStatic(String dcName, String instanceName,
       DataNodeConfig referenceConfig, Map<String, Set<String>> partitionsToInstancesInDc,
       InstanceConfigToDataNodeConfigAdapter.Converter converter) {
     InstanceConfig referenceInstanceConfig =
@@ -1059,7 +932,7 @@ public class HelixBootstrapUpgradeUtil {
             partitionsToInstancesInDc, instanceToDiskReplicasMap, referenceInstanceConfig));
   }
 
-  private DataNodeConfig getDataNodeConfigFromHelix(String dcName, String instanceName,
+  protected DataNodeConfig getDataNodeConfigFromHelix(String dcName, String instanceName,
       PropertyStoreToDataNodeConfigAdapter adapter, InstanceConfigToDataNodeConfigAdapter.Converter converter) {
     DataNodeConfig dataNodeConfig;
     if (dataNodeConfigSourceType == PROPERTY_STORE) {
@@ -1070,7 +943,7 @@ public class HelixBootstrapUpgradeUtil {
     return dataNodeConfig;
   }
 
-  private void setDataNodeConfigInHelix(String dcName, String instanceName, DataNodeConfig config,
+  protected void setDataNodeConfigInHelix(String dcName, String instanceName, DataNodeConfig config,
       PropertyStoreToDataNodeConfigAdapter adapter, InstanceConfigToDataNodeConfigAdapter.Converter converter) {
     if (dataNodeConfigSourceType == PROPERTY_STORE) {
       if (!adapter.set(config)) {
@@ -1082,7 +955,7 @@ public class HelixBootstrapUpgradeUtil {
     }
   }
 
-  private void addDataNodeConfigToHelix(String dcName, DataNodeConfig dataNodeConfig,
+  protected void addDataNodeConfigToHelix(String dcName, DataNodeConfig dataNodeConfig,
       PropertyStoreToDataNodeConfigAdapter adapter, InstanceConfigToDataNodeConfigAdapter.Converter converter) {
     // if this is a new instance, we should add it to both InstanceConfig and PropertyStore
     if (dataNodeConfigSourceType == PROPERTY_STORE) {
@@ -1100,7 +973,7 @@ public class HelixBootstrapUpgradeUtil {
     }
   }
 
-  private void removeDataNodeConfigFromHelix(String dcName, String instanceName,
+  protected void removeDataNodeConfigFromHelix(String dcName, String instanceName,
       PropertyStoreToDataNodeConfigAdapter adapter) {
     adminForDc.get(dcName).dropInstance(clusterName, new InstanceConfig(instanceName));
     if (dataNodeConfigSourceType == PROPERTY_STORE) {
@@ -1113,192 +986,19 @@ public class HelixBootstrapUpgradeUtil {
 
   /**
    * Add and/or update resources in Helix based on the information in the static cluster map. This may involve adding
-   * or removing partitions from under a resource, and adding or dropping resources altogether. This may also involve
-   * changing the instance set for a partition under a resource, based on the static cluster map.
+   * or removing partitions from under a resource, and adding or dropping resources altogether.
    * @param dcName the name of the datacenter being processed.
    * @param partitionsToInstancesInDc a map to be filled with the mapping of partitions to their instance sets in the
    *                                  given datacenter.
    */
-  private void addUpdateResources(String dcName, Map<String, Set<String>> partitionsToInstancesInDc) {
-    HelixAdmin dcAdmin = adminForDc.get(dcName);
-    List<String> resourcesInCluster = dcAdmin.getResourcesInCluster(clusterName);
-    List<String> instancesWithDisabledPartition = new ArrayList<>();
-    HelixPropertyStore<ZNRecord> helixPropertyStore =
-        helixAdminOperation == HelixAdminOperation.DisablePartition ? createHelixPropertyStore(dcName) : null;
-    // maxResource may vary from one dc to another (special partition class allows partitions to exist in one dc only)
-    int maxResource = -1;
-    for (String resourceName : resourcesInCluster) {
-      boolean resourceModified = false;
-      if (!resourceName.matches("\\d+")) {
-        // there may be other resources created under the cluster (say, for stats) that are not part of the
-        // cluster map. These will be ignored.
-        continue;
-      }
-      maxResource = Math.max(maxResource, Integer.parseInt(resourceName));
-      IdealState resourceIs = dcAdmin.getResourceIdealState(clusterName, resourceName);
-      for (String partitionName : new HashSet<>(resourceIs.getPartitionSet())) {
-        Set<String> instanceSetInHelix = resourceIs.getInstanceSet(partitionName);
-        Set<String> instanceSetInStatic = partitionsToInstancesInDc.remove(partitionName);
-        if (instanceSetInStatic == null || instanceSetInStatic.isEmpty()) {
-          if (forceRemove) {
-            info("[{}] *** Partition {} no longer present in the static clustermap, {} *** ", dcName.toUpperCase(),
-                partitionName, dryRun ? "no action as dry run" : "removing from Resource");
-            // this is a hacky way of removing a partition from the resource, as there isn't another way today.
-            // Helix team is planning to provide an API for this.
-            if (!dryRun) {
-              resourceIs.getRecord().getListFields().remove(partitionName);
-            }
-            resourceModified = true;
-          } else {
-            info(
-                "[{}] *** forceRemove option not provided, resources will not be removed (use --forceRemove to forcefully remove)",
-                dcName.toUpperCase());
-            expectMoreInHelixDuringValidate = true;
-            partitionsNotForceRemovedByDc.computeIfAbsent(dcName, k -> ConcurrentHashMap.newKeySet())
-                .add(partitionName);
-          }
-        } else if (!instanceSetInStatic.equals(instanceSetInHelix)) {
-          // we change the IdealState only when the operation is meant to bootstrap cluster or indeed update IdealState
-          if (EnumSet.of(HelixAdminOperation.UpdateIdealState, HelixAdminOperation.BootstrapCluster)
-              .contains(helixAdminOperation)) {
-            // @formatter:off
-            info(
-                "[{}] Different instance sets for partition {} under resource {}. {}. "
-                    + "Previous instance set: [{}], new instance set: [{}]",
-                dcName.toUpperCase(), partitionName, resourceName,
-                dryRun ? "No action as dry run" : "Updating Helix using static",
-                String.join(",", instanceSetInHelix), String.join(",", instanceSetInStatic));
-            // @formatter:on
-            if (!dryRun) {
-              ArrayList<String> newInstances = new ArrayList<>(instanceSetInStatic);
-              Collections.shuffle(newInstances);
-              resourceIs.setPreferenceList(partitionName, newInstances);
-              // Existing resources may not have ANY_LIVEINSTANCE set as the numReplicas (which allows for different
-              // replication for different partitions under the same resource). So set it here (We use the name() method and
-              // not the toString() method for the enum as that is what Helix uses).
-              resourceIs.setReplicas(ResourceConfig.ResourceConfigConstants.ANY_LIVEINSTANCE.name());
-            }
-            resourceModified = true;
-          } else if (helixAdminOperation == HelixAdminOperation.DisablePartition) {
-            // if this is DisablePartition operation, we don't modify IdealState and only make InstanceConfig to disable
-            // certain partition on specific node.
-            // 1. extract difference between Helix and Static instance sets. Determine which replica is removed
-            instanceSetInHelix.removeAll(instanceSetInStatic);
-            // 2. disable removed replica on certain node.
-            for (String instanceInHelixOnly : instanceSetInHelix) {
-              info("Partition {} under resource {} on node {} is no longer in static clustermap. {}.", partitionName,
-                  resourceName, instanceInHelixOnly, dryRun ? "No action as dry run" : "Disabling it");
-              if (!dryRun) {
-                InstanceConfig instanceConfig = dcAdmin.getInstanceConfig(clusterName, instanceInHelixOnly);
-                String instanceName = instanceConfig.getInstanceName();
-                // create a Znode (if not present) in PropertyStore for this instance before disabling partition, which
-                // will be deleted in the end. The reason to create a ZNode is to ensure replica decommission is blocked
-                // on updating InstanceConfig until this tool has completed. TODO, remove this logic once migration to PropertyStore is done.
-                if (!instancesWithDisabledPartition.contains(instanceName)) {
-                  ZNRecord znRecord = new ZNRecord(instanceName);
-                  String path = PARTITION_DISABLED_ZNODE_PATH + instanceName;
-                  if (!helixPropertyStore.create(path, znRecord, AccessOption.PERSISTENT)) {
-                    logger.error("Failed to create a ZNode for {} in datacenter {} before disabling partition.",
-                        instanceName, dcName);
-                    continue;
-                  }
-                }
-                instanceConfig.setInstanceEnabledForPartition(resourceName, partitionName, false);
-                dcAdmin.setInstanceConfig(clusterName, instanceInHelixOnly, instanceConfig);
-                instancesWithDisabledPartition.add(instanceName);
-              }
-              partitionsDisabled.getAndIncrement();
-            }
-            // Disabling partition won't remove certain replica from IdealState. So replicas of this partition in Helix
-            // will be more than that in static clustermap.
-            expectMoreInHelixDuringValidate = true;
-          }
-        }
-      }
-      // update state model def if necessary
-      if (!resourceIs.getStateModelDefRef().equals(stateModelDef)) {
-        info("[{}] Resource {} has different state model {}. Updating it with {}", dcName.toUpperCase(), resourceName,
-            resourceIs.getStateModelDefRef(), stateModelDef);
-        resourceIs.setStateModelDefRef(stateModelDef);
-        resourceModified = true;
-      }
-      resourceIs.setNumPartitions(resourceIs.getPartitionSet().size());
-      if (resourceModified) {
-        if (resourceIs.getPartitionSet().isEmpty()) {
-          info("[{}] Resource {} has no partition, {}", dcName.toUpperCase(), resourceName,
-              dryRun ? "no action as dry run" : "dropping");
-          if (!dryRun) {
-            dcAdmin.dropResource(clusterName, resourceName);
-          }
-          resourcesDropped.getAndIncrement();
-        } else {
-          if (!dryRun) {
-            dcAdmin.setResourceIdealState(clusterName, resourceName, resourceIs);
-            System.out.println("------------------add resource!");
-            System.out.println(resourceName);
-            System.out.println(resourceName);
-          }
-          resourcesUpdated.getAndIncrement();
-        }
-      }
-    }
-    // note that disabling partition also updates InstanceConfig of certain nodes which host the partitions.
-    instancesUpdated.getAndAdd(instancesWithDisabledPartition.size());
-    // if there are some partitions are disabled, mark whole disabling process complete in Helix PropertyStore to unblock
-    // replica decommission thread on each datanode.
-    if (helixPropertyStore != null) {
-      maybeAwaitForLatch();
-      for (String instanceName : instancesWithDisabledPartition) {
-        String path = PARTITION_DISABLED_ZNODE_PATH + instanceName;
-        if (!helixPropertyStore.remove(path, AccessOption.PERSISTENT)) {
-          logger.error("Failed to remove a ZNode for {} in datacenter {} after disabling partition completed.",
-              instanceName, dcName);
-        }
-      }
-      helixPropertyStore.stop();
-    }
-
-    // Add what is not already in Helix under new resources.
-    int fromIndex = 0;
-    List<Map.Entry<String, Set<String>>> newPartitions = new ArrayList<>(partitionsToInstancesInDc.entrySet());
-    while (fromIndex < newPartitions.size()) {
-      String resourceName = Integer.toString(++maxResource);
-      int toIndex = Math.min(fromIndex + maxPartitionsInOneResource, newPartitions.size());
-      List<Map.Entry<String, Set<String>>> partitionsUnderNextResource = newPartitions.subList(fromIndex, toIndex);
-      fromIndex = toIndex;
-      IdealState idealState = new IdealState(resourceName);
-      idealState.setStateModelDefRef(stateModelDef);
-      info("[{}] Adding partitions for next resource {} in {}. {}.", dcName.toUpperCase(), resourceName, dcName,
-          dryRun ? "Actual IdealState is not changed as dry run" : "IdealState is being updated");
-      for (Map.Entry<String, Set<String>> entry : partitionsUnderNextResource) {
-        String partitionName = entry.getKey();
-        ArrayList<String> instances = new ArrayList<>(entry.getValue());
-        Collections.shuffle(instances);
-        idealState.setPreferenceList(partitionName, instances);
-      }
-      idealState.setNumPartitions(partitionsUnderNextResource.size());
-      idealState.setReplicas(ResourceConfig.ResourceConfigConstants.ANY_LIVEINSTANCE.name());
-      if (!idealState.isValid()) {
-        throw new IllegalStateException("IdealState could not be validated for new resource " + resourceName);
-      }
-      if (!dryRun) {
-        dcAdmin.addResource(clusterName, resourceName, idealState);
-        info("[{}] Added {} new partitions under resource {} in datacenter {}", dcName.toUpperCase(),
-            partitionsUnderNextResource.size(), resourceName, dcName);
-      } else {
-        info("[{}] Under DryRun mode, {} new partitions are added to resource {} in datacenter {}",
-            dcName.toUpperCase(), partitionsUnderNextResource.size(), resourceName, dcName);
-      }
-      resourcesAdded.getAndIncrement();
-    }
-  }
+  protected abstract void addUpdateResources(String dcName, Map<String, Set<String>> partitionsToInstancesInDc);
 
   /**
    * Create a {@link HelixPropertyStore} for given datacenter.
    * @param dcName the name of datacenter
    * @return {@link HelixPropertyStore} associated with given dc.
    */
-  private HelixPropertyStore<ZNRecord> createHelixPropertyStore(String dcName) {
+  protected HelixPropertyStore<ZNRecord> createHelixPropertyStore(String dcName) {
     Properties storeProps = new Properties();
     storeProps.setProperty("helix.property.store.root.path", "/" + clusterName + "/" + PROPERTYSTORE_STR);
     HelixPropertyStoreConfig propertyStoreConfig = new HelixPropertyStoreConfig(new VerifiableProperties(storeProps));
@@ -1311,7 +1011,7 @@ public class HelixBootstrapUpgradeUtil {
    * @param dcName the datacenter to check in.
    * @return true if the cluster is present and set up in this datacenter.
    */
-  private boolean isClusterPresent(String dcName) {
+  protected boolean isClusterPresent(String dcName) {
     if (zkClientForDc.get(dcName) == null) {
       return Objects.requireNonNull(adminForDc.get(dcName), () -> "no admin for " + dcName)
           .getClusters()
@@ -1324,7 +1024,7 @@ public class HelixBootstrapUpgradeUtil {
   /**
    * Add new state model def to ambry cluster in enabled datacenter(s).
    */
-  private void addStateModelDef() {
+  protected void addStateModelDef() {
     for (Map.Entry<String, HelixAdmin> entry : adminForDc.entrySet()) {
       // Add a cluster entry in every enabled DC
       String dcName = entry.getKey();
@@ -1344,7 +1044,7 @@ public class HelixBootstrapUpgradeUtil {
   /**
    * A comparator for replicas that compares based on the partition ids.
    */
-  private static class ReplicaComparator implements Comparator<ReplicaId> {
+  protected static class ReplicaComparator implements Comparator<ReplicaId> {
     @Override
     public int compare(ReplicaId a, ReplicaId b) {
       return a.getPartitionId().compareTo(b.getPartitionId());
@@ -1442,7 +1142,7 @@ public class HelixBootstrapUpgradeUtil {
   /**
    * Initialize a map of dataCenter to HelixAdmin based on the given zk Connect Strings.
    */
-  private void maybeAddCluster() {
+  protected void maybeAddCluster() {
     for (Map.Entry<String, HelixAdmin> entry : adminForDc.entrySet()) {
       // Add a cluster entry in every DC
       String dcName = entry.getKey();
@@ -1461,7 +1161,7 @@ public class HelixBootstrapUpgradeUtil {
    * @param stateModelDefName the name of state model definition that would be employed by Ambry cluster.
    * @return {@link StateModelDefinition}
    */
-  private StateModelDefinition getStateModelDefinition(String stateModelDefName) {
+  protected StateModelDefinition getStateModelDefinition(String stateModelDefName) {
     StateModelDefinition stateModelDefinition;
     switch (stateModelDefName) {
       case ClusterMapConfig.OLD_STATE_MODEL_DEF:
@@ -1480,7 +1180,7 @@ public class HelixBootstrapUpgradeUtil {
    * Start the Helix Cluster Manager to be used for validation.
    * @throws IOException if there was an error instantiating the cluster manager.
    */
-  private void startClusterManager() throws IOException {
+  protected void startClusterManager() throws IOException {
     ClusterMapConfig clusterMapConfig =
         getClusterMapConfig(clusterName, adminForDc.keySet().iterator().next(), zkLayoutPath);
     HelixClusterAgentsFactory helixClusterAgentsFactory = new HelixClusterAgentsFactory(clusterMapConfig, null, null);
@@ -1522,31 +1222,13 @@ public class HelixBootstrapUpgradeUtil {
    * Validate that the information in Helix is consistent with the information in the static clustermap; and close
    * all the admin connections to ZK hosts.
    */
-  private void validateAndClose() {
-    try {
-      info("Validating static and Helix cluster maps");
-      verifyEquivalencyWithStaticClusterMap(staticClusterMap.hardwareLayout, staticClusterMap.partitionLayout);
-      if (validatingHelixClusterManager != null) {
-        ensureOrThrow(validatingHelixClusterManager.getErrorCount() == 0,
-            "Helix cluster manager should not have encountered any errors");
-      }
-    } catch (Exception e) {
-      logger.error("Exception occurred when verifying equivalency with state clustermap", e);
-    } finally {
-      if (validatingHelixClusterManager != null) {
-        validatingHelixClusterManager.close();
-      }
-      for (HelixAdmin admin : adminForDc.values()) {
-        admin.close();
-      }
-    }
-  }
+  protected abstract void validateAndClose();
 
   /**
    * Get sealed partitions from Helix cluster.
    * @return a set of sealed partitions across all DCs.
    */
-  private Set<String> getSealedPartitionsInHelixCluster() throws Exception {
+  protected Set<String> getSealedPartitionsInHelixCluster() throws Exception {
     info("Aggregating sealed partitions from cluster {} in Helix", clusterName);
     CountDownLatch sealedPartitionLatch = new CountDownLatch(adminForDc.size());
     AtomicInteger errorCount = new AtomicInteger();
@@ -1599,7 +1281,7 @@ public class HelixBootstrapUpgradeUtil {
    *                             be populated in this method.
    * @param nodeToNonExistentReplicas a map to track if any replica is in sealed list but not actually on local node.
    */
-  private void getSealedPartitionsInDc(Datacenter dc, Map<String, Set<String>> dcToSealedPartitions,
+  protected void getSealedPartitionsInDc(Datacenter dc, Map<String, Set<String>> dcToSealedPartitions,
       Map<String, Set<String>> nodeToNonExistentReplicas) {
     String dcName = dc.getName();
     dcToSealedPartitions.put(dcName, new HashSet<>());
@@ -1636,218 +1318,13 @@ public class HelixBootstrapUpgradeUtil {
   }
 
   /**
-   * Verify that the information in Helix and the information in the static clustermap are equivalent.
-   * @param hardwareLayout the {@link HardwareLayout} of the static clustermap.
-   * @param partitionLayout the {@link PartitionLayout} of the static clustermap.
-   */
-  private void verifyEquivalencyWithStaticClusterMap(HardwareLayout hardwareLayout, PartitionLayout partitionLayout)
-      throws Exception {
-    String clusterNameInStaticClusterMap = hardwareLayout.getClusterName();
-    info("Verifying equivalency of static cluster: " + clusterNameInStaticClusterMap + " with the "
-        + "corresponding cluster in Helix: " + clusterName);
-    CountDownLatch verificationLatch = new CountDownLatch(adminForDc.size());
-    AtomicInteger errorCount = new AtomicInteger();
-    for (Datacenter dc : hardwareLayout.getDatacenters()) {
-      HelixAdmin admin = adminForDc.get(dc.getName());
-      if (admin == null) {
-        info("Skipping {}", dc.getName());
-        continue;
-      }
-      ensureOrThrow(isClusterPresent(dc.getName()),
-          "Cluster not found in ZK " + dataCenterToZkAddress.get(dc.getName()));
-      Utils.newThread(() -> {
-        try {
-          verifyResourcesAndPartitionEquivalencyInDc(dc, clusterName, partitionLayout);
-          verifyDataNodeAndDiskEquivalencyInDc(dc, clusterName, partitionLayout);
-        } catch (Throwable t) {
-          logger.error("[{}] error message: {}", dc.getName().toUpperCase(), t.getMessage());
-          errorCount.getAndIncrement();
-        } finally {
-          verificationLatch.countDown();
-        }
-      }, false).start();
-    }
-    verificationLatch.await(10, TimeUnit.MINUTES);
-    ensureOrThrow(errorCount.get() == 0, "Error occurred when verifying equivalency with static cluster map");
-    info("Successfully verified equivalency of static cluster: " + clusterNameInStaticClusterMap
-        + " with the corresponding cluster in Helix: " + clusterName);
-  }
-
-  /**
-   * Verify that the hardware layout information is in sync - which includes the node and disk information. Also verify
-   * that the replicas belonging to disks are in sync between the static cluster map and Helix.
-   * @param dc the datacenter whose information is to be verified.
-   * @param clusterName the cluster to be verified.
-   * @param partitionLayout the {@link PartitionLayout} of the static clustermap.
-   */
-  private void verifyDataNodeAndDiskEquivalencyInDc(Datacenter dc, String clusterName,
-      PartitionLayout partitionLayout) {
-    String dcName = dc.getName();
-    // The following properties are immaterial for the tool, but the ClusterMapConfig mandates their presence.
-    ClusterMapConfig clusterMapConfig = getClusterMapConfig(clusterName, dcName, null);
-    StaticClusterManager staticClusterMap =
-        (new StaticClusterAgentsFactory(clusterMapConfig, partitionLayout)).getClusterMap();
-    String zkConnectStr = dataCenterToZkAddress.get(dcName).getZkConnectStrs().get(0);
-    try (PropertyStoreToDataNodeConfigAdapter propertyStoreAdapter = new PropertyStoreToDataNodeConfigAdapter(
-        zkConnectStr, clusterMapConfig)) {
-      InstanceConfigToDataNodeConfigAdapter.Converter instanceConfigConverter =
-          new InstanceConfigToDataNodeConfigAdapter.Converter(clusterMapConfig);
-      Set<String> allInstancesInHelix = new HashSet<>(getInstanceNamesInHelix(dcName, propertyStoreAdapter));
-      for (DataNodeId dataNodeId : dc.getDataNodes()) {
-        Map<String, Map<String, ReplicaId>> mountPathToReplicas = getMountPathToReplicas(staticClusterMap, dataNodeId);
-        DataNode dataNode = (DataNode) dataNodeId;
-        String instanceName = getInstanceName(dataNode);
-        ensureOrThrow(allInstancesInHelix.remove(instanceName), "Instance not present in Helix " + instanceName);
-        DataNodeConfig dataNodeConfig = getDataNodeConfigFromHelix(dcName, instanceName, propertyStoreAdapter, instanceConfigConverter);
-
-        Map<String, DataNodeConfig.DiskConfig> diskInfos = new HashMap<>(dataNodeConfig.getDiskConfigs());
-        for (Disk disk : dataNode.getDisks()) {
-          DataNodeConfig.DiskConfig diskInfoInHelix = diskInfos.remove(disk.getMountPath());
-          ensureOrThrow(diskInfoInHelix != null,
-              "[" + dcName.toUpperCase() + "] Disk not present for instance " + instanceName + " disk "
-                  + disk.getMountPath());
-          ensureOrThrow(disk.getRawCapacityInBytes() == diskInfoInHelix.getDiskCapacityInBytes(),
-              "[" + dcName.toUpperCase() + "] Capacity mismatch for instance " + instanceName + " disk "
-                  + disk.getMountPath());
-
-          // We check replicaInfo only when this is a Bootstrap or Validate operation. For other operations, replica infos
-          // are expected to be different on certain nodes.
-          if (EnumSet.of(HelixAdminOperation.BootstrapCluster, HelixAdminOperation.ValidateCluster)
-              .contains(helixAdminOperation)) {
-            Set<String> replicasInClusterMap = new HashSet<>();
-            Map<String, ReplicaId> replicaList = mountPathToReplicas.get(disk.getMountPath());
-            if (replicaList != null) {
-              replicasInClusterMap.addAll(replicaList.keySet());
-            }
-            Set<String> replicasInHelix = new HashSet<>();
-            Map<String, DataNodeConfig.ReplicaConfig> replicaConfigMap = diskInfoInHelix.getReplicaConfigs();
-            for (Map.Entry<String, DataNodeConfig.ReplicaConfig> replicaConfigEntry : replicaConfigMap.entrySet()) {
-              String replicaName = replicaConfigEntry.getKey();
-              DataNodeConfig.ReplicaConfig replicaConfig = replicaConfigEntry.getValue();
-              replicasInHelix.add(replicaName);
-              ReplicaId replica = replicaList.get(replicaName);
-              ensureOrThrow(replicaConfig.getReplicaCapacityInBytes() == replica.getCapacityInBytes(),
-                  "[" + dcName.toUpperCase() + "] Replica capacity should be the same.");
-              ensureOrThrow(replicaConfig.getPartitionClass().equals(replica.getPartitionId().getPartitionClass()),
-                  "[" + dcName.toUpperCase() + "] Partition class should be the same.");
-            }
-            ensureOrThrow(replicasInClusterMap.equals(replicasInHelix),
-                "[" + dcName.toUpperCase() + "] Replica information not consistent for instance " + instanceName
-                    + " disk " + disk.getMountPath() + "\n in Helix: " + replicaList + "\n in static clustermap: "
-                    + replicasInClusterMap);
-          }
-        }
-        for (Map.Entry<String, DataNodeConfig.DiskConfig> entry : diskInfos.entrySet()) {
-          String mountPath = entry.getKey();
-          if (!mountPath.startsWith("/mnt")) {
-            logger.warn("[{}] Instance {} has unidentifiable mount path in Helix: {}", dcName.toUpperCase(),
-                instanceName, mountPath);
-          } else {
-            throw new AssertionError(
-                "[" + dcName.toUpperCase() + "] Instance " + instanceName + " has extra disk in Helix: " + entry);
-          }
-        }
-        ensureOrThrow(!dataNode.hasSSLPort() || (dataNode.getSSLPort() == dataNodeConfig.getSslPort()),
-            "[" + dcName.toUpperCase() + "] SSL Port mismatch for instance " + instanceName);
-        ensureOrThrow(!dataNode.hasHttp2Port() || (dataNode.getHttp2Port() == dataNodeConfig.getHttp2Port()),
-            "[" + dcName.toUpperCase() + "] HTTP2 Port mismatch for instance " + instanceName);
-        ensureOrThrow(dataNode.getDatacenterName().equals(dataNodeConfig.getDatacenterName()),
-            "[" + dcName.toUpperCase() + "] Datacenter mismatch for instance " + instanceName);
-        ensureOrThrow(Objects.equals(dataNode.getRackId(), dataNodeConfig.getRackId()),
-            "[" + dcName.toUpperCase() + "] Rack Id mismatch for instance " + instanceName);
-        // xid is not set in PropertyStore based DataNodeConfig and will be decommissioned eventually, hence we don't check xid equivalence
-      }
-      if (expectMoreInHelixDuringValidate) {
-        ensureOrThrow(
-            allInstancesInHelix.equals(instancesNotForceRemovedByDc.getOrDefault(dc.getName(), new HashSet<>())),
-            "[" + dcName.toUpperCase() + "] Additional instances in Helix: " + allInstancesInHelix
-                + " not what is expected " + instancesNotForceRemovedByDc.get(dc.getName()));
-        info("[{}] *** Helix may have more instances than in the given clustermap as removals were not forced.",
-            dcName.toUpperCase());
-      } else {
-        ensureOrThrow(allInstancesInHelix.isEmpty(),
-            "[" + dcName.toUpperCase() + "] Following instances in Helix not found in the clustermap "
-                + allInstancesInHelix);
-      }
-    }
-    info("[{}] Successfully verified datanode and disk equivalency in dc {}", dcName.toUpperCase(), dc.getName());
-  }
-
-  /**
-   * Verify that the partition layout information is in sync.
-   * @param dc the datacenter whose information is to be verified.
-   * @param clusterName the cluster to be verified.
-   * @param partitionLayout the {@link PartitionLayout} of the static clustermap.
-   */
-  private void verifyResourcesAndPartitionEquivalencyInDc(Datacenter dc, String clusterName,
-      PartitionLayout partitionLayout) {
-    String dcName = dc.getName();
-    HelixAdmin admin = adminForDc.get(dc.getName());
-    Map<String, Set<String>> allPartitionsToInstancesInHelix = new HashMap<>();
-    for (String resourceName : admin.getResourcesInCluster(clusterName)) {
-      if (!resourceName.matches("\\d+")) {
-        info("[{}] Ignoring resource {} as it is not part of the cluster map", dcName.toUpperCase(), resourceName);
-        continue;
-      }
-      IdealState resourceIS = admin.getResourceIdealState(clusterName, resourceName);
-      ensureOrThrow(resourceIS.getStateModelDefRef().equals(stateModelDef),
-          "[" + dcName.toUpperCase() + "] StateModel name mismatch for resource " + resourceName);
-      Set<String> resourcePartitions = resourceIS.getPartitionSet();
-      for (String resourcePartition : resourcePartitions) {
-        Set<String> partitionInstanceSet = resourceIS.getInstanceSet(resourcePartition);
-        ensureOrThrow(allPartitionsToInstancesInHelix.put(resourcePartition, partitionInstanceSet) == null,
-            "[" + dcName.toUpperCase() + "] Partition " + resourcePartition
-                + " already found under a different resource.");
-      }
-    }
-    for (PartitionId partitionId : partitionLayout.getPartitions(null)) {
-      Partition partition = (Partition) partitionId;
-      String partitionName = Long.toString(partition.getId());
-      Set<String> replicaHostsInHelix = allPartitionsToInstancesInHelix.remove(partitionName);
-      Set<String> expectedInHelix = new HashSet<>();
-      List<ReplicaId> replicasInStatic = partition.getReplicas()
-          .stream()
-          .filter(replica -> replica.getDataNodeId().getDatacenterName().equals(dcName))
-          .collect(Collectors.toList());
-      ensureOrThrow(replicasInStatic.size() == 0 || replicaHostsInHelix != null,
-          "[" + dcName.toUpperCase() + "] No replicas found for partition " + partitionName + " in Helix");
-      for (ReplicaId replica : replicasInStatic) {
-        String instanceName = getInstanceName(replica.getDataNodeId());
-        expectedInHelix.add(instanceName);
-        ensureOrThrow(replicaHostsInHelix.remove(instanceName),
-            "[" + dcName.toUpperCase() + "] Instance " + instanceName
-                + " for the given replica in the clustermap not found in Helix");
-      }
-      if (!expectMoreInHelixDuringValidate) {
-        ensureOrThrow(replicaHostsInHelix == null || replicaHostsInHelix.isEmpty(),
-            "[" + dcName.toUpperCase() + "] More instances in Helix than in clustermap for partition: " + partitionName
-                + ", expected: " + expectedInHelix + ", found additional instances: " + replicaHostsInHelix);
-      }
-    }
-    if (expectMoreInHelixDuringValidate) {
-      ensureOrThrow(allPartitionsToInstancesInHelix.keySet()
-              .equals(partitionsNotForceRemovedByDc.getOrDefault(dcName, new HashSet<>())),
-          "[" + dcName.toUpperCase() + "] Additional partitions in Helix: " + allPartitionsToInstancesInHelix.keySet()
-              + " not what is expected " + partitionsNotForceRemovedByDc.get(dcName));
-      info(
-          "[{}] *** Helix may have more partitions or replicas than in the given clustermap as removals were not forced.",
-          dcName.toUpperCase());
-    } else {
-      ensureOrThrow(allPartitionsToInstancesInHelix.isEmpty(),
-          "[" + dcName.toUpperCase() + "] More partitions in Helix than in clustermap, additional partitions: "
-              + allPartitionsToInstancesInHelix.keySet());
-    }
-    info("[{}] Successfully verified resources and partitions equivalency in dc {}", dcName.toUpperCase(), dcName);
-  }
-
-  /**
    * A helper method that returns a map of mountPaths to a map of replicas -> replicaCapacity for a given
    * {@link DataNodeId}
    * @param staticClusterMap the static {@link StaticClusterManager}
    * @param dataNodeId the {@link DataNodeId} of interest.
    * @return the constructed map.
    */
-  private static Map<String, Map<String, ReplicaId>> getMountPathToReplicas(StaticClusterManager staticClusterMap,
+  protected static Map<String, Map<String, ReplicaId>> getMountPathToReplicas(StaticClusterManager staticClusterMap,
       DataNodeId dataNodeId) {
     Map<String, Map<String, ReplicaId>> mountPathToReplicas = new HashMap<>();
     for (ReplicaId replica : staticClusterMap.getReplicas(dataNodeId)) {
@@ -1868,25 +1345,9 @@ public class HelixBootstrapUpgradeUtil {
    * @param condition the boolean condition to check.
    * @param errStr the error message to associate with the assertion error.
    */
-  private void ensureOrThrow(boolean condition, String errStr) {
+  protected void ensureOrThrow(boolean condition, String errStr) {
     if (!condition) {
       throw new AssertionError(errStr);
-    }
-  }
-
-  /**
-   * Exposed for testing
-   */
-  private void maybeAwaitForLatch() {
-    if (disablePartitionLatch != null) {
-      disablePartitionLatch.countDown();
-    }
-    if (blockRemovingNodeLatch != null) {
-      try {
-        blockRemovingNodeLatch.await();
-      } catch (Exception e) {
-        logger.error("Interrupted when waiting for latch ", e);
-      }
     }
   }
 
@@ -1895,41 +1356,13 @@ public class HelixBootstrapUpgradeUtil {
    * @param format format
    * @param arguments arguments
    */
-  private static void info(String format, Object... arguments) {
+  protected static void info(String format, Object... arguments) {
     logger.info(format, arguments);
   }
 
   /**
    * Log the summary of this run.
    */
-  private void logSummary() {
-    if (instancesUpdated.get() + instancesAdded.get() + instancesDropped.get() + resourcesUpdated.get() + resourcesAdded
-        .get() + resourcesDropped.get() + partitionsDisabled.get() + partitionsEnabled.get() + partitionsReset.get()
-        > 0) {
-      if (!dryRun) {
-        info("========Cluster in Helix was updated, summary:========");
-      } else {
-        info("========Dry run: Actual run would update the cluster in the following way:========");
-      }
-      info("New instances added: {}", instancesAdded.get());
-      info("Existing instances updated: {}", instancesUpdated.get());
-      info("Existing instances dropped: {}", instancesDropped.get());
-      info("New resources added: {}", resourcesAdded.get());
-      info("Existing resources updated: {}", resourcesUpdated.get());
-      info("Existing resources dropped: {}", resourcesDropped.get());
-      info("Partitions disabled: {}", partitionsDisabled.get());
-      info("Partitions enabled: {}", partitionsEnabled.get());
-      info("Partitions reset: {}", partitionsReset.get());
-    } else {
-      info("========No updates were done to the cluster in Helix========");
-    }
-    if (validatingHelixClusterManager != null) {
-      info("========Validating HelixClusterManager metrics========");
-      info("Instance config change count: {}",
-          validatingHelixClusterManager.helixClusterManagerMetrics.instanceConfigChangeTriggerCount.getCount());
-      info("Instance config update ignored count: {}",
-          validatingHelixClusterManager.helixClusterManagerMetrics.ignoredUpdatesCount.getCount());
-    }
-  }
+  protected abstract void logSummary();
 }
 

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeUtilFullAuto.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeUtilFullAuto.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2023 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.clustermap;
+
+import com.github.ambry.config.ClusterMapConfig;
+import com.github.ambry.utils.Utils;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.stream.Collectors;
+import org.apache.helix.ConfigAccessor;
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.api.config.StateTransitionThrottleConfig;
+import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.model.InstanceConfig;
+import org.json.JSONException;
+
+
+public class HelixBootstrapUpgradeUtilFullAuto extends HelixBootstrapUpgradeUtil {
+
+  // Waged auto rebalancer configs
+  static final String FULL_AUTO_FAULT_ZONE_TYPE = "rack";
+  static final int FULL_AUTO_MAX_PARTITIONS_IN_TRANSITION = 50;
+  static final int LESS_MOVEMENT = 2;
+  static final int EVENNESS = 3;
+  // the default of partition. each partition can store up to 24 * 16 = 384 GB data, and leave 2 GB here for margin
+  static final int PARTITION_WEIGHT = 386;
+  static final String CAPACITY_DISK_KEY = "DISK";
+  static final String RACK_KEY = "rack";
+  static final String HOST_KEY = "host";
+  static final String FULL_AUTO_TOPOLOGY = "/" + RACK_KEY + "/" + HOST_KEY;
+
+  /**
+   * Instantiates this class with the given information.
+   * @param hardwareLayoutPath the path to the hardware layout file.
+   * @param partitionLayoutPath the path to the partition layout file.
+   * @param zkLayoutPath the path to the zookeeper layout file.
+   * @param clusterNamePrefix the prefix that when combined with the cluster name in the static cluster map files
+   *                          will give the cluster name in Helix to bootstrap or upgrade.
+   * @param dcs the comma-separated list of datacenters that needs to be upgraded/bootstrapped.
+   * @param dryRun if true, perform a dry run; do not update anything in Helix.
+   * @param forceRemove if true, removes any hosts from Helix not present in the json files.
+   * @param helixAdminFactory the {@link HelixAdminFactory} to use to instantiate {@link HelixAdmin}
+   * @param stateModelDef the state model definition to use in Ambry cluster.
+   * @param hostname the host (if not null) on which the admin operation should be performed.
+   * @param portNum the port number (if not null) associated with host.
+   * @param partitionName the partition (if not null) on which the admin operation should be performed.
+   * @param helixAdminOperation the {@link HelixAdminOperation} to perform.
+   * @param dataNodeConfigSourceType the {@link DataNodeConfigSourceType} associated with this cluster.
+   * @param overrideReplicaStatus whether to override sealed/stopped/disabled replica status lists.
+   * @throws IOException if there is an error reading a file.
+   * @throws JSONException if there is an error parsing the JSON content in any of the files.
+   */
+  public HelixBootstrapUpgradeUtilFullAuto(String hardwareLayoutPath, String partitionLayoutPath, String zkLayoutPath,
+      String clusterNamePrefix, String dcs, int maxPartitionsInOneResource, boolean dryRun, boolean forceRemove,
+      HelixAdminFactory helixAdminFactory, String stateModelDef, String hostname, Integer portNum, String partitionName,
+      HelixAdminOperation helixAdminOperation, DataNodeConfigSourceType dataNodeConfigSourceType,
+      boolean overrideReplicaStatus) throws Exception {
+    super(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterNamePrefix, dcs, maxPartitionsInOneResource,
+        dryRun, forceRemove, helixAdminFactory, stateModelDef, hostname, portNum, partitionName, helixAdminOperation,
+        dataNodeConfigSourceType, overrideReplicaStatus);
+  }
+
+  /**
+   * Convert resources from semi-auto to full-auto.
+   * @param commaSeparatedResources the comma-separated list of resources that needs to be migrated
+   */
+  public void migrateToFullAuto(String commaSeparatedResources) throws InterruptedException {
+    CountDownLatch migrationComplete = new CountDownLatch(adminForDc.size());
+    // different DCs can be migrated in parallel
+    adminForDc.forEach((dcName, helixAdmin) -> Utils.newThread(() -> {
+      try {
+        logger.info("Starting resource migration to full-auto in {}", dcName);
+
+        // Get property store
+        ClusterMapConfig config = getClusterMapConfig(clusterName, dcName, null);
+        String zkConnectStr = dataCenterToZkAddress.get(dcName).getZkConnectStrs().get(0);
+        try (PropertyStoreToDataNodeConfigAdapter propertyStoreAdapter = new PropertyStoreToDataNodeConfigAdapter(
+            zkConnectStr, config)) {
+
+          // Get resources to migrate from user input.
+          Set<String> helixResources = new HashSet<>(helixAdmin.getResourcesInCluster(clusterName));
+          Set<String> resources;
+          if (commaSeparatedResources.equalsIgnoreCase(ALL)) {
+            resources = helixResources;
+          } else {
+            resources = Arrays.stream(commaSeparatedResources.replaceAll("\\p{Space}", "").split(","))
+                .collect(Collectors.toSet());
+          }
+
+          ConfigAccessor configAccessor =
+              new ConfigAccessor(dataCenterToZkAddress.get(dcName).getZkConnectStrs().get(0));
+
+          // 1. Update cluster config
+          updateClusterConfig(configAccessor);
+
+          // 2. Update instance config for all instances present in this resource
+          Set<String> allInstances = new HashSet<>();
+          for (String resource : resources) {
+            // a. Get list of instances sharing partitions in this resource
+            IdealState idealState = helixAdmin.getResourceIdealState(clusterName, resource);
+            Set<String> partitions = idealState.getPartitionSet();
+            Set<String> instances = new HashSet<>();
+            partitions.forEach(partitionName -> instances.addAll(idealState.getInstanceSet(partitionName)));
+            // b. Update instance config for each instance
+            for (String instance : instances) {
+              DataNodeConfig nodeConfigFromHelix =
+                  getDataNodeConfigFromHelix(dcName, instance, propertyStoreAdapter, null);
+              long instanceCapacity = 0;
+              for (DataNodeConfig.DiskConfig diskConfig : nodeConfigFromHelix.getDiskConfigs().values()) {
+                instanceCapacity += diskConfig.getDiskCapacityInBytes();
+              }
+              updateInstanceConfig(configAccessor, instance, "TAG_" + resource, nodeConfigFromHelix.getRackId(),
+                  instanceCapacity);
+            }
+            allInstances.addAll(instances);
+          }
+
+          // 3. Validate configs
+          Map<String, Boolean> instanceValidationResultMap =
+              helixAdmin.validateInstancesForWagedRebalance(clusterName, new ArrayList<>(allInstances));
+          if (instanceValidationResultMap.containsValue(Boolean.FALSE)) {
+            throw new IllegalStateException("Instances are not configured correctly for waged rebalancer");
+          }
+          Map<String, Boolean> resourceValidationResultMap =
+              helixAdmin.validateResourcesForWagedRebalance(clusterName, new ArrayList<>(resources));
+          if (resourceValidationResultMap.containsValue(Boolean.FALSE)) {
+            throw new IllegalStateException("Resources are not configured correctly for waged rebalancer");
+          }
+
+          if(!dryRun){
+            // TODO. For testing, we will use helix rest APIs
+            // 4. Enter maintenance mode
+
+            // 5. Update ideal state
+
+            // 6. Exit maintainence mode
+
+          }
+          logger.info("Successfully migrated resources to full-auto in {}", dcName);
+        }
+      } catch (Throwable t) {
+        logger.error("Error while migrating resources to full-auto in {}", dcName, t);
+      } finally {
+        migrationComplete.countDown();
+      }
+    }, false).start());
+
+    migrationComplete.await();
+  }
+
+  /**
+   * Update cluster config to use waged rebalancer
+   * @param configAccessor the {@link ConfigAccessor} to access configuration in Helix.
+   */
+  private void updateClusterConfig(ConfigAccessor configAccessor) {
+    ClusterConfig clusterConfig = configAccessor.getClusterConfig(clusterName);
+    // 1. Set topology awareness
+    clusterConfig.setTopologyAwareEnabled(true);
+    clusterConfig.setTopology(FULL_AUTO_TOPOLOGY);
+    clusterConfig.setFaultZoneType(FULL_AUTO_FAULT_ZONE_TYPE);
+    StateTransitionThrottleConfig stateTransitionThrottleConfig =
+        new StateTransitionThrottleConfig(StateTransitionThrottleConfig.RebalanceType.LOAD_BALANCE,
+            StateTransitionThrottleConfig.ThrottleScope.INSTANCE, FULL_AUTO_MAX_PARTITIONS_IN_TRANSITION);
+    clusterConfig.setStateTransitionThrottleConfigs(Collections.singletonList(stateTransitionThrottleConfig));
+    // 2. Set default weight for each partition
+    Map<String, Integer> defaultPartitionWeightMap = new HashMap<>();
+    defaultPartitionWeightMap.put(CAPACITY_DISK_KEY, PARTITION_WEIGHT);
+    clusterConfig.setDefaultPartitionWeightMap(defaultPartitionWeightMap);
+    // 3. Set instance capacity keys
+    clusterConfig.setInstanceCapacityKeys(Collections.singletonList(CAPACITY_DISK_KEY));
+    // 4. Set evenness and less movement for cluster
+    Map<ClusterConfig.GlobalRebalancePreferenceKey, Integer> globalRebalancePreferenceKeyIntegerMap = new HashMap<>();
+    globalRebalancePreferenceKeyIntegerMap.put(ClusterConfig.GlobalRebalancePreferenceKey.EVENNESS, EVENNESS);
+    globalRebalancePreferenceKeyIntegerMap.put(ClusterConfig.GlobalRebalancePreferenceKey.LESS_MOVEMENT, LESS_MOVEMENT);
+    clusterConfig.setGlobalRebalancePreference(globalRebalancePreferenceKeyIntegerMap);
+    // Send request to update modified cluster config in Helix/ZK
+    configAccessor.setClusterConfig(clusterName, clusterConfig);
+  }
+
+  /**
+   * @param configAccessor the {@link ConfigAccessor} to access configuration in Helix.
+   * @param instanceName instance name
+   * @param tag tag for the instance.
+   * @param rackId rack in which the instance lives in.
+   * @param capacity storage capacity of the instance.
+   */
+  private void updateInstanceConfig(ConfigAccessor configAccessor, String instanceName, String tag, String rackId,
+      long capacity) {
+    InstanceConfig instanceConfig = configAccessor.getInstanceConfig(clusterName, instanceName);
+    // 1. Add tag
+    instanceConfig.addTag(tag);
+    // 2. Setup domain information
+    Map<String, String> domainMap = new HashMap<>();
+    domainMap.put(RACK_KEY, rackId);
+    domainMap.put(HOST_KEY, instanceName);
+    instanceConfig.setDomain(domainMap);
+    // 3. Set instance capacity
+    Map<String, Integer> capacityMap = new HashMap<>();
+    capacityMap.put(CAPACITY_DISK_KEY, (int) capacity);
+    instanceConfig.setInstanceCapacityMap(capacityMap);
+    configAccessor.updateInstanceConfig(clusterName, instanceName, instanceConfig);
+  }
+
+
+  @Override
+  protected void updateClusterMapInHelix(boolean startValidatingClusterManager) throws Exception {
+
+  }
+
+  @Override
+  protected void addUpdateInstances(String dcName, Map<String, Set<String>> partitionsToInstancesInDc) {
+
+  }
+
+  @Override
+  protected void addUpdateResources(String dcName, Map<String, Set<String>> partitionsToInstancesInDc) {
+
+  }
+
+  @Override
+  protected void validateAndClose() {
+
+  }
+
+  @Override
+  protected void logSummary() {
+
+  }
+}

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeUtilSemiAuto.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeUtilSemiAuto.java
@@ -1,0 +1,736 @@
+/*
+ * Copyright 2023 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.clustermap;
+
+import com.github.ambry.config.ClusterMapConfig;
+import com.github.ambry.utils.Utils;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import org.apache.helix.AccessOption;
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.model.ResourceConfig;
+import org.apache.helix.store.HelixPropertyStore;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.json.JSONException;
+
+import static com.github.ambry.clustermap.ClusterMapUtils.*;
+
+
+/**
+ * A class to bootstrap static cluster map information into Helix.
+ *
+ * For each node that is added to Helix, its {@link InstanceConfig} will contain the node level information, which is
+ * of the following format currently:
+ *
+ *InstanceConfig: {
+ *  "id" : "localhost_17088",                              # id is the instanceName [host_port]
+ *  "mapFields" : {
+ *    "/tmp/c/0" : {                                       # disk is identified by the [mountpath]. DiskInfo consists of:
+ *      "capacityInBytes" : "912680550400",                # [capacity]
+ *      "diskState" : "AVAILABLE",                         # [state]
+ *      "Replicas" : "10:107374182400:default,"            # comma-separated list of partition ids whose replicas are
+ *    },                                                   # hosted on this disk in
+ *                                                         # [replica:replicaCapacity:partitionClass] format.
+ *    "/tmp/c/1" : {
+ *      "capacityInBytes" : "912680550400",
+ *      "diskState" : "AVAILABLE",
+ *      "Replicas" : "40:107374182400:default,20:107374182400:special,"
+ *    },
+ *    "/tmp/c/2" : {
+ *      "capacityInBytes" : "912680550400",
+ *      "diskState" : "AVAILABLE",
+ *      "Replicas" : "30:107374182400:default,"
+ *    }
+ *  },
+ *  "listFields" : {
+ *    "SEALED" : [ "20" ]                                  # comma-separated list of sealed replicas on this node.
+ *  },
+ *  "simpleFields" : {
+ *    "HELIX_HOST" : "localhost",                          #  hostname (Helix field)
+ *    "HELIX_PORT" : "17088",                              #  port     (Helix field)
+ *    "datacenter" : "dc1",                                # [datacenterName]
+ *    "rackId" : "1611",                                   # [rackId]
+ *    "sslPort": "27088"                                   # [sslPort]
+ *    "schemaVersion": "0"                                 # [schema version]
+ *    "xid" : "0"                                          # [xid (last update to the data in this InstanceConfig)]
+ *  }
+ *}
+ */
+public class HelixBootstrapUpgradeUtilSemiAuto extends HelixBootstrapUpgradeUtil {
+
+  /**
+   * Instantiates this class with the given information.
+   * @param hardwareLayoutPath the path to the hardware layout file.
+   * @param partitionLayoutPath the path to the partition layout file.
+   * @param zkLayoutPath the path to the zookeeper layout file.
+   * @param clusterNamePrefix the prefix that when combined with the cluster name in the static cluster map files
+   *                          will give the cluster name in Helix to bootstrap or upgrade.
+   * @param dcs the comma-separated list of datacenters that needs to be upgraded/bootstrapped.
+   * @param dryRun if true, perform a dry run; do not update anything in Helix.
+   * @param forceRemove if true, removes any hosts from Helix not present in the json files.
+   * @param helixAdminFactory the {@link HelixAdminFactory} to use to instantiate {@link HelixAdmin}
+   * @param stateModelDef the state model definition to use in Ambry cluster.
+   * @param hostname the host (if not null) on which the admin operation should be performed.
+   * @param portNum the port number (if not null) associated with host.
+   * @param partitionName the partition (if not null) on which the admin operation should be performed.
+   * @param helixAdminOperation the {@link HelixAdminOperation} to perform.
+   * @param dataNodeConfigSourceType the {@link DataNodeConfigSourceType} associated with this cluster.
+   * @param overrideReplicaStatus whether to override sealed/stopped/disabled replica status lists.
+   * @throws IOException if there is an error reading a file.
+   * @throws JSONException if there is an error parsing the JSON content in any of the files.
+   */
+  public HelixBootstrapUpgradeUtilSemiAuto(String hardwareLayoutPath, String partitionLayoutPath, String zkLayoutPath,
+      String clusterNamePrefix, String dcs, int maxPartitionsInOneResource, boolean dryRun, boolean forceRemove,
+      HelixAdminFactory helixAdminFactory, String stateModelDef, String hostname, Integer portNum, String partitionName,
+      HelixAdminOperation helixAdminOperation, DataNodeConfigSourceType dataNodeConfigSourceType,
+      boolean overrideReplicaStatus) throws Exception {
+    super(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterNamePrefix, dcs, maxPartitionsInOneResource,
+        dryRun, forceRemove, helixAdminFactory, stateModelDef, hostname, portNum, partitionName, helixAdminOperation,
+        dataNodeConfigSourceType, overrideReplicaStatus);
+  }
+
+  /**
+   * Map the information in the layout files to Helix. Calling this method multiple times has no effect if the
+   * information in the static files do not change. This tool is therefore safe to use for upgrades.
+   *
+   * Instead of defining the entire cluster under a single resource, or defining a resource for every partition, the
+   * tool groups together partitions under resources, with a limit to the number of partitions that will be grouped
+   * under a single resource.
+   *
+   * The logic is as follows to optimize a single setInstanceConfig() all for any node:
+   *
+   * for each datacenter/admin:
+   *   for each instance in datacenter present in both static clustermap and Helix:
+   *     get replicas it hosts with their sealed state and capacity from static.
+   *     newInstanceConfig = create one with the replicas and other information for the instance.
+   *     existingInstanceConfig = get InstanceConfig from helix;
+   *     if (newInstanceConfig.equals(existingInstanceConfig)):
+   *         continue;
+   *     else:
+   *       setInstanceConfig(newInstanceConfig);
+   *     endif
+   *   endfor
+   *
+   *   for each instance in datacenter present in static clustermap but not in Helix:
+   *     get replicas it hosts with their sealed state and capacity from static.
+   *     newInstanceConfig = create one with the replicas and other information for the instance.
+   *     addNewInstanceInHelix(newInstanceConfig);
+   *   endfor
+   *
+   *   // Optional:
+   *   for each instance in Helix not present in static:
+   *     dropInstanceFromHelix()
+   *   endfor
+   * endfor
+   *
+   * @param startValidatingClusterManager whether validation should include staring up a {@link HelixClusterManager}
+   */
+  @Override
+  protected void updateClusterMapInHelix(boolean startValidatingClusterManager) throws Exception {
+    info("Initializing admins and possibly adding cluster in Helix (if non-existent)");
+    maybeAddCluster();
+    info("Validating cluster manager is {}", startValidatingClusterManager ? "ENABLED" : "DISABLED");
+    if (startValidatingClusterManager) {
+      startClusterManager();
+    }
+    info("Populating resources and partitions set");
+    populateInstancesAndPartitionsMap();
+    info("Populated resources and partitions set");
+    final CountDownLatch bootstrapLatch = new CountDownLatch(adminForDc.size());
+    for (Datacenter dc : staticClusterMap.hardwareLayout.getDatacenters()) {
+      if (adminForDc.containsKey(dc.getName())) {
+        Utils.newThread(() -> {
+          info("\n=======Starting datacenter: {}=========\n", dc.getName());
+          Map<String, Set<String>> partitionsToInstancesInDc = new HashMap<>();
+          addUpdateInstances(dc.getName(), partitionsToInstancesInDc);
+          // Process those partitions that are already under resources. Just update their instance sets if that has changed.
+          info(
+              "[{}] Done adding all instances in {}, now scanning resources in Helix and ensuring instance set for partitions are the same.",
+              dc.getName().toUpperCase(), dc.getName());
+          addUpdateResources(dc.getName(), partitionsToInstancesInDc);
+          bootstrapLatch.countDown();
+        }, false).start();
+      } else {
+        info("\n========Skipping datacenter: {}==========\n", dc.getName());
+      }
+    }
+    // make sure bootstrap has completed in all dcs (can extend timeout if amount of resources in each datacenter is really large)
+    bootstrapLatch.await(15, TimeUnit.MINUTES);
+  }
+
+  @Override
+  protected void addUpdateInstances(String dcName, Map<String, Set<String>> partitionsToInstancesInDc) {
+    ClusterMapConfig config = getClusterMapConfig(clusterName, dcName, null);
+    String zkConnectStr = dataCenterToZkAddress.get(dcName).getZkConnectStrs().get(0);
+    try (PropertyStoreToDataNodeConfigAdapter propertyStoreAdapter = new PropertyStoreToDataNodeConfigAdapter(
+        zkConnectStr, config)) {
+      InstanceConfigToDataNodeConfigAdapter.Converter instanceConfigConverter =
+          new InstanceConfigToDataNodeConfigAdapter.Converter(config);
+      info("[{}] Getting list of instances in {}", dcName.toUpperCase(), dcName);
+      Set<String> instancesInHelix = new HashSet<>(getInstanceNamesInHelix(dcName, propertyStoreAdapter));
+      Set<String> instancesInStatic = dcToInstanceNameToDataNodeId.get(dcName) == null ? new HashSet<>()
+          : new HashSet<>(dcToInstanceNameToDataNodeId.get(dcName).keySet());
+      Set<String> instancesInBoth = new HashSet<>(instancesInHelix);
+      // set instances in both correctly.
+      instancesInBoth.retainAll(instancesInStatic);
+      // set instances in Helix only correctly.
+      instancesInHelix.removeAll(instancesInBoth);
+      // set instances in Static only correctly.
+      instancesInStatic.removeAll(instancesInBoth);
+      int totalInstances = instancesInBoth.size() + instancesInHelix.size() + instancesInStatic.size();
+      for (String instanceName : instancesInBoth) {
+        DataNodeConfig nodeConfigFromHelix =
+            getDataNodeConfigFromHelix(dcName, instanceName, propertyStoreAdapter, instanceConfigConverter);
+        DataNodeConfig nodeConfigFromStatic =
+            createDataNodeConfigFromStatic(dcName, instanceName, nodeConfigFromHelix, partitionsToInstancesInDc,
+                instanceConfigConverter);
+        if (!nodeConfigFromStatic.equals(nodeConfigFromHelix, !overrideReplicaStatus)) {
+          if (helixAdminOperation == HelixAdminOperation.BootstrapCluster) {
+            if (!dryRun) {
+              info(
+                  "[{}] Instance {} already present in Helix {}, but config has changed, updating. Remaining instances: {}",
+                  dcName.toUpperCase(), instanceName, dataNodeConfigSourceType.name(), --totalInstances);
+              // Continuing on the note above, if there is indeed a change, we must make a call on whether RO/RW, replica
+              // availability and so on should be updated at all (if not, nodeConfigFromStatic should be replaced with
+              // the appropriate dataNodeConfig that is constructed with the correct values from both).
+              // For now, only bootstrapping cluster is allowed to directly change DataNodeConfig
+              setDataNodeConfigInHelix(dcName, instanceName, nodeConfigFromStatic, propertyStoreAdapter,
+                  instanceConfigConverter);
+            } else {
+              info(
+                  "[{}] Instance {} already present in Helix {}, but config has changed, no action as dry run. Remaining instances: {}",
+                  dcName.toUpperCase(), instanceName, dataNodeConfigSourceType.name(), --totalInstances);
+              logger.debug("[{}] Previous config: {} \n New config: {}", dcName.toUpperCase(), nodeConfigFromHelix,
+                  nodeConfigFromStatic);
+            }
+            // for dryRun, we update counter but don't really change the DataNodeConfig in Helix
+            instancesUpdated.getAndIncrement();
+          }
+        } else {
+          if (!dryRun) {
+            info("[{}] Instance {} already present in Helix {}, with same Data, skipping. Remaining instances: {}",
+                dcName.toUpperCase(), instanceName, dataNodeConfigSourceType.name(), --totalInstances);
+          }
+        }
+      }
+
+      for (String instanceName : instancesInStatic) {
+        DataNodeConfig nodeConfigFromStatic =
+            createDataNodeConfigFromStatic(dcName, instanceName, null, partitionsToInstancesInDc,
+                instanceConfigConverter);
+        info("[{}] Instance {} is new, {}. Remaining instances: {}", dcName.toUpperCase(), instanceName,
+            dryRun ? "no action as dry run" : "adding to Helix " + dataNodeConfigSourceType.name(), --totalInstances);
+        // Note: if we want to move replica to new instance (not present in cluster yet), we can prepare a transient
+        // clustermap in which we keep existing replicas and add new replicas/instances. We should be able to upgrade cluster
+        // normally (update both datanode configs and IdealState). Helix controller will notify new instance to perform
+        // replica addition.
+        if (helixAdminOperation == HelixAdminOperation.BootstrapCluster) {
+          if (!dryRun) {
+            addDataNodeConfigToHelix(dcName, nodeConfigFromStatic, propertyStoreAdapter, instanceConfigConverter);
+          }
+          instancesAdded.getAndIncrement();
+        }
+      }
+
+      for (String instanceName : instancesInHelix) {
+        if (forceRemove) {
+          info("[{}] Instance {} is in Helix {}, but not in static. {}. Remaining instances: {}", dcName.toUpperCase(),
+              instanceName, dataNodeConfigSourceType.name(), dryRun ? "No action as dry run" : "Forcefully removing",
+              --totalInstances);
+          if (helixAdminOperation == HelixAdminOperation.BootstrapCluster) {
+            if (!dryRun) {
+              removeDataNodeConfigFromHelix(dcName, instanceName, propertyStoreAdapter);
+            }
+            instancesDropped.getAndIncrement();
+          }
+        } else {
+          info(
+              "[{}] Instance {} is in Helix {}, but not in static. Ignoring for now (use --forceRemove to forcefully remove). "
+                  + "Remaining instances: {}", dcName.toUpperCase(), instanceName, dataNodeConfigSourceType.name(),
+              --totalInstances);
+          expectMoreInHelixDuringValidate = true;
+          instancesNotForceRemovedByDc.computeIfAbsent(dcName, k -> ConcurrentHashMap.newKeySet()).add(instanceName);
+        }
+      }
+    }
+  }
+
+  /**
+   * Add and/or update resources in Helix based on the information in the static cluster map. This may involve adding
+   * or removing partitions from under a resource, and adding or dropping resources altogether. This may also involve
+   * changing the instance set for a partition under a resource, based on the static cluster map.
+   * @param dcName the name of the datacenter being processed.
+   * @param partitionsToInstancesInDc a map to be filled with the mapping of partitions to their instance sets in the
+   *                                  given datacenter.
+   */
+  @Override
+  protected void addUpdateResources(String dcName, Map<String, Set<String>> partitionsToInstancesInDc) {
+    HelixAdmin dcAdmin = adminForDc.get(dcName);
+    List<String> resourcesInCluster = dcAdmin.getResourcesInCluster(clusterName);
+    List<String> instancesWithDisabledPartition = new ArrayList<>();
+    HelixPropertyStore<ZNRecord> helixPropertyStore =
+        helixAdminOperation == HelixAdminOperation.DisablePartition ? createHelixPropertyStore(dcName) : null;
+    // maxResource may vary from one dc to another (special partition class allows partitions to exist in one dc only)
+    int maxResource = -1;
+    for (String resourceName : resourcesInCluster) {
+      boolean resourceModified = false;
+      if (!resourceName.matches("\\d+")) {
+        // there may be other resources created under the cluster (say, for stats) that are not part of the
+        // cluster map. These will be ignored.
+        continue;
+      }
+      maxResource = Math.max(maxResource, Integer.parseInt(resourceName));
+      IdealState resourceIs = dcAdmin.getResourceIdealState(clusterName, resourceName);
+      for (String partitionName : new HashSet<>(resourceIs.getPartitionSet())) {
+        Set<String> instanceSetInHelix = resourceIs.getInstanceSet(partitionName);
+        Set<String> instanceSetInStatic = partitionsToInstancesInDc.remove(partitionName);
+        if (instanceSetInStatic == null || instanceSetInStatic.isEmpty()) {
+          if (forceRemove) {
+            info("[{}] *** Partition {} no longer present in the static clustermap, {} *** ", dcName.toUpperCase(),
+                partitionName, dryRun ? "no action as dry run" : "removing from Resource");
+            // this is a hacky way of removing a partition from the resource, as there isn't another way today.
+            // Helix team is planning to provide an API for this.
+            if (!dryRun) {
+              resourceIs.getRecord().getListFields().remove(partitionName);
+            }
+            resourceModified = true;
+          } else {
+            info(
+                "[{}] *** forceRemove option not provided, resources will not be removed (use --forceRemove to forcefully remove)",
+                dcName.toUpperCase());
+            expectMoreInHelixDuringValidate = true;
+            partitionsNotForceRemovedByDc.computeIfAbsent(dcName, k -> ConcurrentHashMap.newKeySet())
+                .add(partitionName);
+          }
+        } else if (!instanceSetInStatic.equals(instanceSetInHelix)) {
+          // we change the IdealState only when the operation is meant to bootstrap cluster or indeed update IdealState
+          if (EnumSet.of(HelixAdminOperation.UpdateIdealState, HelixAdminOperation.BootstrapCluster)
+              .contains(helixAdminOperation)) {
+            // @formatter:off
+            info(
+                "[{}] Different instance sets for partition {} under resource {}. {}. "
+                    + "Previous instance set: [{}], new instance set: [{}]",
+                dcName.toUpperCase(), partitionName, resourceName,
+                dryRun ? "No action as dry run" : "Updating Helix using static",
+                String.join(",", instanceSetInHelix), String.join(",", instanceSetInStatic));
+            // @formatter:on
+            if (!dryRun) {
+              ArrayList<String> newInstances = new ArrayList<>(instanceSetInStatic);
+              Collections.shuffle(newInstances);
+              resourceIs.setPreferenceList(partitionName, newInstances);
+              // Existing resources may not have ANY_LIVEINSTANCE set as the numReplicas (which allows for different
+              // replication for different partitions under the same resource). So set it here (We use the name() method and
+              // not the toString() method for the enum as that is what Helix uses).
+              resourceIs.setReplicas(ResourceConfig.ResourceConfigConstants.ANY_LIVEINSTANCE.name());
+            }
+            resourceModified = true;
+          } else if (helixAdminOperation == HelixAdminOperation.DisablePartition) {
+            // if this is DisablePartition operation, we don't modify IdealState and only make InstanceConfig to disable
+            // certain partition on specific node.
+            // 1. extract difference between Helix and Static instance sets. Determine which replica is removed
+            instanceSetInHelix.removeAll(instanceSetInStatic);
+            // 2. disable removed replica on certain node.
+            for (String instanceInHelixOnly : instanceSetInHelix) {
+              info("Partition {} under resource {} on node {} is no longer in static clustermap. {}.", partitionName,
+                  resourceName, instanceInHelixOnly, dryRun ? "No action as dry run" : "Disabling it");
+              if (!dryRun) {
+                InstanceConfig instanceConfig = dcAdmin.getInstanceConfig(clusterName, instanceInHelixOnly);
+                String instanceName = instanceConfig.getInstanceName();
+                // create a Znode (if not present) in PropertyStore for this instance before disabling partition, which
+                // will be deleted in the end. The reason to create a ZNode is to ensure replica decommission is blocked
+                // on updating InstanceConfig until this tool has completed. TODO, remove this logic once migration to PropertyStore is done.
+                if (!instancesWithDisabledPartition.contains(instanceName)) {
+                  ZNRecord znRecord = new ZNRecord(instanceName);
+                  String path = PARTITION_DISABLED_ZNODE_PATH + instanceName;
+                  if (!helixPropertyStore.create(path, znRecord, AccessOption.PERSISTENT)) {
+                    logger.error("Failed to create a ZNode for {} in datacenter {} before disabling partition.",
+                        instanceName, dcName);
+                    continue;
+                  }
+                }
+                instanceConfig.setInstanceEnabledForPartition(resourceName, partitionName, false);
+                dcAdmin.setInstanceConfig(clusterName, instanceInHelixOnly, instanceConfig);
+                instancesWithDisabledPartition.add(instanceName);
+              }
+              partitionsDisabled.getAndIncrement();
+            }
+            // Disabling partition won't remove certain replica from IdealState. So replicas of this partition in Helix
+            // will be more than that in static clustermap.
+            expectMoreInHelixDuringValidate = true;
+          }
+        }
+      }
+      // update state model def if necessary
+      if (!resourceIs.getStateModelDefRef().equals(stateModelDef)) {
+        info("[{}] Resource {} has different state model {}. Updating it with {}", dcName.toUpperCase(), resourceName,
+            resourceIs.getStateModelDefRef(), stateModelDef);
+        resourceIs.setStateModelDefRef(stateModelDef);
+        resourceModified = true;
+      }
+      resourceIs.setNumPartitions(resourceIs.getPartitionSet().size());
+      if (resourceModified) {
+        if (resourceIs.getPartitionSet().isEmpty()) {
+          info("[{}] Resource {} has no partition, {}", dcName.toUpperCase(), resourceName,
+              dryRun ? "no action as dry run" : "dropping");
+          if (!dryRun) {
+            dcAdmin.dropResource(clusterName, resourceName);
+          }
+          resourcesDropped.getAndIncrement();
+        } else {
+          if (!dryRun) {
+            dcAdmin.setResourceIdealState(clusterName, resourceName, resourceIs);
+            System.out.println("------------------add resource!");
+            System.out.println(resourceName);
+            System.out.println(resourceName);
+          }
+          resourcesUpdated.getAndIncrement();
+        }
+      }
+    }
+    // note that disabling partition also updates InstanceConfig of certain nodes which host the partitions.
+    instancesUpdated.getAndAdd(instancesWithDisabledPartition.size());
+    // if there are some partitions are disabled, mark whole disabling process complete in Helix PropertyStore to unblock
+    // replica decommission thread on each datanode.
+    if (helixPropertyStore != null) {
+      maybeAwaitForLatch();
+      for (String instanceName : instancesWithDisabledPartition) {
+        String path = PARTITION_DISABLED_ZNODE_PATH + instanceName;
+        if (!helixPropertyStore.remove(path, AccessOption.PERSISTENT)) {
+          logger.error("Failed to remove a ZNode for {} in datacenter {} after disabling partition completed.",
+              instanceName, dcName);
+        }
+      }
+      helixPropertyStore.stop();
+    }
+
+    // Add what is not already in Helix under new resources.
+    int fromIndex = 0;
+    List<Map.Entry<String, Set<String>>> newPartitions = new ArrayList<>(partitionsToInstancesInDc.entrySet());
+    while (fromIndex < newPartitions.size()) {
+      String resourceName = Integer.toString(++maxResource);
+      int toIndex = Math.min(fromIndex + maxPartitionsInOneResource, newPartitions.size());
+      List<Map.Entry<String, Set<String>>> partitionsUnderNextResource = newPartitions.subList(fromIndex, toIndex);
+      fromIndex = toIndex;
+      IdealState idealState = new IdealState(resourceName);
+      idealState.setStateModelDefRef(stateModelDef);
+      info("[{}] Adding partitions for next resource {} in {}. {}.", dcName.toUpperCase(), resourceName, dcName,
+          dryRun ? "Actual IdealState is not changed as dry run" : "IdealState is being updated");
+      for (Map.Entry<String, Set<String>> entry : partitionsUnderNextResource) {
+        String partitionName = entry.getKey();
+        ArrayList<String> instances = new ArrayList<>(entry.getValue());
+        Collections.shuffle(instances);
+        idealState.setPreferenceList(partitionName, instances);
+      }
+      idealState.setNumPartitions(partitionsUnderNextResource.size());
+      idealState.setReplicas(ResourceConfig.ResourceConfigConstants.ANY_LIVEINSTANCE.name());
+      if (!idealState.isValid()) {
+        throw new IllegalStateException("IdealState could not be validated for new resource " + resourceName);
+      }
+      if (!dryRun) {
+        dcAdmin.addResource(clusterName, resourceName, idealState);
+        info("[{}] Added {} new partitions under resource {} in datacenter {}", dcName.toUpperCase(),
+            partitionsUnderNextResource.size(), resourceName, dcName);
+      } else {
+        info("[{}] Under DryRun mode, {} new partitions are added to resource {} in datacenter {}",
+            dcName.toUpperCase(), partitionsUnderNextResource.size(), resourceName, dcName);
+      }
+      resourcesAdded.getAndIncrement();
+    }
+  }
+
+  @Override
+  protected void validateAndClose() {
+    try {
+      info("Validating static and Helix cluster maps");
+      verifyEquivalencyWithStaticClusterMap(staticClusterMap.hardwareLayout, staticClusterMap.partitionLayout);
+      if (validatingHelixClusterManager != null) {
+        ensureOrThrow(validatingHelixClusterManager.getErrorCount() == 0,
+            "Helix cluster manager should not have encountered any errors");
+      }
+    } catch (Exception e) {
+      logger.error("Exception occurred when verifying equivalency with state clustermap", e);
+    } finally {
+      if (validatingHelixClusterManager != null) {
+        validatingHelixClusterManager.close();
+      }
+      for (HelixAdmin admin : adminForDc.values()) {
+        admin.close();
+      }
+    }
+  }
+
+  @Override
+  protected void logSummary() {
+    if (instancesUpdated.get() + instancesAdded.get() + instancesDropped.get() + resourcesUpdated.get() + resourcesAdded
+        .get() + resourcesDropped.get() + partitionsDisabled.get() + partitionsEnabled.get() + partitionsReset.get()
+        > 0) {
+      if (!dryRun) {
+        info("========Cluster in Helix was updated, summary:========");
+      } else {
+        info("========Dry run: Actual run would update the cluster in the following way:========");
+      }
+      info("New instances added: {}", instancesAdded.get());
+      info("Existing instances updated: {}", instancesUpdated.get());
+      info("Existing instances dropped: {}", instancesDropped.get());
+      info("New resources added: {}", resourcesAdded.get());
+      info("Existing resources updated: {}", resourcesUpdated.get());
+      info("Existing resources dropped: {}", resourcesDropped.get());
+      info("Partitions disabled: {}", partitionsDisabled.get());
+      info("Partitions enabled: {}", partitionsEnabled.get());
+      info("Partitions reset: {}", partitionsReset.get());
+    } else {
+      info("========No updates were done to the cluster in Helix========");
+    }
+    if (validatingHelixClusterManager != null) {
+      info("========Validating HelixClusterManager metrics========");
+      info("Instance config change count: {}",
+          validatingHelixClusterManager.helixClusterManagerMetrics.instanceConfigChangeTriggerCount.getCount());
+      info("Instance config update ignored count: {}",
+          validatingHelixClusterManager.helixClusterManagerMetrics.ignoredUpdatesCount.getCount());
+    }
+  }
+
+  private void verifyEquivalencyWithStaticClusterMap(HardwareLayout hardwareLayout, PartitionLayout partitionLayout)
+      throws Exception {
+    String clusterNameInStaticClusterMap = hardwareLayout.getClusterName();
+    info("Verifying equivalency of static cluster: " + clusterNameInStaticClusterMap + " with the "
+        + "corresponding cluster in Helix: " + clusterName);
+    CountDownLatch verificationLatch = new CountDownLatch(adminForDc.size());
+    AtomicInteger errorCount = new AtomicInteger();
+    for (Datacenter dc : hardwareLayout.getDatacenters()) {
+      HelixAdmin admin = adminForDc.get(dc.getName());
+      if (admin == null) {
+        info("Skipping {}", dc.getName());
+        continue;
+      }
+      ensureOrThrow(isClusterPresent(dc.getName()),
+          "Cluster not found in ZK " + dataCenterToZkAddress.get(dc.getName()));
+      Utils.newThread(() -> {
+        try {
+          verifyResourcesAndPartitionEquivalencyInDc(dc, clusterName, partitionLayout);
+          verifyDataNodeAndDiskEquivalencyInDc(dc, clusterName, partitionLayout);
+        } catch (Throwable t) {
+          logger.error("[{}] error message: {}", dc.getName().toUpperCase(), t.getMessage());
+          errorCount.getAndIncrement();
+        } finally {
+          verificationLatch.countDown();
+        }
+      }, false).start();
+    }
+    verificationLatch.await(10, TimeUnit.MINUTES);
+    ensureOrThrow(errorCount.get() == 0, "Error occurred when verifying equivalency with static cluster map");
+    info("Successfully verified equivalency of static cluster: " + clusterNameInStaticClusterMap
+        + " with the corresponding cluster in Helix: " + clusterName);
+  }
+
+  /**
+   * Verify that the hardware layout information is in sync - which includes the node and disk information. Also verify
+   * that the replicas belonging to disks are in sync between the static cluster map and Helix.
+   * @param dc the datacenter whose information is to be verified.
+   * @param clusterName the cluster to be verified.
+   * @param partitionLayout the {@link PartitionLayout} of the static clustermap.
+   */
+  private void verifyDataNodeAndDiskEquivalencyInDc(Datacenter dc, String clusterName,
+      PartitionLayout partitionLayout) {
+    String dcName = dc.getName();
+    // The following properties are immaterial for the tool, but the ClusterMapConfig mandates their presence.
+    ClusterMapConfig clusterMapConfig = getClusterMapConfig(clusterName, dcName, null);
+    StaticClusterManager staticClusterMap =
+        (new StaticClusterAgentsFactory(clusterMapConfig, partitionLayout)).getClusterMap();
+    String zkConnectStr = dataCenterToZkAddress.get(dcName).getZkConnectStrs().get(0);
+    try (PropertyStoreToDataNodeConfigAdapter propertyStoreAdapter = new PropertyStoreToDataNodeConfigAdapter(
+        zkConnectStr, clusterMapConfig)) {
+      InstanceConfigToDataNodeConfigAdapter.Converter instanceConfigConverter =
+          new InstanceConfigToDataNodeConfigAdapter.Converter(clusterMapConfig);
+      Set<String> allInstancesInHelix = new HashSet<>(getInstanceNamesInHelix(dcName, propertyStoreAdapter));
+      for (DataNodeId dataNodeId : dc.getDataNodes()) {
+        Map<String, Map<String, ReplicaId>> mountPathToReplicas = getMountPathToReplicas(staticClusterMap, dataNodeId);
+        DataNode dataNode = (DataNode) dataNodeId;
+        String instanceName = getInstanceName(dataNode);
+        ensureOrThrow(allInstancesInHelix.remove(instanceName), "Instance not present in Helix " + instanceName);
+        DataNodeConfig dataNodeConfig =
+            getDataNodeConfigFromHelix(dcName, instanceName, propertyStoreAdapter, instanceConfigConverter);
+
+        Map<String, DataNodeConfig.DiskConfig> diskInfos = new HashMap<>(dataNodeConfig.getDiskConfigs());
+        for (Disk disk : dataNode.getDisks()) {
+          DataNodeConfig.DiskConfig diskInfoInHelix = diskInfos.remove(disk.getMountPath());
+          ensureOrThrow(diskInfoInHelix != null,
+              "[" + dcName.toUpperCase() + "] Disk not present for instance " + instanceName + " disk "
+                  + disk.getMountPath());
+          ensureOrThrow(disk.getRawCapacityInBytes() == diskInfoInHelix.getDiskCapacityInBytes(),
+              "[" + dcName.toUpperCase() + "] Capacity mismatch for instance " + instanceName + " disk "
+                  + disk.getMountPath());
+
+          // We check replicaInfo only when this is a Bootstrap or Validate operation. For other operations, replica infos
+          // are expected to be different on certain nodes.
+          if (EnumSet.of(HelixAdminOperation.BootstrapCluster, HelixAdminOperation.ValidateCluster)
+              .contains(helixAdminOperation)) {
+            Set<String> replicasInClusterMap = new HashSet<>();
+            Map<String, ReplicaId> replicaList = mountPathToReplicas.get(disk.getMountPath());
+            if (replicaList != null) {
+              replicasInClusterMap.addAll(replicaList.keySet());
+            }
+            Set<String> replicasInHelix = new HashSet<>();
+            Map<String, DataNodeConfig.ReplicaConfig> replicaConfigMap = diskInfoInHelix.getReplicaConfigs();
+            for (Map.Entry<String, DataNodeConfig.ReplicaConfig> replicaConfigEntry : replicaConfigMap.entrySet()) {
+              String replicaName = replicaConfigEntry.getKey();
+              DataNodeConfig.ReplicaConfig replicaConfig = replicaConfigEntry.getValue();
+              replicasInHelix.add(replicaName);
+              ReplicaId replica = replicaList.get(replicaName);
+              ensureOrThrow(replicaConfig.getReplicaCapacityInBytes() == replica.getCapacityInBytes(),
+                  "[" + dcName.toUpperCase() + "] Replica capacity should be the same.");
+              ensureOrThrow(replicaConfig.getPartitionClass().equals(replica.getPartitionId().getPartitionClass()),
+                  "[" + dcName.toUpperCase() + "] Partition class should be the same.");
+            }
+            ensureOrThrow(replicasInClusterMap.equals(replicasInHelix),
+                "[" + dcName.toUpperCase() + "] Replica information not consistent for instance " + instanceName
+                    + " disk " + disk.getMountPath() + "\n in Helix: " + replicaList + "\n in static clustermap: "
+                    + replicasInClusterMap);
+          }
+        }
+        for (Map.Entry<String, DataNodeConfig.DiskConfig> entry : diskInfos.entrySet()) {
+          String mountPath = entry.getKey();
+          if (!mountPath.startsWith("/mnt")) {
+            logger.warn("[{}] Instance {} has unidentifiable mount path in Helix: {}", dcName.toUpperCase(),
+                instanceName, mountPath);
+          } else {
+            throw new AssertionError(
+                "[" + dcName.toUpperCase() + "] Instance " + instanceName + " has extra disk in Helix: " + entry);
+          }
+        }
+        ensureOrThrow(!dataNode.hasSSLPort() || (dataNode.getSSLPort() == dataNodeConfig.getSslPort()),
+            "[" + dcName.toUpperCase() + "] SSL Port mismatch for instance " + instanceName);
+        ensureOrThrow(!dataNode.hasHttp2Port() || (dataNode.getHttp2Port() == dataNodeConfig.getHttp2Port()),
+            "[" + dcName.toUpperCase() + "] HTTP2 Port mismatch for instance " + instanceName);
+        ensureOrThrow(dataNode.getDatacenterName().equals(dataNodeConfig.getDatacenterName()),
+            "[" + dcName.toUpperCase() + "] Datacenter mismatch for instance " + instanceName);
+        ensureOrThrow(Objects.equals(dataNode.getRackId(), dataNodeConfig.getRackId()),
+            "[" + dcName.toUpperCase() + "] Rack Id mismatch for instance " + instanceName);
+        // xid is not set in PropertyStore based DataNodeConfig and will be decommissioned eventually, hence we don't check xid equivalence
+      }
+      if (expectMoreInHelixDuringValidate) {
+        ensureOrThrow(
+            allInstancesInHelix.equals(instancesNotForceRemovedByDc.getOrDefault(dc.getName(), new HashSet<>())),
+            "[" + dcName.toUpperCase() + "] Additional instances in Helix: " + allInstancesInHelix
+                + " not what is expected " + instancesNotForceRemovedByDc.get(dc.getName()));
+        info("[{}] *** Helix may have more instances than in the given clustermap as removals were not forced.",
+            dcName.toUpperCase());
+      } else {
+        ensureOrThrow(allInstancesInHelix.isEmpty(),
+            "[" + dcName.toUpperCase() + "] Following instances in Helix not found in the clustermap "
+                + allInstancesInHelix);
+      }
+    }
+    info("[{}] Successfully verified datanode and disk equivalency in dc {}", dcName.toUpperCase(), dc.getName());
+  }
+
+  /**
+   * Verify that the partition layout information is in sync.
+   * @param dc the datacenter whose information is to be verified.
+   * @param clusterName the cluster to be verified.
+   * @param partitionLayout the {@link PartitionLayout} of the static clustermap.
+   */
+  private void verifyResourcesAndPartitionEquivalencyInDc(Datacenter dc, String clusterName,
+      PartitionLayout partitionLayout) {
+    String dcName = dc.getName();
+    HelixAdmin admin = adminForDc.get(dc.getName());
+    Map<String, Set<String>> allPartitionsToInstancesInHelix = new HashMap<>();
+    for (String resourceName : admin.getResourcesInCluster(clusterName)) {
+      if (!resourceName.matches("\\d+")) {
+        info("[{}] Ignoring resource {} as it is not part of the cluster map", dcName.toUpperCase(), resourceName);
+        continue;
+      }
+      IdealState resourceIS = admin.getResourceIdealState(clusterName, resourceName);
+      ensureOrThrow(resourceIS.getStateModelDefRef().equals(stateModelDef),
+          "[" + dcName.toUpperCase() + "] StateModel name mismatch for resource " + resourceName);
+      Set<String> resourcePartitions = resourceIS.getPartitionSet();
+      for (String resourcePartition : resourcePartitions) {
+        Set<String> partitionInstanceSet = resourceIS.getInstanceSet(resourcePartition);
+        ensureOrThrow(allPartitionsToInstancesInHelix.put(resourcePartition, partitionInstanceSet) == null,
+            "[" + dcName.toUpperCase() + "] Partition " + resourcePartition
+                + " already found under a different resource.");
+      }
+    }
+    for (PartitionId partitionId : partitionLayout.getPartitions(null)) {
+      Partition partition = (Partition) partitionId;
+      String partitionName = Long.toString(partition.getId());
+      Set<String> replicaHostsInHelix = allPartitionsToInstancesInHelix.remove(partitionName);
+      Set<String> expectedInHelix = new HashSet<>();
+      List<ReplicaId> replicasInStatic = partition.getReplicas()
+          .stream()
+          .filter(replica -> replica.getDataNodeId().getDatacenterName().equals(dcName))
+          .collect(Collectors.toList());
+      ensureOrThrow(replicasInStatic.size() == 0 || replicaHostsInHelix != null,
+          "[" + dcName.toUpperCase() + "] No replicas found for partition " + partitionName + " in Helix");
+      for (ReplicaId replica : replicasInStatic) {
+        String instanceName = getInstanceName(replica.getDataNodeId());
+        expectedInHelix.add(instanceName);
+        ensureOrThrow(replicaHostsInHelix.remove(instanceName),
+            "[" + dcName.toUpperCase() + "] Instance " + instanceName
+                + " for the given replica in the clustermap not found in Helix");
+      }
+      if (!expectMoreInHelixDuringValidate) {
+        ensureOrThrow(replicaHostsInHelix == null || replicaHostsInHelix.isEmpty(),
+            "[" + dcName.toUpperCase() + "] More instances in Helix than in clustermap for partition: " + partitionName
+                + ", expected: " + expectedInHelix + ", found additional instances: " + replicaHostsInHelix);
+      }
+    }
+    if (expectMoreInHelixDuringValidate) {
+      ensureOrThrow(allPartitionsToInstancesInHelix.keySet()
+              .equals(partitionsNotForceRemovedByDc.getOrDefault(dcName, new HashSet<>())),
+          "[" + dcName.toUpperCase() + "] Additional partitions in Helix: " + allPartitionsToInstancesInHelix.keySet()
+              + " not what is expected " + partitionsNotForceRemovedByDc.get(dcName));
+      info(
+          "[{}] *** Helix may have more partitions or replicas than in the given clustermap as removals were not forced.",
+          dcName.toUpperCase());
+    } else {
+      ensureOrThrow(allPartitionsToInstancesInHelix.isEmpty(),
+          "[" + dcName.toUpperCase() + "] More partitions in Helix than in clustermap, additional partitions: "
+              + allPartitionsToInstancesInHelix.keySet());
+    }
+    info("[{}] Successfully verified resources and partitions equivalency in dc {}", dcName.toUpperCase(), dcName);
+  }
+
+  /**
+   * Exposed for testing
+   */
+  private void maybeAwaitForLatch() {
+    if (disablePartitionLatch != null) {
+      disablePartitionLatch.countDown();
+    }
+    if (blockRemovingNodeLatch != null) {
+      try {
+        blockRemovingNodeLatch.await();
+      } catch (Exception e) {
+        logger.error("Interrupted when waiting for latch ", e);
+      }
+    }
+  }
+}
+

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixParticipantTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixParticipantTest.java
@@ -122,7 +122,7 @@ public class HelixParticipantTest {
 
     HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, "", "DC0",
         DEFAULT_MAX_PARTITIONS_PER_RESOURCE, false, false, new HelixAdminFactory(), false, stateModelDef,
-        BootstrapCluster, dataNodeConfigSourceType, false);
+        BootstrapCluster, dataNodeConfigSourceType, false, RebalanceMode.SEMI_AUTO);
     propertyStoreAdapter =
         dataNodeConfigSourceType == DataNodeConfigSourceType.PROPERTY_STORE ? new PropertyStoreToDataNodeConfigAdapter(
             "localhost:" + zkInfo.getPort(), clusterMapConfig) : null;
@@ -512,8 +512,10 @@ public class HelixParticipantTest {
         getDataNodeConfigInHelix(helixAdmin, instanceName));
     // create two new replicas on the same disk of local node
     int currentPartitionCount = testPartitionLayout.getPartitionCount();
-    Partition newPartition1 = new Partition(currentPartitionCount++, DEFAULT_PARTITION_CLASS, PartitionState.READ_WRITE, testPartitionLayout.replicaCapacityInBytes);
-    Partition newPartition2 = new Partition(currentPartitionCount, DEFAULT_PARTITION_CLASS, PartitionState.READ_WRITE, testPartitionLayout.replicaCapacityInBytes);
+    Partition newPartition1 = new Partition(currentPartitionCount++, DEFAULT_PARTITION_CLASS, PartitionState.READ_WRITE,
+        testPartitionLayout.replicaCapacityInBytes);
+    Partition newPartition2 = new Partition(currentPartitionCount, DEFAULT_PARTITION_CLASS, PartitionState.READ_WRITE,
+        testPartitionLayout.replicaCapacityInBytes);
     Disk disk = (Disk) existingReplica.getDiskId();
     // 2. add new partition2 (id = 10, replicaFromPartition2) to Helix
     ReplicaId replicaFromPartition2 = new Replica(newPartition2, disk, clusterMapConfig);
@@ -555,7 +557,7 @@ public class HelixParticipantTest {
     helixAdmin.close();
   }
 
-  private DataNodeConfig getDataNodeConfigInHelix(HelixAdmin helixAdmin, String instanceName){
+  private DataNodeConfig getDataNodeConfigInHelix(HelixAdmin helixAdmin, String instanceName) {
     return dataNodeConfigSourceType == DataNodeConfigSourceType.INSTANCE_CONFIG ? instanceConfigConverter.convert(
         helixAdmin.getInstanceConfig(clusterName, instanceName)) : propertyStoreAdapter.get(instanceName);
   }
@@ -592,7 +594,7 @@ public class HelixParticipantTest {
       String mountPath = entry.getKey();
       DataNodeConfig.DiskConfig diskConfig = entry.getValue();
       StringBuilder replicaStrBuilder = new StringBuilder();
-      for (Map.Entry<String, DataNodeConfig.ReplicaConfig> replicaEntry: diskConfig.getReplicaConfigs().entrySet()) {
+      for (Map.Entry<String, DataNodeConfig.ReplicaConfig> replicaEntry : diskConfig.getReplicaConfigs().entrySet()) {
         DataNodeConfig.ReplicaConfig replicaConfig = replicaEntry.getValue();
         replicaStrBuilder.append(replicaEntry.getKey())
             .append(REPLICAS_STR_SEPARATOR)

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixCluster.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixCluster.java
@@ -66,7 +66,8 @@ public class MockHelixCluster {
     dataCenterToZkAddress = parseDcJsonAndPopulateDcInfo(jsonString);
     HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterName,
         "all", MAX_PARTITIONS_IN_ONE_RESOURCE, false, false, helixAdminFactory, false,
-        ClusterMapConfig.DEFAULT_STATE_MODEL_DEF, BootstrapCluster, DataNodeConfigSourceType.INSTANCE_CONFIG, false);
+        ClusterMapConfig.DEFAULT_STATE_MODEL_DEF, BootstrapCluster, DataNodeConfigSourceType.INSTANCE_CONFIG, false,
+        RebalanceMode.SEMI_AUTO);
     this.clusterName = clusterName;
     this.localHelixAdmin =
         helixAdminFactory.getHelixAdmin(dataCenterToZkAddress.get(localDC).getZkConnectStrs().get(0));
@@ -80,7 +81,8 @@ public class MockHelixCluster {
   void upgradeWithNewHardwareLayout(String hardwareLayoutPath) throws Exception {
     HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterName,
         "all", MAX_PARTITIONS_IN_ONE_RESOURCE, false, false, helixAdminFactory, false,
-        ClusterMapConfig.DEFAULT_STATE_MODEL_DEF, BootstrapCluster, DataNodeConfigSourceType.INSTANCE_CONFIG, false);
+        ClusterMapConfig.DEFAULT_STATE_MODEL_DEF, BootstrapCluster, DataNodeConfigSourceType.INSTANCE_CONFIG, false,
+        RebalanceMode.SEMI_AUTO);
     triggerInstanceConfigChangeNotification();
   }
 
@@ -94,7 +96,7 @@ public class MockHelixCluster {
       HelixBootstrapUpgradeUtil.HelixAdminOperation adminOperation) throws Exception {
     HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterName,
         "all", 3, false, false, helixAdminFactory, false, ClusterMapConfig.DEFAULT_STATE_MODEL_DEF, adminOperation,
-        DataNodeConfigSourceType.INSTANCE_CONFIG, false);
+        DataNodeConfigSourceType.INSTANCE_CONFIG, false, RebalanceMode.SEMI_AUTO);
     triggerInstanceConfigChangeNotification();
   }
 

--- a/ambry-server/src/integration-test/java/com/github/ambry/server/VcrAutomationTest.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/VcrAutomationTest.java
@@ -24,6 +24,7 @@ import com.github.ambry.clustermap.HelixBootstrapUpgradeUtil;
 import com.github.ambry.clustermap.HelixClusterAgentsFactory;
 import com.github.ambry.clustermap.HelixVcrUtil;
 
+import com.github.ambry.clustermap.RebalanceMode;
 import com.github.ambry.config.CloudConfig;
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.VerifiableProperties;
@@ -124,7 +125,8 @@ public class VcrAutomationTest {
 
     HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterPrefix,
         dcName, 10, false, false, new HelixAdminFactory(), false, mainClusterStateModelDef,
-        HelixBootstrapUpgradeUtil.HelixAdminOperation.BootstrapCluster, dataNodeConfigSourceType, false);
+        HelixBootstrapUpgradeUtil.HelixAdminOperation.BootstrapCluster, dataNodeConfigSourceType, false,
+        RebalanceMode.SEMI_AUTO);
 
     HelixControllerManager helixControllerManager =
         new HelixControllerManager(zkConnectString, clusterPrefix + clusterName);
@@ -180,7 +182,8 @@ public class VcrAutomationTest {
 
     HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterPrefix,
         dcName, 10, false, false, new HelixAdminFactory(), false, mainClusterStateModelDef,
-        HelixBootstrapUpgradeUtil.HelixAdminOperation.BootstrapCluster, dataNodeConfigSourceType, false);
+        HelixBootstrapUpgradeUtil.HelixAdminOperation.BootstrapCluster, dataNodeConfigSourceType, false,
+        RebalanceMode.SEMI_AUTO);
 
     makeSureHelixBalance(vcrServer, helixBalanceVerifier);
     Assert.assertTrue("Partition assignment is not correct.",
@@ -193,7 +196,8 @@ public class VcrAutomationTest {
     Utils.writeJsonObjectToFile(testPartitionLayout.getPartitionLayout().toJSONObject(), partitionLayoutPath);
     HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterPrefix,
         dcName, 10, false, true, new HelixAdminFactory(), false, mainClusterStateModelDef,
-        HelixBootstrapUpgradeUtil.HelixAdminOperation.BootstrapCluster, dataNodeConfigSourceType, false);
+        HelixBootstrapUpgradeUtil.HelixAdminOperation.BootstrapCluster, dataNodeConfigSourceType, false,
+        RebalanceMode.SEMI_AUTO);
 
     makeSureHelixBalance(vcrServer, helixBalanceVerifier);
     Assert.assertTrue("Partition assignment is not correct.", TestUtils.checkAndSleep(partitionCount,

--- a/ambry-tools/src/integration-test/java/com/github/ambry/clustermap/HelixBootstrapUpgradeToolTest.java
+++ b/ambry-tools/src/integration-test/java/com/github/ambry/clustermap/HelixBootstrapUpgradeToolTest.java
@@ -15,7 +15,6 @@
 package com.github.ambry.clustermap;
 
 import com.codahale.metrics.MetricRegistry;
-import com.github.ambry.clustermap.TestUtils.*;
 import com.github.ambry.commons.CommonUtils;
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.HelixPropertyStoreConfig;
@@ -206,7 +205,8 @@ public class HelixBootstrapUpgradeToolTest {
     // bootstrap a cluster
     HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
         CLUSTER_NAME_PREFIX, dcStr, DEFAULT_MAX_PARTITIONS_PER_RESOURCE, false, false, new HelixAdminFactory(), false,
-        ClusterMapConfig.OLD_STATE_MODEL_DEF, BootstrapCluster, dataNodeConfigSourceType, false);
+        ClusterMapConfig.OLD_STATE_MODEL_DEF, BootstrapCluster, dataNodeConfigSourceType, false,
+        RebalanceMode.SEMI_AUTO);
     // add new state model def
     HelixBootstrapUpgradeUtil.addStateModelDef(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
         CLUSTER_NAME_PREFIX, dcStr, ClusterMapConfig.AMBRY_STATE_MODEL_DEF);
@@ -245,7 +245,8 @@ public class HelixBootstrapUpgradeToolTest {
       try {
         HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
             CLUSTER_NAME_PREFIX, dcStr, DEFAULT_MAX_PARTITIONS_PER_RESOURCE, false, false, new HelixAdminFactory(),
-            false, ClusterMapConfig.DEFAULT_STATE_MODEL_DEF, BootstrapCluster, dataNodeConfigSourceType, false);
+            false, ClusterMapConfig.DEFAULT_STATE_MODEL_DEF, BootstrapCluster, dataNodeConfigSourceType, false,
+            RebalanceMode.SEMI_AUTO);
         fail("Should have thrown IllegalArgumentException as a zk host is missing for one of the dcs");
       } catch (IllegalArgumentException e) {
         // OK
@@ -601,7 +602,8 @@ public class HelixBootstrapUpgradeToolTest {
     // upgrade Helix by updating IdealState: AdminOperation = UpdateIdealState
     HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
         CLUSTER_NAME_PREFIX, dcStr, DEFAULT_MAX_PARTITIONS_PER_RESOURCE, false, false, new HelixAdminFactory(), false,
-        ClusterMapConfig.DEFAULT_STATE_MODEL_DEF, UpdateIdealState, dataNodeConfigSourceType, false);
+        ClusterMapConfig.DEFAULT_STATE_MODEL_DEF, UpdateIdealState, dataNodeConfigSourceType, false,
+        RebalanceMode.SEMI_AUTO);
     verifyResourceCount(testHardwareLayout.getHardwareLayout(), expectedResourceCount);
 
     // verify IdealState has been updated
@@ -677,7 +679,8 @@ public class HelixBootstrapUpgradeToolTest {
         // Upgrade Helix by updating IdealState: AdminOperation = DisablePartition
         HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
             CLUSTER_NAME_PREFIX, dcStr, DEFAULT_MAX_PARTITIONS_PER_RESOURCE, false, false, new HelixAdminFactory(),
-            false, ClusterMapConfig.DEFAULT_STATE_MODEL_DEF, DisablePartition, dataNodeConfigSourceType, false);
+            false, ClusterMapConfig.DEFAULT_STATE_MODEL_DEF, DisablePartition, dataNodeConfigSourceType, false,
+            RebalanceMode.SEMI_AUTO);
         bootstrapCompletionLatch.countDown();
       } catch (Exception e) {
         // do nothing, if there is any exception subsequent test should fail.
@@ -1069,7 +1072,8 @@ public class HelixBootstrapUpgradeToolTest {
     // This updates and verifies that the information in Helix is consistent with the one in the static cluster map.
     HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
         CLUSTER_NAME_PREFIX, dcStr, DEFAULT_MAX_PARTITIONS_PER_RESOURCE, false, forceRemove, new HelixAdminFactory(),
-        false, ClusterMapConfig.DEFAULT_STATE_MODEL_DEF, BootstrapCluster, dataNodeConfigSourceType, false);
+        false, ClusterMapConfig.DEFAULT_STATE_MODEL_DEF, BootstrapCluster, dataNodeConfigSourceType, false,
+        RebalanceMode.SEMI_AUTO);
     verifyResourceCount(testHardwareLayout.getHardwareLayout(), expectedResourceCount);
   }
 


### PR DESCRIPTION
1. Changed `HelixBootstrapUpgradeUtil` class to base class and extended `HelixBootstrapUpgradeUtilSemiAuto` and `HelixBootstrapUpgradeUtilFullAuto` from it.
2. Added method `migrateToFullAuto` in `HelixBootstrapUpgradeUtilFullAuto` class to help set up cluster/instance/resource configs for migration to Full Auto.