### PR TITLE
Implemented Offline Repair in the frontend for delete operation.

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -29,6 +29,19 @@ jobs:
           java-version: '11'
           distribution: 'adopt'
 
+      - name: Set up MySQL
+        run: |
+          sudo systemctl start mysql.service
+          mysql -e 'CREATE DATABASE AmbryRepairRequests;' -uroot -proot
+          mysql -e 'USE AmbryRepairRequests; SOURCE ./ambry-mysql/src/main/resources/AmbryRepairRequests.ddl;' -uroot -proot
+
+      - name: Add custom MySQL user
+        # Temporary settings to use same username and password as travis ci
+        run: |
+          mysql -e 'CREATE USER 'travis'@'localhost';' -uroot -proot
+          mysql -e 'GRANT ALL PRIVILEGES ON * . * TO 'travis'@'localhost';' -uroot -proot
+          mysql -e 'FLUSH PRIVILEGES;' -uroot -proot
+
       - uses: burrunan/gradle-cache-action@v1
         name: Run unit tests excluding ambry-store
         with:

--- a/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
@@ -135,6 +135,12 @@ public class RouterConfig {
   public static final String ROUTER_REPAIR_WITH_REPLICATE_BLOB_ON_DELETE_ENABLED =
       "router.repair.with.replicate.blob.on.delete.enabled";
   public static final String ROUTER_REPAIR_WITH_REPLICATE_BLOB_ENABLED = "router.repair.with.replicate.blob.enabled";
+  // offline repair partially failed ttl update
+  public static final String ROUTER_TTLUPDATE_OFFLINE_REPAIR_ENABLED = "router.ttlupdate.offline.repair.enabled";
+  // offline repair partially failed delete request
+  public static final String ROUTER_DELETE_OFFLINE_REPAIR_ENABLED = "router.delete.offline.repair.enabled";
+  // offline repair db factory
+  public static final String ROUTER_REPAIR_REQUESTS_DB_FACTORY = "router.repair.requests.db.factory";
   public static final String ROUTER_OPERATION_TRACKER_CHECK_ALL_ORIGINATING_REPLICAS_FOR_NOT_FOUND =
       "router.operation.tracker.check.all.originating.replicas.for.not.found";
   public static final String RESERVED_METADATA_ENABLED = "router.reserved.metadata.enabled";
@@ -688,6 +694,26 @@ public class RouterConfig {
   public final boolean routerRepairWithReplicateBlobOnDeleteEnabled;
 
   /**
+   * If this config is set to {@code true}, when ttlupdate is partially failed,
+   * the operation will save it to the secondary storage and fix it in the background.
+   */
+  @Config(ROUTER_TTLUPDATE_OFFLINE_REPAIR_ENABLED)
+  public final boolean routerTtlUpdateOfflineRepairEnabled;
+
+  /**
+   * If this config is set to {@code true}, when delete is partially failed,
+   * the operation will save it to the secondary storage and fix it in the background.
+   */
+  @Config(ROUTER_DELETE_OFFLINE_REPAIR_ENABLED)
+  public final boolean routerDeleteOfflineRepairEnabled;
+
+  /**
+   * Specify the RepairRequestsDBFactory we use for the background repair.
+   */
+  @Config(ROUTER_REPAIR_REQUESTS_DB_FACTORY)
+  public final String routerRepairRequestsDbFactory;
+
+  /**
    * The maximum duration in seconds to retry. If the get blob operation takes more than this duration, we would not retry.
    */
   @Config(ROUTER_GET_BLOB_RETRY_LIMIT_IN_SEC)
@@ -872,6 +898,10 @@ public class RouterConfig {
         verifiableProperties.getBoolean(ROUTER_REPAIR_WITH_REPLICATE_BLOB_ON_TTLUPDATE_ENABLED, false);
     routerRepairWithReplicateBlobOnDeleteEnabled =
         verifiableProperties.getBoolean(ROUTER_REPAIR_WITH_REPLICATE_BLOB_ON_DELETE_ENABLED, false);
+    routerRepairRequestsDbFactory = verifiableProperties.getString(ROUTER_REPAIR_REQUESTS_DB_FACTORY, null);
+    routerTtlUpdateOfflineRepairEnabled =
+        verifiableProperties.getBoolean(ROUTER_TTLUPDATE_OFFLINE_REPAIR_ENABLED, false);
+    routerDeleteOfflineRepairEnabled = verifiableProperties.getBoolean(ROUTER_DELETE_OFFLINE_REPAIR_ENABLED, false);
     routerGetBlobRetryLimitInSec = verifiableProperties.getIntInRange(ROUTER_GET_BLOB_RETRY_LIMIT_IN_SEC, 0, 0,
         ROUTER_GET_BLOB_RETRY_LIMIT_IN_SEC_MAX);
     routerGetBlobRetryLimitCount = verifiableProperties.getIntInRange(ROUTER_GET_BLOB_RETRY_LIMIT_COUNT, 0, 0,

--- a/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouter.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouter.java
@@ -22,6 +22,7 @@ import com.github.ambry.commons.Callback;
 import com.github.ambry.commons.CallbackUtils;
 import com.github.ambry.commons.ResponseHandler;
 import com.github.ambry.config.RouterConfig;
+import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.messageformat.BlobInfo;
 import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.network.NetworkClient;
@@ -29,6 +30,8 @@ import com.github.ambry.network.NetworkClientFactory;
 import com.github.ambry.notification.NotificationSystem;
 import com.github.ambry.protocol.GetOption;
 import com.github.ambry.quota.QuotaChargeCallback;
+import com.github.ambry.repair.RepairRequestsDb;
+import com.github.ambry.repair.RepairRequestsDbFactory;
 import com.github.ambry.store.StoreKey;
 import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
@@ -74,9 +77,12 @@ public class NonBlockingRouter implements Router {
 
   public final AtomicInteger currentOperationsCount = new AtomicInteger(0);
 
+  private RepairRequestsDb repairRequestsDb = null;
+
   /**
    * Constructs a NonBlockingRouter.
    * @param routerConfig the configs for the router.
+   * @oaran vProps verifiable properties.
    * @param routerMetrics the metrics for the router.
    * @param networkClientFactory the {@link NetworkClientFactory} used by the {@link OperationController} to create
    *                             instances of {@link NetworkClient}.
@@ -93,11 +99,11 @@ public class NonBlockingRouter implements Router {
    * @throws IOException if the OperationController could not be successfully created.
    * @throws ReflectiveOperationException if the OperationController could not be successfully created.
    */
-  public NonBlockingRouter(RouterConfig routerConfig, NonBlockingRouterMetrics routerMetrics,
-      NetworkClientFactory networkClientFactory, NotificationSystem notificationSystem, ClusterMap clusterMap,
-      KeyManagementService kms, CryptoService cryptoService, CryptoJobHandler cryptoJobHandler,
-      AccountService accountService, Time time, String defaultPartitionClass, AmbryCache blobMetadataCache)
-      throws IOException, ReflectiveOperationException {
+  public NonBlockingRouter(RouterConfig routerConfig, VerifiableProperties vProps,
+      NonBlockingRouterMetrics routerMetrics, NetworkClientFactory networkClientFactory,
+      NotificationSystem notificationSystem, ClusterMap clusterMap, KeyManagementService kms,
+      CryptoService cryptoService, CryptoJobHandler cryptoJobHandler, AccountService accountService, Time time,
+      String defaultPartitionClass, AmbryCache blobMetadataCache) throws IOException, ReflectiveOperationException {
     this.routerConfig = routerConfig;
     this.routerMetrics = routerMetrics;
     ResponseHandler responseHandler = new ResponseHandler(clusterMap);
@@ -133,6 +139,48 @@ public class NonBlockingRouter implements Router {
         .build();
     routerMetrics.initializeNotFoundCacheMetrics(notFoundCache);
     routerMetrics.initializeQuotaOCMetrics(ocList);
+
+    // create the RepairRequestsDb if we enable offline request repair.
+    if (routerConfig.routerRepairRequestsDbFactory != null && vProps != null) {
+      try {
+        byte localDcId = clusterMap.getLocalDatacenterId();
+        String localDc = clusterMap.getDatacenterName(localDcId);
+        RepairRequestsDbFactory factory =
+            Utils.getObj(routerConfig.routerRepairRequestsDbFactory, vProps, clusterMap.getMetricRegistry(), localDc);
+        repairRequestsDb = factory.getRepairRequestsDb();
+        logger.info("RepairRequests: open the db data source {}.", repairRequestsDb);
+      } catch (Exception e) {
+        logger.error("RepairRequests: Cannot connect to the RepairRequestsDB. ", e);
+      }
+    }
+  }
+
+  /**
+   * Constructs a NonBlockingRouter.
+   * @param routerConfig the configs for the router.
+   * @param routerMetrics the metrics for the router.
+   * @param networkClientFactory the {@link NetworkClientFactory} used by the {@link OperationController} to create
+   *                             instances of {@link NetworkClient}.
+   * @param notificationSystem the notification system to use to notify about blob creations and deletions.
+   * @param clusterMap the cluster map for the cluster.
+   * @param kms {@link KeyManagementService} to assist in fetching container keys for encryption or decryption
+   * @param cryptoService {@link CryptoService} to assist in encryption or decryption
+   * @param cryptoJobHandler {@link CryptoJobHandler} to assist in the execution of crypto jobs
+   * @param accountService the {@link AccountService} to use.
+   * @param time the time instance.
+   * @param defaultPartitionClass the default partition class to choose partitions from (if none is found in the
+   *                              container config). Can be {@code null} if no affinity is required for the puts for
+   *                              which the container contains no partition class hints.
+   * @throws IOException if the OperationController could not be successfully created.
+   * @throws ReflectiveOperationException if the OperationController could not be successfully created.
+   */
+  public NonBlockingRouter(RouterConfig routerConfig, NonBlockingRouterMetrics routerMetrics,
+      NetworkClientFactory networkClientFactory, NotificationSystem notificationSystem, ClusterMap clusterMap,
+      KeyManagementService kms, CryptoService cryptoService, CryptoJobHandler cryptoJobHandler,
+      AccountService accountService, Time time, String defaultPartitionClass, AmbryCache blobMetadataCache)
+      throws IOException, ReflectiveOperationException {
+    this(routerConfig, null, routerMetrics, networkClientFactory, notificationSystem, clusterMap, kms, cryptoService,
+        cryptoJobHandler, accountService, time, defaultPartitionClass, blobMetadataCache);
   }
 
   /**
@@ -148,6 +196,14 @@ public class NonBlockingRouter implements Router {
    */
   public AmbryCache getBlobMetadataCache() {
     return blobMetadataCache;
+  }
+
+  /**
+   * Returns the {@link RepairRequestsDb}
+   * @return Returns the repair requests db.
+   */
+  public RepairRequestsDb getRepairRequestsDb() {
+    return repairRequestsDb;
   }
 
   /**

--- a/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouter.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouter.java
@@ -82,7 +82,7 @@ public class NonBlockingRouter implements Router {
   /**
    * Constructs a NonBlockingRouter.
    * @param routerConfig the configs for the router.
-   * @oaran vProps verifiable properties.
+   * @oaran repairRequestsDbFactory the {@link RepairRequestsDbFactory} use to create the {@link RepairRequestsDb}
    * @param routerMetrics the metrics for the router.
    * @param networkClientFactory the {@link NetworkClientFactory} used by the {@link OperationController} to create
    *                             instances of {@link NetworkClient}.
@@ -99,7 +99,7 @@ public class NonBlockingRouter implements Router {
    * @throws IOException if the OperationController could not be successfully created.
    * @throws ReflectiveOperationException if the OperationController could not be successfully created.
    */
-  public NonBlockingRouter(RouterConfig routerConfig, VerifiableProperties vProps,
+  public NonBlockingRouter(RouterConfig routerConfig, RepairRequestsDbFactory repairRequestsDbFactory,
       NonBlockingRouterMetrics routerMetrics, NetworkClientFactory networkClientFactory,
       NotificationSystem notificationSystem, ClusterMap clusterMap, KeyManagementService kms,
       CryptoService cryptoService, CryptoJobHandler cryptoJobHandler, AccountService accountService, Time time,
@@ -140,14 +140,10 @@ public class NonBlockingRouter implements Router {
     routerMetrics.initializeNotFoundCacheMetrics(notFoundCache);
     routerMetrics.initializeQuotaOCMetrics(ocList);
 
-    // create the RepairRequestsDb if we enable offline request repair.
-    if (routerConfig.routerRepairRequestsDbFactory != null && vProps != null) {
+    // create the RepairRequestsDb if repairRequestsDbFactory is not null.
+    if (repairRequestsDbFactory != null) {
       try {
-        byte localDcId = clusterMap.getLocalDatacenterId();
-        String localDc = clusterMap.getDatacenterName(localDcId);
-        RepairRequestsDbFactory factory =
-            Utils.getObj(routerConfig.routerRepairRequestsDbFactory, vProps, clusterMap.getMetricRegistry(), localDc);
-        repairRequestsDb = factory.getRepairRequestsDb();
+        repairRequestsDb = repairRequestsDbFactory.getRepairRequestsDb();
         logger.info("RepairRequests: open the db data source {}.", repairRequestsDb);
       } catch (Exception e) {
         logger.error("RepairRequests: Cannot connect to the RepairRequestsDB. ", e);

--- a/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterFactory.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterFactory.java
@@ -59,6 +59,7 @@ public class NonBlockingRouterFactory implements RouterFactory {
   private final CryptoService cryptoService;
   private final CryptoJobHandler cryptoJobHandler;
   private final String defaultPartitionClass;
+  private final VerifiableProperties verifiableProperties;
   private static final Logger logger = LoggerFactory.getLogger(NonBlockingRouterFactory.class);
 
   /**
@@ -89,6 +90,7 @@ public class NonBlockingRouterFactory implements RouterFactory {
     this.clusterMap = clusterMap;
     this.notificationSystem = notificationSystem;
     this.accountService = accountService;
+    this.verifiableProperties = verifiableProperties;
     MetricRegistry registry = clusterMap.getMetricRegistry();
     routerMetrics = new NonBlockingRouterMetrics(clusterMap, routerConfig);
     networkConfig = new NetworkConfig(verifiableProperties);
@@ -130,8 +132,9 @@ public class NonBlockingRouterFactory implements RouterFactory {
       logger.info("[{}] Smallest blob to qualify for metadata caching = {} bytes",
           blobMetadataCache.getCacheId(),
           routerConfig.routerSmallestBlobForMetadataCache);
-      return new NonBlockingRouter(routerConfig, routerMetrics, networkClientFactory, notificationSystem, clusterMap,
-          kms, cryptoService, cryptoJobHandler, accountService, time, defaultPartitionClass, blobMetadataCache);
+      return new NonBlockingRouter(routerConfig, verifiableProperties, routerMetrics, networkClientFactory,
+          notificationSystem, clusterMap, kms, cryptoService, cryptoJobHandler, accountService, time,
+          defaultPartitionClass, blobMetadataCache);
     } catch (IOException | ReflectiveOperationException e) {
       throw new IllegalStateException("Error instantiating NonBlocking Router ", e);
     }

--- a/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTestBase.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTestBase.java
@@ -35,6 +35,7 @@ import com.github.ambry.notification.NotificationSystem;
 import com.github.ambry.protocol.DeleteRequest;
 import com.github.ambry.protocol.PutRequest;
 import com.github.ambry.protocol.UndeleteRequest;
+import com.github.ambry.repair.RepairRequestsDbFactory;
 import com.github.ambry.store.StoreKey;
 import com.github.ambry.utils.MockTime;
 import com.github.ambry.utils.NettyByteBufLeakHelper;
@@ -219,7 +220,12 @@ public class NonBlockingRouterTestBase {
     VerifiableProperties verifiableProperties = new VerifiableProperties((props));
     routerConfig = new RouterConfig(verifiableProperties);
     routerMetrics = new NonBlockingRouterMetrics(mockClusterMap, routerConfig);
-    router = new NonBlockingRouter(routerConfig, verifiableProperties, routerMetrics,
+    RepairRequestsDbFactory factory = null;
+    if (routerConfig.routerRepairRequestsDbFactory != null) {
+      factory = Utils.getObj(routerConfig.routerRepairRequestsDbFactory, verifiableProperties,
+          routerMetrics.getMetricRegistry(), localDcName);
+    }
+    router = new NonBlockingRouter(routerConfig, factory, routerMetrics,
         new MockNetworkClientFactory(verifiableProperties, mockSelectorState, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
             CHECKOUT_TIMEOUT_MS, serverLayout, mockTime), notificationSystem, mockClusterMap, kms, cryptoService,
         cryptoJobHandler, accountService, mockTime, MockClusterMap.DEFAULT_PARTITION_CLASS, null);

--- a/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTestBase.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTestBase.java
@@ -196,9 +196,6 @@ public class NonBlockingRouterTestBase {
     properties.setProperty("router.metadata.content.version", String.valueOf(metadataContentVersion));
     properties.setProperty("router.not.found.cache.ttl.in.ms", String.valueOf(NOT_FOUND_CACHE_TTL_MS));
     properties.setProperty("router.get.eligible.replicas.by.state.enabled", "true");
-    properties.setProperty("router.repair.with.replicate.blob.enabled", "true");
-    properties.setProperty("router.repair.with.replicate.blob.on.delete.enabled", "true");
-
     return properties;
   }
 
@@ -222,7 +219,7 @@ public class NonBlockingRouterTestBase {
     VerifiableProperties verifiableProperties = new VerifiableProperties((props));
     routerConfig = new RouterConfig(verifiableProperties);
     routerMetrics = new NonBlockingRouterMetrics(mockClusterMap, routerConfig);
-    router = new NonBlockingRouter(routerConfig, routerMetrics,
+    router = new NonBlockingRouter(routerConfig, verifiableProperties, routerMetrics,
         new MockNetworkClientFactory(verifiableProperties, mockSelectorState, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
             CHECKOUT_TIMEOUT_MS, serverLayout, mockTime), notificationSystem, mockClusterMap, kms, cryptoService,
         cryptoJobHandler, accountService, mockTime, MockClusterMap.DEFAULT_PARTITION_CLASS, null);


### PR DESCRIPTION
If delete is partially failed and offline repair is enabled, insert one RepairRecord to the db and return success status for the delete.

Will create metrics in a separate PR.