### PR TITLE
Adding more logs and metrics and make transactionIsolationLevel tunable

### DIFF
--- a/ambry-account/src/main/java/com/github/ambry/account/mysql/MySqlAccountStore.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/mysql/MySqlAccountStore.java
@@ -50,7 +50,7 @@ public class MySqlAccountStore {
    */
   public MySqlAccountStore(List<MySqlUtils.DbEndpoint> dbEndpoints, String localDatacenter, MySqlMetrics metrics,
       MySqlAccountServiceConfig config) throws SQLException {
-    mySqlDataAccessor = new MySqlDataAccessor(dbEndpoints, localDatacenter, metrics);
+    mySqlDataAccessor = new MySqlDataAccessor(dbEndpoints, localDatacenter, metrics, config);
     accountDao = new AccountDao(mySqlDataAccessor);
     datasetDao = new DatasetDao(mySqlDataAccessor, config, metrics);
     this.config = config;

--- a/ambry-api/src/main/java/com/github/ambry/config/MySqlAccountServiceConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/MySqlAccountServiceConfig.java
@@ -13,6 +13,10 @@
  */
 package com.github.ambry.config;
 
+import com.github.ambry.named.TransactionIsolationLevel;
+
+
+
 /**
  * Configs for MySqlAccountService
  */
@@ -36,6 +40,7 @@ public class MySqlAccountServiceConfig extends AccountServiceConfig {
   public static final String LIST_DATASETS_MAX_RESULT = MYSQL_ACCOUNT_SERVICE_PREFIX + "list.datasets.max.results";
   public static final String LIST_DATASET_VERSIONS_MAX_RESULT =
       MYSQL_ACCOUNT_SERVICE_PREFIX + "list.dataset.versions.max.result";
+  public static final String TRANSACTION_ISOLATION_LEVEL = MYSQL_ACCOUNT_SERVICE_PREFIX + "transaction.isolation.level";
 
   /**
    * Serialized json array containing the information about all mysql end points.
@@ -160,6 +165,13 @@ public class MySqlAccountServiceConfig extends AccountServiceConfig {
   @Default("100")
   public final int listDatasetVersionsMaxResult;
 
+  /**
+   * Transaction isolation level to be set on DB Connection. When nothing is set, default MySQL DB transaction level
+   * (REPEATABLE_READ) will take effect.
+   */
+  @Config(TRANSACTION_ISOLATION_LEVEL)
+  public final TransactionIsolationLevel transactionIsolationLevel;
+
   public MySqlAccountServiceConfig(VerifiableProperties verifiableProperties) {
     super(verifiableProperties);
     dbInfo = verifiableProperties.getString(DB_INFO);
@@ -178,6 +190,10 @@ public class MySqlAccountServiceConfig extends AccountServiceConfig {
     maxMajorVersionForSemanticSchemaDataset =
         verifiableProperties.getIntInRange(MAX_MAJOR_VERSION_FOR_SEMANTIC_SCHEMA_DATASET, 999, 1, Integer.MAX_VALUE);
     listDatasetsMaxResult = verifiableProperties.getIntInRange(LIST_DATASETS_MAX_RESULT, 100, 1, Integer.MAX_VALUE);
-    listDatasetVersionsMaxResult = verifiableProperties.getIntInRange(LIST_DATASET_VERSIONS_MAX_RESULT, 100, 1, Integer.MAX_VALUE);
+    listDatasetVersionsMaxResult =
+        verifiableProperties.getIntInRange(LIST_DATASET_VERSIONS_MAX_RESULT, 100, 1, Integer.MAX_VALUE);
+    this.transactionIsolationLevel =
+        verifiableProperties.getEnum(TRANSACTION_ISOLATION_LEVEL, TransactionIsolationLevel.class,
+            TransactionIsolationLevel.TRANSACTION_NONE);
   }
 }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/AccountAndContainerInjector.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/AccountAndContainerInjector.java
@@ -448,7 +448,7 @@ public class AccountAndContainerInjector {
         frontendMetrics.unrecognizedDatasetNameCount.inc();
         logger.error(
             "Dataset get failed for accountName " + accountName + " containerName " + containerName + " datasetName "
-                + datasetName);
+                + datasetName, e);
         throw new RestServiceException(e.getMessage(), RestServiceErrorCode.getRestServiceErrorCode(e.getErrorCode()));
       }
     }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/DeleteBlobHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/DeleteBlobHandler.java
@@ -231,7 +231,7 @@ public class DeleteBlobHandler {
       } catch (AccountServiceException ex) {
         LOGGER.error(
             "Failed to delete dataset version for accountName: " + accountName + " containerName: " + containerName
-                + " datasetName: " + datasetName + " version: " + version);
+                + " datasetName: " + datasetName + " version: " + version, ex);
         throw new RestServiceException(ex.getMessage(),
             RestServiceErrorCode.getRestServiceErrorCode(ex.getErrorCode()));
       }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/DeleteDatasetHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/DeleteDatasetHandler.java
@@ -167,7 +167,7 @@ public class DeleteDatasetHandler {
       } catch (AccountServiceException ex) {
         LOGGER.error(
             "Dataset get failed for accountName " + accountName + " containerName " + containerName + " datasetName "
-                + datasetName);
+                + datasetName, ex);
         throw new RestServiceException(ex.getMessage(),
             RestServiceErrorCode.getRestServiceErrorCode(ex.getErrorCode()));
       }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendMetrics.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendMetrics.java
@@ -44,6 +44,7 @@ public class FrontendMetrics {
   public final RestRequestMetricsGroup getClusterMapSnapshotMetricsGroup;
   public final RestRequestMetricsGroup getAccountsMetricsGroup;
   public final RestRequestMetricsGroup getDatasetsMetricsGroup;
+  public final RestRequestMetricsGroup listDatasetsMetricsGroup;
   public final RestRequestMetricsGroup getStatsReportMetricsGroup;
   // HEAD
   public final RestRequestMetricsGroup headBlobMetricsGroup;
@@ -75,7 +76,7 @@ public class FrontendMetrics {
   public final AsyncOperationTracker.Metrics updateBlobTtlSecurityProcessResponseMetrics;
   // NAMED BLOB TTL
   public final AsyncOperationTracker.Metrics updateNamedBlobTtlCallbackMetrics;
-  
+
   public final AsyncOperationTracker.Metrics deleteBlobSecurityProcessRequestMetrics;
   public final AsyncOperationTracker.Metrics deleteBlobSecurityPostProcessRequestMetrics;
   public final AsyncOperationTracker.Metrics deleteBlobRouterMetrics;
@@ -121,6 +122,9 @@ public class FrontendMetrics {
 
   public final AsyncOperationTracker.Metrics getDatasetsSecurityProcessRequestMetrics;
   public final AsyncOperationTracker.Metrics getDatasetsSecurityPostProcessRequestMetrics;
+
+  public final AsyncOperationTracker.Metrics listDatasetsSecurityProcessRequestMetrics;
+  public final AsyncOperationTracker.Metrics listDatasetsSecurityPostProcessRequestMetrics;
 
   public final AsyncOperationTracker.Metrics deleteDatasetsSecurityProcessRequestMetrics;
   public final AsyncOperationTracker.Metrics deleteDatasetsSecurityPostProcessRequestMetrics;
@@ -317,6 +321,8 @@ public class FrontendMetrics {
         new RestRequestMetricsGroup(GetAccountsHandler.class, "GetAccounts", false, metricRegistry, frontendConfig);
     getDatasetsMetricsGroup =
         new RestRequestMetricsGroup(GetDatasetsHandler.class, "GetDatasets", false, metricRegistry, frontendConfig);
+    listDatasetsMetricsGroup =
+        new RestRequestMetricsGroup(GetDatasetsHandler.class, "ListDatasets", false, metricRegistry, frontendConfig);
     getStatsReportMetricsGroup =
         new RestRequestMetricsGroup(GetStatsReportHandler.class, "GetStatsReport", false, metricRegistry,
             frontendConfig);
@@ -447,6 +453,11 @@ public class FrontendMetrics {
     getDatasetsSecurityProcessRequestMetrics =
         new AsyncOperationTracker.Metrics(GetDatasetsHandler.class, "SecurityProcessRequest", metricRegistry);
     getDatasetsSecurityPostProcessRequestMetrics =
+        new AsyncOperationTracker.Metrics(GetDatasetsHandler.class, "SecurityPostProcessRequest", metricRegistry);
+
+    listDatasetsSecurityProcessRequestMetrics =
+        new AsyncOperationTracker.Metrics(GetDatasetsHandler.class, "SecurityProcessRequest", metricRegistry);
+    listDatasetsSecurityPostProcessRequestMetrics =
         new AsyncOperationTracker.Metrics(GetDatasetsHandler.class, "SecurityPostProcessRequest", metricRegistry);
 
     deleteDatasetsSecurityProcessRequestMetrics =

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/GetBlobHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/GetBlobHandler.java
@@ -353,7 +353,7 @@ public class GetBlobHandler {
       } catch (AccountServiceException ex) {
         LOGGER.error(
             "Failed to get dataset version for accountName: " + accountName + " containerName: " + containerName
-                + " datasetName: " + datasetName + " version: " + version);
+                + " datasetName: " + datasetName + " version: " + version, ex);
         throw new RestServiceException(ex.getMessage(),
             RestServiceErrorCode.getRestServiceErrorCode(ex.getErrorCode()));
       }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/GetDatasetsHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/GetDatasetsHandler.java
@@ -153,7 +153,7 @@ public class GetDatasetsHandler {
       } catch (AccountServiceException ex) {
         LOGGER.error(
             "Dataset get failed for accountName " + accountName + " containerName " + containerName + " datasetName "
-                + datasetName);
+                + datasetName, ex);
         throw new RestServiceException(ex.getMessage(),
             RestServiceErrorCode.getRestServiceErrorCode(ex.getErrorCode()));
       }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/ListDatasetsHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/ListDatasetsHandler.java
@@ -65,7 +65,7 @@ public class ListDatasetsHandler {
   void handle(RestRequest restRequest, RestResponseChannel restResponseChannel,
       Callback<ReadableStreamChannel> callback) throws RestServiceException {
     RestRequestMetrics requestMetrics =
-        frontendMetrics.getDatasetsMetricsGroup.getRestRequestMetrics(restRequest.isSslUsed(), false);
+        frontendMetrics.listDatasetsMetricsGroup.getRestRequestMetrics(restRequest.isSslUsed(), false);
     restRequest.getMetricsTracker().injectMetrics(requestMetrics);
     // get dataset request have their account/container name in request header, so checks can be done at early stage.
     accountAndContainerInjector.injectAccountAndContainerForDatasetRequest(restRequest);
@@ -103,7 +103,7 @@ public class ListDatasetsHandler {
     }
 
     private Callback<Void> securityProcessRequestCallback() {
-      return buildCallback(frontendMetrics.getDatasetsSecurityProcessRequestMetrics,
+      return buildCallback(frontendMetrics.listDatasetsSecurityProcessRequestMetrics,
           securityCheckResult -> securityService.postProcessRequest(restRequest, securityPostProcessRequestCallback()),
           uri, LOGGER, finalCallback);
     }
@@ -114,7 +114,7 @@ public class ListDatasetsHandler {
      * @return a {@link Callback} to be used with {@link SecurityService#processRequest}.
      */
     private Callback<Void> securityPostProcessRequestCallback() {
-      return buildCallback(frontendMetrics.getDatasetsSecurityPostProcessRequestMetrics, securityCheckResult -> {
+      return buildCallback(frontendMetrics.listDatasetsSecurityPostProcessRequestMetrics, securityCheckResult -> {
         LOGGER.debug("Received request for listing all datasets with arguments: {}", restRequest.getArgs());
         Page<String> datasetList = listAllValidDatasets();
         ReadableStreamChannel channel =
@@ -143,7 +143,7 @@ public class ListDatasetsHandler {
       } catch (AccountServiceException ex) {
         LOGGER.error(
             "Dataset get failed for accountName " + accountName + " containerName " + containerName + " pageToken "
-                + pageToken);
+                + pageToken, ex);
         throw new RestServiceException(ex.getMessage(),
             RestServiceErrorCode.getRestServiceErrorCode(ex.getErrorCode()));
       }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
@@ -640,7 +640,7 @@ public class NamedBlobPutHandler {
       } catch (AccountServiceException ex) {
         LOGGER.error(
             "Dataset version update failed for accountName: " + accountName + " containerName: " + containerName
-                + " datasetName: " + datasetName + " version: " + targetVersion);
+                + " datasetName: " + datasetName + " version: " + targetVersion, ex);
         throw new RestServiceException(ex.getMessage(),
             RestServiceErrorCode.getRestServiceErrorCode(ex.getErrorCode()));
       }
@@ -729,7 +729,7 @@ public class NamedBlobPutHandler {
                 dataset.getDatasetName(), version);
           }
         } catch (Exception ex) {
-          LOGGER.error("Best effort to delete the dataset version when upload failed");
+          LOGGER.error("Best effort to delete the dataset version when upload failed", ex);
           frontendMetrics.deleteDatasetVersionError.inc();
         }
         if (callback != null) {

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/PostDatasetsHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/PostDatasetsHandler.java
@@ -192,7 +192,7 @@ public class PostDatasetsHandler {
       } catch (AccountServiceException ex) {
         logger.error(
             "Dataset update failed for accountName " + accountName + " containerName " + containerName + " datasetName "
-                + datasetName);
+                + datasetName, ex);
         throw new RestServiceException(ex.getMessage(),
             RestServiceErrorCode.getRestServiceErrorCode(ex.getErrorCode()));
       }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/TtlUpdateHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/TtlUpdateHandler.java
@@ -245,7 +245,7 @@ class TtlUpdateHandler {
       } catch (AccountServiceException ex) {
         LOGGER.error(
             "Dataset version update failed for accountName: " + accountName + " containerName: " + containerName
-                + " datasetName: " + datasetName + " version: " + version);
+                + " datasetName: " + datasetName + " version: " + version, ex);
         metrics.ttlUpdateDatasetVersionError.inc();
         throw new RestServiceException(ex.getMessage(),
             RestServiceErrorCode.getRestServiceErrorCode(ex.getErrorCode()));

--- a/ambry-mysql/src/main/java/com/github/ambry/mysql/MySqlDataAccessor.java
+++ b/ambry-mysql/src/main/java/com/github/ambry/mysql/MySqlDataAccessor.java
@@ -13,6 +13,8 @@
  */
 package com.github.ambry.mysql;
 
+import com.github.ambry.config.MySqlAccountServiceConfig;
+import com.github.ambry.named.TransactionIsolationLevel;
 import com.github.ambry.utils.Pair;
 import com.mysql.cj.exceptions.MysqlErrorNumbers;
 import java.sql.BatchUpdateException;
@@ -30,7 +32,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
-import org.apache.zookeeper.Op;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,6 +59,7 @@ public class MySqlDataAccessor {
   private long lastConnectionAttemptTime = 0;
   // TODO: make config property
   private long connectionRetryWaitTime = TimeUnit.SECONDS.toMillis(30);
+  private MySqlAccountServiceConfig config;
 
   /**
    * List of operation types on the mysql store.
@@ -67,10 +69,12 @@ public class MySqlDataAccessor {
   }
 
   /** Production constructor */
-  public MySqlDataAccessor(List<DbEndpoint> inputEndpoints, String localDatacenter, MySqlMetrics metrics)
+  public MySqlDataAccessor(List<DbEndpoint> inputEndpoints, String localDatacenter, MySqlMetrics metrics,
+      MySqlAccountServiceConfig config)
       throws SQLException {
     this.metrics = metrics;
     setup(inputEndpoints, localDatacenter);
+    this.config = config;
   }
 
   /** Test constructor */
@@ -177,6 +181,10 @@ public class MySqlDataAccessor {
 
     // If the active connection is good and it's the best endpoint, keep it.
     if (activeConnection != null && !isBetterEndpoint(bestEndpoint, connectedEndpoint)) {
+      if (config != null && !config.transactionIsolationLevel.equals(TransactionIsolationLevel.TRANSACTION_NONE)) {
+        activeConnection.setTransactionIsolation(
+            convertStringToTransactionLevel(config.transactionIsolationLevel.name()));
+      }
       return activeConnection;
     }
     // See if we can do better
@@ -190,9 +198,36 @@ public class MySqlDataAccessor {
       connectedEndpoint = endpointConnectionPair.getFirst();
       activeConnection = endpointConnectionPair.getSecond();
       String qualifier = connectedEndpoint.isWriteable() ? "writable" : "read-only";
-      logger.info("Connected to {} enpoint: {}", qualifier, connectedEndpoint.getUrl());
+      logger.info("Connected to {} endpoint: {}", qualifier, connectedEndpoint.getUrl());
+    }
+    //since we will support auto purge, it's better that the isolation level con be programmed by config.
+    if (config != null && !config.transactionIsolationLevel.equals(TransactionIsolationLevel.TRANSACTION_NONE)) {
+      activeConnection.setTransactionIsolation(
+          convertStringToTransactionLevel(config.transactionIsolationLevel.name()));
     }
     return activeConnection;
+  }
+
+  /**
+   * Convert the String value to the Isolation level.
+   * @param transactionIsolationLevel The string value of isolation level.
+   * @return the Isolation level.
+   */
+  private int convertStringToTransactionLevel(String transactionIsolationLevel) {
+    switch (transactionIsolationLevel) {
+      case "TRANSACTION_NONE":
+        return Connection.TRANSACTION_NONE;
+      case "TRANSACTION_READ_UNCOMMITTED":
+        return Connection.TRANSACTION_READ_UNCOMMITTED;
+      case "TRANSACTION_READ_COMMITTED":
+        return Connection.TRANSACTION_READ_COMMITTED;
+      case "TRANSACTION_REPEATABLE_READ":
+        return Connection.TRANSACTION_REPEATABLE_READ;
+      case "TRANSACTION_SERIALIZABLE":
+        return Connection.TRANSACTION_SERIALIZABLE;
+      default:
+        throw new IllegalArgumentException("Invalid transaction level: " + transactionIsolationLevel);
+    }
   }
 
   /**

--- a/ambry-mysql/src/test/java/com/github/ambry/mysql/MySqlDataAccessorTest.java
+++ b/ambry-mysql/src/test/java/com/github/ambry/mysql/MySqlDataAccessorTest.java
@@ -14,6 +14,9 @@
 package com.github.ambry.mysql;
 
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.config.MySqlAccountServiceConfig;
+import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.utils.Utils;
 import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.SQLException;
@@ -52,8 +55,8 @@ public class MySqlDataAccessorTest {
   @Test
   public void testInputErrors() throws Exception {
     // Pass no endpoints
-    expectFailure(() -> new MySqlDataAccessor(Collections.emptyList(), localDc, metrics), "no endpoints",
-        e -> e instanceof IllegalArgumentException);
+    expectFailure(() -> new MySqlDataAccessor(Collections.emptyList(), localDc, metrics, null),
+        "no endpoints", e -> e instanceof IllegalArgumentException);
   }
 
   @Test


### PR DESCRIPTION
This pr support:
1. Adding more logs and metrics.
2. Make the transactionIsolationLevel tunable for metadata db since we will support auto purge. This is similar like what we've been done for named blob db.