### PR TITLE
[repl] Do not advance token when there are invalid messages

### DIFF
--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -1305,10 +1305,9 @@ public class ReplicaThread implements Runnable {
                     messageInfoList);
               }
 
-              remoteReplicaInfo.setToken(exchangeMetadataResponse.remoteToken);
-              remoteReplicaInfo.setLocalLagFromRemoteInBytes(exchangeMetadataResponse.localLagFromRemoteInBytes);
-              // reset stored metadata response for this replica
-              remoteReplicaInfo.setExchangeMetadataResponse(new ExchangeMetadataResponse(ServerErrorCode.No_Error));
+              if (!validMessageDetectionInputStream.hasInvalidMessages()) {
+                advanceToken(remoteReplicaInfo, exchangeMetadataResponse);
+              }
 
               logger.trace("Remote node: {} Thread name: {} Remote replica: {} Token after speaking to remote node: {}",
                   remoteNode, threadName, remoteReplicaInfo.getReplicaId(), exchangeMetadataResponse.remoteToken);
@@ -1340,6 +1339,18 @@ public class ReplicaThread implements Runnable {
     long batchStoreWriteTime = time.milliseconds() - startTime;
     replicationMetrics.updateBatchStoreWriteTime(batchStoreWriteTime, totalBytesFixed, totalBlobsFixed,
         replicatingFromRemoteColo, replicatingOverSsl, datacenterName, remoteColoGetRequestForStandby);
+  }
+
+  /**
+   * Advances local token to make progress on replication
+   * @param remoteReplicaInfo Remote replica info object
+   * @param exchangeMetadataResponse Metadata object exchanged between replicas
+   */
+  protected void advanceToken(RemoteReplicaInfo remoteReplicaInfo, ExchangeMetadataResponse exchangeMetadataResponse) {
+    remoteReplicaInfo.setToken(exchangeMetadataResponse.remoteToken);
+    remoteReplicaInfo.setLocalLagFromRemoteInBytes(exchangeMetadataResponse.localLagFromRemoteInBytes);
+    // reset stored metadata response for this replica so that we send next request for metadata
+    remoteReplicaInfo.setExchangeMetadataResponse(new ExchangeMetadataResponse(ServerErrorCode.No_Error));
   }
 
   /**

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -1310,7 +1310,7 @@ public class ReplicaThread implements Runnable {
               }
 
               logger.trace("Remote node: {} Thread name: {} Remote replica: {} Token after speaking to remote node: {}",
-                  remoteNode, threadName, remoteReplicaInfo.getReplicaId(), exchangeMetadataResponse.remoteToken);
+                  remoteNode, threadName, remoteReplicaInfo.getReplicaId(), remoteReplicaInfo.getToken());
             } catch (StoreException e) {
               if (e.getErrorCode() != StoreErrorCodes.Already_Exist) {
                 replicationMetrics.updateLocalStoreError(remoteReplicaInfo.getReplicaId());


### PR DESCRIPTION
In the existing replication logic, when a CRC mismatch occurs, the system simply bypasses those keys and moves forward with the token. Consequently, we end up overlooking those specific keys, and there is no opportunity to revisit them later.

For instance, we encountered a bug that caused us to unintentionally skip the backup of 1090 blobs as a direct consequence of this issue.