### PR TITLE
If TtlUpdate is partially failed, inject the RepairRequests to the db and return success.

### DIFF
--- a/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterMetrics.java
@@ -130,6 +130,8 @@ public class NonBlockingRouterMetrics {
   public final Counter replicateBlobErrorCount;
   public final Counter offlineRepairOnDeleteCount;
   public final Counter offlineRepairOnDeleteErrorCount;
+  public final Counter offlineRepairOnTtlUpdateCount;
+  public final Counter offlineRepairOnTtlUpdateErrorCount;
   public final Counter operationAbortCount;
   public final Counter routerRequestErrorCount;
 
@@ -474,6 +476,10 @@ public class NonBlockingRouterMetrics {
         metricRegistry.counter(MetricRegistry.name(DeleteOperation.class, "OfflineRepairOnDeleteCount"));
     offlineRepairOnDeleteErrorCount =
         metricRegistry.counter(MetricRegistry.name(DeleteOperation.class, "OfflineRepairOnDeleteErrorCount"));
+    offlineRepairOnTtlUpdateCount =
+        metricRegistry.counter(MetricRegistry.name(DeleteOperation.class, "OfflineRepairOnTtlUpdateCount"));
+    offlineRepairOnTtlUpdateErrorCount =
+        metricRegistry.counter(MetricRegistry.name(DeleteOperation.class, "OfflineRepairOnTtlUpdateErrorCount"));
 
     // Performance metrics for operation managers.
     putManagerPollTimeMs = metricRegistry.histogram(MetricRegistry.name(PutManager.class, "PutManagerPollTimeMs"));

--- a/ambry-router/src/main/java/com/github/ambry/router/SimpleOperationTracker.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/SimpleOperationTracker.java
@@ -383,13 +383,17 @@ class SimpleOperationTracker implements OperationTracker {
   }
 
   /**
-   * @param eligibleReplicaCount eligible replicas to send Delete Requests.
-   * @return true if it's possible to run offline repair for the Delete
+   * @param eligibleReplicaCount eligible replicas to send Requests.
+   * @return true if it's possible to run offline repair for the Delete or TtlUpdate
    */
   public boolean possibleRunOfflineRepair(int eligibleReplicaCount) {
-    // LOCAL_CONSISTENCY_TODO: after enabled TtlUpdate offline repair in TtlUpdateOperation, add the condition here.
-    return (eligibleReplicaCount >= 1 && routerOperation == RouterOperation.DeleteOperation
-        && routerConfig.routerDeleteOfflineRepairEnabled);
+    // @formatter:off
+    return (eligibleReplicaCount >= 1
+        && (
+              (routerOperation == RouterOperation.TtlUpdateOperation && routerConfig.routerTtlUpdateOfflineRepairEnabled)
+              || (routerOperation == RouterOperation.DeleteOperation && routerConfig.routerDeleteOfflineRepairEnabled)
+           ));
+    // @formatter:on
   }
 
   /**

--- a/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTestBase.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTestBase.java
@@ -89,6 +89,7 @@ public class NonBlockingRouterTestBase {
   protected static final int PUT_CONTENT_SIZE = 1000;
   protected static final int USER_METADATA_SIZE = 10;
   protected static final int NOT_FOUND_CACHE_TTL_MS = 1000;
+  protected static final short LIFE_VERSION_FROM_FRONTEND = -1;
   protected final AtomicReference<MockSelectorState> mockSelectorState = new AtomicReference<>(MockSelectorState.Good);
   protected final MockTime mockTime;
   protected final MockKeyManagementService kms;


### PR DESCRIPTION
Open up the Offline repair code path for TtlUpdate besides the Delete.