### PR TITLE
Support enable get from new db only

### DIFF
--- a/ambry-account/src/integration-test/java/com/github/ambry/account/MySqlAccountServiceMigrationIntegrationTest.java
+++ b/ambry-account/src/integration-test/java/com/github/ambry/account/MySqlAccountServiceMigrationIntegrationTest.java
@@ -137,6 +137,21 @@ public class MySqlAccountServiceMigrationIntegrationTest {
     assertEquals("Mismatch in container retrieved by name", updatedContainer,
         mySqlAccountService.getContainerByName(testAccount2.getName(), testContainer2.getName()));
     assertNull(mySqlAccountService.getAccountByIdNew(testAccount2.getId()));
+
+    // add testAccount2 to new db, enable the config for enableGetFromNewDbOnly
+    mySqlAccountService.updateAccounts(Collections.singletonList(testAccount2));
+    mySqlConfigProps.setProperty(ENABLE_GET_FROM_NEW_DB_ONLY, "true");
+    mySqlAccountService = getAccountService();
+    assertEquals("Mismatch in account retrieved by name",
+        mySqlAccountService.getAccountByNameOld(testAccount1.getName()),
+        mySqlAccountService.getAccountByName(testAccount1.getName()));
+    assertEquals("Mismatch in account retrieved by id", mySqlAccountService.getAccountByIdOld(testAccount1.getId()),
+        mySqlAccountService.getAccountById(testAccount1.getId()));
+    assertEquals("Mismatch in account retrieved by name",
+        mySqlAccountService.getAccountByNameOld(testAccount2.getName()),
+        mySqlAccountService.getAccountByName(testAccount2.getName()));
+    assertEquals("Mismatch in account retrieved by id", mySqlAccountService.getAccountByIdOld(testAccount2.getId()),
+        mySqlAccountService.getAccountById(testAccount2.getId()));
   }
 
   private void cleanup() throws SQLException {

--- a/ambry-account/src/main/java/com/github/ambry/account/AccountServiceMetrics.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/AccountServiceMetrics.java
@@ -39,8 +39,12 @@ public class AccountServiceMetrics {
   public static final String UNRECOGNIZED_MESSAGE_ERROR_COUNT = "UnrecognizedMessageErrorCount";
   public static final String NOTIFY_ACCOUNT_DATA_CHANGE_ERROR_COUNT = "NotifyAccountDataChangeErrorCount";
   public static final String UPDATE_ACCOUNT_ERROR_COUNT = "UpdateAccountErrorCount";
-  public static final String UPDATE_CONTAINER_ERROR_COUNT = "UpdateContainerErrorCount";
-  public static final String UPDATE_CONTAINER_ERROR_COUNT_NEW = "UpdateContainerErrorCountNew";
+  public static final String UPDATE_CONTAINERS_ERROR_COUNT = "UpdateContainersErrorCount";
+  public static final String UPDATE_CONTAINERS_ERROR_COUNT_NEW = "UpdateContainersErrorCountNew";
+  public static final String UPDATE_ACCOUNTS_ERROR_COUNT = "UpdateAccountsErrorCount";
+  public static final String UPDATE_ACCOUNTS_ERROR_COUNT_NEW = "UpdateAccountsErrorCountNew";
+  public static final String FETCH_AND_UPDATE_CACHE_ERROR_COUNT = "FetchAndUpdateCacheErrorCount";
+  public static final String FETCH_AND_UPDATE_CACHE_ERROR_COUNT_NEW = "FetchAndUpdateCacheErrorCountNew";
   public static final String UPDATE_ACCOUNT_ERROR_COUNT_NEW = "UpdateAccountErrorCountNew";
   public static final String CONFLICT_RETRY_COUNT = "ConflictRetryCount";
   public static final String ACCOUNT_UPDATES_TO_STORE_ERROR_COUNT = "AccountUpdatesToStoreErrorCount";
@@ -92,7 +96,9 @@ public class AccountServiceMetrics {
   public final Counter getAccountInconsistencyCount;
   public final Counter onDemandContainerFetchCount;
   public final Counter updateAccountFromOldCacheToNewDbCount;
-  public final Counter updateContainerErrorCount;
+  public final Counter updateContainersErrorCount;
+  public final Counter fetchAndUpdateCacheErrorCount;
+  public final Counter updateAccountsErrorCount;
 
   // Gauge
   Gauge<Integer> accountDataInconsistencyCount;
@@ -141,8 +147,12 @@ public class AccountServiceMetrics {
           metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, FETCH_REMOTE_ACCOUNT_ERROR_COUNT_NEW));
       onDemandContainerFetchCount =
           metricRegistry.counter(MetricRegistry.name(MySqlAccountService.class, ON_DEMAND_CONTAINER_FETCH_COUNT_NEW));
-      updateContainerErrorCount =
-          metricRegistry.counter(MetricRegistry.name(MySqlAccountService.class, UPDATE_CONTAINER_ERROR_COUNT_NEW));
+      updateContainersErrorCount =
+          metricRegistry.counter(MetricRegistry.name(MySqlAccountService.class, UPDATE_CONTAINERS_ERROR_COUNT_NEW));
+      fetchAndUpdateCacheErrorCount =
+          metricRegistry.counter(MetricRegistry.name(MySqlAccountService.class, FETCH_AND_UPDATE_CACHE_ERROR_COUNT_NEW));
+      updateAccountsErrorCount =
+          metricRegistry.counter(MetricRegistry.name(MySqlAccountService.class, UPDATE_ACCOUNTS_ERROR_COUNT_NEW));
     } else {
       updateAccountErrorCount =
           metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, UPDATE_ACCOUNT_ERROR_COUNT));
@@ -150,8 +160,12 @@ public class AccountServiceMetrics {
           metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, FETCH_REMOTE_ACCOUNT_ERROR_COUNT));
       onDemandContainerFetchCount =
           metricRegistry.counter(MetricRegistry.name(MySqlAccountService.class, ON_DEMAND_CONTAINER_FETCH_COUNT));
-      updateContainerErrorCount =
-          metricRegistry.counter(MetricRegistry.name(MySqlAccountService.class, UPDATE_CONTAINER_ERROR_COUNT));
+      updateContainersErrorCount =
+          metricRegistry.counter(MetricRegistry.name(MySqlAccountService.class, UPDATE_CONTAINERS_ERROR_COUNT));
+      fetchAndUpdateCacheErrorCount =
+          metricRegistry.counter(MetricRegistry.name(MySqlAccountService.class, FETCH_AND_UPDATE_CACHE_ERROR_COUNT));
+      updateAccountsErrorCount =
+          metricRegistry.counter(MetricRegistry.name(MySqlAccountService.class, UPDATE_ACCOUNTS_ERROR_COUNT));
     }
     conflictRetryCount = metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, CONFLICT_RETRY_COUNT));
     accountUpdatesToStoreErrorCount =

--- a/ambry-account/src/main/java/com/github/ambry/account/CachedAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/CachedAccountService.java
@@ -502,6 +502,9 @@ public class CachedAccountService extends AbstractAccountService {
     try {
       Pair<Short, Short> accountAndContainerIdPair =
           getAccountAndContainerIdFromName(dataset.getAccountName(), dataset.getContainerName());
+      if (mySqlAccountStore == null) {
+        mySqlAccountStore = this.supplier.get();
+      }
       mySqlAccountStore.addDataset(accountAndContainerIdPair.getFirst(), accountAndContainerIdPair.getSecond(),
           dataset);
     } catch (SQLException e) {
@@ -514,6 +517,9 @@ public class CachedAccountService extends AbstractAccountService {
     try {
       Pair<Short, Short> accountAndContainerIdPair =
           getAccountAndContainerIdFromName(dataset.getAccountName(), dataset.getContainerName());
+      if (mySqlAccountStore == null) {
+        mySqlAccountStore = this.supplier.get();
+      }
       mySqlAccountStore.updateDataset(accountAndContainerIdPair.getFirst(), accountAndContainerIdPair.getSecond(),
           dataset);
     } catch (SQLException e) {
@@ -526,6 +532,9 @@ public class CachedAccountService extends AbstractAccountService {
       throws AccountServiceException {
     try {
       Pair<Short, Short> accountAndContainerIdPair = getAccountAndContainerIdFromName(accountName, containerName);
+      if (mySqlAccountStore == null) {
+        mySqlAccountStore = this.supplier.get();
+      }
       return mySqlAccountStore.getDataset(accountAndContainerIdPair.getFirst(), accountAndContainerIdPair.getSecond(),
           accountName, containerName, datasetName);
     } catch (SQLException e) {
@@ -538,6 +547,9 @@ public class CachedAccountService extends AbstractAccountService {
       throws AccountServiceException {
     try {
       Pair<Short, Short> accountAndContainerIdPair = getAccountAndContainerIdFromName(accountName, containerName);
+      if (mySqlAccountStore == null) {
+        mySqlAccountStore = this.supplier.get();
+      }
       mySqlAccountStore.deleteDataset(accountAndContainerIdPair.getFirst(), accountAndContainerIdPair.getSecond(),
           datasetName);
     } catch (SQLException e) {
@@ -550,6 +562,9 @@ public class CachedAccountService extends AbstractAccountService {
       String version, long timeToLiveInSeconds, long creationTimeInMs, boolean datasetVersionTtlEnabled) throws AccountServiceException {
     try {
       Pair<Short, Short> accountAndContainerIdPair = getAccountAndContainerIdFromName(accountName, containerName);
+      if (mySqlAccountStore == null) {
+        mySqlAccountStore = this.supplier.get();
+      }
       return mySqlAccountStore.addDatasetVersion(accountAndContainerIdPair.getFirst(),
           accountAndContainerIdPair.getSecond(), accountName, containerName, datasetName, version, timeToLiveInSeconds,
           creationTimeInMs, datasetVersionTtlEnabled);
@@ -563,6 +578,9 @@ public class CachedAccountService extends AbstractAccountService {
       String version) throws AccountServiceException {
     try {
       Pair<Short, Short> accountAndContainerIdPair = getAccountAndContainerIdFromName(accountName, containerName);
+      if (mySqlAccountStore == null) {
+        mySqlAccountStore = this.supplier.get();
+      }
       return mySqlAccountStore.getDatasetVersion(accountAndContainerIdPair.getFirst(),
           accountAndContainerIdPair.getSecond(), accountName, containerName, datasetName, version);
     } catch (SQLException e) {
@@ -575,6 +593,9 @@ public class CachedAccountService extends AbstractAccountService {
       String version) throws AccountServiceException {
     try {
       Pair<Short, Short> accountAndContainerIdPair = getAccountAndContainerIdFromName(accountName, containerName);
+      if (mySqlAccountStore == null) {
+        mySqlAccountStore = this.supplier.get();
+      }
       mySqlAccountStore.deleteDatasetVersion(accountAndContainerIdPair.getFirst(),
           accountAndContainerIdPair.getSecond(), datasetName, version);
     } catch (SQLException e) {
@@ -587,6 +608,9 @@ public class CachedAccountService extends AbstractAccountService {
       throws AccountServiceException {
     try {
       Pair<Short, Short> accountAndContainerIdPair = getAccountAndContainerIdFromName(accountName, containerName);
+      if (mySqlAccountStore == null) {
+        mySqlAccountStore = this.supplier.get();
+      }
       return mySqlAccountStore.getAllValidVersion(accountAndContainerIdPair.getFirst(),
           accountAndContainerIdPair.getSecond(), datasetName);
     } catch (SQLException e) {
@@ -745,9 +769,6 @@ public class CachedAccountService extends AbstractAccountService {
     }
     final short accountId = container.getParentAccountId();
     final short containerId = container.getId();
-    if (mySqlAccountStore == null) {
-      mySqlAccountStore = this.supplier.get();
-    }
     return new Pair<>(accountId, containerId);
   }
 

--- a/ambry-account/src/main/java/com/github/ambry/account/CachedAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/CachedAccountService.java
@@ -497,6 +497,171 @@ public class CachedAccountService extends AbstractAccountService {
     super.publishChangeNotice();
   }
 
+  @Override
+  public void addDataset(Dataset dataset) throws AccountServiceException {
+    try {
+      String accountName = dataset.getAccountName();
+      String containerName = dataset.getContainerName();
+      Container container = getContainerByName(accountName, containerName);
+      if (container == null) {
+        throw new AccountServiceException("Can't find the container: " + containerName + " in account: " + accountName,
+            AccountServiceErrorCode.BadRequest);
+      }
+      short accountId = container.getParentAccountId();
+      short containerId = container.getId();
+      if (mySqlAccountStore == null) {
+        mySqlAccountStore = this.supplier.get();
+      }
+      mySqlAccountStore.addDataset(accountId, containerId, dataset);
+    } catch (SQLException e) {
+      throw translateSQLException(e);
+    }
+  }
+
+  @Override
+  public void updateDataset(Dataset dataset) throws AccountServiceException {
+    try {
+      String accountName = dataset.getAccountName();
+      String containerName = dataset.getContainerName();
+      Container container = getContainerByName(accountName, containerName);
+      if (container == null) {
+        throw new AccountServiceException("Can't find the container: " + containerName + " in account: " + accountName,
+            AccountServiceErrorCode.BadRequest);
+      }
+      short accountId = container.getParentAccountId();
+      short containerId = container.getId();
+      if (mySqlAccountStore == null) {
+        mySqlAccountStore = this.supplier.get();
+      }
+      mySqlAccountStore.updateDataset(accountId, containerId, dataset);
+    } catch (SQLException e) {
+      throw translateSQLException(e);
+    }
+  }
+
+  @Override
+  public Dataset getDataset(String accountName, String containerName, String datasetName)
+      throws AccountServiceException {
+    try {
+      Container container = getContainerByName(accountName, containerName);
+      if (container == null) {
+        throw new AccountServiceException(
+            "Can't find the container: " + containerName + " in account: " + accountName,
+            AccountServiceErrorCode.BadRequest);
+      }
+      short accountId = container.getParentAccountId();
+      short containerId = container.getId();
+      if (mySqlAccountStore == null) {
+        mySqlAccountStore = this.supplier.get();
+      }
+      return mySqlAccountStore.getDataset(accountId, containerId, accountName, containerName, datasetName);
+    } catch (SQLException e) {
+      throw translateSQLException(e);
+    }
+  }
+
+  @Override
+  public void deleteDataset(String accountName, String containerName, String datasetName)
+      throws AccountServiceException {
+    try {
+      Container container = getContainerByName(accountName, containerName);
+      if (container == null) {
+        throw new AccountServiceException("Can't find the container: " + containerName + " in account: " + accountName,
+            AccountServiceErrorCode.BadRequest);
+      }
+      short accountId = container.getParentAccountId();
+      short containerId = container.getId();
+      if (mySqlAccountStore == null) {
+        mySqlAccountStore = this.supplier.get();
+      }
+      mySqlAccountStore.deleteDataset(accountId, containerId, datasetName);
+    } catch (SQLException e) {
+      throw translateSQLException(e);
+    }
+  }
+
+  @Override
+  public DatasetVersionRecord addDatasetVersion(String accountName, String containerName, String datasetName,
+      String version, long timeToLiveInSeconds, long creationTimeInMs, boolean datasetVersionTtlEnabled) throws AccountServiceException {
+    try {
+      Container container = getContainerByName(accountName, containerName);
+      if (container == null) {
+        throw new AccountServiceException("Can't find the container: " + containerName + " in account: " + accountName,
+            AccountServiceErrorCode.BadRequest);
+      }
+      short accountId = container.getParentAccountId();
+      short containerId = container.getId();
+      if (mySqlAccountStore == null) {
+        mySqlAccountStore = this.supplier.get();
+      }
+      return mySqlAccountStore.addDatasetVersion(accountId, containerId, accountName, containerName, datasetName,
+          version, timeToLiveInSeconds, creationTimeInMs, datasetVersionTtlEnabled);
+    } catch (SQLException e) {
+      throw translateSQLException(e);
+    }
+  }
+
+  @Override
+  public DatasetVersionRecord getDatasetVersion(String accountName, String containerName, String datasetName,
+      String version) throws AccountServiceException {
+    try {
+      Container container = getContainerByName(accountName, containerName);
+      if (container == null) {
+        throw new AccountServiceException("Can't find the container: " + containerName + " in account: " + accountName,
+            AccountServiceErrorCode.BadRequest);
+      }
+      short accountId = container.getParentAccountId();
+      short containerId = container.getId();
+      if (mySqlAccountStore == null) {
+        mySqlAccountStore = this.supplier.get();
+      }
+      return mySqlAccountStore.getDatasetVersion(accountId, containerId, accountName, containerName, datasetName,
+          version);
+    } catch (SQLException e) {
+      throw translateSQLException(e);
+    }
+  }
+
+  @Override
+  public void deleteDatasetVersion(String accountName, String containerName, String datasetName,
+      String version) throws AccountServiceException {
+    try {
+      Container container = getContainerByName(accountName, containerName);
+      if (container == null) {
+        throw new AccountServiceException("Can't find the container: " + containerName + " in account: " + accountName,
+            AccountServiceErrorCode.BadRequest);
+      }
+      short accountId = container.getParentAccountId();
+      short containerId = container.getId();
+      if (mySqlAccountStore == null) {
+        mySqlAccountStore = this.supplier.get();
+      }
+      mySqlAccountStore.deleteDatasetVersion(accountId, containerId, datasetName, version);
+    } catch (SQLException e) {
+      throw translateSQLException(e);
+    }
+  }
+
+  @Override
+  public List<DatasetVersionRecord> getAllValidVersion(String accountName, String containerName, String datasetName)
+      throws AccountServiceException {
+    try {
+      Container container = getContainerByName(accountName, containerName);
+      if (container == null) {
+        throw new AccountServiceException("Can't find the container: " + containerName + " in account: " + accountName,
+            AccountServiceErrorCode.BadRequest);
+      }
+      short accountId = container.getParentAccountId();
+      short containerId = container.getId();
+      if (mySqlAccountStore == null) {
+        mySqlAccountStore = this.supplier.get();
+      }
+      return mySqlAccountStore.getAllValidVersion(accountId, containerId, datasetName);
+    } catch (SQLException e) {
+      throw translateSQLException(e);
+    }
+  }
+
   /**
    * Gets all the {@link Account}s in this {@code AccountService}. The {@link Account}s <em>MUST</em> have their
    * ids and names one-to-one mapped.

--- a/ambry-account/src/main/java/com/github/ambry/account/CachedAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/CachedAccountService.java
@@ -500,19 +500,10 @@ public class CachedAccountService extends AbstractAccountService {
   @Override
   public void addDataset(Dataset dataset) throws AccountServiceException {
     try {
-      String accountName = dataset.getAccountName();
-      String containerName = dataset.getContainerName();
-      Container container = getContainerByName(accountName, containerName);
-      if (container == null) {
-        throw new AccountServiceException("Can't find the container: " + containerName + " in account: " + accountName,
-            AccountServiceErrorCode.BadRequest);
-      }
-      short accountId = container.getParentAccountId();
-      short containerId = container.getId();
-      if (mySqlAccountStore == null) {
-        mySqlAccountStore = this.supplier.get();
-      }
-      mySqlAccountStore.addDataset(accountId, containerId, dataset);
+      Pair<Short, Short> accountAndContainerIdPair =
+          getAccountAndContainerIdFromName(dataset.getAccountName(), dataset.getContainerName());
+      mySqlAccountStore.addDataset(accountAndContainerIdPair.getFirst(), accountAndContainerIdPair.getSecond(),
+          dataset);
     } catch (SQLException e) {
       throw translateSQLException(e);
     }
@@ -521,19 +512,10 @@ public class CachedAccountService extends AbstractAccountService {
   @Override
   public void updateDataset(Dataset dataset) throws AccountServiceException {
     try {
-      String accountName = dataset.getAccountName();
-      String containerName = dataset.getContainerName();
-      Container container = getContainerByName(accountName, containerName);
-      if (container == null) {
-        throw new AccountServiceException("Can't find the container: " + containerName + " in account: " + accountName,
-            AccountServiceErrorCode.BadRequest);
-      }
-      short accountId = container.getParentAccountId();
-      short containerId = container.getId();
-      if (mySqlAccountStore == null) {
-        mySqlAccountStore = this.supplier.get();
-      }
-      mySqlAccountStore.updateDataset(accountId, containerId, dataset);
+      Pair<Short, Short> accountAndContainerIdPair =
+          getAccountAndContainerIdFromName(dataset.getAccountName(), dataset.getContainerName());
+      mySqlAccountStore.updateDataset(accountAndContainerIdPair.getFirst(), accountAndContainerIdPair.getSecond(),
+          dataset);
     } catch (SQLException e) {
       throw translateSQLException(e);
     }
@@ -543,18 +525,9 @@ public class CachedAccountService extends AbstractAccountService {
   public Dataset getDataset(String accountName, String containerName, String datasetName)
       throws AccountServiceException {
     try {
-      Container container = getContainerByName(accountName, containerName);
-      if (container == null) {
-        throw new AccountServiceException(
-            "Can't find the container: " + containerName + " in account: " + accountName,
-            AccountServiceErrorCode.BadRequest);
-      }
-      short accountId = container.getParentAccountId();
-      short containerId = container.getId();
-      if (mySqlAccountStore == null) {
-        mySqlAccountStore = this.supplier.get();
-      }
-      return mySqlAccountStore.getDataset(accountId, containerId, accountName, containerName, datasetName);
+      Pair<Short, Short> accountAndContainerIdPair = getAccountAndContainerIdFromName(accountName, containerName);
+      return mySqlAccountStore.getDataset(accountAndContainerIdPair.getFirst(), accountAndContainerIdPair.getSecond(),
+          accountName, containerName, datasetName);
     } catch (SQLException e) {
       throw translateSQLException(e);
     }
@@ -564,17 +537,9 @@ public class CachedAccountService extends AbstractAccountService {
   public void deleteDataset(String accountName, String containerName, String datasetName)
       throws AccountServiceException {
     try {
-      Container container = getContainerByName(accountName, containerName);
-      if (container == null) {
-        throw new AccountServiceException("Can't find the container: " + containerName + " in account: " + accountName,
-            AccountServiceErrorCode.BadRequest);
-      }
-      short accountId = container.getParentAccountId();
-      short containerId = container.getId();
-      if (mySqlAccountStore == null) {
-        mySqlAccountStore = this.supplier.get();
-      }
-      mySqlAccountStore.deleteDataset(accountId, containerId, datasetName);
+      Pair<Short, Short> accountAndContainerIdPair = getAccountAndContainerIdFromName(accountName, containerName);
+      mySqlAccountStore.deleteDataset(accountAndContainerIdPair.getFirst(), accountAndContainerIdPair.getSecond(),
+          datasetName);
     } catch (SQLException e) {
       throw translateSQLException(e);
     }
@@ -584,18 +549,10 @@ public class CachedAccountService extends AbstractAccountService {
   public DatasetVersionRecord addDatasetVersion(String accountName, String containerName, String datasetName,
       String version, long timeToLiveInSeconds, long creationTimeInMs, boolean datasetVersionTtlEnabled) throws AccountServiceException {
     try {
-      Container container = getContainerByName(accountName, containerName);
-      if (container == null) {
-        throw new AccountServiceException("Can't find the container: " + containerName + " in account: " + accountName,
-            AccountServiceErrorCode.BadRequest);
-      }
-      short accountId = container.getParentAccountId();
-      short containerId = container.getId();
-      if (mySqlAccountStore == null) {
-        mySqlAccountStore = this.supplier.get();
-      }
-      return mySqlAccountStore.addDatasetVersion(accountId, containerId, accountName, containerName, datasetName,
-          version, timeToLiveInSeconds, creationTimeInMs, datasetVersionTtlEnabled);
+      Pair<Short, Short> accountAndContainerIdPair = getAccountAndContainerIdFromName(accountName, containerName);
+      return mySqlAccountStore.addDatasetVersion(accountAndContainerIdPair.getFirst(),
+          accountAndContainerIdPair.getSecond(), accountName, containerName, datasetName, version, timeToLiveInSeconds,
+          creationTimeInMs, datasetVersionTtlEnabled);
     } catch (SQLException e) {
       throw translateSQLException(e);
     }
@@ -605,18 +562,9 @@ public class CachedAccountService extends AbstractAccountService {
   public DatasetVersionRecord getDatasetVersion(String accountName, String containerName, String datasetName,
       String version) throws AccountServiceException {
     try {
-      Container container = getContainerByName(accountName, containerName);
-      if (container == null) {
-        throw new AccountServiceException("Can't find the container: " + containerName + " in account: " + accountName,
-            AccountServiceErrorCode.BadRequest);
-      }
-      short accountId = container.getParentAccountId();
-      short containerId = container.getId();
-      if (mySqlAccountStore == null) {
-        mySqlAccountStore = this.supplier.get();
-      }
-      return mySqlAccountStore.getDatasetVersion(accountId, containerId, accountName, containerName, datasetName,
-          version);
+      Pair<Short, Short> accountAndContainerIdPair = getAccountAndContainerIdFromName(accountName, containerName);
+      return mySqlAccountStore.getDatasetVersion(accountAndContainerIdPair.getFirst(),
+          accountAndContainerIdPair.getSecond(), accountName, containerName, datasetName, version);
     } catch (SQLException e) {
       throw translateSQLException(e);
     }
@@ -626,17 +574,9 @@ public class CachedAccountService extends AbstractAccountService {
   public void deleteDatasetVersion(String accountName, String containerName, String datasetName,
       String version) throws AccountServiceException {
     try {
-      Container container = getContainerByName(accountName, containerName);
-      if (container == null) {
-        throw new AccountServiceException("Can't find the container: " + containerName + " in account: " + accountName,
-            AccountServiceErrorCode.BadRequest);
-      }
-      short accountId = container.getParentAccountId();
-      short containerId = container.getId();
-      if (mySqlAccountStore == null) {
-        mySqlAccountStore = this.supplier.get();
-      }
-      mySqlAccountStore.deleteDatasetVersion(accountId, containerId, datasetName, version);
+      Pair<Short, Short> accountAndContainerIdPair = getAccountAndContainerIdFromName(accountName, containerName);
+      mySqlAccountStore.deleteDatasetVersion(accountAndContainerIdPair.getFirst(),
+          accountAndContainerIdPair.getSecond(), datasetName, version);
     } catch (SQLException e) {
       throw translateSQLException(e);
     }
@@ -646,17 +586,9 @@ public class CachedAccountService extends AbstractAccountService {
   public List<DatasetVersionRecord> getAllValidVersion(String accountName, String containerName, String datasetName)
       throws AccountServiceException {
     try {
-      Container container = getContainerByName(accountName, containerName);
-      if (container == null) {
-        throw new AccountServiceException("Can't find the container: " + containerName + " in account: " + accountName,
-            AccountServiceErrorCode.BadRequest);
-      }
-      short accountId = container.getParentAccountId();
-      short containerId = container.getId();
-      if (mySqlAccountStore == null) {
-        mySqlAccountStore = this.supplier.get();
-      }
-      return mySqlAccountStore.getAllValidVersion(accountId, containerId, datasetName);
+      Pair<Short, Short> accountAndContainerIdPair = getAccountAndContainerIdFromName(accountName, containerName);
+      return mySqlAccountStore.getAllValidVersion(accountAndContainerIdPair.getFirst(),
+          accountAndContainerIdPair.getSecond(), datasetName);
     } catch (SQLException e) {
       throw translateSQLException(e);
     }
@@ -795,6 +727,28 @@ public class CachedAccountService extends AbstractAccountService {
     }
 
     return new Pair<>(addedContainers, updatedContainers);
+  }
+
+  /**
+   * A helper function to get account and container id from its name.
+   * @param accountName the name of the account.
+   * @param containerName the name of the container.
+   * @return the pair of accountId and containerId.
+   * @throws AccountServiceException
+   */
+  private Pair<Short, Short> getAccountAndContainerIdFromName(String accountName, String containerName)
+      throws AccountServiceException {
+    final Container container = getContainerByName(accountName, containerName);
+    if (container == null) {
+      throw new AccountServiceException("Can't find the container: " + containerName + " in account: " + accountName,
+          AccountServiceErrorCode.BadRequest);
+    }
+    final short accountId = container.getParentAccountId();
+    final short containerId = container.getId();
+    if (mySqlAccountStore == null) {
+      mySqlAccountStore = this.supplier.get();
+    }
+    return new Pair<>(accountId, containerId);
   }
 
   /**

--- a/ambry-account/src/main/java/com/github/ambry/account/MySqlAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/MySqlAccountService.java
@@ -115,6 +115,7 @@ public class MySqlAccountService extends AbstractAccountService {
         cachedAccountServiceNew.fetchAndUpdateCache();
       } catch (SQLException e) {
         if (config.ignoreNewDatabaseUploadError) {
+          accountServiceMetricsNew.fetchAndUpdateCacheErrorCount.inc();
           logger.error("failed to do fetchAndUpdateCache for new db");
         } else {
           throw e;
@@ -201,6 +202,7 @@ public class MySqlAccountService extends AbstractAccountService {
         cachedAccountServiceNew.updateAccounts(accounts);
       } catch (AccountServiceException e) {
         if (config.ignoreNewDatabaseUploadError) {
+          accountServiceMetricsNew.updateAccountsErrorCount.inc();
           logger.error("failed to do updateAccounts for new db");
         } else {
           throw e;
@@ -269,8 +271,8 @@ public class MySqlAccountService extends AbstractAccountService {
         cachedAccountServiceNew.updateContainers(accountName, containers);
       } catch (AccountServiceException e) {
         // if before migration, update container for new db would fail due to the account does not exist.
-        accountServiceMetricsNew.updateContainerErrorCount.inc();
         if (config.ignoreNewDatabaseUploadError) {
+          accountServiceMetricsNew.updateContainersErrorCount.inc();
           logger.trace("This is expected due to the account {} does not exist in new db", accountName);
         } else {
           throw e;

--- a/ambry-account/src/main/java/com/github/ambry/account/MySqlAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/MySqlAccountService.java
@@ -98,6 +98,9 @@ public class MySqlAccountService extends AbstractAccountService {
    * @return set (LRA cache) of containers not found in recent get attempts. Used in only tests.
    */
   Set<String> getRecentNotFoundContainersCache() {
+    if (config.enableGetFromNewDbOnly) {
+      return cachedAccountServiceNew.getRecentNotFoundContainersCache();
+    }
     return cachedAccountService.getRecentNotFoundContainersCache();
   }
 
@@ -108,28 +111,56 @@ public class MySqlAccountService extends AbstractAccountService {
   synchronized void fetchAndUpdateCache() throws SQLException {
     cachedAccountService.fetchAndUpdateCache();
     if (config.enableNewDatabaseForMigration) {
-      cachedAccountServiceNew.fetchAndUpdateCache();
+      try {
+        cachedAccountServiceNew.fetchAndUpdateCache();
+      } catch (SQLException e) {
+        if (config.ignoreNewDatabaseUploadError) {
+          logger.error("failed to do fetchAndUpdateCache for new db");
+        } else {
+          throw e;
+        }
+      }
     }
   }
 
   @Override
   public Account getAccountById(short accountId) {
+    if (config.enableGetFromNewDbOnly) {
+      return cachedAccountServiceNew.getAccountById(accountId);
+    }
     return cachedAccountService.getAccountById(accountId);
   }
 
   @Override
   public Account getAccountByName(String accountName) {
+    if (config.enableGetFromNewDbOnly) {
+      return cachedAccountServiceNew.getAccountByName(accountName);
+    }
     return cachedAccountService.getAccountByName(accountName);
   }
 
   @Override
   public boolean addAccountUpdateConsumer(Consumer<Collection<Account>> accountUpdateConsumer) {
-    return cachedAccountService.addAccountUpdateConsumer(accountUpdateConsumer);
+    boolean result = cachedAccountService.addAccountUpdateConsumer(accountUpdateConsumer);
+    if (config.enableNewDatabaseForMigration) {
+      boolean resultNew = cachedAccountServiceNew.addAccountUpdateConsumer(accountUpdateConsumer);
+      if (config.enableGetFromNewDbOnly) {
+        return resultNew;
+      }
+    }
+    return result;
   }
 
   @Override
   public boolean removeAccountUpdateConsumer(Consumer<Collection<Account>> accountUpdateConsumer) {
-    return cachedAccountService.removeAccountUpdateConsumer(accountUpdateConsumer);
+    boolean result = cachedAccountService.removeAccountUpdateConsumer(accountUpdateConsumer);
+    if (config.enableNewDatabaseForMigration) {
+      boolean resultNew = cachedAccountServiceNew.removeAccountUpdateConsumer(accountUpdateConsumer);
+      if (config.enableGetFromNewDbOnly) {
+        return resultNew;
+      }
+    }
+    return result;
   }
 
   /**
@@ -146,18 +177,43 @@ public class MySqlAccountService extends AbstractAccountService {
     return cachedAccountServiceNew.getAccountByName(accountName);
   }
 
+  /**
+   * This method is used for uploading data to old db for testing purpose only.
+   */
+  protected Account getAccountByIdOld(short accountId) {
+    return cachedAccountService.getAccountById(accountId);
+  }
+
+  /**
+   * This method is used for uploading data to old db for testing purpose only.
+   */
+  protected Account getAccountByNameOld(String accountName) {
+    return cachedAccountService.getAccountByName(accountName);
+  }
+
   protected CachedAccountService getCachedAccountService() {return cachedAccountService;}
 
   @Override
   public void updateAccounts(Collection<Account> accounts) throws AccountServiceException {
     cachedAccountService.updateAccounts(accounts);
     if (config.enableNewDatabaseForMigration) {
-      cachedAccountServiceNew.updateAccounts(accounts);
+      try {
+        cachedAccountServiceNew.updateAccounts(accounts);
+      } catch (AccountServiceException e) {
+        if (config.ignoreNewDatabaseUploadError) {
+          logger.error("failed to do updateAccounts for new db");
+        } else {
+          throw e;
+        }
+      }
     }
   }
 
   @Override
   public Collection<Account> getAllAccounts() {
+    if (config.enableGetFromNewDbOnly) {
+      return cachedAccountServiceNew.getAllAccountsHelper();
+    }
     return cachedAccountService.getAllAccountsHelper();
   }
 
@@ -190,6 +246,9 @@ public class MySqlAccountService extends AbstractAccountService {
 
   @Override
   public Set<Container> getContainersByStatus(Container.ContainerStatus containerStatus) {
+    if (config.enableGetFromNewDbOnly) {
+      return cachedAccountServiceNew.getContainersByStatus(containerStatus);
+    }
     return cachedAccountService.getContainersByStatus(containerStatus);
   }
 
@@ -211,7 +270,11 @@ public class MySqlAccountService extends AbstractAccountService {
       } catch (AccountServiceException e) {
         // if before migration, update container for new db would fail due to the account does not exist.
         accountServiceMetricsNew.updateContainerErrorCount.inc();
-        logger.trace("This is expected due to the account {} does not exist in new db", accountName);
+        if (config.ignoreNewDatabaseUploadError) {
+          logger.trace("This is expected due to the account {} does not exist in new db", accountName);
+        } else {
+          throw e;
+        }
       }
     }
     return containerList;
@@ -227,6 +290,9 @@ public class MySqlAccountService extends AbstractAccountService {
    */
   @Override
   public Container getContainerByName(String accountName, String containerName) throws AccountServiceException {
+    if (config.enableGetFromNewDbOnly) {
+      return cachedAccountServiceNew.getContainerByNameHelper(accountName, containerName);
+    }
     return cachedAccountService.getContainerByNameHelper(accountName, containerName);
   }
 
@@ -240,14 +306,10 @@ public class MySqlAccountService extends AbstractAccountService {
    */
   @Override
   public Container getContainerById(short accountId, Short containerId) throws AccountServiceException {
+    if (config.enableGetFromNewDbOnly) {
+      return cachedAccountServiceNew.getContainerByIdHelper(accountId, containerId);
+    }
     return cachedAccountService.getContainerByIdHelper(accountId, containerId);
-  }
-
-  /**
-   * @return the total number of containers in all accounts.
-   */
-  public int getContainerCount() {
-    return cachedAccountService.getContainerCount();
   }
 
   @FunctionalInterface
@@ -271,143 +333,79 @@ public class MySqlAccountService extends AbstractAccountService {
 
   @Override
   public void addDataset(Dataset dataset) throws AccountServiceException {
-    try {
-      String accountName = dataset.getAccountName();
-      String containerName = dataset.getContainerName();
-      Container container = getContainerByName(accountName, containerName);
-      if (container == null) {
-        throw new AccountServiceException("Can't find the container: " + containerName + " in account: " + accountName,
-            AccountServiceErrorCode.BadRequest);
-      }
-      short accountId = container.getParentAccountId();
-      short containerId = container.getId();
-      mySqlAccountStore.addDataset(accountId, containerId, dataset);
-    } catch (SQLException e) {
-      throw translateSQLException(e);
+    if (config.enableNewDatabaseForMigration) {
+      cachedAccountServiceNew.addDataset(dataset);
+    } else {
+      cachedAccountService.addDataset(dataset);
     }
   }
 
   @Override
   public void updateDataset(Dataset dataset) throws AccountServiceException {
-    try {
-      String accountName = dataset.getAccountName();
-      String containerName = dataset.getContainerName();
-      Container container = getContainerByName(accountName, containerName);
-      if (container == null) {
-        throw new AccountServiceException("Can't find the container: " + containerName + " in account: " + accountName,
-            AccountServiceErrorCode.BadRequest);
-      }
-      short accountId = container.getParentAccountId();
-      short containerId = container.getId();
-      mySqlAccountStore.updateDataset(accountId, containerId, dataset);
-    } catch (SQLException e) {
-      throw translateSQLException(e);
+    if (config.enableNewDatabaseForMigration) {
+      cachedAccountServiceNew.updateDataset(dataset);
+    } else {
+      cachedAccountService.updateDataset(dataset);
     }
   }
 
   @Override
   public Dataset getDataset(String accountName, String containerName, String datasetName)
       throws AccountServiceException {
-    try {
-      Container container = getContainerByName(accountName, containerName);
-      if (container == null) {
-        throw new AccountServiceException(
-            "Can't find the container: " + containerName + " in account: " + accountName,
-            AccountServiceErrorCode.BadRequest);
-      }
-      short accountId = container.getParentAccountId();
-      short containerId = container.getId();
-      return mySqlAccountStore.getDataset(accountId, containerId, accountName, containerName, datasetName);
-    } catch (SQLException e) {
-      throw translateSQLException(e);
+    if (config.enableNewDatabaseForMigration) {
+      return cachedAccountServiceNew.getDataset(accountName, containerName, datasetName);
     }
+    return cachedAccountService.getDataset(accountName, containerName, datasetName);
   }
 
   @Override
   public void deleteDataset(String accountName, String containerName, String datasetName)
       throws AccountServiceException {
-    try {
-      Container container = getContainerByName(accountName, containerName);
-      if (container == null) {
-        throw new AccountServiceException("Can't find the container: " + containerName + " in account: " + accountName,
-            AccountServiceErrorCode.BadRequest);
-      }
-      short accountId = container.getParentAccountId();
-      short containerId = container.getId();
-      mySqlAccountStore.deleteDataset(accountId, containerId, datasetName);
-    } catch (SQLException e) {
-      throw translateSQLException(e);
+    if (config.enableNewDatabaseForMigration) {
+      cachedAccountServiceNew.deleteDataset(accountName, containerName, datasetName);
+    } else {
+      cachedAccountService.deleteDataset(accountName, containerName, datasetName);
     }
   }
 
   @Override
   public DatasetVersionRecord addDatasetVersion(String accountName, String containerName, String datasetName,
-      String version, long timeToLiveInSeconds, long creationTimeInMs, boolean datasetVersionTtlEnabled) throws AccountServiceException {
-    try {
-      Container container = getContainerByName(accountName, containerName);
-      if (container == null) {
-        throw new AccountServiceException("Can't find the container: " + containerName + " in account: " + accountName,
-            AccountServiceErrorCode.BadRequest);
-      }
-      short accountId = container.getParentAccountId();
-      short containerId = container.getId();
-      return mySqlAccountStore.addDatasetVersion(accountId, containerId, accountName, containerName, datasetName,
-          version, timeToLiveInSeconds, creationTimeInMs, datasetVersionTtlEnabled);
-    } catch (SQLException e) {
-      throw translateSQLException(e);
+      String version, long timeToLiveInSeconds, long creationTimeInMs, boolean datasetVersionTtlEnabled)
+      throws AccountServiceException {
+    if (config.enableNewDatabaseForMigration) {
+      return cachedAccountServiceNew.addDatasetVersion(accountName, containerName, datasetName, version,
+          timeToLiveInSeconds, creationTimeInMs, datasetVersionTtlEnabled);
     }
+    return cachedAccountService.addDatasetVersion(accountName, containerName, datasetName, version, timeToLiveInSeconds,
+        creationTimeInMs, datasetVersionTtlEnabled);
   }
 
   @Override
   public DatasetVersionRecord getDatasetVersion(String accountName, String containerName, String datasetName,
       String version) throws AccountServiceException {
-    try {
-      Container container = getContainerByName(accountName, containerName);
-      if (container == null) {
-        throw new AccountServiceException("Can't find the container: " + containerName + " in account: " + accountName,
-            AccountServiceErrorCode.BadRequest);
-      }
-      short accountId = container.getParentAccountId();
-      short containerId = container.getId();
-      return mySqlAccountStore.getDatasetVersion(accountId, containerId, accountName, containerName, datasetName,
-          version);
-    } catch (SQLException e) {
-      throw translateSQLException(e);
+    if (config.enableNewDatabaseForMigration) {
+      return cachedAccountServiceNew.getDatasetVersion(accountName, containerName, datasetName, version);
     }
+    return cachedAccountService.getDatasetVersion(accountName, containerName, datasetName, version);
   }
 
   @Override
   public void deleteDatasetVersion(String accountName, String containerName, String datasetName,
       String version) throws AccountServiceException {
-    try {
-      Container container = getContainerByName(accountName, containerName);
-      if (container == null) {
-        throw new AccountServiceException("Can't find the container: " + containerName + " in account: " + accountName,
-            AccountServiceErrorCode.BadRequest);
-      }
-      short accountId = container.getParentAccountId();
-      short containerId = container.getId();
-      mySqlAccountStore.deleteDatasetVersion(accountId, containerId, datasetName, version);
-    } catch (SQLException e) {
-      throw translateSQLException(e);
+    if (config.enableNewDatabaseForMigration) {
+      cachedAccountServiceNew.deleteDatasetVersion(accountName, containerName, datasetName, version);
+    } else {
+      cachedAccountService.deleteDatasetVersion(accountName, containerName, datasetName, version);
     }
   }
 
   @Override
   public List<DatasetVersionRecord> getAllValidVersion(String accountName, String containerName, String datasetName)
       throws AccountServiceException {
-    try {
-      Container container = getContainerByName(accountName, containerName);
-      if (container == null) {
-        throw new AccountServiceException("Can't find the container: " + containerName + " in account: " + accountName,
-            AccountServiceErrorCode.BadRequest);
-      }
-      short accountId = container.getParentAccountId();
-      short containerId = container.getId();
-      return mySqlAccountStore.getAllValidVersion(accountId, containerId, datasetName);
-    } catch (SQLException e) {
-      throw translateSQLException(e);
+    if (config.enableNewDatabaseForMigration) {
+      return cachedAccountServiceNew.getAllValidVersion(accountName, containerName, datasetName);
     }
+      return cachedAccountService.getAllValidVersion(accountName, containerName, datasetName);
   }
 
   /**

--- a/ambry-api/src/main/java/com/github/ambry/config/MySqlAccountServiceConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/MySqlAccountServiceConfig.java
@@ -33,7 +33,12 @@ public class MySqlAccountServiceConfig extends AccountServiceConfig {
   public static final String WRITE_CACHE_AFTER_UPDATE = MYSQL_ACCOUNT_SERVICE_PREFIX + "write.cache.after.update";
   public static final String MAX_MAJOR_VERSION_FOR_SEMANTIC_SCHEMA_DATASET =
       MYSQL_ACCOUNT_SERVICE_PREFIX + "max.major.version.for.semantic.schema.dataset";
-  public static final String ENABLE_NEW_DATABASE_FOR_MIGRATION = MYSQL_ACCOUNT_SERVICE_PREFIX + "enable.new.database.for.migration";
+  public static final String ENABLE_NEW_DATABASE_FOR_MIGRATION =
+      MYSQL_ACCOUNT_SERVICE_PREFIX + "enable.new.database.for.migration";
+  public static final String IGNORE_NEW_DATABASE_UPLOAD_ERROR =
+      MYSQL_ACCOUNT_SERVICE_PREFIX + "ignore.new.database.upload.error";
+  public static final String ENABLE_GET_FROM_NEW_DB_ONLY = MYSQL_ACCOUNT_SERVICE_PREFIX + "enable.get.from.new.db.only";
+
 
   /**
    * Serialized json array containing the information about all mysql end points.
@@ -151,6 +156,20 @@ public class MySqlAccountServiceConfig extends AccountServiceConfig {
   @Default("false")
   public final boolean enableNewDatabaseForMigration;
 
+  /**
+   * If true, ignore the error when uploading data to new database.
+   */
+  @Config(IGNORE_NEW_DATABASE_UPLOAD_ERROR)
+  @Default("true")
+  public final boolean ignoreNewDatabaseUploadError;
+
+  /**
+   * If true, enable get from new database only.
+   */
+  @Config(ENABLE_GET_FROM_NEW_DB_ONLY)
+  @Default("false")
+  public final boolean enableGetFromNewDbOnly;
+
   public MySqlAccountServiceConfig(VerifiableProperties verifiableProperties) {
     super(verifiableProperties);
     dbInfo = verifiableProperties.getString(DB_INFO);
@@ -161,6 +180,8 @@ public class MySqlAccountServiceConfig extends AccountServiceConfig {
     backupDir = verifiableProperties.getString(BACKUP_DIRECTORY_KEY, "");
     updateDisabled = verifiableProperties.getBoolean(UPDATE_DISABLED, false);
     enableNewDatabaseForMigration = verifiableProperties.getBoolean(ENABLE_NEW_DATABASE_FOR_MIGRATION, false);
+    ignoreNewDatabaseUploadError = verifiableProperties.getBoolean(IGNORE_NEW_DATABASE_UPLOAD_ERROR, true);
+    enableGetFromNewDbOnly = verifiableProperties.getBoolean(ENABLE_GET_FROM_NEW_DB_ONLY, false);
     dbInfoNew = enableNewDatabaseForMigration ? verifiableProperties.getString(DB_INFO_NEW)
         : verifiableProperties.getString(DB_INFO_NEW, "");
     backupDirNew = verifiableProperties.getString(BACKUP_DIRECTORY_KEY_NEW, "");


### PR DESCRIPTION
This pr support:
1. when we have new db set up, we directly issue dataset request against new db since we don't need to migrate any data.
2. when ignoreNewDatabaseUploadError has been enabled, we ignore the upload failure against new db. this can be used at early stage where we don't want the new db upload affect the old db upload until we verify the data are in sync.
3. when enableGetFromNewDbOnly has been enabled, we only get data from new database. this will be enabled after the migration is done and been verified.