### PR TITLE
Tested Offline Repair can apply TtlUpdate even the Blob is expired.

### DIFF
--- a/ambry-server/src/integration-test/java/com/github/ambry/server/MockCluster.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/MockCluster.java
@@ -257,6 +257,7 @@ public class MockCluster {
     props.setProperty("store.deleted.message.retention.minutes", "60");
     props.setProperty("store.validate.authorization", "true");
     props.setProperty("store.segment.size.in.bytes", Long.toString(MockReplicaId.MOCK_REPLICA_CAPACITY / 10));
+    props.setProperty("store.ttl.update.buffer.time.seconds", "0");
     props.setProperty("replication.token.flush.interval.seconds", "5");
     props.setProperty("replication.validate.message.stream", "true");
     props.setProperty("clustermap.cluster.name", "test");


### PR DESCRIPTION
Offline Repair uses the original operation time when the partial failed request was sent.
So when the RepairRequest is executed, even at that time, the blob is expired, the appleTTL still works because it used the saved operation time, not the current system time.