### PR TITLE
Add changes to make disk selection locally when rolling back from Full-Auto to Semi-auto

### DIFF
--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
@@ -57,6 +57,7 @@ public class ClusterMapUtils {
   public static final String PARTITION_OVERRIDE_STR = "PartitionOverride";
   public static final String REPLICA_ADDITION_STR = "ReplicaAddition";
   public static final String PARTITION_DISABLED_STR = "PartitionDisabled";
+  public static final String FULL_AUTO_MIGRATION_STR = "FullAutoMigration";
   public static final String PROPERTYSTORE_STR = "PROPERTYSTORE";
   // Following two ZNode paths are the path to ZNode that stores some admin configs. Partition override config is used
   // to administratively override partition from frontend's point of view. Replica addition config is used to specify
@@ -67,6 +68,7 @@ public class ClusterMapUtils {
   public static final String PARTITION_OVERRIDE_ZNODE_PATH = ADMIN_CONFIG_ZNODE_PATH + PARTITION_OVERRIDE_STR;
   public static final String REPLICA_ADDITION_ZNODE_PATH = ADMIN_CONFIG_ZNODE_PATH + REPLICA_ADDITION_STR;
   public static final String PARTITION_DISABLED_ZNODE_PATH = ADMIN_CONFIG_ZNODE_PATH + PARTITION_DISABLED_STR + "/";
+  public static final String FULL_AUTO_MIGRATION_ZNODE_PATH = ADMIN_CONFIG_ZNODE_PATH + FULL_AUTO_MIGRATION_STR;
   static final String DISK_CAPACITY_STR = "capacityInBytes";
   static final String DISK_STATE = "diskState";
   static final String PARTITION_STATE = "state";
@@ -83,6 +85,7 @@ public class ClusterMapUtils {
   static final String PARTIALLY_SEALED_STR = "PARTIALLY_SEALED";
   static final String STOPPED_REPLICAS_STR = "STOPPED";
   static final String DISABLED_REPLICAS_STR = "DISABLED";
+  static final String RESOURCES_STR = "RESOURCES";
   static final String AVAILABLE_STR = "AVAILABLE";
   static final String UNAVAILABLE_STR = "UNAVAILABLE";
   static final String READ_ONLY_STR = "RO";

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeUtil.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeUtil.java
@@ -955,7 +955,11 @@ public class HelixBootstrapUpgradeUtil {
             }
             helixAdmin.enableWagedRebalance(clusterName, new ArrayList<>(resources));
 
-            // 7. Exit maintenance mode
+            // 7. Update the list of resources migrating to full_auto in helix property store. This is used by servers
+            // in case we want to fall back to semi_auto later.
+             updateAdminConfigForFullAutoMigration(dcName, resources);
+
+            // 8. Exit maintenance mode
             helixAdmin.manuallyEnableMaintenanceMode(clusterName, false, "Complete migrating to Full auto",
                 Collections.emptyMap());
 
@@ -974,6 +978,42 @@ public class HelixBootstrapUpgradeUtil {
     }, false).start());
 
     migrationComplete.await();
+  }
+
+  /**
+   * Add admin config in Helix to keep track of list of resources migrating to Full-Auto
+   * @param dcName data center name
+   * @param resources migrating to Full Auto
+   */
+  private void updateAdminConfigForFullAutoMigration(String dcName, Set<String> resources) {
+    HelixPropertyStore<ZNRecord> helixPropertyStore = createHelixPropertyStore(dcName);
+    try {
+      // Get property store ZNode path
+      ZNRecord zNRecord = helixPropertyStore.get(FULL_AUTO_MIGRATION_ZNODE_PATH, null, AccessOption.PERSISTENT);
+      if (zNRecord == null) {
+        info("Creating {} znode record for datacenter to keep list of resources migrating to full_auto {}.",
+            FULL_AUTO_MIGRATION_ZNODE_PATH, dcName);
+        zNRecord = new ZNRecord(FULL_AUTO_MIGRATION_STR);
+      } else {
+        info("Updating {} znode record for datacenter to keep list of resources migrating to full_auto {}.",
+            FULL_AUTO_MIGRATION_ZNODE_PATH, dcName);
+      }
+
+      // Update list field in ZNode
+      List<String> migratingResourcesList = zNRecord.getListField(RESOURCES_STR) == null ? new ArrayList<>()
+          : zNRecord.getListField(RESOURCES_STR);
+      Set<String> migratingResourcesSet = new HashSet<>(migratingResourcesList);
+      migratingResourcesSet.addAll(resources);
+      zNRecord.setListField(RESOURCES_STR, new ArrayList<>(migratingResourcesSet));
+
+      // Set property store Znode path
+      if (!helixPropertyStore.set(FULL_AUTO_MIGRATION_ZNODE_PATH, zNRecord, AccessOption.PERSISTENT)) {
+        logger.error("Failed to create/update {} znode record for datacenter {}",
+            FULL_AUTO_MIGRATION_ZNODE_PATH, dcName);
+      }
+    } finally {
+      helixPropertyStore.stop();
+    }
   }
 
   /**


### PR DESCRIPTION
During roll back to Semi-auto, we will use the replica placement calculated by Helix (in Full-auto mode) to avoid too many replica movements. However, this means that we should continue to choose disk for the replica locally on the server instead of relying on the static map.

To distinguish the rollback scenario from regular semi-auto, we will keep track of list of resources migrating to Full-Auto. We will read this list on servers and choose disk locally if the resource is present in the list.