### PR TITLE
Return 400 error instead of 500 when URI path is invalid

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/rest/RequestPath.java
+++ b/ambry-api/src/main/java/com/github/ambry/rest/RequestPath.java
@@ -59,7 +59,13 @@ public class RequestPath {
           parse(blobIdHeader, Collections.emptyMap(), prefixesToRemove, clusterName).getOperationOrBlobId(false);
       restRequest.setArg(Headers.BLOB_ID, blobIdStr);
     }
-    return parse(restRequest.getPath(), restRequest.getArgs(), prefixesToRemove, clusterName);
+    String path;
+    try {
+      path = restRequest.getPath();
+    } catch (IllegalArgumentException e) {
+      throw new RestServiceException("Invalid URI path", e, RestServiceErrorCode.BadRequest);
+    }
+    return parse(path, restRequest.getArgs(), prefixesToRemove, clusterName);
   }
 
   /**

--- a/ambry-api/src/test/java/com/github/ambry/rest/RequestPathTest.java
+++ b/ambry-api/src/test/java/com/github/ambry/rest/RequestPathTest.java
@@ -151,6 +151,23 @@ public class RequestPathTest {
   }
 
   /**
+   * Tests that the expected exception is thrown when URL path is invalid
+   */
+  @Test
+  public void testInvalidPath() throws UnsupportedEncodingException, URISyntaxException {
+    String requestPath = "/SOME_INVALID_PATH";
+    List<String> prefixesToRemove = new ArrayList<>();
+    RestRequest restRequest = RestUtilsTest.createRestRequest(RestMethod.GET, requestPath, null);
+    ((MockRestRequest) restRequest).throwExceptionOnGetPath(true);
+    try {
+      RequestPath.parse(restRequest, prefixesToRemove, CLUSTER_NAME);
+      fail();
+    } catch (RestServiceException e) {
+      assertEquals(RestServiceErrorCode.BadRequest, e.getErrorCode());
+    }
+  }
+
+  /**
    * Test that blob id string (with prefix and sub-resource) is specified in request header. The {@link RequestPath#parse(RestRequest, List, String)}
    * should correctly remove prefix, sub-resource and use pure blob id to update request header.
    */

--- a/ambry-test-utils/src/main/java/com/github/ambry/rest/MockRestRequest.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/rest/MockRestRequest.java
@@ -97,6 +97,7 @@ public class MockRestRequest implements RestRequest {
   private final List<EventListener> listeners = new ArrayList<EventListener>();
   private final RestRequestMetricsTracker restRequestMetricsTracker = new RestRequestMetricsTracker();
   private final AtomicLong bytesReceived = new AtomicLong(0);
+  private boolean throwExceptionOnGetPath = false;
 
   private MessageDigest digest = null;
   private byte[] digestBytes = null;
@@ -156,7 +157,10 @@ public class MockRestRequest implements RestRequest {
   @Override
   public String getPath() {
     onEventComplete(Event.GetPath);
-    return (uri == null) ? null: uri.getPath();
+    if (throwExceptionOnGetPath) {
+      throw new IllegalArgumentException();
+    }
+    return (uri == null) ? null : uri.getPath();
   }
 
   @Override
@@ -286,6 +290,14 @@ public class MockRestRequest implements RestRequest {
   public RestRequestMetricsTracker getMetricsTracker() {
     onEventComplete(Event.GetMetricsTracker);
     return restRequestMetricsTracker;
+  }
+
+  /**
+   * @param throwExceptionOnGetPath If {@code True}, throws {@link IllegalArgumentException} on {@link this#getPath()}
+   *                                call
+   */
+  public void throwExceptionOnGetPath(boolean throwExceptionOnGetPath) {
+    this.throwExceptionOnGetPath = throwExceptionOnGetPath;
   }
 
   /**


### PR DESCRIPTION
When GET path is invalid, we are returning 500 error code as below. Return 400 instead.


```
2023/08/22 22:00:36.859 ERROR [NettyResponseChannel] [RequestWorker-4] [ambry-frontend] [] Unexpected error handling request /media/named/aero/assets/sc/h/1tydv2s1frabizt0fx37lpqfh%MOATCLIENTLEVELTOKEN% with method GET
java.lang.IllegalArgumentException: invalid hex byte 'MO' at index 56 of '/media/named/aero/assets/sc/h/1tydv2s1frabizt0fx37lpqfh%MOATCLIENTLEVELTOKEN%'
	at io.netty.util.internal.StringUtil.decodeHexByte(StringUtil.java:269) ~[io.netty.netty-common-4.1.82.Final.jar:4.1.82.Final]
	at io.netty.handler.codec.http.QueryStringDecoder.decodeComponent(QueryStringDecoder.java:373) ~[io.netty.netty-codec-http-4.1.82.Final.jar:4.1.82.Final]
	at io.netty.handler.codec.http.QueryStringDecoder.path(QueryStringDecoder.java:189) ~[io.netty.netty-codec-http-4.1.82.Final.jar:4.1.82.Final]
	at com.github.ambry.rest.NettyRequest.getPath(NettyRequest.java:237) ~[com.github.ambry.ambry-rest-0.4.161.jar:?]
	at com.github.ambry.rest.RequestPath.parse(RequestPath.java:62) ~[com.github.ambry.ambry-api-0.4.161.jar:?]
	at com.github.ambry.frontend.FrontendRestRequestService.lambda$preProcessAndRouteRequest$25(FrontendRestRequestService.java:484) ~[com.github.ambry.ambry-frontend-0.4.161.jar:?]
	at com.github.ambry.commons.CallbackUtils.lambda$chainCallback$0(CallbackUtils.java:50) ~[com.github.ambry.ambry-api-0.4.161.jar:?]
	at com.linkedin.ambry.frontend.AmbryLiSecurityService.completeOperation(AmbryLiSecurityService.java:1166) [ambry-impl-17.0.705.jar:?]
	at com.linkedin.ambry.frontend.AmbryLiSecurityService.preProcessRequest(AmbryLiSecurityService.java:396) [ambry-impl-17.0.705.jar:?]
	at com.github.ambry.frontend.FrontendRestRequestService.preProcessAndRouteRequest(FrontendRestRequestService.java:483) [com.github.ambry.ambry-frontend-0.4.161.jar:?]
	at com.github.ambry.frontend.FrontendRestRequestService.handleGet(FrontendRestRequestService.java:306) [com.github.ambry.ambry-frontend-0.4.161.jar:?]
	at com.github.ambry.rest.AsyncRequestWorker.processRequest(AsyncRequestResponseHandler.java:417) [com.github.ambry.ambry-rest-0.4.161.jar:?]
	at com.github.ambry.rest.AsyncRequestWorker.run(AsyncRequestResponseHandler.java:297) [com.github.ambry.ambry-rest-0.4.161.jar:?]
	at java.lang.Thread.run(Thread.java:834) [?:?]
``` 