### PR TITLE
FULL_AUTO: Dont check property store for datanode outside of clustermap

### DIFF
--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
@@ -407,7 +407,7 @@ public class HelixClusterManager implements ClusterMap {
     String instanceName = getInstanceName(dataNodeId.getHostname(), dataNodeId.getPort());
     try {
       ReplicaId bootstrapReplica =
-          isDataNodeInFullAutoMode(dataNodeId) ? getBootstrapReplicaInFullAuto(partitionIdStr, dataNodeId)
+          isDataNodeInFullAutoMode(dataNodeId, true) ? getBootstrapReplicaInFullAuto(partitionIdStr, dataNodeId)
               : getBootstrapReplicaInSemiAuto(partitionIdStr, dataNodeId);
       // For now this method is only called by server which new replica will be added to. So if datanode equals to current
       // node, we temporarily add this into a map (because we don't know whether store addition in storage manager
@@ -443,7 +443,19 @@ public class HelixClusterManager implements ClusterMap {
    */
   @Override
   public boolean isDataNodeInFullAutoMode(DataNodeId dataNodeId) {
-    ZNRecord zNRecord = helixPropertyStoreInLocalDc.get(FULL_AUTO_MIGRATION_ZNODE_PATH, null, AccessOption.PERSISTENT);
+    return isDataNodeInFullAutoMode(dataNodeId, false);
+  }
+
+  /**
+   * Return if the data node is in full auto mode. If the {@code shouldCheckPropertyStore} is true,
+   * this mode would also check if the data node is going through FULL_AUTO migration from property
+   * store.
+   * @param dataNodeId The {@link DataNodeId} to check.
+   * @param shouldCheckPropertyStore True to check property store if this data node id is in full auto
+   *                                 migration and return true if that's the case.
+   * @return
+   */
+  boolean isDataNodeInFullAutoMode(DataNodeId dataNodeId, boolean shouldCheckPropertyStore) {
     String instanceName = getInstanceName(dataNodeId.getHostname(), dataNodeId.getPort());
     if (instanceNameToAmbryDataNode.get(instanceName) == null) {
       throw new IllegalArgumentException("Instance " + instanceName + " doesn't exist");
@@ -470,12 +482,19 @@ public class HelixClusterManager implements ClusterMap {
     // Make sure all the resources turned on FULL_AUTO mode
     String tag = tags.iterator().next();
     ResourceProperty property = dcToTagToResourceProperty.get(dcName).get(tag);
-    if (property != null) {
-      // Return true if either the resource is in Full-auto or we are rolling back from Full-auto to Semi-auto
-      return property.rebalanceMode.equals(IdealState.RebalanceMode.FULL_AUTO) || ((zNRecord != null)
-          && zNRecord.getListField(RESOURCES_STR).contains(property.name));
+    if (property == null) {
+      return false;
     }
-    return false;
+    // Return true if either the resource is in Full-auto or we are rolling back from Full-auto to Semi-auto
+    if (property.rebalanceMode.equals(IdealState.RebalanceMode.FULL_AUTO)) {
+      return true;
+    }
+    // If we are here, then ResourceProperty shows RebalanceMode as NOT FULL_AUTO.
+    if (!shouldCheckPropertyStore) {
+      return false;
+    }
+    ZNRecord zNRecord = helixPropertyStoreInLocalDc.get(FULL_AUTO_MIGRATION_ZNODE_PATH, null, AccessOption.PERSISTENT);
+    return zNRecord != null && zNRecord.getListField(RESOURCES_STR).contains(property.name);
   }
 
   @Override

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixClusterManagerTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2017 LinkedIn Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -1028,7 +1028,7 @@ public class HelixClusterManagerTest {
       InstanceConfig instanceConfig =
           helixCluster.getHelixAdminFromDc(localDc).getInstanceConfig(helixCluster.getClusterName(), instanceName);
       instanceConfig.addTag(instanceGroupTag);
-      assertTrue("Should be on FULL_AUTO", helixClusterManager.isDataNodeInFullAutoMode(dataNode));
+      assertTrue("Should be on FULL_AUTO", helixClusterManager.isDataNodeInFullAutoMode(dataNode, true));
     }
 
     // 2. Test data node rollback for a resource present in /AdminConfigs/FullAutoMigration
@@ -1042,7 +1042,9 @@ public class HelixClusterManagerTest {
     helixCluster.refreshIdealState();
     for (DataNode dataNode : allLocalDcDataNodes) {
       assertTrue("Resource should considered as FULL AUTO while it is rolling back to help with local disk selection",
-          helixClusterManager.isDataNodeInFullAutoMode(dataNode));
+          helixClusterManager.isDataNodeInFullAutoMode(dataNode, true));
+      assertFalse("Resource should considered NOT IN FULL AUTO when not checking the property store",
+          helixClusterManager.isDataNodeInFullAutoMode(dataNode, false));
     }
   }
 
@@ -1084,7 +1086,10 @@ public class HelixClusterManagerTest {
     idealState.setRebalanceMode(IdealState.RebalanceMode.SEMI_AUTO);
     helixCluster.refreshIdealState();
     for (DataNode dataNode : allLocalDcDataNodes) {
-      assertFalse("Resource should considered as SEMI AUTO", helixClusterManager.isDataNodeInFullAutoMode(dataNode));
+      assertFalse("Resource should considered as SEMI AUTO",
+          helixClusterManager.isDataNodeInFullAutoMode(dataNode, true));
+      assertFalse("Resource should considered as SEMI AUTO",
+          helixClusterManager.isDataNodeInFullAutoMode(dataNode, false));
     }
   }
 


### PR DESCRIPTION
This PR changes the isDataNodeInFullAutoMode method so that, outside of clustermap, we don't check if we are in FULL_AUTO migration by checking property store.  Only check property store when it's in the clustermap to get a bootstrap replica.