### PR TITLE
Support retention policy for dataset with default value

### DIFF
--- a/ambry-account/src/integration-test/java/com/github/ambry/account/MySqlAccountServiceIntegrationTest.java
+++ b/ambry-account/src/integration-test/java/com/github/ambry/account/MySqlAccountServiceIntegrationTest.java
@@ -51,6 +51,7 @@ import static com.github.ambry.config.MySqlAccountServiceConfig.*;
 import static com.github.ambry.mysql.MySqlUtils.*;
 import static com.github.ambry.utils.AccountTestUtils.*;
 import static com.github.ambry.utils.TestUtils.*;
+import static com.github.ambry.utils.Utils.*;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
@@ -756,7 +757,8 @@ public class MySqlAccountServiceIntegrationTest {
     datasetFromMysql = mySqlAccountStore.getDataset(testAccount.getId(), testContainer.getId(), testAccount.getName(),
         testContainer.getName(), DATASET_NAME);
 
-    assertEquals("Mistmatch in dataset read from db", dataset, datasetFromMysql);
+    assertEquals("Mismatch in dataset read from db", dataset, datasetFromMysql);
+    assertEquals("Mismatch in retentionPolicy", DEFAULT_RETENTION_POLICY, datasetFromMysql.getRetentionPolicy());
 
     // Add dataset again, should fail due to already exist.
     try {

--- a/ambry-account/src/main/java/com/github/ambry/account/CachedAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/CachedAccountService.java
@@ -607,6 +607,21 @@ public class CachedAccountService extends AbstractAccountService {
   }
 
   @Override
+  public List<DatasetVersionRecord> getAllValidVersionsOutOfRetentionCount(String accountName,
+      String containerName, String datasetName) throws AccountServiceException {
+    try {
+      Pair<Short, Short> accountAndContainerIdPair = getAccountAndContainerIdFromName(accountName, containerName);
+      if (mySqlAccountStore == null) {
+        mySqlAccountStore = this.supplier.get();
+      }
+      return mySqlAccountStore.getAllValidVersionsOutOfRetentionCount(accountAndContainerIdPair.getFirst(),
+          accountAndContainerIdPair.getSecond(), accountName, containerName, datasetName);
+    } catch (SQLException e) {
+      throw translateSQLException(e);
+    }
+  }
+
+  @Override
   public List<DatasetVersionRecord> getAllValidVersion(String accountName, String containerName, String datasetName)
       throws AccountServiceException {
     try {

--- a/ambry-account/src/main/java/com/github/ambry/account/MySqlAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/MySqlAccountService.java
@@ -396,6 +396,16 @@ public class MySqlAccountService extends AbstractAccountService {
   }
 
   @Override
+  public List<DatasetVersionRecord> getAllValidVersionsOutOfRetentionCount(String accountName,
+      String containerName, String datasetName) throws AccountServiceException {
+    if (config.enableNewDatabaseForMigration) {
+      return cachedAccountServiceNew.getAllValidVersionsOutOfRetentionCount(accountName, containerName, datasetName);
+    } else {
+      return cachedAccountService.getAllValidVersionsOutOfRetentionCount(accountName, containerName, datasetName);
+    }
+  }
+
+  @Override
   public List<DatasetVersionRecord> getAllValidVersion(String accountName, String containerName, String datasetName)
       throws AccountServiceException {
     if (config.enableNewDatabaseForMigration) {

--- a/ambry-account/src/main/resources/AccountSchema.ddl
+++ b/ambry-account/src/main/resources/AccountSchema.ddl
@@ -50,6 +50,7 @@ CREATE TABLE IF NOT EXISTS Datasets (
     containerId INT NOT NULL,
     datasetName VARCHAR(235) NOT NULL,
     versionSchema INT NOT NULL,
+    retentionPolicy VARCHAR(50) DEFAULT NULL,
     retentionCount INT DEFAULT NULL,
     retentionTimeInSeconds BIGINT DEFAULT NULL,
     userTags JSON DEFAULT NULL,

--- a/ambry-account/src/main/resources/AccountSchemaNew.ddl
+++ b/ambry-account/src/main/resources/AccountSchemaNew.ddl
@@ -52,6 +52,7 @@ CREATE TABLE IF NOT EXISTS Datasets (
     containerId INT NOT NULL,
     datasetName VARCHAR(235) NOT NULL,
     versionSchema INT NOT NULL,
+    retentionPolicy VARCHAR(50) DEFAULT NULL,
     retentionCount INT DEFAULT NULL,
     retentionTimeInSeconds BIGINT DEFAULT NULL,
     userTags JSON DEFAULT NULL,

--- a/ambry-api/src/main/java/com/github/ambry/account/Dataset.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/Dataset.java
@@ -41,6 +41,7 @@ import java.util.regex.Pattern;
  *    "datasetName": "MyPrivateDataset",
  *    "versionSchema": "TIMESTAMP",
  *    "expirationTimeMs": -1,
+ *    "retentionPolicy": "DefaultCounterBasedPolicy",
  *    "retentionCount": 10,
  *    "retentionTimeInSeconds": 3600,
  *    "userTags": "{userTag1:tagValue1}"
@@ -61,6 +62,7 @@ public class Dataset {
   static final String CONTAINER_NAME_KEY = "containerName";
   static final String DATASET_NAME_KEY = "datasetName";
   static final String JSON_VERSION_SCHEMA_KEY = "versionSchema";
+  static final String JSON_RETENTION_POLICY = "retentionPolicy";
   static final String JSON_RETENTION_COUNT_KEY = "retentionCount";
   static final String JSON_RETENTION_TIME_KEY = "retentionTimeInSeconds";
   static final String JSON_USER_TAGS_KEY = "userTags";
@@ -73,6 +75,8 @@ public class Dataset {
   private final String datasetName;
   @JsonProperty(JSON_VERSION_SCHEMA_KEY)
   private final VersionSchema versionSchema;
+  @JsonProperty(JSON_RETENTION_POLICY)
+  private final String retentionPolicy;
   @JsonProperty(JSON_RETENTION_COUNT_KEY)
   @JsonInclude(JsonInclude.Include.NON_DEFAULT)
   private final Integer retentionCount;
@@ -88,17 +92,19 @@ public class Dataset {
    * @param containerName The name of the container. Cannot be null.
    * @param datasetName The name of the dataset. Cannot be null.
    * @param versionSchema The schema of the version. Cannot be null.
+   * @param retentionPolicy The retention policy which based on count value we have.
    * @param retentionCount The retention of dataset by count. The older versions will be deprecated. Can be null.
    * @param retentionTimeInSeconds The time-to-live for versions of this dataset. Numbers equals to -1 indicate an unlimited retention.
    * @param userTags The user defined metadata. Can be null.
    */
   public Dataset(String accountName, String containerName, String datasetName, VersionSchema versionSchema,
-      Integer retentionCount, Long retentionTimeInSeconds, Map<String, String> userTags) {
+      String retentionPolicy, Integer retentionCount, Long retentionTimeInSeconds, Map<String, String> userTags) {
     checkPreconditions(accountName, containerName, datasetName);
     this.accountName = accountName;
     this.containerName = containerName;
     this.datasetName = datasetName;
     this.versionSchema = versionSchema;
+    this.retentionPolicy = retentionPolicy;
     this.retentionCount = retentionCount;
     this.retentionTimeInSeconds = retentionTimeInSeconds;
     this.userTags = userTags;
@@ -143,6 +149,11 @@ public class Dataset {
   public Integer getRetentionCount() {
     return retentionCount;
   }
+
+  /**
+   * @return the retention policy based on count values.
+   */
+  public String getRetentionPolicy() {return retentionPolicy; }
 
   /**
    * @return the time-to-live for versions of this dataset.
@@ -194,6 +205,7 @@ public class Dataset {
         && Objects.equals(containerName, dataset.containerName)
         && Objects.equals(datasetName, dataset.datasetName)
         && versionSchema == dataset.versionSchema
+        && Objects.equals(retentionPolicy, dataset.retentionPolicy)
         && Objects.equals(retentionCount, dataset.retentionCount)
         && Objects.equals(retentionTimeInSeconds, dataset.retentionTimeInSeconds)
         && Objects.equals(userTags, dataset.userTags);

--- a/ambry-api/src/main/java/com/github/ambry/account/DatasetBuilder.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/DatasetBuilder.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Map;
 
 import static com.github.ambry.account.Dataset.*;
+import static com.github.ambry.utils.Utils.*;
 
 
 /**
@@ -32,6 +33,7 @@ public class DatasetBuilder {
   // necessary for insert, not update.
   private Dataset.VersionSchema versionSchema;
   //optional
+  private String retentionPolicy = DEFAULT_RETENTION_POLICY;
   private Integer retentionCount = null;
   private Long retentionTimeInSeconds = null;
   private Map<String, String> userTags = null;
@@ -56,6 +58,7 @@ public class DatasetBuilder {
     containerName = origin.getContainerName();
     datasetName = origin.getDatasetName();
     versionSchema = origin.getVersionSchema();
+    retentionPolicy = origin.getRetentionPolicy();
     retentionCount = origin.getRetentionCount();
     retentionTimeInSeconds = origin.getRetentionTimeInSeconds();
     userTags = origin.getUserTags();
@@ -118,6 +121,17 @@ public class DatasetBuilder {
   }
 
   /**
+   * Set the retention policy
+   * @param retentionPolicy the retention policy, default is counter based.
+   * @return the retention policy.
+   */
+  @JsonProperty(JSON_RETENTION_POLICY)
+  public DatasetBuilder setRetentionPolicy(String retentionPolicy) {
+    this.retentionPolicy = retentionPolicy;
+    return this;
+  }
+
+  /**
    * Set the retention count of the {@link Dataset} to build.
    * @param retentionCount the retention count to set.
    * @return the builder.
@@ -156,6 +170,7 @@ public class DatasetBuilder {
    * @return a {@link Dataset} object.
    */
   public Dataset build() {
-    return new Dataset(accountName, containerName, datasetName, versionSchema, retentionCount, retentionTimeInSeconds, userTags);
+    return new Dataset(accountName, containerName, datasetName, versionSchema, retentionPolicy, retentionCount,
+        retentionTimeInSeconds, userTags);
   }
 }

--- a/ambry-api/src/test/java/com/github/ambry/account/AccountContainerTest.java
+++ b/ambry-api/src/test/java/com/github/ambry/account/AccountContainerTest.java
@@ -40,6 +40,7 @@ import org.junit.runners.Parameterized;
 
 import static com.github.ambry.account.Account.*;
 import static com.github.ambry.account.Container.*;
+import static com.github.ambry.utils.Utils.*;
 import static org.junit.Assert.*;
 import static org.junit.Assume.*;
 
@@ -93,6 +94,7 @@ public class AccountContainerTest {
   private List<Dataset.VersionSchema> refDatasetVersionSchemas;
   private List<Long> refDatasetRetentionTimeInSeconds;
   private List<Integer> refDatasetRetentionCounts;
+  private List<String> refDatasetRetentionPolicy;
   private List<Map<String, String>> refDatasetUserTags;
 
 
@@ -309,6 +311,7 @@ public class AccountContainerTest {
       Dataset datasetFromBuilder = buildDatasetWithOtherFields(
           new DatasetBuilder(refAccountName, refContainers.get(0).getName(), refDatasetNames.get(i))
               .setVersionSchema(refDatasetVersionSchemas.get(i))
+              .setRetentionPolicy(refDatasetRetentionPolicy.get(i))
               .setRetentionTimeInSeconds(refDatasetRetentionTimeInSeconds.get(i))
               .setRetentionCount(refDatasetRetentionCounts.get(i))
               .setUserTags(refDatasetUserTags.get(i)), refDatasets.get(i));
@@ -841,6 +844,7 @@ public class AccountContainerTest {
     assertEquals("Wrong container name", refContainers.get(0).getName(), dataset.getContainerName());
     assertEquals("Wrong dataset name", refDatasetNames.get(index), dataset.getDatasetName());
     assertEquals("Wrong version schema", refDatasetVersionSchemas.get(index), dataset.getVersionSchema());
+    assertEquals("Wrong retention policy", refDatasetRetentionPolicy.get(index), dataset.getRetentionPolicy());
     assertEquals("Wrong retention count", refDatasetRetentionCounts.get(index), dataset.getRetentionCount());
     assertEquals("Wrong retention time", refDatasetRetentionTimeInSeconds.get(index), dataset.getRetentionTimeInSeconds());
     assertEquals("Wrong user tage", refDatasetUserTags.get(index), dataset.getUserTags());
@@ -1088,6 +1092,7 @@ public class AccountContainerTest {
     refDatasetNames = new ArrayList<>();
     refDatasetVersionSchemas = new ArrayList<>();
     refDatasetRetentionTimeInSeconds = new ArrayList<>();
+    refDatasetRetentionPolicy = new ArrayList<>();
     refDatasetRetentionCounts = new ArrayList<>();
     refDatasetUserTags = new ArrayList<>();
     refDatasets = new ArrayList<>();
@@ -1104,9 +1109,10 @@ public class AccountContainerTest {
       Map<String, String> userTags = new HashMap<>();
       userTags.put(UUID.randomUUID().toString(), UUID.randomUUID().toString());
       refDatasetUserTags.add(userTags);
+      refDatasetRetentionPolicy.add(DEFAULT_RETENTION_POLICY);
       refDatasets.add(new Dataset(refAccountName, refContainers.get(0).getName(), refDatasetNames.get(i),
-          refDatasetVersionSchemas.get(i), refDatasetRetentionCounts.get(i), refDatasetRetentionTimeInSeconds.get(i),
-          refDatasetUserTags.get(i)));
+          refDatasetVersionSchemas.get(i), refDatasetRetentionPolicy.get(i), refDatasetRetentionCounts.get(i),
+          refDatasetRetentionTimeInSeconds.get(i), refDatasetUserTags.get(i)));
     }
   }
 

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendMetrics.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendMetrics.java
@@ -257,6 +257,7 @@ public class FrontendMetrics {
   public final Counter addDatasetVersionError;
   public final Counter getDatasetVersionError;
   public final Counter deleteDatasetVersionError;
+  public final Counter deleteDatasetVersionOutOfRetentionError;
   public final Meter addDatasetVersionRate;
   public final Meter getDatasetVersionRate;
   public final Meter deleteDatasetVersionRate;
@@ -661,6 +662,8 @@ public class FrontendMetrics {
         metricRegistry.counter(MetricRegistry.name(GetBlobHandler.class, "GetDatasetVersionError"));
     deleteDatasetVersionError =
         metricRegistry.counter(MetricRegistry.name(GetBlobHandler.class, "DeleteDatasetVersionError"));
+    deleteDatasetVersionOutOfRetentionError = metricRegistry.counter(
+        MetricRegistry.name(NamedBlobPutHandler.class, "DeleteDatasetVersionOutOfRetentionError"));
     addDatasetVersionRate =
         metricRegistry.meter(MetricRegistry.name(NamedBlobPutHandler.class, "AddDatasetVersionRate"));
     getDatasetVersionRate = metricRegistry.meter(MetricRegistry.name(GetBlobHandler.class, "GetDatasetVersionRate"));

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
@@ -620,6 +620,7 @@ public class NamedBlobPutHandler {
               recursiveCallback(datasetVersionRecordList, 1, accountName, containerName, datasetName));
         }
       } catch (Exception e) {
+        frontendMetrics.deleteDatasetVersionOutOfRetentionError.inc();
         LOGGER.error("Failed to delete dataset version out of retention count for this dataset: " + dataset.toString());
       }
     }

--- a/ambry-utils/src/main/java/com/github/ambry/utils/Utils.java
+++ b/ambry-utils/src/main/java/com/github/ambry/utils/Utils.java
@@ -99,6 +99,10 @@ public class Utils {
    * The separator used to construct account-container pair in stats report.
    */
   public static final String ACCOUNT_CONTAINER_SEPARATOR = "___";
+  /**
+   * Default retention policy for dataset.
+   */
+  public static final String DEFAULT_RETENTION_POLICY = "DefaultCounterBasedPolicy";
   private static final String CLIENT_RESET_EXCEPTION_MSG = "Connection reset by peer";
   private static final String CLIENT_BROKEN_PIPE_EXCEPTION_MSG = "Broken pipe";
   // This is found in Netty's SslHandler, which does not expose the exception message as a constant. Be careful, since


### PR DESCRIPTION
1.Due to espresso back up use case, we plan to support customized retention policy.
By default, user will use the default counter based retention policy which will delete versions out of retention count.
This pr is to support a new field at dataset level so in the future we can support customized retention policy.
2.Also, I realized that the getAllValidVersionsOutOfRetentionCount is missing in mysqlAccountService. Adding the method and metrics.
