### PR TITLE
Fix a logical error in disk failure handling

### DIFF
--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryServerReplica.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryServerReplica.java
@@ -114,4 +114,24 @@ class AmbryServerReplica extends AmbryReplica {
   public void markDiskUp() {
     disk.onDiskOk();
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    AmbryServerReplica replica = (AmbryServerReplica) o;
+    // Replicas are the same partition and in the same disk
+    return this.disk == replica.disk && replica.getPartitionId().equals(replica.getPartitionId());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(this.disk.getDataNode().getHostname(), this.disk.getDataNode().getPort(),
+        this.disk.getMountPath(), this.getPartitionId());
+  }
 }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryServerReplica.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryServerReplica.java
@@ -114,24 +114,4 @@ class AmbryServerReplica extends AmbryReplica {
   public void markDiskUp() {
     disk.onDiskOk();
   }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-
-    AmbryServerReplica replica = (AmbryServerReplica) o;
-    // Replicas are the same partition and in the same disk
-    return this.disk == replica.disk && replica.getPartitionId().equals(replica.getPartitionId());
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(this.disk.getDataNode().getHostname(), this.disk.getDataNode().getPort(),
-        this.disk.getMountPath(), this.getPartitionId());
-  }
 }

--- a/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
@@ -454,14 +454,13 @@ public class DiskManager {
       } else if (!compactionManager.removeBlobStore(store)) {
         logger.error("Fail to remove store {} from compaction manager.", id);
       } else {
-        store.deleteStoreFiles();
-        // Since all the files are either deleted or returned to reserve pool, increase available space in the disk
-        disk.increaseAvailableSpaceInBytes(partitionToReplicaMap.get(id).getCapacityInBytes());
-        logger.info("Store {} is successfully removed from disk manager", id);
         stores.remove(id);
         stoppedReplicas.remove(id.toPathString());
-        partitionToReplicaMap.remove(id);
+        ReplicaId replicaId = partitionToReplicaMap.remove(id);
         logger.info("Store {} is successfully removed from disk manager", id);
+        store.deleteStoreFiles();
+        // Since all the files are either deleted or returned to reserve pool, increase available space in the disk
+        disk.increaseAvailableSpaceInBytes(replicaId.getCapacityInBytes());
         succeed = true;
       }
     } finally {

--- a/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
@@ -755,7 +755,7 @@ public class StorageManager implements StoreManager {
       // INACTIVE -> OFFLINE -> DROPPED steps). If so, go through decommission steps to make sure peer replicas are
       // caught up with local replica and we update DataNodeConfig in Helix.
       if (store.recoverFromDecommission() || (clusterMap.isDataNodeInFullAutoMode(replica.getDataNodeId())
-          && store.getPreviousState() == ReplicaState.OFFLINE)) {
+          && store.getPreviousState() == ReplicaState.OFFLINE && !replicaIdsOnFailedDisks.contains(replica))) {
         try {
           resumeDecommission(partitionName);
         } catch (Exception e) {

--- a/ambry-store/src/test/java/com/github/ambry/store/StorageManagerTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/StorageManagerTest.java
@@ -1345,7 +1345,7 @@ public class StorageManagerTest {
       assertTrue(clusterMap.isDataNodeInFullAutoMode(localNode));
       // Set every replicas to error state
       sendStateTransitionMessages(helixParticipant.getHelixManager(), "10000", replicas, "OFFLINE", "BOOTSTRAP");
-      Thread.sleep(1000);
+      Thread.sleep(2000);
 
       long failureCountBefore = storageManager.getStoreMainMetrics().handleDiskFailureCount.getCount();
       // The case where there is no failed disk, running handler doesn't change anything.

--- a/ambry-store/src/test/java/com/github/ambry/store/StorageManagerTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/StorageManagerTest.java
@@ -73,6 +73,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import org.apache.helix.HelixAdmin;
+import org.apache.helix.HelixManager;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.InstanceConfig;
 import org.json.JSONObject;
@@ -1295,6 +1296,7 @@ public class StorageManagerTest {
     PartitionStateChangeListener listener = mock(PartitionStateChangeListener.class);
     doThrow(new StateTransitionException("error", StateTransitionException.TransitionErrorCode.BootstrapFailure)).when(
         listener).onPartitionBecomeBootstrapFromOffline(anyString());
+    //doReturn(null).when(listener).onPartitionBecomeDroppedFromOffline(anyString());
     helixParticipant.registerPartitionStateChangeListener(StateModelListenerType.StatsManagerListener, listener);
     helixParticipant.participate(Collections.emptyList(), null, null);
 
@@ -1362,15 +1364,14 @@ public class StorageManagerTest {
       assertEquals(failureCountBefore, storageManager.getStoreMainMetrics().handleDiskFailureCount.getCount());
 
       // The case where all replicas on this disk are down
-      long successCount = storageManager.getStoreMainMetrics().handleDiskFailureSuccessCount.getCount();
       storageManager.getStore(replicasOnFailedDisk.get(replicasOnFailedDisk.size() - 1).getPartitionId(), false)
           .shutdown();
-      verifyDiskFailureSuccess(storageManager, handler, helixAdmin, clusterMap, clusterName, localNode, diskToReplicas,
-          diskToFail);
+      verifyDiskFailureSuccess(storageManager, handler, helixParticipant, clusterMap, clusterName, localNode,
+          diskToReplicas, diskToFail);
 
       // The case to run this again, since there is no new failed disk, running the handler again won't change anything.
       failureCountBefore = storageManager.getStoreMainMetrics().handleDiskFailureCount.getCount();
-      successCount = storageManager.getStoreMainMetrics().handleDiskFailureSuccessCount.getCount();
+      long successCount = storageManager.getStoreMainMetrics().handleDiskFailureSuccessCount.getCount();
       handler.run();
       assertEquals(failureCountBefore, storageManager.getStoreMainMetrics().handleDiskFailureCount.getCount());
       assertEquals(successCount, storageManager.getStoreMainMetrics().handleDiskFailureSuccessCount.getCount());
@@ -1383,8 +1384,8 @@ public class StorageManagerTest {
       for (ReplicaId replica : replicasOnFailedDisk) {
         storageManager.getStore(replica.getPartitionId(), false).shutdown();
       }
-      verifyDiskFailureSuccess(storageManager, handler, helixAdmin, clusterMap, clusterName, localNode, diskToReplicas,
-          diskToFail);
+      verifyDiskFailureSuccess(storageManager, handler, helixParticipant, clusterMap, clusterName, localNode,
+          diskToReplicas, diskToFail);
 
       // The case that all the disks are down.
       AtomicBoolean invoked = new AtomicBoolean();
@@ -1426,8 +1427,8 @@ public class StorageManagerTest {
    * Verify the state after handling a disk failure.
    * @param storageManager The {@link StorageManager}.
    * @param handler The {@link com.github.ambry.store.StorageManager.DiskFailureHandler}.
-   * @param helixAdmin The {@link HelixAdmin}.
-   * @param clusterMap The {@link ClusterMap}.
+   * @param helixParticipant The {@link HelixParticipant}.
+   * @param clusterMap The {@link ClusterMap}
    * @param clusterName The cluster name
    * @param localNode The local node
    * @param diskToReplicas The map from disk id to a list of replicas
@@ -1435,15 +1436,23 @@ public class StorageManagerTest {
    * @throws Exception
    */
   private void verifyDiskFailureSuccess(StorageManager storageManager, StorageManager.DiskFailureHandler handler,
-      HelixAdmin helixAdmin, ClusterMap clusterMap, String clusterName, DataNodeId localNode,
+      HelixParticipant helixParticipant, ClusterMap clusterMap, String clusterName, DataNodeId localNode,
       Map<DiskId, List<ReplicaId>> diskToReplicas, DiskId diskToFail) throws Exception {
+    HelixAdmin helixAdmin = helixParticipant.getHelixAdmin();
+    HelixManager helixManager = helixParticipant.getHelixManager();
+
     long failureCountBefore = storageManager.getStoreMainMetrics().handleDiskFailureCount.getCount();
     long successCountBefore = storageManager.getStoreMainMetrics().handleDiskFailureSuccessCount.getCount();
-    List<? extends ReplicaId> allReplicaIds = clusterMap.getReplicaIds(localNode);
-    int numDisksInMemory = storageManager.getDiskToDiskManager().size();
     String instanceName = ClusterMapUtils.getInstanceName(localNode.getHostname(), localNode.getPort());
     int failedDisksBefore = handler.getFailedDisks().size();
     int offlineReplicasBefore = getNumberOfReplicaInStateFromMetric("offline", metricRegistry);
+    List<? extends ReplicaId> allReplicaIds = clusterMap.getReplicaIds(localNode);
+    List<ReplicaId> replicasOnFailedDisk = diskToReplicas.get(diskToFail);
+    for (ReplicaId replicaId : replicasOnFailedDisk) {
+      assertNotNull(storageManager.getStore(replicaId.getPartitionId(), true));
+      assertNotNull(storageManager.getReplica(replicaId.getPartitionId().toPathString()));
+      assertNotNull(storageManager.getDiskManager(replicaId.getPartitionId()));
+    }
 
     handler.run();
     Thread.sleep(500); // wait for clustermap to sync with zookeepe
@@ -1452,13 +1461,6 @@ public class StorageManagerTest {
 
     assertEquals("1 more disk failed", failedDisksBefore + 1, handler.getFailedDisks().size());
     assertFalse("Cluster should not in maintenance mode", helixAdmin.isInMaintenanceMode(clusterName));
-    // replicas should be removed from helix clustermap
-    List<? extends ReplicaId> healthyReplicaIds = clusterMap.getReplicaIds(localNode);
-    Set<? extends ReplicaId> removedReplicas = new HashSet<>(allReplicaIds);
-    removedReplicas.removeAll(healthyReplicaIds);
-    List<ReplicaId> replicasOnFailedDisk = diskToReplicas.get(diskToFail);
-    assertEquals("Replicas should be removed from helix clustermap", new HashSet<>(replicasOnFailedDisk),
-        removedReplicas);
     assertEquals("Disk should be unavailable now", HardwareState.UNAVAILABLE, diskToFail.getState());
     assertEquals("Replicas should be reset to offline", replicasOnFailedDisk.size() + offlineReplicasBefore,
         getNumberOfReplicaInStateFromMetric("offline", metricRegistry));
@@ -1472,11 +1474,23 @@ public class StorageManagerTest {
             .get(HelixParticipant.DISK_KEY)
             .intValue());
     for (ReplicaId replicaId : replicasOnFailedDisk) {
-      assertNull(storageManager.getStore(replicaId.getPartitionId(), false));
-      assertNull(storageManager.getReplica(replicaId.getPartitionId().toPathString()));
-      assertNull(storageManager.getDiskManager(replicaId.getPartitionId()));
+      assertNotNull(storageManager.getStore(replicaId.getPartitionId(), true));
+      assertNotNull(storageManager.getReplica(replicaId.getPartitionId().toPathString()));
+      assertNotNull(storageManager.getDiskManager(replicaId.getPartitionId()));
     }
-    assertEquals(numDisksInMemory - 1, storageManager.getDiskToDiskManager().size());
+    // Now send the message from offline to dropped
+    sendStateTransitionMessages(helixManager, "10000", replicasOnFailedDisk, "OFFLINE", "DROPPED");
+    Thread.sleep(1000);
+    // replicas should be removed from helix clustermap
+    List<? extends ReplicaId> healthyReplicaIds = clusterMap.getReplicaIds(localNode);
+    Set<? extends ReplicaId> removedReplicas = new HashSet<>(allReplicaIds);
+    removedReplicas.removeAll(healthyReplicaIds);
+    assertEquals("Replicas should be removed from helix clustermap", new HashSet<>(replicasOnFailedDisk),
+        removedReplicas);
+    for (ReplicaId replicaId : replicasOnFailedDisk) {
+      assertNull(storageManager.getStore(replicaId.getPartitionId(), true));
+      assertNull(storageManager.getReplica(replicaId.getPartitionId().toPathString()));
+    }
   }
 
   /**

--- a/ambry-store/src/test/java/com/github/ambry/store/StorageManagerTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/StorageManagerTest.java
@@ -1345,7 +1345,7 @@ public class StorageManagerTest {
       assertTrue(clusterMap.isDataNodeInFullAutoMode(localNode));
       // Set every replicas to error state
       sendStateTransitionMessages(helixParticipant.getHelixManager(), "10000", replicas, "OFFLINE", "BOOTSTRAP");
-      Thread.sleep(2000);
+      Thread.sleep(1000);
 
       long failureCountBefore = storageManager.getStoreMainMetrics().handleDiskFailureCount.getCount();
       // The case where there is no failed disk, running handler doesn't change anything.
@@ -1479,6 +1479,9 @@ public class StorageManagerTest {
       assertNotNull(storageManager.getDiskManager(replicaId.getPartitionId()));
     }
     // Now send the message from offline to dropped
+    // Remove one replica's directory to simulate disk error, this should not be an issue for disk failure handling
+    ReplicaId replicaToIOError = replicasOnFailedDisk.get(0);
+    Utils.deleteFileOrDirectory(new File(replicaToIOError.getReplicaPath()));
     sendStateTransitionMessages(helixManager, "10000", replicasOnFailedDisk, "OFFLINE", "DROPPED");
     Thread.sleep(1000);
     // replicas should be removed from helix clustermap


### PR DESCRIPTION
Before this PR, we removed the failed replicas in helix clustermap, and then remove these replicas from storage manager inmemory maps. This is not working with replication and stats manager. Replication manager and stats manager didn't get notified by this change. This is fine when helix decides to move these replicas to a different host, but it will cause some issues when helix decides to allocate some of these replicas in the same host. Since replication manager still keeps the remote token in manager for these replicas, we would not be able to copy existing data for replicas. 

There are two different ways to deal with this issue.
1. Remove these replicas from replication and stats manager in the disk failure handling method.
2. Rely on storage manager's state transition callback to deal with replication and stats manager.

I prefer the second approach since we already have all the logic in the callback. We don't have to duplicate the same logic in a different method.