### PR TITLE
Add default replica capacity as a cluster map config

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
@@ -338,6 +338,12 @@ public class ClusterMapConfig {
   @Default("60 * 1000")
   public final long clustermapDistributedLockLeaseTimeoutInMs;
 
+  /**
+   * Default capacity of a replica in this cluster.
+   */
+  @Config("clustermap.default.replica.capacity.in.bytes")
+  public final long clustermapDefaultReplicaCapacityInBytes;
+
   public ClusterMapConfig(VerifiableProperties verifiableProperties) {
     clusterMapFixedTimeoutDatanodeErrorThreshold =
         verifiableProperties.getIntInRange("clustermap.fixedtimeout.datanode.error.threshold", 3, 1, 100);
@@ -410,5 +416,8 @@ public class ClusterMapConfig {
     clusterMapUseAggregatedView = verifiableProperties.getBoolean(CLUSTERMAP_USE_AGGREGATED_VIEW, false);
     clustermapDistributedLockLeaseTimeoutInMs =
         verifiableProperties.getLong(DISTRIBUTED_LOCK_LEASE_TIMEOUT_IN_MS, 60 * 1000);
+    clustermapDefaultReplicaCapacityInBytes =
+        verifiableProperties.getLongInRange("clustermap.default.replica.capacity.in.bytes", 384L * 1024 * 1024 * 1024,
+            0, Long.MAX_VALUE);
   }
 }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
@@ -107,9 +107,6 @@ public class ClusterMapUtils {
   public static long MIN_REPLICA_CAPACITY_IN_BYTES = 1024 * 1024 * 1024L;
   static final long MAX_REPLICA_CAPACITY_IN_BYTES = 10L * 1024 * 1024 * 1024 * 1024;
   static final long MIN_DISK_CAPACITY_IN_BYTES = 10L * 1024 * 1024 * 1024;
-  // TODO: Temporary defaults to be used when adding replicas in helix FULL_AUTO mode. These replica configs will need
-  //  to stored in configs or helix for each cluster.
-  static final long DEFAULT_REPLICA_CAPACITY_IN_BYTES = 100L * 1024 * 1024 * 1024;
   static final int CURRENT_SCHEMA_VERSION = 0;
   static final String WRITABLE_LOG_STR = "writable";
   static final String FULLY_WRITABLE_LOG_STR = "fully writable";

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeUtil.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeUtil.java
@@ -1173,10 +1173,7 @@ public class HelixBootstrapUpgradeUtil {
         clusterConfigFields.partitionDiskWeightInGB + PARTITION_BUFFER_CAPACITY_FOR_INDEX_FILES_IN_GB));
 
     // 3. Update resource configs in helix
-    final long GB = 1024 * 1024 * 1024;
     resourceConfig.setPartitionCapacityMap(partitionCapacityMap);
-    resourceConfig.putSimpleConfig(DEFAULT_REPLICA_CAPACITY_STR,
-        String.valueOf(GB * clusterConfigFields.partitionDiskWeightInGB));
     configAccessor.setResourceConfig(clusterName, resourceName, resourceConfig);
     info("Updated resource config/partition weights for resource {}. Partition weights: {}", resourceName,
         resourceConfig.getPartitionCapacityMap());


### PR DESCRIPTION
Moving configuration for default replica capacity from helix to local server configuration for simplicity. We just have to make sure that same capacity is used in offline Tools (HelixBootstrap or lipy-clustermap) when migrating or bootstrapping new cluster in FULL_AUTO mode. 