### PR TITLE
Remove swapped host from container stats database

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/accountstats/AccountStatsStore.java
+++ b/ambry-api/src/main/java/com/github/ambry/accountstats/AccountStatsStore.java
@@ -17,6 +17,8 @@ import com.github.ambry.server.HostAccountStorageStatsWrapper;
 import com.github.ambry.server.HostPartitionClassStorageStatsWrapper;
 import com.github.ambry.server.storagestats.AggregatedAccountStorageStats;
 import com.github.ambry.server.storagestats.AggregatedPartitionClassStorageStats;
+import com.github.ambry.utils.Pair;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -83,6 +85,14 @@ public interface AccountStatsStore {
    * @throws Exception
    */
   AggregatedAccountStorageStats queryMonthlyAggregatedAccountStorageStats() throws Exception;
+
+  /**
+   * Retain the host account storage stats for the given list of host and port, and remove the account storage stats for
+   * the other hosts.
+   * @param hosts The list of host and port pair
+   * @throws Exception
+   */
+  void retainHostAccountStorageStatsForHosts(List<Pair<String, Integer>> hosts) throws Exception;
 
   /**
    * Return the month value of the current container storage snapshot.

--- a/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
@@ -37,6 +37,8 @@ public class ClusterMapConfig {
       "clustermap.enable.delete.invalid.data.in.mysql.aggregation.task";
   public static final String ENABLE_AGGREGATED_MONTHLY_ACCOUNT_REPORT =
       "clustermap.enable.aggregated.monthly.account.report";
+  public static final String DELETE_INVALID_HOSTS_IN_MYSQL_AGGREGATION_TASK_POSSIBILITY =
+      "clustermap.delete.invalid.hosts.in.mysql.aggregation.task.possibility";
   private static final String MAX_REPLICAS_ALL_DATACENTERS = "max-replicas-all-datacenters";
 
   /**
@@ -329,6 +331,15 @@ public class ClusterMapConfig {
   @Default("false")
   public final boolean clustermapEnableDeleteInvalidDataInMysqlAggregationTask;
 
+  /**
+   * The possibility to delete invalid hosts in mysql aggregation tasks. It should be a value between 0 and 1.
+   * When it's 0, it means we are never going to delete invalid hosts in the aggregation task. When it's 1, it
+   * means every time we run an aggregation task, we will try to delete the invalid hosts.
+   */
+  @Config(DELETE_INVALID_HOSTS_IN_MYSQL_AGGREGATION_TASK_POSSIBILITY)
+  @Default("0.01")
+  public final float clustermapDeleteInvalidHostsInMysqlAggregationTaskPossibility;
+
   public ClusterMapConfig(VerifiableProperties verifiableProperties) {
     clusterMapFixedTimeoutDatanodeErrorThreshold =
         verifiableProperties.getIntInRange("clustermap.fixedtimeout.datanode.error.threshold", 3, 1, 100);
@@ -397,6 +408,8 @@ public class ClusterMapConfig {
         verifiableProperties.getBoolean(ENABLE_AGGREGATED_MONTHLY_ACCOUNT_REPORT, false);
     clustermapEnableDeleteInvalidDataInMysqlAggregationTask =
         verifiableProperties.getBoolean(ENABLE_DELETE_INVALID_DATA_IN_MYSQL_AGGREGATION_TASK, false);
+    clustermapDeleteInvalidHostsInMysqlAggregationTaskPossibility =
+        verifiableProperties.getFloatInRange(DELETE_INVALID_HOSTS_IN_MYSQL_AGGREGATION_TASK_POSSIBILITY, 0.01f, 0f, 1f);
     clusterMapAggregatedViewClusterName = verifiableProperties.getString(CLUSTERMAP_AGGREGATED_VIEW_CLUSTER_NAME, "");
     clusterMapUseAggregatedView = verifiableProperties.getBoolean(CLUSTERMAP_USE_AGGREGATED_VIEW, false);
   }

--- a/ambry-mysql/src/main/java/com/github/ambry/accountstats/InmemoryAccountStatsStore.java
+++ b/ambry-mysql/src/main/java/com/github/ambry/accountstats/InmemoryAccountStatsStore.java
@@ -17,6 +17,8 @@ import com.github.ambry.server.HostAccountStorageStatsWrapper;
 import com.github.ambry.server.HostPartitionClassStorageStatsWrapper;
 import com.github.ambry.server.storagestats.AggregatedAccountStorageStats;
 import com.github.ambry.server.storagestats.AggregatedPartitionClassStorageStats;
+import com.github.ambry.utils.Pair;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -87,6 +89,11 @@ public class InmemoryAccountStatsStore implements AccountStatsStore {
   @Override
   public AggregatedAccountStorageStats queryMonthlyAggregatedAccountStorageStats() throws Exception {
     return monthlyAggregatedAccountStats;
+  }
+
+  @Override
+  public void retainHostAccountStorageStatsForHosts(List<Pair<String, Integer>> hosts) throws Exception {
+
   }
 
   @Override

--- a/ambry-utils/src/main/java/com/github/ambry/utils/Pair.java
+++ b/ambry-utils/src/main/java/com/github/ambry/utils/Pair.java
@@ -27,6 +27,18 @@ public class Pair<A, B> {
   private final B second;
 
   /**
+   * Return a pair of objects.
+   * @param first The first element in the pair.
+   * @param second The second element in the pair.
+   * @param <A> The type of the first element
+   * @param <B> The type fo the second element
+   * @return A pair of objects.
+   */
+  public static <A, B> Pair<A, B> of(A first, B second) {
+    return new Pair<A, B>(first, second);
+  }
+
+  /**
    * Construct a pair from two objects.
    * @param first the first object in the pair.
    * @param second the second object in the pair.


### PR DESCRIPTION
This PR would try to remove the swapped hosts from the container stats database and save some disk space for the database.

This is an time consuming operation, but host swap won't happen that often. So I put a possibility check for this operation. Only a random value is less than the possibility we provide in the configuration file should we clean up the swapped hosts. 