### PR TITLE
Remove java8 incompatible code and settings

### DIFF
--- a/ambry-commons/src/test/java/com/github/ambry/compression/LZ4CompressionTest.java
+++ b/ambry-commons/src/test/java/com/github/ambry/compression/LZ4CompressionTest.java
@@ -255,7 +255,8 @@ public class LZ4CompressionTest {
       Assert.assertEquals(testMessageSize, decompressedSize);
       Assert.assertEquals(testMessageSize, decompressedBufferDirect.position() - bufferLeftPadSize);
       Assert.assertEquals(0, compressedBufferHeap.remaining());
-      decompressedBufferDirect.position(bufferLeftPadSize).get(decompressedMessage);
+      decompressedBufferDirect.position(bufferLeftPadSize);
+      decompressedBufferDirect.get(decompressedMessage);
       Assert.assertEquals(testMessage, new String(decompressedMessage, StandardCharsets.UTF_8));
 
       // Decompress Direct to Heap.
@@ -265,7 +266,8 @@ public class LZ4CompressionTest {
       Assert.assertEquals(testMessageSize, decompressedSize);
       Assert.assertEquals(testMessageSize, decompressedBufferHeap.position() - bufferLeftPadSize);
       Assert.assertEquals(0, compressedBufferDirect.remaining());
-      Assert.assertEquals(testMessage, new String(decompressedBufferHeap.array(), bufferLeftPadSize, testMessageSize, StandardCharsets.UTF_8));
+      Assert.assertEquals(testMessage,
+          new String(decompressedBufferHeap.array(), bufferLeftPadSize, testMessageSize, StandardCharsets.UTF_8));
     }
 
     // Decompress Direct to Direct.
@@ -275,7 +277,8 @@ public class LZ4CompressionTest {
     Assert.assertEquals(testMessageSize, decompressedSize);
     Assert.assertEquals(testMessageSize, decompressedBufferDirect.position() - bufferLeftPadSize);
     Assert.assertEquals(0, compressedBufferDirect.remaining());
-    decompressedBufferDirect.position(bufferLeftPadSize).get(decompressedMessage);
+    decompressedBufferDirect.position(bufferLeftPadSize);
+    decompressedBufferDirect.get(decompressedMessage);
     Assert.assertEquals(testMessage, new String(decompressedMessage, StandardCharsets.UTF_8));
   }
 }

--- a/ambry-router/src/test/java/com/github/ambry/router/CompressionServiceTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/CompressionServiceTest.java
@@ -196,7 +196,8 @@ public class CompressionServiceTest {
     LZ4Compression lz4 = new LZ4Compression();
     ByteBuffer compressedByteBuffer = ByteBuffer.allocate(lz4.getCompressBufferSize(sourceBuffer.length));
     lz4.compress(ByteBuffer.wrap(sourceBuffer), compressedByteBuffer);
-    ByteBuf compressedBuffer = Unpooled.wrappedBuffer(compressedByteBuffer.flip());
+    compressedByteBuffer.flip();
+    ByteBuf compressedBuffer = Unpooled.wrappedBuffer(compressedByteBuffer);
 
     CompressionMetrics metrics = new CompressionMetrics(new MetricRegistry());
     CompressionService service = new CompressionService(config, metrics);
@@ -204,8 +205,9 @@ public class CompressionServiceTest {
     // Test: decompress() throws exception.
     // Create a test CompressionService and replace the compressor with a mock.
     LZ4Compression mockCompression = Mockito.mock(LZ4Compression.class, Mockito.CALLS_REAL_METHODS);
-    Mockito.doThrow(new RuntimeException("Decompress failed.")).when(mockCompression).decompress(
-        Mockito.any(ByteBuffer.class), Mockito.any(ByteBuffer.class));
+    Mockito.doThrow(new RuntimeException("Decompress failed."))
+        .when(mockCompression)
+        .decompress(Mockito.any(ByteBuffer.class), Mockito.any(ByteBuffer.class));
     service.allCompressions.add(mockCompression);
     Exception ex = TestUtils.getException(() -> service.decompress(compressedBuffer, compressedBuffer.readableBytes(), false));
     Assert.assertTrue(ex instanceof CompressionException);
@@ -221,7 +223,8 @@ public class CompressionServiceTest {
     LZ4Compression lz4 = new LZ4Compression();
     ByteBuffer compressedByteBuffer = ByteBuffer.allocate(lz4.getCompressBufferSize(sourceBuffer.length));
     lz4.compress(ByteBuffer.wrap(sourceBuffer), compressedByteBuffer);
-    ByteBuf compressedBuffer = Unpooled.wrappedBuffer(compressedByteBuffer.flip());
+    compressedByteBuffer.flip();
+    ByteBuf compressedBuffer = Unpooled.wrappedBuffer(compressedByteBuffer);
 
     // Decompressed full chunk.
     CompressionMetrics metrics = new CompressionMetrics(new MetricRegistry());

--- a/build.gradle
+++ b/build.gradle
@@ -142,7 +142,10 @@ subprojects {
         systemProperty 'io.netty.allocator.maxCachedBufferCapacity', '0'
 
         // make sure Powermockito would be happy
-        jvmArgs '--add-exports=java.xml/jdk.xml.internal=ALL-UNNAMED'
+        if (JavaVersion.current().java9Compatible) {
+            jvmArgs '--add-exports=java.xml/jdk.xml.internal=ALL-UNNAMED'
+        }
+
     }
 
     task intTest(type: Test) {
@@ -252,7 +255,7 @@ project(':ambry-commons') {
         compile "io.netty:netty-tcnative-boringssl-static:$nettyTcNativeBoringSSLStatic_linux_x86_64"
         compile "io.netty:netty-tcnative-boringssl-static:$nettyTcNativeBoringSSLStatic_osx_aarch_64"
         compile "org.apache.helix:helix-core:$helixVersion"
-        compile "com.github.ben-manes.caffeine:caffeine:3.1.1"
+        compile "com.github.ben-manes.caffeine:caffeine:$caffeineVersion"
         testCompile project(':ambry-test-utils')
         testCompile project(path: ':ambry-clustermap', configuration: 'testArchives')
     }

--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -38,4 +38,5 @@ ext {
     zstdVersion = "1.5.2-3"
     mockitoVersion = "2.+"
     powermockVersion = "2.+"
+    caffeineVersion = "2.9.3"
 }


### PR DESCRIPTION
We have some code and dependencies that are not compatible with Java 8 version. This PR removes/fixes all of them.