### PR TITLE
Support latest version auto incremental

### DIFF
--- a/ambry-account/src/integration-test/java/com/github/ambry/account/MySqlAccountServiceIntegrationTest.java
+++ b/ambry-account/src/integration-test/java/com/github/ambry/account/MySqlAccountServiceIntegrationTest.java
@@ -894,6 +894,15 @@ public class MySqlAccountServiceIntegrationTest {
             testContainer.getName(), DATASET_NAME, version);
     assertEquals("Mismatch in dataset", expectedDatasetVersionRecord, datasetVersionRecordFromMysql);
 
+    // Deleted version 2 and add new latest version
+    mySqlAccountStore.deleteDatasetVersion(testAccount.getId(), testContainer.getId(), DATASET_NAME, "2");
+    expectedDatasetVersionRecord =
+        new DatasetVersionRecord(testAccount.getId(), testContainer.getId(), DATASET_NAME, "3", -1);
+    datasetVersionRecordFromMysql =
+        mySqlAccountStore.addDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
+            testContainer.getName(), DATASET_NAME, version, -1, System.currentTimeMillis(), false);
+    assertEquals("Mismatch in dataset", expectedDatasetVersionRecord, datasetVersionRecordFromMysql);
+
     // Add a dataset with semantic version
     dataset =
         new DatasetBuilder(testAccount.getName(), testContainer.getName(), DATASET_NAME_WITH_SEMANTIC).setVersionSchema(

--- a/ambry-account/src/integration-test/java/com/github/ambry/account/MySqlAccountServiceIntegrationTest.java
+++ b/ambry-account/src/integration-test/java/com/github/ambry/account/MySqlAccountServiceIntegrationTest.java
@@ -846,6 +846,131 @@ public class MySqlAccountServiceIntegrationTest {
   }
 
   /**
+   * Test add and get latest version.
+   * @throws Exception
+   */
+  @Test
+  public void testLatestVersionSupport() throws Exception {
+    Account testAccount = makeTestAccountWithContainer();
+    Container testContainer = new ArrayList<>(testAccount.getAllContainers()).get(0);
+    Dataset dataset = new DatasetBuilder(testAccount.getName(), testContainer.getName(), DATASET_NAME).setVersionSchema(
+        Dataset.VersionSchema.MONOTONIC).build();
+
+    // Add a dataset to db
+    mySqlAccountStore.addDataset(testAccount.getId(), testContainer.getId(), dataset);
+
+    // get a latest dataset version when no version exist, should fail.
+    String version = "LATEST";
+    DatasetVersionRecord datasetVersionRecordFromMysql;
+    try {
+      mySqlAccountStore.getDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
+          testContainer.getName(), DATASET_NAME, version);
+      fail();
+    } catch (AccountServiceException e) {
+      assertEquals("Mismatch on error code", AccountServiceErrorCode.NotFound, e.getErrorCode());
+    }
+
+    // Add a LATEST dataset version
+    DatasetVersionRecord expectedDatasetVersionRecord =
+        new DatasetVersionRecord(testAccount.getId(), testContainer.getId(), DATASET_NAME, "1", -1);
+    datasetVersionRecordFromMysql =
+        mySqlAccountStore.addDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
+            testContainer.getName(), DATASET_NAME, version, -1, System.currentTimeMillis(), false);
+    assertEquals("Mismatch in dataset", expectedDatasetVersionRecord, datasetVersionRecordFromMysql);
+
+    // Add a new LATEST dataset version
+    expectedDatasetVersionRecord =
+        new DatasetVersionRecord(testAccount.getId(), testContainer.getId(), DATASET_NAME, "2", -1);
+    datasetVersionRecordFromMysql =
+        mySqlAccountStore.addDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
+            testContainer.getName(), DATASET_NAME, version, -1, System.currentTimeMillis(), false);
+    assertEquals("Mismatch in dataset", expectedDatasetVersionRecord, datasetVersionRecordFromMysql);
+
+    // Get the LATEST dataset version
+    expectedDatasetVersionRecord =
+        new DatasetVersionRecord(testAccount.getId(), testContainer.getId(), DATASET_NAME, "2", -1);
+    datasetVersionRecordFromMysql =
+        mySqlAccountStore.getDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
+            testContainer.getName(), DATASET_NAME, version);
+    assertEquals("Mismatch in dataset", expectedDatasetVersionRecord, datasetVersionRecordFromMysql);
+
+    // Add a dataset with semantic version
+    dataset =
+        new DatasetBuilder(testAccount.getName(), testContainer.getName(), DATASET_NAME_WITH_SEMANTIC).setVersionSchema(
+            Dataset.VersionSchema.SEMANTIC).build();
+    mySqlAccountStore.addDataset(testAccount.getId(), testContainer.getId(), dataset);
+
+    // get a latest dataset version when no version exist, should fail.
+    version = "LATEST";
+    try {
+      mySqlAccountStore.getDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
+          testContainer.getName(), DATASET_NAME_WITH_SEMANTIC, version);
+      fail();
+    } catch (AccountServiceException e) {
+      assertEquals("Mismatch on error code", AccountServiceErrorCode.NotFound, e.getErrorCode());
+    }
+
+    // add a major version for timestamp schema, should fail.
+
+    // add a major version.
+    version = "MAJOR";
+    expectedDatasetVersionRecord =
+        new DatasetVersionRecord(testAccount.getId(), testContainer.getId(), DATASET_NAME_WITH_SEMANTIC, "1.0.0", -1);
+    datasetVersionRecordFromMysql =
+        mySqlAccountStore.addDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
+            testContainer.getName(), DATASET_NAME_WITH_SEMANTIC, version, -1, System.currentTimeMillis(), false);
+    assertEquals("Mismatch in dataset", expectedDatasetVersionRecord, datasetVersionRecordFromMysql);
+    // add second major version
+    expectedDatasetVersionRecord =
+        new DatasetVersionRecord(testAccount.getId(), testContainer.getId(), DATASET_NAME_WITH_SEMANTIC, "2.0.0", -1);
+    datasetVersionRecordFromMysql =
+        mySqlAccountStore.addDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
+            testContainer.getName(), DATASET_NAME_WITH_SEMANTIC, version, -1, System.currentTimeMillis(), false);
+    assertEquals("Mismatch in dataset", expectedDatasetVersionRecord, datasetVersionRecordFromMysql);
+
+    // add a patch version.
+    version = "PATCH";
+    expectedDatasetVersionRecord =
+        new DatasetVersionRecord(testAccount.getId(), testContainer.getId(), DATASET_NAME_WITH_SEMANTIC, "2.0.1", -1);
+    datasetVersionRecordFromMysql =
+        mySqlAccountStore.addDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
+            testContainer.getName(), DATASET_NAME_WITH_SEMANTIC, version, -1, System.currentTimeMillis(), false);
+    assertEquals("Mismatch in dataset", expectedDatasetVersionRecord, datasetVersionRecordFromMysql);
+    // add second path version
+    expectedDatasetVersionRecord =
+        new DatasetVersionRecord(testAccount.getId(), testContainer.getId(), DATASET_NAME_WITH_SEMANTIC, "2.0.2", -1);
+    datasetVersionRecordFromMysql =
+        mySqlAccountStore.addDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
+            testContainer.getName(), DATASET_NAME_WITH_SEMANTIC, version, -1, System.currentTimeMillis(), false);
+    assertEquals("Mismatch in dataset", expectedDatasetVersionRecord, datasetVersionRecordFromMysql);
+
+    // add a minor version.
+    version = "MINOR";
+    expectedDatasetVersionRecord =
+        new DatasetVersionRecord(testAccount.getId(), testContainer.getId(), DATASET_NAME_WITH_SEMANTIC, "2.1.0", -1);
+    datasetVersionRecordFromMysql =
+        mySqlAccountStore.addDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
+            testContainer.getName(), DATASET_NAME_WITH_SEMANTIC, version, -1, System.currentTimeMillis(), false);
+    assertEquals("Mismatch in dataset", expectedDatasetVersionRecord, datasetVersionRecordFromMysql);
+    // add second minor version
+    expectedDatasetVersionRecord =
+        new DatasetVersionRecord(testAccount.getId(), testContainer.getId(), DATASET_NAME_WITH_SEMANTIC, "2.2.0", -1);
+    datasetVersionRecordFromMysql =
+        mySqlAccountStore.addDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
+            testContainer.getName(), DATASET_NAME_WITH_SEMANTIC, version, -1, System.currentTimeMillis(), false);
+    assertEquals("Mismatch in dataset", expectedDatasetVersionRecord, datasetVersionRecordFromMysql);
+
+    //get the latest version.
+    version = "LATEST";
+    expectedDatasetVersionRecord =
+        new DatasetVersionRecord(testAccount.getId(), testContainer.getId(), DATASET_NAME_WITH_SEMANTIC, "2.2.0", -1);
+    datasetVersionRecordFromMysql =
+        mySqlAccountStore.getDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
+            testContainer.getName(), DATASET_NAME_WITH_SEMANTIC, version);
+    assertEquals("Mismatch in dataset", expectedDatasetVersionRecord, datasetVersionRecordFromMysql);
+  }
+
+  /**
    * Test add and get dataset version with different input.
    */
   @Test
@@ -930,12 +1055,6 @@ public class MySqlAccountServiceIntegrationTest {
             testContainer.getName(), DATASET_NAME, version);
     assertEquals("Mismatch in dataset expirationTimeMs", (long) dataset.getRetentionTimeInSeconds(),
         TimeUnit.MILLISECONDS.toSeconds(datasetVersionRecordWithTtl.getExpirationTimeMs() - creationTimeInMs));
-
-    Collections.reverse(versions);
-    long expectedLatestVersion = versions.get(0);
-    long latestVersionFromMysql =
-        mySqlAccountStore.getLatestVersion(testAccount.getId(), testContainer.getId(), DATASET_NAME);
-    assertEquals("Unexpected latest version", expectedLatestVersion, latestVersionFromMysql);
 
     //Test semantic version.
     dataset =

--- a/ambry-account/src/main/java/com/github/ambry/account/mysql/AccountDao.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/mysql/AccountDao.java
@@ -49,6 +49,12 @@ public class AccountDao {
   private final MySqlDataAccessor dataAccessor;
   private final MySqlAccountServiceConfig mySqlAccountServiceConfig;
   private final ObjectMapper objectMapper = new ObjectMapper();
+  private static final long MAX_TIMESTAMP_MONOTONIC_VERSION_VALUE = 9999999999L;
+  private static final long MAX_SEMANTIC_MAJOR_MINOR_PATH_VERSION_VALUE = 999L;
+  private static final String LATEST = "LATEST";
+  private static final String MAJOR = "MAJOR";
+  private static final String MINOR = "MINOR";
+  private static final String PATCH = "PATCH";
 
   // Account table fields
   public static final String ACCOUNT_TABLE = "Accounts";
@@ -96,7 +102,7 @@ public class AccountDao {
   private final String getDatasetVersionByNameSql;
   private final String deleteDatasetVersionByIdSql;
   private final String updateDatasetVersionIfExpiredSql;
-  private final String listVersionSql;
+  private final String listLatestVersionSql;
   private final String listValidVersionSql;
   private final String listVersionByModifiedTimeSql;
 
@@ -171,9 +177,9 @@ public class AccountDao {
     insertDatasetVersionSql =
         String.format("insert into %s (%s, %s, %s, %s, %s, %s) values (?, ?, ?, ?, now(3), ?)", DATASET_VERSION_TABLE,
             ACCOUNT_ID, CONTAINER_ID, DATASET_NAME, VERSION, LAST_MODIFIED_TIME, DELETE_TS);
-    listVersionSql =
-        String.format("select %1$s from %2$s " + "where (%3$s, %4$s, %5$s) = (?, ?, ?) ORDER BY %1$s DESC LIMIT 1",
-            VERSION, DATASET_VERSION_TABLE, ACCOUNT_ID, CONTAINER_ID, DATASET_NAME);
+    listLatestVersionSql = String.format("select %1$s from %2$s "
+            + "where (%3$s IS NULL or %3$s > now(3)) and (%4$s, %5$s, %6$s) = (?, ?, ?) ORDER BY %1$s DESC LIMIT 1",
+        VERSION, DATASET_VERSION_TABLE, DELETE_TS, ACCOUNT_ID, CONTAINER_ID, DATASET_NAME);
     listValidVersionSql =
         String.format("select %s, %s from %s " + "where (%s IS NULL or %s > now(3)) and %s = ? and %s = ? and %s = ?",
             VERSION, DELETE_TS, DATASET_VERSION_TABLE, DELETE_TS, DELETE_TS, ACCOUNT_ID, CONTAINER_ID, DATASET_NAME);
@@ -364,29 +370,30 @@ public class AccountDao {
     long startTimeMs = System.currentTimeMillis();
     long versionNumber = 0;
     Dataset dataset = null;
+    DatasetVersionRecord datasetVersionRecord;
     try {
       dataset = getDataset(accountId, containerId, accountName, containerName, datasetName);
       dataAccessor.getDatabaseConnection(true);
-      PreparedStatement insertDatasetVersionStatement =
-          dataAccessor.getPreparedStatement(insertDatasetVersionSql, true);
-      //TODO: if version == null, add the latest version from db + 1.
-      versionNumber = getVersionBasedOnSchema(version, dataset.getVersionSchema());
-      long newExpirationTimeMs =
-          executeAddDatasetVersionStatement(insertDatasetVersionStatement, accountId, containerId, datasetName,
-              versionNumber, timeToLiveInSeconds, creationTimeInMs, dataset, datasetVersionTtlEnabled);
+      if (isAutoCreatedVersionForUpload(version)) {
+        datasetVersionRecord =
+            retryWithLatestAutoIncrementedVersion(accountId, containerId, dataset, version, timeToLiveInSeconds,
+                creationTimeInMs, datasetVersionTtlEnabled);
+      } else {
+        versionNumber = getVersionBasedOnSchema(version, dataset.getVersionSchema());
+        datasetVersionRecord =
+            addDatasetVersionHelper(accountId, containerId, dataset, version, timeToLiveInSeconds, creationTimeInMs,
+                datasetVersionTtlEnabled, versionNumber);
+      }
       dataAccessor.onSuccess(Write, System.currentTimeMillis() - startTimeMs);
-      return new DatasetVersionRecord(accountId, containerId, datasetName, version, newExpirationTimeMs);
+      return datasetVersionRecord;
     } catch (SQLException | AccountServiceException e) {
       if (e instanceof SQLIntegrityConstraintViolationException) {
-        PreparedStatement updateDatasetSqlIfExpiredStatement =
-            dataAccessor.getPreparedStatement(updateDatasetVersionIfExpiredSql, true);
         try {
-          long newExpirationTimeMs =
-              executeUpdateDatasetVersionIfExpiredSqlStatement(updateDatasetSqlIfExpiredStatement, accountId,
-                  containerId, datasetName, versionNumber, timeToLiveInSeconds, creationTimeInMs, dataset,
-                  datasetVersionTtlEnabled);
+          datasetVersionRecord =
+              updateDatasetVersionHelper(accountId, containerId, dataset, version, timeToLiveInSeconds,
+                  creationTimeInMs, datasetVersionTtlEnabled, versionNumber);
           dataAccessor.onSuccess(Write, System.currentTimeMillis() - startTimeMs);
-          return new DatasetVersionRecord(accountId, containerId, datasetName, version, newExpirationTimeMs);
+          return datasetVersionRecord;
         } catch (SQLException | AccountServiceException ex) {
           dataAccessor.onException(ex, Write);
           throw ex;
@@ -395,6 +402,91 @@ public class AccountDao {
       dataAccessor.onException(e, Write);
       throw e;
     }
+  }
+
+  /**
+   * Helper function to support add dataset verison.
+   * @param accountId the id for the parent account.
+   * @param containerId the id of the container.
+   * @param dataset the {@link Dataset}
+   * @param version the version of the dataset.
+   * @param timeToLiveInSeconds The dataset version level ttl.
+   * @param creationTimeInMs the creation time of the dataset.
+   * @param datasetVersionTtlEnabled set to true if dataset version ttl want to override the dataset level default ttl.
+   * @return the {@link DatasetVersionRecord} and the latest version.
+   * @throws SQLException
+   * @throws AccountServiceException
+   */
+  private DatasetVersionRecord addDatasetVersionHelper(int accountId, int containerId, Dataset dataset, String version,
+      long timeToLiveInSeconds, long creationTimeInMs, boolean datasetVersionTtlEnabled, long versionNumber)
+      throws SQLException, AccountServiceException {
+    dataAccessor.getDatabaseConnection(true);
+    PreparedStatement insertDatasetVersionStatement = dataAccessor.getPreparedStatement(insertDatasetVersionSql, true);
+    long newExpirationTimeMs = executeAddDatasetVersionStatement(insertDatasetVersionStatement, accountId, containerId,
+        dataset.getDatasetName(), versionNumber, timeToLiveInSeconds, creationTimeInMs, dataset,
+        datasetVersionTtlEnabled);
+    return new DatasetVersionRecord(accountId, containerId, dataset.getDatasetName(), version, newExpirationTimeMs);
+  }
+
+  /**
+   * Retry and add the latest auto incremented dataset version
+   * @param accountId the id for the parent account.
+   * @param containerId the id of the container.
+   * @param dataset the {@link Dataset}
+   * @param version the version of the dataset.
+   * @param timeToLiveInSeconds The dataset version level ttl.
+   * @param creationTimeInMs the creation time of the dataset.
+   * @param datasetVersionTtlEnabled set to true if dataset version ttl want to override the dataset level default ttl.
+   * @return the {@link DatasetVersionRecord} with the latest auto incremented dataset version
+   * @throws AccountServiceException
+   * @throws SQLException
+   */
+  private DatasetVersionRecord retryWithLatestAutoIncrementedVersion(int accountId, int containerId, Dataset dataset,
+      String version, long timeToLiveInSeconds, long creationTimeInMs, boolean datasetVersionTtlEnabled)
+      throws AccountServiceException, SQLException {
+    long versionNumber;
+    while (true) {
+      try {
+        versionNumber =
+            getAutoIncrementedVersionBasedOnLatestAvailableVersion(accountId, containerId, dataset.getVersionSchema(),
+                dataset.getDatasetName(), version);
+        version = convertVersionValueToVersion(versionNumber, dataset.getVersionSchema());
+        //always retry with the latest version + 1 until it has been successfully uploading without conflict or failed with exception.
+        return addDatasetVersionHelper(accountId, containerId, dataset, version, timeToLiveInSeconds, creationTimeInMs,
+            datasetVersionTtlEnabled, versionNumber);
+      } catch (SQLException | AccountServiceException ex) {
+        // if the version already exist in database, retry with the new latest version +1.
+        if (!(ex instanceof SQLIntegrityConstraintViolationException)) {
+          throw ex;
+        }
+      }
+    }
+  }
+
+  /**
+   * Helper function to support update dataset version.
+   * @param accountId the id for the parent account.
+   * @param containerId the id of the container.
+   * @param dataset the {@link Dataset}
+   * @param version the version of the dataset.
+   * @param timeToLiveInSeconds The dataset version level ttl.
+   * @param creationTimeInMs the creation time of the dataset.
+   * @param datasetVersionTtlEnabled set to true if dataset version ttl want to override the dataset level default ttl.
+   * @param versionNumber the version number converted by version string.
+   * @return
+   * @throws SQLException
+   * @throws AccountServiceException
+   */
+  private DatasetVersionRecord updateDatasetVersionHelper(int accountId, int containerId, Dataset dataset,
+      String version, long timeToLiveInSeconds, long creationTimeInMs, boolean datasetVersionTtlEnabled,
+      long versionNumber) throws SQLException, AccountServiceException {
+    PreparedStatement updateDatasetVersionSqlIfExpiredStatement =
+        dataAccessor.getPreparedStatement(updateDatasetVersionIfExpiredSql, true);
+    long newExpirationTimeMs =
+        executeUpdateDatasetVersionIfExpiredSqlStatement(updateDatasetVersionSqlIfExpiredStatement, accountId,
+            containerId, dataset.getDatasetName(), versionNumber, timeToLiveInSeconds, creationTimeInMs, dataset,
+            datasetVersionTtlEnabled);
+    return new DatasetVersionRecord(accountId, containerId, dataset.getDatasetName(), version, newExpirationTimeMs);
   }
 
   /**
@@ -418,8 +510,15 @@ public class AccountDao {
       dataAccessor.getDatabaseConnection(false);
       PreparedStatement getDatasetVersionStatement =
           dataAccessor.getPreparedStatement(getDatasetVersionByNameSql, false);
-      //TODO: if version == null, get the latest version from db + 1.
-      long versionValue = getVersionBasedOnSchema(version, versionSchema);
+      long versionValue;
+      if (isAutoCreatedVersionForDownload(version)) {
+        PreparedStatement listLatestVersionStatement = dataAccessor.getPreparedStatement(listLatestVersionSql, false);
+        versionValue =
+            executeListLatestVersionStatement(listLatestVersionStatement, accountId, containerId, datasetName);
+        version = convertVersionValueToVersion(versionValue, versionSchema);
+      } else {
+        versionValue = getVersionBasedOnSchema(version, versionSchema);
+      }
       DatasetVersionRecord result =
           executeGetDatasetVersionStatement(getDatasetVersionStatement, accountId, containerId, datasetName,
               versionValue, version);
@@ -664,22 +763,36 @@ public class AccountDao {
   }
 
   /**
-   * Get the latest version value of the dataset.
+   * Get the auto incremented version based on latest available version.
    * @param accountId the id for the parent account.
    * @param containerId the id of the container.
+   * @param versionSchema the {@link com.github.ambry.account.Dataset.VersionSchema} of the dataset.
    * @param datasetName the name of the dataset.
    * @return the latest version.
    * @throws SQLException
    */
-  public synchronized long getLatestVersion(short accountId, short containerId, String datasetName)
+  private synchronized long getAutoIncrementedVersionBasedOnLatestAvailableVersion(int accountId, int containerId,
+      Dataset.VersionSchema versionSchema, String datasetName, String version)
       throws SQLException, AccountServiceException {
+    long latestVersionValue;
     try {
       long startTimeMs = System.currentTimeMillis();
       dataAccessor.getDatabaseConnection(false);
-      PreparedStatement listVersionStatement = dataAccessor.getPreparedStatement(listVersionSql, false);
-      long latestVersion = executeListVersionStatement(listVersionStatement, accountId, containerId, datasetName);
+      PreparedStatement listLatestVersionStatement = dataAccessor.getPreparedStatement(listLatestVersionSql, false);
+      try {
+        latestVersionValue =
+            executeListLatestVersionStatement(listLatestVersionStatement, accountId, containerId, datasetName);
+      } catch (AccountServiceException e) {
+        if (AccountServiceErrorCode.NotFound.equals(e.getErrorCode())) {
+          latestVersionValue = 0;
+        } else {
+          throw e;
+        }
+      }
+      long autoIncrementedVersionBasedOnSchema =
+          generateAutoIncrementedVersionBasedOnSchema(latestVersionValue, versionSchema, version);
       dataAccessor.onSuccess(Read, System.currentTimeMillis() - startTimeMs);
-      return latestVersion;
+      return autoIncrementedVersionBasedOnSchema;
     } catch (SQLException | AccountServiceException e) {
       dataAccessor.onException(e, Read);
       throw e;
@@ -826,7 +939,7 @@ public class AccountDao {
    * @return the latest version of the dataset.
    * @throws SQLException
    */
-  private long executeListVersionStatement(PreparedStatement statement, int accountId, int containerId,
+  private long executeListLatestVersionStatement(PreparedStatement statement, int accountId, int containerId,
       String datasetName) throws SQLException, AccountServiceException {
     ResultSet resultSet = null;
     try {
@@ -843,6 +956,87 @@ public class AccountDao {
     } finally {
       closeQuietly(resultSet);
     }
+  }
+
+  /**
+   * Generate the auto incremented version based on the latest valid version and the version schema.
+   * @param versionValue the latest version value for current dataset.
+   * @param versionSchema the {@link com.github.ambry.account.Dataset.VersionSchema} of the dataset.
+   * @param version the version string to indicate if user provide LATEST, MAJOR, MINOR or PATCH option.
+   * @return the auto incremented value base on latest version.
+   */
+  private long generateAutoIncrementedVersionBasedOnSchema(long versionValue, Dataset.VersionSchema versionSchema,
+      String version) {
+    long autoIncrementedVersionValue;
+    switch (versionSchema) {
+      case TIMESTAMP:
+      case MONOTONIC:
+        if (!LATEST.equals(version)) {
+          throw new IllegalArgumentException(
+              "The current version string " + version + " is not supported for Timestamp or Monotonic version schema");
+        }
+        autoIncrementedVersionValue = versionValue + 1;
+        if (autoIncrementedVersionValue > MAX_TIMESTAMP_MONOTONIC_VERSION_VALUE) {
+          throw new IllegalArgumentException(
+              "The largest version for Timestamp and Monotonic version should be less than "
+                  + MAX_TIMESTAMP_MONOTONIC_VERSION_VALUE + ", currentVersion: " + versionValue);
+        }
+        return autoIncrementedVersionValue;
+      case SEMANTIC:
+        //Given a version number MAJOR.MINOR.PATCH, increment the:
+        //1.MAJOR version when you make incompatible API changes
+        //2.MINOR version when you add functionality in a backwards compatible manner
+        //3.PATCH version when you make backwards compatible bug fixes
+        //The MAJOR,MINOR and PATCH version are non-negative value.
+        if (!MAJOR.equals(version) && !MINOR.equals(version) && !PATCH.equals(version)) {
+          throw new IllegalArgumentException(
+              "The current version string " + version + " is not supported for Semantic version schema");
+        }
+        long majorVersion = versionValue / 1000000;
+        long minorVersion = ((versionValue % 1000000) / 1000);
+        long patchVersion = versionValue % 1000;
+        if (MAJOR.equals(version)) {
+          majorVersion += 1;
+          minorVersion = 0;
+          patchVersion = 0;
+          if (majorVersion > MAX_SEMANTIC_MAJOR_MINOR_PATH_VERSION_VALUE) {
+            throw new IllegalArgumentException("The largest version for Semantic Major version should be less than "
+                + MAX_SEMANTIC_MAJOR_MINOR_PATH_VERSION_VALUE + ", currentMajorVersion: " + majorVersion);
+          }
+        } else if (MINOR.equals(version)) {
+          minorVersion += 1;
+          patchVersion = 0;
+          if (minorVersion > MAX_SEMANTIC_MAJOR_MINOR_PATH_VERSION_VALUE) {
+            throw new IllegalArgumentException("The largest version for Semantic Major version should be less than "
+                + MAX_SEMANTIC_MAJOR_MINOR_PATH_VERSION_VALUE + ", currentMinorVersion: " + minorVersion);
+          }
+        } else {
+          patchVersion += 1;
+          if (patchVersion > MAX_SEMANTIC_MAJOR_MINOR_PATH_VERSION_VALUE) {
+            throw new IllegalArgumentException("The largest version for Semantic Major version should be less than "
+                + MAX_SEMANTIC_MAJOR_MINOR_PATH_VERSION_VALUE + ", currentPatchVersion: " + patchVersion);
+          }
+        }
+        return majorVersion * 1000000 + minorVersion * 1000 + patchVersion;
+      default:
+        throw new IllegalArgumentException("Unsupported version schema: " + versionSchema);
+    }
+  }
+
+  /**
+   * @param version the version string.
+   * @return {@code} true if the version is auto created version for upload.
+   */
+  private boolean isAutoCreatedVersionForUpload(String version) {
+    return LATEST.equals(version) || MAJOR.equals(version) || MINOR.equals(version) || PATCH.equals(version);
+  }
+
+  /**
+   * @param version the version string.
+   * @return {@code} true if the version is auto created version for download.
+   */
+  private boolean isAutoCreatedVersionForDownload(String version) {
+    return LATEST.equals(version);
   }
 
   /**

--- a/ambry-account/src/main/java/com/github/ambry/account/mysql/MySqlAccountStore.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/mysql/MySqlAccountStore.java
@@ -225,19 +225,6 @@ public class MySqlAccountStore {
   }
 
   /**
-   * Get the latest version value of the dataset versions.
-   * @param accountId the id for the parent account.
-   * @param containerId the id of the container.
-   * @param datasetName the name of the dataset.
-   * @return the latest version of the dataset.
-   * @throws SQLException
-   */
-  public long getLatestVersion(short accountId, short containerId, String datasetName)
-      throws SQLException, AccountServiceException {
-    return accountDao.getLatestVersion(accountId, containerId, datasetName);
-  }
-
-  /**
    * Get a list of dataset versions which is not expired or been deleted for specific dataset.
    * @param accountId the id for the parent account.
    * @param containerId the id of the container.

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
@@ -31,9 +31,7 @@ import com.github.ambry.named.NamedBlobDb;
 import com.github.ambry.named.NamedBlobRecord;
 import com.github.ambry.quota.QuotaManager;
 import com.github.ambry.quota.QuotaUtils;
-import com.github.ambry.rest.NettyRequest;
 import com.github.ambry.rest.RequestPath;
-import com.github.ambry.rest.ResponseStatus;
 import com.github.ambry.rest.RestRequest;
 import com.github.ambry.rest.RestResponseChannel;
 import com.github.ambry.rest.RestServiceErrorCode;
@@ -50,7 +48,6 @@ import com.github.ambry.utils.Utils;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
-import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -572,6 +569,8 @@ public class NamedBlobPutHandler {
         List<DatasetVersionRecord> datasetVersionRecordList =
             accountService.getAllValidVersionsOutOfRetentionCount(accountName, containerName, datasetName);
         if (datasetVersionRecordList.size() > 0) {
+          LOGGER.info(
+              "Number of records need to be deleted due to out of retention count: " + datasetVersionRecordList.size());
           DatasetVersionRecord record = datasetVersionRecordList.get(0);
           String version = record.getVersion();
           RequestPath requestPath = getRequestPath(restRequest);


### PR DESCRIPTION
This pr support:
1. for put request, if user provide LATEST for timestamp/monotonic schema dataset, we will issue a put with currentLatestVersion+1.
2. for put request, if user provide MAJOR/MINOR/PATCH for semantic schema dataset, we will issue a put with major/minor/patch version +1 depend on different option.
3. for get request, when user provide LATEST, will return the currentLatest dataset version.