### PR TITLE
[FULL_AUTO] Use tag to determine if a host is on FULL_AUTO or not

### DIFF
--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
@@ -30,7 +30,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
@@ -41,6 +40,7 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.apache.helix.AccessOption;
+import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixManager;
 import org.apache.helix.InstanceType;
 import org.apache.helix.NotificationContext;
@@ -48,11 +48,13 @@ import org.apache.helix.api.listeners.IdealStateChangeListener;
 import org.apache.helix.api.listeners.LiveInstanceChangeListener;
 import org.apache.helix.api.listeners.RoutingTableChangeListener;
 import org.apache.helix.model.IdealState;
+import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.LiveInstance;
 import org.apache.helix.spectator.RoutingTableSnapshot;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.zookeeper.zkclient.IZkDataListener;
+import org.apache.logging.log4j.util.Strings;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -90,9 +92,8 @@ public class HelixClusterManager implements ClusterMap {
   // Routing table snapshot reference used in aggregated cluster view.
   private final AtomicReference<RoutingTableSnapshot> globalRoutingTableSnapshotRef = new AtomicReference<>();
   private final ConcurrentHashMap<String, AmbryDataNode> instanceNameToAmbryDataNode = new ConcurrentHashMap<>();
-  private final Map<String, ConcurrentHashMap<String, Set<String>>> dcToInstanceNameToResources =
-      new ConcurrentHashMap<>();
-  private final Map<String, ConcurrentHashMap<String, ResourceProperty>> dcToResourceNameToResourceProperty =
+  private final Map<String, ConcurrentHashMap<String, Set<String>>> dcToInstanceNameToTags = new ConcurrentHashMap<>();
+  private final Map<String, ConcurrentHashMap<String, ResourceProperty>> dcToTagToResourceProperty =
       new ConcurrentHashMap<>();
   private final AtomicLong errorCount = new AtomicLong(0);
   private final AtomicLong clusterWideRawCapacityBytes = new AtomicLong(0);
@@ -105,6 +106,7 @@ public class HelixClusterManager implements ClusterMap {
   private final Map<String, Map<String, String>> partitionOverrideInfoMap = new HashMap<>();
   private final Map<String, ReplicaId> bootstrapReplicas = new ConcurrentHashMap<>();
   private ZkHelixPropertyStore<ZNRecord> helixPropertyStoreInLocalDc = null;
+  private HelixAdmin localHelixAdmin = null;
   // The current xid currently does not change after instantiation. This can change in the future, allowing the cluster
   // manager to dynamically incorporate newer changes in the cluster. This variable is atomic so that the gauge metric
   // reflects the current value.
@@ -236,6 +238,8 @@ public class HelixClusterManager implements ClusterMap {
     helixPropertyStoreInLocalDc = manager.getHelixPropertyStore();
     logger.info("HelixPropertyStore from local datacenter {} is: {}", dcZkInfo.getDcName(),
         helixPropertyStoreInLocalDc);
+    localHelixAdmin = manager.getClusterManagmentTool();
+    logger.info("HelixAdmin from local datacenter {} is: {}", dcZkInfo.getDcName(), localHelixAdmin);
     IZkDataListener dataListener = new IZkDataListener() {
       @Override
       public void handleDataChange(String dataPath, Object data) {
@@ -440,18 +444,23 @@ public class HelixClusterManager implements ClusterMap {
       throw new IllegalArgumentException("Instance " + instanceName + " doesn't exist");
     }
     String dcName = dataNodeId.getDatacenterName();
-    Set<String> resourceNames = dcToInstanceNameToResources.get(dcName).get(instanceName);
-    if (resourceNames == null || resourceNames.isEmpty()) {
-      logger.trace("DataNode {} doesn't have any resources", instanceName);
+    InstanceConfig instanceConfig = localHelixAdmin.getInstanceConfig(clusterName, instanceName);
+    if (instanceConfig == null) {
+      throw new IllegalArgumentException("Instance config for " + instanceName + " doesn't exist");
+    }
+    List<String> tags = instanceConfig.getTags();
+    if (tags == null || tags.isEmpty()) {
+      logger.trace("DataNode {} doesn't have any tags", instanceName);
       return false;
     }
     // Before turn on FULL_AUTO, we have to make sure each host only stores partitions from one resource
-    if (resourceNames.size() != 1) {
+    if (tags.size() != 1) {
+      logger.trace("DataNode {} has multiple tags {}", instanceName, tags);
       return false;
     }
     // Make sure all the resources turned on FULL_AUTO mode
-    String resourceName = resourceNames.iterator().next();
-    ResourceProperty property = dcToResourceNameToResourceProperty.get(dcName).get(resourceName);
+    String tag = tags.iterator().next();
+    ResourceProperty property = dcToTagToResourceProperty.get(dcName).get(tag);
     return property != null && property.rebalanceMode.equals(IdealState.RebalanceMode.FULL_AUTO);
   }
 
@@ -477,6 +486,10 @@ public class HelixClusterManager implements ClusterMap {
     }
     if (helixPropertyStoreInLocalDc != null) {
       helixPropertyStoreInLocalDc.stop();
+    }
+
+    if (localHelixAdmin != null) {
+      localHelixAdmin.close();
     }
   }
 
@@ -1315,8 +1328,7 @@ public class HelixClusterManager implements ClusterMap {
       if (dcName != null) {
         // Rebuild the entire partition-to-resource map in current dc
         ConcurrentHashMap<String, String> partitionToResourceMap = new ConcurrentHashMap<>();
-        ConcurrentHashMap<String, Set<String>> instanceNameToResourceNames = new ConcurrentHashMap<>();
-        ConcurrentHashMap<String, ResourceProperty> resourceNameToProperty = new ConcurrentHashMap<>();
+        ConcurrentHashMap<String, ResourceProperty> tagToProperty = new ConcurrentHashMap<>();
         for (IdealState state : idealStates) {
           String resourceName = state.getResourceName();
           for (String partitionName : state.getPartitionSet()) {
@@ -1324,17 +1336,13 @@ public class HelixClusterManager implements ClusterMap {
                 partitionToResourceMap.compute(partitionName, resourceNameReplaceFunc(resourceName));
             if (mappedResourceName.equals(resourceName)) {
               ResourceProperty resourceProperty = new ResourceProperty(resourceName, state.getRebalanceMode());
-              resourceNameToProperty.put(resourceName, resourceProperty);
-
-              for (String instanceName : state.getInstanceSet(partitionName)) {
-                instanceNameToResourceNames.computeIfAbsent(instanceName, k -> ConcurrentHashMap.newKeySet())
-                    .add(resourceName);
+              if (!Strings.isEmpty(state.getInstanceGroupTag())) {
+                tagToProperty.put(state.getInstanceGroupTag(), resourceProperty);
               }
             }
           }
         }
-        dcToResourceNameToResourceProperty.put(dcName, resourceNameToProperty);
-        dcToInstanceNameToResources.put(dcName, instanceNameToResourceNames);
+        dcToTagToResourceProperty.put(dcName, tagToProperty);
         partitionToResourceNameByDc.put(dcName, partitionToResourceMap);
       } else {
         logger.warn("Partition to resource mapping for aggregated cluster view would be built from external view");
@@ -1643,11 +1651,10 @@ public class HelixClusterManager implements ClusterMap {
         Collection<String> partiallySealedReplicas) {
       ReplicaSealStatus replicaSealStatus = ReplicaSealStatus.NOT_SEALED;
       if (clusterMapConfig.clusterMapEnablePartitionOverride && partitionOverrideInfoMap.containsKey(partitionName)) {
-        replicaSealStatus =
-            ClusterMapUtils.partitionStateStrToReplicaSealStatus(partitionOverrideInfoMap.get(partitionName)
-                .get(ClusterMapUtils.PARTITION_STATE));
+        replicaSealStatus = ClusterMapUtils.partitionStateStrToReplicaSealStatus(
+            partitionOverrideInfoMap.get(partitionName).get(ClusterMapUtils.PARTITION_STATE));
         if (replicaSealStatus == ReplicaSealStatus.SEALED) {
-          return  replicaSealStatus;
+          return replicaSealStatus;
         }
       } else {
         if (sealedReplicas.contains(partitionName)) {

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixClusterManagerTest.java
@@ -622,12 +622,20 @@ public class HelixClusterManagerTest {
     assumeTrue(!useComposite);
     metricRegistry = new MetricRegistry();
 
-    // Set the node to FullAuto
+    // Set the resource and all data nodes in local dc to FULL_AUTO
     List<String> resourceNames = helixCluster.getResources(localDc);
     String resourceName = resourceNames.get(0);
+    String tag = "TAG_100000";
     IdealState idealState = helixCluster.getResourceIdealState(resourceName, localDc);
     idealState.setRebalanceMode(IdealState.RebalanceMode.FULL_AUTO);
+    idealState.setInstanceGroupTag(tag);
     helixCluster.refreshIdealState();
+    for (DataNode dataNode : testHardwareLayout.getAllDataNodesFromDc(localDc)) {
+      String instanceName = ClusterMapUtils.getInstanceName(dataNode.getHostname(), dataNode.getPort());
+      InstanceConfig instanceConfig =
+          helixCluster.getHelixAdminFromDc(localDc).getInstanceConfig(helixCluster.getClusterName(), instanceName);
+      instanceConfig.addTag(tag);
+    }
 
     // Set ZNRecord is NULL in Helix PropertyStore
     HelixClusterManager helixClusterManager = new HelixClusterManager(clusterMapConfig, selfInstanceName,
@@ -653,9 +661,18 @@ public class HelixClusterManagerTest {
     // Set the node to FullAuto
     List<String> resourceNames = helixCluster.getResources(localDc);
     String resourceName = resourceNames.get(0);
+    String tag = "TAG_100000";
     IdealState idealState = helixCluster.getResourceIdealState(resourceName, localDc);
     idealState.setRebalanceMode(IdealState.RebalanceMode.FULL_AUTO);
+    idealState.setInstanceGroupTag(tag);
     helixCluster.refreshIdealState();
+    for (DataNode dataNode : testHardwareLayout.getAllDataNodesFromDc(localDc)) {
+      String instanceName = ClusterMapUtils.getInstanceName(dataNode.getHostname(), dataNode.getPort());
+      InstanceConfig instanceConfig =
+          helixCluster.getHelixAdminFromDc(localDc).getInstanceConfig(helixCluster.getClusterName(), instanceName);
+      instanceConfig.addTag(tag);
+    }
+
     // Set ZNRecord is NULL in Helix PropertyStore
     HelixClusterManager helixClusterManager = new HelixClusterManager(clusterMapConfig, selfInstanceName,
         new MockHelixManagerFactory(helixCluster, null, null, useAggregatedView), metricRegistry);

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixClusterManagerTest.java
@@ -16,6 +16,7 @@ package com.github.ambry.clustermap;
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.clustermap.HelixClusterManager.HelixClusterChangeHandler;
 import com.github.ambry.commons.CommonUtils;
 import com.github.ambry.commons.ResponseHandler;
 import com.github.ambry.config.ClusterMapConfig;
@@ -61,7 +62,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-import com.github.ambry.clustermap.HelixClusterManager.HelixClusterChangeHandler;
 
 import static com.github.ambry.clustermap.ClusterMapUtils.*;
 import static com.github.ambry.clustermap.TestUtils.*;
@@ -187,18 +187,21 @@ public class HelixClusterManagerTest {
         new PartitionRangeCheckParams(defaultRo.rangeEnd + 1, 5, SPECIAL_PARTITION_CLASS, PartitionState.READ_ONLY);
     testPartitionLayout.addNewPartitions(specialRo.count, SPECIAL_PARTITION_CLASS, PartitionState.READ_ONLY, localDc);
     // add 5 PRW partitions for default class
-    defaultPrw =
-        new PartitionRangeCheckParams(specialRo.rangeEnd + 1, 5, DEFAULT_PARTITION_CLASS, PartitionState.PARTIAL_READ_WRITE);
-    testPartitionLayout.addNewPartitions(defaultPrw.count, DEFAULT_PARTITION_CLASS, PartitionState.PARTIAL_READ_WRITE, localDc);
+    defaultPrw = new PartitionRangeCheckParams(specialRo.rangeEnd + 1, 5, DEFAULT_PARTITION_CLASS,
+        PartitionState.PARTIAL_READ_WRITE);
+    testPartitionLayout.addNewPartitions(defaultPrw.count, DEFAULT_PARTITION_CLASS, PartitionState.PARTIAL_READ_WRITE,
+        localDc);
     // add 5 PRW partitions for special class
-    specialPrw =
-        new PartitionRangeCheckParams(defaultPrw.rangeEnd + 1, 5, SPECIAL_PARTITION_CLASS, PartitionState.PARTIAL_READ_WRITE);
-    testPartitionLayout.addNewPartitions(specialPrw.count, SPECIAL_PARTITION_CLASS, PartitionState.PARTIAL_READ_WRITE, localDc);
+    specialPrw = new PartitionRangeCheckParams(defaultPrw.rangeEnd + 1, 5, SPECIAL_PARTITION_CLASS,
+        PartitionState.PARTIAL_READ_WRITE);
+    testPartitionLayout.addNewPartitions(specialPrw.count, SPECIAL_PARTITION_CLASS, PartitionState.PARTIAL_READ_WRITE,
+        localDc);
     // add 3 RW partition for the default class (these will be overridden to PRW for tests)
     defaultRwForPrw =
         new PartitionRangeCheckParams(specialPrw.rangeEnd + 1, numOfPartialReadWrite, DEFAULT_PARTITION_CLASS,
             PartitionState.READ_WRITE);
-    testPartitionLayout.addNewPartitions(defaultRwForPrw.count, DEFAULT_PARTITION_CLASS, PartitionState.READ_WRITE, localDc);
+    testPartitionLayout.addNewPartitions(defaultRwForPrw.count, DEFAULT_PARTITION_CLASS, PartitionState.READ_WRITE,
+        localDc);
 
     Utils.writeJsonObjectToFile(zkJson, zkLayoutPath);
     Utils.writeJsonObjectToFile(testHardwareLayout.getHardwareLayout().toJSONObject(), hardwareLayoutPath);
@@ -206,7 +209,8 @@ public class HelixClusterManagerTest {
 
     // Mock the override partition map
     Random rand = new Random();
-    int totalPartitionNum = testPartitionLayout.getPartitionCount() - numOfPartialReadWrite; // - numOfPartialReadWrite because last 3 partitions are reserved to be overrideen to PRW
+    int totalPartitionNum = testPartitionLayout.getPartitionCount()
+        - numOfPartialReadWrite; // - numOfPartialReadWrite because last 3 partitions are reserved to be overrideen to PRW
     numOfReadOnly = rand.nextInt(totalPartitionNum / 2 - 1);
     numOfReadWrite = totalPartitionNum - numOfReadOnly;
     partitionOverrideMap = new HashMap<>();
@@ -671,7 +675,8 @@ public class HelixClusterManagerTest {
 
     // 1. Success case: Verify all disks are used in round-robin fashion
     for (int i = 0; i < disks.size(); i++) {
-      ReplicaId bootstrapReplica = helixClusterManager.getBootstrapReplica(partitionOfNewReplica.toPathString(), ambryDataNode);
+      ReplicaId bootstrapReplica =
+          helixClusterManager.getBootstrapReplica(partitionOfNewReplica.toPathString(), ambryDataNode);
       assertTrue("Correct disk is not used", potentialDisks.contains((AmbryDisk) bootstrapReplica.getDiskId()));
       potentialDisks.remove((AmbryDisk) bootstrapReplica.getDiskId());
     }
@@ -880,8 +885,11 @@ public class HelixClusterManagerTest {
     }
     List<DataNode> allRemoteDcDataNodes = testHardwareLayout.getAllDataNodesFromDc(remoteDc);
     for (DataNode dataNode : allRemoteDcDataNodes) {
-      assertFalse("By default, remote node should not on FULL_AUTO",
-          helixClusterManager.isDataNodeInFullAutoMode(dataNode));
+      try {
+        helixClusterManager.isDataNodeInFullAutoMode(dataNode);
+        fail("By default, remote node should throw an exception");
+      } catch (IllegalArgumentException e) {
+      }
     }
 
     // Should have only one Resource when bootup
@@ -904,36 +912,65 @@ public class HelixClusterManagerTest {
     idealState.setRebalanceMode(IdealState.RebalanceMode.FULL_AUTO);
     helixCluster.refreshIdealState();
     for (DataNode dataNode : allLocalDcDataNodes) {
-      assertTrue("FULL_AUTO mode, local node should be on FULL_AUTO",
+      assertFalse("IdealState is on FULL_AUTO, but there is no tag for resource",
           helixClusterManager.isDataNodeInFullAutoMode(dataNode));
     }
-    // Remote data nodes should not be impacted
-    for (DataNode dataNode : allRemoteDcDataNodes) {
-      assertFalse("Local DC change, remote node should not on FULL_AUTO",
-          helixClusterManager.isDataNodeInFullAutoMode(dataNode));
-    }
-
-    // Now add new resource to the local dc, it will make hosts back to off FULL_AUTO.
-    // User MockHelixAdmin::addResource to add resource and external view
-    MockHelixAdmin localHelixAdmin = helixCluster.getHelixAdminFromDc(localDc);
-    // 1. add new resource
-    // 2. update partition to resource map
-    // 3. generate different states for different instances for again
-    String newResourceName = String.valueOf(Integer.valueOf(resourceName) + 1000);
-    localHelixAdmin.addResource("", newResourceName, cloneIdealState(idealState, newResourceName));
+    // Now update resource to have a tag
+    final String instanceGroupTag = "TAG_1000000";
+    idealState.setInstanceGroupTag(instanceGroupTag);
     helixCluster.refreshIdealState();
-
-    resourceNames = helixCluster.getResources(localDc);
-    assertEquals("Should have two resources after adding a new resource", 2, resourceNames.size());
     for (DataNode dataNode : allLocalDcDataNodes) {
-      assertFalse("More than one resources, local node should not on FULL_AUTO",
+      assertFalse("IdealState is on FULL_AUTO with tag, but instances don't have tags",
           helixClusterManager.isDataNodeInFullAutoMode(dataNode));
     }
 
-    helixCluster.removeResourceIdealState(newResourceName, localDc);
+    // Now update data node to have the same tag
     for (DataNode dataNode : allLocalDcDataNodes) {
-      assertTrue("Back to one resource, local node should on FULL_AUTO",
-          helixClusterManager.isDataNodeInFullAutoMode(dataNode));
+      String instanceName = ClusterMapUtils.getInstanceName(dataNode.getHostname(), dataNode.getPort());
+      InstanceConfig instanceConfig =
+          helixCluster.getHelixAdminFromDc(localDc).getInstanceConfig(helixCluster.getClusterName(), instanceName);
+      instanceConfig.addTag(instanceGroupTag);
+      assertTrue("Should be on FULL_AUTO", helixClusterManager.isDataNodeInFullAutoMode(dataNode));
+    }
+
+    // Now update data node to have another tag
+    for (DataNode dataNode : allLocalDcDataNodes) {
+      String instanceName = ClusterMapUtils.getInstanceName(dataNode.getHostname(), dataNode.getPort());
+      InstanceConfig instanceConfig =
+          helixCluster.getHelixAdminFromDc(localDc).getInstanceConfig(helixCluster.getClusterName(), instanceName);
+      instanceConfig.addTag(instanceGroupTag + "_another_one");
+      assertFalse("Instance has multiple tags", helixClusterManager.isDataNodeInFullAutoMode(dataNode));
+    }
+
+    // Now update data node to remove the extra tag
+    for (DataNode dataNode : allLocalDcDataNodes) {
+      String instanceName = ClusterMapUtils.getInstanceName(dataNode.getHostname(), dataNode.getPort());
+      InstanceConfig instanceConfig =
+          helixCluster.getHelixAdminFromDc(localDc).getInstanceConfig(helixCluster.getClusterName(), instanceName);
+      instanceConfig.removeTag(instanceGroupTag + "_another_one");
+      assertTrue("Should be on FULL_AUTO", helixClusterManager.isDataNodeInFullAutoMode(dataNode));
+    }
+
+    // Now update data node to remove the tag and add a new tag
+    for (DataNode dataNode : allLocalDcDataNodes) {
+      String instanceName = ClusterMapUtils.getInstanceName(dataNode.getHostname(), dataNode.getPort());
+      InstanceConfig instanceConfig =
+          helixCluster.getHelixAdminFromDc(localDc).getInstanceConfig(helixCluster.getClusterName(), instanceName);
+      instanceConfig.removeTag(instanceGroupTag);
+      instanceConfig.addTag("random_tag");
+      assertFalse("Instance has random tag", helixClusterManager.isDataNodeInFullAutoMode(dataNode));
+    }
+
+    // Now update data node to has the same tag but switch resource back to semi auto
+    idealState.setRebalanceMode(IdealState.RebalanceMode.SEMI_AUTO);
+    helixCluster.refreshIdealState();
+    for (DataNode dataNode : allLocalDcDataNodes) {
+      String instanceName = ClusterMapUtils.getInstanceName(dataNode.getHostname(), dataNode.getPort());
+      InstanceConfig instanceConfig =
+          helixCluster.getHelixAdminFromDc(localDc).getInstanceConfig(helixCluster.getClusterName(), instanceName);
+      instanceConfig.removeTag("random_tag");
+      instanceConfig.addTag(instanceGroupTag);
+      assertFalse("Resource is in SEMI AUTO", helixClusterManager.isDataNodeInFullAutoMode(dataNode));
     }
   }
 
@@ -1544,11 +1581,12 @@ public class HelixClusterManagerTest {
     // "good" cases for getPartitions() and getWritablePartitions() only
     // getPartitions(), class null
     List<? extends PartitionId> returnedPartitions = clusterManager.getAllPartitionIds(null);
-    checkReturnedPartitions(returnedPartitions, Arrays.asList(defaultRw, defaultRo, defaultPrw, specialRw, specialRo,
-        specialPrw, defaultRwForPrw));
+    checkReturnedPartitions(returnedPartitions,
+        Arrays.asList(defaultRw, defaultRo, defaultPrw, specialRw, specialRo, specialPrw, defaultRwForPrw));
     // getWritablePartitions(), class null
     returnedPartitions = clusterManager.getWritablePartitionIds(null);
-    checkReturnedPartitions(returnedPartitions, Arrays.asList(defaultRw, specialRw, specialPrw, defaultPrw, defaultRwForPrw));
+    checkReturnedPartitions(returnedPartitions,
+        Arrays.asList(defaultRw, specialRw, specialPrw, defaultPrw, defaultRwForPrw));
     // getFullyWritablePartitions(), class null
     returnedPartitions = clusterManager.getFullyWritablePartitionIds(null);
     checkReturnedPartitions(returnedPartitions, Arrays.asList(defaultRw, specialRw, defaultRwForPrw));
@@ -1612,8 +1650,8 @@ public class HelixClusterManagerTest {
       assertEquals(ReplicaSealStatus.PARTIALLY_SEALED,
           helixClusterChangeHandler.resolveReplicaSealStatus(Integer.toString(firstPartitionId), sealedList,
               partiallySealedList));
-      assertEquals(ReplicaSealStatus.NOT_SEALED, helixClusterChangeHandler.resolveReplicaSealStatus(partitionName3,
-          sealedList, partiallySealedList));
+      assertEquals(ReplicaSealStatus.NOT_SEALED,
+          helixClusterChangeHandler.resolveReplicaSealStatus(partitionName3, sealedList, partiallySealedList));
     }
   }
 


### PR DESCRIPTION
## Summary 
This PR change the implementation of `isDataNodeInFullAutoMode`.

The issue with the current implementation is that when data node restarts, helix would remove it from all the IdealState and ExternalView so we can't figure out which resource this host's partitions belong to. In this case, whenever a data node restarts, it will be changed back out to SEMI AUTO.

The new implementation fixes this issue.

The new implementation relies on the tag rather then the IdealState. Before we turn on FULL_AUTO on any resource, we would add a tag to the resource and the same tag to all the instances that belong to this resource. The tag is not going to disappear when the instance (data node) restarts. In this way, we can rely on this tag to determine if the FULL_AUTO is turned on.