### PR TITLE
Add a config storeDeletedMessageRetentionMinutes to determine how many minutes a key must be in deleted state before it is hard deleted or compacted away.

### DIFF
--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobStore.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobStore.java
@@ -1113,7 +1113,7 @@ class CloudBlobStore implements Store {
       throw new StoreException("Id " + key + " is already undeleted in cloud", StoreErrorCodes.ID_Undeleted);
     } else if (!metadata.isDeleted()) {
       throw new StoreException("Id " + key + " is not deleted yet in cloud ", StoreErrorCodes.ID_Not_Deleted);
-    } else if (metadata.getDeletionTime() + TimeUnit.HOURS.toMillis(storeConfig.storeDeletedMessageRetentionHours)
+    } else if (metadata.getDeletionTime() + TimeUnit.MINUTES.toMillis(storeConfig.storeDeletedMessageRetentionMinutes)
         < System.currentTimeMillis()) {
       throw new StoreException("Id " + key + " already permanently deleted in cloud ",
           StoreErrorCodes.ID_Deleted_Permanently);

--- a/ambry-server/src/integration-test/java/com/github/ambry/server/MockCluster.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/MockCluster.java
@@ -254,7 +254,7 @@ public class MockCluster {
     props.setProperty("port", Integer.toString(dataNodeId.getPort()));
     props.setProperty("store.data.flush.interval.seconds", "1");
     props.setProperty("store.enable.hard.delete", Boolean.toString(enableHardDeletes));
-    props.setProperty("store.deleted.message.retention.hours", "1");
+    props.setProperty("store.deleted.message.retention.minutes", "60");
     props.setProperty("store.validate.authorization", "true");
     props.setProperty("store.segment.size.in.bytes", Long.toString(MockReplicaId.MOCK_REPLICA_CAPACITY / 10));
     props.setProperty("replication.token.flush.interval.seconds", "5");

--- a/ambry-server/src/integration-test/java/com/github/ambry/server/ServerHardDeleteTest.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/ServerHardDeleteTest.java
@@ -94,7 +94,7 @@ public class ServerHardDeleteTest {
     props.setProperty("port", Integer.toString(mockClusterMap.getDataNodes().get(0).getPort()));
     props.setProperty("store.data.flush.interval.seconds", "1");
     props.setProperty("store.enable.hard.delete", "true");
-    props.setProperty("store.deleted.message.retention.hours", "168");
+    props.setProperty("store.deleted.message.retention.hours", "10080");
     props.setProperty("server.handle.undelete.request.enabled", "true");
     props.setProperty("clustermap.cluster.name", "test");
     props.setProperty("clustermap.datacenter.name", "DC1");

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreStats.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreStats.java
@@ -105,7 +105,7 @@ class BlobStoreStats implements StoreStats, Closeable {
       ScheduledExecutorService longLiveTaskScheduler, ScheduledExecutorService shortLiveTaskScheduler,
       DiskIOScheduler diskIOScheduler, StoreMetrics metrics) {
     this(storeId, index, config.storeStatsBucketCount, TimeUnit.MINUTES.toMillis(config.storeStatsBucketSpanInMinutes),
-        TimeUnit.HOURS.toMillis(config.storeDeletedMessageRetentionHours),
+        TimeUnit.MINUTES.toMillis(config.storeDeletedMessageRetentionMinutes),
         TimeUnit.MINUTES.toMillis(config.storeStatsRecentEntryProcessingIntervalInMinutes),
         config.storeStatsWaitTimeoutInSecs, config.storeEnableBucketForLogSegmentReports,
         config.storeCompactionPurgeDeleteTombstone, time, longLiveTaskScheduler, shortLiveTaskScheduler,

--- a/ambry-store/src/main/java/com/github/ambry/store/CompactAllPolicyFactory.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/CompactAllPolicyFactory.java
@@ -53,7 +53,7 @@ class CompactAllPolicy implements CompactionPolicy {
   CompactAllPolicy(StoreConfig storeConfig, Time time) {
     this.storeConfig = storeConfig;
     this.time = time;
-    this.messageRetentionTimeInMs = TimeUnit.HOURS.toMillis(storeConfig.storeDeletedMessageRetentionHours);
+    this.messageRetentionTimeInMs = TimeUnit.MINUTES.toMillis(storeConfig.storeDeletedMessageRetentionMinutes);
   }
 
   @Override

--- a/ambry-store/src/main/java/com/github/ambry/store/HardDeleter.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/HardDeleter.java
@@ -120,7 +120,7 @@ public class HardDeleter implements Runnable {
     this.time = time;
     // Times 10 is an optimization for findDeletedEntriesSince, which keeps delete entries only in the end.
     scanSizeInBytes = config.storeHardDeleteOperationsBytesPerSec * 10;
-    messageRetentionSeconds = (int) TimeUnit.HOURS.toSeconds(config.storeDeletedMessageRetentionHours);
+    messageRetentionSeconds = (int) TimeUnit.MINUTES.toSeconds(config.storeDeletedMessageRetentionMinutes);
   }
 
   @Override

--- a/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
@@ -1094,7 +1094,7 @@ class PersistentIndex {
           "Id " + key + " requires first value to be a put and last value to be a delete in index " + dataDir,
           StoreErrorCodes.ID_Not_Deleted);
     }
-    if (latestValue.getOperationTimeInMs() + TimeUnit.HOURS.toMillis(config.storeDeletedMessageRetentionHours)
+    if (latestValue.getOperationTimeInMs() + TimeUnit.MINUTES.toMillis(config.storeDeletedMessageRetentionMinutes)
         < time.milliseconds()) {
       throw new StoreException("Id " + key + " already permanently deleted in index " + dataDir,
           StoreErrorCodes.ID_Deleted_Permanently);

--- a/ambry-store/src/main/java/com/github/ambry/store/StatsBasedCompactionPolicy.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StatsBasedCompactionPolicy.java
@@ -40,7 +40,7 @@ class StatsBasedCompactionPolicy implements CompactionPolicy {
   StatsBasedCompactionPolicy(StoreConfig storeConfig, Time time) {
     this.storeConfig = storeConfig;
     this.time = time;
-    this.messageRetentionTimeInMs = TimeUnit.HOURS.toMillis(storeConfig.storeDeletedMessageRetentionHours);
+    this.messageRetentionTimeInMs = TimeUnit.MINUTES.toMillis(storeConfig.storeDeletedMessageRetentionMinutes);
   }
 
   @Override

--- a/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
@@ -166,8 +166,8 @@ public class StorageManager implements StoreManager {
     /* NOTE: We must ensure that the store never performs hard deletes on the part of the log that is not yet flushed.
        We do this by making sure that the retention period for deleted messages (which determines the end point for hard
        deletes) is always greater than the log flush period. */
-    if (storeConfig.storeEnableHardDelete && storeConfig.storeDeletedMessageRetentionHours
-        < TimeUnit.SECONDS.toHours(storeConfig.storeDataFlushIntervalSeconds) + 1) {
+    if (storeConfig.storeEnableHardDelete && storeConfig.storeDeletedMessageRetentionMinutes
+        < TimeUnit.SECONDS.toMinutes(storeConfig.storeDataFlushIntervalSeconds) + 1) {
       throw new StoreException(
           "Message retention hours must be greater than the store flush interval period when hard delete is enabled",
           StoreErrorCodes.Initialization_Error);

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
@@ -3030,7 +3030,7 @@ public class BlobStoreTest {
     properties.put("store.index.max.number.of.inmem.elements", Integer.toString(MAX_IN_MEM_ELEMENTS));
     properties.put("store.segment.size.in.bytes", Long.toString(segmentCapacity));
     properties.put("store.validate.authorization", "true");
-    properties.put("store.deleted.message.retention.hours", Integer.toString(CuratedLogIndexState.deleteRetentionHour));
+    properties.put("store.deleted.message.retention.minutes", Integer.toString(CuratedLogIndexState.deleteRetentionHour * 60));
     store = createBlobStore(getMockReplicaId(tempDirStr));
     store.start();
     // advance time by a second in order to be able to add expired keys and to avoid keys that are expired from

--- a/ambry-store/src/test/java/com/github/ambry/store/CompactAllPolicyTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CompactAllPolicyTest.java
@@ -40,7 +40,7 @@ public class CompactAllPolicyTest {
   public CompactAllPolicyTest() throws InterruptedException {
     Pair<MockBlobStore, StoreConfig> initState = CompactionPolicyTest.initializeBlobStore(properties, time, -1, -1, -1);
     config = initState.getSecond();
-    messageRetentionTimeInMs = TimeUnit.HOURS.toMillis(config.storeDeletedMessageRetentionHours);
+    messageRetentionTimeInMs = TimeUnit.MINUTES.toMillis(config.storeDeletedMessageRetentionMinutes);
     blobStore = initState.getFirst();
     compactionPolicy = new CompactAllPolicy(config, time);
   }

--- a/ambry-store/src/test/java/com/github/ambry/store/CuratedLogIndexState.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CuratedLogIndexState.java
@@ -206,7 +206,7 @@ class CuratedLogIndexState {
     // not used but set anyway since this is a package private variable.
     properties.put("store.segment.size.in.bytes", Long.toString(segmentCapacity));
     // set the delete retention day
-    properties.put("store.deleted.message.retention.hours", Integer.toString(CuratedLogIndexState.deleteRetentionHour));
+    properties.put("store.deleted.message.retention.minutes", Integer.toString(CuratedLogIndexState.deleteRetentionHour * 60));
     properties.put("store.rebuild.token.based.on.reset.key", Boolean.toString(enableResetKey));
     properties.put("store.auto.close.last.log.segment.enabled", Boolean.toString(enableAutoCloseLastLogSegment));
     if (addUndeletes) {

--- a/ambry-store/src/test/java/com/github/ambry/store/HardDeleterTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/HardDeleterTest.java
@@ -184,7 +184,7 @@ public class HardDeleterTest {
     Properties props = new Properties();
     // the test will set the tokens, so disable the index persistor.
     props.setProperty("store.data.flush.interval.seconds", "3600");
-    props.setProperty("store.deleted.message.retention.hours", "1");
+    props.setProperty("store.deleted.message.retention.minutes", "60");
     props.setProperty("store.index.max.number.of.inmem.elements", "2");
     props.setProperty("store.segment.size.in.bytes", "10000");
     // the following determines the number of entries that will be fetched at most. We need this to test the

--- a/ambry-store/src/test/java/com/github/ambry/store/IndexTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/IndexTest.java
@@ -720,7 +720,7 @@ public class IndexTest {
    */
   @Test
   public void hardDeleteTest() throws IOException, StoreException {
-    state.properties.put("store.deleted.message.retention.hours", Integer.toString(1));
+    state.properties.put("store.deleted.message.retention.minutes", Integer.toString(60));
     state.properties.put("store.hard.delete.operations.bytes.per.sec", Integer.toString(Integer.MAX_VALUE / 10));
     state.reloadIndex(true, false);
     state.index.hardDeleter.enabled.set(true);
@@ -2535,7 +2535,7 @@ public class IndexTest {
    * @throws StoreException
    */
   private void testHardDeletePauseResume(boolean reloadIndex) throws InterruptedException, IOException, StoreException {
-    state.properties.put("store.deleted.message.retention.hours", Integer.toString(1));
+    state.properties.put("store.deleted.message.retention.minutes", Integer.toString(60));
     state.properties.put("store.hard.delete.operations.bytes.per.sec", Integer.toString(Integer.MAX_VALUE / 10));
     state.properties.setProperty("store.data.flush.interval.seconds", "3600");
     // enable daemon thread to run hard deletes

--- a/ambry-store/src/test/java/com/github/ambry/store/StatsBasedCompactionPolicyTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/StatsBasedCompactionPolicyTest.java
@@ -49,7 +49,7 @@ public class StatsBasedCompactionPolicyTest {
     config = initState.getSecond();
     blobStore = initState.getFirst();
     mockBlobStoreStats = blobStore.getBlobStoreStats();
-    messageRetentionTimeInMs = TimeUnit.HOURS.toMillis(config.storeDeletedMessageRetentionHours);
+    messageRetentionTimeInMs = TimeUnit.MINUTES.toMillis(config.storeDeletedMessageRetentionMinutes);
     compactionPolicy = new StatsBasedCompactionPolicy(config, time);
   }
 


### PR DESCRIPTION
This will provide more granular control for the retention period.