### PR TITLE
Fix bug for acl check and retention

### DIFF
--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/AccountAndContainerInjector.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/AccountAndContainerInjector.java
@@ -126,7 +126,7 @@ public class AccountAndContainerInjector {
    *                     if {@link ContainerMetrics} instantiation is not needed.
    * @throws RestServiceException
    */
-  public void injectAccountContainerAndDatasetForNamedBlob(RestRequest restRequest, RestRequestMetricsGroup metricsGroup)
+  public void injectAccountContainerForNamedBlob(RestRequest restRequest, RestRequestMetricsGroup metricsGroup)
       throws RestServiceException {
     accountAndContainerSanityCheck(restRequest);
 
@@ -166,6 +166,16 @@ public class AccountAndContainerInjector {
           RestServiceErrorCode.BadRequest);
     }
     setTargetAccountAndContainerInRestRequest(restRequest, targetAccount, targetContainer, metricsGroup);
+  }
+
+  /**
+   * Injects target {@link Dataset} for named blob requests.
+   * This will treat the request path as a named blob path that includes the dataset names.
+   * @param restRequest restRequest The Put {@link RestRequest}.
+   * @throws RestServiceException
+   */
+  public void injectDatasetForNamedBlob(RestRequest restRequest) throws RestServiceException {
+    NamedBlobPath namedBlobPath = NamedBlobPath.parse(getRequestPath(restRequest), restRequest.getArgs());
     setTargetDatasetAndVersionInRestRequestIfNeeded(restRequest, namedBlobPath);
   }
 

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbryIdConverterFactory.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbryIdConverterFactory.java
@@ -39,12 +39,15 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Future;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
  * Factory that instantiates an {@link IdConverter} implementation for the frontend.
  */
 public class AmbryIdConverterFactory implements IdConverterFactory {
+  private static final Logger LOGGER = LoggerFactory.getLogger(AmbryIdConverterFactory.class);
   private final IdSigningService idSigningService;
   private final NamedBlobDb namedBlobDb;
   private final FrontendMetrics frontendMetrics;
@@ -155,6 +158,8 @@ public class AmbryIdConverterFactory implements IdConverterFactory {
     private CompletionStage<String> convertId(String input, RestRequest restRequest, BlobInfo blobInfo)
         throws RestServiceException {
       CompletionStage<String> conversionFuture;
+      LOGGER.debug("input for convertId : " + input);
+      LOGGER.debug("restRequest for convertId : " + restRequest);
       if (RequestPath.matchesOperation(input, Operations.NAMED_BLOB)) {
         NamedBlobPath namedBlobPath = NamedBlobPath.parse(input, Collections.emptyMap());
         GetOption getOption = RestUtils.getGetOption(restRequest, GetOption.None);

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/DeleteBlobHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/DeleteBlobHandler.java
@@ -77,7 +77,7 @@ public class DeleteBlobHandler {
     RequestPath requestPath = getRequestPath(restRequest);
     // named blob requests have their account/container in the URI, so checks can be done prior to ID conversion.
     if (requestPath.matchesOperation(Operations.NAMED_BLOB)) {
-      accountAndContainerInjector.injectAccountContainerAndDatasetForNamedBlob(restRequest, metrics.deleteBlobMetricsGroup);
+      accountAndContainerInjector.injectAccountContainerForNamedBlob(restRequest, metrics.deleteBlobMetricsGroup);
     }
     restRequest.getMetricsTracker().injectMetrics(requestMetrics);
     new CallbackChain(restRequest, restResponseChannel, callback).start();
@@ -160,6 +160,7 @@ public class DeleteBlobHandler {
         if (RestUtils.isDatasetVersionQueryEnabled(restRequest.getArgs())) {
           try {
             metrics.deleteDatasetVersionRate.mark();
+            accountAndContainerInjector.injectDatasetForNamedBlob(restRequest);
             deleteDatasetVersion(restRequest);
           } catch (RestServiceException e) {
             metrics.deleteDatasetVersionError.inc();

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/GetBlobHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/GetBlobHandler.java
@@ -95,7 +95,7 @@ public class GetBlobHandler {
     RestRequestMetrics restRequestMetrics = metricsGroup.getRestRequestMetrics(restRequest.isSslUsed(), false);
     // named blob requests have their account/container in the URI, so checks can be done prior to ID conversion.
     if (requestPath.matchesOperation(Operations.NAMED_BLOB)) {
-      accountAndContainerInjector.injectAccountContainerAndDatasetForNamedBlob(restRequest, metricsGroup);
+      accountAndContainerInjector.injectAccountContainerForNamedBlob(restRequest, metricsGroup);
     }
     restRequest.getMetricsTracker().injectMetrics(restRequestMetrics);
     new CallbackChain(restRequest, restResponseChannel, metricsGroup, requestPath, subResource, options,
@@ -146,6 +146,7 @@ public class GetBlobHandler {
         if (RestUtils.isDatasetVersionQueryEnabled(restRequest.getArgs())) {
           try {
             metrics.getDatasetVersionRate.mark();
+            accountAndContainerInjector.injectDatasetForNamedBlob(restRequest);
             blobIdStr = getDatasetVersion(restRequest);
           } catch (RestServiceException e) {
             metrics.getDatasetVersionError.inc();

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/HeadBlobHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/HeadBlobHandler.java
@@ -69,7 +69,7 @@ public class HeadBlobHandler {
       throws RestServiceException {
     // named blob requests have their account/container in the URI, so checks can be done prior to ID conversion.
     if (getRequestPath(restRequest).matchesOperation(Operations.NAMED_BLOB)) {
-      accountAndContainerInjector.injectAccountContainerAndDatasetForNamedBlob(restRequest, metrics.headBlobMetricsGroup);
+      accountAndContainerInjector.injectAccountContainerForNamedBlob(restRequest, metrics.headBlobMetricsGroup);
     }
     new CallbackChain(restRequest, restResponseChannel, callback).start();
   }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobDeleteHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobDeleteHandler.java
@@ -63,7 +63,7 @@ class NamedBlobDeleteHandler {
    */
   void handle(RestRequest restRequest, RestResponseChannel restResponseChannel, Callback<Void> callback)
       throws RestServiceException {
-    accountAndContainerInjector.injectAccountContainerAndDatasetForNamedBlob(restRequest, metrics.deleteBlobMetricsGroup);
+    accountAndContainerInjector.injectAccountContainerForNamedBlob(restRequest, metrics.deleteBlobMetricsGroup);
     RequestPath requestPath = getRequestPath(restRequest);
     // Get blob id and reconstruct RequestPath
     // this is the three-part named blob id, including account name, container name and the custom blob name.

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobGetHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobGetHandler.java
@@ -67,7 +67,7 @@ class NamedBlobGetHandler {
   void handle(RestRequest restRequest, RestResponseChannel restResponseChannel,
       Callback<ReadableStreamChannel> callback) throws RestServiceException {
     RequestPath requestPath = getRequestPath(restRequest);
-    accountAndContainerInjector.injectAccountContainerAndDatasetForNamedBlob(restRequest,
+    accountAndContainerInjector.injectAccountContainerForNamedBlob(restRequest,
         getMetricsGroupForGet(metrics, requestPath.getSubResource()));
 
     // Get blob id and reconstruct RequestPath

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobListHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobListHandler.java
@@ -99,7 +99,7 @@ public class NamedBlobListHandler {
         RestRequestMetrics requestMetrics =
             frontendMetrics.getAccountsMetricsGroup.getRestRequestMetrics(restRequest.isSslUsed(), false);
         restRequest.getMetricsTracker().injectMetrics(requestMetrics);
-        accountAndContainerInjector.injectAccountContainerAndDatasetForNamedBlob(restRequest,
+        accountAndContainerInjector.injectAccountContainerForNamedBlob(restRequest,
             frontendMetrics.getBlobMetricsGroup);
         if (namedBlobDb == null) {
           throw new RestServiceException("Named blob support not enabled", RestServiceErrorCode.BadRequest);

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
@@ -179,8 +179,7 @@ public class NamedBlobPutHandler {
           .injectMetrics(frontendMetrics.putBlobMetricsGroup.getRestRequestMetrics(restRequest.isSslUsed(), false));
       try {
         // Start the callback chain by parsing blob info headers and performing request security processing.
-        BlobInfo blobInfo = getBlobInfoFromRequest();
-        securityService.processRequest(restRequest, securityProcessRequestCallback(blobInfo));
+        securityService.processRequest(restRequest, securityProcessRequestCallback());
       } catch (Exception e) {
         finalCallback.onCompletion(null, e);
       }
@@ -192,10 +191,12 @@ public class NamedBlobPutHandler {
      * @param blobInfo the {@link BlobInfo} to carry to future stages.
      * @return a {@link Callback} to be used with {@link SecurityService#processRequest}.
      */
-    private Callback<Void> securityProcessRequestCallback(BlobInfo blobInfo) {
-      return buildCallback(frontendMetrics.putSecurityProcessRequestMetrics,
-          securityCheckResult -> securityService.postProcessRequest(restRequest,
-              securityPostProcessRequestCallback(blobInfo)), uri, LOGGER, finalCallback);
+    private Callback<Void> securityProcessRequestCallback() {
+      return buildCallback(frontendMetrics.putSecurityProcessRequestMetrics, securityCheckResult -> {
+        //make sure this has been called after processRequest(permission check) since it needs to query dataset db.
+        BlobInfo blobInfo = getBlobInfoFromRequest();
+        securityService.postProcessRequest(restRequest, securityPostProcessRequestCallback(blobInfo));
+      }, uri, LOGGER, finalCallback);
     }
 
     /**
@@ -208,6 +209,7 @@ public class NamedBlobPutHandler {
       return buildCallback(frontendMetrics.putSecurityPostProcessRequestMetrics, securityCheckResult -> {
         if (RestUtils.isNamedBlobStitchRequest(restRequest)) {
           if (RestUtils.isDatasetVersionQueryEnabled(restRequest.getArgs())) {
+            accountAndContainerInjector.injectDatasetForNamedBlob(restRequest);
             addDatasetVersion(blobInfo.getBlobProperties(), restRequest);
           }
           RetainingAsyncWritableChannel channel =
@@ -215,6 +217,7 @@ public class NamedBlobPutHandler {
           restRequest.readInto(channel, fetchStitchRequestBodyCallback(channel, blobInfo));
         } else {
           if (RestUtils.isDatasetVersionQueryEnabled(restRequest.getArgs())) {
+            accountAndContainerInjector.injectDatasetForNamedBlob(restRequest);
             addDatasetVersion(blobInfo.getBlobProperties(), restRequest);
           }
           PutBlobOptions options = getPutBlobOptionsFromRequest();
@@ -345,8 +348,9 @@ public class NamedBlobPutHandler {
      */
     private BlobInfo getBlobInfoFromRequest() throws RestServiceException {
       long propsBuildStartTime = System.currentTimeMillis();
-      accountAndContainerInjector.injectAccountContainerAndDatasetForNamedBlob(restRequest,
+      accountAndContainerInjector.injectAccountContainerForNamedBlob(restRequest,
           frontendMetrics.putBlobMetricsGroup);
+      accountAndContainerInjector.injectDatasetForNamedBlob(restRequest);
       BlobProperties blobProperties = RestUtils.buildBlobProperties(restRequest.getArgs());
       Container container = RestUtils.getContainerFromArgs(restRequest.getArgs());
       if (blobProperties.getTimeToLiveInSeconds() + TimeUnit.MILLISECONDS.toSeconds(
@@ -652,9 +656,10 @@ public class NamedBlobPutHandler {
     private Callback<Void> recursiveCallback(List<DatasetVersionRecord> datasetVersionRecordList, int idx, String accountName,
         String containerName, String datasetName) {
       if (idx == datasetVersionRecordList.size()) {
-        //set the rest method back.
-        restRequest.setRestMethod(RestMethod.PUT);
-        return null;
+        return (r, e) -> {
+          //In the last callback, set the rest method back.
+          restRequest.setRestMethod(RestMethod.PUT);
+        };
       }
       Callback<Void> nextCallBack =
           recursiveCallback(datasetVersionRecordList, idx + 1, accountName, containerName, datasetName);

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
@@ -753,6 +753,11 @@ public class FrontendRestRequestServiceTest {
         CompletableFuture.completedFuture(new PutResult(namedBlobRecord2)));
 
     doOperation(restRequest, restResponseChannel);
+    //make sure the two records has been deleted.
+    verify(namedBlobDb, times(1)).delete(namedBlobRecord1.getAccountName(), namedBlobRecord1.getContainerName(),
+        blobNameNew1);
+    verify(namedBlobDb, times(1)).delete(namedBlobRecord.getAccountName(), namedBlobRecord.getContainerName(),
+        blobNameNew);
 
     namedBlobPathUri =
         NAMED_BLOB_PREFIX + SLASH + testAccount.getName() + SLASH + testContainer.getName() + SLASH + DATASET_NAME


### PR DESCRIPTION
1.  For dataset version upload, we should run permission check before query the dataset table.
2. For retention policy support, we need to make sure the put has been set back after last call back has been triggered, not when generating the callback. Adding the test cases to make sure the delete has been called.