### PR TITLE
[Efficient Metadata Operations] Reserve metadata chunkid for chunked uploads.

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/frontend/ReservedMetadataIdMetrics.java
+++ b/ambry-api/src/main/java/com/github/ambry/frontend/ReservedMetadataIdMetrics.java
@@ -33,6 +33,10 @@ public class ReservedMetadataIdMetrics {
   public final Counter noReservedMetadataFoundForChunkedUploadResponseCount;
   public final Counter noReservedMetadataForChunkedUploadCount;
   public final Counter mismatchedReservedMetadataForChunkedUploadCount;
+  public final Counter metadataIdNotReservedCount;
+  public final Counter stitchedBlobMetadataIdDeserErrorCount;
+  public final Counter stitchedBlobMetadataIdMismatchCount;
+  public final Counter reservedMetadataPassedInForNonChunkedUploadCount;
 
   /**
    * Constructor for {@link ReservedMetadataIdMetrics}.
@@ -57,6 +61,14 @@ public class ReservedMetadataIdMetrics {
         MetricRegistry.name(ReservedMetadataIdMetrics.class, "NoReservedMetadataForChunkedUploadCount"));
     mismatchedReservedMetadataForChunkedUploadCount = metricRegistry.counter(
         MetricRegistry.name(ReservedMetadataIdMetrics.class, "MismatchedReservedMetadataForChunkedUploadCount"));
+    metadataIdNotReservedCount = metricRegistry.counter(
+        MetricRegistry.name(ReservedMetadataIdMetrics.class, "MetadataIdNotReservedCount"));
+    stitchedBlobMetadataIdDeserErrorCount = metricRegistry.counter(
+        MetricRegistry.name(ReservedMetadataIdMetrics.class, "StitchedBlobMetadataIdDeserErrorCount"));
+    stitchedBlobMetadataIdMismatchCount = metricRegistry.counter(
+        MetricRegistry.name(ReservedMetadataIdMetrics.class, "StitchedBlobMetadataIdMismatchCount"));
+    reservedMetadataPassedInForNonChunkedUploadCount = metricRegistry.counter(
+        MetricRegistry.name(ReservedMetadataIdMetrics.class, "ReservedMetadataPassedInForNonChunkedUploadCount"));
   }
 
   /**

--- a/ambry-api/src/main/java/com/github/ambry/router/RouterErrorCode.java
+++ b/ambry-api/src/main/java/com/github/ambry/router/RouterErrorCode.java
@@ -32,6 +32,12 @@ public enum RouterErrorCode {
   InvalidBlobId,
 
   /**
+   * Caller passed in an invalid reserved metadata chunk id or the reserved metadata chunk id didn't match for all the
+   * chunks to stitch. May occur only for {@link Router#stitchBlob} operation or chunked uploads.
+   */
+  InvalidOrMismatchedStitchBlobReservedMetadataChunkId,
+
+  /**
    * Caller passed in an illegal argument for
    * {@link Router#putBlob(com.github.ambry.messageformat.BlobProperties, byte[], ReadableStreamChannel, PutBlobOptions)}
    * operation (and its variant).

--- a/ambry-router/src/main/java/com/github/ambry/router/PutManager.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/PutManager.java
@@ -17,6 +17,7 @@ import com.github.ambry.account.Account;
 import com.github.ambry.account.AccountService;
 import com.github.ambry.account.Container;
 import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.clustermap.ClusterMapUtils;
 import com.github.ambry.commons.ByteBufferAsyncWritableChannel;
 import com.github.ambry.commons.Callback;
 import com.github.ambry.commons.ResponseHandler;
@@ -187,15 +188,9 @@ class PutManager {
    * @return the partition class as required by the properties
    */
   private String getPartitionClass(BlobProperties blobProperties) {
-    String partitionClass = defaultPartitionClass;
     Account account = accountService.getAccountById(blobProperties.getAccountId());
-    if (account != null) {
-      Container container = account.getContainerById(blobProperties.getContainerId());
-      if (container != null && !Utils.isNullOrEmpty(container.getReplicationPolicy())) {
-        partitionClass = container.getReplicationPolicy();
-      }
-    }
-    return partitionClass;
+    return ClusterMapUtils.getPartitionClass(account,
+        account == null ? null : account.getContainerById(blobProperties.getContainerId()), defaultPartitionClass);
   }
 
   /**

--- a/ambry-router/src/test/java/com/github/ambry/router/RouterTestHelpers.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/RouterTestHelpers.java
@@ -331,6 +331,23 @@ class RouterTestHelpers {
   }
 
   /**
+   * Build chunk list from the specified params.
+   *
+   * @param clusterMap the {@link ClusterMap} for generating blob IDs.
+   * @param blobDataType the {@link BlobId.BlobDataType} field to set for the chunk blob IDs.
+   * @param ttl the TTL for the chunks.
+   * @param chunkSizeStream a stream of chunk sizes to use for the chunks in the list.
+   * @param reservedMetadataIdStr the reserved metadata id of the chunks.
+   * @return a list of {@link ChunkInfo} objects for a stitch call.
+   */
+  static List<ChunkInfo> buildChunkList(ClusterMap clusterMap, BlobId.BlobDataType blobDataType, long ttl,
+      LongStream chunkSizeStream, String reservedMetadataIdStr) {
+    return chunkSizeStream.mapToObj(
+        chunkSize -> new ChunkInfo(getRandomBlobId(clusterMap, blobDataType), chunkSize, ttl,
+            reservedMetadataIdStr)).collect(Collectors.toList());
+  }
+
+  /**
    *
    * @param clusterMap the {@link ClusterMap} for generating blob IDs.
    * @param blobDataType the {@link BlobId.BlobDataType}.


### PR DESCRIPTION
There are 4 cases to handle in order to reserve metadata chunks:

1. Reserve metadata chunk id for regular Post requests to upload a regular simple or composite blob.
2. Reserve metadata chunk id for POST signed-url requests with the "chunked-upload" header set to true. This reserved metadata id will be used for chunked uploads and the subsequent stitch blob operation.
3. For chunked uploads use the reserved metadata id encoded in the signed URL and after upload encode the reserved metadata id in the signed-id of the chunk.
4. For stitch requests use the reserved metadata id in the signed-ids of the chunks.