### PR TITLE
Fix an issue in replication

### DIFF
--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -293,9 +293,6 @@ public class ReplicaThread implements Runnable {
         logger.error("ReplicaThread: {}, RemoteReplicaInfos Set is not created for DataNode {}, RemoteReplicaInfo: {}.",
             threadName, dataNodeId, remoteReplicaInfo);
       }
-      // We are removing this replica from replica thread, we don't need to keep "disabled" information in replica thread
-      // anymore. So passing true to enable would remove any "disabled" information.
-      controlReplicationForPartitions(Collections.singleton(remoteReplicaInfo.getReplicaId().getPartitionId()), true);
     } finally {
       lock.unlock();
     }

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationManager.java
@@ -43,6 +43,7 @@ import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -236,6 +237,9 @@ public class ReplicationManager extends ReplicationEngine {
       if (replicationConfig.replicationTrackPerPartitionLagFromRemote) {
         replicationMetrics.removeLagMetricForPartition(replicaId.getPartitionId());
       }
+      // We are removing this replica from replica thread, we don't need to keep "disabled" information in replica thread
+      // anymore. So passing true to enable would remove any "disabled" information.
+      controlReplicationForPartitions(Collections.singleton(replicaId.getPartitionId()), Collections.emptyList(), true);
       logger.info("{} is successfully removed from replication manager", replicaId.getPartitionId());
     } finally {
       rwLock.writeLock().unlock();

--- a/ambry-replication/src/test/java/com/github/ambry/replication/MockReplicationManager.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/MockReplicationManager.java
@@ -106,6 +106,7 @@ public class MockReplicationManager extends ReplicationManager {
         dataNodeId, factory, clusterMap.getMetricRegistry(), null, storeKeyConverterFactory, transformerClassName,
         clusterParticipant, null, findTokenHelper, time);
     reset();
+    controlReplicationReturnVal = true;
   }
 
   @Override


### PR DESCRIPTION
Remove the disabled information of a partition from replication manager, not replica thread. Since this information is stored in all replica threads. 