### PR TITLE
Implemented benefits based middle range compaction

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -233,6 +233,20 @@ public class StoreConfig {
   public final int storeMinLogSegmentCountToReclaimToTriggerCompaction;
 
   /**
+   * Only the log segment whose valid data percentage is less or equal than the specified number
+   * will be qualified for compaction.number.
+   */
+  @Config("store.max.log.segment.valid.data.percentage.to.qualify.compaction")
+  public final double storeMaxLogSegmentValidDataPercentageToQualifyCompaction;
+
+  /**
+   * the time interval to run the "middle range compaction" in the stalts based compaction.
+   * the interval is in milliseconds.
+   */
+  @Config("store.stats.based.middle.range.compaction.interval.in.ms")
+  public final long storeStatsBasedMiddleRangeCompactionIntervalInMs;
+
+  /**
    * The number of buckets for stats bucketing, a value of 0 will disable bucketing.
    */
   @Config("store.stats.bucket.count")
@@ -615,6 +629,12 @@ public class StoreConfig {
         "com.github.ambry.store.CompactAllPolicyFactory");
     storeMinLogSegmentCountToReclaimToTriggerCompaction =
         verifiableProperties.getIntInRange("store.min.log.segment.count.to.reclaim.to.trigger.compaction", 1, 1, 1000);
+    storeMaxLogSegmentValidDataPercentageToQualifyCompaction =
+        verifiableProperties.getDoubleInRange("store.max.log.segment.valid.data.percentage.to.qualify.compaction", 0.30,
+            0.0, 1.0);
+    storeStatsBasedMiddleRangeCompactionIntervalInMs =
+        verifiableProperties.getLongInRange("store.stats.based.middle.range.compaction.interval.in.ms", 0, 0,
+            Long.MAX_VALUE);
     storeStatsBucketCount = verifiableProperties.getIntInRange("store.stats.bucket.count", 0, 0, 10000);
     storeStatsBucketSpanInMinutes =
         verifiableProperties.getLongInRange("store.stats.bucket.span.in.minutes", 60, 1, 10000);

--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -234,7 +234,7 @@ public class StoreConfig {
 
   /**
    * Only the log segment whose valid data percentage is less or equal than the specified number
-   * will be qualified for compaction.number.
+   * will be qualified for compaction.
    */
   @Config("store.max.log.segment.valid.data.percentage.to.qualify.compaction")
   public final double storeMaxLogSegmentValidDataPercentageToQualifyCompaction;
@@ -247,7 +247,7 @@ public class StoreConfig {
   public final double storeStatsBasedCompactionMinCostInPercentage;
 
   /**
-   * the time interval to run the "middle range compaction" in the stalts based compaction.
+   * the time interval to run the "middle range compaction" in the stats based compaction.
    * the interval is in milliseconds.
    */
   @Config("store.stats.based.middle.range.compaction.interval.in.ms")

--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -240,6 +240,13 @@ public class StoreConfig {
   public final double storeMaxLogSegmentValidDataPercentageToQualifyCompaction;
 
   /**
+   * In the stats based compaction, set the min cost for each log segment.
+   * If the IO effort is less than it, still count the cost as this min cost.
+   */
+  @Config("store.stats.based.compaction.min.cost.in.percentage")
+  public final double storeStatsBasedCompactionMinCostInPercentage;
+
+  /**
    * the time interval to run the "middle range compaction" in the stalts based compaction.
    * the interval is in milliseconds.
    */
@@ -629,12 +636,14 @@ public class StoreConfig {
         "com.github.ambry.store.CompactAllPolicyFactory");
     storeMinLogSegmentCountToReclaimToTriggerCompaction =
         verifiableProperties.getIntInRange("store.min.log.segment.count.to.reclaim.to.trigger.compaction", 1, 1, 1000);
-    storeMaxLogSegmentValidDataPercentageToQualifyCompaction =
-        verifiableProperties.getDoubleInRange("store.max.log.segment.valid.data.percentage.to.qualify.compaction", 0.30,
-            0.0, 1.0);
     storeStatsBasedMiddleRangeCompactionIntervalInMs =
         verifiableProperties.getLongInRange("store.stats.based.middle.range.compaction.interval.in.ms", 0, 0,
             Long.MAX_VALUE);
+    storeMaxLogSegmentValidDataPercentageToQualifyCompaction =
+        verifiableProperties.getDoubleInRange("store.max.log.segment.valid.data.percentage.to.qualify.compaction", 0.30,
+            0.0, 1.0);
+    storeStatsBasedCompactionMinCostInPercentage =
+        verifiableProperties.getDoubleInRange("store.stats.based.compaction.min.cost.in.percentage", 0.06, 0.0, 1.0);
     storeStatsBucketCount = verifiableProperties.getIntInRange("store.stats.bucket.count", 0, 0, 10000);
     storeStatsBucketSpanInMinutes =
         verifiableProperties.getLongInRange("store.stats.bucket.span.in.minutes", 60, 1, 10000);

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreStats.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreStats.java
@@ -381,6 +381,17 @@ class BlobStoreStats implements StoreStats, Closeable {
     return retValue;
   }
 
+  String dumpLogSegmentSize(NavigableMap<LogSegmentName, Long> validDataSizeByLogSegment, long segmentCapacity,
+      String dataDir) {
+    final StringBuilder sizeLog = new StringBuilder("Valid data size for " + dataDir + " from log segments: ");
+    validDataSizeByLogSegment.forEach((logSegmentName, validDataSize) -> {
+      sizeLog.append(
+          logSegmentName + " " + validDataSize / 1000 / 1000 / 1000.0 + "GB " + validDataSize * 1.0 / segmentCapacity
+              + "%;");
+    });
+    return sizeLog.toString();
+  }
+
   /**
    * Gets the storage stats for all serviceIds and their containerIds as of now (the time when the API is called).
    * Storage stats is comprised of 3 values: 1. valid data size (logicalStorageUsage) 2. physical data size 3. number of blobs.

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreStats.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreStats.java
@@ -381,6 +381,13 @@ class BlobStoreStats implements StoreStats, Closeable {
     return retValue;
   }
 
+  /**
+   * Dump the log segment size in a human readable way.
+   * @param validDataSizeByLogSegment a map from log segment name to valid size
+   * @param segmentCapacity Segment capacity of one {@link LogSegment}
+   * @param dataDir data directory on the disk
+   * @return the dump string of the log segment valid size in a human readable way.
+   */
   String dumpLogSegmentSize(NavigableMap<LogSegmentName, Long> validDataSizeByLogSegment, long segmentCapacity,
       String dataDir) {
     final StringBuilder sizeLog = new StringBuilder("Valid data size for " + dataDir + " from log segments: ");

--- a/ambry-store/src/main/java/com/github/ambry/store/CompactAllPolicyFactory.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/CompactAllPolicyFactory.java
@@ -47,7 +47,6 @@ public class CompactAllPolicyFactory implements CompactionPolicyFactory {
  */
 class CompactAllPolicy implements CompactionPolicy {
 
-  final static long ERROR_MARGIN_MS = 1000 * 60 * 60;
   private final StoreConfig storeConfig;
   private final Time time;
   private final long messageRetentionTimeInMs;
@@ -74,14 +73,9 @@ class CompactAllPolicy implements CompactionPolicy {
             blobStoreStats.getValidDataSizeByLogSegment(
                 new TimeRange(time.milliseconds() - messageRetentionTimeInMs - ERROR_MARGIN_MS, ERROR_MARGIN_MS));
         if (validDataSizeByLogSegment != null) {
-          final StringBuilder sizeLog = new StringBuilder(
-              "Valid data size for " + dataDir + " from BlobStoreStats " + validDataSizeByLogSegment.getFirst()
-                  + " segments: ");
-          validDataSizeByLogSegment.getSecond().forEach((logSegmentName, validDataSize) -> {
-            sizeLog.append(logSegmentName + " " + validDataSize / 1000 / 1000 / 1000.0 + "GB "
-                + validDataSize * 1.0 / segmentCapacity + "%;");
-          });
-          logger.info(sizeLog.toString());
+          String sizeLog =
+              blobStoreStats.dumpLogSegmentSize(validDataSizeByLogSegment.getSecond(), segmentCapacity, dataDir);
+          logger.info(sizeLog);
         }
       }
     }

--- a/ambry-store/src/main/java/com/github/ambry/store/CompactAllPolicyFactory.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/CompactAllPolicyFactory.java
@@ -73,15 +73,17 @@ class CompactAllPolicy implements CompactionPolicy {
         Pair<Long, NavigableMap<LogSegmentName, Long>> validDataSizeByLogSegment =
             blobStoreStats.getValidDataSizeByLogSegment(
                 new TimeRange(time.milliseconds() - messageRetentionTimeInMs - ERROR_MARGIN_MS, ERROR_MARGIN_MS));
-        final StringBuilder sizeLog = new StringBuilder(
-            "Valid data size for " + dataDir + " from BlobStoreStats " + validDataSizeByLogSegment.getFirst()
-                + " segments: ");
-        validDataSizeByLogSegment.getSecond().forEach((logSegmentName, validDataSize) -> {
-          sizeLog.append(
-              logSegmentName + " " + validDataSize / 1000 / 1000 / 1000.0 + "GB " + validDataSize / segmentCapacity
-                  + "%;");
-        });
-        logger.info(sizeLog.toString());
+        if (validDataSizeByLogSegment != null) {
+          final StringBuilder sizeLog = new StringBuilder(
+              "Valid data size for " + dataDir + " from BlobStoreStats " + validDataSizeByLogSegment.getFirst()
+                  + " segments: ");
+          validDataSizeByLogSegment.getSecond().forEach((logSegmentName, validDataSize) -> {
+            sizeLog.append(
+                logSegmentName + " " + validDataSize / 1000 / 1000 / 1000.0 + "GB " + validDataSize / segmentCapacity
+                    + "%;");
+          });
+          logger.info(sizeLog.toString());
+        }
       }
     }
     return details;

--- a/ambry-store/src/main/java/com/github/ambry/store/CompactAllPolicyFactory.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/CompactAllPolicyFactory.java
@@ -78,9 +78,8 @@ class CompactAllPolicy implements CompactionPolicy {
               "Valid data size for " + dataDir + " from BlobStoreStats " + validDataSizeByLogSegment.getFirst()
                   + " segments: ");
           validDataSizeByLogSegment.getSecond().forEach((logSegmentName, validDataSize) -> {
-            sizeLog.append(
-                logSegmentName + " " + validDataSize / 1000 / 1000 / 1000.0 + "GB " + validDataSize / segmentCapacity
-                    + "%;");
+            sizeLog.append(logSegmentName + " " + validDataSize / 1000 / 1000 / 1000.0 + "GB "
+                + validDataSize * 1.0 / segmentCapacity + "%;");
           });
           logger.info(sizeLog.toString());
         }

--- a/ambry-store/src/main/java/com/github/ambry/store/CompactionPolicy.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/CompactionPolicy.java
@@ -20,6 +20,7 @@ import java.util.List;
  * CompactionPolicy is used to determine the log segments that needs to be compacted for a given {@link BlobStore}
  */
 interface CompactionPolicy {
+  final static long ERROR_MARGIN_MS = 1000 * 60 * 60;
 
   /**
    * Get compaction details for a given {@link BlobStore} containing information about the log segments to compact.

--- a/ambry-store/src/main/java/com/github/ambry/store/StatsBasedCompactionPolicy.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StatsBasedCompactionPolicy.java
@@ -87,11 +87,12 @@ class StatsBasedCompactionPolicy implements CompactionPolicy {
 
   /**
    * Finds middle range to compact.
-   * The first log segment and the last segment have to have less valid data then the configured threshold.
+   * The first log segment and the last segment have to have less valid data than the configured threshold.
    * @param validDataPerLogSegments the valid data size for each log segment in the form of a {@link NavigableMap}
    * @param segmentCapacity Segment capacity of one {@link LogSegment}
    * @param segmentHeaderSize Segment header size of a {@link LogSegment}
    * @param maxBlobSize The max blob size
+   * @param blobStoreStats the {@link BlobStoreStats}
    * @return the {@link CostBenefitInfo} for the best candidate to compact. {@code null} if there isn't any.
    */
   private CostBenefitInfo getMiddleRangeToCompact(NavigableMap<LogSegmentName, Long> validDataPerLogSegments,
@@ -152,6 +153,7 @@ class StatsBasedCompactionPolicy implements CompactionPolicy {
    * @param segmentCapacity Segment capacity of one {@link LogSegment}
    * @param segmentHeaderSize Segment header size of a {@link LogSegment}
    * @param maxBlobSize The max blob size
+   * @param blobStoreStats the {@link BlobStoreStats}
    * @return the {@link CostBenefitInfo} for the best candidate to compact. {@code null} if there isn't any.
    */
   private CostBenefitInfo getBestCandidateToCompact(NavigableMap<LogSegmentName, Long> validDataPerLogSegments,


### PR DESCRIPTION
Two major tunings,
1. Periodically pack the middle range log segments. It's similar with existing full compaction but smarter.
2. Stats based compaction overly care about the IO cost. When IO cost is lower than some threshold, the difference can be ignored. Rather we should value "compaction benefit" more when the IO cost is very low.
