### PR TITLE
Optimize named blob cleanup process

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/FrontendConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/FrontendConfig.java
@@ -85,7 +85,7 @@ public class FrontendConfig {
    * The time interval in seconds for named blob stale data cleanup process
    */
   @Config("frontend.named.blob.cleanup.seconds")
-  @Default("24 * 60 * 60")
+  @Default("60 * 60 * 24 * 7")
   public final int namedBlobCleanupSeconds;
 
 
@@ -284,7 +284,7 @@ public class FrontendConfig {
     cacheValiditySeconds = verifiableProperties.getLong("frontend.cache.validity.seconds", 365 * 24 * 60 * 60);
     optionsValiditySeconds = verifiableProperties.getLong("frontend.options.validity.seconds", 24 * 60 * 60);
     enableNamedBlobCleanupTask = verifiableProperties.getBoolean("frontend.enable.named.blob.cleanup.task", false);
-    namedBlobCleanupSeconds = verifiableProperties.getInt("frontend.named.blob.cleanup.seconds", 24 * 60 * 60);
+    namedBlobCleanupSeconds = verifiableProperties.getInt("frontend.named.blob.cleanup.seconds", 60 * 60 * 24 * 7);
     permanentNamedBlobInitialPutTtl =
         verifiableProperties.getLong("permanent.named.blob.initial.put.ttl", 25 * 60 * 60);
     optionsAllowMethods =

--- a/ambry-api/src/main/java/com/github/ambry/config/FrontendConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/FrontendConfig.java
@@ -80,6 +80,15 @@ public class FrontendConfig {
   @Default("false")
   public final boolean enableNamedBlobCleanupTask;
 
+
+  /**
+   * The time interval in seconds for named blob stale data cleanup process
+   */
+  @Config("frontend.named.blob.cleanup.seconds")
+  @Default("24 * 60 * 60")
+  public final int namedBlobCleanupSeconds;
+
+
   /**
    * For permanent named blob, the put procedure is put, database insert and then ttlUpdate. This config is the ttl used
    * in the initial put. This value should be greater than {@link StoreConfig#storeTtlUpdateBufferTimeSeconds}
@@ -275,6 +284,7 @@ public class FrontendConfig {
     cacheValiditySeconds = verifiableProperties.getLong("frontend.cache.validity.seconds", 365 * 24 * 60 * 60);
     optionsValiditySeconds = verifiableProperties.getLong("frontend.options.validity.seconds", 24 * 60 * 60);
     enableNamedBlobCleanupTask = verifiableProperties.getBoolean("frontend.enable.named.blob.cleanup.task", false);
+    namedBlobCleanupSeconds = verifiableProperties.getInt("frontend.named.blob.cleanup.seconds", 24 * 60 * 60);
     permanentNamedBlobInitialPutTtl =
         verifiableProperties.getLong("permanent.named.blob.initial.put.ttl", 25 * 60 * 60);
     optionsAllowMethods =

--- a/ambry-api/src/main/java/com/github/ambry/config/MySqlNamedBlobDbConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/MySqlNamedBlobDbConfig.java
@@ -58,14 +58,14 @@ public class MySqlNamedBlobDbConfig {
    * The maximum number of entries to return per each stale blobs pull request.
    */
   @Config(QUERY_STALE_DATA_MAX_RESULTS)
-  @Default("1000")
+  @Default("10000")
   public final int queryStaleDataMaxResults;
 
   /**
    * The maximum number of days for a stale blob to say uncleaned.
    */
   @Config(STALE_DATA_RETENTION_DAYS)
-  @Default("5")
+  @Default("20")
   public final int staleDataRetentionDays;
 
   /**
@@ -86,8 +86,8 @@ public class MySqlNamedBlobDbConfig {
     this.localPoolSize = verifiableProperties.getIntInRange(LOCAL_POOL_SIZE, 5, 1, Integer.MAX_VALUE);
     this.remotePoolSize = verifiableProperties.getIntInRange(REMOTE_POOL_SIZE, 1, 1, Integer.MAX_VALUE);
     this.listMaxResults = verifiableProperties.getIntInRange(LIST_MAX_RESULTS, 100, 1, Integer.MAX_VALUE);
-    this.queryStaleDataMaxResults = verifiableProperties.getIntInRange(QUERY_STALE_DATA_MAX_RESULTS, 1000, 1, Integer.MAX_VALUE);
-    this.staleDataRetentionDays = verifiableProperties.getIntInRange(STALE_DATA_RETENTION_DAYS, 5, 1, Integer.MAX_VALUE);
+    this.queryStaleDataMaxResults = verifiableProperties.getIntInRange(QUERY_STALE_DATA_MAX_RESULTS, 10000, 1, Integer.MAX_VALUE);
+    this.staleDataRetentionDays = verifiableProperties.getIntInRange(STALE_DATA_RETENTION_DAYS, 20, 1, Integer.MAX_VALUE);
     this.dbTransition = verifiableProperties.getBoolean(DB_TRANSITION, false);
     this.dbRelyOnNewTable = verifiableProperties.getBoolean(DB_RELY_ON_NEW_TABLE, false);
   }

--- a/ambry-api/src/main/java/com/github/ambry/config/MySqlNamedBlobDbConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/MySqlNamedBlobDbConfig.java
@@ -58,7 +58,7 @@ public class MySqlNamedBlobDbConfig {
    * The maximum number of entries to return per each stale blobs pull request.
    */
   @Config(QUERY_STALE_DATA_MAX_RESULTS)
-  @Default("10000")
+  @Default("1000")
   public final int queryStaleDataMaxResults;
 
   /**
@@ -86,7 +86,7 @@ public class MySqlNamedBlobDbConfig {
     this.localPoolSize = verifiableProperties.getIntInRange(LOCAL_POOL_SIZE, 5, 1, Integer.MAX_VALUE);
     this.remotePoolSize = verifiableProperties.getIntInRange(REMOTE_POOL_SIZE, 1, 1, Integer.MAX_VALUE);
     this.listMaxResults = verifiableProperties.getIntInRange(LIST_MAX_RESULTS, 100, 1, Integer.MAX_VALUE);
-    this.queryStaleDataMaxResults = verifiableProperties.getIntInRange(QUERY_STALE_DATA_MAX_RESULTS, 10000, 1, Integer.MAX_VALUE);
+    this.queryStaleDataMaxResults = verifiableProperties.getIntInRange(QUERY_STALE_DATA_MAX_RESULTS, 1000, 1, Integer.MAX_VALUE);
     this.staleDataRetentionDays = verifiableProperties.getIntInRange(STALE_DATA_RETENTION_DAYS, 20, 1, Integer.MAX_VALUE);
     this.dbTransition = verifiableProperties.getBoolean(DB_TRANSITION, false);
     this.dbRelyOnNewTable = verifiableProperties.getBoolean(DB_RELY_ON_NEW_TABLE, false);

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestService.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestService.java
@@ -213,11 +213,11 @@ class FrontendRestRequestService implements RestRequestService {
     namedBlobsCleanupRunner = new NamedBlobsCleanupRunner(router, namedBlobDb);
     if (frontendConfig.enableNamedBlobCleanupTask) {
       namedBlobsCleanupScheduler = Utils.newScheduler(1, "named-blobs-cleanup-", false);
-      int oneWeekInSeconds = 60 * 60 * 24 * 7;
-      int initialDelayInSeconds = random.nextInt(oneWeekInSeconds);
+      int oneDayInSeconds = 60 * 60 * 24;
+      int initialDelayInSeconds = random.nextInt(oneDayInSeconds);
       namedBlobsCleanupTask =
           namedBlobsCleanupScheduler.scheduleAtFixedRate(
-              namedBlobsCleanupRunner, initialDelayInSeconds, oneWeekInSeconds, TimeUnit.SECONDS);
+              namedBlobsCleanupRunner, initialDelayInSeconds, oneDayInSeconds, TimeUnit.SECONDS);
       logger.info("Named Blob Stale Data Cleanup Process has started with {} seconds initial delay", initialDelayInSeconds);
     }
 

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestService.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestService.java
@@ -213,11 +213,10 @@ class FrontendRestRequestService implements RestRequestService {
     namedBlobsCleanupRunner = new NamedBlobsCleanupRunner(router, namedBlobDb);
     if (frontendConfig.enableNamedBlobCleanupTask) {
       namedBlobsCleanupScheduler = Utils.newScheduler(1, "named-blobs-cleanup-", false);
-      int oneDayInSeconds = 60 * 60 * 24;
-      int initialDelayInSeconds = random.nextInt(oneDayInSeconds);
+      int initialDelayInSeconds = random.nextInt(frontendConfig.namedBlobCleanupSeconds);
       namedBlobsCleanupTask =
           namedBlobsCleanupScheduler.scheduleAtFixedRate(
-              namedBlobsCleanupRunner, initialDelayInSeconds, oneDayInSeconds, TimeUnit.SECONDS);
+              namedBlobsCleanupRunner, initialDelayInSeconds, frontendConfig.namedBlobCleanupSeconds, TimeUnit.SECONDS);
       logger.info("Named Blob Stale Data Cleanup Process has started with {} seconds initial delay", initialDelayInSeconds);
     }
 

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestService.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestService.java
@@ -39,6 +39,7 @@ import com.github.ambry.utils.ThrowingConsumer;
 import com.github.ambry.utils.Utils;
 import java.io.IOException;
 import java.util.GregorianCalendar;
+import java.util.Random;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -100,6 +101,7 @@ class FrontendRestRequestService implements RestRequestService {
   private GetStatsReportHandler getStatsReportHandler;
   private QuotaManager quotaManager;
   private boolean isUp = false;
+  private final Random random = new Random();
 
   /**
    * Create a new instance of FrontendRestRequestService by supplying it with config, metrics, cluster map, a
@@ -209,7 +211,7 @@ class FrontendRestRequestService implements RestRequestService {
     if (frontendConfig.enableNamedBlobCleanupTask) {
       namedBlobsCleanupScheduler = Utils.newScheduler(1, "named-blobs-cleanup-", false);
       namedBlobsCleanupTask =
-          namedBlobsCleanupScheduler.scheduleAtFixedRate(namedBlobsCleanupRunner, 60 * 10, 60 * 10, TimeUnit.SECONDS);
+          namedBlobsCleanupScheduler.schedule(namedBlobsCleanupRunner, random.nextInt(60*60*24*7), TimeUnit.SECONDS);
       logger.info("Named Blob Stale Data Cleanup Process has started");
     }
 

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestService.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestService.java
@@ -210,9 +210,12 @@ class FrontendRestRequestService implements RestRequestService {
     namedBlobsCleanupRunner = new NamedBlobsCleanupRunner(router, namedBlobDb);
     if (frontendConfig.enableNamedBlobCleanupTask) {
       namedBlobsCleanupScheduler = Utils.newScheduler(1, "named-blobs-cleanup-", false);
+      int oneWeekInSeconds = 60 * 60 * 24 * 7;
+      int initialDelayInSeconds = random.nextInt(oneWeekInSeconds);
       namedBlobsCleanupTask =
-          namedBlobsCleanupScheduler.schedule(namedBlobsCleanupRunner, random.nextInt(60*60*24*7), TimeUnit.SECONDS);
-      logger.info("Named Blob Stale Data Cleanup Process has started");
+          namedBlobsCleanupScheduler.scheduleAtFixedRate(
+              namedBlobsCleanupRunner, initialDelayInSeconds, oneWeekInSeconds, TimeUnit.SECONDS);
+      logger.info("Named Blob Stale Data Cleanup Process has started with {} seconds initial delay", initialDelayInSeconds);
     }
 
     isUp = true;

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobsCleanupRunner.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobsCleanupRunner.java
@@ -19,6 +19,8 @@ import com.github.ambry.router.Router;
 import com.github.ambry.router.RouterErrorCode;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,6 +58,8 @@ public class NamedBlobsCleanupRunner implements Runnable {
       namedBlobDb.cleanupStaleData(staleResultList);
       logger.info("Named Blobs Cleanup Runner is completed for {} stale cases (there are {} failed cases)",
           staleResultList.size(), failedResults.size());
+      Set<String> cleanedBlobIds = staleResultList.stream().map(StaleNamedBlob::getBlobId).collect(Collectors.toSet());
+      logger.info("The cleaned blobIds are: {}", cleanedBlobIds);
     } catch (Throwable t) {
       logger.error("Exception occurs when running Named Blobs Cleanup Runner", t);
     }

--- a/ambry-named-mysql/src/main/java/com/github/ambry/named/MySqlNamedBlobDb.java
+++ b/ambry-named-mysql/src/main/java/com/github/ambry/named/MySqlNamedBlobDb.java
@@ -160,7 +160,7 @@ class MySqlNamedBlobDb implements NamedBlobDb {
    */
   // @formatter:off
   private static final String GET_STALE_QUERY = String.format(""
-          + "SELECT t1.%s, t1.%s, t1.%s, t1.%s, t1.%s, t1.%s, %s "
+          + "SELECT %s, %s, %s, %s, %s, %s, %s "
           + "FROM %s "
           + "WHERE blob_id not in "
           + "   (SELECT distinct(blob_id) "
@@ -169,7 +169,7 @@ class MySqlNamedBlobDb implements NamedBlobDb {
           + "      FROM %s "
           + "      WHERE blob_state = 1 and version != 0 "
           + "      GROUP BY account_id, container_id, blob_name))"
-          + " AND t1.%s<? ORDER BY blob_id LIMIT ?",
+          + " AND %s<? ORDER BY blob_id LIMIT ?",
       ACCOUNT_ID,
       CONTAINER_ID,
       BLOB_NAME,


### PR DESCRIPTION
Optimize named blob cleanup process:
1. Update the mysql query to avoid cleaning up any blob_id that's associated with Valid Latest Record of any named blob.
2. Adjust the config parameters for cleanup process.