### PR TITLE
Use ExternalView as RouterTableProvider

### DIFF
--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixDatacenterInitializer.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixDatacenterInitializer.java
@@ -145,7 +145,7 @@ class HelixDatacenterInitializer {
     // read constructed view. The latter one takes lesser time since we don't have to wait for controller to calculate
     // the view but has more read traffic.
     logger.info("Creating routing table provider associated with Helix manager at {}", zkConnectStr);
-    RoutingTableProvider routingTableProvider = new RoutingTableProvider(manager, PropertyType.CURRENTSTATES);
+    RoutingTableProvider routingTableProvider = new RoutingTableProvider(manager, PropertyType.EXTERNALVIEW);
     logger.info("Routing table provider is created in {}", dcName);
     routingTableProvider.addRoutingTableChangeListener(clusterChangeHandler, null);
     logger.info("Registered routing table change listeners in {}", dcName);

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixManager.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixManager.java
@@ -276,11 +276,7 @@ class MockHelixManager implements HelixManager {
 
   void triggerRoutingTableNotification() {
     NotificationContext notificationContext = new NotificationContext(this);
-    if (isAggregatedViewCluster) {
-      routingTableProvider.onExternalViewChange(Collections.emptyList(), notificationContext);
-    } else {
-      routingTableProvider.onStateChange(instanceName, Collections.emptyList(), notificationContext);
-    }
+    routingTableProvider.onExternalViewChange(Collections.emptyList(), notificationContext);
   }
 
   //****************************


### PR DESCRIPTION
## Summary

Both external view and current states can provide routing table to the client, however, the external view is slower but requires less round trips to zookeeper. We are already using external view in aggregated view, now we change the non-aggregated view to leverage external view for routing table.
