### PR TITLE
Add a network client implementation to communicate with cloud

### DIFF
--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/RecoveryNetworkClient.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/RecoveryNetworkClient.java
@@ -251,6 +251,12 @@ public class RecoveryNetworkClient implements NetworkClient {
     return store.getSizeInBytes() - totalBytesRead;
   }
 
+  /**
+   * Handle GetRequest but return fake blob content with all zero value bytes
+   * @param content
+   * @return
+   * @throws IOException
+   */
   private GetResponse handleGetRequest(ByteBuf content) throws IOException {
     GetRequest request = GetRequest.readFrom(new NettyByteBufDataInputStream(content), clustermap);
     if (request.getMessageFormatFlag() != MessageFormatFlags.All) {

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/RecoveryNetworkClient.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/RecoveryNetworkClient.java
@@ -1,0 +1,249 @@
+/**
+ * Copyright 2023 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.cloud;
+
+import com.azure.cosmos.ConsistencyLevel;
+import com.azure.cosmos.CosmosContainer;
+import com.azure.cosmos.models.CosmosQueryRequestOptions;
+import com.azure.cosmos.models.FeedResponse;
+import com.azure.cosmos.models.PartitionKey;
+import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.clustermap.DataNodeId;
+import com.github.ambry.clustermap.PartitionId;
+import com.github.ambry.clustermap.ReplicaType;
+import com.github.ambry.commons.BlobId;
+import com.github.ambry.network.NetworkClient;
+import com.github.ambry.network.NetworkClientErrorCode;
+import com.github.ambry.network.RequestInfo;
+import com.github.ambry.network.ResponseInfo;
+import com.github.ambry.network.Send;
+import com.github.ambry.protocol.ReplicaMetadataRequest;
+import com.github.ambry.protocol.ReplicaMetadataRequestInfo;
+import com.github.ambry.protocol.ReplicaMetadataResponse;
+import com.github.ambry.protocol.ReplicaMetadataResponseInfo;
+import com.github.ambry.protocol.RequestOrResponseType;
+import com.github.ambry.replication.FindTokenHelper;
+import com.github.ambry.server.ServerErrorCode;
+import com.github.ambry.server.StoreManager;
+import com.github.ambry.store.MessageInfo;
+import com.github.ambry.store.Store;
+import com.github.ambry.utils.NettyByteBufDataInputStream;
+import io.netty.buffer.ByteBuf;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * An implementation of {@link NetworkClient} that get the response for each request from Azure cloud.
+ */
+public class RecoveryNetworkClient implements NetworkClient {
+  private final static Logger logger = LoggerFactory.getLogger(RecoveryNetworkClient.class);
+  private final ClusterMap clustermap;
+  private final FindTokenHelper findTokenHelper;
+  private final StoreManager storeManager;
+  protected final CosmosContainer cosmosContainer;
+
+  public RecoveryNetworkClient(ClusterMap clustermap, FindTokenHelper findTokenHelper, StoreManager storeManager,
+      CosmosContainer cosmosContainer) {
+    this.clustermap = clustermap;
+    this.findTokenHelper = findTokenHelper;
+    this.storeManager = storeManager;
+    this.cosmosContainer = cosmosContainer;
+  }
+
+  @Override
+  public List<ResponseInfo> sendAndPoll(List<RequestInfo> requestsToSend, Set<Integer> requestsToDrop,
+      int pollTimeoutMs) {
+    List<ResponseInfo> responseInfos = new ArrayList<>();
+    for (RequestInfo requestInfo : requestsToSend) {
+      ByteBuf content = requestInfo.getRequest().content();
+      RequestOrResponseType type = null;
+      Send send = null;
+      try {
+        content.readLong(); // Skip the size of the
+        type = RequestOrResponseType.values()[content.readShort()];
+        // RecoveryNetworkClient only cares about the ReplicaMetadataRequest and GetRequest
+        switch (type) {
+          case ReplicaMetadataRequest:
+            send = handleReplicaMetadataRequest(content);
+            break;
+          default:
+        }
+      } catch (Exception exception) {
+        logger.error("Failed to handle request: type {}", type, exception);
+      } finally {
+        content.release();
+      }
+      ResponseInfo responseInfo;
+      if (send != null) {
+        responseInfo = new ResponseInfo(requestInfo, null, requestInfo.getReplicaId().getDataNodeId(), send);
+      } else {
+        responseInfo = new ResponseInfo(requestInfo, NetworkClientErrorCode.NetworkError,
+            requestInfo.getReplicaId().getDataNodeId(), null);
+      }
+      responseInfos.add(responseInfo);
+    }
+    return responseInfos;
+  }
+
+  private ReplicaMetadataResponse handleReplicaMetadataRequest(ByteBuf content) throws IOException {
+    ReplicaMetadataRequest request =
+        ReplicaMetadataRequest.readFrom(new NettyByteBufDataInputStream(content), clustermap, findTokenHelper);
+    final String COSMOS_QUERY = "select * from c where c.partitionId = \"%s\"";
+    List<ReplicaMetadataResponseInfo> replicaMetadataResponseList =
+        new ArrayList<>(request.getReplicaMetadataRequestInfoList().size());
+    short replicaMetadataRequestVersion = ReplicaMetadataResponse.getCompatibleResponseVersion(request.getVersionId());
+    for (ReplicaMetadataRequestInfo replicaMetadataRequestInfo : request.getReplicaMetadataRequestInfoList()) {
+      PartitionId partitionId = replicaMetadataRequestInfo.getPartitionId();
+      ReplicaType replicaType = replicaMetadataRequestInfo.getReplicaType();
+      String partitionPath = String.valueOf(partitionId.getId());
+      Store store = storeManager.getStore(partitionId);
+
+      RecoveryToken currRecoveryToken = (RecoveryToken) replicaMetadataRequestInfo.getToken();
+      RecoveryToken nextRecoveryToken = new RecoveryToken();
+      List<MessageInfo> messageEntries = new ArrayList<>();
+      String cosmosQuery = String.format(COSMOS_QUERY, partitionPath);
+      CosmosQueryRequestOptions cosmosQueryRequestOptions = new CosmosQueryRequestOptions();
+      cosmosQueryRequestOptions.setPartitionKey(new PartitionKey(partitionPath));
+      // eventual consistency is cheapest
+      cosmosQueryRequestOptions.setConsistencyLevel(ConsistencyLevel.EVENTUAL);
+      long lastQueryTime = System.currentTimeMillis();
+      String queryName = String.join("_", "recovery_query", partitionPath, String.valueOf(lastQueryTime));
+      cosmosQueryRequestOptions.setQueryName(queryName);
+      logger.trace("QueryName = {} | Sending cosmos query '{}'", queryName, cosmosQuery);
+      try {
+        long startTime = System.currentTimeMillis();
+        int numPages = 0, numItems = 0;
+        double requestCharge = 0;
+        Iterable<FeedResponse<CloudBlobMetadata>> cloudBlobMetadataIter =
+            cosmosContainer.queryItems(cosmosQuery, cosmosQueryRequestOptions, CloudBlobMetadata.class)
+                .iterableByPage(currRecoveryToken.getCosmosContinuationToken());
+
+        String firstBlobId = currRecoveryToken.getEarliestBlob(), lastBlobId = currRecoveryToken.getLatestBlob();
+        long totalBlobBytesRead = 0, backupStartTime = currRecoveryToken.getBackupStartTimeMs(), backupEndTime =
+            currRecoveryToken.getBackupEndTimeMs();
+
+        for (FeedResponse<CloudBlobMetadata> page : cloudBlobMetadataIter) {
+          requestCharge += page.getRequestCharge();
+          for (CloudBlobMetadata cloudBlobMetadata : page.getResults()) {
+            MessageInfo messageInfo = getMessageInfoFromMetadata(cloudBlobMetadata);
+            messageEntries.add(messageInfo);
+            totalBlobBytesRead += cloudBlobMetadata.getSize();
+            if (backupStartTime == -1 || (cloudBlobMetadata.getCreationTime() < backupStartTime)) {
+              backupStartTime = cloudBlobMetadata.getCreationTime();
+              firstBlobId = cloudBlobMetadata.getId();
+            }
+            if (backupEndTime == -1 || (backupEndTime < cloudBlobMetadata.getLastUpdateTime() * 1000)) {
+              backupEndTime = cloudBlobMetadata.getLastUpdateTime() * 1000;
+              lastBlobId = cloudBlobMetadata.getId();
+            }
+            numItems += !(messageInfo.isDeleted() || messageInfo.isExpired()) ? 1 : 0;
+          }
+          //if (numItems != page.getResults().size()) {
+          //  logger.error("Item count mismatch numItems = {}, page.size = {}, prev_token = {}", numItems,
+          //      page.getResults().size(), currRecoveryToken.getCosmosContinuationToken());
+          //}
+          String nextCosmosContinuationToken = getCosmosContinuationToken(page.getContinuationToken());
+          nextRecoveryToken = new RecoveryToken(queryName,
+              nextCosmosContinuationToken == null ? currRecoveryToken.getCosmosContinuationToken()
+                  : page.getContinuationToken(), currRecoveryToken.getRequestUnits() + page.getRequestCharge(),
+              currRecoveryToken.getNumItems() + (currRecoveryToken.isEndOfPartitionReached() ? 0 : numItems),
+              currRecoveryToken.getNumBlobBytes() + (currRecoveryToken.isEndOfPartitionReached() ? 0
+                  : totalBlobBytesRead), nextCosmosContinuationToken == null, currRecoveryToken.getTokenCreateTime(),
+              backupStartTime, backupEndTime, lastQueryTime, firstBlobId, lastBlobId);
+          ++numPages;
+          long resultFetchtime = System.currentTimeMillis() - startTime;
+          logger.trace(
+              "Received cosmos query results page = {}, time = {} ms, RU = {}/s, numRows = {}, tokenLen = {}, isTokenNull = {}, isTokenSameAsPrevious = {}",
+              queryName, numPages, resultFetchtime, requestCharge, page != null ? page.getResults().size() : "null",
+              nextCosmosContinuationToken != null ? nextCosmosContinuationToken.length() : "null",
+              nextCosmosContinuationToken != null ? nextCosmosContinuationToken.isEmpty() : "null",
+              nextCosmosContinuationToken != null ? nextCosmosContinuationToken.equals(
+                  currRecoveryToken.getCosmosContinuationToken()) : "null");
+
+          break;
+        }
+        replicaMetadataResponseList.add(
+            new ReplicaMetadataResponseInfo(partitionId, replicaType, nextRecoveryToken, messageEntries,
+                getRemoteReplicaLag(store, totalBlobBytesRead), replicaMetadataRequestVersion));
+        // Catching and printing CosmosException does not work. The error is thrown and printed elsewhere.
+      } catch (Exception exception) {
+        logger.error("[{}] Failed due to {}", queryName, exception);
+        // Still sending a response back, but with io error
+        replicaMetadataResponseList.add(
+            new ReplicaMetadataResponseInfo(partitionId, replicaType, ServerErrorCode.IO_Error,
+                replicaMetadataRequestVersion));
+      }
+    }
+    return new ReplicaMetadataResponse(request.getCorrelationId(), request.getClientId(), ServerErrorCode.No_Error,
+        replicaMetadataResponseList, replicaMetadataRequestVersion);
+  }
+
+  /**
+   * Create {@link MessageInfo} object from {@link CloudBlobMetadata} object.
+   * @param metadata {@link CloudBlobMetadata} object.
+   * @return {@link MessageInfo} object.
+   * @throws IOException
+   */
+  private MessageInfo getMessageInfoFromMetadata(CloudBlobMetadata metadata) throws IOException {
+    BlobId blobId = new BlobId(metadata.getId(), clustermap);
+    long operationTime = (metadata.getDeletionTime() > 0) ? metadata.getDeletionTime()
+        : (metadata.getCreationTime() > 0) ? metadata.getCreationTime() : metadata.getUploadTime();
+    boolean isDeleted = metadata.getDeletionTime() > 0;
+    boolean isTtlUpdated = false;  // No way to know
+    return new MessageInfo(blobId, metadata.getSize(), isDeleted, isTtlUpdated, metadata.getExpirationTime(),
+        (short) metadata.getAccountId(), (short) metadata.getContainerId(), operationTime);
+  }
+
+  protected String getCosmosContinuationToken(String continuationToken) {
+    if (continuationToken == null || continuationToken.isEmpty()) {
+      return null;
+    }
+    try {
+      JSONObject continuationTokenJson = new JSONObject(continuationToken);
+      // compositeToken = continuationTokenJson.getString("token");
+      // compositeToken = compositeToken.substring(compositeToken.indexOf('{'), compositeToken.lastIndexOf('}') + 1).replace('\"', '"');
+      return continuationTokenJson.getString("token");
+    } catch (Exception e) {
+      logger.error("ContinuationToken = {} | failed to getToken due to {} ", continuationToken, e.toString());
+    }
+    return null;
+  }
+
+  protected long getRemoteReplicaLag(Store store, long totalBytesRead) {
+    return store.getSizeInBytes() - totalBytesRead;
+  }
+
+  @Override
+  public int warmUpConnections(List<DataNodeId> dataNodeIds, int connectionWarmUpPercentagePerDataNode,
+      long timeForWarmUp, List<ResponseInfo> responseInfoList) {
+    logger.info("Warmup is called");
+    return 0;
+  }
+
+  @Override
+  public void wakeup() {
+    logger.info("Wakeup is called");
+  }
+
+  @Override
+  public void close() {
+    logger.info("Close is called");
+  }
+}

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/RecoveryNetworkClientFactory.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/RecoveryNetworkClientFactory.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2023 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.cloud;
+
+import com.azure.cosmos.CosmosContainer;
+import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.network.NetworkClient;
+import com.github.ambry.network.NetworkClientFactory;
+import com.github.ambry.replication.FindTokenHelper;
+import com.github.ambry.server.StoreManager;
+import java.io.IOException;
+
+
+/**
+ * Factory to create a {@link RecoveryNetworkClient}.
+ */
+public class RecoveryNetworkClientFactory implements NetworkClientFactory {
+  private final ClusterMap clustermap;
+  private final FindTokenHelper findTokenHelper;
+  private final StoreManager storeManager;
+  private final CosmosContainer cosmosContainer;
+
+  /**
+   * Constructor to create the factory
+   * @param clusterMap The {@link ClusterMap} object.
+   * @param findTokenHelper The {@link FindTokenHelper} object.
+   * @param storeManager The {@link StoreManager} object.
+   * @param cosmosContainer The {@link CosmosContainer} object.
+   */
+  public RecoveryNetworkClientFactory(ClusterMap clusterMap, FindTokenHelper findTokenHelper, StoreManager storeManager,
+      CosmosContainer cosmosContainer) {
+    this.clustermap = clusterMap;
+    this.findTokenHelper = findTokenHelper;
+    this.storeManager = storeManager;
+    this.cosmosContainer = cosmosContainer;
+  }
+
+  @Override
+  public NetworkClient getNetworkClient() throws IOException {
+    return new RecoveryNetworkClient(clustermap, findTokenHelper, storeManager, cosmosContainer);
+  }
+}

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/RecoveryToken.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/RecoveryToken.java
@@ -1,0 +1,191 @@
+/**
+ * Copyright 2023 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.cloud;
+
+import com.github.ambry.replication.FindToken;
+import com.github.ambry.replication.FindTokenType;
+import java.lang.reflect.Field;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.LinkedHashMap;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class RecoveryToken implements FindToken {
+  private final Logger logger = LoggerFactory.getLogger(RecoveryToken.class);
+  public static final String QUERY_NAME = "last_query_name";
+  public static final String COSMOS_CONTINUATION_TOKEN = "cosmos_continuation_token";
+  public static final String REQUEST_UNITS = "request_units_charged_so_far";
+  public static final String NUM_ITEMS = "num_items_read_so_far";
+  public static final String NUM_BLOB_BYTES = "blob_bytes_read_so_far";
+  public static final String END_OF_PARTITION = "end_of_partition_reached";
+  public static final String TOKEN_CREATE_TIME = "token_create_time_gmt";
+  public static final String EARLIEST_BLOB = "earliest_blob_id";
+  public static final String BACKUP_START_TIME = "earliest_blob_create_time_ms";
+  public static final String BACKUP_START_TIME_GMT = "earliest_blob_create_time_gmt";
+
+  public static final String LATEST_BLOB = "latest_blob_id";
+  public static final String BACKUP_END_TIME = "latest_blob_update_time_ms";
+  public static final String BACKUP_END_TIME_GMT = "latest_blob_update_time_gmt";
+
+  public static final String LAST_QUERY_TIME = "last_query_time_gmt";
+  public static final DateFormat DATE_FORMAT = new SimpleDateFormat("dd MMM yyyy HH:mm:ss:SSS");
+
+  private String queryName = null;
+  private String cosmosContinuationToken = null;
+  private double requestUnits = 0;
+  private long numItems = 0;
+  private long numBlobBytes = 0;
+  private boolean endOfPartitionReached = false;
+  private final String tokenCreateTime;
+  private long backupStartTime = -1;
+  private long backupEndTime = -1;
+  private String lastQueryTime = null;
+  private String firstBlobId = null;
+  private String lastBlobId = null;
+
+  public RecoveryToken(String queryName, String cosmosContinuationToken, double requestUnits, long numItems,
+      long numBytes, boolean endOfPartitionReached, String tokenCreateTime, long backupStartTime, long backupEndTime,
+      long lastQueryTime, String firstBlobId, String lastBlobId) {
+    this.queryName = queryName;
+    this.cosmosContinuationToken = cosmosContinuationToken;
+    this.requestUnits = requestUnits;
+    this.numItems = numItems;
+    this.numBlobBytes = numBytes;
+    this.endOfPartitionReached = endOfPartitionReached;
+    this.tokenCreateTime = tokenCreateTime;
+    this.backupStartTime = backupStartTime;
+    this.backupEndTime = backupEndTime;
+    this.lastQueryTime = DATE_FORMAT.format(lastQueryTime);
+    this.firstBlobId = firstBlobId;
+    this.lastBlobId = lastBlobId;
+  }
+
+  public RecoveryToken(JSONObject jsonObject) {
+    this.queryName = jsonObject.getString(QUERY_NAME);
+    this.cosmosContinuationToken = jsonObject.getString(COSMOS_CONTINUATION_TOKEN);
+    this.requestUnits = jsonObject.getDouble(REQUEST_UNITS);
+    this.numItems = jsonObject.getLong(NUM_ITEMS);
+    this.numBlobBytes = jsonObject.getLong(NUM_BLOB_BYTES);
+    this.endOfPartitionReached = jsonObject.getBoolean(END_OF_PARTITION);
+    this.tokenCreateTime = jsonObject.getString(TOKEN_CREATE_TIME);
+    this.firstBlobId = jsonObject.getString(EARLIEST_BLOB);
+    this.backupStartTime = jsonObject.getLong(BACKUP_START_TIME);
+    this.lastBlobId = jsonObject.getString(LATEST_BLOB);
+    this.backupEndTime = jsonObject.getLong(BACKUP_END_TIME);
+    this.lastQueryTime = jsonObject.getString(LAST_QUERY_TIME);
+  }
+
+  public RecoveryToken() {
+    this.tokenCreateTime = DATE_FORMAT.format(System.currentTimeMillis());
+  }
+
+  public String getQueryName() {
+    return queryName;
+  }
+
+  public String getCosmosContinuationToken() {
+    return cosmosContinuationToken;
+  }
+
+  public double getRequestUnits() {
+    return requestUnits;
+  }
+
+  public long getNumItems() {
+    return numItems;
+  }
+
+  public long getNumBlobBytes() {
+    return numBlobBytes;
+  }
+
+  public boolean isEndOfPartitionReached() {
+    return endOfPartitionReached;
+  }
+
+  public boolean isEmpty() {
+    return getCosmosContinuationToken().isEmpty();
+  }
+
+  public String getTokenCreateTime() {
+    return tokenCreateTime;
+  }
+
+  public long getBackupStartTimeMs() {
+    return backupStartTime;
+  }
+
+  public long getBackupEndTimeMs() {
+    return backupEndTime;
+  }
+
+  public String getEarliestBlob() {
+    return firstBlobId;
+  }
+
+  public String getLatestBlob() {
+    return lastBlobId;
+  }
+
+  public String toString() {
+    JSONObject jsonObject = new JSONObject();
+    try {
+      Field changeMap = jsonObject.getClass().getDeclaredField("map");
+      changeMap.setAccessible(true);
+      changeMap.set(jsonObject, new LinkedHashMap<>());
+      changeMap.setAccessible(false);
+    } catch (IllegalAccessException | NoSuchFieldException e) {
+      logger.error(e.getMessage());
+      jsonObject = new JSONObject();
+    }
+    jsonObject.put(COSMOS_CONTINUATION_TOKEN, this.getCosmosContinuationToken());
+    jsonObject.put(EARLIEST_BLOB, this.firstBlobId);
+    jsonObject.put(BACKUP_START_TIME, backupStartTime);
+    jsonObject.put(BACKUP_START_TIME_GMT, DATE_FORMAT.format(backupStartTime));
+    jsonObject.put(LATEST_BLOB, this.lastBlobId);
+    jsonObject.put(BACKUP_END_TIME, backupEndTime);
+    jsonObject.put(BACKUP_END_TIME_GMT, DATE_FORMAT.format(backupEndTime));
+    jsonObject.put(END_OF_PARTITION, this.isEndOfPartitionReached());
+    jsonObject.put(QUERY_NAME, this.getQueryName());
+    jsonObject.put(TOKEN_CREATE_TIME, this.getTokenCreateTime());
+    jsonObject.put(LAST_QUERY_TIME, lastQueryTime);
+    jsonObject.put(NUM_ITEMS, this.getNumItems());
+    jsonObject.put(NUM_BLOB_BYTES, this.getNumBlobBytes());
+    jsonObject.put(REQUEST_UNITS, this.getRequestUnits());
+    return jsonObject.toString(4);
+  }
+
+  @Override
+  public byte[] toBytes() {
+    return new byte[0];
+  }
+
+  @Override
+  public long getBytesRead() {
+    return 0;
+  }
+
+  @Override
+  public FindTokenType getType() {
+    return FindTokenType.CloudBased;
+  }
+
+  @Override
+  public short getVersion() {
+    return 0;
+  }
+}


### PR DESCRIPTION
## Summary

Adding a NetworkClient implementation to return responses by talking to cloud. This would be useful in RecoveryManager to recover data from cloud, with a nonblocking network client. However, in this implementation, the client is a blocking client. But it's fine to be in this way. If later we can have a real nonblocking implementation, we can later replace it.