### PR TITLE
Simplify discarding of header bytes in http2 server code

### DIFF
--- a/ambry-network/src/test/java/com/github/ambry/network/NettyServerRequestResponseChannelTest.java
+++ b/ambry-network/src/test/java/com/github/ambry/network/NettyServerRequestResponseChannelTest.java
@@ -54,15 +54,11 @@ public class NettyServerRequestResponseChannelTest {
     Assert.assertEquals(13, ((NettyServerRequest) request).content().readableBytes());
 
     channel.sendRequest(createEmptyNettyServerRequest());
-    channel.sendRequest(createEmptyNettyServerRequest());
-    channel.sendRequest(createNettyServerRequest(17));
-
-    request = channel.receiveRequest();
-    Assert.assertTrue(request instanceof NettyServerRequest);
-    Assert.assertEquals(17, ((NettyServerRequest) request).content().readableBytes());
-
     channel.sendRequest(createNettyServerRequest(19));
     channel.sendRequest(createNettyServerRequest(23));
+    request = channel.receiveRequest();
+    Assert.assertTrue(request instanceof NettyServerRequest);
+    Assert.assertEquals(0, ((NettyServerRequest) request).content().readableBytes());
     request = channel.receiveRequest();
     Assert.assertTrue(request instanceof NettyServerRequest);
     Assert.assertEquals(19, ((NettyServerRequest) request).content().readableBytes());
@@ -136,10 +132,8 @@ public class NettyServerRequestResponseChannelTest {
   }
 
   private NettyServerRequest createNettyServerRequest(int len) {
-    byte[] array = new byte[len + 8];
+    byte[] array = new byte[len];
     TestUtils.RANDOM.nextBytes(array);
-    ByteBuffer byteBuffer = ByteBuffer.wrap(array);
-    byteBuffer.putLong(len);
     ByteBuf content = Unpooled.wrappedBuffer(array);
     return new NettyServerRequest(null, content);
   }


### PR DESCRIPTION
Move code for discarding first 8 bytes of ambry server requests from `NettyServerRequestResponseChannel.java` to `AmbryNetworkRequestHandler.java` to avoid calling the code in multiple places. 

(Background on these 8 bytes are: When sending requests from frontend to server using Socket server stack, we use first 8 bytes to represent the size of the content so that we know how many bytes to be read from socket. This size header is not needed for HTTP2 server stack since Ambry requests go as content in HTTP2 and Netty stack reads the exact content. To maintain backward compatibility, we just discard first 8 bytes of the request in HTTP2 server stack.)