### PR TITLE
Add more unit tests for reject requests

### DIFF
--- a/ambry-network/src/test/java/com/github/ambry/network/NettyServerRequestResponseChannelTest.java
+++ b/ambry-network/src/test/java/com/github/ambry/network/NettyServerRequestResponseChannelTest.java
@@ -14,19 +14,37 @@
 package com.github.ambry.network;
 
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.clustermap.MockClusterMap;
+import com.github.ambry.commons.BlobId;
+import com.github.ambry.commons.CommonTestUtils;
 import com.github.ambry.commons.ServerMetrics;
 import com.github.ambry.config.NetworkConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.network.http2.Http2ServerMetrics;
+import com.github.ambry.protocol.DeleteRequest;
+import com.github.ambry.protocol.DeleteResponse;
+import com.github.ambry.protocol.RequestOrResponse;
+import com.github.ambry.protocol.RequestOrResponseType;
+import com.github.ambry.server.ServerErrorCode;
+import com.github.ambry.utils.ByteBufferChannel;
 import com.github.ambry.utils.MockTime;
 import com.github.ambry.utils.TestUtils;
+import com.github.ambry.utils.Utils;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
 import java.util.Properties;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 
@@ -37,6 +55,37 @@ public class NettyServerRequestResponseChannelTest {
   private final static int TIMEOUT = 500;
   private final static int CAPACITY = 2;
 
+  /**
+   * Test send and receive requests
+   * @throws Exception
+   */
+  @Test
+  public void testSendAndReceiveRequest() throws Exception {
+    Properties properties = new Properties();
+    RequestResponseChannel channel =
+        new NettyServerRequestResponseChannel(new NetworkConfig(new VerifiableProperties(properties)),
+            new Http2ServerMetrics(new MetricRegistry()), new ServerMetrics(new MetricRegistry(), this.getClass()),
+            null);
+
+    channel.sendRequest(createNettyServerRequest(13));
+    NetworkRequest request = channel.receiveRequest();
+    Assert.assertTrue(request instanceof NettyServerRequest);
+    assertEquals(13, ((NettyServerRequest) request).content().readableBytes());
+
+    channel.sendRequest(createEmptyNettyServerRequest());
+    channel.sendRequest(createNettyServerRequest(19));
+    channel.sendRequest(createNettyServerRequest(23));
+    request = channel.receiveRequest();
+    Assert.assertTrue(request instanceof NettyServerRequest);
+    assertEquals(0, ((NettyServerRequest) request).content().readableBytes());
+    request = channel.receiveRequest();
+    Assert.assertTrue(request instanceof NettyServerRequest);
+    assertEquals(19, ((NettyServerRequest) request).content().readableBytes());
+    request = channel.receiveRequest();
+    Assert.assertTrue(request instanceof NettyServerRequest);
+    assertEquals(23, ((NettyServerRequest) request).content().readableBytes());
+  }
+
   @Test
   public void testNoRejectRequests() throws InterruptedException {
     Properties properties = new Properties();
@@ -45,15 +94,14 @@ public class NettyServerRequestResponseChannelTest {
         spy(new NettyServerRequestResponseChannel(new NetworkConfig(new VerifiableProperties(properties)),
             new Http2ServerMetrics(new MetricRegistry()), new ServerMetrics(new MetricRegistry(), this.getClass()),
             null));
-    // Fill up channel
     channel.sendRequest(createNettyServerRequest(1));
     channel.sendRequest(createNettyServerRequest(1));
-    // Verify rejectRequest() is not invoked
+    // 1. Verify rejectRequest() is not invoked
     verify(channel, never()).rejectRequest(any(), anyBoolean());
   }
 
   @Test
-  public void testRejectRequests() throws InterruptedException {
+  public void testRejectRequestsOnOverFlow() throws InterruptedException {
     Properties properties = new Properties();
     properties.setProperty(NetworkConfig.REQUEST_QUEUE_CAPACITY, "2");
     ServerRequestResponseHelper requestResponseHelper = mock(ServerRequestResponseHelper.class);
@@ -62,34 +110,12 @@ public class NettyServerRequestResponseChannelTest {
             new Http2ServerMetrics(new MetricRegistry()), new ServerMetrics(new MetricRegistry(), this.getClass()),
             requestResponseHelper));
     doNothing().when(channel).rejectRequest(any(), anyBoolean());
-    // Fill up channel
     channel.sendRequest(createNettyServerRequest(1));
     channel.sendRequest(createNettyServerRequest(1));
-    // Add overflow
-    channel.sendRequest(createNettyServerRequest(1));
-    // Verify rejectRequest() is invoked
-    verify(channel, atLeastOnce()).rejectRequest(any(), anyBoolean());
-  }
-
-  @Test
-  public void testRejectRequestsWithException() throws IOException, InterruptedException {
-    Properties properties = new Properties();
-    properties.setProperty(NetworkConfig.REQUEST_QUEUE_CAPACITY, "2");
-    ServerRequestResponseHelper requestResponseHelper = mock(ServerRequestResponseHelper.class);
-    NettyServerRequestResponseChannel channel =
-        spy(new NettyServerRequestResponseChannel(new NetworkConfig(new VerifiableProperties(properties)),
-            new Http2ServerMetrics(new MetricRegistry()), new ServerMetrics(new MetricRegistry(), this.getClass()),
-            requestResponseHelper));
-    when(requestResponseHelper.getDecodedRequest(any())).thenThrow(
-        new UnsupportedOperationException("Request type not supported"));
-    // Fill up channel
-    channel.sendRequest(createNettyServerRequest(1));
-    channel.sendRequest(createNettyServerRequest(1));
-    channel.sendRequest(createNettyServerRequest(1));
-    // Verify rejectRequest() is invoked for last request
-    verify(channel, times(1)).rejectRequest(any(), anyBoolean());
-    // Verify close connection is invoked due to exception
-    verify(channel, times(1)).closeConnection(any());
+    // 1. Verify rejectRequest() is invoked for last request
+    NettyServerRequest overFlowRequest = createNettyServerRequest(1);
+    channel.sendRequest(overFlowRequest);
+    verify(channel, times(1)).rejectRequest(eq(overFlowRequest), eq(false));
   }
 
   @Test
@@ -101,46 +127,117 @@ public class NettyServerRequestResponseChannelTest {
         spy(new NettyServerRequestResponseChannel(new Http2ServerMetrics(new MetricRegistry()),
             new ServerMetrics(new MetricRegistry(), this.getClass()), requestResponseHelper, requestQueue));
     doNothing().when(channel).rejectRequest(any(), anyBoolean());
-    // 1. Queue 2 requests with a sleep between them so that 1st request expires
-    NettyServerRequest expiredRequest = createNettyServerRequest(1, mockTime.milliseconds());
+    // Queue 2 requests with a sleep between them so that 1st request expires
+    NettyServerRequest expiredRequest = createNettyServerRequest(mockTime.milliseconds());
     channel.sendRequest(expiredRequest);
     mockTime.sleep(TIMEOUT + 1);
-    channel.sendRequest(createNettyServerRequest(1, mockTime.milliseconds()));
-    channel.receiveRequest();
-    // 2. Verify rejectRequest() is invoked inside receiveRequest() since request is expired
+    NettyServerRequest validRequest = createNettyServerRequest(mockTime.milliseconds());
+    channel.sendRequest(validRequest);
+    // 1. Verify received request is 2nd request
+    NetworkRequest receiveRequest = channel.receiveRequest();
+    assertEquals("Mismatch in request dequeued", validRequest, receiveRequest);
+    // 2. Verify rejectRequest() is invoked with 1st request
     verify(channel, times(1)).rejectRequest(eq(expiredRequest), eq(true));
   }
 
-  /**
-   * Test send and receive requests
-   * @throws Exception
-   */
   @Test
-  public void testSendAndReceiveRequest() throws Exception {
-
+  public void testRejectRequestsOnOverFlowWithException() throws IOException, InterruptedException {
     Properties properties = new Properties();
-    RequestResponseChannel channel =
-        new NettyServerRequestResponseChannel(new NetworkConfig(new VerifiableProperties(properties)),
+    properties.setProperty(NetworkConfig.REQUEST_QUEUE_CAPACITY, "2");
+    ServerRequestResponseHelper requestResponseHelper = mock(ServerRequestResponseHelper.class);
+    NettyServerRequestResponseChannel channel =
+        spy(new NettyServerRequestResponseChannel(new NetworkConfig(new VerifiableProperties(properties)),
             new Http2ServerMetrics(new MetricRegistry()), new ServerMetrics(new MetricRegistry(), this.getClass()),
-            null);
+            requestResponseHelper));
+    doNothing().when(channel).sendResponse(any(), any(), any());
+    when(requestResponseHelper.getDecodedRequest(any())).thenThrow(
+        new UnsupportedOperationException("Request type not supported"));
+    try {
+      channel.sendRequest(createNettyServerRequest(1));
+      channel.sendRequest(createNettyServerRequest(1));
+      // 1. Verify rejectRequest() is invoked for last request
+      NettyServerRequest overFlowRequest = createNettyServerRequest(1);
+      channel.sendRequest(overFlowRequest);
+      verify(channel, times(1)).rejectRequest(eq(overFlowRequest), eq(false));
+      // 2. Verify close connection is invoked due to exception thrown and caught inside rejectRequest()
+      verify(channel, times(1)).closeConnection(any());
+    } catch (Exception e) {
+      fail("Should not have thrown any exception");
+    }
+  }
 
-    channel.sendRequest(createNettyServerRequest(13));
-    NetworkRequest request = channel.receiveRequest();
-    Assert.assertTrue(request instanceof NettyServerRequest);
-    Assert.assertEquals(13, ((NettyServerRequest) request).content().readableBytes());
+  @Test
+  public void testRejectRequestsOnExpiryWithException() throws IOException, InterruptedException {
+    ServerRequestResponseHelper requestResponseHelper = mock(ServerRequestResponseHelper.class);
+    MockTime mockTime = new MockTime();
+    FifoNetworkRequestQueue requestQueue = new FifoNetworkRequestQueue(TIMEOUT, mockTime, CAPACITY);
+    NettyServerRequestResponseChannel channel =
+        spy(new NettyServerRequestResponseChannel(new Http2ServerMetrics(new MetricRegistry()),
+            new ServerMetrics(new MetricRegistry(), this.getClass()), requestResponseHelper, requestQueue));
+    doNothing().when(channel).sendResponse(any(), any(), any());
+    when(requestResponseHelper.getDecodedRequest(any())).thenThrow(
+        new UnsupportedOperationException("Request type not supported"));
+    try {
+      // Queue 2 requests with a sleep between them so that 1st request expires
+      NettyServerRequest expiredRequest = createNettyServerRequest(mockTime.milliseconds());
+      channel.sendRequest(expiredRequest);
+      mockTime.sleep(TIMEOUT + 1);
+      NettyServerRequest validRequest = createNettyServerRequest(mockTime.milliseconds());
+      channel.sendRequest(validRequest);
+      // 1. Verify received request is 2nd request
+      NetworkRequest receiveRequest = channel.receiveRequest();
+      assertEquals("Mismatch in request dequeued", validRequest, receiveRequest);
+      // 2. Verify rejectRequest() is invoked with 1st request
+      verify(channel, times(1)).rejectRequest(eq(expiredRequest), eq(true));
+      // Verify close connection is invoked due to exception thrown and caught in rejectRequests()
+      verify(channel, times(1)).closeConnection(any());
+    } catch (Exception e) {
+      fail("Should not have thrown any exception");
+    }
+  }
 
-    channel.sendRequest(createEmptyNettyServerRequest());
-    channel.sendRequest(createNettyServerRequest(19));
-    channel.sendRequest(createNettyServerRequest(23));
-    request = channel.receiveRequest();
-    Assert.assertTrue(request instanceof NettyServerRequest);
-    Assert.assertEquals(0, ((NettyServerRequest) request).content().readableBytes());
-    request = channel.receiveRequest();
-    Assert.assertTrue(request instanceof NettyServerRequest);
-    Assert.assertEquals(19, ((NettyServerRequest) request).content().readableBytes());
-    request = channel.receiveRequest();
-    Assert.assertTrue(request instanceof NettyServerRequest);
-    Assert.assertEquals(23, ((NettyServerRequest) request).content().readableBytes());
+  @Test
+  public void testRejectRequestErrorCode() throws IOException, InterruptedException {
+    // Create a delete network request
+    MockClusterMap clusterMap = new MockClusterMap();
+    short accountId = Utils.getRandomShort(TestUtils.RANDOM);
+    short containerId = Utils.getRandomShort(TestUtils.RANDOM);
+    BlobId id1 = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
+        ClusterMap.UNKNOWN_DATACENTER_ID, accountId, containerId,
+        clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false,
+        BlobId.BlobDataType.DATACHUNK);
+    long deletionTimeMs = Utils.getRandomLong(TestUtils.RANDOM, Long.MAX_VALUE);
+    int correlationId = TestUtils.RANDOM.nextInt();
+    String clientId = "clientId";
+    DeleteRequest deleteRequest;
+    deleteRequest = new DeleteRequest(correlationId, clientId, id1, deletionTimeMs);
+    DataInputStream requestStream = serAndPrepForRead(deleteRequest);
+    MockRequest mockRequest = new MockRequest(requestStream);
+
+    // Create NettyServerRequestResponseChannel
+    ServerRequestResponseHelper requestResponseHelper = new ServerRequestResponseHelper(clusterMap, null);
+    Properties properties = new Properties();
+    properties.setProperty(NetworkConfig.REQUEST_QUEUE_CAPACITY, "2");
+    NettyServerRequestResponseChannel channel =
+        spy(new NettyServerRequestResponseChannel(new NetworkConfig(new VerifiableProperties(properties)),
+            new Http2ServerMetrics(new MetricRegistry()), new ServerMetrics(new MetricRegistry(), this.getClass()),
+            requestResponseHelper));
+    doNothing().when(channel).sendResponse(any(), any(), any());
+
+    channel.sendRequest(createNettyServerRequest(1));
+    channel.sendRequest(createNettyServerRequest(1));
+    channel.sendRequest(mockRequest);
+    // 1.Verify rejectRequest() is invoked
+    verify(channel, times(1)).rejectRequest(eq(mockRequest), eq(false));
+    // 2. Verify send response is called
+    ArgumentCaptor<DeleteResponse> argument = ArgumentCaptor.forClass(DeleteResponse.class);
+    verify(channel, atLeastOnce()).sendResponse(argument.capture(), any(), any());
+    // 3. Verify error code is correct
+    assertEquals("Mismatch in response type", argument.getValue().getRequestType(),
+        RequestOrResponseType.DeleteResponse);
+    assertEquals("Mismatch in response correlation id", argument.getValue().getCorrelationId(), correlationId);
+    assertEquals("Mismatch in response client id", argument.getValue().getClientId(), clientId);
+    assertEquals("Mismatch in error code", argument.getValue().getError(), ServerErrorCode.Retry_After_Backoff);
   }
 
   private NettyServerRequest createNettyServerRequest(int len) {
@@ -150,8 +247,8 @@ public class NettyServerRequestResponseChannelTest {
     return new NettyServerRequest(null, content);
   }
 
-  private NettyServerRequest createNettyServerRequest(int len, long creationTime) {
-    byte[] array = new byte[len];
+  private NettyServerRequest createNettyServerRequest(long creationTime) {
+    byte[] array = new byte[1];
     TestUtils.RANDOM.nextBytes(array);
     ByteBuf content = Unpooled.wrappedBuffer(array);
     return new NettyServerRequest(null, content, creationTime);
@@ -161,5 +258,43 @@ public class NettyServerRequestResponseChannelTest {
     byte[] array = new byte[0];
     ByteBuf content = Unpooled.wrappedBuffer(array);
     return new NettyServerRequest(null, content);
+  }
+
+  private DataInputStream serAndPrepForRead(RequestOrResponse requestOrResponse) throws IOException {
+    DataInputStream stream;
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    do {
+      ByteBufferChannel channel = new ByteBufferChannel(ByteBuffer.allocate((int) requestOrResponse.sizeInBytes()));
+      requestOrResponse.writeTo(channel);
+      ByteBuffer underlyingBuf = channel.getBuffer();
+      underlyingBuf.flip();
+      outputStream.write(underlyingBuf.array(), underlyingBuf.arrayOffset(), underlyingBuf.remaining());
+    } while (!requestOrResponse.isSendComplete());
+    stream = new DataInputStream(new ByteArrayInputStream(outputStream.toByteArray()));
+    // read length
+    stream.readLong();
+    return stream;
+  }
+
+  /**
+   * Implementation of {@link NetworkRequest} to help with tests.
+   */
+  private static class MockRequest implements NetworkRequest {
+
+    private final InputStream stream;
+
+    public MockRequest(InputStream stream) {
+      this.stream = stream;
+    }
+
+    @Override
+    public InputStream getInputStream() {
+      return stream;
+    }
+
+    @Override
+    public long getStartTimeInMs() {
+      return 0;
+    }
   }
 }

--- a/ambry-network/src/test/java/com/github/ambry/network/ServerRequestResponseHelperTest.java
+++ b/ambry-network/src/test/java/com/github/ambry/network/ServerRequestResponseHelperTest.java
@@ -1,0 +1,275 @@
+/**
+ * Copyright 2023 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package com.github.ambry.network;
+
+import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.clustermap.MockClusterMap;
+import com.github.ambry.clustermap.MockPartitionId;
+import com.github.ambry.clustermap.PartitionId;
+import com.github.ambry.commons.BlobId;
+import com.github.ambry.commons.CommonTestUtils;
+import com.github.ambry.messageformat.BlobProperties;
+import com.github.ambry.messageformat.BlobType;
+import com.github.ambry.messageformat.MessageFormatFlags;
+import com.github.ambry.protocol.AdminRequest;
+import com.github.ambry.protocol.AdminRequestOrResponseType;
+import com.github.ambry.protocol.DeleteRequest;
+import com.github.ambry.protocol.GetOption;
+import com.github.ambry.protocol.GetRequest;
+import com.github.ambry.protocol.PartitionRequestInfo;
+import com.github.ambry.protocol.PutRequest;
+import com.github.ambry.protocol.ReplicateBlobRequest;
+import com.github.ambry.protocol.RequestOrResponse;
+import com.github.ambry.protocol.RequestOrResponseType;
+import com.github.ambry.protocol.Response;
+import com.github.ambry.protocol.TtlUpdateRequest;
+import com.github.ambry.protocol.UndeleteRequest;
+import com.github.ambry.server.ServerErrorCode;
+import com.github.ambry.utils.ByteBufferChannel;
+import com.github.ambry.utils.TestUtils;
+import com.github.ambry.utils.Utils;
+import io.netty.buffer.Unpooled;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+public class ServerRequestResponseHelperTest {
+
+  MockClusterMap clusterMap;
+  private final ServerRequestResponseHelper requestResponseHelper;
+  String clientId = "client";
+  int correlationId = TestUtils.RANDOM.nextInt();
+  BlobId blobId;
+
+  public ServerRequestResponseHelperTest() throws IOException {
+    clusterMap = new MockClusterMap();
+    requestResponseHelper = new ServerRequestResponseHelper(clusterMap, null);
+    blobId = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
+        ClusterMap.UNKNOWN_DATACENTER_ID, (short) 1, (short) 1,
+        clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false,
+        BlobId.BlobDataType.DATACHUNK);
+  }
+
+  @Test
+  public void putRequestResponseTest() throws IOException {
+    byte[] userMetadata = new byte[50];
+    TestUtils.RANDOM.nextBytes(userMetadata);
+    int blobKeyLength = TestUtils.RANDOM.nextInt(4096);
+    byte[] blobKey = new byte[blobKeyLength];
+    TestUtils.RANDOM.nextBytes(blobKey);
+    int blobSize = 100;
+    byte[] blob = new byte[blobSize];
+    TestUtils.RANDOM.nextBytes(blob);
+    BlobProperties blobProperties =
+        new BlobProperties(blobSize, "serviceID", "memberId", "contentType", false, Utils.Infinite_Time,
+            Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM),
+            TestUtils.RANDOM.nextBoolean(), null, null, null);
+    PutRequest putRequest =
+        new PutRequest(correlationId, clientId, blobId, blobProperties, ByteBuffer.wrap(userMetadata),
+            Unpooled.wrappedBuffer(blob), blobSize, BlobType.DataBlob, null);
+    DataInputStream requestStream = serAndPrepForRead(putRequest);
+    MockRequest mockRequest = new MockRequest(requestStream);
+    // 1. Verify request is decoded correctly
+    RequestOrResponse request = requestResponseHelper.getDecodedRequest(mockRequest);
+    assertEquals("Mismatch in request type", request.getRequestType(), RequestOrResponseType.PutRequest);
+    // 2. Verify response is formed correctly
+    Response response = requestResponseHelper.createErrorResponse(request, ServerErrorCode.Retry_After_Backoff);
+    assertEquals("Mismatch in response type", response.getRequestType(), RequestOrResponseType.PutResponse);
+    assertEquals("Mismatch in response correlation id", response.getCorrelationId(), correlationId);
+    assertEquals("Mismatch in response client id", response.getClientId(), clientId);
+    assertEquals("Mismatch in error code", response.getError(), ServerErrorCode.Retry_After_Backoff);
+    request.release();
+    response.release();
+  }
+
+  @Test
+  public void getRequestResponseTest() throws IOException {
+    PartitionRequestInfo partitionRequestInfo =
+        new PartitionRequestInfo(new MockPartitionId(), Collections.singletonList(blobId));
+    GetRequest getRequest = new GetRequest(correlationId, clientId, MessageFormatFlags.Blob,
+        Collections.singletonList(partitionRequestInfo), GetOption.None);
+    DataInputStream requestStream = serAndPrepForRead(getRequest);
+    MockRequest mockRequest = new MockRequest(requestStream);
+    // 1. Verify request is decoded correctly
+    RequestOrResponse request = requestResponseHelper.getDecodedRequest(mockRequest);
+    assertEquals("Mismatch in request type", request.getRequestType(), RequestOrResponseType.GetRequest);
+    // 2. Verify response is formed correctly
+    Response response = requestResponseHelper.createErrorResponse(request, ServerErrorCode.Retry_After_Backoff);
+    assertEquals("Mismatch in response type", response.getRequestType(), RequestOrResponseType.GetResponse);
+    assertEquals("Mismatch in response correlation id", response.getCorrelationId(), correlationId);
+    assertEquals("Mismatch in response client id", response.getClientId(), clientId);
+    assertEquals("Mismatch in error code", response.getError(), ServerErrorCode.Retry_After_Backoff);
+    request.release();
+    response.release();
+  }
+
+  @Test
+  public void ttlUpdateRequestResponseTest() throws IOException {
+    TtlUpdateRequest ttlUpdateRequest =
+        new TtlUpdateRequest(correlationId, clientId, blobId, System.currentTimeMillis() + 1000,
+            System.currentTimeMillis(), (short) 1);
+    DataInputStream requestStream = serAndPrepForRead(ttlUpdateRequest);
+    MockRequest mockRequest = new MockRequest(requestStream);
+    // 1. Verify request is decoded correctly
+    RequestOrResponse request = requestResponseHelper.getDecodedRequest(mockRequest);
+    assertEquals("Mismatch in request type", request.getRequestType(), RequestOrResponseType.TtlUpdateRequest);
+    // 2. Verify response is formed correctly
+    Response response = requestResponseHelper.createErrorResponse(request, ServerErrorCode.Retry_After_Backoff);
+    assertEquals("Mismatch in response type", response.getRequestType(), RequestOrResponseType.TtlUpdateResponse);
+    assertEquals("Mismatch in response correlation id", response.getCorrelationId(), correlationId);
+    assertEquals("Mismatch in response client id", response.getClientId(), clientId);
+    assertEquals("Mismatch in error code", response.getError(), ServerErrorCode.Retry_After_Backoff);
+    request.release();
+    response.release();
+  }
+
+  @Test
+  public void deleteRequestResponseTest() throws IOException {
+    DeleteRequest deleteRequest = new DeleteRequest(correlationId, clientId, blobId, System.currentTimeMillis());
+    DataInputStream requestStream = serAndPrepForRead(deleteRequest);
+    MockRequest mockRequest = new MockRequest(requestStream);
+    // 1. Verify request is decoded correctly
+    RequestOrResponse request = requestResponseHelper.getDecodedRequest(mockRequest);
+    assertEquals("Mismatch in request type", request.getRequestType(), RequestOrResponseType.DeleteRequest);
+    // 2. Verify response is formed correctly
+    Response response = requestResponseHelper.createErrorResponse(request, ServerErrorCode.Retry_After_Backoff);
+    assertEquals("Mismatch in response type", response.getRequestType(), RequestOrResponseType.DeleteResponse);
+    assertEquals("Mismatch in response correlation id", response.getCorrelationId(), correlationId);
+    assertEquals("Mismatch in response client id", response.getClientId(), clientId);
+    assertEquals("Mismatch in error code", response.getError(), ServerErrorCode.Retry_After_Backoff);
+    request.release();
+    response.release();
+  }
+
+  /**
+   * Test for undelete request and response.
+   * @throws IOException
+   */
+  @Test
+  public void undeleteRequestResponseTest() throws IOException {
+    UndeleteRequest undeleteRequest = new UndeleteRequest(correlationId, clientId, blobId, System.currentTimeMillis());
+    DataInputStream requestStream = serAndPrepForRead(undeleteRequest);
+    MockRequest mockRequest = new MockRequest(requestStream);
+    // 1. Verify request is decoded correctly
+    RequestOrResponse request = requestResponseHelper.getDecodedRequest(mockRequest);
+    assertEquals("Mismatch in request type", request.getRequestType(), RequestOrResponseType.UndeleteRequest);
+    // 2. Verify response is formed correctly
+    Response response = requestResponseHelper.createErrorResponse(request, ServerErrorCode.Retry_After_Backoff);
+    assertEquals("Mismatch in response type", response.getRequestType(), RequestOrResponseType.UndeleteResponse);
+    assertEquals("Mismatch in response correlation id", response.getCorrelationId(), correlationId);
+    assertEquals("Mismatch in response client id", response.getClientId(), clientId);
+    assertEquals("Mismatch in error code", response.getError(), ServerErrorCode.Retry_After_Backoff);
+    request.release();
+    response.release();
+  }
+
+  @Test
+  public void adminRequestResponseTest() throws IOException {
+    for (AdminRequestOrResponseType type : AdminRequestOrResponseType.values()) {
+      PartitionId id = clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0);
+      // with a valid partition id
+      AdminRequest adminRequest = new AdminRequest(type, id, correlationId, clientId);
+      DataInputStream requestStream = serAndPrepForRead(adminRequest);
+      MockRequest mockRequest = new MockRequest(requestStream);
+      // 1. Verify request is decoded correctly
+      RequestOrResponse request = requestResponseHelper.getDecodedRequest(mockRequest);
+      assertEquals("Mismatch in request type", request.getRequestType(), RequestOrResponseType.AdminRequest);
+      // 2. Verify response is formed correctly
+      Response response = requestResponseHelper.createErrorResponse(request, ServerErrorCode.Retry_After_Backoff);
+      assertEquals("Mismatch in response type", response.getRequestType(), RequestOrResponseType.AdminResponse);
+      assertEquals("Mismatch in response correlation id", response.getCorrelationId(), correlationId);
+      assertEquals("Mismatch in response client id", response.getClientId(), clientId);
+      assertEquals("Mismatch in error code", response.getError(), ServerErrorCode.Retry_After_Backoff);
+      request.release();
+      response.release();
+    }
+  }
+
+  @Test
+  public void replicateBlobRequestResponseTest() throws IOException {
+    RequestOrResponseType operationType =
+        RequestOrResponseType.values()[Utils.getRandomShort(TestUtils.RANDOM) % RequestOrResponseType.values().length];
+    short[] versions = new short[]{ReplicateBlobRequest.VERSION_1, ReplicateBlobRequest.VERSION_2};
+    for (short version : versions) {
+      final ReplicateBlobRequest replicateBlobRequest;
+      if (version == ReplicateBlobRequest.VERSION_1) {
+        replicateBlobRequest = new ReplicateBlobRequest(correlationId, clientId, blobId, "datacenter1_host1", 15058);
+      } else {
+        replicateBlobRequest =
+            new ReplicateBlobRequest(correlationId, clientId, blobId, "datacenter1_host1", 15058, operationType,
+                System.currentTimeMillis(), (short) 1, 1L);
+      }
+      DataInputStream requestStream = serAndPrepForRead(replicateBlobRequest);
+      MockRequest mockRequest = new MockRequest(requestStream);
+      // 1. Verify request is decoded correctly
+      RequestOrResponse request = requestResponseHelper.getDecodedRequest(mockRequest);
+      assertEquals("Mismatch in request type", request.getRequestType(), RequestOrResponseType.ReplicateBlobRequest);
+      // 2. Verify response is formed correctly
+      Response response = requestResponseHelper.createErrorResponse(request, ServerErrorCode.Retry_After_Backoff);
+      assertEquals("Mismatch in response type", response.getRequestType(), RequestOrResponseType.ReplicateBlobResponse);
+      assertEquals("Mismatch in response correlation id", response.getCorrelationId(), correlationId);
+      assertEquals("Mismatch in response client id", response.getClientId(), clientId);
+      assertEquals("Mismatch in error code", response.getError(), ServerErrorCode.Retry_After_Backoff);
+      request.release();
+      response.release();
+    }
+  }
+
+  private DataInputStream serAndPrepForRead(RequestOrResponse requestOrResponse) throws IOException {
+    DataInputStream stream;
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    do {
+      ByteBufferChannel channel = new ByteBufferChannel(ByteBuffer.allocate((int) requestOrResponse.sizeInBytes()));
+      requestOrResponse.writeTo(channel);
+      ByteBuffer underlyingBuf = channel.getBuffer();
+      underlyingBuf.flip();
+      outputStream.write(underlyingBuf.array(), underlyingBuf.arrayOffset(), underlyingBuf.remaining());
+    } while (!requestOrResponse.isSendComplete());
+    stream = new DataInputStream(new ByteArrayInputStream(outputStream.toByteArray()));
+    // read length
+    stream.readLong();
+    return stream;
+  }
+
+  /**
+   * Implementation of {@link NetworkRequest} to help with tests.
+   */
+  private static class MockRequest implements NetworkRequest {
+
+    private final InputStream stream;
+
+    public MockRequest(InputStream stream) {
+      this.stream = stream;
+    }
+
+    @Override
+    public InputStream getInputStream() {
+      return stream;
+    }
+
+    @Override
+    public long getStartTimeInMs() {
+      return 0;
+    }
+  }
+}

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/TtlUpdateRequest.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/TtlUpdateRequest.java
@@ -72,7 +72,7 @@ public class TtlUpdateRequest extends RequestOrResponse {
    * @param operationTimeMs the time of the operation (in ms)
    * @param version the version of the TtlUpdateRequest
    */
-  TtlUpdateRequest(int correlationId, String clientId, BlobId blobId, long expiresAtMs, long operationTimeMs,
+  public TtlUpdateRequest(int correlationId, String clientId, BlobId blobId, long expiresAtMs, long operationTimeMs,
       short version) {
     super(TtlUpdateRequest, version, correlationId, clientId);
     this.blobId = blobId;


### PR DESCRIPTION
Adding more unit tests for `NettyServerRequestResponseChannel` and `ServerRequestResponseHelper` classes.