### PR TITLE
[Full-Auto] Avoid using same disk for concurrent replica additions 

### DIFF
--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
@@ -714,6 +714,8 @@ public class HelixClusterManager implements ClusterMap {
           logger.info("Replica addition infos map doesn't contain disk capacity. Disk {} capacity {} is not changed",
               targetDisk, targetDisk.getRawCapacityInBytes());
         }
+        // Update disk usage. However, this is just for tracking. We only check the disk usage in Full-auto mode.
+        targetDisk.decreaseAvailableSpaceInBytes(replicaCapacity);
         // A bootstrap replica is always ReplicaSealedStatus#NOT_SEALED.
         bootstrapReplica = new AmbryServerReplica(clusterMapConfig, currentPartition, targetDisk, true, replicaCapacity,
             ReplicaSealStatus.NOT_SEALED);
@@ -801,6 +803,7 @@ public class HelixClusterManager implements ClusterMap {
     AmbryDisk disk = potentialDisks.get(0);
 
     // Update disk usage
+    // TODO: Add a metric for this
     disk.decreaseAvailableSpaceInBytes(DEFAULT_REPLICA_CAPACITY_IN_BYTES);
 
     return disk;

--- a/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
@@ -373,8 +373,6 @@ public class DiskManager {
         // create a bootstrap-in-progress file to distinguish it from regular stores (the file will be checked during
         // BOOTSTRAP -> STANDBY transition)
         createBootstrapFileIfAbsent(replica);
-        // Update the disk used space
-        disk.decreaseAvailableSpaceInBytes(replica.getCapacityInBytes());
         logger.info("New store is successfully added into DiskManager.");
         succeed = true;
       }

--- a/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
@@ -522,6 +522,9 @@ public class StorageManager implements StoreManager {
         // sure old store of this replica is deleted (this store may be created in previous replica addition but failed
         // at some point). Then a brand new store associated with this replica should be created and started.
         if (!addBlobStore(replicaToAdd)) {
+          // We have decreased the available disk space in HelixClusterManager#getDiskForBootstrapReplica. Increase it
+          // back since addition of store failed.
+          replicaToAdd.getDiskId().increaseAvailableSpaceInBytes(replicaToAdd.getCapacityInBytes());
           logger.error("Failed to add store {} into storage manager", partitionName);
           throw new StateTransitionException("Failed to add store " + partitionName + " into storage manager",
               ReplicaOperationFailure);

--- a/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockClusterMap.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockClusterMap.java
@@ -637,6 +637,8 @@ public class MockClusterMap implements ClusterMap {
       for (ReplicaId replicaId : partition.getReplicaIds()) {
         if (replicaId.getDataNodeId().compareTo(dataNodeId) == 0) {
           newReplica = replicaId;
+          // Decrease available disk capacity in bytes. This is checked in StorageManagerTest#updateDiskSpaceOnReplicaAdditionTest()
+          newReplica.getDiskId().decreaseAvailableSpaceInBytes(replicaId.getCapacityInBytes());
           break;
         }
       }


### PR DESCRIPTION
When multiple replicas are bootstrapped concurrently on helix callback threads, we used the same disk repeatedly since the used disk space is only updated in the end. To avoid it, update available disk space as soon as it is selected for a replica.