### PR TITLE
[Efficient Metadata Operations] Serialize-Deserialize reserved metadata chunk id

### DIFF
--- a/ambry-messageformat/src/test/java/com/github/ambry/messageformat/BlobPropertiesTest.java
+++ b/ambry-messageformat/src/test/java/com/github/ambry/messageformat/BlobPropertiesTest.java
@@ -58,7 +58,7 @@ public class BlobPropertiesTest {
   @Parameterized.Parameters
   public static List<Object[]> data() {
     return Arrays.asList(new Object[][]{{BlobPropertiesSerDe.VERSION_1}, {BlobPropertiesSerDe.VERSION_2},
-        {BlobPropertiesSerDe.VERSION_3}, {BlobPropertiesSerDe.VERSION_4}});
+        {BlobPropertiesSerDe.VERSION_3}, {BlobPropertiesSerDe.VERSION_4}, {BlobPropertiesSerDe.VERSION_5}});
   }
 
   public BlobPropertiesTest(short version) {
@@ -72,8 +72,8 @@ public class BlobPropertiesTest {
     String ownerId = "OwnerId";
     String contentType = "ContentType";
     String externalAssetTag = "some-external-asset-tag";
-    String contentEncoding = version == BlobPropertiesSerDe.VERSION_4 ? "gzip" : null;
-    String filename = version == BlobPropertiesSerDe.VERSION_4 ? "filename" : null;
+    String contentEncoding = version >= BlobPropertiesSerDe.VERSION_4 ? "gzip" : null;
+    String filename = version >= BlobPropertiesSerDe.VERSION_4 ? "filename" : null;
     int timeToLiveInSeconds = 144;
     short accountId = Utils.getRandomShort(TestUtils.RANDOM);
     short containerId = Utils.getRandomShort(TestUtils.RANDOM);
@@ -198,7 +198,7 @@ public class BlobPropertiesTest {
     blobProperties = BlobPropertiesSerDe.getBlobPropertiesFromStream(
         new DataInputStream(new ByteBufferInputStream(serializedBuffer)));
     verifyBlobProperties(blobProperties, blobSize, serviceId, "", "", false, timeToLiveInSeconds + 1, accountIdToExpect,
-        containerIdToExpect, encryptFlagToExpect, null, contentEncodingToExpect, filenameToExpect, null);
+        containerIdToExpect, encryptFlagToExpect, null, contentEncodingToExpect, filenameToExpect, version > VERSION_4 ? blobId : null);
   }
 
   /**
@@ -264,6 +264,8 @@ public class BlobPropertiesTest {
         outputBuffer.flip();
         break;
       case BlobPropertiesSerDe.VERSION_4:
+      case BlobPropertiesSerDe.VERSION_5:
+        BlobPropertiesSerDe.CURRENT_VERSION = version;
         outputBuffer = ByteBuffer.allocate(BlobPropertiesSerDe.getBlobPropertiesSerDeSize(blobProperties));
         BlobPropertiesSerDe.serializeBlobProperties(outputBuffer, blobProperties);
         outputBuffer.flip();

--- a/ambry-server/src/integration-test/java/com/github/ambry/server/ServerHardDeleteTest.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/ServerHardDeleteTest.java
@@ -24,6 +24,7 @@ import com.github.ambry.commons.TestSSLUtils;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.messageformat.BlobData;
 import com.github.ambry.messageformat.BlobProperties;
+import com.github.ambry.messageformat.BlobPropertiesSerDe;
 import com.github.ambry.messageformat.BlobType;
 import com.github.ambry.messageformat.MessageFormatFlags;
 import com.github.ambry.messageformat.MessageFormatRecord;
@@ -319,6 +320,10 @@ public class ServerHardDeleteTest {
     // There are 6 * (4 + 4 + 1). 6 stands for the times for putBlob, 4 stands for 4 extra blobProperty Bytes for each field,
     // plus 1 byte for compression flag.
     int expectedTokenValueT1 = 198732 + 14 + 54;
+    if (BlobPropertiesSerDe.CURRENT_VERSION > BlobPropertiesSerDe.VERSION_4) {
+      // Add (6 * Integer.BYTES) because for properties of a put blob, there is a new field for size of reserved metadata id.
+      expectedTokenValueT1 += 6 * Integer.BYTES;
+    }
     ensureCleanupTokenCatchesUp(chosenPartition.getReplicaIds().get(0).getReplicaPath(), mockClusterMap,
         expectedTokenValueT1);
 
@@ -356,6 +361,10 @@ public class ServerHardDeleteTest {
     time.sleep(TimeUnit.DAYS.toMillis(1));
     // For each future change to this offset, add to this variable and write an explanation of why the number changed.
     int expectedTokenValueT2 = 298416 + 98 + 28 + 81;
+    if (BlobPropertiesSerDe.CURRENT_VERSION > BlobPropertiesSerDe.VERSION_4) {
+      // Add (9 * Integer.BYTES) because for properties of a put blob, there is a new field for size of reserved metadata id.
+      expectedTokenValueT2 += 9 * Integer.BYTES;
+    }
     // old value: 298400. Increased by 16 (4 * 4) to 298416 because the format for delete record went from 2 to 3 which
     // adds 4 bytes (two shorts) extra. The last record is a delete record so its extra 4 bytes are not added
     //

--- a/ambry-server/src/integration-test/java/com/github/ambry/server/VcrRecoveryTest.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/VcrRecoveryTest.java
@@ -26,6 +26,7 @@ import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.config.ReplicationConfig;
 import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.messageformat.BlobPropertiesSerDe;
 import com.github.ambry.messageformat.MessageFormatFlags;
 import com.github.ambry.messageformat.PutMessageFormatInputStream;
 import com.github.ambry.network.ConnectedChannel;
@@ -188,9 +189,19 @@ public class VcrRecoveryTest {
     for (PartitionResponseInfo partitionResponseInfo : getResponse.getPartitionResponseInfoList()) {
       assertEquals("Error in getting the recovered blobs", ServerErrorCode.No_Error,
           partitionResponseInfo.getErrorCode());
-      //old value is 272. Adding 9 Bytes due to the two fields added 4 + 4 Blob Property BYTE, + 1 for compression.
+      int cloudStoreSizeDifference;
+      if (BlobPropertiesSerDe.CURRENT_VERSION <= BlobPropertiesSerDe.VERSION_4) {
+        // old value is 272. Adding 9 Bytes due to the two fields added 4 + 4 Blob Property BYTE, +1 for compression.
+        // the reason we have to add this, is because these fields are present in the storage logs, but not present in cloud metadata.
+        cloudStoreSizeDifference = 9;
+      } else {
+        // old value is 272. Adding 13 Bytes due to the two fields added 4 + 4 Blob Property BYTE, 4 bytes for reserved metadata +1 for compression.
+        // the reason we have to add this, is because these fields are present in the storage logs, but not present in cloud metadata.
+        cloudStoreSizeDifference = 13;
+      }
       for (MessageInfo messageInfo : partitionResponseInfo.getMessageInfoList()) {
-        assertEquals(blobIdToSizeMap.get(messageInfo.getStoreKey()) + 281, messageInfo.getSize());
+        assertEquals(blobIdToSizeMap.get(messageInfo.getStoreKey()) + 272 + cloudStoreSizeDifference,
+            messageInfo.getSize());
       }
     }
   }


### PR DESCRIPTION
Update the serialization-deserialization logic of BlobProperties in storage nodes to include reserver metadata id.