### PR TITLE
Adding dataset version state for partial upload

### DIFF
--- a/ambry-account/src/main/java/com/github/ambry/account/CachedAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/CachedAccountService.java
@@ -17,6 +17,7 @@ import com.github.ambry.account.mysql.MySqlAccountStore;
 import com.github.ambry.commons.Notifier;
 import com.github.ambry.config.MySqlAccountServiceConfig;
 import com.github.ambry.frontend.Page;
+import com.github.ambry.protocol.DatasetVersionState;
 import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.SystemTime;
 import java.io.IOException;
@@ -562,7 +563,8 @@ public class CachedAccountService extends AbstractAccountService {
 
   @Override
   public DatasetVersionRecord addDatasetVersion(String accountName, String containerName, String datasetName,
-      String version, long timeToLiveInSeconds, long creationTimeInMs, boolean datasetVersionTtlEnabled) throws AccountServiceException {
+      String version, long timeToLiveInSeconds, long creationTimeInMs, boolean datasetVersionTtlEnabled,
+      DatasetVersionState datasetVersionState) throws AccountServiceException {
     try {
       Pair<Short, Short> accountAndContainerIdPair = getAccountAndContainerIdFromName(accountName, containerName);
       if (mySqlAccountStore == null) {
@@ -570,7 +572,22 @@ public class CachedAccountService extends AbstractAccountService {
       }
       return mySqlAccountStore.addDatasetVersion(accountAndContainerIdPair.getFirst(),
           accountAndContainerIdPair.getSecond(), accountName, containerName, datasetName, version, timeToLiveInSeconds,
-          creationTimeInMs, datasetVersionTtlEnabled);
+          creationTimeInMs, datasetVersionTtlEnabled, datasetVersionState);
+    } catch (SQLException e) {
+      throw translateSQLException(e);
+    }
+  }
+
+  @Override
+  public void updateDatasetVersionState(String accountName, String containerName, String datasetName,
+      String version, DatasetVersionState datasetVersionState) throws AccountServiceException {
+    try {
+      Pair<Short, Short> accountAndContainerIdPair = getAccountAndContainerIdFromName(accountName, containerName);
+      if (mySqlAccountStore == null) {
+        mySqlAccountStore = this.supplier.get();
+      }
+      mySqlAccountStore.updateDatasetVersionState(accountAndContainerIdPair.getFirst(),
+          accountAndContainerIdPair.getSecond(), accountName, containerName, datasetName, version, datasetVersionState);
     } catch (SQLException e) {
       throw translateSQLException(e);
     }
@@ -614,7 +631,7 @@ public class CachedAccountService extends AbstractAccountService {
       if (mySqlAccountStore == null) {
         mySqlAccountStore = this.supplier.get();
       }
-      return mySqlAccountStore.getAllValidVersion(accountAndContainerIdPair.getFirst(),
+      return mySqlAccountStore.getAllValidVersionForDatasetDeletion(accountAndContainerIdPair.getFirst(),
           accountAndContainerIdPair.getSecond(), datasetName);
     } catch (SQLException e) {
       throw translateSQLException(e);

--- a/ambry-account/src/main/java/com/github/ambry/account/MySqlAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/MySqlAccountService.java
@@ -19,6 +19,7 @@ import com.github.ambry.commons.Notifier;
 import com.github.ambry.config.MySqlAccountServiceConfig;
 import com.github.ambry.frontend.Page;
 import com.github.ambry.mysql.MySqlDataAccessor;
+import com.github.ambry.protocol.DatasetVersionState;
 import com.github.ambry.server.storagestats.AggregatedAccountStorageStats;
 import com.github.ambry.utils.Utils;
 import java.io.IOException;
@@ -366,14 +367,26 @@ public class MySqlAccountService extends AbstractAccountService {
 
   @Override
   public DatasetVersionRecord addDatasetVersion(String accountName, String containerName, String datasetName,
-      String version, long timeToLiveInSeconds, long creationTimeInMs, boolean datasetVersionTtlEnabled)
+      String version, long timeToLiveInSeconds, long creationTimeInMs, boolean datasetVersionTtlEnabled,
+      DatasetVersionState datasetVersionState)
       throws AccountServiceException {
     if (config.enableNewDatabaseForMigration) {
       return cachedAccountServiceNew.addDatasetVersion(accountName, containerName, datasetName, version,
-          timeToLiveInSeconds, creationTimeInMs, datasetVersionTtlEnabled);
+          timeToLiveInSeconds, creationTimeInMs, datasetVersionTtlEnabled, datasetVersionState);
     }
     return cachedAccountService.addDatasetVersion(accountName, containerName, datasetName, version, timeToLiveInSeconds,
-        creationTimeInMs, datasetVersionTtlEnabled);
+        creationTimeInMs, datasetVersionTtlEnabled, datasetVersionState);
+  }
+
+  @Override
+  public void updateDatasetVersionState(String accountName, String containerName, String datasetName, String version,
+      DatasetVersionState datasetVersionState) throws AccountServiceException {
+    if (config.enableNewDatabaseForMigration) {
+      cachedAccountServiceNew.updateDatasetVersionState(accountName, containerName, datasetName, version,
+          datasetVersionState);
+    }
+    cachedAccountService.updateDatasetVersionState(accountName, containerName, datasetName, version,
+        datasetVersionState);
   }
 
   @Override

--- a/ambry-account/src/main/java/com/github/ambry/account/mysql/MySqlAccountStore.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/mysql/MySqlAccountStore.java
@@ -24,6 +24,7 @@ import com.github.ambry.frontend.Page;
 import com.github.ambry.mysql.MySqlDataAccessor;
 import com.github.ambry.mysql.MySqlMetrics;
 import com.github.ambry.mysql.MySqlUtils;
+import com.github.ambry.protocol.DatasetVersionState;
 import java.sql.SQLException;
 import java.util.Collection;
 import java.util.List;
@@ -186,14 +187,22 @@ public class MySqlAccountStore {
    * @param timeToLiveInSeconds The dataset version level ttl.
    * @param creationTimeInMs the creation time of the dataset.
    * @param datasetVersionTtlEnabled set to true if dataset version ttl want to override the dataset level default ttl.
+   * @param datasetVersionState the {@link DatasetVersionState}
    * @return the corresponding {@link Dataset}
    * @throws SQLException
    */
   public DatasetVersionRecord addDatasetVersion(int accountId, int containerId, String accountName,
       String containerName, String datasetName, String version, long timeToLiveInSeconds, long creationTimeInMs,
-      boolean datasetVersionTtlEnabled) throws SQLException, AccountServiceException {
+      boolean datasetVersionTtlEnabled, DatasetVersionState datasetVersionState) throws SQLException, AccountServiceException {
     return accountDao.addDatasetVersions(accountId, containerId, accountName, containerName, datasetName, version,
-        timeToLiveInSeconds, creationTimeInMs, datasetVersionTtlEnabled);
+        timeToLiveInSeconds, creationTimeInMs, datasetVersionTtlEnabled, datasetVersionState);
+  }
+
+  public void updateDatasetVersionState(int accountId, int containerId, String accountName, String containerName,
+      String datasetName, String version, DatasetVersionState datasetVersionState)
+      throws SQLException, AccountServiceException {
+    accountDao.updateDatasetVersionState(accountId, containerId, accountName, containerName, datasetName, version,
+        datasetVersionState);
   }
 
   /**
@@ -234,9 +243,9 @@ public class MySqlAccountStore {
    * @return a list of dataset versions which is not expired for specific dataset.
    * @throws SQLException
    */
-  public List<DatasetVersionRecord> getAllValidVersion(short accountId, short containerId, String datasetName)
-      throws SQLException {
-    return accountDao.getAllValidVersion(accountId, containerId, datasetName);
+  public List<DatasetVersionRecord> getAllValidVersionForDatasetDeletion(short accountId, short containerId,
+      String datasetName) throws SQLException {
+    return accountDao.getAllValidVersionForDatasetDeletion(accountId, containerId, datasetName);
   }
 
   /**

--- a/ambry-account/src/main/resources/AccountSchema.ddl
+++ b/ambry-account/src/main/resources/AccountSchema.ddl
@@ -64,6 +64,8 @@ CREATE TABLE IF NOT EXISTS DatasetVersions (
     containerId INT NOT NULL,
     datasetName VARCHAR(235) NOT NULL,
     version BIGINT NOT NULL,
+    datasetVersionState SMALLINT NOT NULL,
+    creationTime DATETIME(3) NOT NULL,
     lastModifiedTime DATETIME(3) NOT NULL,
     delete_ts DATETIME(6) DEFAULT NULL,
     PRIMARY KEY (accountId, containerId, datasetName, version)

--- a/ambry-account/src/main/resources/AccountSchemaNew.ddl
+++ b/ambry-account/src/main/resources/AccountSchemaNew.ddl
@@ -66,6 +66,8 @@ CREATE TABLE IF NOT EXISTS DatasetVersions (
     containerId INT NOT NULL,
     datasetName VARCHAR(235) NOT NULL,
     version BIGINT NOT NULL,
+    datasetVersionState SMALLINT NOT NULL,
+    creationTime DATETIME(3) NOT NULL,
     lastModifiedTime DATETIME(3) NOT NULL,
     delete_ts DATETIME(6) DEFAULT NULL,
     PRIMARY KEY (accountId, containerId, datasetName, version)

--- a/ambry-api/src/main/java/com/github/ambry/account/AccountService.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/AccountService.java
@@ -14,6 +14,7 @@
 package com.github.ambry.account;
 
 import com.github.ambry.frontend.Page;
+import com.github.ambry.protocol.DatasetVersionState;
 import com.github.ambry.server.storagestats.AggregatedAccountStorageStats;
 import java.io.Closeable;
 import java.util.Collection;
@@ -186,12 +187,28 @@ public interface AccountService extends Closeable {
    * @param timeToLiveInSeconds The dataset version level ttl.
    * @param creationTimeInMs the creationTime of the dataset version.
    * @param datasetVersionTtlEnabled set to true if dataset version ttl want to override the dataset level default ttl.
+   * @param datasetVersionState the {@link DatasetVersionState}
    * @return the {@link DatasetVersionRecord}.
    * @throws AccountServiceException
    */
   default DatasetVersionRecord addDatasetVersion(String accountName, String containerName, String datasetName,
-      String version, long timeToLiveInSeconds, long creationTimeInMs, boolean datasetVersionTtlEnabled)
+      String version, long timeToLiveInSeconds, long creationTimeInMs, boolean datasetVersionTtlEnabled,
+      DatasetVersionState datasetVersionState)
       throws AccountServiceException {
+    throw new UnsupportedOperationException("This method is not supported");
+  }
+
+  /**
+   * Update the dataset version state.
+   * @param accountName The name for the parent account.
+   * @param containerName The name for the container.
+   * @param datasetName The name of the dataset.
+   * @param version The version of the dataset.
+   * @param datasetVersionState the {@link DatasetVersionState}
+   * @throws AccountServiceException
+   */
+  default void updateDatasetVersionState(String accountName, String containerName, String datasetName,
+      String version, DatasetVersionState datasetVersionState) throws AccountServiceException {
     throw new UnsupportedOperationException("This method is not supported");
   }
 

--- a/ambry-api/src/main/java/com/github/ambry/protocol/DatasetVersionState.java
+++ b/ambry-api/src/main/java/com/github/ambry/protocol/DatasetVersionState.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2023 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package com.github.ambry.protocol;
+
+public enum DatasetVersionState {
+  IN_PROGRESS,
+  READY
+}

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/NamedBlobPutHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/NamedBlobPutHandlerTest.java
@@ -115,9 +115,9 @@ public class NamedBlobPutHandlerTest {
       ACCOUNT_SERVICE.addDataset(new DatasetBuilder(REF_ACCOUNT.getName(), REF_CONTAINER_WITH_TTL_REQUIRED.getName(),
           DATASET_NAME).setRetentionTimeInSeconds(-1).build());
       ACCOUNT_SERVICE.addDatasetVersion(REF_ACCOUNT.getName(), REF_CONTAINER.getName(), DATASET_NAME, VERSION, -1,
-          System.currentTimeMillis(), false);
+          System.currentTimeMillis(), false, null);
       ACCOUNT_SERVICE.addDatasetVersion(REF_ACCOUNT.getName(), REF_CONTAINER_WITH_TTL_REQUIRED.getName(), DATASET_NAME,
-          VERSION, -1, System.currentTimeMillis(), false);
+          VERSION, -1, System.currentTimeMillis(), false, null);
     } catch (Exception e) {
       throw new IllegalStateException(e);
     }

--- a/ambry-test-utils/src/main/java/com/github/ambry/account/InMemAccountService.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/account/InMemAccountService.java
@@ -15,6 +15,7 @@
 package com.github.ambry.account;
 
 import com.github.ambry.frontend.Page;
+import com.github.ambry.protocol.DatasetVersionState;
 import com.github.ambry.quota.QuotaResourceType;
 import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.TestUtils;
@@ -23,14 +24,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.TreeMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
 
@@ -133,7 +132,7 @@ public class InMemAccountService implements AccountService {
   @Override
   public synchronized DatasetVersionRecord addDatasetVersion(String accountName, String containerName,
       String datasetName, String version, long timeToLiveInSeconds, long creationTimeInMs,
-      boolean datasetVersionTtlEnabled) throws AccountServiceException {
+      boolean datasetVersionTtlEnabled, DatasetVersionState datasetVersionState) throws AccountServiceException {
     Account account = nameToAccountMap.get(accountName);
     short accountId = account.getId();
     short containerId = account.getContainerByName(containerName).getId();
@@ -292,6 +291,12 @@ public class InMemAccountService implements AccountService {
       }
     }
     return datasetVersionRecords;
+  }
+
+  @Override
+  public synchronized void updateDatasetVersionState (String accountName, String containerName, String datasetName,
+      String version, DatasetVersionState datasetVersionState) {
+    //no-op
   }
 
   @Override


### PR DESCRIPTION
Previously, we support best effort when dataset version upload failed, we fallback to delete that version, and if dataset version deletion failed, we ask user to manually deleted it. That would lead to a problem that we will count the partial upload data into retention policy. So this logic is to resolve this issue. 
But the latest version should still count the partial upload data since before manual delete, the record are still in datasetVersion db which can't be used for next upload.