### PR TITLE
[Efficient Metadata Operations] Create a metric to track the number of successful metadata chunks being put.

### DIFF
--- a/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterMetrics.java
@@ -232,6 +232,7 @@ public class NonBlockingRouterMetrics {
   public final Counter failedMaybeDueToOriginatingDcOfflineReplicasCount;
   public final Counter failedMaybeDueToTotalOfflineReplicasCount;
   public final Counter failedMaybeDueToUnavailableReplicasCount;
+  public final Counter metadataChunkCreationCount;
 
   // Workload characteristics
   public final AgeAtAccessMetrics ageAtGet;
@@ -577,6 +578,8 @@ public class NonBlockingRouterMetrics {
         MetricRegistry.name(SimpleOperationTracker.class, "FailedMaybeDueToOriginatingDcOfflineReplicasCount"));
     failedMaybeDueToUnavailableReplicasCount = metricRegistry.counter(
         MetricRegistry.name(SimpleOperationTracker.class, "FailedMaybeDueToUnavailableReplicasCount"));
+    metadataChunkCreationCount = metricRegistry.counter(
+        MetricRegistry.name(PutOperation.class, "MetadataChunkCreationCount"));
 
     // Workload
     ageAtGet = new AgeAtAccessMetrics(metricRegistry, "OnGet");

--- a/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
@@ -1463,6 +1463,10 @@ class PutOperation {
                 quotaException.toString());
           }
         }
+        if(this instanceof MetadataPutChunk && chunkException == null) {
+          // if this is a metadata chunk, and it was successful then increment the count of metadata chunk creation.
+          routerMetrics.metadataChunkCreationCount.inc();
+        }
         state = ChunkState.Complete;
       }
     }

--- a/ambry-router/src/test/java/com/github/ambry/router/PutManagerTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/PutManagerTest.java
@@ -192,6 +192,8 @@ public class PutManagerTest {
       // since the puts are processed one at a time, it is fair to check the last partition class set
       checkLastRequestPartitionClasses(1, MockClusterMap.DEFAULT_PARTITION_CLASS);
     }
+    Assert.assertEquals("Metrics should show no creation of metadata chunk", 0,
+        metrics.metadataChunkCreationCount.getCount());
   }
 
   /**
@@ -209,6 +211,8 @@ public class PutManagerTest {
       // one extra call if there is a metadata blob
       checkLastRequestPartitionClasses(i == 1 ? 1 : i + 1, MockClusterMap.DEFAULT_PARTITION_CLASS);
     }
+    Assert.assertEquals("Metrics should show creation of metadata chunk", 1,
+        metrics.metadataChunkCreationCount.getCount());
   }
 
   /**
@@ -224,6 +228,8 @@ public class PutManagerTest {
       // since the puts are processed one "large" blob at a time, it is fair to check the last partition classes set
       checkLastRequestPartitionClasses(i + 2, MockClusterMap.DEFAULT_PARTITION_CLASS);
     }
+    Assert.assertEquals("Metrics should show creation of metadata chunk", 1,
+        metrics.metadataChunkCreationCount.getCount());
   }
 
   /**
@@ -245,6 +251,7 @@ public class PutManagerTest {
         new RequestAndResult(chunkSize + 1, null, new PutBlobOptionsBuilder().maxUploadSize(2 * chunkSize - 1).build(),
             null));
     runTest.accept(new RequestAndResult(0, null, new PutBlobOptionsBuilder().maxUploadSize(0).build(), null));
+    Assert.assertEquals(0, metrics.metadataChunkCreationCount.getCount());
   }
 
   /**
@@ -314,6 +321,8 @@ public class PutManagerTest {
       runTest.accept(RouterTestHelpers.buildChunkList(mockClusterMap, BlobDataType.DATACHUNK, Utils.Infinite_Time,
           LongStream.of(200, 201)));
     }
+    Assert.assertEquals("Metrics should show creation of metadata chunk", 1,
+        metrics.metadataChunkCreationCount.getCount());
   }
 
   /**

--- a/ambry-router/src/test/java/com/github/ambry/router/PutOperationTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/PutOperationTest.java
@@ -218,6 +218,8 @@ public class PutOperationTest {
     responseInfo.release();
     requestInfos.forEach(info -> info.getRequest().release());
     Assert.assertTrue("Operation should be complete at this time", op.isOperationComplete());
+    Assert.assertEquals("Metrics should show creation of metadata chunk", 1,
+        routerMetrics.metadataChunkCreationCount.getCount());
   }
 
   /**
@@ -303,6 +305,9 @@ public class PutOperationTest {
     Assert.assertEquals("Failure count should be 1", 1,
         ((SimpleOperationTracker) putChunk.getOperationTrackerInUse()).getFailedCount());
     mockServer.resetServerErrors();
+    Assert.assertEquals("Metrics should show no metadata chunk was created", 0,
+        routerMetrics.metadataChunkCreationCount.getCount());
+
     // Release all the other requests
     requestInfos.forEach(info -> info.getRequest().release());
   }
@@ -353,6 +358,8 @@ public class PutOperationTest {
     responseInfo.release();
     Assert.assertTrue(op.isOperationComplete());
     Assert.assertEquals(RouterErrorCode.TooManyRequests, ((RouterException)op.getOperationException()).getErrorCode());
+    Assert.assertEquals("Metrics should show no metadata chunk was created", 0,
+        routerMetrics.metadataChunkCreationCount.getCount());
   }
 
   /**
@@ -496,6 +503,8 @@ public class PutOperationTest {
     op.setOperationExceptionAndComplete(new RouterException("RouterError", RouterErrorCode.InsufficientCapacity));
     Assert.assertEquals(((RouterException) op.getOperationException()).getErrorCode(),
         RouterErrorCode.InsufficientCapacity);
+    Assert.assertEquals("Metrics should show no metadata chunk was created", 0,
+        routerMetrics.metadataChunkCreationCount.getCount());
   }
 
   /**


### PR DESCRIPTION
This will help show the amount of data being uploaded for metadata chunks.