### PR TITLE
Make the other StaticClusterAgentsFactory constructor public.

### DIFF
--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/StaticClusterAgentsFactory.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/StaticClusterAgentsFactory.java
@@ -63,7 +63,7 @@ public class StaticClusterAgentsFactory implements ClusterAgentsFactory {
    * Instantiate an instance of this factory.
    * @param partitionLayout the {@link PartitionLayout} to use.
    */
-  StaticClusterAgentsFactory(ClusterMapConfig clusterMapConfig, PartitionLayout partitionLayout) {
+  public StaticClusterAgentsFactory(ClusterMapConfig clusterMapConfig, PartitionLayout partitionLayout) {
     this.clusterMapConfig = Objects.requireNonNull(clusterMapConfig, "ClusterMapConfig cannot be null");
     this.partitionLayout = Objects.requireNonNull(partitionLayout, "PartitionLayout cannot be null");
     this.metricRegistry = new MetricRegistry();


### PR DESCRIPTION
This is required by Caspian to instantiate StaticClusterAgentsFactory using an a PartitionLayout instance.  Caspian does not use the other public constructor that requires passing in full path of the Hardware and Partition Layout file.

