### PR TITLE
Minor bug: return empty list in CompactionLog

### DIFF
--- a/ambry-store/src/main/java/com/github/ambry/store/CompactionLog.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/CompactionLog.java
@@ -158,6 +158,9 @@ class CompactionLog implements Closeable {
     File storeDir = new File(dir);
     File[] files =
         storeDir.listFiles((fileDir, name) -> name.startsWith(storeId + COMPACTION_LOG_SUFFIX + BlobStore.SEPARATOR));
+    if (files == null || files.length == 0) {
+      return Collections.emptyList();
+    }
     List<File> sortedFiles = Stream.of(files)
         .sorted((file1, file2) -> getStartTimeFromFile(file2) - getStartTimeFromFile(file1) > 0 ? 1 : -1)
         .collect(Collectors.toList());

--- a/ambry-store/src/main/java/com/github/ambry/store/CompactionLog.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/CompactionLog.java
@@ -159,7 +159,7 @@ class CompactionLog implements Closeable {
     File[] files =
         storeDir.listFiles((fileDir, name) -> name.startsWith(storeId + COMPACTION_LOG_SUFFIX + BlobStore.SEPARATOR));
     if (files == null || files.length == 0) {
-      return Collections.emptyList();
+      return new ArrayList<>();
     }
     List<File> sortedFiles = Stream.of(files)
         .sorted((file1, file2) -> getStartTimeFromFile(file2) - getStartTimeFromFile(file1) > 0 ? 1 : -1)


### PR DESCRIPTION
Fix an bug when there is a no compactionlog in the directory, we throw an exception.