### PR TITLE
Add transaction isolation level for Named blobs MySql DB

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/MySqlNamedBlobDbConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/MySqlNamedBlobDbConfig.java
@@ -15,6 +15,9 @@
 
 package com.github.ambry.config;
 
+import com.github.ambry.named.TransactionIsolationLevel;
+
+
 public class MySqlNamedBlobDbConfig {
   private static final String PREFIX = "mysql.named.blob.";
   public static final String DB_INFO = PREFIX + "db.info";
@@ -25,6 +28,7 @@ public class MySqlNamedBlobDbConfig {
   public static final String  LIST_MAX_RESULTS = PREFIX + "list.max.results";
   public static final String  QUERY_STALE_DATA_MAX_RESULTS = PREFIX + "query.stale.data.max.results";
   public static final String  STALE_DATA_RETENTION_DAYS = PREFIX + "stale.data.retention.days";
+  public static final String TRANSACTION_ISOLATION_LEVEL = PREFIX + "transaction.isolation.level";
 
   /**
    * Serialized json array containing the information about all mysql end points.
@@ -81,6 +85,13 @@ public class MySqlNamedBlobDbConfig {
   @Default("false")
   public final boolean dbRelyOnNewTable;
 
+  /**
+   * Transaction isolation level to be set on DB Connection. When nothing is set, default MySQL DB transaction level
+   * (REPEATABLE_READ) will take effect.
+   */
+  @Config(TRANSACTION_ISOLATION_LEVEL)
+  public final TransactionIsolationLevel transactionIsolationLevel;
+
   public MySqlNamedBlobDbConfig(VerifiableProperties verifiableProperties) {
     this.dbInfo = verifiableProperties.getString(DB_INFO);
     this.localPoolSize = verifiableProperties.getIntInRange(LOCAL_POOL_SIZE, 5, 1, Integer.MAX_VALUE);
@@ -90,5 +101,8 @@ public class MySqlNamedBlobDbConfig {
     this.staleDataRetentionDays = verifiableProperties.getIntInRange(STALE_DATA_RETENTION_DAYS, 5, 1, Integer.MAX_VALUE);
     this.dbTransition = verifiableProperties.getBoolean(DB_TRANSITION, false);
     this.dbRelyOnNewTable = verifiableProperties.getBoolean(DB_RELY_ON_NEW_TABLE, false);
+    this.transactionIsolationLevel =
+        verifiableProperties.getEnum(TRANSACTION_ISOLATION_LEVEL, TransactionIsolationLevel.class,
+            TransactionIsolationLevel.TRANSACTION_NONE);
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/named/TransactionIsolationLevel.java
+++ b/ambry-api/src/main/java/com/github/ambry/named/TransactionIsolationLevel.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.named;
+
+import java.sql.Connection;
+
+
+/**
+ * Transaction isolation level. Name of the enum must match to constant names in java {@link Connection} class such as
+ * {@link Connection#TRANSACTION_NONE} or {@link Connection#TRANSACTION_READ_UNCOMMITTED} or
+ * {@link Connection#TRANSACTION_READ_COMMITTED} or {@link Connection#TRANSACTION_REPEATABLE_READ} or
+ * {@link Connection#TRANSACTION_SERIALIZABLE}
+ */
+public enum TransactionIsolationLevel {
+  TRANSACTION_NONE,
+  TRANSACTION_READ_UNCOMMITTED,
+  TRANSACTION_READ_COMMITTED,
+  TRANSACTION_REPEATABLE_READ,
+  TRANSACTION_SERIALIZABLE;
+}

--- a/ambry-named-mysql/src/main/java/com/github/ambry/named/MySqlNamedBlobDbFactory.java
+++ b/ambry-named-mysql/src/main/java/com/github/ambry/named/MySqlNamedBlobDbFactory.java
@@ -71,6 +71,9 @@ public class MySqlNamedBlobDbFactory implements NamedBlobDbFactory {
     hikariConfig.addDataSourceProperty("prepStmtCacheSize", "250");
     hikariConfig.addDataSourceProperty("prepStmtCacheSqlLimit", "2048");
     hikariConfig.addDataSourceProperty("useServerPrepStmts", "true");
+    if (!config.transactionIsolationLevel.equals(TransactionIsolationLevel.TRANSACTION_NONE)) {
+      hikariConfig.setTransactionIsolation(config.transactionIsolationLevel.name());
+    }
     hikariConfig.setMetricRegistry(metricRegistry);
     return new HikariDataSource(hikariConfig);
   }


### PR DESCRIPTION
Set transaction isolation level to connections for Named Blob DB. The value is taken via configuration.