### PR TITLE
Add error threshold and verify domain name for instance in helix tool

### DIFF
--- a/config/WagedRebalancerHelixConfig.json
+++ b/config/WagedRebalancerHelixConfig.json
@@ -8,6 +8,7 @@
     "lessMovement": 2,
     "partitionDiskWeightInGB": 100,
     "maxPartitionInTransition": 50,
-    "delayRebalanceTimeInMs": 1200000
+    "delayRebalanceTimeInMs": 1200000,
+    "errorOrRecoverPartitionThresholdForLoadBalance": 100
   }
 }


### PR DESCRIPTION
This PR introduces two changes
1. Add error or recover threshold to the cluster config
2. Verify that all the instances have domain field before enabling topology awareness for cluster.