### PR TITLE
[Efficient Metadata Operations] Implement Request and Response for Purge Message from frontend to server.

### DIFF
--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/PurgeRequest.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/PurgeRequest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2023 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.protocol;
+
+import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.commons.BlobId;
+import com.github.ambry.utils.Utils;
+import java.io.DataInputStream;
+import java.io.IOException;
+
+import static com.github.ambry.protocol.RequestOrResponseType.PurgeRequest;
+
+
+/**
+ * Request to purge a blob.
+ * This message is sent by the frontend when it has determined that a chunk is no longer needed (i.e, is expired or deleted
+ * and past retention window). Once compaction sees a purge message, it will clean up the chunk without any other checks.
+ * While this message originates from frontend it can also be replicated.
+ */
+public class PurgeRequest extends RequestOrResponse {
+
+  static final short PURGE_MESSAGE_REQUEST_VERSION_1 = 1;
+  private final static short CURRENT_VERSION = PURGE_MESSAGE_REQUEST_VERSION_1;
+
+  private final BlobId blobId;
+
+  /**
+   * Helper to construct PurgeRequest from a stream
+   * @param stream the stream to read data from
+   * @param map the {@link ClusterMap} to use
+   * @return a TtlUpdateRequest based on data read off of the stream
+   * @throws IOException if there were any problems reading the stream
+   */
+  public static PurgeRequest readFrom(DataInputStream stream, ClusterMap map) throws IOException {
+    short version = stream.readShort();
+    if (version == PURGE_MESSAGE_REQUEST_VERSION_1) {
+      return PurgeRequest_V1.readFrom(stream, map);
+    }
+    throw new IllegalStateException("Unknown Purge Request version " + version);
+  }
+
+  /**
+   * @param correlationId the correlation id for the request
+   * @param clientId the id of the client generating the request
+   * @param blobId the blob ID whose TTL needs to be updated
+   */
+  public PurgeRequest(int correlationId, String clientId, BlobId blobId) {
+    this(correlationId, clientId, blobId, CURRENT_VERSION);
+  }
+
+  /**
+   * @param correlationId the correlation id for the request
+   * @param clientId the id of the client generating the request
+   * @param blobId the blob ID that needs to be purged.
+   * @param version the version of the {@link PurgeRequest}.
+   */
+  PurgeRequest(int correlationId, String clientId, BlobId blobId, short version) {
+    super(PurgeRequest, version, correlationId, clientId);
+    this.blobId = blobId;
+  }
+
+  @Override
+  public void accept(RequestVisitor visitor) {
+    // TODO Efficient Metadata Operations: Implement this.
+  }
+
+  @Override
+  protected void prepareBuffer() {
+    super.prepareBuffer();
+    bufferToSend.writeBytes(blobId.toBytes());
+  }
+
+  /**
+   * @return the blob ID that needs to be purged.
+   */
+  public BlobId getBlobId() {
+    return blobId;
+  }
+
+  /**
+   * @return the id of the account that the blob belongs to
+   */
+  public short getAccountId() {
+    return blobId.getAccountId();
+  }
+
+  /**
+   * @return the id of the container that the blob belongs to
+   */
+  public short getContainerId() {
+    return blobId.getContainerId();
+  }
+
+  @Override
+  public long sizeInBytes() {
+    // header + blobId
+    return super.sizeInBytes() + blobId.sizeInBytes();
+  }
+
+  @Override
+  public String toString() {
+    return "PurgeRequest[" + "BlobID=" + blobId + ", " + "PartitionId=" + blobId.getPartition() + ", " + "ClientId="
+        + clientId + ", " + "CorrelationId=" + correlationId + ", " + "AccountId=" + blobId.getAccountId() + ", "
+        + "ContainerId=" + blobId.getContainerId() + "]";
+  }
+
+  /**
+   * Class to read protocol version 1 PurgeRequest from the stream.
+   */
+  public static class PurgeRequest_V1 {
+    static PurgeRequest readFrom(DataInputStream stream, ClusterMap map) throws IOException {
+      int correlationId = stream.readInt();
+      String clientId = Utils.readIntString(stream);
+      BlobId id = new BlobId(stream, map);
+      return new PurgeRequest(correlationId, clientId, id, PURGE_MESSAGE_REQUEST_VERSION_1);
+    }
+  }
+}

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/PurgeResponse.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/PurgeResponse.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.protocol;
+
+import com.github.ambry.server.ServerErrorCode;
+import com.github.ambry.utils.Utils;
+import java.io.DataInputStream;
+import java.io.IOException;
+
+
+/**
+ * Response to a {@link PurgeRequest}.
+ * The main purpose of the response is to indicate whether the purge request succeeded or not.
+ */
+public class PurgeResponse extends Response {
+  private static final short PURGE_RESPONSE_VERSION_1 = 1;
+
+  /**
+   * @param correlationId the correlation id from the {@link PurgeRequest}
+   * @param clientId the id of the client from the {@link PurgeRequest}
+   * @param error the {@link ServerErrorCode} for the operation
+   */
+  public PurgeResponse(int correlationId, String clientId, ServerErrorCode error) {
+    super(RequestOrResponseType.PurgeResponse, PURGE_RESPONSE_VERSION_1, correlationId, clientId, error);
+  }
+
+  /**
+   * Helper to help construct {@link PurgeResponse} from the {@code stream}.
+   * @param stream the stream to read bytes from
+   * @return a {@link PurgeResponse} based on data read from the {@code stream}
+   * @throws IOException if there was any problem reading the stream
+   */
+  public static PurgeResponse readFrom(DataInputStream stream) throws IOException {
+    RequestOrResponseType type = RequestOrResponseType.values()[stream.readShort()];
+    if (type != RequestOrResponseType.PurgeResponse) {
+      throw new IllegalArgumentException("The type of request response is not compatible");
+    }
+    short version = stream.readShort();
+    if (version != PURGE_RESPONSE_VERSION_1) {
+      throw new IllegalStateException("Unknown PurgeResponse version: " + version);
+    }
+    int correlationId = stream.readInt();
+    String clientId = Utils.readIntString(stream);
+    ServerErrorCode error = ServerErrorCode.values()[stream.readShort()];
+    return new PurgeResponse(correlationId, clientId, error);
+  }
+
+  @Override
+  public String toString() {
+    return "PurgeResponse[" + "ServerErrorCode=" + getError() + "]";
+  }
+}

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/RequestOrResponseType.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/RequestOrResponseType.java
@@ -34,4 +34,6 @@ public enum RequestOrResponseType {
   UndeleteResponse,
   ReplicateBlobRequest,
   ReplicateBlobResponse,
+  PurgeRequest,
+  PurgeResponse
 }


### PR DESCRIPTION
In the efficient metadata operations design, the frontend will need to send message to storage nodes to indicate that a data chunk is ready to be compacted away, when the metadata chunk is expired or deleted and past retention time. This PR implements the Purge Message will be used to pass this message from frontend to server.