### PR TITLE
Fix unsupported request type error handling and catch exception

### DIFF
--- a/ambry-network/src/main/java/com/github/ambry/network/NettyServerRequest.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/NettyServerRequest.java
@@ -36,6 +36,16 @@ public class NettyServerRequest extends AbstractByteBufHolder<NettyServerRequest
     this.startTimeInMs = System.currentTimeMillis();
   }
 
+  /**
+   * Test constructor
+   */
+  public NettyServerRequest(ChannelHandlerContext ctx, ByteBuf content, long creationTime) {
+    this.ctx = ctx;
+    this.content = content;
+    this.inputStream = new NettyByteBufDataInputStream(content);
+    this.startTimeInMs = creationTime;
+  }
+
   ChannelHandlerContext getCtx() {
     return ctx;
   }

--- a/ambry-network/src/main/java/com/github/ambry/network/NettyServerRequestResponseChannel.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/NettyServerRequestResponseChannel.java
@@ -161,7 +161,7 @@ public class NettyServerRequestResponseChannel implements RequestResponseChannel
       long requestProcessingTime = SystemTime.getInstance().milliseconds() - networkRequest.getStartTimeInMs();
       publicAccessLogger.info("{} {} processingTime {}", request, response, requestProcessingTime);
       sendResponse(response, networkRequest, null);
-    } catch (Exception e) {
+    } catch (Throwable e) {
       logger.error("Error while handling request {} closing connection", networkRequest, e);
       closeConnection(networkRequest);
     } finally {

--- a/ambry-network/src/main/java/com/github/ambry/network/NettyServerRequestResponseChannel.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/NettyServerRequestResponseChannel.java
@@ -59,6 +59,17 @@ public class NettyServerRequestResponseChannel implements RequestResponseChannel
     serverMetrics.registerRequestQueuesMetrics(networkRequestQueue::size);
   }
 
+  /**
+   * Test constructor
+   */
+  public NettyServerRequestResponseChannel(Http2ServerMetrics http2ServerMetrics, ServerMetrics serverMetrics,
+      ServerRequestResponseHelper requestResponseHelper, NetworkRequestQueue networkRequestQueue) {
+    this.http2ServerMetrics = http2ServerMetrics;
+    this.networkRequestQueue = networkRequestQueue;
+    this.serverMetrics = serverMetrics;
+    this.requestResponseHelper = requestResponseHelper;
+  }
+
   /** Send a request to be handled */
   @Override
   public void sendRequest(NetworkRequest request) throws InterruptedException {
@@ -137,9 +148,8 @@ public class NettyServerRequestResponseChannel implements RequestResponseChannel
    * @param isExpired      {@code true} if request is expired. Else {@code false}
    */
   void rejectRequest(NetworkRequest networkRequest, boolean isExpired) throws InterruptedException {
-    RequestOrResponse request;
     try {
-      request = requestResponseHelper.getDecodedRequest(networkRequest);
+      RequestOrResponse request = requestResponseHelper.getDecodedRequest(networkRequest);
       Response response = requestResponseHelper.createErrorResponse(request, ServerErrorCode.Retry_After_Backoff);
       if (isExpired) {
         http2ServerMetrics.requestResponseChannelDroppedOnExpiryCount.inc();

--- a/ambry-network/src/main/java/com/github/ambry/network/ServerRequestResponseHelper.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/ServerRequestResponseHelper.java
@@ -21,10 +21,14 @@ import com.github.ambry.protocol.DeleteRequest;
 import com.github.ambry.protocol.DeleteResponse;
 import com.github.ambry.protocol.GetRequest;
 import com.github.ambry.protocol.GetResponse;
+import com.github.ambry.protocol.PurgeRequest;
+import com.github.ambry.protocol.PurgeResponse;
 import com.github.ambry.protocol.PutRequest;
 import com.github.ambry.protocol.PutResponse;
 import com.github.ambry.protocol.ReplicaMetadataRequest;
 import com.github.ambry.protocol.ReplicaMetadataResponse;
+import com.github.ambry.protocol.ReplicateBlobRequest;
+import com.github.ambry.protocol.ReplicateBlobResponse;
 import com.github.ambry.protocol.RequestOrResponse;
 import com.github.ambry.protocol.RequestOrResponseType;
 import com.github.ambry.protocol.Response;
@@ -86,6 +90,12 @@ public class ServerRequestResponseHelper {
         case AdminRequest:
           request = AdminRequest.readFrom(dis, clusterMap);
           break;
+        case ReplicateBlobRequest:
+          request = ReplicateBlobRequest.readFrom(dis, clusterMap);
+          break;
+        case PurgeRequest:
+          request = PurgeRequest.readFrom(dis, clusterMap);
+          break;
         default:
           throw new UnsupportedOperationException("Request type not supported");
       }
@@ -136,6 +146,12 @@ public class ServerRequestResponseHelper {
         break;
       case AdminRequest:
         response = new AdminResponse(request.getCorrelationId(), request.getClientId(), serverErrorCode);
+        break;
+      case ReplicateBlobRequest:
+        response = new ReplicateBlobResponse(request.getCorrelationId(), request.getClientId(), serverErrorCode);
+        break;
+      case PurgeRequest:
+        response = new PurgeResponse(request.getCorrelationId(), request.getClientId(), serverErrorCode);
         break;
       default:
         throw new UnsupportedOperationException("Request type not supported");


### PR DESCRIPTION
Catch exception in `NettyRequestResponseChannel.rejectRequests` so that it is not propagated to request handler threads and cause server shutdown