### PR TITLE
Remove blocking channel from ReplicaThread

### DIFF
--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicationManager.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicationManager.java
@@ -28,7 +28,7 @@ import com.github.ambry.config.CloudConfig;
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.ReplicationConfig;
 import com.github.ambry.config.StoreConfig;
-import com.github.ambry.network.ConnectionPool;
+import com.github.ambry.network.NetworkClientFactory;
 import com.github.ambry.notification.NotificationSystem;
 import com.github.ambry.replication.FindTokenFactory;
 import com.github.ambry.replication.RemoteReplicaInfo;
@@ -40,7 +40,6 @@ import com.github.ambry.store.StoreException;
 import com.github.ambry.store.StoreKeyConverterFactory;
 import com.github.ambry.store.StoreKeyFactory;
 import com.github.ambry.utils.SystemTime;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -83,11 +82,11 @@ public class VcrReplicationManager extends ReplicationEngine {
   public VcrReplicationManager(CloudConfig cloudConfig, ReplicationConfig replicationConfig,
       ClusterMapConfig clusterMapConfig, StoreConfig storeConfig, StoreManager storeManager,
       StoreKeyFactory storeKeyFactory, ClusterMap clusterMap, VcrClusterParticipant vcrClusterParticipant,
-      CloudDestination cloudDestination, ScheduledExecutorService scheduler, ConnectionPool connectionPool,
+      CloudDestination cloudDestination, ScheduledExecutorService scheduler, NetworkClientFactory networkClientFactory,
       VcrMetrics vcrMetrics, NotificationSystem requestNotification, StoreKeyConverterFactory storeKeyConverterFactory,
-      String transformerClassName) throws ReplicationException, IllegalStateException {
+      String transformerClassName) throws IllegalStateException, ReplicationException {
     super(replicationConfig, clusterMapConfig, storeConfig, storeKeyFactory, clusterMap, scheduler,
-        vcrClusterParticipant.getCurrentDataNodeId(), Collections.emptyList(), connectionPool,
+        vcrClusterParticipant.getCurrentDataNodeId(), Collections.emptyList(), networkClientFactory,
         vcrMetrics.getMetricRegistry(), requestNotification, storeKeyConverterFactory, transformerClassName, null,
         storeManager, null, true);
     this.cloudConfig = cloudConfig;

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrServer.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrServer.java
@@ -200,7 +200,7 @@ public class VcrServer {
         networkClientFactory =
             new SocketNetworkClientFactory(new NetworkMetrics(registry), networkConfig, sslSocketFactory, 20, 20, 50000,
                 time);
-        logger.info("Using blocking channel for VCR replication.");
+        logger.info("Using socket channel for VCR replication.");
       }
 
       StoreKeyConverterFactory storeKeyConverterFactory =

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrServer.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrServer.java
@@ -186,7 +186,6 @@ public class VcrServer {
       StoreKeyFactory storeKeyFactory = Utils.getObj(storeConfig.storeKeyFactory, clusterMap);
 
       SSLFactory sslHttp2Factory = new NettySslHttp2Factory(sslConfig);
-      SSLFactory sslSocketFactory = SSLFactory.getNewInstance(sslConfig);
       NetworkClientFactory networkClientFactory = null;
       Time time = SystemTime.getInstance();
       if (clusterMapConfig.clusterMapEnableHttp2Replication) {
@@ -196,6 +195,8 @@ public class VcrServer {
             new Http2NetworkClientFactory(http2ClientMetrics, http2ClientConfig, sslHttp2Factory, time);
         logger.info("Using http2 for VCR replication.");
       } else {
+        SSLFactory sslSocketFactory =
+            clusterMapConfig.clusterMapSslEnabledDatacenters.length() > 0 ? SSLFactory.getNewInstance(sslConfig) : null;
         networkClientFactory =
             new SocketNetworkClientFactory(new NetworkMetrics(registry), networkConfig, sslSocketFactory, 20, 20, 50000,
                 time);

--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageFormatSend.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageFormatSend.java
@@ -13,9 +13,9 @@
  */
 package com.github.ambry.messageformat;
 
+import com.github.ambry.commons.Callback;
 import com.github.ambry.network.Send;
 import com.github.ambry.router.AsyncWritableChannel;
-import com.github.ambry.commons.Callback;
 import com.github.ambry.store.MessageReadSet;
 import com.github.ambry.store.StoreKey;
 import com.github.ambry.store.StoreKeyFactory;

--- a/ambry-network/src/main/java/com/github/ambry/network/NetworkMetrics.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/NetworkMetrics.java
@@ -178,8 +178,8 @@ public class NetworkMetrics {
       }
       return activeConnectionsCount;
     };
-    registry.register(MetricRegistry.name(Selector.class, "SelectorActiveConnectionsCount"),
-        selectorActiveConnectionsCount);
+    registry.gauge(MetricRegistry.name(Selector.class, "SelectorActiveConnectionsCount"),
+        () -> selectorActiveConnectionsCount);
 
     final Gauge<Long> selectorUnreadyConnectionsCount = () -> {
       long unreadyConnectionCount = 0;
@@ -188,8 +188,8 @@ public class NetworkMetrics {
       }
       return unreadyConnectionCount;
     };
-    registry.register(MetricRegistry.name(Selector.class, "SelectorUnreadyConnectionsCount"),
-        selectorUnreadyConnectionsCount);
+    registry.gauge(MetricRegistry.name(Selector.class, "SelectorUnreadyConnectionsCount"),
+        () -> selectorUnreadyConnectionsCount);
 
     final Gauge<Long> networkClientPendingRequestsCount = () -> {
       long pendingRequestsCount = 0;
@@ -198,8 +198,8 @@ public class NetworkMetrics {
       }
       return pendingRequestsCount;
     };
-    registry.register(MetricRegistry.name(NetworkClient.class, "NetworkClientPendingConnectionsCount"),
-        networkClientPendingRequestsCount);
+    registry.gauge(MetricRegistry.name(NetworkClient.class, "NetworkClientPendingConnectionsCount"),
+        () -> networkClientPendingRequestsCount);
   }
 
   /**

--- a/ambry-network/src/main/java/com/github/ambry/network/SocketServer.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/SocketServer.java
@@ -64,6 +64,11 @@ public class SocketServer implements NetworkServer {
   private SSLFactory sslFactory;
 
   public SocketServer(NetworkConfig config, SSLConfig sslConfig, MetricRegistry registry, ArrayList<Port> portList) {
+    this(config, (SSLFactory) null, registry, portList);
+    this.initializeSSLFactory(sslConfig);
+  }
+
+  public SocketServer(NetworkConfig config, SSLFactory sslFactory, MetricRegistry registry, ArrayList<Port> portList) {
     this.networkConfig = config;
     this.host = config.hostName;
     this.port = config.port;
@@ -76,7 +81,7 @@ public class SocketServer implements NetworkServer {
     this.acceptors = new ArrayList<>();
     this.ports = new HashMap<>();
     this.validatePorts(portList);
-    this.initializeSSLFactory(sslConfig);
+    this.sslFactory = sslFactory;
   }
 
   public String getHost() {

--- a/ambry-network/src/main/java/com/github/ambry/network/SocketServer.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/SocketServer.java
@@ -64,11 +64,6 @@ public class SocketServer implements NetworkServer {
   private SSLFactory sslFactory;
 
   public SocketServer(NetworkConfig config, SSLConfig sslConfig, MetricRegistry registry, ArrayList<Port> portList) {
-    this(config, (SSLFactory) null, registry, portList);
-    this.initializeSSLFactory(sslConfig);
-  }
-
-  public SocketServer(NetworkConfig config, SSLFactory sslFactory, MetricRegistry registry, ArrayList<Port> portList) {
     this.networkConfig = config;
     this.host = config.hostName;
     this.port = config.port;
@@ -81,7 +76,7 @@ public class SocketServer implements NetworkServer {
     this.acceptors = new ArrayList<>();
     this.ports = new HashMap<>();
     this.validatePorts(portList);
-    this.sslFactory = sslFactory;
+    this.initializeSSLFactory(sslConfig);
   }
 
   public String getHost() {

--- a/ambry-replication/src/main/java/com/github/ambry/replication/BackupCheckerFileManager.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/BackupCheckerFileManager.java
@@ -15,11 +15,18 @@ package com.github.ambry.replication;
 
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.config.ReplicationConfig;
+import com.github.ambry.store.MessageInfoType;
+import com.github.ambry.store.StoreKey;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.EnumSet;
+
 
 /**
  * File manager for BackupChecker, although it can be used for other purposes
  */
 public class BackupCheckerFileManager {
+  public static final DateFormat DATE_FORMAT = new SimpleDateFormat("dd MMM yyyy HH:mm:ss:SSS");
 
   public BackupCheckerFileManager(ReplicationConfig replicationConfig, MetricRegistry metricRegistry) {
   }
@@ -37,6 +44,25 @@ public class BackupCheckerFileManager {
   }
 
   /**
+   * Append these information to the give file.
+   * @param filePath The file path to append
+   * @param remoteReplicaInfo The {@link RemoteReplicaInfo}.
+   * @param acceptableLocalBlobStates The set of acceptable local blob states
+   * @param storeKey The {@link StoreKey}.
+   * @param operationTime The operation time in ms
+   * @param remoteBlobState The blob state from remote
+   * @param localBlobState The blob state from local, could also be error codes
+   * @return True if append was successful, false otherwise
+   */
+  protected boolean appendToFile(String filePath, RemoteReplicaInfo remoteReplicaInfo,
+      EnumSet<MessageInfoType> acceptableLocalBlobStates, StoreKey storeKey, long operationTime,
+      EnumSet<MessageInfoType> remoteBlobState, Object localBlobState) {
+    String messageFormat = "%s | Missing %s | %s | Optime = %s | RemoteBlobState = %s | LocalBlobState = %s \n";
+    return appendToFile(filePath, String.format(messageFormat, remoteReplicaInfo, acceptableLocalBlobStates, storeKey,
+        DATE_FORMAT.format(operationTime), remoteBlobState, localBlobState));
+  }
+
+  /**
    * Truncates a file and then writes to it.
    * Creates the file if absent.
    * @param filePath Path of the file in the system
@@ -46,5 +72,21 @@ public class BackupCheckerFileManager {
   protected boolean truncateAndWriteToFile(String filePath, String text) {
     // open-source impl
     return true;
+  }
+
+  /**
+   * Truncates a fie and then writes these information to it.
+   * @param filePath The file to truncate
+   * @param remoteReplicaInfo The {@link RemoteReplicaInfo}.
+   * @param localLagFromRemoteInBytes The lag from remote in bytes
+   * @return True if write was successful, false otherwise
+   */
+  protected boolean truncateAndWriteToFile(String filePath, RemoteReplicaInfo remoteReplicaInfo,
+      long localLagFromRemoteInBytes) {
+    String text =
+        String.format("%s | isSealed = %s | Token = %s | localLagFromRemoteInBytes = %s \n", remoteReplicaInfo,
+            remoteReplicaInfo.getReplicaId().isSealed(), remoteReplicaInfo.getToken().toString(),
+            localLagFromRemoteInBytes);
+    return truncateAndWriteToFile(filePath, text);
   }
 }

--- a/ambry-replication/src/main/java/com/github/ambry/replication/BackupCheckerThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/BackupCheckerThread.java
@@ -154,8 +154,7 @@ public class BackupCheckerThread extends ReplicaThread {
         if (exchangeMetadataResponse.serverErrorCode == ServerErrorCode.No_Error) {
           for (MessageInfo messageInfo : exchangeMetadataResponse.getMissingStoreMessages()) {
             // Check local store once before logging an error
-            checkLocalStore(messageInfo, replicasToReplicatePerNode.get(0), acceptableLocalBlobStates,
-                acceptableStoreErrorCodes);
+            checkLocalStore(messageInfo, remoteReplicaInfo, acceptableLocalBlobStates, acceptableStoreErrorCodes);
           }
           // Advance token so that we make progress in spite of missing keys,
           // else the replication code will be stuck waiting for missing keys to appear in local store.

--- a/ambry-replication/src/main/java/com/github/ambry/replication/CloudToStoreReplicationManager.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/CloudToStoreReplicationManager.java
@@ -27,7 +27,7 @@ import com.github.ambry.clustermap.VcrClusterSpectator;
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.ReplicationConfig;
 import com.github.ambry.config.StoreConfig;
-import com.github.ambry.network.ConnectionPool;
+import com.github.ambry.network.NetworkClientFactory;
 import com.github.ambry.network.Port;
 import com.github.ambry.network.PortType;
 import com.github.ambry.notification.NotificationSystem;
@@ -85,7 +85,6 @@ public class CloudToStoreReplicationManager extends ReplicationEngine {
    * @param clusterMap {@link ClusterMap} object to get the ambry datanode cluster map.
    * @param scheduler {@link ScheduledExecutorService} object for scheduling token persistence.
    * @param currentNode {@link DataNodeId} representing the current node.
-   * @param connectionPool {@link ConnectionPool} object representing the connection pool to talk to replicas.
    * @param metricRegistry {@link MetricRegistry} object.
    * @param requestNotification {@link NotificationSystem} object to notify on events.
    * @param storeKeyConverterFactory {@link StoreKeyConverterFactory} object.
@@ -96,13 +95,13 @@ public class CloudToStoreReplicationManager extends ReplicationEngine {
    */
   public CloudToStoreReplicationManager(ReplicationConfig replicationConfig, ClusterMapConfig clusterMapConfig,
       StoreConfig storeConfig, StoreManager storeManager, StoreKeyFactory storeKeyFactory, ClusterMap clusterMap,
-      ScheduledExecutorService scheduler, DataNodeId currentNode, MetricRegistry metricRegistry,
-      NotificationSystem requestNotification, StoreKeyConverterFactory storeKeyConverterFactory,
-      String transformerClassName, VcrClusterSpectator vcrClusterSpectator, ClusterParticipant clusterParticipant)
-      throws ReplicationException {
+      ScheduledExecutorService scheduler, DataNodeId currentNode, NetworkClientFactory networkClientFactory,
+      MetricRegistry metricRegistry, NotificationSystem requestNotification,
+      StoreKeyConverterFactory storeKeyConverterFactory, String transformerClassName,
+      VcrClusterSpectator vcrClusterSpectator, ClusterParticipant clusterParticipant) throws ReplicationException {
     super(replicationConfig, clusterMapConfig, storeConfig, storeKeyFactory, clusterMap, scheduler, currentNode,
-        Collections.emptyList(), metricRegistry, requestNotification, storeKeyConverterFactory, transformerClassName,
-        clusterParticipant, storeManager, null, false);
+        Collections.emptyList(), networkClientFactory, metricRegistry, requestNotification, storeKeyConverterFactory,
+        transformerClassName, clusterParticipant, storeManager, null, false);
     this.clusterMapConfig = clusterMapConfig;
     this.vcrClusterSpectator = vcrClusterSpectator;
     this.clusterParticipant = clusterParticipant;

--- a/ambry-replication/src/main/java/com/github/ambry/replication/CloudToStoreReplicationManager.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/CloudToStoreReplicationManager.java
@@ -18,12 +18,12 @@ import com.github.ambry.clustermap.CloudDataNode;
 import com.github.ambry.clustermap.CloudReplica;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.ClusterParticipant;
-import com.github.ambry.clustermap.VcrClusterSpectator;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.clustermap.PartitionStateChangeListener;
 import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.clustermap.StateModelListenerType;
+import com.github.ambry.clustermap.VcrClusterSpectator;
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.ReplicationConfig;
 import com.github.ambry.config.StoreConfig;
@@ -96,13 +96,13 @@ public class CloudToStoreReplicationManager extends ReplicationEngine {
    */
   public CloudToStoreReplicationManager(ReplicationConfig replicationConfig, ClusterMapConfig clusterMapConfig,
       StoreConfig storeConfig, StoreManager storeManager, StoreKeyFactory storeKeyFactory, ClusterMap clusterMap,
-      ScheduledExecutorService scheduler, DataNodeId currentNode, ConnectionPool connectionPool,
-      MetricRegistry metricRegistry, NotificationSystem requestNotification,
-      StoreKeyConverterFactory storeKeyConverterFactory, String transformerClassName,
-      VcrClusterSpectator vcrClusterSpectator, ClusterParticipant clusterParticipant) throws ReplicationException {
+      ScheduledExecutorService scheduler, DataNodeId currentNode, MetricRegistry metricRegistry,
+      NotificationSystem requestNotification, StoreKeyConverterFactory storeKeyConverterFactory,
+      String transformerClassName, VcrClusterSpectator vcrClusterSpectator, ClusterParticipant clusterParticipant)
+      throws ReplicationException {
     super(replicationConfig, clusterMapConfig, storeConfig, storeKeyFactory, clusterMap, scheduler, currentNode,
-        Collections.emptyList(), connectionPool, metricRegistry, requestNotification, storeKeyConverterFactory,
-        transformerClassName, clusterParticipant, storeManager, null, false);
+        Collections.emptyList(), metricRegistry, requestNotification, storeKeyConverterFactory, transformerClassName,
+        clusterParticipant, storeManager, null, false);
     this.clusterMapConfig = clusterMapConfig;
     this.vcrClusterSpectator = vcrClusterSpectator;
     this.clusterParticipant = clusterParticipant;

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -252,6 +252,10 @@ public class ReplicaThread implements Runnable {
       }
       logger.info("Begin iteration for thread {}", threadName);
       while (running) {
+        // TODO: Replicate method performs one cycle of replication for every replica and faster replicas would be
+        //  blocked by the slower replicas. There is an optimization we can do, which is let each replica runs replication
+        //  independently without waiting for each other. This would make sure that slower replicas won't block faster
+        //  replicas.
         replicate();
         lock.lock();
         try {

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -1024,8 +1024,11 @@ public class ReplicaThread implements Runnable {
       if (!deletedLocally) {
         // Only adds record when it's not deleted yet. Since delete is the final state for this lifeVersion, if there
         // is a delete record for the current lifeVersion, then nothing needs to be done.
-        MessageInfo info = new MessageInfo(localKey, 0, localKey.getAccountId(), localKey.getContainerId(),
-            messageInfo.getOperationTimeMs(), remoteLifeVersion);
+        MessageInfo info = new MessageInfo.Builder(messageInfo).storeKey(localKey)
+            .size(0)
+            .accountId(localKey.getAccountId())
+            .containerId(localKey.getContainerId())
+            .build();
         if (messageInfo.isTtlUpdated() && !ttlUpdatedLocally) {
           applyTtlUpdate(info, remoteReplicaInfo);
         }

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -510,7 +510,7 @@ public class ReplicaThread implements Runnable {
           logger.error("Thread name: {} Request {} timed out", threadName, entry.getKey());
         }
       } else {
-        // The correlationIdToRequest should be a LinkedHashMap .size()that has a predictable iteration order based on insertion.
+        // The correlationIdToRequest should be a LinkedHashMap that has a predictable iteration order based on insertion.
         // The correlation id increases as we insert it to the map. So if current request is not timed out, then all the
         // requests after are not timed out.
         break;

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
@@ -26,7 +26,6 @@ import com.github.ambry.commons.ResponseHandler;
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.ReplicationConfig;
 import com.github.ambry.config.StoreConfig;
-import com.github.ambry.network.ConnectionPool;
 import com.github.ambry.network.NetworkClient;
 import com.github.ambry.network.NetworkClientFactory;
 import com.github.ambry.notification.NotificationSystem;
@@ -80,7 +79,6 @@ public abstract class ReplicationEngine implements ReplicationAPI {
   protected final ClusterMap clusterMap;
   protected final ScheduledExecutorService scheduler;
   protected final AtomicInteger correlationIdGenerator;
-  protected final ConnectionPool connectionPool;
   protected final NetworkClientFactory networkClientFactory;
   protected final NotificationSystem notification;
   // RemoteReplicaInfo are managed by replicaThread.
@@ -115,23 +113,22 @@ public abstract class ReplicationEngine implements ReplicationAPI {
   public ReplicationEngine(ReplicationConfig replicationConfig, ClusterMapConfig clusterMapConfig,
       StoreConfig storeConfig, StoreKeyFactory storeKeyFactory, ClusterMap clusterMap,
       ScheduledExecutorService scheduler, DataNodeId dataNode, List<? extends ReplicaId> replicaIds,
-      ConnectionPool connectionPool, MetricRegistry metricRegistry, NotificationSystem requestNotification,
+      MetricRegistry metricRegistry, NotificationSystem requestNotification,
       StoreKeyConverterFactory storeKeyConverterFactory, String transformerClassName,
       ClusterParticipant clusterParticipant, StoreManager storeManager, Predicate<MessageInfo> skipPredicate,
       boolean enableClusterMapListener) throws ReplicationException {
     this(replicationConfig, clusterMapConfig, storeConfig, storeKeyFactory, clusterMap, scheduler, dataNode, replicaIds,
-        connectionPool, null, metricRegistry, requestNotification, storeKeyConverterFactory, transformerClassName,
-        clusterParticipant, storeManager, skipPredicate, null, SystemTime.getInstance(), enableClusterMapListener);
+        null, metricRegistry, requestNotification, storeKeyConverterFactory, transformerClassName, clusterParticipant,
+        storeManager, skipPredicate, null, SystemTime.getInstance(), enableClusterMapListener);
   }
 
   public ReplicationEngine(ReplicationConfig replicationConfig, ClusterMapConfig clusterMapConfig,
       StoreConfig storeConfig, StoreKeyFactory storeKeyFactory, ClusterMap clusterMap,
       ScheduledExecutorService scheduler, DataNodeId dataNode, List<? extends ReplicaId> replicaIds,
-      ConnectionPool connectionPool, NetworkClientFactory networkClientFactory, MetricRegistry metricRegistry,
-      NotificationSystem requestNotification, StoreKeyConverterFactory storeKeyConverterFactory,
-      String transformerClassName, ClusterParticipant clusterParticipant, StoreManager storeManager,
-      Predicate<MessageInfo> skipPredicate, FindTokenHelper findTokenHelper, Time time,
-      boolean enableClusterMapListener) throws ReplicationException {
+      NetworkClientFactory networkClientFactory, MetricRegistry metricRegistry, NotificationSystem requestNotification,
+      StoreKeyConverterFactory storeKeyConverterFactory, String transformerClassName,
+      ClusterParticipant clusterParticipant, StoreManager storeManager, Predicate<MessageInfo> skipPredicate,
+      FindTokenHelper findTokenHelper, Time time, boolean enableClusterMapListener) throws ReplicationException {
     this.replicationConfig = replicationConfig;
     this.storeConfig = storeConfig;
     this.storeKeyFactory = storeKeyFactory;
@@ -153,7 +150,6 @@ public abstract class ReplicationEngine implements ReplicationAPI {
     this.scheduler = scheduler;
     this.correlationIdGenerator = new AtomicInteger(0);
     this.dataNodeId = dataNode;
-    this.connectionPool = connectionPool;
     this.networkClientFactory = networkClientFactory;
     this.notification = requestNotification;
     this.metricRegistry = metricRegistry;
@@ -361,15 +357,15 @@ public abstract class ReplicationEngine implements ReplicationAPI {
    * Returns replication thread
    */
   protected ReplicaThread getReplicaThread(String threadName, FindTokenHelper findTokenHelper, ClusterMap clusterMap,
-      AtomicInteger correlationIdGenerator, DataNodeId dataNodeId, ConnectionPool connectionPool,
-      NetworkClient networkClient, ReplicationConfig replicationConfig, ReplicationMetrics replicationMetrics,
-      NotificationSystem notification, StoreKeyConverter storeKeyConverter, Transformer transformer,
-      MetricRegistry metricRegistry, boolean replicatingOverSsl, String datacenterName, ResponseHandler responseHandler,
-      Time time, ReplicaSyncUpManager replicaSyncUpManager, Predicate<MessageInfo> skipPredicate,
+      AtomicInteger correlationIdGenerator, DataNodeId dataNodeId, NetworkClient networkClient,
+      ReplicationConfig replicationConfig, ReplicationMetrics replicationMetrics, NotificationSystem notification,
+      StoreKeyConverter storeKeyConverter, Transformer transformer, MetricRegistry metricRegistry,
+      boolean replicatingOverSsl, String datacenterName, ResponseHandler responseHandler, Time time,
+      ReplicaSyncUpManager replicaSyncUpManager, Predicate<MessageInfo> skipPredicate,
       ReplicationManager.LeaderBasedReplicationAdmin leaderBasedReplicationAdmin) {
-    return new ReplicaThread(threadName, tokenHelper, clusterMap, correlationIdGenerator, dataNodeId, connectionPool,
-        networkClient, replicationConfig, replicationMetrics, notification, storeKeyConverter, transformer,
-        metricRegistry, replicatingOverSsl, datacenterName, responseHandler, time, replicaSyncUpManager, skipPredicate,
+    return new ReplicaThread(threadName, tokenHelper, clusterMap, correlationIdGenerator, dataNodeId, networkClient,
+        replicationConfig, replicationMetrics, notification, storeKeyConverter, transformer, metricRegistry,
+        replicatingOverSsl, datacenterName, responseHandler, time, replicaSyncUpManager, skipPredicate,
         leaderBasedReplicationAdmin);
   }
 

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
@@ -114,13 +114,13 @@ public abstract class ReplicationEngine implements ReplicationAPI {
   public ReplicationEngine(ReplicationConfig replicationConfig, ClusterMapConfig clusterMapConfig,
       StoreConfig storeConfig, StoreKeyFactory storeKeyFactory, ClusterMap clusterMap,
       ScheduledExecutorService scheduler, DataNodeId dataNode, List<? extends ReplicaId> replicaIds,
-      MetricRegistry metricRegistry, NotificationSystem requestNotification,
+      NetworkClientFactory networkClientFactory, MetricRegistry metricRegistry, NotificationSystem requestNotification,
       StoreKeyConverterFactory storeKeyConverterFactory, String transformerClassName,
       ClusterParticipant clusterParticipant, StoreManager storeManager, Predicate<MessageInfo> skipPredicate,
       boolean enableClusterMapListener) throws ReplicationException {
     this(replicationConfig, clusterMapConfig, storeConfig, storeKeyFactory, clusterMap, scheduler, dataNode, replicaIds,
-        null, metricRegistry, requestNotification, storeKeyConverterFactory, transformerClassName, clusterParticipant,
-        storeManager, skipPredicate, null, SystemTime.getInstance(), enableClusterMapListener);
+        networkClientFactory, metricRegistry, requestNotification, storeKeyConverterFactory, transformerClassName,
+        clusterParticipant, storeManager, skipPredicate, null, SystemTime.getInstance(), enableClusterMapListener);
   }
 
   public ReplicationEngine(ReplicationConfig replicationConfig, ClusterMapConfig clusterMapConfig,

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationManager.java
@@ -62,24 +62,24 @@ public class ReplicationManager extends ReplicationEngine {
 
   public ReplicationManager(ReplicationConfig replicationConfig, ClusterMapConfig clusterMapConfig,
       StoreConfig storeConfig, StoreManager storeManager, StoreKeyFactory storeKeyFactory, ClusterMap clusterMap,
-      ScheduledExecutorService scheduler, DataNodeId dataNode, ConnectionPool connectionPool,
-      NetworkClientFactory networkClientFactory, MetricRegistry metricRegistry, NotificationSystem requestNotification,
+      ScheduledExecutorService scheduler, DataNodeId dataNode, NetworkClientFactory networkClientFactory,
+      MetricRegistry metricRegistry, NotificationSystem requestNotification,
       StoreKeyConverterFactory storeKeyConverterFactory, String transformerClassName,
       ClusterParticipant clusterParticipant, Predicate<MessageInfo> skipPredicate) throws ReplicationException {
     this(replicationConfig, clusterMapConfig, storeConfig, storeManager, storeKeyFactory, clusterMap, scheduler,
-        dataNode, connectionPool, networkClientFactory, metricRegistry, requestNotification, storeKeyConverterFactory,
+        dataNode, networkClientFactory, metricRegistry, requestNotification, storeKeyConverterFactory,
         transformerClassName, clusterParticipant, skipPredicate, null, SystemTime.getInstance());
   }
 
   public ReplicationManager(ReplicationConfig replicationConfig, ClusterMapConfig clusterMapConfig,
       StoreConfig storeConfig, StoreManager storeManager, StoreKeyFactory storeKeyFactory, ClusterMap clusterMap,
-      ScheduledExecutorService scheduler, DataNodeId dataNode, ConnectionPool connectionPool,
-      NetworkClientFactory networkClientFactory, MetricRegistry metricRegistry, NotificationSystem requestNotification,
+      ScheduledExecutorService scheduler, DataNodeId dataNode, NetworkClientFactory networkClientFactory,
+      MetricRegistry metricRegistry, NotificationSystem requestNotification,
       StoreKeyConverterFactory storeKeyConverterFactory, String transformerClassName,
       ClusterParticipant clusterParticipant, Predicate<MessageInfo> skipPredicate, FindTokenHelper findTokenHelper,
       Time time) throws ReplicationException {
     super(replicationConfig, clusterMapConfig, storeConfig, storeKeyFactory, clusterMap, scheduler, dataNode,
-        clusterMap.getReplicaIds(dataNode), connectionPool, networkClientFactory, metricRegistry, requestNotification,
+        clusterMap.getReplicaIds(dataNode), networkClientFactory, metricRegistry, requestNotification,
         storeKeyConverterFactory, transformerClassName, clusterParticipant, storeManager, skipPredicate,
         findTokenHelper, time, true);
     trackPerPartitionLagInMetric = replicationConfig.replicationTrackPerDatacenterLagFromLocal;
@@ -125,18 +125,18 @@ public class ReplicationManager extends ReplicationEngine {
       MetricRegistry metricRegistry, boolean replicatingOverSsl, String datacenterName, ResponseHandler responseHandler,
       Time time, ReplicaSyncUpManager replicaSyncUpManager, Predicate<MessageInfo> skipPredicate,
       ReplicationManager.LeaderBasedReplicationAdmin leaderBasedReplicationAdmin) {
-    switch(replicationConfig.replicationThreadType) {
+    switch (replicationConfig.replicationThreadType) {
       case ReplicationConfig.BACKUP_CHECKER_THREAD:
         return new BackupCheckerThread(threadName, tokenHelper, clusterMap, correlationIdGenerator, dataNodeId,
-            connectionPool, networkClient, replicationConfig, replicationMetrics, notification,
-            storeKeyConverter, transformer, metricRegistry, replicatingOverSsl, datacenterName,
-            responseHandler, time, replicaSyncUpManager, skipPredicate, leaderBasedReplicationAdmin);
+            connectionPool, networkClient, replicationConfig, replicationMetrics, notification, storeKeyConverter,
+            transformer, metricRegistry, replicatingOverSsl, datacenterName, responseHandler, time,
+            replicaSyncUpManager, skipPredicate, leaderBasedReplicationAdmin);
       case ReplicationConfig.DEFAULT_REPLICATION_THREAD:
       default:
         return new ReplicaThread(threadName, tokenHelper, clusterMap, correlationIdGenerator, dataNodeId,
-            connectionPool, networkClient, replicationConfig, replicationMetrics, notification,
-            storeKeyConverter, transformer, metricRegistry, replicatingOverSsl, datacenterName,
-            responseHandler, time, replicaSyncUpManager, skipPredicate, leaderBasedReplicationAdmin);
+            connectionPool, networkClient, replicationConfig, replicationMetrics, notification, storeKeyConverter,
+            transformer, metricRegistry, replicatingOverSsl, datacenterName, responseHandler, time,
+            replicaSyncUpManager, skipPredicate, leaderBasedReplicationAdmin);
     }
   }
 

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationManager.java
@@ -28,7 +28,6 @@ import com.github.ambry.commons.ResponseHandler;
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.ReplicationConfig;
 import com.github.ambry.config.StoreConfig;
-import com.github.ambry.network.ConnectionPool;
 import com.github.ambry.network.NetworkClient;
 import com.github.ambry.network.NetworkClientFactory;
 import com.github.ambry.notification.NotificationSystem;
@@ -119,24 +118,24 @@ public class ReplicationManager extends ReplicationEngine {
    */
   @Override
   protected ReplicaThread getReplicaThread(String threadName, FindTokenHelper findTokenHelper, ClusterMap clusterMap,
-      AtomicInteger correlationIdGenerator, DataNodeId dataNodeId, ConnectionPool connectionPool,
-      NetworkClient networkClient, ReplicationConfig replicationConfig, ReplicationMetrics replicationMetrics,
-      NotificationSystem notification, StoreKeyConverter storeKeyConverter, Transformer transformer,
-      MetricRegistry metricRegistry, boolean replicatingOverSsl, String datacenterName, ResponseHandler responseHandler,
-      Time time, ReplicaSyncUpManager replicaSyncUpManager, Predicate<MessageInfo> skipPredicate,
+      AtomicInteger correlationIdGenerator, DataNodeId dataNodeId, NetworkClient networkClient,
+      ReplicationConfig replicationConfig, ReplicationMetrics replicationMetrics, NotificationSystem notification,
+      StoreKeyConverter storeKeyConverter, Transformer transformer, MetricRegistry metricRegistry,
+      boolean replicatingOverSsl, String datacenterName, ResponseHandler responseHandler, Time time,
+      ReplicaSyncUpManager replicaSyncUpManager, Predicate<MessageInfo> skipPredicate,
       ReplicationManager.LeaderBasedReplicationAdmin leaderBasedReplicationAdmin) {
     switch (replicationConfig.replicationThreadType) {
       case ReplicationConfig.BACKUP_CHECKER_THREAD:
         return new BackupCheckerThread(threadName, tokenHelper, clusterMap, correlationIdGenerator, dataNodeId,
-            connectionPool, networkClient, replicationConfig, replicationMetrics, notification, storeKeyConverter,
-            transformer, metricRegistry, replicatingOverSsl, datacenterName, responseHandler, time,
-            replicaSyncUpManager, skipPredicate, leaderBasedReplicationAdmin);
+            networkClient, replicationConfig, replicationMetrics, notification, storeKeyConverter, transformer,
+            metricRegistry, replicatingOverSsl, datacenterName, responseHandler, time, replicaSyncUpManager,
+            skipPredicate, leaderBasedReplicationAdmin);
       case ReplicationConfig.DEFAULT_REPLICATION_THREAD:
       default:
-        return new ReplicaThread(threadName, tokenHelper, clusterMap, correlationIdGenerator, dataNodeId,
-            connectionPool, networkClient, replicationConfig, replicationMetrics, notification, storeKeyConverter,
-            transformer, metricRegistry, replicatingOverSsl, datacenterName, responseHandler, time,
-            replicaSyncUpManager, skipPredicate, leaderBasedReplicationAdmin);
+        return new ReplicaThread(threadName, tokenHelper, clusterMap, correlationIdGenerator, dataNodeId, networkClient,
+            replicationConfig, replicationMetrics, notification, storeKeyConverter, transformer, metricRegistry,
+            replicatingOverSsl, datacenterName, responseHandler, time, replicaSyncUpManager, skipPredicate,
+            leaderBasedReplicationAdmin);
     }
   }
 

--- a/ambry-replication/src/test/java/com/github/ambry/replication/BackupCheckerThreadTest.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/BackupCheckerThreadTest.java
@@ -1,0 +1,156 @@
+/**
+ * Copyright 2023 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.replication;
+
+import com.github.ambry.clustermap.DataNodeId;
+import com.github.ambry.clustermap.MockClusterMap;
+import com.github.ambry.clustermap.PartitionId;
+import com.github.ambry.commons.BlobIdFactory;
+import com.github.ambry.protocol.ReplicaMetadataRequest;
+import com.github.ambry.protocol.ReplicaMetadataResponse;
+import com.github.ambry.store.MessageInfoType;
+import com.github.ambry.store.MockStoreKeyConverterFactory;
+import com.github.ambry.store.StoreKey;
+import com.github.ambry.store.StoreKeyFactory;
+import com.github.ambry.store.Transformer;
+import com.github.ambry.utils.Pair;
+import com.github.ambry.utils.Utils;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+
+@RunWith(Parameterized.class)
+public class BackupCheckerThreadTest extends ReplicationTestHelper {
+
+  @Parameterized.Parameters
+  public static List<Object[]> data() {
+    //@formatter:off
+    return Arrays.asList(new Object[][]{
+        {ReplicaMetadataRequest.Replica_Metadata_Request_Version_V1, ReplicaMetadataResponse.REPLICA_METADATA_RESPONSE_VERSION_V_5},
+        {ReplicaMetadataRequest.Replica_Metadata_Request_Version_V2, ReplicaMetadataResponse.REPLICA_METADATA_RESPONSE_VERSION_V_6},
+    });
+    //@formatter:on
+  }
+
+  public BackupCheckerThreadTest(short requestVersion, short responseVersion) {
+    super(requestVersion, responseVersion);
+  }
+
+  @Test
+  public void testReplication() throws Exception {
+    MockClusterMap clusterMap = new MockClusterMap();
+    Pair<MockHost, MockHost> localAndRemoteHosts = getLocalAndRemoteHosts(clusterMap);
+    MockHost localHost = localAndRemoteHosts.getFirst();
+    MockHost remoteHost = localAndRemoteHosts.getSecond();
+    List<MockHost> allHosts = Arrays.asList(localHost, remoteHost);
+
+    MockStoreKeyConverterFactory storeKeyConverterFactory = new MockStoreKeyConverterFactory(null, null);
+    storeKeyConverterFactory.setConversionMap(new HashMap<>());
+    storeKeyConverterFactory.setReturnInputIfAbsent(true);
+    MockStoreKeyConverterFactory.MockStoreKeyConverter storeKeyConverter =
+        storeKeyConverterFactory.getStoreKeyConverter();
+
+    StoreKeyFactory storeKeyFactory = new BlobIdFactory(clusterMap);
+    Transformer transformer = new BlobIdTransformer(storeKeyFactory, storeKeyConverter);
+    int batchSize = 100;
+    Pair<Map<DataNodeId, List<RemoteReplicaInfo>>, ReplicaThread> replicasAndThread =
+        getRemoteReplicasAndReplicaThread(true, batchSize, clusterMap, localHost, storeKeyConverter, transformer, null,
+            null, remoteHost);
+    Map<DataNodeId, List<RemoteReplicaInfo>> replicasToReplicate = replicasAndThread.getFirst();
+    BackupCheckerThread checkerThread = (BackupCheckerThread) replicasAndThread.getSecond();
+    MockBackupCheckerFileManager fileManager = (MockBackupCheckerFileManager) checkerThread.getFileManager();
+    MockNetworkClient mockNetworkClient = (MockNetworkClient) checkerThread.getNetworkClient();
+
+    // Test case 1. all the records are on both local and remote host
+    List<PartitionId> partitionIds = clusterMap.getWritablePartitionIds(null);
+    int expectedIndex = -1;
+    for (int i = 0; i < partitionIds.size(); i++) {
+      PartitionId partitionId = partitionIds.get(i);
+      // Adding 1 store key that ends with PUT
+      //        1 store key that ends with ttl_update
+      //        1 store key that ends with ttl_update and delete
+      //        1 store key that ends with delete
+      List<StoreKey> keys = addPutMessagesToReplicasOfPartition(partitionId, allHosts, 4);
+      // ttl update
+      StoreKey key = keys.get(1);
+      addTtlUpdateMessagesToReplicasOfPartition(partitionId, key, allHosts, Utils.Infinite_Time);
+
+      key = keys.get(2);
+      addTtlUpdateMessagesToReplicasOfPartition(partitionId, key, allHosts, Utils.Infinite_Time);
+      addDeleteMessagesToReplicasOfPartition(partitionId, key, allHosts);
+
+      key = keys.get(3);
+      addDeleteMessagesToReplicasOfPartition(partitionId, key, allHosts);
+    }
+    expectedIndex += 8;
+    checkerThread.replicate();
+
+    // There should not be any missing records in the local host
+    // There should not be any GetRequest sent out
+    Assert.assertEquals(0, fileManager.appendRecordsForPartitions.size());
+    Assert.assertEquals(0, mockNetworkClient.numGetRequest.get());
+    List<ReplicaThread.ExchangeMetadataResponse> responses =
+        checkerThread.getExchangeMetadataResponsesInEachCycle().get(remoteHost.dataNodeId);
+    for (ReplicaThread.ExchangeMetadataResponse response : responses) {
+      Assert.assertEquals(expectedIndex, ((MockFindToken) response.remoteToken).getIndex());
+    }
+
+    // Test case 2. Missing deletes in the local host
+    Map<PartitionId, Set<StoreKey>> expectedDeletedKeysByPartition = new HashMap<>();
+    for (int i = 0; i < partitionIds.size(); i++) {
+      PartitionId partitionId = partitionIds.get(i);
+      // Adding 1 store key that ends with PUT to local, but PUT and delete to remote
+      List<StoreKey> keys = addPutMessagesToReplicasOfPartition(partitionId, allHosts, 1);
+      StoreKey key = keys.get(0);
+      addDeleteMessagesToReplicasOfPartition(partitionId, key, Collections.singletonList(remoteHost));
+      expectedDeletedKeysByPartition.put(partitionId, new HashSet<>(keys));
+    }
+    expectedIndex += 2;
+    checkerThread.replicate();
+    Assert.assertEquals(expectedDeletedKeysByPartition.size(), fileManager.appendRecordsForPartitions.size());
+    for (Map.Entry<PartitionId, Set<StoreKey>> expectedDeletedKeys : expectedDeletedKeysByPartition.entrySet()) {
+      Map<StoreKey, BackupCheckerAppendRecord> records =
+          fileManager.appendRecordsForPartitions.get(expectedDeletedKeys.getKey());
+      Assert.assertNotNull(records);
+      Set<StoreKey> keys = expectedDeletedKeys.getValue();
+      Assert.assertEquals(keys.size(), records.size());
+      for (StoreKey key : keys) {
+        BackupCheckerAppendRecord record = records.get(key);
+        Assert.assertNotNull(record);
+        Assert.assertEquals(
+            "/tmp/" + expectedDeletedKeys.getKey().getId() + "/" + record.remoteReplicaInfo.getReplicaId()
+                .getDataNodeId()
+                .getHostname() + "/missingKeys", record.filePath);
+        Assert.assertEquals(EnumSet.of(MessageInfoType.DELETE), record.acceptableLocalBlobStates);
+        Assert.assertEquals(EnumSet.of(MessageInfoType.PUT, MessageInfoType.DELETE), record.remoteBlobState);
+        Assert.assertEquals(EnumSet.of(MessageInfoType.PUT), record.localBlobState);
+      }
+    }
+    Assert.assertEquals(0, mockNetworkClient.numGetRequest.get());
+    responses = checkerThread.getExchangeMetadataResponsesInEachCycle().get(remoteHost.dataNodeId);
+    for (ReplicaThread.ExchangeMetadataResponse response : responses) {
+      Assert.assertEquals(expectedIndex, ((MockFindToken) response.remoteToken).getIndex());
+    }
+  }
+}

--- a/ambry-replication/src/test/java/com/github/ambry/replication/CloudToStoreReplicationManagerTest.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/CloudToStoreReplicationManagerTest.java
@@ -141,8 +141,9 @@ public class CloudToStoreReplicationManagerTest {
             new InMemAccountService(false, false));
     CloudToStoreReplicationManager cloudToStoreReplicationManager =
         new CloudToStoreReplicationManager(replicationConfig, clusterMapConfig, storeConfig, storageManager,
-            storeKeyFactory, clusterMap, mockScheduler, currentNode, clusterMap.getMetricRegistry(), null,
-            storeKeyConverterFactory, serverConfig.serverMessageTransformer, mockClusterSpectator, mockHelixParticipant);
+            storeKeyFactory, clusterMap, mockScheduler, currentNode, null, clusterMap.getMetricRegistry(), null,
+            storeKeyConverterFactory, serverConfig.serverMessageTransformer, mockClusterSpectator,
+            mockHelixParticipant);
     storageManager.start();
     cloudToStoreReplicationManager.start();
     mockClusterSpectator.spectate();
@@ -181,8 +182,9 @@ public class CloudToStoreReplicationManagerTest {
             new InMemAccountService(false, false));
     CloudToStoreReplicationManager cloudToStoreReplicationManager =
         new CloudToStoreReplicationManager(replicationConfig, clusterMapConfig, storeConfig, storageManager,
-            storeKeyFactory, clusterMap, mockScheduler, currentNode, clusterMap.getMetricRegistry(), null,
-            storeKeyConverterFactory, serverConfig.serverMessageTransformer, mockClusterSpectator, mockHelixParticipant);
+            storeKeyFactory, clusterMap, mockScheduler, currentNode, null, clusterMap.getMetricRegistry(), null,
+            storeKeyConverterFactory, serverConfig.serverMessageTransformer, mockClusterSpectator,
+            mockHelixParticipant);
     storageManager.start();
     cloudToStoreReplicationManager.start();
     mockClusterSpectator.spectate();

--- a/ambry-replication/src/test/java/com/github/ambry/replication/CloudToStoreReplicationManagerTest.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/CloudToStoreReplicationManagerTest.java
@@ -29,6 +29,7 @@ import com.github.ambry.config.ReplicationConfig;
 import com.github.ambry.config.ServerConfig;
 import com.github.ambry.config.StoreConfig;
 import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.network.NetworkClientFactory;
 import com.github.ambry.network.Port;
 import com.github.ambry.network.PortType;
 import com.github.ambry.store.MockStoreKeyConverterFactory;
@@ -141,9 +142,9 @@ public class CloudToStoreReplicationManagerTest {
             new InMemAccountService(false, false));
     CloudToStoreReplicationManager cloudToStoreReplicationManager =
         new CloudToStoreReplicationManager(replicationConfig, clusterMapConfig, storeConfig, storageManager,
-            storeKeyFactory, clusterMap, mockScheduler, currentNode, null, clusterMap.getMetricRegistry(), null,
-            storeKeyConverterFactory, serverConfig.serverMessageTransformer, mockClusterSpectator,
-            mockHelixParticipant);
+            storeKeyFactory, clusterMap, mockScheduler, currentNode, mock(NetworkClientFactory.class),
+            clusterMap.getMetricRegistry(), null, storeKeyConverterFactory, serverConfig.serverMessageTransformer,
+            mockClusterSpectator, mockHelixParticipant);
     storageManager.start();
     cloudToStoreReplicationManager.start();
     mockClusterSpectator.spectate();
@@ -182,9 +183,9 @@ public class CloudToStoreReplicationManagerTest {
             new InMemAccountService(false, false));
     CloudToStoreReplicationManager cloudToStoreReplicationManager =
         new CloudToStoreReplicationManager(replicationConfig, clusterMapConfig, storeConfig, storageManager,
-            storeKeyFactory, clusterMap, mockScheduler, currentNode, null, clusterMap.getMetricRegistry(), null,
-            storeKeyConverterFactory, serverConfig.serverMessageTransformer, mockClusterSpectator,
-            mockHelixParticipant);
+            storeKeyFactory, clusterMap, mockScheduler, currentNode, mock(NetworkClientFactory.class),
+            clusterMap.getMetricRegistry(), null, storeKeyConverterFactory, serverConfig.serverMessageTransformer,
+            mockClusterSpectator, mockHelixParticipant);
     storageManager.start();
     cloudToStoreReplicationManager.start();
     mockClusterSpectator.spectate();

--- a/ambry-replication/src/test/java/com/github/ambry/replication/CloudToStoreReplicationManagerTest.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/CloudToStoreReplicationManagerTest.java
@@ -17,10 +17,10 @@ import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.account.InMemAccountService;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.MockClusterMap;
-import com.github.ambry.clustermap.MockVcrClusterSpectator;
 import com.github.ambry.clustermap.MockDataNodeId;
 import com.github.ambry.clustermap.MockHelixParticipant;
 import com.github.ambry.clustermap.MockPartitionId;
+import com.github.ambry.clustermap.MockVcrClusterSpectator;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.config.ClusterMapConfig;
@@ -141,9 +141,8 @@ public class CloudToStoreReplicationManagerTest {
             new InMemAccountService(false, false));
     CloudToStoreReplicationManager cloudToStoreReplicationManager =
         new CloudToStoreReplicationManager(replicationConfig, clusterMapConfig, storeConfig, storageManager,
-            storeKeyFactory, clusterMap, mockScheduler, currentNode, null, clusterMap.getMetricRegistry(), null,
-            storeKeyConverterFactory, serverConfig.serverMessageTransformer, mockClusterSpectator,
-            mockHelixParticipant);
+            storeKeyFactory, clusterMap, mockScheduler, currentNode, clusterMap.getMetricRegistry(), null,
+            storeKeyConverterFactory, serverConfig.serverMessageTransformer, mockClusterSpectator, mockHelixParticipant);
     storageManager.start();
     cloudToStoreReplicationManager.start();
     mockClusterSpectator.spectate();
@@ -182,9 +181,8 @@ public class CloudToStoreReplicationManagerTest {
             new InMemAccountService(false, false));
     CloudToStoreReplicationManager cloudToStoreReplicationManager =
         new CloudToStoreReplicationManager(replicationConfig, clusterMapConfig, storeConfig, storageManager,
-            storeKeyFactory, clusterMap, mockScheduler, currentNode, null, clusterMap.getMetricRegistry(), null,
-            storeKeyConverterFactory, serverConfig.serverMessageTransformer, mockClusterSpectator,
-            mockHelixParticipant);
+            storeKeyFactory, clusterMap, mockScheduler, currentNode, clusterMap.getMetricRegistry(), null,
+            storeKeyConverterFactory, serverConfig.serverMessageTransformer, mockClusterSpectator, mockHelixParticipant);
     storageManager.start();
     cloudToStoreReplicationManager.start();
     mockClusterSpectator.spectate();

--- a/ambry-replication/src/test/java/com/github/ambry/replication/InMemoryStore.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/InMemoryStore.java
@@ -413,7 +413,12 @@ class InMemoryStore implements Store {
 
   @Override
   public MessageInfo findKey(StoreKey key) throws StoreException {
-    return getMergedMessageInfo(key, messageInfos);
+    MessageInfo info = getMergedMessageInfo(key, messageInfos);
+    if (info == null) {
+      throw new StoreException("Key " + key + " not found in store. Cannot check if it is deleted",
+          StoreErrorCodes.ID_Not_Found);
+    }
+    return info;
   }
 
   @Override

--- a/ambry-replication/src/test/java/com/github/ambry/replication/LeaderBasedReplicationTest.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/LeaderBasedReplicationTest.java
@@ -514,7 +514,7 @@ public class LeaderBasedReplicationTest extends ReplicationTestHelper {
     for (RemoteReplicaInfo remoteReplicaInfo : remoteReplicaInfosForRemoteDC) {
       if (leaderReplicasOnLocalAndRemoteNodes.contains(remoteReplicaInfo.getReplicaId())) {
         assertEquals("remote token mismatch for leader replicas",
-            ((MockFindToken) remoteReplicaInfo.getToken()).getIndex(), batchSize - 1);
+            ((MockFindToken) remoteReplicaInfo.getToken()).getIndex(), batchSize);
       } else {
         assertEquals("remote token should not move forward for standby replicas until missing keys are fetched",
             ((MockFindToken) remoteReplicaInfo.getToken()).getIndex(), 0);
@@ -527,7 +527,7 @@ public class LeaderBasedReplicationTest extends ReplicationTestHelper {
     // verify that remote token will be moved for all intra-colo replicas with token index = batchSize-1
     for (RemoteReplicaInfo replicaInfo : remoteReplicaInfosForLocalDC) {
       assertEquals("mismatch in remote token set for intra colo replicas",
-          ((MockFindToken) replicaInfo.getToken()).getIndex(), batchSize - 1);
+          ((MockFindToken) replicaInfo.getToken()).getIndex(), batchSize);
     }
 
     // process missing keys for cross colo replicas from previous metadata exchange
@@ -539,7 +539,7 @@ public class LeaderBasedReplicationTest extends ReplicationTestHelper {
     // as missing keys must now be obtained via intra-dc replication
     for (RemoteReplicaInfo replicaInfo : remoteReplicaInfosForRemoteDC) {
       assertEquals("mismatch in remote token set for inter colo replicas",
-          ((MockFindToken) replicaInfo.getToken()).getIndex(), batchSize - 1);
+          ((MockFindToken) replicaInfo.getToken()).getIndex(), batchSize);
     }
 
     // If we have a local standby replica with leader partition on remote node, change its state to leader
@@ -558,10 +558,10 @@ public class LeaderBasedReplicationTest extends ReplicationTestHelper {
       if (leaderReplicasOnLocalAndRemoteNodes.contains(remoteReplicaInfo.getReplicaId())
           || (remoteReplicaInfo.getLocalReplicaId().equals(localStandbyReplicaWithLeaderPartitionOnRemoteNode))) {
         assertEquals("remote token mismatch for leader replicas",
-            ((MockFindToken) remoteReplicaInfo.getToken()).getIndex(), batchSize * 2 - 2);
+            ((MockFindToken) remoteReplicaInfo.getToken()).getIndex(), batchSize * 2);
       } else {
         assertEquals("remote token should not move forward for standby replicas until missing keys are fetched",
-            ((MockFindToken) remoteReplicaInfo.getToken()).getIndex(), batchSize - 1);
+            ((MockFindToken) remoteReplicaInfo.getToken()).getIndex(), batchSize);
       }
     }
 
@@ -571,7 +571,7 @@ public class LeaderBasedReplicationTest extends ReplicationTestHelper {
     // verify that remote token is moved forward for all intra-colo replicas.
     for (RemoteReplicaInfo replicaInfo : remoteReplicaInfosForLocalDC) {
       assertEquals("mismatch in remote token set for intra colo replicas",
-          ((MockFindToken) replicaInfo.getToken()).getIndex(), batchSize * 2 - 2);
+          ((MockFindToken) replicaInfo.getToken()).getIndex(), batchSize * 2);
     }
 
     // process missing keys for cross colo replicas from previous metadata exchange
@@ -583,7 +583,7 @@ public class LeaderBasedReplicationTest extends ReplicationTestHelper {
     // via intra-dc replication.
     for (RemoteReplicaInfo remoteReplicaInfo : remoteReplicaInfosForRemoteDC) {
       assertEquals("mismatch in remote token set for intra colo replicas",
-          ((MockFindToken) remoteReplicaInfo.getToken()).getIndex(), batchSize * 2 - 2);
+          ((MockFindToken) remoteReplicaInfo.getToken()).getIndex(), batchSize * 2);
     }
 
     storageManager.shutdown();
@@ -710,7 +710,7 @@ public class LeaderBasedReplicationTest extends ReplicationTestHelper {
     for (RemoteReplicaInfo remoteReplicaInfo : remoteReplicaInfosForRemoteDC) {
       if (leaderReplicasOnLocalAndRemoteNodes.contains(remoteReplicaInfo.getReplicaId())) {
         assertEquals("remote token mismatch for leader replicas",
-            ((MockFindToken) remoteReplicaInfo.getToken()).getIndex(), batchSize - 1);
+            ((MockFindToken) remoteReplicaInfo.getToken()).getIndex(), batchSize);
       } else {
         assertEquals("remote token should not move forward for standby replicas until missing keys are fetched",
             ((MockFindToken) remoteReplicaInfo.getToken()).getIndex(), 0);
@@ -723,7 +723,7 @@ public class LeaderBasedReplicationTest extends ReplicationTestHelper {
     // verify that remote token will be moved for all replicas as it is intra-dc replication
     for (RemoteReplicaInfo remoteReplicaInfo : remoteReplicaInfosForLocalDC) {
       assertEquals("mismatch in remote token set for intra colo replicas",
-          ((MockFindToken) remoteReplicaInfo.getToken()).getIndex(), numOfMessagesOnRemoteNodeInLocalDC - 1);
+          ((MockFindToken) remoteReplicaInfo.getToken()).getIndex(), numOfMessagesOnRemoteNodeInLocalDC);
     }
 
     // process missing messages if any from previous metadata exchange for cross colo replicas as they must now be obtained
@@ -776,7 +776,7 @@ public class LeaderBasedReplicationTest extends ReplicationTestHelper {
     for (RemoteReplicaInfo remoteReplicaInfo : remoteReplicaInfosForRemoteDC) {
       if (!leaderReplicasOnLocalAndRemoteNodes.contains(remoteReplicaInfo.getReplicaId())) {
         assertEquals("mismatch in remote token set for standby cross colo replicas",
-            ((MockFindToken) remoteReplicaInfo.getToken()).getIndex(), batchSize - 1);
+            ((MockFindToken) remoteReplicaInfo.getToken()).getIndex(), batchSize);
         assertFalse("missing store messages should be empty for standby replicas now",
             crossColoReplicaThread.containsMissingKeysFromPreviousMetadataExchange(remoteReplicaInfo));
       }

--- a/ambry-replication/src/test/java/com/github/ambry/replication/MockConnectionPool.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/MockConnectionPool.java
@@ -260,23 +260,21 @@ public class MockConnectionPool implements ConnectionPool {
               host.infosByPartition.getOrDefault(requestInfo.getPartitionId(), new ArrayList<>());
           int startIndex = ((MockFindToken) (requestInfo.getToken())).getIndex();
           int endIndex = Math.min(allMessageInfos.size(), startIndex + maxSizeToReturn);
-          int indexRequested = 0;
           Set<StoreKey> processedKeys = new HashSet<>();
           for (int i = startIndex; i < endIndex; i++) {
             StoreKey key = allMessageInfos.get(i).getStoreKey();
             if (processedKeys.add(key)) {
               messageInfosToReturn.add(getMergedMessageInfo(key, allMessageInfos));
             }
-            indexRequested = i;
           }
-          long bytesRead = allMessageInfos.size() > 0 ? allMessageInfos.subList(0, indexRequested + 1)
+          long bytesRead = allMessageInfos.size() > 0 ? allMessageInfos.subList(0, endIndex)
               .stream()
               .mapToLong(MessageInfo::getSize)
               .sum() : 0;
           long total = allMessageInfos.stream().mapToLong(MessageInfo::getSize).sum();
           ReplicaMetadataResponseInfo replicaMetadataResponseInfo =
               new ReplicaMetadataResponseInfo(requestInfo.getPartitionId(), requestInfo.getReplicaType(),
-                  new MockFindToken(indexRequested + 1, bytesRead), messageInfosToReturn, total - bytesRead,
+                  new MockFindToken(endIndex, bytesRead), messageInfosToReturn, total - bytesRead,
                   ReplicaMetadataResponse.getCompatibleResponseVersion(metadataRequest.getVersionId()));
           responseInfoList.add(replicaMetadataResponseInfo);
         }

--- a/ambry-replication/src/test/java/com/github/ambry/replication/MockConnectionPool.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/MockConnectionPool.java
@@ -16,7 +16,6 @@ package com.github.ambry.replication;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.PartitionId;
-import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.messageformat.MessageMetadata;
 import com.github.ambry.network.ChannelOutput;
 import com.github.ambry.network.ConnectedChannel;
@@ -33,6 +32,7 @@ import com.github.ambry.protocol.ReplicaMetadataRequestInfo;
 import com.github.ambry.protocol.ReplicaMetadataResponse;
 import com.github.ambry.protocol.ReplicaMetadataResponseInfo;
 import com.github.ambry.protocol.Response;
+import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.store.MessageInfo;
 import com.github.ambry.store.StoreKey;
 import com.github.ambry.utils.AbstractByteBufHolder;
@@ -163,7 +163,7 @@ public class MockConnectionPool implements ConnectionPool {
     }
 
     private final MockHost host;
-    private final int maxSizeToReturn;
+    private volatile int maxSizeToReturn;
 
     private List<ByteBuffer> buffersToReturn;
     private Map<PartitionId, List<MessageInfo>> infosToReturn;
@@ -322,6 +322,10 @@ public class MockConnectionPool implements ConnectionPool {
     @Override
     public int getRemotePort() {
       return host.dataNodeId.getPort();
+    }
+
+    public void setMaxSizeToReturn(int maxSizeToReturn) {
+      this.maxSizeToReturn = maxSizeToReturn;
     }
   }
 }

--- a/ambry-replication/src/test/java/com/github/ambry/replication/MockConnectionPool.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/MockConnectionPool.java
@@ -276,7 +276,7 @@ public class MockConnectionPool implements ConnectionPool {
           long total = allMessageInfos.stream().mapToLong(MessageInfo::getSize).sum();
           ReplicaMetadataResponseInfo replicaMetadataResponseInfo =
               new ReplicaMetadataResponseInfo(requestInfo.getPartitionId(), requestInfo.getReplicaType(),
-                  new MockFindToken(indexRequested, bytesRead), messageInfosToReturn, total - bytesRead,
+                  new MockFindToken(indexRequested + 1, bytesRead), messageInfosToReturn, total - bytesRead,
                   ReplicaMetadataResponse.getCompatibleResponseVersion(metadataRequest.getVersionId()));
           responseInfoList.add(replicaMetadataResponseInfo);
         }

--- a/ambry-replication/src/test/java/com/github/ambry/replication/MockConnectionPool.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/MockConnectionPool.java
@@ -256,7 +256,8 @@ public class MockConnectionPool implements ConnectionPool {
         List<ReplicaMetadataResponseInfo> responseInfoList = new ArrayList<>();
         for (ReplicaMetadataRequestInfo requestInfo : metadataRequest.getReplicaMetadataRequestInfoList()) {
           List<MessageInfo> messageInfosToReturn = new ArrayList<>();
-          List<MessageInfo> allMessageInfos = host.infosByPartition.get(requestInfo.getPartitionId());
+          List<MessageInfo> allMessageInfos =
+              host.infosByPartition.getOrDefault(requestInfo.getPartitionId(), new ArrayList<>());
           int startIndex = ((MockFindToken) (requestInfo.getToken())).getIndex();
           int endIndex = Math.min(allMessageInfos.size(), startIndex + maxSizeToReturn);
           int indexRequested = 0;
@@ -268,8 +269,10 @@ public class MockConnectionPool implements ConnectionPool {
             }
             indexRequested = i;
           }
-          long bytesRead =
-              allMessageInfos.subList(0, indexRequested + 1).stream().mapToLong(MessageInfo::getSize).sum();
+          long bytesRead = allMessageInfos.size() > 0 ? allMessageInfos.subList(0, indexRequested + 1)
+              .stream()
+              .mapToLong(MessageInfo::getSize)
+              .sum() : 0;
           long total = allMessageInfos.stream().mapToLong(MessageInfo::getSize).sum();
           ReplicaMetadataResponseInfo replicaMetadataResponseInfo =
               new ReplicaMetadataResponseInfo(requestInfo.getPartitionId(), requestInfo.getReplicaType(),

--- a/ambry-replication/src/test/java/com/github/ambry/replication/MockNetworkClient.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/MockNetworkClient.java
@@ -46,7 +46,7 @@ public class MockNetworkClient implements NetworkClient {
   private final Map<DataNodeId, MockConnectionPool.MockConnection> connections;
   private final ClusterMap clusterMap;
   private final FindTokenHelper findTokenHelper;
-  private final int batchSize;
+  private volatile int batchSize;
   private final Map<Integer, RequestInfo> correlationIdToRequestInfos = new HashMap<>();
 
   private volatile NetworkClientErrorCode expectedNetworkClientErrorCode = null;
@@ -82,6 +82,13 @@ public class MockNetworkClient implements NetworkClient {
 
   void setSendAndPollCallback(Runnable callback) {
     sendAndPoolCallback = callback;
+  }
+
+  void setBatchSize(int batchSize) {
+    this.batchSize = batchSize;
+    for (MockConnectionPool.MockConnection connection : connections.values()) {
+      connection.setMaxSizeToReturn(batchSize);
+    }
   }
 
   @Override

--- a/ambry-replication/src/test/java/com/github/ambry/replication/MockNetworkClient.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/MockNetworkClient.java
@@ -37,6 +37,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 
 /**
@@ -56,6 +57,7 @@ public class MockNetworkClient implements NetworkClient {
   private volatile ServerErrorCode expectedGetResponseError = ServerErrorCode.No_Error;
   private volatile boolean shouldReturnResponseForDroppedRequests = true;
   private Runnable sendAndPoolCallback = null;
+  final AtomicInteger numGetRequest = new AtomicInteger();
 
   public MockNetworkClient(Map<DataNodeId, MockHost> hosts, ClusterMap clusterMap, int batchSize,
       FindTokenHelper findTokenHelper) {
@@ -145,6 +147,7 @@ public class MockNetworkClient implements NetworkClient {
           } else if (requestInfo.getRequest()
               .getRequestOrResponseType()
               .equals(RequestOrResponseType.GetRequest.name())) {
+            numGetRequest.incrementAndGet();
             if (expectedGetResponseError == ServerErrorCode.No_Error) {
               responseInfos.add(new ResponseInfo(requestInfo, null, Unpooled.wrappedBuffer(bytes)));
             } else {

--- a/ambry-replication/src/test/java/com/github/ambry/replication/MockNetworkClientFactory.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/MockNetworkClientFactory.java
@@ -41,4 +41,8 @@ public class MockNetworkClientFactory implements NetworkClientFactory {
   public NetworkClient getNetworkClient() throws IOException {
     return new MockNetworkClient(hosts, clusterMap, batchSize, findTokenHelper);
   }
+
+  public FindTokenHelper getFindTokenHelper() {
+    return findTokenHelper;
+  }
 }

--- a/ambry-replication/src/test/java/com/github/ambry/replication/MockReplicationManager.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/MockReplicationManager.java
@@ -23,7 +23,6 @@ import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.ReplicationConfig;
 import com.github.ambry.config.StoreConfig;
 import com.github.ambry.config.VerifiableProperties;
-import com.github.ambry.network.ConnectionPool;
 import com.github.ambry.network.NetworkClientFactory;
 import com.github.ambry.store.StorageManager;
 import com.github.ambry.store.StoreKey;
@@ -37,6 +36,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
+
+import static org.mockito.Mockito.*;
 
 
 /**
@@ -82,8 +83,8 @@ public class MockReplicationManager extends ReplicationManager {
       StoreKeyConverterFactory storeKeyConverterFactory, ClusterParticipant clusterParticipant)
       throws ReplicationException {
     this(replicationConfig, clusterMapConfig, storeConfig, storageManager, clusterMap, dataNodeId,
-        storeKeyConverterFactory, clusterParticipant, null, null, null, BlobIdTransformer.class.getName(),
-        new StoreKeyFactory() {
+        storeKeyConverterFactory, clusterParticipant, mock(NetworkClientFactory.class), null,
+        BlobIdTransformer.class.getName(), new StoreKeyFactory() {
           @Override
           public StoreKey getStoreKey(DataInputStream stream) {
             return null;
@@ -99,11 +100,11 @@ public class MockReplicationManager extends ReplicationManager {
   public MockReplicationManager(ReplicationConfig replicationConfig, ClusterMapConfig clusterMapConfig,
       StoreConfig storeConfig, StorageManager storageManager, ClusterMap clusterMap, DataNodeId dataNodeId,
       StoreKeyConverterFactory storeKeyConverterFactory, ClusterParticipant clusterParticipant,
-      ConnectionPool connectionPool, NetworkClientFactory factory, FindTokenHelper findTokenHelper,
-      String transformerClassName, StoreKeyFactory storeKeyFactory, Time time) throws ReplicationException {
+      NetworkClientFactory factory, FindTokenHelper findTokenHelper, String transformerClassName,
+      StoreKeyFactory storeKeyFactory, Time time) throws ReplicationException {
     super(replicationConfig, clusterMapConfig, storeConfig, storageManager, storeKeyFactory, clusterMap, null,
-        dataNodeId, connectionPool, factory, clusterMap.getMetricRegistry(), null, storeKeyConverterFactory,
-        transformerClassName, clusterParticipant, null, findTokenHelper, time);
+        dataNodeId, factory, clusterMap.getMetricRegistry(), null, storeKeyConverterFactory, transformerClassName,
+        clusterParticipant, null, findTokenHelper, time);
     reset();
   }
 

--- a/ambry-replication/src/test/java/com/github/ambry/replication/ReplicationTestHelper.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/ReplicationTestHelper.java
@@ -75,7 +75,6 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 import org.json.JSONObject;
 import org.mockito.Mockito;
 
@@ -484,17 +483,13 @@ public class ReplicationTestHelper {
    * @throws Exception
    */
   protected void replicateAndVerify(ReplicationTestSetup testSetup, String expectedStr) throws Exception {
-    PartitionId partitionId = testSetup.partitionIds.get(0);
-    List<RemoteReplicaInfo> singleReplicaList = testSetup.replicasToReplicate.get(testSetup.remoteHost.dataNodeId)
-        .stream()
-        .filter(e -> e.getReplicaId().getPartitionId() == partitionId)
-        .collect(Collectors.toList());
 
     // Do the replica metadata exchange.
     testSetup.replicaThread.replicate();
 
     // Verify
     String[] expectedResults = expectedStr.equals("") ? new String[0] : expectedStr.split("\\s");
+    PartitionId partitionId = testSetup.partitionIds.get(0);
     int size = testSetup.localHost.infosByPartition.get(partitionId).size();
     assertEquals("Mismatch in number of messages on local host after replication", expectedResults.length, size);
     for (int i = 0; i < size; ++i) {
@@ -1097,6 +1092,7 @@ public class ReplicationTestHelper {
               null, remoteHost);
       replicasToReplicate = replicasAndThread.getFirst();
       replicaThread = replicasAndThread.getSecond();
+      ((MockNetworkClient) replicaThread.getNetworkClient()).setConversionMap(remoteConversionMap);
     }
   }
 

--- a/ambry-replication/src/test/java/com/github/ambry/replication/ReplicationTestHelper.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/ReplicationTestHelper.java
@@ -296,7 +296,8 @@ public class ReplicationTestHelper {
       ClusterMapConfig clusterMapConfig, MockHelixParticipant clusterParticipant) throws Exception {
 
     return createStorageManagerAndReplicationManager(clusterMap, clusterMapConfig, clusterParticipant,
-        new MockNetworkClientFactory(new HashMap<>(), clusterMap, 0, new FindTokenHelper()));
+        new MockNetworkClientFactory(new HashMap<>(), clusterMap, 0,
+            new MockFindTokenHelper(new BlobIdFactory(clusterMap), replicationConfig)));
   }
 
   /**

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryServer.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryServer.java
@@ -264,9 +264,8 @@ public class AmbryServer {
         vcrClusterSpectator = _vcrClusterAgentsFactory.getVcrClusterSpectator(cloudConfig, clusterMapConfig);
         cloudToStoreReplicationManager =
             new CloudToStoreReplicationManager(replicationConfig, clusterMapConfig, storeConfig, storageManager,
-                storeKeyFactory, clusterMap, scheduler, nodeId, connectionPool, registry, notificationSystem,
-                storeKeyConverterFactory, serverConfig.serverMessageTransformer, vcrClusterSpectator,
-                clusterParticipants.get(0));
+                storeKeyFactory, clusterMap, scheduler, nodeId, registry, notificationSystem, storeKeyConverterFactory,
+                serverConfig.serverMessageTransformer, vcrClusterSpectator, clusterParticipants.get(0));
         cloudToStoreReplicationManager.start();
       }
 

--- a/ambry-server/src/test/java/com/github/ambry/server/AmbryServerRequestsTest.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/AmbryServerRequestsTest.java
@@ -171,7 +171,7 @@ public class AmbryServerRequestsTest extends ReplicationTestHelper {
   public AmbryServerRequestsTest(boolean validateRequestOnStoreState)
       throws IOException, ReplicationException, StoreException, InterruptedException, ReflectiveOperationException {
     super(ReplicaMetadataRequest.Replica_Metadata_Request_Version_V2,
-        ReplicaMetadataResponse.REPLICA_METADATA_RESPONSE_VERSION_V_6, false);
+        ReplicaMetadataResponse.REPLICA_METADATA_RESPONSE_VERSION_V_6);
     this.validateRequestOnStoreState = validateRequestOnStoreState;
     clusterMap = new MockClusterMap();
     localDc = clusterMap.getDatacenterName(clusterMap.getLocalDatacenterId());


### PR DESCRIPTION
Now that we enabled nonblocking network client in replica thread, we should remove all the blocking channel code from replciation.