### PR TITLE
Fix bug for retentionLogic and latest version

### DIFF
--- a/ambry-account/src/integration-test/java/com/github/ambry/account/MySqlAccountServiceIntegrationTest.java
+++ b/ambry-account/src/integration-test/java/com/github/ambry/account/MySqlAccountServiceIntegrationTest.java
@@ -1001,7 +1001,7 @@ public class MySqlAccountServiceIntegrationTest {
     // Deleted version 2 and add new latest version
     mySqlAccountStore.deleteDatasetVersion(testAccount.getId(), testContainer.getId(), DATASET_NAME, "2");
     expectedDatasetVersionRecord =
-        new DatasetVersionRecord(testAccount.getId(), testContainer.getId(), DATASET_NAME, "3", -1);
+        new DatasetVersionRecord(testAccount.getId(), testContainer.getId(), DATASET_NAME, "2", -1);
     datasetVersionRecordFromMysql =
         mySqlAccountStore.addDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
             testContainer.getName(), DATASET_NAME, version, -1, System.currentTimeMillis(), false,

--- a/ambry-account/src/main/java/com/github/ambry/account/MySqlAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/MySqlAccountService.java
@@ -384,9 +384,10 @@ public class MySqlAccountService extends AbstractAccountService {
     if (config.enableNewDatabaseForMigration) {
       cachedAccountServiceNew.updateDatasetVersionState(accountName, containerName, datasetName, version,
           datasetVersionState);
+    } else {
+      cachedAccountService.updateDatasetVersionState(accountName, containerName, datasetName, version,
+          datasetVersionState);
     }
-    cachedAccountService.updateDatasetVersionState(accountName, containerName, datasetName, version,
-        datasetVersionState);
   }
 
   @Override

--- a/ambry-api/src/main/java/com/github/ambry/rest/RestRequest.java
+++ b/ambry-api/src/main/java/com/github/ambry/rest/RestRequest.java
@@ -44,6 +44,12 @@ public interface RestRequest extends ReadableStreamChannel {
   RestMethod getRestMethod();
 
   /**
+   * Set the generic {@link RestMethod} that this request desires.
+   * @param restMethod the {@link RestMethod}
+   */
+  void setRestMethod(RestMethod restMethod);
+
+  /**
    * Return the path (the parts of the URI after the domain excluding query parameters).
    * @return path String that represents part of the uri excluding domain and query parameters.
    */

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
@@ -33,6 +33,7 @@ import com.github.ambry.protocol.DatasetVersionState;
 import com.github.ambry.quota.QuotaManager;
 import com.github.ambry.quota.QuotaUtils;
 import com.github.ambry.rest.RequestPath;
+import com.github.ambry.rest.RestMethod;
 import com.github.ambry.rest.RestRequest;
 import com.github.ambry.rest.RestResponseChannel;
 import com.github.ambry.rest.RestServiceErrorCode;
@@ -629,6 +630,8 @@ public class NamedBlobPutHandler {
           restRequest.setArg(InternalKeys.REQUEST_PATH, newRequestPath);
           restRequest.setArg(InternalKeys.TARGET_ACCOUNT_KEY, null);
           restRequest.setArg(InternalKeys.TARGET_CONTAINER_KEY, null);
+          //set the rest method to delete in order to delete data in named blob.
+          restRequest.setRestMethod(RestMethod.DELETE);
           deleteBlobHandler.handle(restRequest, restResponseChannel,
               recursiveCallback(datasetVersionRecordList, 1, accountName, containerName, datasetName));
         }
@@ -649,6 +652,8 @@ public class NamedBlobPutHandler {
     private Callback<Void> recursiveCallback(List<DatasetVersionRecord> datasetVersionRecordList, int idx, String accountName,
         String containerName, String datasetName) {
       if (idx == datasetVersionRecordList.size()) {
+        //set the rest method back.
+        restRequest.setRestMethod(RestMethod.PUT);
         return null;
       }
       Callback<Void> nextCallBack =

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
@@ -774,7 +774,7 @@ public class FrontendRestRequestServiceTest {
     headers = new JSONObject();
     headers.put(RestUtils.Headers.DATASET_VERSION_QUERY_ENABLED, true);
     restRequest = createRestRequest(RestMethod.GET, namedBlobPathUri1, headers, null);
-    restResponseChannel = new MockRestResponseChannel();
+    verifyOperationFailure(restRequest, RestServiceErrorCode.Deleted);
 
     //get the 3rd dataset version, should exist
     headers = new JSONObject();
@@ -3735,6 +3735,11 @@ class BadRestRequest extends BadRSC implements RestRequest {
   @Override
   public RestMethod getRestMethod() {
     return null;
+  }
+
+  @Override
+  public void setRestMethod(RestMethod restMethod) {
+    throw new IllegalStateException("Not implemented");
   }
 
   @Override

--- a/ambry-rest/src/main/java/com/github/ambry/rest/NettyRequest.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/NettyRequest.java
@@ -79,7 +79,6 @@ public class NettyRequest implements RestRequest {
 
   private final long size;
   private final QueryStringDecoder query;
-  private final RestMethod restMethod;
   private final RestRequestMetricsTracker restRequestMetricsTracker = new RestRequestMetricsTracker();
   private final AtomicBoolean channelOpen = new AtomicBoolean(true);
   protected final AtomicLong bytesReceived = new AtomicLong(0);
@@ -88,6 +87,7 @@ public class NettyRequest implements RestRequest {
   private final RecvByteBufAllocator recvByteBufAllocator = new DefaultMaxBytesRecvByteBufAllocator();
   private final SSLSession sslSession;
 
+  private RestMethod restMethod;
   private MessageDigest digest;
   private byte[] digestBytes;
   private long digestCalculationTimeInMs = -1;
@@ -240,6 +240,11 @@ public class NettyRequest implements RestRequest {
   @Override
   public RestMethod getRestMethod() {
     return restMethod;
+  }
+
+  @Override
+  public void setRestMethod(RestMethod restMethod) {
+    this.restMethod = restMethod;
   }
 
   @Override

--- a/ambry-rest/src/test/java/com/github/ambry/rest/AsyncRequestResponseHandlerTest.java
+++ b/ambry-rest/src/test/java/com/github/ambry/rest/AsyncRequestResponseHandlerTest.java
@@ -868,6 +868,11 @@ class BadRestRequest implements RestRequest {
   }
 
   @Override
+  public void setRestMethod(RestMethod restMethod) {
+    throw new IllegalStateException("Not implemented");
+  }
+
+  @Override
   public String getPath() {
     return null;
   }

--- a/ambry-test-utils/src/main/java/com/github/ambry/rest/MockRestRequest.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/rest/MockRestRequest.java
@@ -88,7 +88,7 @@ public class MockRestRequest implements RestRequest {
   // header fields
   public static String CONTENT_LENGTH_HEADER_KEY = "Content-Length";
 
-  private final RestMethod restMethod;
+  private RestMethod restMethod;
   private final URI uri;
   private final Map<String, Object> args = new HashMap<String, Object>();
   private final ReentrantLock contentLock = new ReentrantLock();
@@ -146,6 +146,11 @@ public class MockRestRequest implements RestRequest {
   public RestMethod getRestMethod() {
     onEventComplete(Event.GetRestMethod);
     return restMethod;
+  }
+
+  @Override
+  public void setRestMethod(RestMethod restMethod) {
+    this.restMethod = restMethod;
   }
 
   @Override

--- a/ambry-tools/src/main/java/com/github/ambry/tools/perf/rest/PerfNioServer.java
+++ b/ambry-tools/src/main/java/com/github/ambry/tools/perf/rest/PerfNioServer.java
@@ -208,7 +208,7 @@ class PerfNioServer implements NioServer {
     private static final String PERF_URI = "perf-uri";
     private static final String MULTIPLE_HEADER_VALUE_DELIMITER = ", ";
 
-    private final RestMethod restMethod;
+    private RestMethod restMethod;
     private final ReadableStreamChannel readableStreamChannel;
     private final Map<String, Object> args;
     private final RestRequestMetricsTracker restRequestMetricsTracker = new RestRequestMetricsTracker();
@@ -238,6 +238,11 @@ class PerfNioServer implements NioServer {
     @Override
     public RestMethod getRestMethod() {
       return restMethod;
+    }
+
+    @Override
+    public void setRestMethod(RestMethod restMethod) {
+      this.restMethod = restMethod;
     }
 
     @Override


### PR DESCRIPTION
1. fix the bug that only update state for new db.
2. for latest version, if the version gets deleted, it will be considered as invalid version and we need to update it.
3. update restMethod when delete dataset out of retention.