### PR TITLE
Add Log4J structured logging for public access logs

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/RestServerConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/RestServerConfig.java
@@ -19,6 +19,7 @@ package com.github.ambry.config;
 public class RestServerConfig {
   public static final String CONFIG_PREFIX = "rest.server.";
   public static final String ENABLE_ADDED_CHANNEL_HANDLERS = CONFIG_PREFIX + "enable.added.channel.handlers";
+  public static final String ENABLE_STRUCTURED_LOGGING = CONFIG_PREFIX + "enable.structured.logging";
 
   /**
    * The RestRequestServiceFactory that needs to be used by the RestServer
@@ -87,6 +88,13 @@ public class RestServerConfig {
   public final String restServerPublicAccessLogResponseHeaders;
 
   /**
+   * Whether to use Log4j 2 structured logging or not (true means we use it).
+   */
+  @Config(ENABLE_STRUCTURED_LOGGING)
+  @Default("false")
+  public final boolean restServerEnableStructuredLogging;
+
+  /**
    * Health check URI for load balancers (VIPs)
    */
   @Config("rest.server.health.check.uri")
@@ -120,6 +128,7 @@ public class RestServerConfig {
             "Host,Referer,User-Agent,Content-Length,x-ambry-content-type,x-ambry-owner-id,x-ambry-ttl,x-ambry-private,x-ambry-service-id,X-Forwarded-For");
     restServerPublicAccessLogResponseHeaders =
         verifiableProperties.getString("rest.server.public.access.log.response.headers", "Location,x-ambry-blob-size");
+    restServerEnableStructuredLogging = verifiableProperties.getBoolean(ENABLE_STRUCTURED_LOGGING, false);
     restServerHealthCheckUri = verifiableProperties.getString("rest.server.health.check.uri", "/healthCheck");
     restServerEnableAddedChannelHandlers = verifiableProperties.getBoolean(ENABLE_ADDED_CHANNEL_HANDLERS, false);
   }

--- a/ambry-rest/src/main/java/com/github/ambry/rest/PublicAccessLogger.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/PublicAccessLogger.java
@@ -13,8 +13,12 @@
  */
 package com.github.ambry.rest;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+//import org.slf4j.Logger;
+//import org.slf4j.LoggerFactory;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.message.StringMapMessage;
 
 
 /**
@@ -22,18 +26,22 @@ import org.slf4j.LoggerFactory;
  */
 public class PublicAccessLogger {
 
-  private static final Logger publicAccessLogger = LoggerFactory.getLogger("PublicAccessLogger");
+  //private static final Logger publicAccessLogger = LoggerFactory.getLogger("PublicAccessLogger");
+  private static final Logger publicAccessLogger = LogManager.getLogger("PublicAccessLogger");
 
   private final String[] requestHeaders;
   private final String[] responseHeaders;
+  private boolean enableStructuredLogging;
 
   /**
    * @param requestHeaders the request headers to log.
    * @param responseHeaders the response headers to log.
+   * @param enableStructuredLogging {@code true} if we want to use structured logging (for Kusto), {@code false} otherwise
    */
-  public PublicAccessLogger(String[] requestHeaders, String[] responseHeaders) {
+  public PublicAccessLogger(String[] requestHeaders, String[] responseHeaders, boolean enableStructuredLogging) {
     this.requestHeaders = requestHeaders;
     this.responseHeaders = responseHeaders;
+    this.enableStructuredLogging = enableStructuredLogging;
   }
 
   public String[] getRequestHeaders() {
@@ -44,11 +52,23 @@ public class PublicAccessLogger {
     return responseHeaders;
   }
 
+  public boolean structuredLoggingEnabled() {
+    return enableStructuredLogging;
+  }
+
   public void logError(String message) {
     publicAccessLogger.error(message);
   }
 
+  public void logError(StringMapMessage message) {
+    publicAccessLogger.error(message);
+  }
+
   public void logInfo(String message) {
+    publicAccessLogger.info(message);
+  }
+
+  public void logInfo(StringMapMessage message) {
     publicAccessLogger.info(message);
   }
 }

--- a/ambry-rest/src/main/java/com/github/ambry/rest/RestServer.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/RestServer.java
@@ -232,7 +232,8 @@ public class RestServer {
     restResponseHandler = restHandlerFactory.getRestResponseHandler();
 
     publicAccessLogger = new PublicAccessLogger(restServerConfig.restServerPublicAccessLogRequestHeaders.split(","),
-        restServerConfig.restServerPublicAccessLogResponseHeaders.split(","));
+        restServerConfig.restServerPublicAccessLogResponseHeaders.split(","),
+        restServerConfig.restServerEnableStructuredLogging);
 
     NioServerFactory nioServerFactory =
         Utils.getObj(restServerConfig.restServerNioServerFactory, verifiableProperties, metricRegistry,

--- a/ambry-rest/src/test/java/com/github/ambry/rest/FrontendNettyFactoryTest.java
+++ b/ambry-rest/src/test/java/com/github/ambry/rest/FrontendNettyFactoryTest.java
@@ -38,7 +38,10 @@ public class FrontendNettyFactoryTest {
   private static final RestRequestHandler REST_REQUEST_HANDLER =
       new AsyncRequestResponseHandler(new RequestResponseHandlerMetrics(new MetricRegistry()), 1,
           new MockRestRequestService(new VerifiableProperties(new Properties()), new MockRouter()));
-  private static final PublicAccessLogger PUBLIC_ACCESS_LOGGER = new PublicAccessLogger(new String[]{}, new String[]{});
+  private static final PublicAccessLogger PUBLIC_ACCESS_LOGGER =
+      new PublicAccessLogger(new String[]{}, new String[]{}, false);
+  private static final PublicAccessLogger STRUCTURED_PUBLIC_ACCESS_LOGGER =
+      new PublicAccessLogger(new String[]{}, new String[]{}, true);
   private static final RestServerState REST_SERVER_STATE = new RestServerState("/healthCheck");
   private static final SSLFactory SSL_FACTORY = RestTestUtils.getTestSSLFactory();
 
@@ -103,10 +106,10 @@ public class FrontendNettyFactoryTest {
         SSL_FACTORY);
     doConstructionFailureTest(verifiableProperties, metricRegistry, REST_REQUEST_HANDLER, null, REST_SERVER_STATE,
         SSL_FACTORY);
-    doConstructionFailureTest(verifiableProperties, metricRegistry, REST_REQUEST_HANDLER, PUBLIC_ACCESS_LOGGER, null,
-        SSL_FACTORY);
-    doConstructionFailureTest(verifiableProperties, metricRegistry, REST_REQUEST_HANDLER, PUBLIC_ACCESS_LOGGER,
-        REST_SERVER_STATE, null);
+    doConstructionFailureTest(verifiableProperties, metricRegistry, REST_REQUEST_HANDLER,
+        STRUCTURED_PUBLIC_ACCESS_LOGGER, null, SSL_FACTORY);
+    doConstructionFailureTest(verifiableProperties, metricRegistry, REST_REQUEST_HANDLER,
+        STRUCTURED_PUBLIC_ACCESS_LOGGER, REST_SERVER_STATE, null);
   }
 
   /**

--- a/ambry-rest/src/test/java/com/github/ambry/rest/MockPublicAccessLogger.java
+++ b/ambry-rest/src/test/java/com/github/ambry/rest/MockPublicAccessLogger.java
@@ -18,8 +18,8 @@ public class MockPublicAccessLogger extends PublicAccessLogger {
   private StringBuilder publicAccessLogger = new StringBuilder();
   private String lastPublicAccessLogEntry = new String();
 
-  public MockPublicAccessLogger(String[] requestHeaders, String[] responseHeaders) {
-    super(requestHeaders, responseHeaders);
+  public MockPublicAccessLogger(String[] requestHeaders, String[] responseHeaders, boolean enableStructuredLogging) {
+    super(requestHeaders, responseHeaders, enableStructuredLogging);
   }
 
   @Override

--- a/ambry-rest/src/test/java/com/github/ambry/rest/NettyServerTest.java
+++ b/ambry-rest/src/test/java/com/github/ambry/rest/NettyServerTest.java
@@ -38,7 +38,7 @@ public class NettyServerTest {
   private static final RestRequestService REST_REQUEST_SERVICE =
       new MockRestRequestService(new VerifiableProperties(new Properties()), new MockRouter());
   private static final RestRequestHandler REQUEST_HANDLER = new MockRestRequestResponseHandler(REST_REQUEST_SERVICE);
-  private static final PublicAccessLogger PUBLIC_ACCESS_LOGGER = new PublicAccessLogger(new String[]{}, new String[]{});
+  private static final PublicAccessLogger PUBLIC_ACCESS_LOGGER = new PublicAccessLogger(new String[]{}, new String[]{}, false);
   private static final RestServerState REST_SERVER_STATE = new RestServerState("/healthCheck");
   private static final ConnectionStatsHandler CONNECTION_STATS_HANDLER = new ConnectionStatsHandler(NETTY_METRICS);
   private static final SSLFactory SSL_FACTORY = RestTestUtils.getTestSSLFactory();

--- a/ambry-rest/src/test/java/com/github/ambry/rest/PublicAccessLogHandlerTest.java
+++ b/ambry-rest/src/test/java/com/github/ambry/rest/PublicAccessLogHandlerTest.java
@@ -71,7 +71,7 @@ public class PublicAccessLogHandlerTest {
    * Sets up the mock public access logger that {@link PublicAccessLogHandler} can use.
    */
   public PublicAccessLogHandlerTest() {
-    publicAccessLogger = new MockPublicAccessLogger(REQUEST_HEADERS.split(","), RESPONSE_HEADERS.split(","));
+    publicAccessLogger = new MockPublicAccessLogger(REQUEST_HEADERS.split(","), RESPONSE_HEADERS.split(","), false);
   }
 
   /**

--- a/ambry-rest/src/test/java/com/github/ambry/rest/PublicAccessLoggerTest.java
+++ b/ambry-rest/src/test/java/com/github/ambry/rest/PublicAccessLoggerTest.java
@@ -29,7 +29,7 @@ public class PublicAccessLoggerTest {
   public void testPublicAccessLoggerHeaders() {
     String[] requestHeaders = new String[]{REQUEST_HEADER_PREFIX + "1", REQUEST_HEADER_PREFIX + "2"};
     String[] responseHeaders = new String[]{RESPONSE_HEADER_PREFIX + "1", RESPONSE_HEADER_PREFIX + "2"};
-    PublicAccessLogger publicAccessLogger = new PublicAccessLogger(requestHeaders, responseHeaders);
+    PublicAccessLogger publicAccessLogger = new PublicAccessLogger(requestHeaders, responseHeaders, false);
     Assert.assertTrue("Request Headers mismatch ",
         Arrays.deepEquals(publicAccessLogger.getRequestHeaders(), requestHeaders));
     Assert.assertTrue("Response Headers mismatch ",


### PR DESCRIPTION
This PR changes the public access logging so that instead of writing out a single large string for each log statement, structured logs are emitted. The advantage of this is that our logs will be much easier to search with Azure Kusto, since the LinkedIn Kusto integration breaks up the structured log fields into separate fields in Kusto. This way, we won't have to write regular expressions to parse out individual fields in Kusto.

The changes are guarded by a new configuration that is set to false by default.

The code is a little messy, essentially copying each log instruction to a new, structured log, instruction. I left it like this on purpose, since we don't really have any way to properly test these changes other than to deploy to a test host and check Kusto afterwards.

If we get this working, I intend to follow up with another PR that either removes the old logging or cleans up this code so the new and old ways can exist side by side.