### PR TITLE
Reduce number of SocketServer threads

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/ServerConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/ServerConfig.java
@@ -30,6 +30,15 @@ public class ServerConfig {
   @Default("7")
   public final int serverRequestHandlerNumOfThreads;
 
+
+  /**
+   * The number of request handler threads used by the server to process requests
+   */
+  public static final String SERVER_REQUEST_HANDLER_NUM_SOCKET_SERVER_THREADS = "server.request.handler.num.socket.server.threads";
+  public final int DEFAULT_SERVER_REQUEST_HANDLER_NUM_SOCKET_SERVER_THREADS = 1;
+  @Config(SERVER_REQUEST_HANDLER_NUM_SOCKET_SERVER_THREADS)
+  public final int serverRequestHandlerNumSocketServerThreads;
+
   /**
    * The number of scheduler threads the server will use to perform background tasks (store, replication)
    */
@@ -119,6 +128,9 @@ public class ServerConfig {
   public final String serverRepairRequestsDbFactory;
 
   public ServerConfig(VerifiableProperties verifiableProperties) {
+    serverRequestHandlerNumSocketServerThreads =
+        verifiableProperties.getInt(SERVER_REQUEST_HANDLER_NUM_SOCKET_SERVER_THREADS,
+            DEFAULT_SERVER_REQUEST_HANDLER_NUM_SOCKET_SERVER_THREADS);
     serverRequestHandlerNumOfThreads = verifiableProperties.getInt("server.request.handler.num.of.threads", 7);
     serverSchedulerNumOfthreads = verifiableProperties.getInt("server.scheduler.num.of.threads", 10);
     serverStatsReportsToPublish =

--- a/ambry-api/src/main/java/com/github/ambry/config/ServerConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/ServerConfig.java
@@ -32,7 +32,7 @@ public class ServerConfig {
 
 
   /**
-   * The number of request handler threads used by the server to process requests
+   * The number of request handler threads used by the socket-server to process requests
    */
   public static final String SERVER_REQUEST_HANDLER_NUM_SOCKET_SERVER_THREADS = "server.request.handler.num.socket.server.threads";
   public final int DEFAULT_SERVER_REQUEST_HANDLER_NUM_SOCKET_SERVER_THREADS = 1;

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrServer.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrServer.java
@@ -242,7 +242,7 @@ public class VcrServer {
               registry, serverMetrics, new FindTokenHelper(storeKeyFactory, replicationConfig), notificationSystem,
               vcrReplicationManager, storeKeyFactory, storeKeyConverterFactory);
 
-      requestHandlerPool = new RequestHandlerPool(serverConfig.serverRequestHandlerNumOfThreads,
+      requestHandlerPool = new RequestHandlerPool(serverConfig.serverRequestHandlerNumSocketServerThreads,
           networkServer.getRequestResponseChannel(), requests);
 
       networkServer.start();

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryServer.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryServer.java
@@ -308,7 +308,7 @@ public class AmbryServer {
       requests = new AmbryServerRequests(storageManager, networkServer.getRequestResponseChannel(), clusterMap, nodeId,
           registry, metrics, findTokenHelper, notificationSystem, replicationManager, storeKeyFactory, serverConfig,
           diskManagerConfig, storeKeyConverterFactory, statsManager, clusterParticipants.get(0));
-      requestHandlerPool = new RequestHandlerPool(serverConfig.serverRequestHandlerNumOfThreads,
+      requestHandlerPool = new RequestHandlerPool(1,
           networkServer.getRequestResponseChannel(), requests);
       networkServer.start();
 

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryServer.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryServer.java
@@ -308,7 +308,7 @@ public class AmbryServer {
       requests = new AmbryServerRequests(storageManager, networkServer.getRequestResponseChannel(), clusterMap, nodeId,
           registry, metrics, findTokenHelper, notificationSystem, replicationManager, storeKeyFactory, serverConfig,
           diskManagerConfig, storeKeyConverterFactory, statsManager, clusterParticipants.get(0));
-      requestHandlerPool = new RequestHandlerPool(1,
+      requestHandlerPool = new RequestHandlerPool(serverConfig.serverRequestHandlerNumSocketServerThreads,
           networkServer.getRequestResponseChannel(), requests);
       networkServer.start();
 


### PR DESCRIPTION
We don't use socket server code but we still end up creating 100s of thread just sitting idle.
This pollutes thread dumps. So let's just reduce the number of socket server threads to 1.