### PR TITLE
Initialize Disk Health Status

### DIFF
--- a/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
@@ -544,6 +544,7 @@ public class DiskManager {
     File mountPath = new File(disk.getMountPath());
     if (!mountPath.exists() && diskHealthStatus != DiskHealthStatus.MOUNT_NOT_ACCESSIBLE) {
       metrics.diskMountPathFailures.inc();
+      diskHealthStatus = DiskHealthStatus.MOUNT_NOT_ACCESSIBLE;
       throw new StoreException("Mount path does not exist: " + mountPath + " ; cannot start stores on this disk",
           StoreErrorCodes.Initialization_Error);
     }


### PR DESCRIPTION
When we initialize the Disk, we check if the disk is mount accessible. In that time, we could error out before we set the disk health status which would lead to the diskHealthStatus having no reason assigned to it for the error, which is very ambiguous. As a solution, when we checkMountPathAccessible, we will by default set the status to `MOUNT_NOT_ACCESSIBLE`.