### PR TITLE
[Efficient Metadata Operations] Reserve metadata id for signed-url request for POST with chunked-upload enabled.

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
@@ -718,7 +718,7 @@ public class RouterConfig {
   /**
    * Feature flag to indicate if reserved metadata is enabled.
    */
-  // TODO EMO: get rid of this flag once the efficient metadata operations feature is complete.
+  // TODO EMO: Remove this flag and its usages once the efficient metadata operations feature is complete.
   @Config(RESERVED_METADATA_ENABLED)
   @Default("false")
   public final boolean routerReservedMetadataEnabled;

--- a/ambry-api/src/main/java/com/github/ambry/frontend/ReservedMetadataIdMetrics.java
+++ b/ambry-api/src/main/java/com/github/ambry/frontend/ReservedMetadataIdMetrics.java
@@ -29,6 +29,7 @@ public class ReservedMetadataIdMetrics {
   public final Counter numReservedPartitionFoundReadOnlyCount;
   public final Counter numReservedPartitionFoundUnavailableInLocalDcCount;
   public final Counter numReservedPartitionFoundUnavailableInAllDcCount;
+  public final Counter reserveMetadataIdFailedForPostSignedUrlCount;
 
   /**
    * Constructor for {@link ReservedMetadataIdMetrics}.
@@ -45,6 +46,8 @@ public class ReservedMetadataIdMetrics {
         MetricRegistry.name(ReservedMetadataIdMetrics.class, "NumReservedPartitionFoundUnavailableInLocalDcCount"));
     numReservedPartitionFoundUnavailableInAllDcCount = metricRegistry.counter(
         MetricRegistry.name(ReservedMetadataIdMetrics.class, "NumReservedPartitionFoundUnavailableInAllDcCount"));
+    reserveMetadataIdFailedForPostSignedUrlCount = metricRegistry.counter(
+        MetricRegistry.name(ReservedMetadataIdMetrics.class, "ReserveMetadataIdFailedForPostSignedUrlCount"));
   }
 
   /**

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbryUrlSigningServiceFactory.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbryUrlSigningServiceFactory.java
@@ -14,6 +14,7 @@
 package com.github.ambry.frontend;
 
 import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.FrontendConfig;
 import com.github.ambry.config.RouterConfig;
 import com.github.ambry.config.VerifiableProperties;
@@ -32,11 +33,15 @@ public class AmbryUrlSigningServiceFactory implements UrlSigningServiceFactory {
   private final FrontendConfig config;
   private final int chunkUploadMaxChunkSize;
   private final ClusterMap clusterMap;
+  private final ClusterMapConfig clusterMapConfig;
+  private final RouterConfig routerConfig;
 
   public AmbryUrlSigningServiceFactory(VerifiableProperties verifiableProperties, ClusterMap clusterMap) {
     config = new FrontendConfig(verifiableProperties);
-    chunkUploadMaxChunkSize = new RouterConfig(verifiableProperties).routerMaxPutChunkSizeBytes;
     this.clusterMap = clusterMap;
+    this.clusterMapConfig = new ClusterMapConfig(verifiableProperties);
+    this.routerConfig = new RouterConfig(verifiableProperties);
+    this.chunkUploadMaxChunkSize = routerConfig.routerMaxPutChunkSizeBytes;
   }
 
   @Override
@@ -54,6 +59,7 @@ public class AmbryUrlSigningServiceFactory implements UrlSigningServiceFactory {
 
     return new AmbryUrlSigningService(uploadEndpoint, downloadEndpoint, config.urlSignerDefaultUrlTtlSecs,
         config.urlSignerDefaultMaxUploadSizeBytes, config.urlSignerMaxUrlTtlSecs,
-        config.chunkUploadInitialChunkTtlSecs, chunkUploadMaxChunkSize, SystemTime.getInstance(), clusterMap);
+        config.chunkUploadInitialChunkTtlSecs, chunkUploadMaxChunkSize, SystemTime.getInstance(), clusterMap,
+        clusterMapConfig, routerConfig);
   }
 }

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
@@ -35,8 +35,10 @@ import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.ByteBufferReadableStreamChannel;
 import com.github.ambry.commons.Callback;
 import com.github.ambry.commons.CommonTestUtils;
+import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.FrontendConfig;
 import com.github.ambry.config.QuotaConfig;
+import com.github.ambry.config.RouterConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.messageformat.BlobInfo;
 import com.github.ambry.messageformat.BlobProperties;
@@ -45,7 +47,6 @@ import com.github.ambry.named.NamedBlobDb;
 import com.github.ambry.named.NamedBlobRecord;
 import com.github.ambry.named.PutResult;
 import com.github.ambry.protocol.GetOption;
-import com.github.ambry.protocol.NamedBlobState;
 import com.github.ambry.quota.AmbryQuotaManager;
 import com.github.ambry.quota.QuotaMetrics;
 import com.github.ambry.quota.SimpleQuotaRecommendationMergePolicy;
@@ -202,6 +203,7 @@ public class FrontendRestRequestServiceTest {
     configProps.setProperty("frontend.path.prefixes.to.remove", "/media");
     configProps.setProperty("frontend.enable.undelete", "true");
     configProps.setProperty(FrontendConfig.CONTAINER_METRICS_EXCLUDED_ACCOUNTS, "random-name," + excludedAccountName);
+    CommonTestUtils.populateRequiredRouterProps(configProps);
     verifiableProperties = new VerifiableProperties(configProps);
     clusterMap = new MockClusterMap();
     clusterMap.setPermanentMetricRegistry(metricRegistry);
@@ -211,7 +213,8 @@ public class FrontendRestRequestServiceTest {
     String endpoint = "http://localhost:1174";
     urlSigningService = new AmbryUrlSigningService(endpoint, endpoint, frontendConfig.urlSignerDefaultUrlTtlSecs,
         frontendConfig.urlSignerDefaultMaxUploadSizeBytes, frontendConfig.urlSignerMaxUrlTtlSecs,
-        frontendConfig.chunkUploadInitialChunkTtlSecs, 4 * 1024 * 1024, SystemTime.getInstance(), clusterMap);
+        frontendConfig.chunkUploadInitialChunkTtlSecs, 4 * 1024 * 1024, SystemTime.getInstance(), clusterMap,
+        new ClusterMapConfig(verifiableProperties), new RouterConfig(verifiableProperties));
     idSigningService = new AmbryIdSigningService();
     namedBlobDb = mock(NamedBlobDb.class);
     idConverterFactory =

--- a/ambry-test-utils/src/main/java/com/github/ambry/commons/CommonTestUtils.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/commons/CommonTestUtils.java
@@ -40,5 +40,8 @@ public class CommonTestUtils {
   public static void populateRequiredRouterProps(Properties props) {
     props.setProperty("router.hostname", "localhost");
     props.setProperty("router.datacenter.name", "localDC");
+    props.put("clustermap.cluster.name", "dev");
+    props.put("clustermap.datacenter.name", "localDC");
+    props.put("clustermap.host.name", "localhost");
   }
 }


### PR DESCRIPTION
There are 4 cases to handle in order to reserve metadata chunks:

1. Reserve metadata chunk id for regular Post requests to upload a regular simple or composite blob.
2. Reserve metadata chunk id for POST signed-url requests with the "chunked-upload" header set to true. This reserved metadata id will be used for chunked uploads and the subsequent stitch blob operation.
3. For chunked uploads use the reserved metadata id encoded in the signed URL and after upload encode the reserved metadata id in the signed-id of the chunk.
4. For stitch requests use the reserved metadata id in the signed-ids of the chunks.

This PR handles case 2.