### PR TITLE
[Efficient Metadata Operations] Add reserved metadata id property in the ChunkInfo class.

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/router/ChunkInfo.java
+++ b/ambry-api/src/main/java/com/github/ambry/router/ChunkInfo.java
@@ -24,16 +24,20 @@ public class ChunkInfo {
   private final String blobId;
   private final long chunkSizeInBytes;
   private final long expirationTimeInMs;
+  private final String reservedMetadataId;
 
   /**
    * @param blobId the blob ID for the chunk.
    * @param chunkSizeInBytes the size of the chunk content in bytes.
    * @param expirationTimeInMs the expiration time of the chunk in milliseconds.
+   * @param reservedMetadataId the metadata id reserved for the chunk.
    */
-  public ChunkInfo(String blobId, long chunkSizeInBytes, long expirationTimeInMs) {
+  public ChunkInfo(String blobId, long chunkSizeInBytes, long expirationTimeInMs, String reservedMetadataId) {
     this.blobId = Objects.requireNonNull(blobId, "blobId cannot be null");
     this.chunkSizeInBytes = chunkSizeInBytes;
     this.expirationTimeInMs = expirationTimeInMs;
+    // TODO EMO: After feature completion, reservedMetadataId must be asserted not null.
+    this.reservedMetadataId = reservedMetadataId;
   }
 
   /**
@@ -57,10 +61,17 @@ public class ChunkInfo {
     return expirationTimeInMs;
   }
 
+  /**
+   * @return the reserved metadata id of the chunk.
+   */
+  public String getReservedMetadataId() {
+    return reservedMetadataId;
+  }
+
   @Override
   public String toString() {
     return "ChunkInfo{" + "blobId='" + blobId + '\'' + ", chunkSizeInBytes=" + chunkSizeInBytes
-        + ", expirationTimeInMs=" + expirationTimeInMs + '}';
+        + ", expirationTimeInMs=" + expirationTimeInMs + ", reservedMetadataId=" + reservedMetadataId + '}';
   }
 
   @Override
@@ -73,7 +84,7 @@ public class ChunkInfo {
     }
     ChunkInfo chunkInfo = (ChunkInfo) o;
     return chunkSizeInBytes == chunkInfo.chunkSizeInBytes && expirationTimeInMs == chunkInfo.expirationTimeInMs
-        && Objects.equals(blobId, chunkInfo.blobId);
+        && Objects.equals(blobId, chunkInfo.blobId) && Objects.equals(reservedMetadataId, chunkInfo.reservedMetadataId);
   }
 
   @Override

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
@@ -457,7 +457,7 @@ public class NamedBlobPutHandler {
         long expirationTimeMs = RestUtils.getLongHeader(metadata, EXPIRATION_TIME_MS_KEY, true);
         verifyChunkAccountAndContainer(blobId, stitchedBlobProperties);
 
-        chunksToStitch.add(new ChunkInfo(blobId, chunkSizeBytes, expirationTimeMs));
+        chunksToStitch.add(new ChunkInfo(blobId, chunkSizeBytes, expirationTimeMs, null));
       }
       //the actual blob size for stitched blob is the sum of all the chunk sizes
       restResponseChannel.setHeader(RestUtils.Headers.BLOB_SIZE, totalStitchedBlobSize);

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/PostBlobHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/PostBlobHandler.java
@@ -388,7 +388,7 @@ class PostBlobHandler {
         long expirationTimeMs = RestUtils.getLongHeader(metadata, EXPIRATION_TIME_MS_KEY, true);
         verifyChunkAccountAndContainer(blobId, stitchedBlobProperties);
 
-        chunksToStitch.add(new ChunkInfo(blobId, chunkSizeBytes, expirationTimeMs));
+        chunksToStitch.add(new ChunkInfo(blobId, chunkSizeBytes, expirationTimeMs, null));
       }
       //the actual blob size for stitched blob is the sum of all the chunk sizes
       restResponseChannel.setHeader(RestUtils.Headers.BLOB_SIZE, totalStitchedBlobSize);

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/NamedBlobPutHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/NamedBlobPutHandlerTest.java
@@ -279,7 +279,7 @@ public class NamedBlobPutHandlerTest {
           restServiceExceptionChecker(RestServiceErrorCode.BadRequest));
       // invalid blob ID
       stitchBlobAndVerify(
-          getStitchRequestBody(Collections.singletonList(getSignedId(new ChunkInfo("abcd", 200, -1), uploadSession))),
+          getStitchRequestBody(Collections.singletonList(getSignedId(new ChunkInfo("abcd", 200, -1, null), uploadSession))),
           null, restServiceExceptionChecker(RestServiceErrorCode.BadRequest));
       // unsigned ID
       stitchBlobAndVerify(getStitchRequestBody(Collections.singletonList("/notASignedId")), null,
@@ -495,7 +495,7 @@ public class NamedBlobPutHandlerTest {
           router.putBlob(blobProperties, null, new ByteBufferReadableStreamChannel(ByteBuffer.wrap(content)),
               new PutBlobOptionsBuilder().chunkUpload(true).build()).get(TIMEOUT_SECS, TimeUnit.SECONDS);
 
-      chunks.add(new ChunkInfo(blobId, chunkSize, Utils.addSecondsToEpochTime(creationTimeMs, blobTtlSecs)));
+      chunks.add(new ChunkInfo(blobId, chunkSize, Utils.addSecondsToEpochTime(creationTimeMs, blobTtlSecs), null));
     }
     return chunks;
   }

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/PostBlobHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/PostBlobHandlerTest.java
@@ -276,7 +276,7 @@ public class PostBlobHandlerTest {
           restServiceExceptionChecker(RestServiceErrorCode.BadRequest));
       // invalid blob ID
       stitchBlobAndVerify(
-          getStitchRequestBody(Collections.singletonList(getSignedId(new ChunkInfo("abcd", 200, -1), uploadSession))),
+          getStitchRequestBody(Collections.singletonList(getSignedId(new ChunkInfo("abcd", 200, -1, null), uploadSession))),
           null, restServiceExceptionChecker(RestServiceErrorCode.BadRequest));
       // unsigned ID
       stitchBlobAndVerify(getStitchRequestBody(Collections.singletonList("/notASignedId")), null,
@@ -468,7 +468,7 @@ public class PostBlobHandlerTest {
           router.putBlob(blobProperties, null, new ByteBufferReadableStreamChannel(ByteBuffer.wrap(content)),
               new PutBlobOptionsBuilder().chunkUpload(true).build()).get(TIMEOUT_SECS, TimeUnit.SECONDS);
 
-      chunks.add(new ChunkInfo(blobId, chunkSize, Utils.addSecondsToEpochTime(creationTimeMs, blobTtlSecs)));
+      chunks.add(new ChunkInfo(blobId, chunkSize, Utils.addSecondsToEpochTime(creationTimeMs, blobTtlSecs), null));
     }
     return chunks;
   }

--- a/ambry-router/src/test/java/com/github/ambry/router/GetManagerTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/GetManagerTest.java
@@ -288,7 +288,7 @@ public class GetManagerTest {
       curBlobSize -= curChunkSize;
       stitchBlobsIds.add(
           router.putBlob(putBlobProperties, putUserMetadata, putChannel, new PutBlobOptionsBuilder().build()).get());
-      chunkInfos.add(new ChunkInfo(stitchBlobsIds.get(i), curChunkSize, -1L));
+      chunkInfos.add(new ChunkInfo(stitchBlobsIds.get(i), curChunkSize, -1L, null));
     }
     setOperationParams(blobSize, null);
     this.options = new GetBlobOptionsBuilder().build();

--- a/ambry-router/src/test/java/com/github/ambry/router/NonBlockingQuotaTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/NonBlockingQuotaTest.java
@@ -249,7 +249,7 @@ public class NonBlockingQuotaTest extends NonBlockingRouterTestBase {
       }
 
       String stitchedBlobId = router.stitchBlob(putBlobProperties, putUserMetadata, blobIds.stream()
-          .map(blobId -> new ChunkInfo(blobId, PUT_CONTENT_SIZE, Utils.Infinite_Time))
+          .map(blobId -> new ChunkInfo(blobId, PUT_CONTENT_SIZE, Utils.Infinite_Time, null))
           .collect(Collectors.toList()), null, quotaChargeCallback).get();
       assertEquals(expectedChargeCallbackCount, listenerCalledCount.get());
 

--- a/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTest.java
@@ -240,7 +240,7 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
     }
     setOperationParams();
     String stitchedBlobId = router.stitchBlob(putBlobProperties, putUserMetadata, blobIds.stream()
-        .map(blobId -> new ChunkInfo(blobId, PUT_CONTENT_SIZE, Utils.Infinite_Time))
+        .map(blobId -> new ChunkInfo(blobId, PUT_CONTENT_SIZE, Utils.Infinite_Time, null))
         .collect(Collectors.toList())).get();
 
     // Test router for individual blob operations on the stitched blob's chunks.
@@ -306,7 +306,7 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
       }
       setOperationParams();
       List<ChunkInfo> chunksToStitch = blobIds.stream()
-          .map(blobId -> new ChunkInfo(blobId, PUT_CONTENT_SIZE, Utils.Infinite_Time))
+          .map(blobId -> new ChunkInfo(blobId, PUT_CONTENT_SIZE, Utils.Infinite_Time, null))
           .collect(Collectors.toList());
       String stitchedBlobId = router.stitchBlob(putBlobProperties, putUserMetadata, chunksToStitch).get();
       ensureStitchInAllServers(stitchedBlobId, mockServerLayout, chunksToStitch, PUT_CONTENT_SIZE);
@@ -422,7 +422,7 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
       }
       setOperationParams();
       List<ChunkInfo> chunksToStitch = blobIds.stream()
-          .map(blobId -> new ChunkInfo(blobId, PUT_CONTENT_SIZE, Utils.Infinite_Time))
+          .map(blobId -> new ChunkInfo(blobId, PUT_CONTENT_SIZE, Utils.Infinite_Time, null))
           .collect(Collectors.toList());
       String blobId = router.stitchBlob(putBlobProperties, putUserMetadata, chunksToStitch).get();
       ensureStitchInAllServers(blobId, mockServerLayout, chunksToStitch, PUT_CONTENT_SIZE);
@@ -1088,7 +1088,7 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
                 .get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
             long expirationTime = Utils.addSecondsToEpochTime(putBlobProperties.getCreationTimeInMs(),
                 putBlobProperties.getTimeToLiveInSeconds());
-            chunksToStitch.add(new ChunkInfo(blobId, chunkSize, expirationTime));
+            chunksToStitch.add(new ChunkInfo(blobId, chunkSize, expirationTime, null));
             stitchedContentStream.write(putContent);
           }
           byte[] expectedContent = stitchedContentStream.toByteArray();

--- a/ambry-router/src/test/java/com/github/ambry/router/RouterTestHelpers.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/RouterTestHelpers.java
@@ -326,7 +326,7 @@ class RouterTestHelpers {
   static List<ChunkInfo> buildChunkList(ClusterMap clusterMap, BlobId.BlobDataType blobDataType, long ttl,
       LongStream chunkSizeStream) {
     return chunkSizeStream.mapToObj(
-        chunkSize -> new ChunkInfo(getRandomBlobId(clusterMap, blobDataType), chunkSize, ttl))
+        chunkSize -> new ChunkInfo(getRandomBlobId(clusterMap, blobDataType), chunkSize, ttl, null))
         .collect(Collectors.toList());
   }
 


### PR DESCRIPTION
The chunked uploads will have reserved metadata pre-reserved for them when a signed url request was made with the "chunked-upload" header set to true. This pre-reserved metadata id will be encoded in the signed-url.
On chunk upload, this information will need to be decoded and passed onto the PutOperation. Adding reserved metadata id property in the ChunkInfo class facilitates passing this information.