### PR TITLE
Allow SimpleOperationTracker continue to run even there is not enough quorum

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
@@ -899,9 +899,11 @@ public class RouterConfig {
     routerRepairWithReplicateBlobOnDeleteEnabled =
         verifiableProperties.getBoolean(ROUTER_REPAIR_WITH_REPLICATE_BLOB_ON_DELETE_ENABLED, false);
     routerRepairRequestsDbFactory = verifiableProperties.getString(ROUTER_REPAIR_REQUESTS_DB_FACTORY, null);
-    routerTtlUpdateOfflineRepairEnabled =
-        verifiableProperties.getBoolean(ROUTER_TTLUPDATE_OFFLINE_REPAIR_ENABLED, false);
-    routerDeleteOfflineRepairEnabled = verifiableProperties.getBoolean(ROUTER_DELETE_OFFLINE_REPAIR_ENABLED, false);
+    routerTtlUpdateOfflineRepairEnabled = routerRepairRequestsDbFactory == null ? false
+        : verifiableProperties.getBoolean(ROUTER_TTLUPDATE_OFFLINE_REPAIR_ENABLED, false);
+    routerDeleteOfflineRepairEnabled = routerRepairRequestsDbFactory == null ? false
+        : verifiableProperties.getBoolean(ROUTER_DELETE_OFFLINE_REPAIR_ENABLED, false);
+
     routerGetBlobRetryLimitInSec = verifiableProperties.getIntInRange(ROUTER_GET_BLOB_RETRY_LIMIT_IN_SEC, 0, 0,
         ROUTER_GET_BLOB_RETRY_LIMIT_IN_SEC_MAX);
     routerGetBlobRetryLimitCount = verifiableProperties.getIntInRange(ROUTER_GET_BLOB_RETRY_LIMIT_COUNT, 0, 0,

--- a/ambry-router/src/main/java/com/github/ambry/router/DeleteOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/DeleteOperation.java
@@ -379,6 +379,9 @@ class DeleteOperation {
     // 3. and at least one replica returned successful status.
     // 4. and error code precedence is over AmbryUnavailable. We don't do replication if there BlobExpired or TooManyRequests.
     // 5. It's not a delete request from the BackgroundDeleter. We don't do on-demand replication for background deleter.
+    if (operationException.get() == null) {
+      return false;
+    }
     RouterErrorCode errorCode = ((RouterException) operationException.get()).getErrorCode();
     // @formatter:off
     return (routerConfig.routerRepairWithReplicateBlobOnDeleteEnabled && operationTracker.hasNotFound()


### PR DESCRIPTION
If we only have one single eligible replica, SimpleOperationTracker fails the Delete Request right away. We don't have chance to run Offline Repair.
When offline repair is enabled, allow SimpleOperationTracker continue to run even there is not enough replicas to fulfill the success target count.
