### PR TITLE
Server: check size of prefetched data

### DIFF
--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageFormatRecord.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageFormatRecord.java
@@ -1684,7 +1684,6 @@ public class MessageFormatRecord {
       if (dataSize > Integer.MAX_VALUE) {
         throw new IOException("We only support data of max size == MAX_INT. Error while reading blob from store");
       }
-      System.out.println("The data size is " + dataSize);
       ByteBuf byteBuf = Utils.readNettyByteBufFromCrcInputStream(crcStream, (int) dataSize);
       long crc = crcStream.getValue();
       long streamCrc = dataStream.readLong();
@@ -1743,7 +1742,6 @@ public class MessageFormatRecord {
       if (dataSize > Integer.MAX_VALUE) {
         throw new IOException("We only support data of max size == MAX_INT. Error while reading blob from store");
       }
-      System.out.println("The data size is " + dataSize);
       ByteBuf byteBuf = Utils.readNettyByteBufFromCrcInputStream(crcStream, (int) dataSize);
       long crc = crcStream.getValue();
       long streamCrc = dataStream.readLong();
@@ -1815,7 +1813,6 @@ public class MessageFormatRecord {
       if (dataSize > Integer.MAX_VALUE) {
         throw new IOException("We only support data of max size == MAX_INT. Error while reading blob from store");
       }
-      System.out.println("The data size is " + dataSize);
       ByteBuf byteBuf = Utils.readNettyByteBufFromCrcInputStream(crcStream, (int) dataSize);
       long crc = crcStream.getValue();
       long streamCrc = dataStream.readLong();

--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageFormatRecord.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageFormatRecord.java
@@ -1684,6 +1684,7 @@ public class MessageFormatRecord {
       if (dataSize > Integer.MAX_VALUE) {
         throw new IOException("We only support data of max size == MAX_INT. Error while reading blob from store");
       }
+      System.out.println("The data size is " + dataSize);
       ByteBuf byteBuf = Utils.readNettyByteBufFromCrcInputStream(crcStream, (int) dataSize);
       long crc = crcStream.getValue();
       long streamCrc = dataStream.readLong();
@@ -1742,6 +1743,7 @@ public class MessageFormatRecord {
       if (dataSize > Integer.MAX_VALUE) {
         throw new IOException("We only support data of max size == MAX_INT. Error while reading blob from store");
       }
+      System.out.println("The data size is " + dataSize);
       ByteBuf byteBuf = Utils.readNettyByteBufFromCrcInputStream(crcStream, (int) dataSize);
       long crc = crcStream.getValue();
       long streamCrc = dataStream.readLong();
@@ -1813,6 +1815,7 @@ public class MessageFormatRecord {
       if (dataSize > Integer.MAX_VALUE) {
         throw new IOException("We only support data of max size == MAX_INT. Error while reading blob from store");
       }
+      System.out.println("The data size is " + dataSize);
       ByteBuf byteBuf = Utils.readNettyByteBufFromCrcInputStream(crcStream, (int) dataSize);
       long crc = crcStream.getValue();
       long streamCrc = dataStream.readLong();

--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageFormatSend.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageFormatSend.java
@@ -22,6 +22,7 @@ import com.github.ambry.store.StoreKeyFactory;
 import com.github.ambry.utils.AbstractByteBufHolder;
 import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.ByteBufferOutputStream;
+import com.github.ambry.utils.NettyByteBufDataInputStream;
 import com.github.ambry.utils.SystemTime;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
@@ -129,7 +130,7 @@ public class MessageFormatSend extends AbstractByteBufHolder<MessageFormatSend> 
           // If we can successfully deserialize BlobAll, then the message content is correct
           try {
             ByteBuf messageData = readSet.getPrefetchedData(i).duplicate();
-            MessageFormatRecord.deserializeBlobAll(new ByteBufInputStream(messageData), storeKeyFactory);
+            MessageFormatRecord.deserializeBlobAll(new NettyByteBufDataInputStream(messageData), storeKeyFactory);
           } catch (Exception e) {
             metrics.messageFormatExceptionCount.inc();
             logger.error("Failed to deserialize the BlobAll from message format send for StoreKey {}.", storeKey, e);
@@ -230,7 +231,7 @@ public class MessageFormatSend extends AbstractByteBufHolder<MessageFormatSend> 
         data.release();
       }
       if (!(e instanceof MessageFormatException)) {
-        logger.trace("Error when calculating offsets", e);
+        logger.error("Error when calculating offsets", e);
         throw new MessageFormatException("IOError when calculating offsets ", e, MessageFormatErrorCodes.IO_Error);
       } else {
         throw (MessageFormatException) e;


### PR DESCRIPTION
## Summary
After prefetch data from file, check the size of the actual returned data with the desired size, and make sure that are equal, otherwise, throw an error.
