### PR TITLE
Allow empty replicas to be deactivated immediately since there is no need for peers to sync up

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/clustermap/ReplicaSyncUpManager.java
+++ b/ambry-api/src/main/java/com/github/ambry/clustermap/ReplicaSyncUpManager.java
@@ -83,7 +83,8 @@ public interface ReplicaSyncUpManager {
   void onDeactivationError(ReplicaId replicaId);
 
   /**
-   * Initiate deactivation process if the replica should become INACTIVE from STANDBY on current node.
+   * Initiate deactivation process if the replica is transitioning from STANDBY to INACTIVE on current node. This is
+   * used to track remote peers lag from last PUT record in local replica. This is not needed for empty replica.
    * @param replicaId the replica to deactivate
    */
   void initiateDeactivation(ReplicaId replicaId);
@@ -97,7 +98,8 @@ public interface ReplicaSyncUpManager {
 
   /**
    * Initiate disconnection process to stop replica and make it offline. This happens when replica is going to be
-   * removed from current node. For Ambry, it disconnection occurs in Inactive-To-Offline transition.
+   * removed from current node. For Ambry, it disconnection occurs in Inactive-To-Offline transition. This is used to
+   * track remote peers lag from last record in local replica. This is not needed for empty replica.
    * @param replicaId the {@link ReplicaId} to be disconnected.
    */
   void initiateDisconnection(ReplicaId replicaId);

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryReplicaSyncUpManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryReplicaSyncUpManager.java
@@ -105,9 +105,7 @@ public class AmbryReplicaSyncUpManager implements ReplicaSyncUpManager {
   public void waitDeactivationCompleted(String partitionName) throws InterruptedException {
     CountDownLatch latch = partitionToDeactivationLatch.get(partitionName);
     if (latch == null) {
-      logger.error("Partition {} is not found for deactivation", partitionName);
-      throw new StateTransitionException("No deactivation latch is found for partition " + partitionName,
-          ReplicaNotFound);
+      logger.info("Skipping deactivation. Partition {} is either not present or empty", partitionName);
     } else {
       logger.info("Waiting for partition {} to be deactivated", partitionName);
       latch.await();
@@ -124,9 +122,7 @@ public class AmbryReplicaSyncUpManager implements ReplicaSyncUpManager {
   public void waitDisconnectionCompleted(String partitionName) throws InterruptedException {
     CountDownLatch latch = partitionToDisconnectionLatch.get(partitionName);
     if (latch == null) {
-      logger.error("Partition {} is not found for disconnection", partitionName);
-      throw new StateTransitionException("No disconnection latch is found for partition " + partitionName,
-          ReplicaNotFound);
+      logger.info("Skipping disconnection. Partition {} is either not present or empty", partitionName);
     } else {
       logger.info("Waiting for partition {} to be disconnected", partitionName);
       latch.await();

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/AmbryReplicaSyncUpManagerTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/AmbryReplicaSyncUpManagerTest.java
@@ -215,14 +215,6 @@ public class AmbryReplicaSyncUpManagerTest {
    */
   @Test
   public void deactivationFailureTest() throws Exception {
-    // test replica not found exception (get another partition that is not present in ReplicaSyncUpManager)
-    PartitionId partition = clusterMap.getAllPartitionIds(null).get(1);
-    try {
-      replicaSyncUpService.waitDeactivationCompleted(partition.toPathString());
-      fail("should fail because replica is not found");
-    } catch (StateTransitionException e) {
-      assertEquals("Error code is not expected", ReplicaNotFound, e.getErrorCode());
-    }
     // test deactivation failure for some reason (triggered by calling onDeactivationError)
     CountDownLatch stateModelLatch = new CountDownLatch(1);
     mockHelixParticipant.listenerLatch = new CountDownLatch(1);
@@ -275,14 +267,6 @@ public class AmbryReplicaSyncUpManagerTest {
    */
   @Test
   public void disconnectionFailureTest() throws Exception {
-    // test replica-not-found case (pass in another partition that is not present in ReplicaSyncUpManager)
-    PartitionId secondPartition = clusterMap.getAllPartitionIds(null).get(1);
-    try {
-      replicaSyncUpService.waitDisconnectionCompleted(secondPartition.toPathString());
-      fail("should fail because replica is not tracked by ReplicaSyncUpManager");
-    } catch (StateTransitionException e) {
-      assertEquals("Error code doesn't match", ReplicaNotFound, e.getErrorCode());
-    }
     // test disconnection failure (this is induced by call onDisconnectionError)
     CountDownLatch stateModelLatch = new CountDownLatch(1);
     mockHelixParticipant.listenerLatch = new CountDownLatch(1);

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
@@ -243,6 +243,11 @@ public abstract class ReplicationEngine implements ReplicationAPI {
     RemoteReplicaInfo foundRemoteReplicaInfo = null;
 
     PartitionInfo partitionInfo = partitionToPartitionInfo.get(partitionId);
+    if (partitionInfo == null) {
+      logger.debug("Remote replica info not present for partition {}, hostname {}, path {}", partitionId, hostName,
+          replicaPath);
+      return null;
+    }
     for (RemoteReplicaInfo remoteReplicaInfo : partitionInfo.getRemoteReplicaInfos()) {
       if (remoteReplicaInfo.getReplicaId().getReplicaPath().equals(replicaPath) && remoteReplicaInfo.getReplicaId()
           .getDataNodeId()

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationManager.java
@@ -360,7 +360,10 @@ public class ReplicationManager extends ReplicationEngine {
         throw new StateTransitionException(
             "Store " + partitionName + " is not started during Standby-To-Inactive transition", StoreNotStarted);
       }
-      replicaSyncUpManager.initiateDeactivation(localReplica);
+      if (!store.isEmpty()) {
+        // Wait for peers to sync up if this replica is not empty
+        replicaSyncUpManager.initiateDeactivation(localReplica);
+      }
     }
 
     @Override
@@ -381,7 +384,10 @@ public class ReplicationManager extends ReplicationEngine {
       }
       // set local store state to OFFLINE and initiate disconnection
       store.setCurrentState(ReplicaState.OFFLINE);
-      replicaSyncUpManager.initiateDisconnection(localReplica);
+      if (!store.isEmpty()) {
+        // Wait for peers to sync up if this replica is not empty
+        replicaSyncUpManager.initiateDisconnection(localReplica);
+      }
     }
 
     @Override


### PR DESCRIPTION
Issue: An empty replica still has a log size of 18 bytes for its header. During it's deactivation process, we think that its peers are 18 bytes behind and wait indefinitely for them to catch up during INACTIVE to OFFLINE transition. 