### PR TITLE
UrlDecode blob id in the header to suport blob name with non-ascii characters

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/rest/RequestPath.java
+++ b/ambry-api/src/main/java/com/github/ambry/rest/RequestPath.java
@@ -13,6 +13,9 @@
  */
 package com.github.ambry.rest;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -57,6 +60,12 @@ public class RequestPath {
       // to ensure IdConverter and IdSigningService can receive a valid blob id and correctly identify it.
       String blobIdStr =
           parse(blobIdHeader, Collections.emptyMap(), prefixesToRemove, clusterName).getOperationOrBlobId(false);
+      // BlobId is url encoded in order to pass blob names with special characters
+      try {
+        blobIdStr = URLDecoder.decode(blobIdStr, StandardCharsets.UTF_8.name());
+      } catch (UnsupportedEncodingException exception) {
+        throw new RestServiceException("Invalid blob id " + blobIdStr, exception, RestServiceErrorCode.BadRequest);
+      }
       restRequest.setArg(Headers.BLOB_ID, blobIdStr);
     }
     String path;


### PR DESCRIPTION
We are trying to support all blob names in update ttl and signed url. In both operations, blob names will be provided by client in the http header. Blob names can have any characters so in order to pass the correct blob names to ambry frontend, client would have to url encode blob names with utf8 charset. Ambry frontend would also have to decode the blob names back its original characters.