### PR TITLE
[Efficient Metadata Operations] Add reserved metadata id in the blob properties.

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/messageformat/BlobProperties.java
+++ b/ambry-api/src/main/java/com/github/ambry/messageformat/BlobProperties.java
@@ -37,6 +37,7 @@ public class BlobProperties {
   private long timeToLiveInSeconds;
   // Non persistent blob properties.
   private final String externalAssetTag;
+  private final String reservedMetadataBlobId;
 
   /**
    * @param blobSize The size of the blob in bytes
@@ -47,7 +48,7 @@ public class BlobProperties {
    */
   public BlobProperties(long blobSize, String serviceId, short accountId, short containerId, boolean isEncrypted) {
     this(blobSize, serviceId, null, null, false, Utils.Infinite_Time, SystemTime.getInstance().milliseconds(),
-        accountId, containerId, isEncrypted, null, null, null);
+        accountId, containerId, isEncrypted, null, null, null, null);
   }
 
   /**
@@ -61,7 +62,7 @@ public class BlobProperties {
   public BlobProperties(long blobSize, String serviceId, short accountId, short containerId, boolean isEncrypted,
       long creationTimeInMs) {
     this(blobSize, serviceId, null, null, false, Utils.Infinite_Time, creationTimeInMs, accountId, containerId,
-        isEncrypted, null, null, null);
+        isEncrypted, null, null, null, null);
   }
 
   /**
@@ -83,7 +84,30 @@ public class BlobProperties {
       String contentEncoding, String filename) {
     this(blobSize, serviceId, ownerId, contentType, isPrivate, timeToLiveInSeconds,
         SystemTime.getInstance().milliseconds(), accountId, containerId, isEncrypted, externalAssetTag, contentEncoding,
-        filename);
+        filename, null);
+  }
+
+  /**
+   * @param blobSize The size of the blob in bytes
+   * @param serviceId The service id that is creating this blob
+   * @param ownerId The owner of the blob (For example , memberId or groupId)
+   * @param contentType The content type of the blob (eg: mime). Can be Null
+   * @param isPrivate Is the blob secure
+   * @param timeToLiveInSeconds The time to live, in seconds, relative to blob creation time.
+   * @param accountId accountId of the user who owns the blob
+   * @param containerId containerId of the blob
+   * @param isEncrypted whether this blob is encrypted.
+   * @param externalAssetTag externalAssetTag for this blob. This is a non-persistent field.
+   * @param contentEncoding the field to identify if the blob is compressed.
+   * @param reservedMetadataBlobId the reserved metadata blob id for chunked uploads or stitched blobs. Can be {@code null}.
+   * @param filename the name of the file.
+   */
+  public BlobProperties(long blobSize, String serviceId, String ownerId, String contentType, boolean isPrivate,
+      long timeToLiveInSeconds, short accountId, short containerId, boolean isEncrypted, String externalAssetTag,
+      String contentEncoding, String filename, String reservedMetadataBlobId) {
+    this(blobSize, serviceId, ownerId, contentType, isPrivate, timeToLiveInSeconds,
+        SystemTime.getInstance().milliseconds(), accountId, containerId, isEncrypted, externalAssetTag, contentEncoding,
+        filename, reservedMetadataBlobId);
   }
 
   /**
@@ -100,10 +124,11 @@ public class BlobProperties {
    * @param externalAssetTag externalAssetTag for this blob. This is a non-persistent field.
    * @param contentEncoding the field to identify if the blob is compressed.
    * @param filename the name of the file.
+   * @param reservedMetadataBlobId the reserved metadata blob id for chunked uploads or stitched blobs. Can be {@code null}.
    */
   public BlobProperties(long blobSize, String serviceId, String ownerId, String contentType, boolean isPrivate,
       long timeToLiveInSeconds, long creationTimeInMs, short accountId, short containerId, boolean isEncrypted,
-      String externalAssetTag, String contentEncoding, String filename) {
+      String externalAssetTag, String contentEncoding, String filename, String reservedMetadataBlobId) {
     this.blobSize = blobSize;
     this.serviceId = serviceId;
     this.ownerId = ownerId;
@@ -117,6 +142,7 @@ public class BlobProperties {
     this.externalAssetTag = externalAssetTag;
     this.contentEncoding = contentEncoding;
     this.filename = filename;
+    this.reservedMetadataBlobId = reservedMetadataBlobId;
   }
 
   /**
@@ -126,7 +152,7 @@ public class BlobProperties {
   public BlobProperties(BlobProperties other) {
     this(other.blobSize, other.serviceId, other.ownerId, other.contentType, other.isPrivate, other.timeToLiveInSeconds,
         other.creationTimeInMs, other.accountId, other.containerId, other.isEncrypted, other.externalAssetTag,
-        other.contentEncoding, other.filename);
+        other.contentEncoding, other.filename, other.reservedMetadataBlobId);
   }
 
   public long getTimeToLiveInSeconds() {
@@ -194,6 +220,13 @@ public class BlobProperties {
   }
 
   /**
+   * @return the reserved metadata blob id for chunked uploads or stitched blobs. Can be {@code null}.
+   */
+  public String getReservedMetadataBlobId() {
+    return reservedMetadataBlobId;
+  }
+
+  /**
    * @param timeToLiveInSeconds the new value of timeToLiveInSeconds
    */
   public void setTimeToLiveInSeconds(long timeToLiveInSeconds) {
@@ -228,6 +261,9 @@ public class BlobProperties {
     sb.append(", ").append("externalAssetTag=").append(getExternalAssetTag());
     sb.append(", ").append("ContentEncoding=").append(getContentEncoding());
     sb.append(", ").append("Filename=").append(getFilename());
+    sb.append(", ")
+        .append("ReservedMetadataBlobId=")
+        .append(nullOrEmptry(getReservedMetadataBlobId())? "null" : getReservedMetadataBlobId());
     sb.append("]");
     return sb.toString();
   }
@@ -246,7 +282,7 @@ public class BlobProperties {
         && timeToLiveInSeconds == that.timeToLiveInSeconds && Objects.equals(serviceId, that.serviceId)
         && Objects.equals(ownerId, that.ownerId) && Objects.equals(contentType, that.contentType) && Objects.equals(
         contentEncoding, that.contentEncoding) && Objects.equals(filename, that.filename) && Objects.equals(
-        externalAssetTag, that.externalAssetTag);
+        externalAssetTag, that.externalAssetTag) && Objects.equals(reservedMetadataBlobId, that.reservedMetadataBlobId);
   }
 
   /**
@@ -283,6 +319,7 @@ public class BlobProperties {
         && (Objects.equals(contentType, that.contentType) || (nullOrEmptry(contentType) && nullOrEmptry(that.contentType)))
         && Objects.equals(contentEncoding, that.contentEncoding)
         && Objects.equals(filename, that.filename)
-        && Objects.equals(externalAssetTag, that.externalAssetTag);
+        && Objects.equals(externalAssetTag, that.externalAssetTag)
+        && Objects.equals(reservedMetadataBlobId, that.reservedMetadataBlobId);
   }
 }

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/NamedBlobPutHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/NamedBlobPutHandlerTest.java
@@ -490,7 +490,7 @@ public class NamedBlobPutHandlerTest {
       BlobProperties blobProperties =
           new BlobProperties(-1, SERVICE_ID, OWNER_ID, CONTENT_TYPE, !container.isCacheable(), blobTtlSecs,
               creationTimeMs, container.getParentAccountId(), container.getId(), container.isEncrypted(), null, null,
-              null);
+              null, null);
       String blobId =
           router.putBlob(blobProperties, null, new ByteBufferReadableStreamChannel(ByteBuffer.wrap(content)),
               new PutBlobOptionsBuilder().chunkUpload(true).build()).get(TIMEOUT_SECS, TimeUnit.SECONDS);

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/PostBlobHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/PostBlobHandlerTest.java
@@ -463,7 +463,7 @@ public class PostBlobHandlerTest {
       BlobProperties blobProperties =
           new BlobProperties(-1, SERVICE_ID, OWNER_ID, CONTENT_TYPE, !container.isCacheable(), blobTtlSecs,
               creationTimeMs, container.getParentAccountId(), container.getId(), container.isEncrypted(), null, null,
-              null);
+              null, null);
       String blobId =
           router.putBlob(blobProperties, null, new ByteBufferReadableStreamChannel(ByteBuffer.wrap(content)),
               new PutBlobOptionsBuilder().chunkUpload(true).build()).get(TIMEOUT_SECS, TimeUnit.SECONDS);

--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/BlobPropertiesSerDe.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/BlobPropertiesSerDe.java
@@ -65,7 +65,7 @@ public class BlobPropertiesSerDe {
     String contentEncoding = version > VERSION_3 ? Utils.readNullableIntString(stream) : null;
     String filename = version > VERSION_3 ? Utils.readNullableIntString(stream) : null;
     return new BlobProperties(blobSize, serviceId, ownerId, contentType, isPrivate, ttl, creationTime, accountId,
-        containerId, isEncrypted, null, contentEncoding, filename);
+        containerId, isEncrypted, null, contentEncoding, filename, null);
   }
 
   /**

--- a/ambry-replication/src/main/java/com/github/ambry/replication/BlobIdTransformer.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/BlobIdTransformer.java
@@ -251,7 +251,7 @@ public class BlobIdTransformer implements Transformer {
               oldProperties.getContentType(), oldProperties.isPrivate(), oldProperties.getTimeToLiveInSeconds(),
               oldProperties.getCreationTimeInMs(), newBlobId.getAccountId(), newBlobId.getContainerId(),
               oldProperties.isEncrypted(), oldProperties.getExternalAssetTag(), oldProperties.getContentEncoding(),
-              oldProperties.getFilename());
+              oldProperties.getFilename(), oldProperties.getReservedMetadataBlobId());
 
       // BlobIDTransformer only exists on ambry-server and replication between servers is relying on blocking channel
       // which is still using java ByteBuffer. So, no need to consider releasing stuff.

--- a/ambry-replication/src/test/java/com/github/ambry/replication/BlobIdTransformerTest.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/BlobIdTransformerTest.java
@@ -527,7 +527,7 @@ public class BlobIdTransformerTest {
       MessageInfo messageInfo;
       BlobProperties blobProperties =
           new BlobProperties(blobPropertiesSize, "serviceId", "ownerId", "contentType", false, 0, 0,
-              blobId.getAccountId(), blobId.getContainerId(), hasEncryption, null, "gzip", "filename");
+              blobId.getAccountId(), blobId.getContainerId(), hasEncryption, null, "gzip", "filename", null);
       if (clazz != null) {
         MessageFormatInputStream messageFormatInputStream;
         if (clazz == PutMessageFormatInputStream.class) {

--- a/ambry-replication/src/test/java/com/github/ambry/replication/ReplicationTestHelper.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/ReplicationTestHelper.java
@@ -949,7 +949,7 @@ public class ReplicationTestHelper {
     blobIdRandom.nextBytes(usermetadata);
     BlobProperties blobProperties =
         new BlobProperties(blobSize, "test", null, null, false, EXPIRY_TIME_MS - CONSTANT_TIME_MS, CONSTANT_TIME_MS,
-            accountId, containerId, encryptionKey != null, null, null, null);
+            accountId, containerId, encryptionKey != null, null, null, null, null);
     MessageFormatInputStream stream =
         new PutMessageFormatInputStream(id, encryptionKey == null ? null : ByteBuffer.wrap(encryptionKey),
             blobProperties, ByteBuffer.wrap(usermetadata), new ByteBufferInputStream(ByteBuffer.wrap(blob)), blobSize,

--- a/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
@@ -1218,13 +1218,14 @@ class PutOperation {
                 passedInBlobProperties.getAccountId(), passedInBlobProperties.getContainerId(), partitionId,
                 passedInBlobProperties.isEncrypted(), blobDataType);
 
+        // TODO: Efficient Metadata Operations: The reserved metadata blob id needs to be passed as chunk properties.
         chunkBlobProperties = new BlobProperties(chunkBlobSize, passedInBlobProperties.getServiceId(),
             passedInBlobProperties.getOwnerId(), passedInBlobProperties.getContentType(),
             passedInBlobProperties.isPrivate(), passedInBlobProperties.getTimeToLiveInSeconds(),
             passedInBlobProperties.getCreationTimeInMs(), passedInBlobProperties.getAccountId(),
             passedInBlobProperties.getContainerId(), passedInBlobProperties.isEncrypted(),
             passedInBlobProperties.getExternalAssetTag(), passedInBlobProperties.getContentEncoding(),
-            passedInBlobProperties.getFilename());
+            passedInBlobProperties.getFilename(), null);
         operationTracker = getOperationTracker();
         correlationIdToChunkPutRequestInfo.clear();
         logger.trace("{}: Chunk {} is ready for sending out to server", loggingContext, chunkIndex);
@@ -1881,7 +1882,7 @@ class PutOperation {
               passedInBlobProperties.getTimeToLiveInSeconds(), passedInBlobProperties.getCreationTimeInMs(),
               passedInBlobProperties.getAccountId(), passedInBlobProperties.getContainerId(),
               passedInBlobProperties.isEncrypted(), passedInBlobProperties.getExternalAssetTag(),
-              passedInBlobProperties.getContentEncoding(), passedInBlobProperties.getFilename());
+              passedInBlobProperties.getContentEncoding(), passedInBlobProperties.getFilename(), null);
       if (isStitchOperation() || getNumDataChunks() > 1) {
         ByteBuffer serialized = null;
         // values returned are in the right order as TreeMap returns them in key-order.

--- a/ambry-server/src/integration-test/java/com/github/ambry/server/ServerTestUtil.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/ServerTestUtil.java
@@ -223,7 +223,7 @@ final class ServerTestUtil {
       // put blob 2 with an expiry time and apply TTL update later
       BlobProperties propertiesForTtlUpdate =
           new BlobProperties(31870, "serviceid1", "ownerid", "image/png", false, TestUtils.TTL_SECS,
-              cluster.time.milliseconds(), accountId, containerId, testEncryption, null, null, null);
+              cluster.time.milliseconds(), accountId, containerId, testEncryption, null, null, null, null);
       long ttlUpdateBlobExpiryTimeMs = getExpiryTimeMs(propertiesForTtlUpdate);
       PutRequest putRequest2 =
           new PutRequest(1, "client1", blobId2, propertiesForTtlUpdate, ByteBuffer.wrap(userMetadata),
@@ -245,7 +245,7 @@ final class ServerTestUtil {
       // put blob 4 that is expired
       BlobProperties propertiesExpired =
           new BlobProperties(31870, "serviceid1", "ownerid", "jpeg", false, 0, cluster.time.milliseconds(), accountId,
-              containerId, testEncryption, null, null, null);
+              containerId, testEncryption, null, null, null, null);
       PutRequest putRequest4 = new PutRequest(1, "client1", blobId4, propertiesExpired, ByteBuffer.wrap(userMetadata),
           Unpooled.wrappedBuffer(data), properties.getBlobSize(), BlobType.DataBlob,
           testEncryption ? ByteBuffer.wrap(encryptionKey) : null);
@@ -803,7 +803,7 @@ final class ServerTestUtil {
     long ttl = doTtlUpdate ? TimeUnit.DAYS.toMillis(1) : Utils.Infinite_Time;
     BlobProperties properties =
         new BlobProperties(blobSize, "serviceid1", null, null, false, ttl, cluster.time.milliseconds(), accountId,
-            containerId, false, null, null, null);
+            containerId, false, null, null, null, null);
     TestUtils.RANDOM.nextBytes(userMetadata);
     TestUtils.RANDOM.nextBytes(data);
 
@@ -879,7 +879,7 @@ final class ServerTestUtil {
     short containerId = Utils.getRandomShort(TestUtils.RANDOM);
     BlobProperties properties =
         new BlobProperties(100, "serviceid1", null, null, false, TestUtils.TTL_SECS, cluster.time.milliseconds(),
-            accountId, containerId, false, null, null, null);
+            accountId, containerId, false, null, null, null, null);
     long expectedExpiryTimeMs = getExpiryTimeMs(properties);
     TestUtils.RANDOM.nextBytes(usermetadata);
     TestUtils.RANDOM.nextBytes(data);
@@ -1559,7 +1559,7 @@ final class ServerTestUtil {
       int size = new Random().nextInt(5000);
       final BlobProperties properties =
           new BlobProperties(size, "service1", "owner id check", "image/jpeg", false, TestUtils.TTL_SECS,
-              cluster.time.milliseconds(), accountId, containerId, false, null, null, null);
+              cluster.time.milliseconds(), accountId, containerId, false, null, null, null, null);
       final byte[] metadata = new byte[new Random().nextInt(1000)];
       final byte[] blob = new byte[size];
       TestUtils.RANDOM.nextBytes(metadata);
@@ -1748,7 +1748,7 @@ final class ServerTestUtil {
         short containerId = Utils.getRandomShort(TestUtils.RANDOM);
         propertyList.add(
             new BlobProperties(1000, "serviceid1", null, null, false, TestUtils.TTL_SECS, cluster.time.milliseconds(),
-                accountId, containerId, testEncryption, null, null, null));
+                accountId, containerId, testEncryption, null, null, null, null));
         blobIdList.add(new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
             clusterMap.getLocalDatacenterId(), accountId, containerId, partition, false,
             BlobId.BlobDataType.DATACHUNK));
@@ -2514,7 +2514,7 @@ final class ServerTestUtil {
       long ttl = 24 * 60 * 60 + 5;
       BlobProperties propertiesExpired =
           new BlobProperties(31870, "serviceid1", "ownerid", "jpeg", false, ttl, cluster.time.milliseconds(), accountId,
-              containerId, false, null, null, null);
+              containerId, false, null, null, null, null);
       BlobId blobId2 = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, clusterMap.getLocalDatacenterId(),
           propertiesExpired.getAccountId(), propertiesExpired.getContainerId(), partitionIds.get(0), false,
           BlobId.BlobDataType.DATACHUNK);
@@ -2637,12 +2637,12 @@ final class ServerTestUtil {
       // property with 7days expiration
       BlobProperties propertiesWithTtl =
           new BlobProperties(dataSize, "serviceid1", "ownerid", "image/png", false, TestUtils.TTL_SECS,
-              cluster.time.milliseconds(), accountId, containerId, testEncryption, null, null, null);
+              cluster.time.milliseconds(), accountId, containerId, testEncryption, null, null, null, null);
       long ttlUpdateBlobExpiryTimeMs = getExpiryTimeMs(propertiesWithTtl);
       // property of expired blob
       BlobProperties propertiesExpired =
           new BlobProperties(dataSize, "serviceid1", "ownerid", "jpeg", false, 0, cluster.time.milliseconds(),
-              accountId, containerId, testEncryption, null, null, null);
+              accountId, containerId, testEncryption, null, null, null, null);
       // property of blob with the infinite TTL
       BlobProperties properties = new BlobProperties(dataSize, "serviceid1", accountId, containerId, testEncryption,
           cluster.time.milliseconds());
@@ -4045,7 +4045,7 @@ final class ServerTestUtil {
     byte[] data = new byte[blobSize];
     BlobProperties blobProperties =
         new BlobProperties(blobSize, "serviceid1", null, null, false, Utils.Infinite_Time, accountId, containerId,
-            false, null, null, null);
+            false, null, null, null, null);
     TestUtils.RANDOM.nextBytes(data);
     blobIdToSizeMap.put(blobId, blobSize);
     return new PutMessageFormatInputStream(blobId, null, blobProperties, ByteBuffer.wrap(userMetadata),

--- a/ambry-server/src/integration-test/java/com/github/ambry/server/Verifier.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/Verifier.java
@@ -262,7 +262,7 @@ class Verifier implements Runnable {
                     new BlobProperties(old.getBlobSize(), old.getServiceId(), old.getOwnerId(), old.getContentType(),
                         old.isEncrypted(), Utils.Infinite_Time, old.getCreationTimeInMs(), old.getAccountId(),
                         old.getContainerId(), old.isEncrypted(), old.getExternalAssetTag(), old.getContentEncoding(),
-                        old.getFilename());
+                        old.getFilename(), old.getReservedMetadataBlobId());
               }
             } catch (Exception e) {
               if (channel1 != null) {

--- a/ambry-test-utils/src/main/java/com/github/ambry/router/InMemoryRouter.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/router/InMemoryRouter.java
@@ -129,7 +129,7 @@ public class InMemoryRouter implements Router {
               blobProperties.getContentType(), blobProperties.isPrivate(), blobProperties.getTimeToLiveInSeconds(),
               blobProperties.getCreationTimeInMs(), blobProperties.getAccountId(), blobProperties.getContainerId(),
               blobProperties.isEncrypted(), blobProperties.getExternalAssetTag(), blobProperties.getContentEncoding(),
-              blobProperties.getFilename());
+              blobProperties.getFilename(), blobProperties.getReservedMetadataBlobId());
       this.userMetadata = userMetadata;
       this.blob = blob;
       this.stitchedChunks = stitchedChunks;


### PR DESCRIPTION
The reserved metadata id in blob properties will be used to save the parent anchor of the data chunks in the server and to pass the reserved metadata id in case of chunked and stitched requests.

Note that the only significant change in this PR is that it adds a field "reservedMetadataBlobId" in the BlobProperties class and updates its constructors. All other changes are just to update the constructor arguments in other places.