### PR TITLE
Add a new callback method to ClusterMapChangeListener

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/clustermap/ClusterMapChangeListener.java
+++ b/ambry-api/src/main/java/com/github/ambry/clustermap/ClusterMapChangeListener.java
@@ -28,6 +28,13 @@ public interface ClusterMapChangeListener {
   void onReplicaAddedOrRemoved(List<ReplicaId> addedReplicas, List<ReplicaId> removedReplicas);
 
   /**
+   * Take actions when a data node is removed from the clustermap
+   * @param removedDataNode {@link DataNodeId} that has been removed
+   */
+  default void onDataNodeRemoved(DataNodeId removedDataNode) {
+  }
+
+  /**
    * Take actions when there is a routing table update. This is triggered whenever there is any change to state of a replicas in the cluster.
    * On this trigger, we can look up the latest states of all the replicas from the routing table snapshot {@link org.apache.helix.spectator.RoutingTableSnapshot}
    * with the help of various APIs provided in its class.

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
@@ -1170,6 +1170,9 @@ public class HelixClusterManager implements ClusterMap {
               listener.onReplicaAddedOrRemoved(Collections.emptyList(), removedReplicas);
             }
           }
+          for (ClusterMapChangeListener listener : clusterMapChangeListeners) {
+            listener.onDataNodeRemoved(datanode);
+          }
           logger.info("Removed {} and its {} replicas from cluster map", instanceName, removedReplicas.size());
           // Since the replicas on deleted hosts could be sealed, increase the sealed change counter so that latest
           // partition state (RO or RW) is queried again in AmbryPartition#resolvePartitionState().

--- a/ambry-server/src/integration-test/java/com/github/ambry/server/StatsManagerIntegrationTest.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/StatsManagerIntegrationTest.java
@@ -67,6 +67,7 @@ public class StatsManagerIntegrationTest {
   private final AccountStatsMySqlStore accountStatsMySqlStore;
   private final HostAccountStorageStats hostAccountStorageStats;
   private final HostPartitionClassStorageStats hostPartitionClassStorageStats;
+  private final MockClusterMap mockClusterMap;
   private final StatsManager statsManager;
   private final List<ReplicaId> replicas = new ArrayList<>();
   private final Map<PartitionId, Store> storeMap = new HashMap<>();
@@ -90,15 +91,16 @@ public class StatsManagerIntegrationTest {
       PartitionId partitionId =
           new MockPartitionId(i, partitionClassName, Collections.singletonList((MockDataNodeId) dataNodeId), 0);
       StoreStats storeStats =
-          new StatsManagerTest.MockStoreStats(hostAccountStorageStats.getStorageStats().get((long)i), false, null);
+          new StatsManagerTest.MockStoreStats(hostAccountStorageStats.getStorageStats().get((long) i), false, null);
       storeMap.put(partitionId, new StatsManagerTest.MockStore(storeStats));
       replicas.add(partitionId.getReplicaIds().get(0));
       hostPartitionClassStorageStatsMap.computeIfAbsent(partitionClassName, k -> new HashMap<>())
-          .put((long) i, hostAccountStorageStats.getStorageStats().get((long)i));
+          .put((long) i, hostAccountStorageStats.getStorageStats().get((long) i));
     }
     hostPartitionClassStorageStats = new HostPartitionClassStorageStats(hostPartitionClassStorageStatsMap);
     StorageManager storageManager = new MockStorageManager(storeMap, dataNodeId);
-    statsManager = new StatsManager(storageManager, replicas, new MetricRegistry(),
+    mockClusterMap = new MockClusterMap();
+    statsManager = new StatsManager(storageManager, mockClusterMap, replicas, new MetricRegistry(),
         new StatsManagerConfig(new VerifiableProperties(properties)), new MockTime(), null, null,
         new InMemAccountService(false, false));
   }

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryServer.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryServer.java
@@ -277,8 +277,9 @@ public class AmbryServer {
       accountStatsMySqlStore =
           statsConfig.enableMysqlReport ? (AccountStatsMySqlStore) new AccountStatsMySqlStoreFactory(properties,
               clusterMapConfig, registry).getAccountStatsStore() : null;
-      statsManager = new StatsManager(storageManager, clusterMap.getReplicaIds(nodeId), registry, statsConfig, time,
-          clusterParticipants.get(0), accountStatsMySqlStore, accountService);
+      statsManager =
+          new StatsManager(storageManager, clusterMap, clusterMap.getReplicaIds(nodeId), registry, statsConfig, time,
+              clusterParticipants.get(0), accountStatsMySqlStore, accountService);
       statsManager.start();
 
       ArrayList<Port> ports = new ArrayList<Port>();

--- a/ambry-server/src/test/java/com/github/ambry/server/AmbryServerRequestsTest.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/AmbryServerRequestsTest.java
@@ -194,9 +194,8 @@ public class AmbryServerRequestsTest extends ReplicationTestHelper {
     replicationManager =
         MockReplicationManager.getReplicationManager(verifiableProperties, storageManager, clusterMap, dataNodeId,
             storeKeyConverterFactory);
-    statsManager =
-        new MockStatsManager(storageManager, clusterMap.getReplicaIds(dataNodeId), clusterMap.getMetricRegistry(),
-            statsManagerConfig, null);
+    statsManager = new MockStatsManager(storageManager, clusterMap, clusterMap.getReplicaIds(dataNodeId),
+        clusterMap.getMetricRegistry(), statsManagerConfig, null);
     serverMetrics = new ServerMetrics(clusterMap.getMetricRegistry(), AmbryRequests.class, AmbryServer.class);
     requestResponseChannel = new MockRequestResponseChannel(new NetworkConfig(verifiableProperties));
     ambryRequests = new AmbryServerRequests(storageManager, requestResponseChannel, clusterMap, dataNodeId,

--- a/ambry-server/src/test/java/com/github/ambry/server/MockStatsManager.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/MockStatsManager.java
@@ -15,6 +15,7 @@ package com.github.ambry.server;
 
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.account.InMemAccountService;
+import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.ClusterParticipant;
 import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.config.StatsManagerConfig;
@@ -29,10 +30,10 @@ import java.util.List;
 class MockStatsManager extends StatsManager {
   Boolean returnValOfAddReplica = null;
 
-  MockStatsManager(StorageManager storageManager, List<? extends ReplicaId> replicaIds, MetricRegistry metricRegistry,
-      StatsManagerConfig statsManagerConfig, ClusterParticipant clusterParticipant) {
-    super(storageManager, replicaIds, metricRegistry, statsManagerConfig, new MockTime(), clusterParticipant, null,
-        new InMemAccountService(false, false));
+  MockStatsManager(StorageManager storageManager, ClusterMap clusterMap, List<? extends ReplicaId> replicaIds,
+      MetricRegistry metricRegistry, StatsManagerConfig statsManagerConfig, ClusterParticipant clusterParticipant) {
+    super(storageManager, clusterMap, replicaIds, metricRegistry, statsManagerConfig, new MockTime(),
+        clusterParticipant, null, new InMemAccountService(false, false));
   }
 
   @Override

--- a/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockClusterMap.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockClusterMap.java
@@ -672,6 +672,16 @@ public class MockClusterMap implements ClusterMap {
   }
 
   /**
+   * removeDataNode to invoke clustermap change listener. This method doesn't really remove the datanode.
+   * @param dataNodeId The removed data node
+   */
+  public void removeDataNode(DataNodeId dataNodeId) {
+    if (dataNodes.contains(dataNodeId) && clusterMapChangeListener != null) {
+      clusterMapChangeListener.onDataNodeRemoved(dataNodeId);
+    }
+  }
+
+  /**
    * Sets the local datacenter name and changes the views of the partition classes. Not thread safe.
    * @param localDatacenterName the name of the local datacenter
    */


### PR DESCRIPTION
Adding a new callback method to ClusterMapChangeListener for DataNode removal so other components that are interested on this events can be notified. 

Adding a empty callback to StatsManager. The real implementation will be added later.