### PR TITLE
Add configuration to enable disk failure handler and fix a replication bug

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -114,10 +114,55 @@ jobs:
           mysql -e 'FLUSH PRIVILEGES;' -uroot -proot
 
       - uses: burrunan/gradle-cache-action@v1
+        name: Run integration tests excluding server integration test
+        with:
+          job-id: jdk11
+          arguments: --scan intTest -x :ambry-server:intTest codeCoverageReport
+          gradle-version: wrapper
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+
+  server-int-test:
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Ambry
+        uses: actions/checkout@v2
+        # Full fetch depth is used to fetch all existing tags in the repo to assign a version for this build
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+
+      - name: Set up MySQL
+        run: |
+          sudo systemctl start mysql.service
+          mysql -e 'CREATE DATABASE AccountMetadata;' -uroot -proot
+          mysql -e 'USE AccountMetadata; SOURCE ./ambry-account/src/main/resources/AccountSchema.ddl;' -uroot -proot
+          mysql -e 'CREATE DATABASE ambry_container_storage_stats;' -uroot -proot
+          mysql -e 'USE ambry_container_storage_stats; SOURCE ./ambry-mysql/src/main/resources/AmbryContainerStorageStats.ddl;' -uroot -proot
+          mysql -e 'CREATE DATABASE AmbryNamedBlobs;' -uroot -proot
+          mysql -e 'USE AmbryNamedBlobs; SOURCE ./ambry-named-mysql/src/main/resources/NamedBlobsSchema.ddl;' -uroot -proot
+          mysql -e 'CREATE DATABASE AmbryRepairRequests;' -uroot -proot
+          mysql -e 'USE AmbryRepairRequests; SOURCE ./ambry-mysql/src/main/resources/AmbryRepairRequests.ddl;' -uroot -proot
+
+      - name: Add custom MySQL user
+        # Temporary settings to use same username and password as travis ci
+        run: |
+          mysql -e 'CREATE USER 'travis'@'localhost';' -uroot -proot
+          mysql -e 'GRANT ALL PRIVILEGES ON * . * TO 'travis'@'localhost';' -uroot -proot
+          mysql -e 'FLUSH PRIVILEGES;' -uroot -proot
+
+      - uses: burrunan/gradle-cache-action@v1
         name: Run integration tests
         with:
           job-id: jdk11
-          arguments: --scan intTest codeCoverageReport
+          arguments: --scan :ambry-server:intTest codeCoverageReport
           gradle-version: wrapper
 
       - name: Upload coverage to Codecov
@@ -126,7 +171,7 @@ jobs:
   publish:
 
     runs-on: ubuntu-latest
-    needs: [ unit-test, store-test, int-test ]
+    needs: [ unit-test, store-test, int-test, server-int-test ]
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
     env:
       ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}

--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -524,6 +524,13 @@ public class StoreConfig {
       "store.persist.remote.token.interval.in.seconds";
 
   /**
+   * True to enable disk failure handler
+   */
+  @Config(storeDiskFailureHandlerEnabledName)
+  public final boolean storeDiskFailureHandlerEnabled;
+  public static final String storeDiskFailureHandlerEnabledName = "store.disk.failure.handler.enabled";
+
+  /**
    * The interval to run disk failures in a periodical schedule.
    */
   @Config(storeDiskFailureHandlerTaskIntervalInSecondsName)
@@ -690,6 +697,7 @@ public class StoreConfig {
     storeDeletedMessageRetentionMinutes =
         (deletedMessageRetentionMinutes == -1) ? storeDeletedMessageRetentionHours * 60
             : deletedMessageRetentionMinutes;
+    storeDiskFailureHandlerEnabled = verifiableProperties.getBoolean(storeDiskFailureHandlerEnabledName, false);
     storeDiskFailureHandlerTaskIntervalInSeconds =
         verifiableProperties.getIntInRange(storeDiskFailureHandlerTaskIntervalInSecondsName, 10 * 60, 1,
             Integer.MAX_VALUE);

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
@@ -312,7 +312,7 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
         }
       }
       if (dataNodeConfigUpdated) {
-        logger.info("Updating config: {} in Helix by removing partitions {}", dataNodeConfig, partitionNames);
+        logger.info("Updating config in Helix by removing partitions {}", partitionNames);
         removalResult = dataNodeConfigSource.set(dataNodeConfig);
       } else {
         logger.warn("Partitions {} is not found on instance {}, skipping removing them from config in Helix.",

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -293,6 +293,9 @@ public class ReplicaThread implements Runnable {
         logger.error("ReplicaThread: {}, RemoteReplicaInfos Set is not created for DataNode {}, RemoteReplicaInfo: {}.",
             threadName, dataNodeId, remoteReplicaInfo);
       }
+      // We are removing this replica from replica thread, we don't need to keep "disabled" information in replica thread
+      // anymore. So passing true to enable would remove any "disabled" information.
+      controlReplicationForPartitions(Collections.singleton(remoteReplicaInfo.getReplicaId().getPartitionId()), true);
     } finally {
       lock.unlock();
     }

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationManager.java
@@ -43,7 +43,6 @@ import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -237,9 +236,6 @@ public class ReplicationManager extends ReplicationEngine {
       if (replicationConfig.replicationTrackPerPartitionLagFromRemote) {
         replicationMetrics.removeLagMetricForPartition(replicaId.getPartitionId());
       }
-      // We are removing this replica from replica thread, we don't need to keep "disabled" information in replica thread
-      // anymore. So passing true to enable would remove any "disabled" information.
-      controlReplicationForPartitions(Collections.singleton(replicaId.getPartitionId()), Collections.emptyList(), true);
       logger.info("{} is successfully removed from replication manager", replicaId.getPartitionId());
     } finally {
       rwLock.writeLock().unlock();

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationManager.java
@@ -43,6 +43,7 @@ import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -236,6 +237,9 @@ public class ReplicationManager extends ReplicationEngine {
       if (replicationConfig.replicationTrackPerPartitionLagFromRemote) {
         replicationMetrics.removeLagMetricForPartition(replicaId.getPartitionId());
       }
+      // We are removing this replica from replica thread, we don't need to keep "disabled" information in replica thread
+      // anymore. So passing true to enable would remove any "disabled" information.
+      controlReplicationForPartitions(Collections.singleton(replicaId.getPartitionId()), Collections.emptyList(), true);
       logger.info("{} is successfully removed from replication manager", replicaId.getPartitionId());
     } finally {
       rwLock.writeLock().unlock();

--- a/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
@@ -898,10 +898,10 @@ public class StorageManager implements StoreManager {
       storeMainMetrics.handleDiskFailureCount.inc();
 
       // When there is a new disk failure, we need to do several things
-      // 1. remove replicasOnFailedDisks from the property store
-      // 2. remove replicas from replication manager and stats manager
-      // 3. update disk availability
-      // 4. reset the partitions
+      // 1. update disk availability
+      // 2. reset the partitions
+      // 3. remove replicasOnFailedDisks from the property store
+      // 4. remove replicas from replication manager and stats manager
       // 5. update the capacity to instance config
       // 6. remove failed disks from the maps in the memory
       // These steps will be done in maintenance mode so helix would take in all the input and then compute a new
@@ -946,15 +946,15 @@ public class StorageManager implements StoreManager {
       try {
         // 1. enter maintenance mode
         inMaintenanceMode = enterMaintenance();
-        // 2. remove all the replicasOnFailedDisks from the property store
-        removeReplicasFromCluster(replicasOnFailedDisks);
-        // 3: remove all the replicas from replication and state manger
-        removeReplicasFromReplicationAndStatsManager(replicasOnFailedDisks);
-        // 4: update disk availability
+        // 2: update disk availability
         setDiskUnavailable(newFailedDisks);
-        // 5. reset partitions, we have to update disk availability before reset the partitions. This way, we know
+        // 3. reset partitions, we have to update disk availability before reset the partitions. This way, we know
         // The partitions won't be re-assigned back to the same disks.
         resetPartitions(replicasOnFailedDisks);
+        // 4. remove all the replicasOnFailedDisks from the property store
+        removeReplicasFromCluster(replicasOnFailedDisks);
+        // 5: remove all the replicas from replication and state manger
+        removeReplicasFromReplicationAndStatsManager(replicasOnFailedDisks);
         // 6. update disk capacity
         updateDiskCapacity(healthyDiskCapacity);
         // 7. Remove disks from the maps.

--- a/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
@@ -218,9 +218,11 @@ public class StorageManager implements StoreManager {
       diskToDiskManager.values().forEach(diskManager -> unexpectedDirs.addAll(diskManager.getUnexpectedDirs()));
 
       // Add the background task to update the disk capacity
-      DiskFailureHandler diskFailureHandler = new DiskFailureHandler();
-      scheduler.scheduleAtFixedRate(diskFailureHandler, storeConfig.storeDiskFailureHandlerTaskIntervalInSeconds,
-          storeConfig.storeDiskFailureHandlerTaskIntervalInSeconds, TimeUnit.SECONDS);
+      if (storeConfig.storeDiskFailureHandlerEnabled) {
+        DiskFailureHandler diskFailureHandler = new DiskFailureHandler();
+        scheduler.scheduleAtFixedRate(diskFailureHandler, storeConfig.storeDiskFailureHandlerTaskIntervalInSeconds,
+            storeConfig.storeDiskFailureHandlerTaskIntervalInSeconds, TimeUnit.SECONDS);
+      }
       logger.info("Starting storage manager complete");
     } finally {
       metrics.storageManagerStartTimeMs.update(time.milliseconds() - startTimeMs);

--- a/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
@@ -898,8 +898,8 @@ public class StorageManager implements StoreManager {
       storeMainMetrics.handleDiskFailureCount.inc();
 
       // When there is a new disk failure, we need to do several things
-      // 1. update disk availability
-      // 2. reset the partitions
+      // 1. reset the partitions
+      // 2. update disk availability
       // 3. remove replicasOnFailedDisks from the property store
       // 4. remove replicas from replication manager and stats manager
       // 5. update the capacity to instance config
@@ -946,11 +946,11 @@ public class StorageManager implements StoreManager {
       try {
         // 1. enter maintenance mode
         inMaintenanceMode = enterMaintenance();
-        // 2: update disk availability
-        setDiskUnavailable(newFailedDisks);
-        // 3. reset partitions, we have to update disk availability before reset the partitions. This way, we know
-        // The partitions won't be re-assigned back to the same disks.
+        // 2. reset partitions, we do reset first, because it's the only step might fail with a non-transient error.
+        // If it fails, we want to skip all the following steps.
         resetPartitions(replicasOnFailedDisks);
+        // 3: update disk availability
+        setDiskUnavailable(newFailedDisks);
         // 4. remove all the replicasOnFailedDisks from the property store
         removeReplicasFromCluster(replicasOnFailedDisks);
         // 5: remove all the replicas from replication and state manger

--- a/build.gradle
+++ b/build.gradle
@@ -134,7 +134,7 @@ subprojects {
             // Whether tests that initially fail and then pass on retry should fail the task.
             failOnPassedAfterRetry = false
         }
-        maxHeapSize = "3g"
+        maxHeapSize = "6g"
         systemProperty 'io.netty.leakDetection.level', 'paranoid'
         systemProperty 'io.netty.allocator.tinyCacheSize', '0'
         systemProperty 'io.netty.allocator.smallCacheSize', '0'
@@ -170,7 +170,7 @@ subprojects {
             // Whether tests that initially fail and then pass on retry should fail the task.
             failOnPassedAfterRetry = false
         }
-        maxHeapSize = "3g"
+        maxHeapSize = "6g"
         systemProperty 'io.netty.leakDetection.level', 'paranoid'
     }
 


### PR DESCRIPTION
Add a new configuration to enable disk failure handler and fix a replication bug.

When we disable the replica, it would also store a "disabled" information in replica thread to stop replication for this replica. But this is buggy, since when helix decided to add this replica back to this host, this piece of information still exist and this replica can't replicate from other peers.

This pr would fix this issue.