### PR TITLE
StatsManager: add a real listener to remove host from account stats store

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/clustermap/ClusterParticipant.java
+++ b/ambry-api/src/main/java/com/github/ambry/clustermap/ClusterParticipant.java
@@ -147,4 +147,15 @@ public interface ClusterParticipant extends AutoCloseable {
    */
   @Override
   void close();
+
+  /**
+   * Returning a {@link DistributedLock} for the given resource with the given message.
+   * @param resource The resource on which to create a distributed lock. Locks created for different resource
+   *                 should be independent of each other.
+   * @param message The message for this lock creation
+   * @return A {@link DistributedLock} created for the given resource.
+   */
+  default DistributedLock getDistributedLock(String resource, String message) {
+    return new DistributedLockLocalImpl();
+  }
 }

--- a/ambry-api/src/main/java/com/github/ambry/clustermap/DistributedLock.java
+++ b/ambry-api/src/main/java/com/github/ambry/clustermap/DistributedLock.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2023 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.clustermap;
+
+/**
+ * A distributed lock interface. Multiple hosts would use this mutually exclusive distributed lock
+ * to coordinate work so that no more than one host are execute the same job.
+ */
+public interface DistributedLock {
+  /**
+   * Try to acquire the lock.
+   * @return True if the lock is successfully acquired, false otherwise.
+   */
+  boolean tryLock();
+
+  /**
+   * Release the acquired lock. Please make sure that the lock is acquired before unlocking it.
+   */
+  void unlock();
+
+  /**
+   * Close this lock and release all the resources associated with this lock.
+   * After close, this lock can't be used any more.
+   */
+  void close();
+}

--- a/ambry-api/src/main/java/com/github/ambry/clustermap/DistributedLockLocalImpl.java
+++ b/ambry-api/src/main/java/com/github/ambry/clustermap/DistributedLockLocalImpl.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2023 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
 package com.github.ambry.clustermap;
 
 import java.util.concurrent.locks.ReentrantLock;

--- a/ambry-api/src/main/java/com/github/ambry/clustermap/DistributedLockLocalImpl.java
+++ b/ambry-api/src/main/java/com/github/ambry/clustermap/DistributedLockLocalImpl.java
@@ -1,0 +1,26 @@
+package com.github.ambry.clustermap;
+
+import java.util.concurrent.locks.ReentrantLock;
+
+
+/**
+ * A reentrant lock implementation for {@link DistributedLock}. This is a local lock that only works for one process.
+ *
+ */
+public class DistributedLockLocalImpl implements DistributedLock {
+  private final ReentrantLock lock = new ReentrantLock();
+
+  @Override
+  public boolean tryLock() {
+    return lock.tryLock();
+  }
+
+  @Override
+  public void unlock() {
+    lock.unlock();
+  }
+
+  @Override
+  public void close() {
+  }
+}

--- a/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
@@ -329,6 +329,15 @@ public class ClusterMapConfig {
   @Default("false")
   public final boolean clustermapEnableDeleteInvalidDataInMysqlAggregationTask;
 
+  public final static String DISTRIBUTED_LOCK_LEASE_TIMEOUT_IN_MS = "clustermap.distributed.lock.lease.timeout.in.ms";
+  /**
+   * The lease timeout for distributed lock. For now, the lock is only used for removing host from account stats store.
+   * This timeout should be longer than the time to do this task.
+   */
+  @Config(DISTRIBUTED_LOCK_LEASE_TIMEOUT_IN_MS)
+  @Default("60 * 1000")
+  public final long clustermapDistributedLockLeaseTimeoutInMs;
+
   public ClusterMapConfig(VerifiableProperties verifiableProperties) {
     clusterMapFixedTimeoutDatanodeErrorThreshold =
         verifiableProperties.getIntInRange("clustermap.fixedtimeout.datanode.error.threshold", 3, 1, 100);
@@ -399,5 +408,7 @@ public class ClusterMapConfig {
         verifiableProperties.getBoolean(ENABLE_DELETE_INVALID_DATA_IN_MYSQL_AGGREGATION_TASK, false);
     clusterMapAggregatedViewClusterName = verifiableProperties.getString(CLUSTERMAP_AGGREGATED_VIEW_CLUSTER_NAME, "");
     clusterMapUseAggregatedView = verifiableProperties.getBoolean(CLUSTERMAP_USE_AGGREGATED_VIEW, false);
+    clustermapDistributedLockLeaseTimeoutInMs =
+        verifiableProperties.getLong(DISTRIBUTED_LOCK_LEASE_TIMEOUT_IN_MS, 60 * 1000);
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
@@ -329,7 +329,7 @@ public class ClusterMapConfig {
   @Default("false")
   public final boolean clustermapEnableDeleteInvalidDataInMysqlAggregationTask;
 
-  public final static String DISTRIBUTED_LOCK_LEASE_TIMEOUT_IN_MS = "clustermap.distributed.lock.lease.timeout.in.ms";
+  public static final String DISTRIBUTED_LOCK_LEASE_TIMEOUT_IN_MS = "clustermap.distributed.lock.lease.timeout.in.ms";
   /**
    * The lease timeout for distributed lock. For now, the lock is only used for removing host from account stats store.
    * This timeout should be longer than the time to do this task.

--- a/ambry-api/src/main/java/com/github/ambry/config/StatsManagerConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StatsManagerConfig.java
@@ -29,6 +29,8 @@ public class StatsManagerConfig {
   public static final String STATS_PUBLISH_EXCLUDE_ACCOUNT_NAMES = "stats.publish.exclude.account.names";
   public static final String STATS_PUBLISH_PARTITION_CLASS_REPORT_PERIOD_IN_SECS =
       "stats.publish.partition.class.report.period.in.secs";
+  public static final String STATS_ENABLE_REMOVE_HOST_FROM_ACCOUNT_STATS_STORE =
+      "stats.enable.remove.host.from.account.stats.store";
 
   /**
    * True to enable publishing stats to mysql database. StatsManager is tightly coupled with mysql database for now.
@@ -69,6 +71,13 @@ public class StatsManagerConfig {
   @Default("0")
   public final long publishPartitionClassReportPeriodInSecs;
 
+  /**
+   * True to enable removal host from account stats store when the host is removed from clustermap.
+   */
+  @Config(STATS_ENABLE_REMOVE_HOST_FROM_ACCOUNT_STATS_STORE)
+  @Default("false")
+  public final boolean enableRemoveHostFromAccountStatsStore;
+
   public StatsManagerConfig(VerifiableProperties verifiableProperties) {
     publishPeriodInSecs = verifiableProperties.getLongInRange(STATS_PUBLISH_PERIOD_IN_SECS, 7200, 0, Long.MAX_VALUE);
     initialDelayUpperBoundInSecs =
@@ -79,6 +88,8 @@ public class StatsManagerConfig {
         excludeNames.isEmpty() ? Collections.EMPTY_LIST : Arrays.asList(excludeNames.split(","));
     publishPartitionClassReportPeriodInSecs =
         verifiableProperties.getLongInRange(STATS_PUBLISH_PARTITION_CLASS_REPORT_PERIOD_IN_SECS, 0, 0, Long.MAX_VALUE);
+    enableRemoveHostFromAccountStatsStore =
+        verifiableProperties.getBoolean(STATS_ENABLE_REMOVE_HOST_FROM_ACCOUNT_STATS_STORE, false);
     if (publishPartitionClassReportPeriodInSecs != 0 && !enableMysqlReport) {
       throw new IllegalStateException(
           "Bad configuration, you have to enableMysqlReport if you set a non-zero value for publishPartitionClassReportPeriodInSecs");

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
@@ -24,6 +24,7 @@ import com.github.ambry.server.AmbryStatsReport;
 import com.github.ambry.server.storagestats.AggregatedAccountStorageStats;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -37,6 +38,9 @@ import org.apache.helix.AccessOption;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixManager;
 import org.apache.helix.InstanceType;
+import org.apache.helix.lock.LockScope;
+import org.apache.helix.lock.helix.HelixLockScope;
+import org.apache.helix.lock.helix.ZKDistributedNonblockingLock;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.participant.StateMachineEngine;
 import org.apache.helix.store.HelixPropertyStore;
@@ -303,6 +307,42 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
   @Override
   public boolean supportsStateChanges() {
     return true;
+  }
+
+  @Override
+  public DistributedLock getDistributedLock(String resource, String message) {
+    LockScope distributedLockScope =
+        new HelixLockScope(HelixLockScope.LockScopeProperty.RESOURCE, Arrays.asList(clusterName, resource));
+    ZKDistributedNonblockingLock lock =
+        new ZKDistributedNonblockingLock(distributedLockScope, zkConnectStr, (long) 10 * 1000, message,
+            clusterMapConfig.clusterMapHostName);
+    return new DistributedLockImpl(lock);
+  }
+
+  /**
+   * A zookeeper based implementation for distributed lock.
+   */
+  static class DistributedLockImpl implements DistributedLock {
+    private final ZKDistributedNonblockingLock lock;
+
+    DistributedLockImpl(ZKDistributedNonblockingLock lock) {
+      this.lock = lock;
+    }
+
+    @Override
+    public boolean tryLock() {
+      return lock.tryLock();
+    }
+
+    @Override
+    public void unlock() {
+      lock.unlock();
+    }
+
+    @Override
+    public void close() {
+      lock.close();
+    }
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
@@ -313,9 +313,8 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
   public DistributedLock getDistributedLock(String resource, String message) {
     LockScope distributedLockScope =
         new HelixLockScope(HelixLockScope.LockScopeProperty.RESOURCE, Arrays.asList(clusterName, resource));
-    ZKDistributedNonblockingLock lock =
-        new ZKDistributedNonblockingLock(distributedLockScope, zkConnectStr, (long) 10 * 1000, message,
-            clusterMapConfig.clusterMapHostName);
+    ZKDistributedNonblockingLock lock = new ZKDistributedNonblockingLock(distributedLockScope, zkConnectStr,
+        clusterMapConfig.clustermapDistributedLockLeaseTimeoutInMs, message, clusterMapConfig.clusterMapHostName);
     return new DistributedLockImpl(lock);
   }
 

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipantMetrics.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipantMetrics.java
@@ -37,23 +37,23 @@ class HelixParticipantMetrics {
     this.localPartitionAndState = localPartitionAndState;
     EnumSet.complementOf(EnumSet.of(ReplicaState.DROPPED)).forEach(state -> replicaCountByState.put(state, 0));
     Gauge<Integer> bootstrapPartitionCount = () -> getReplicaCountInState(ReplicaState.BOOTSTRAP);
-    metricRegistry.register(MetricRegistry.name(HelixParticipant.class, "bootstrapPartitionCount" + zkSuffix),
-        bootstrapPartitionCount);
+    metricRegistry.gauge(MetricRegistry.name(HelixParticipant.class, "bootstrapPartitionCount" + zkSuffix),
+        () -> bootstrapPartitionCount);
     Gauge<Integer> standbyPartitionCount = () -> getReplicaCountInState(ReplicaState.STANDBY);
-    metricRegistry.register(MetricRegistry.name(HelixParticipant.class, "standbyPartitionCount" + zkSuffix),
-        standbyPartitionCount);
+    metricRegistry.gauge(MetricRegistry.name(HelixParticipant.class, "standbyPartitionCount" + zkSuffix),
+        () -> standbyPartitionCount);
     Gauge<Integer> leaderPartitionCount = () -> getReplicaCountInState(ReplicaState.LEADER);
-    metricRegistry.register(MetricRegistry.name(HelixParticipant.class, "leaderPartitionCount" + zkSuffix),
-        leaderPartitionCount);
+    metricRegistry.gauge(MetricRegistry.name(HelixParticipant.class, "leaderPartitionCount" + zkSuffix),
+        () -> leaderPartitionCount);
     Gauge<Integer> inactivePartitionCount = () -> getReplicaCountInState(ReplicaState.INACTIVE);
-    metricRegistry.register(MetricRegistry.name(HelixParticipant.class, "inactivePartitionCount" + zkSuffix),
-        inactivePartitionCount);
+    metricRegistry.gauge(MetricRegistry.name(HelixParticipant.class, "inactivePartitionCount" + zkSuffix),
+        () -> inactivePartitionCount);
     Gauge<Integer> offlinePartitionCount = () -> getReplicaCountInState(ReplicaState.OFFLINE);
-    metricRegistry.register(MetricRegistry.name(HelixParticipant.class, "offlinePartitionCount" + zkSuffix),
-        offlinePartitionCount);
+    metricRegistry.gauge(MetricRegistry.name(HelixParticipant.class, "offlinePartitionCount" + zkSuffix),
+        () -> offlinePartitionCount);
     Gauge<Integer> errorStatePartitionCount = () -> getReplicaCountInState(ReplicaState.ERROR);
-    metricRegistry.register(MetricRegistry.name(HelixParticipant.class, "errorStatePartitionCount" + zkSuffix),
-        errorStatePartitionCount);
+    metricRegistry.gauge(MetricRegistry.name(HelixParticipant.class, "errorStatePartitionCount" + zkSuffix),
+        () -> errorStatePartitionCount);
     partitionDroppedCount =
         metricRegistry.counter(MetricRegistry.name(HelixParticipant.class, "partitionDroppedCount" + zkSuffix));
     setReplicaDisabledStateErrorCount = metricRegistry.counter(

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixParticipant.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixParticipant.java
@@ -186,6 +186,12 @@ public class MockHelixParticipant extends HelixParticipant {
     super.setPartitionDisabledState(partitionName, disable);
   }
 
+  // Override this method so we don't rely on the HelixParticipant to create a distributed lock.
+  @Override
+  public DistributedLock getDistributedLock(String resource, String message) {
+    return new DistributedLockLocalImpl();
+  }
+
   /**
    * @return the {@link HelixParticipantMetrics} associated with this participant.
    */

--- a/ambry-server/src/integration-test/java/com/github/ambry/server/StatsManagerIntegrationTest.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/StatsManagerIntegrationTest.java
@@ -17,9 +17,9 @@ import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.account.InMemAccountService;
 import com.github.ambry.accountstats.AccountStatsMySqlStore;
 import com.github.ambry.accountstats.AccountStatsMySqlStoreFactory;
-import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.clustermap.MockDataNodeId;
+import com.github.ambry.clustermap.MockHelixParticipant;
 import com.github.ambry.clustermap.MockPartitionId;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.clustermap.ReplicaId;
@@ -27,8 +27,6 @@ import com.github.ambry.config.AccountStatsMySqlConfig;
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.StatsManagerConfig;
 import com.github.ambry.config.VerifiableProperties;
-import com.github.ambry.network.Port;
-import com.github.ambry.network.PortType;
 import com.github.ambry.server.storagestats.ContainerStorageStats;
 import com.github.ambry.server.storagestats.HostAccountStorageStats;
 import com.github.ambry.server.storagestats.HostPartitionClassStorageStats;
@@ -46,10 +44,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import static com.github.ambry.clustermap.TestUtils.*;
 import static org.junit.Assert.*;
 
 
@@ -58,8 +58,7 @@ import static org.junit.Assert.*;
  */
 public class StatsManagerIntegrationTest {
   private static final String CLUSTER_NAME = "ambry-test";
-  private static final String HOSTNAME = "localhost";
-  private static final int PORT = 12345;
+  private static final String DC_NAME = "DC1";
   private static final int BATCH_SIZE = 0;
 
   private final Path tempDir;
@@ -68,18 +67,22 @@ public class StatsManagerIntegrationTest {
   private final HostAccountStorageStats hostAccountStorageStats;
   private final HostPartitionClassStorageStats hostPartitionClassStorageStats;
   private final MockClusterMap mockClusterMap;
+  private final MockHelixParticipant mockClusterParticipant;
   private final StatsManager statsManager;
   private final List<ReplicaId> replicas = new ArrayList<>();
   private final Map<PartitionId, Store> storeMap = new HashMap<>();
+  private final MockDataNodeId currentNode;
 
   public StatsManagerIntegrationTest() throws Exception {
     tempDir = Files.createTempDirectory("StatsManagerIntegrationTest");
     tempDir.toFile().deleteOnExit();
     accountStatsOutputFileString = tempDir.resolve("stats_output.json").toAbsolutePath().toString();
-    Properties properties = initProperties();
+    mockClusterMap = new MockClusterMap();
+    currentNode =
+        mockClusterMap.getDataNodes().stream().filter(dn -> dn.getDatacenterName().equals(DC_NAME)).findFirst().get();
+    Properties properties =
+        initProperties(currentNode.getHostname(), currentNode.getPort(), currentNode.getDatacenterName());
     accountStatsMySqlStore = createAccountStatsMySqlStore(properties);
-    DataNodeId dataNodeId = new MockDataNodeId(Collections.singletonList(new Port(6667, PortType.PLAINTEXT)),
-        Collections.singletonList("/tmp"), "DC1");
 
     hostAccountStorageStats = new HostAccountStorageStats(
         StorageStatsUtilTest.generateRandomHostAccountStorageStats(6, 10, 6, 10000L, 2, 10));
@@ -89,7 +92,7 @@ public class StatsManagerIntegrationTest {
       String partitionClassName =
           i % 2 == 0 ? MockClusterMap.DEFAULT_PARTITION_CLASS : MockClusterMap.SPECIAL_PARTITION_CLASS;
       PartitionId partitionId =
-          new MockPartitionId(i, partitionClassName, Collections.singletonList((MockDataNodeId) dataNodeId), 0);
+          new MockPartitionId(i, partitionClassName, Collections.singletonList((MockDataNodeId) currentNode), 0);
       StoreStats storeStats =
           new StatsManagerTest.MockStoreStats(hostAccountStorageStats.getStorageStats().get((long) i), false, null);
       storeMap.put(partitionId, new StatsManagerTest.MockStore(storeStats));
@@ -98,11 +101,11 @@ public class StatsManagerIntegrationTest {
           .put((long) i, hostAccountStorageStats.getStorageStats().get((long) i));
     }
     hostPartitionClassStorageStats = new HostPartitionClassStorageStats(hostPartitionClassStorageStatsMap);
-    StorageManager storageManager = new MockStorageManager(storeMap, dataNodeId);
-    mockClusterMap = new MockClusterMap();
+    StorageManager storageManager = new MockStorageManager(storeMap, currentNode);
+    mockClusterParticipant = new MockHelixParticipant(new ClusterMapConfig(new VerifiableProperties(properties)));
     statsManager = new StatsManager(storageManager, mockClusterMap, replicas, new MetricRegistry(),
-        new StatsManagerConfig(new VerifiableProperties(properties)), new MockTime(), null, null,
-        new InMemAccountService(false, false));
+        new StatsManagerConfig(new VerifiableProperties(properties)), new MockTime(), mockClusterParticipant,
+        accountStatsMySqlStore, new InMemAccountService(false, false), currentNode);
   }
 
   /**
@@ -129,7 +132,7 @@ public class StatsManagerIntegrationTest {
     publisher.run();
 
     HostAccountStorageStatsWrapper statsWrapper =
-        accountStatsMySqlStore.queryHostAccountStorageStatsByHost(HOSTNAME, PORT);
+        accountStatsMySqlStore.queryHostAccountStorageStatsByHost(currentNode.getHostname(), currentNode.getPort());
     assertEquals(hostAccountStorageStats.getStorageStats(), statsWrapper.getStats().getStorageStats());
   }
 
@@ -150,20 +153,41 @@ public class StatsManagerIntegrationTest {
 
     Map<String, Set<Integer>> partitionNameAndIds = accountStatsMySqlStore.queryPartitionNameAndIds();
     HostPartitionClassStorageStatsWrapper statsWrapper =
-        accountStatsMySqlStore.queryHostPartitionClassStorageStatsByHost(HOSTNAME, PORT, partitionNameAndIds);
+        accountStatsMySqlStore.queryHostPartitionClassStorageStatsByHost(currentNode.getHostname(),
+            currentNode.getPort(), partitionNameAndIds);
     assertEquals(hostPartitionClassStorageStats.getStorageStats(), statsWrapper.getStats().getStorageStats());
   }
 
-  private Properties initProperties() throws Exception {
+  @Test
+  public void testHostRemoval() throws Exception {
+    // Publish some data to account stats store
+    StatsManager.AccountStatsPublisher publisher = statsManager.new AccountStatsPublisher(accountStatsMySqlStore);
+    publisher.run();
+
+    mockClusterMap.invokeListenerForDataNodeRemoval(currentNode);
+    // There should be a task scheduled to delete this current from the account stats store
+    // Sleep for a while so the task can be executed
+    Thread.sleep(2000);
+    HostAccountStorageStatsWrapper statsWrapper =
+        accountStatsMySqlStore.queryHostAccountStorageStatsByHost(currentNode.getHostname(), currentNode.getPort());
+    assertEquals(0, statsWrapper.getStats().getStorageStats().size());
+  }
+
+  private Properties initProperties(String hostname, int port, String dc) throws Exception {
     Properties configProps = Utils.loadPropsFromResource("accountstats_mysql.properties");
     configProps.setProperty(ClusterMapConfig.CLUSTERMAP_CLUSTER_NAME, CLUSTER_NAME);
-    configProps.setProperty(ClusterMapConfig.CLUSTERMAP_HOST_NAME, HOSTNAME);
-    configProps.setProperty(ClusterMapConfig.CLUSTERMAP_DATACENTER_NAME, "dc1");
-    configProps.setProperty(ClusterMapConfig.CLUSTERMAP_PORT, String.valueOf(PORT));
+    configProps.setProperty(ClusterMapConfig.CLUSTERMAP_HOST_NAME, hostname);
+    configProps.setProperty(ClusterMapConfig.CLUSTERMAP_DATACENTER_NAME, dc);
+    configProps.setProperty(ClusterMapConfig.CLUSTERMAP_PORT, String.valueOf(port));
     configProps.setProperty(AccountStatsMySqlConfig.DOMAIN_NAMES_TO_REMOVE, ".github.com");
     configProps.setProperty(AccountStatsMySqlConfig.UPDATE_BATCH_SIZE, String.valueOf(BATCH_SIZE));
     configProps.setProperty(AccountStatsMySqlConfig.LOCAL_BACKUP_FILE_PATH, accountStatsOutputFileString);
     configProps.setProperty(StatsManagerConfig.STATS_ENABLE_MYSQL_REPORT, Boolean.TRUE.toString());
+
+    List<com.github.ambry.utils.TestUtils.ZkInfo> zkInfoList = new ArrayList<>();
+    zkInfoList.add(new com.github.ambry.utils.TestUtils.ZkInfo(null, dc, (byte) 0, 2199, false));
+    JSONObject zkJson = constructZkLayoutJSON(zkInfoList);
+    configProps.setProperty("clustermap.dcs.zk.connect.strings", zkJson.toString(2));
     return configProps;
   }
 

--- a/ambry-server/src/integration-test/java/com/github/ambry/server/StatsManagerIntegrationTest.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/StatsManagerIntegrationTest.java
@@ -183,6 +183,8 @@ public class StatsManagerIntegrationTest {
     configProps.setProperty(AccountStatsMySqlConfig.UPDATE_BATCH_SIZE, String.valueOf(BATCH_SIZE));
     configProps.setProperty(AccountStatsMySqlConfig.LOCAL_BACKUP_FILE_PATH, accountStatsOutputFileString);
     configProps.setProperty(StatsManagerConfig.STATS_ENABLE_MYSQL_REPORT, Boolean.TRUE.toString());
+    configProps.setProperty(StatsManagerConfig.STATS_ENABLE_REMOVE_HOST_FROM_ACCOUNT_STATS_STORE,
+        Boolean.TRUE.toString());
 
     List<com.github.ambry.utils.TestUtils.ZkInfo> zkInfoList = new ArrayList<>();
     zkInfoList.add(new com.github.ambry.utils.TestUtils.ZkInfo(null, dc, (byte) 0, 2199, false));

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryServer.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryServer.java
@@ -279,7 +279,7 @@ public class AmbryServer {
               clusterMapConfig, registry).getAccountStatsStore() : null;
       statsManager =
           new StatsManager(storageManager, clusterMap, clusterMap.getReplicaIds(nodeId), registry, statsConfig, time,
-              clusterParticipants.get(0), accountStatsMySqlStore, accountService);
+              clusterParticipants.get(0), accountStatsMySqlStore, accountService, nodeId);
       statsManager.start();
 
       ArrayList<Port> ports = new ArrayList<Port>();

--- a/ambry-server/src/main/java/com/github/ambry/server/StatsManager.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/StatsManager.java
@@ -22,6 +22,7 @@ import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.ClusterMapChangeListener;
 import com.github.ambry.clustermap.ClusterParticipant;
 import com.github.ambry.clustermap.DataNodeId;
+import com.github.ambry.clustermap.DistributedLock;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.clustermap.PartitionStateChangeListener;
 import com.github.ambry.clustermap.ReplicaId;
@@ -80,7 +81,7 @@ class StatsManager {
   private PartitionClassStatsPublisher partitionClassStatsPublisher = null;
   private final StatsManagerConfig config;
   private final ClusterParticipant clusterParticipant;
-  private final ClusterMap clustermap;
+  private final DataNodeId currentNode;
   private long expiredDeleteTombstoneCount = 0;
   private long expiredDeleteTombstoneTotalSize = 0;
   private long permanentDeleteTombstoneCount = 0;
@@ -100,10 +101,11 @@ class StatsManager {
    * @param clusterParticipant the {@link ClusterParticipant} to register state change listener.
    * @param accountStatsStore the {@link AccountStatsStore} to publish stats.
    * @param accountService the {@link AccountService} to get account ids from account names.
+   * @param dataNodeId the {@link DataNodeId} for current node
    */
   StatsManager(StorageManager storageManager, ClusterMap clustermap, List<? extends ReplicaId> replicaIds,
       MetricRegistry registry, StatsManagerConfig config, Time time, ClusterParticipant clusterParticipant,
-      AccountStatsStore accountStatsStore, AccountService accountService) {
+      AccountStatsStore accountStatsStore, AccountService accountService, DataNodeId dataNodeId) {
     this.storageManager = storageManager;
     this.config = config;
     metrics = new StatsManagerMetrics(registry, aggregatedDeleteTombstoneStats);
@@ -111,7 +113,7 @@ class StatsManager {
         replicaIds.stream().collect(Collectors.toConcurrentMap(ReplicaId::getPartitionId, Function.identity()));
     this.time = time;
     this.clusterParticipant = clusterParticipant;
-    this.clustermap = clustermap;
+    this.currentNode = dataNodeId;
     if (clusterParticipant != null) {
       clusterParticipant.registerPartitionStateChangeListener(StateModelListenerType.StatsManagerListener,
           new PartitionStateChangeListenerImpl());
@@ -119,18 +121,19 @@ class StatsManager {
     }
     clustermap.registerClusterMapListener(new ClusterMapChangeListenerImpl());
     this.accountStatsStore = accountStatsStore;
-    Function<List<String>, List<Short>> convertAccountNamesToIds =
-        names -> names.stream().map(accountService::getAccountByName).filter(Objects::nonNull)
+    Function<List<String>, List<Short>> convertAccountNamesToIds = names -> names.stream()
+        .map(accountService::getAccountByName)
+        .filter(Objects::nonNull)
         .map(Account::getId)
         .collect(Collectors.toList());
     this.publishExcludeAccountIds = convertAccountNamesToIds.apply(config.publishExcludeAccountNames);
+    this.scheduler = Utils.newScheduler(1, false);
   }
 
   /**
    * Start the stats manager by scheduling the periodic task that collect, aggregate and publish stats.
    */
   void start() {
-    scheduler = Utils.newScheduler(1, false);
     if (accountStatsStore != null) {
       accountsStatsPublisher = new AccountStatsPublisher(accountStatsStore);
       int actualDelay = config.initialDelayUpperBoundInSecs > 0 ? ThreadLocalRandom.current()
@@ -468,6 +471,7 @@ class StatsManager {
    */
   private class ClusterMapChangeListenerImpl implements ClusterMapChangeListener {
 
+    // We don't really care about the replica addition and removal for stats manager
     @Override
     public void onReplicaAddedOrRemoved(List<ReplicaId> addedReplicas, List<ReplicaId> removedReplicas) {
     }
@@ -475,6 +479,38 @@ class StatsManager {
     @Override
     public void onDataNodeRemoved(DataNodeId removedDataNode) {
       logger.info("DataNode: {} is removed from clustermap", removedDataNode);
+      if (accountStatsStore != null && removedDataNode.getDatacenterName().equals(currentNode.getDatacenterName())) {
+        // 1. There are many other server nodes that received this message and are taking action now, we have to
+        // use a distributed lock so there will be only one server node who is deleting this data node
+        // 2. Start a new thread for this task so that we don't block the listener.
+        logger.info(
+            "Receive a data node removal message for {}_{}, schedule a task to remove account stats for this host",
+            removedDataNode.getHostname(), removedDataNode.getPort());
+        scheduler.submit(() -> this.tryRemoveHostFromAccountStatsStore(removedDataNode));
+      }
+    }
+
+    private void tryRemoveHostFromAccountStatsStore(DataNodeId removedDataNode) {
+      String resource =
+          "%s_%s_%d".format(LOCK_RESOURCE_PREFIX + removedDataNode.getHostname(), removedDataNode.getPort());
+      DistributedLock lock = clusterParticipant.getDistributedLock(resource, "AccountStatsStoreRemoval");
+      if (lock.tryLock()) {
+        logger.info("Acquired distributed lock for host removal: {}_{}", removedDataNode.getHostname(),
+            removedDataNode.getPort());
+        try {
+          accountStatsStore.deleteHostAccountStorageStatsForHost(removedDataNode.getHostname(),
+              removedDataNode.getPort());
+          logger.info("Successfully removed host {}_{} from account stats store", removedDataNode.getHostname(),
+              removedDataNode.getPort());
+        } catch (Exception e) {
+          logger.error("Failed to remove host {}_{} from account stats store", removedDataNode.getHostname(),
+              removedDataNode.getPort(), e);
+        } finally {
+        }
+      } else {
+        logger.info("Failed to acquire distributed lock for host removal: {}_{}", removedDataNode.getHostname(),
+            removedDataNode.getPort());
+      }
     }
   }
 

--- a/ambry-server/src/main/java/com/github/ambry/server/StatsManager.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/StatsManager.java
@@ -479,7 +479,8 @@ class StatsManager {
     @Override
     public void onDataNodeRemoved(DataNodeId removedDataNode) {
       logger.info("DataNode: {} is removed from clustermap", removedDataNode);
-      if (accountStatsStore != null && removedDataNode.getDatacenterName().equals(currentNode.getDatacenterName())) {
+      if (config.enableRemoveHostFromAccountStatsStore && accountStatsStore != null
+          && removedDataNode.getDatacenterName().equals(currentNode.getDatacenterName())) {
         // 1. There are many other server nodes that received this message and are taking action now, we have to
         // use a distributed lock so there will be only one server node who is deleting this data node
         // 2. Start a new thread for this task so that we don't block the listener.

--- a/ambry-server/src/test/java/com/github/ambry/server/AmbryServerRequestsTest.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/AmbryServerRequestsTest.java
@@ -195,7 +195,7 @@ public class AmbryServerRequestsTest extends ReplicationTestHelper {
         MockReplicationManager.getReplicationManager(verifiableProperties, storageManager, clusterMap, dataNodeId,
             storeKeyConverterFactory);
     statsManager = new MockStatsManager(storageManager, clusterMap, clusterMap.getReplicaIds(dataNodeId),
-        clusterMap.getMetricRegistry(), statsManagerConfig, null);
+        clusterMap.getMetricRegistry(), statsManagerConfig, null, dataNodeId);
     serverMetrics = new ServerMetrics(clusterMap.getMetricRegistry(), AmbryRequests.class, AmbryServer.class);
     requestResponseChannel = new MockRequestResponseChannel(new NetworkConfig(verifiableProperties));
     ambryRequests = new AmbryServerRequests(storageManager, requestResponseChannel, clusterMap, dataNodeId,

--- a/ambry-server/src/test/java/com/github/ambry/server/MockStatsManager.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/MockStatsManager.java
@@ -17,6 +17,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.account.InMemAccountService;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.ClusterParticipant;
+import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.config.StatsManagerConfig;
 import com.github.ambry.store.StorageManager;
@@ -31,9 +32,10 @@ class MockStatsManager extends StatsManager {
   Boolean returnValOfAddReplica = null;
 
   MockStatsManager(StorageManager storageManager, ClusterMap clusterMap, List<? extends ReplicaId> replicaIds,
-      MetricRegistry metricRegistry, StatsManagerConfig statsManagerConfig, ClusterParticipant clusterParticipant) {
+      MetricRegistry metricRegistry, StatsManagerConfig statsManagerConfig, ClusterParticipant clusterParticipant,
+      DataNodeId dataNodeId) {
     super(storageManager, clusterMap, replicaIds, metricRegistry, statsManagerConfig, new MockTime(),
-        clusterParticipant, null, new InMemAccountService(false, false));
+        clusterParticipant, null, new InMemAccountService(false, false), dataNodeId);
   }
 
   @Override

--- a/ambry-server/src/test/resources/accountstats_mysql.properties
+++ b/ambry-server/src/test/resources/accountstats_mysql.properties
@@ -9,4 +9,4 @@
 # under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 # CONDITIONS OF ANY KIND, either express or implied.
 #
-account.stats.mysql.db.info=[{"url":"jdbc:mysql://localhost/ambry_container_storage_stats?serverTimezone=UTC","datacenter":"dc1","isWriteable":"true","username":"travis","password":""}]
+account.stats.mysql.db.info=[{"url":"jdbc:mysql://localhost/ambry_container_storage_stats?serverTimezone=UTC","datacenter":"DC1","isWriteable":"true","username":"travis","password":""}]

--- a/build.gradle
+++ b/build.gradle
@@ -280,6 +280,7 @@ project(':ambry-clustermap') {
                 project(':ambry-commons'),
                 project(':ambry-utils')
         compile "org.apache.helix:helix-core:$helixVersion"
+        compile "org.apache.helix:helix-lock:$helixVersion"
         compile "io.dropwizard.metrics:metrics-core:$metricsVersion"
         compile "org.json:json:$jsonVersion"
         testCompile project(':ambry-commons')


### PR DESCRIPTION
This PR adds a real listener in StatsManager to remove hosts from account stats store when the host is removed from clustermap. However, there are some challenges to this. All the ambry server would listen to this clustermap change event and run the same piece of code to remove hosts from account stats store. We don't need all those ambry-servers to do the same thing, so we need some mechanism to coordinate those hosts to make sure there is only one host executing this task.

In order to do so, we are using helix's distributed lock. We will create a distributed lock for each host that is removed, and all the ambry-server hosts would try to acquire this lock. However, only one server host would succeed. That's how we guarantee that there is only one ambry-server doing this work.