### PR TITLE
[Efficient Metadata Operations] For chunked upload requests decode the reserved metadata id from the request and encode the reserved metadata in the response.

### DIFF
--- a/ambry-account/src/test/java/com/github/ambry/account/MockRouter.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/MockRouter.java
@@ -15,6 +15,7 @@ package com.github.ambry.account;
 
 import com.github.ambry.commons.ByteBufferReadableStreamChannel;
 import com.github.ambry.commons.ReadableStreamChannelInputStream;
+import com.github.ambry.config.RouterConfig;
 import com.github.ambry.messageformat.BlobInfo;
 import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.commons.Callback;
@@ -172,6 +173,11 @@ public class MockRouter implements Router {
   public Future<Void> undeleteBlob(String blobId, String serviceId, Callback<Void> callback,
       QuotaChargeCallback quotaChargeCallback) {
     throw new UnsupportedOperationException("Undelete is currently unsupported");
+  }
+
+  @Override
+  public RouterConfig getRouterConfig() {
+    return null;
   }
 
   /**

--- a/ambry-api/src/main/java/com/github/ambry/frontend/ReservedMetadataIdMetrics.java
+++ b/ambry-api/src/main/java/com/github/ambry/frontend/ReservedMetadataIdMetrics.java
@@ -30,6 +30,9 @@ public class ReservedMetadataIdMetrics {
   public final Counter numReservedPartitionFoundUnavailableInLocalDcCount;
   public final Counter numReservedPartitionFoundUnavailableInAllDcCount;
   public final Counter reserveMetadataIdFailedForPostSignedUrlCount;
+  public final Counter noReservedMetadataFoundForChunkedUploadResponseCount;
+  public final Counter noReservedMetadataForChunkedUploadCount;
+  public final Counter mismatchedReservedMetadataForChunkedUploadCount;
 
   /**
    * Constructor for {@link ReservedMetadataIdMetrics}.
@@ -48,6 +51,12 @@ public class ReservedMetadataIdMetrics {
         MetricRegistry.name(ReservedMetadataIdMetrics.class, "NumReservedPartitionFoundUnavailableInAllDcCount"));
     reserveMetadataIdFailedForPostSignedUrlCount = metricRegistry.counter(
         MetricRegistry.name(ReservedMetadataIdMetrics.class, "ReserveMetadataIdFailedForPostSignedUrlCount"));
+    noReservedMetadataFoundForChunkedUploadResponseCount = metricRegistry.counter(
+        MetricRegistry.name(ReservedMetadataIdMetrics.class, "NoReservedMetadataFoundForChunkedUploadResponseCount"));
+    noReservedMetadataForChunkedUploadCount = metricRegistry.counter(
+        MetricRegistry.name(ReservedMetadataIdMetrics.class, "NoReservedMetadataForChunkedUploadCount"));
+    mismatchedReservedMetadataForChunkedUploadCount = metricRegistry.counter(
+        MetricRegistry.name(ReservedMetadataIdMetrics.class, "MismatchedReservedMetadataForChunkedUploadCount"));
   }
 
   /**

--- a/ambry-api/src/main/java/com/github/ambry/router/Router.java
+++ b/ambry-api/src/main/java/com/github/ambry/router/Router.java
@@ -15,6 +15,7 @@ package com.github.ambry.router;
 
 import com.github.ambry.commons.Callback;
 import com.github.ambry.commons.CallbackUtils;
+import com.github.ambry.config.RouterConfig;
 import com.github.ambry.messageformat.BlobInfo;
 import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.quota.QuotaChargeCallback;
@@ -213,4 +214,9 @@ public interface Router extends Closeable {
     undeleteBlob(blobId, serviceId, CallbackUtils.fromCompletableFuture(future), null);
     return future;
   }
+
+  /**
+   * @return RouterConfig object for the {@link Router}.
+   */
+  RouterConfig getRouterConfig();
 }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendMetrics.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendMetrics.java
@@ -263,6 +263,7 @@ public class FrontendMetrics {
   public final Histogram addDatasetVersionProcessingTimeInMs;
   public final Histogram getDatasetVersionProcessingTimeInMs;
   public final Histogram deleteDatasetVersionProcessingTimeInMs;
+  private final MetricRegistry metricRegistry;
 
   /**
    * Creates an instance of FrontendMetrics using the given {@code metricRegistry}.
@@ -671,5 +672,13 @@ public class FrontendMetrics {
         metricRegistry.histogram(MetricRegistry.name(GetBlobHandler.class, "GetDatasetVersionProcessingTimeInMs"));
     deleteDatasetVersionProcessingTimeInMs =
         metricRegistry.histogram(MetricRegistry.name(GetBlobHandler.class, "DeleteDatasetVersionProcessingTimeInMs"));
+    this.metricRegistry = metricRegistry;
+  }
+
+  /**
+   * @return the MetricRegistry object of {@link FrontendMetrics}.
+   */
+  public MetricRegistry getMetricRegistry() {
+    return metricRegistry;
   }
 }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendUtils.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendUtils.java
@@ -52,6 +52,19 @@ class FrontendUtils {
   static final String SLASH = "/";
 
   /**
+   * Throws the specified {@link RestServiceException} if isEnabled is {@code true}. No-op otherwise.
+   * @param restServiceException {@link RestServiceException} object to throw.
+   * @param isEnabled if {@code true} then throw the specified exception. do nothing otherwise.
+   * @throws RestServiceException the exception to throw.
+   */
+  static void throwRestServiceExceptionIfEnabled(RestServiceException restServiceException, boolean isEnabled)
+      throws RestServiceException {
+    if (isEnabled) {
+      throw restServiceException;
+    }
+  }
+
+  /**
    * Fetches {@link BlobId} from the given string representation of BlobId
    * @param blobIdStr string representation of BlobId
    * @param clusterMap {@link ClusterMap} instance to use

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
@@ -425,6 +425,7 @@ public class NamedBlobPutHandler {
      */
     List<ChunkInfo> getChunksToStitch(BlobProperties stitchedBlobProperties, JSONObject stitchRequestJson)
         throws RestServiceException {
+      String reservedMetadataBlobId = null;
       List<String> signedChunkIds = StitchRequestSerDe.fromJson(stitchRequestJson);
       if (signedChunkIds.isEmpty()) {
         throw new RestServiceException("Must provide at least one ID in stitch request",
@@ -456,8 +457,9 @@ public class NamedBlobPutHandler {
         @SuppressWarnings("ConstantConditions")
         long expirationTimeMs = RestUtils.getLongHeader(metadata, EXPIRATION_TIME_MS_KEY, true);
         verifyChunkAccountAndContainer(blobId, stitchedBlobProperties);
+        reservedMetadataBlobId = getAndVerifyReservedMetadataBlobId(metadata, reservedMetadataBlobId, blobId);
 
-        chunksToStitch.add(new ChunkInfo(blobId, chunkSizeBytes, expirationTimeMs, null));
+        chunksToStitch.add(new ChunkInfo(blobId, chunkSizeBytes, expirationTimeMs, reservedMetadataBlobId));
       }
       //the actual blob size for stitched blob is the sum of all the chunk sizes
       restResponseChannel.setHeader(RestUtils.Headers.BLOB_SIZE, totalStitchedBlobSize);
@@ -486,6 +488,36 @@ public class NamedBlobPutHandler {
             + stitchedBlobProperties.getAccountId() + ", " + stitchedBlobProperties.getContainerId() + ")",
             RestServiceErrorCode.BadRequest);
       }
+    }
+
+    /**
+     * Verify that the reserved metadata id for the specified chunkId is same as seen for previous chunks.
+     * Also return the chunk's reserved metadata id.
+     * @param metadata {@link Map} of metadata set in the signed ids.
+     * @param reservedMetadataBlobId Reserved metadata id for the chunks. Can be {@code null}.
+     * @param chunkId The chunk id.
+     * @return The reserved metadata id.
+     * @throws RestServiceException in case of any exception.
+     */
+    private String getAndVerifyReservedMetadataBlobId(Map<String, String> metadata, String reservedMetadataBlobId,
+        String chunkId) throws RestServiceException {
+      String chunkReservedMetadataBlobId = RestUtils.getHeader(metadata, RestUtils.Headers.RESERVED_METADATA_ID, false);
+      if (chunkReservedMetadataBlobId == null) {
+        ReservedMetadataIdMetrics.getReservedMetadataIdMetrics(
+            frontendMetrics.getMetricRegistry()).noReservedMetadataForChunkedUploadCount.inc();
+        throwRestServiceExceptionIfEnabled(
+            new RestServiceException(String.format("No reserved metadata id present in chunk %s signed url", chunkId),
+                RestServiceErrorCode.BadRequest), router.getRouterConfig().routerReservedMetadataEnabled);
+      }
+      if (reservedMetadataBlobId != null && !reservedMetadataBlobId.equals(chunkReservedMetadataBlobId)) {
+        ReservedMetadataIdMetrics.getReservedMetadataIdMetrics(
+            frontendMetrics.getMetricRegistry()).mismatchedReservedMetadataForChunkedUploadCount.inc();
+        throwRestServiceExceptionIfEnabled(new RestServiceException(String.format(
+                "Reserved metadata id for the chunks are not same. For chunk: %s the reserved metadata id is %s. But reserved metadata id %s was found earlier.",
+                chunkId, chunkReservedMetadataBlobId, reservedMetadataBlobId), RestServiceErrorCode.BadRequest),
+            router.getRouterConfig().routerReservedMetadataEnabled);
+      }
+      return chunkReservedMetadataBlobId;
     }
 
     /**

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/AmbrySecurityServiceTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/AmbrySecurityServiceTest.java
@@ -450,6 +450,7 @@ public class AmbrySecurityServiceTest {
     Map<String, String> userMetadata = RestUtils.buildUserMetadata(userMetadataArray);
     Assert.assertEquals("Encoded user metadata mismatch", Chinese,
         userMetadata.get(RestUtils.Headers.USER_META_DATA_HEADER_PREFIX + "filename"));
+    USER_METADATA.remove(RestUtils.Headers.USER_META_DATA_ENCODED_HEADER_PREFIX + "filename");
   }
 
   /**

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
@@ -3751,6 +3751,11 @@ class FrontendTestRouter implements Router {
   }
 
   @Override
+  public RouterConfig getRouterConfig() {
+    return null;
+  }
+
+  @Override
   public void close() {
     isOpen = false;
   }

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/NamedBlobPutHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/NamedBlobPutHandlerTest.java
@@ -25,6 +25,7 @@ import com.github.ambry.account.InMemAccountService;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.commons.ByteBufferReadableStreamChannel;
+import com.github.ambry.commons.CommonTestUtils;
 import com.github.ambry.config.FrontendConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.messageformat.BlobProperties;
@@ -134,6 +135,7 @@ public class NamedBlobPutHandlerTest {
     idConverterFactory = new FrontendTestIdConverterFactory();
     securityServiceFactory = new FrontendTestSecurityServiceFactory();
     Properties props = new Properties();
+    CommonTestUtils.populateRequiredRouterProps(props);
     VerifiableProperties verifiableProperties = new VerifiableProperties(props);
     router = new InMemoryRouter(verifiableProperties, CLUSTER_MAP);
     FrontendConfig frontendConfig = new FrontendConfig(verifiableProperties);

--- a/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouter.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouter.java
@@ -524,6 +524,11 @@ class NonBlockingRouter implements Router {
     return futureResult;
   }
 
+  @Override
+  public RouterConfig getRouterConfig() {
+    return routerConfig;
+  }
+
   /**
    * Initiated deletes of the blobIds in the given list of ids via the {@link BackgroundDeleter}
    * @param deleteRequests the list of {@link BackgroundDeleteRequest}s to execute.

--- a/ambry-test-utils/src/main/java/com/github/ambry/router/InMemoryRouter.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/router/InMemoryRouter.java
@@ -18,6 +18,7 @@ import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.Callback;
 import com.github.ambry.commons.CommonTestUtils;
+import com.github.ambry.config.RouterConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.messageformat.BlobInfo;
 import com.github.ambry.messageformat.BlobProperties;
@@ -372,6 +373,11 @@ public class InMemoryRouter implements Router {
       completeOperation(futureResult, callback, null, exception);
     }
     return futureResult;
+  }
+
+  @Override
+  public RouterConfig getRouterConfig() {
+    return new RouterConfig(verifiableProperties);
   }
 
   @Override

--- a/ambry-tools/src/main/java/com/github/ambry/tools/perf/rest/PerfRouter.java
+++ b/ambry-tools/src/main/java/com/github/ambry/tools/perf/rest/PerfRouter.java
@@ -16,6 +16,7 @@ package com.github.ambry.tools.perf.rest;
 import com.github.ambry.account.Account;
 import com.github.ambry.account.Container;
 import com.github.ambry.commons.Callback;
+import com.github.ambry.config.RouterConfig;
 import com.github.ambry.messageformat.BlobInfo;
 import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.quota.QuotaChargeCallback;
@@ -208,6 +209,11 @@ class PerfRouter implements Router {
       completeOperation(futureResult, callback, null, null);
     }
     return futureResult;
+  }
+
+  @Override
+  public RouterConfig getRouterConfig() {
+    return null;
   }
 
   @Override


### PR DESCRIPTION
There are 4 cases to handle in order to reserve metadata chunks:

1. Reserve metadata chunk id for regular Post requests to upload a regular simple or composite blob.
2. Reserve metadata chunk id for POST signed-url requests with the "chunked-upload" header set to true. This reserved metadata id will be used for chunked uploads and the subsequent stitch blob operation.
3. For chunked uploads use the reserved metadata id encoded in the signed URL and after upload encode the reserved metadata id in the signed-id of the chunk.
4. For stitch requests use the reserved metadata id in the signed-ids of the chunks.

This PR implements cases 3 & 4.