### PR TITLE
Fix a bug in SimpleOperationTracker that block static clustermap

### DIFF
--- a/ambry-router/src/main/java/com/github/ambry/router/SimpleOperationTracker.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/SimpleOperationTracker.java
@@ -262,8 +262,8 @@ class SimpleOperationTracker implements OperationTracker {
 
     // Order the replicas so that local healthy replicas are ordered and returned first,
     // then the remote healthy ones, and finally the possibly down ones.
-    List<? extends ReplicaId> replicas =
-        routerConfig.routerGetEligibleReplicasByStateEnabled ? eligibleReplicas : partitionId.getReplicaIds();
+    List<? extends ReplicaId> replicas = routerConfig.routerGetEligibleReplicasByStateEnabled ? eligibleReplicas
+        : new ArrayList<>(partitionId.getReplicaIds());
 
     // In a case where a certain dc is decommissioned and blobs previously uploaded to this dc now have a unrecognizable
     // dc id. Current clustermap code will treat originating dc as null if dc id is not identifiable. To improve success


### PR DESCRIPTION
Static clustermap returns an unmodified list but we are trying to shuffle the list in the SimpleOperationTracker. This PR fixes this issue.