### PR TITLE
Change order of NIO shutdown to stop accepting new connections first.

### DIFF
--- a/ambry-rest/src/main/java/com/github/ambry/rest/NettyServer.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/NettyServer.java
@@ -106,8 +106,9 @@ public class NettyServer implements NioServer {
     logger.info("Shutting down NettyServer");
     if (bossGroup != null && workerGroup != null && (!bossGroup.isTerminated() || !workerGroup.isTerminated())) {
       long shutdownBeginTime = System.currentTimeMillis();
-      workerGroup.shutdownGracefully();
+      // Shutdown boss first to stop accepting new connections, then close existing connections.
       bossGroup.shutdownGracefully();
+      workerGroup.shutdownGracefully();
       try {
         if (!(workerGroup.awaitTermination(30, TimeUnit.SECONDS) && bossGroup.awaitTermination(30, TimeUnit.SECONDS))) {
           logger.error("NettyServer shutdown failed after waiting for 30 seconds");


### PR DESCRIPTION
Changing the order of shutdown in NIO (NettyServer).  When shutting down, it should shutdown the boss event loop group first to stop accepting new connections, then shutdown the worker event loop group to clean up the existing connections.  The default shutdown has a 15 seconds timeout, which is sufficient for most operations except lengthy uploads and downloads, in which case no timeout is sufficient.