### PR TITLE
[vcr-2.0] Impl findKey and findMissingKey

### DIFF
--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureMetrics.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureMetrics.java
@@ -80,6 +80,8 @@ public class AzureMetrics {
       "DeprecatedContainerCompactionFailureCount";
   public static final String DEPRECATED_CONTAINER_COMPACTION_SUCCESS_COUNT =
       "DeprecatedContainerCompactionSuccessCount";
+  public static final String FIND_KEY_TIME = "FindKeyTime";
+  public static final String FIND_KEY_ERROR_COUNT = "FindKeyError";
 
   // Metrics
   public final Counter blobUploadRequestCount;
@@ -115,6 +117,8 @@ public class AzureMetrics {
   public final Timer deadBlobsQueryTime;
   public final Timer deletedContainerBlobsQueryTime;
   public final Timer findSinceQueryTime;
+  public final Timer findKeyTime;
+  public final Counter findKeyErrorCount;
   public final Counter blobUpdateErrorCount;
   /* Tracks updates that recovered a missing Cosmos record */
   public final Counter blobUpdateRecoverCount;
@@ -144,6 +148,8 @@ public class AzureMetrics {
   public AzureMetrics(MetricRegistry registry) {
     this.metricRegistry = registry;
 
+    findKeyErrorCount = registry.counter(MetricRegistry.name(CloudBlobStoreV2.class, FIND_KEY_ERROR_COUNT));
+    findKeyTime = registry.timer(MetricRegistry.name(CloudBlobStoreV2.class, FIND_KEY_TIME));
     blobUploadRequestCount =
         registry.counter(MetricRegistry.name(AzureCloudDestination.class, BLOB_UPLOAD_REQUEST_COUNT));
     blobUploadSuccessCount =

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -762,7 +762,7 @@ public class ReplicaThread implements Runnable {
               logger.info("Local store not started for remote replica: {}", remoteReplicaInfo.getReplicaId());
               exchangeMetadataResponseList.add(new ExchangeMetadataResponse(ServerErrorCode.Temporarily_Disabled));
             } else {
-              logger.error("Remote node: {} Thread name: {} Remote replica: {}", remoteNode, threadName,
+              logger.error("Remote node: {} Thread name: {} Remote replica: {} Error: {}", remoteNode, threadName,
                   remoteReplicaInfo.getReplicaId(), e);
               replicationMetrics.updateLocalStoreError(remoteReplicaInfo.getReplicaId());
               responseHandler.onEvent(remoteReplicaInfo.getReplicaId(), e);


### PR DESCRIPTION
This patch implements findKey and findMissingKey for Azure blob storage.
findKey is used to fetch a blob metadata to update it including ttl-update, delete and undelete timestamps.
findMissingKey is used to determine keys absent in Azure blob storage.

This patch also prints errlog in replica thread that was not being printed before.