### PR TITLE
Dont increase refCnt in Utils methods

### DIFF
--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageFormatRecord.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageFormatRecord.java
@@ -219,13 +219,6 @@ public class MessageFormatRecord {
     }
   }
 
-  /**
-   * Deserialize the bytes in the InputStream to A BlobData
-   * @param stream
-   * @return
-   * @throws IOException
-   * @throws MessageFormatException
-   */
   public static BlobData deserializeBlob(InputStream stream) throws IOException, MessageFormatException {
     return deserializeAndGetBlobWithVersion(stream).getBlobData();
   }

--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageFormatRecord.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageFormatRecord.java
@@ -219,6 +219,13 @@ public class MessageFormatRecord {
     }
   }
 
+  /**
+   * Deserialize the bytes in the InputStream to A BlobData
+   * @param stream
+   * @return
+   * @throws IOException
+   * @throws MessageFormatException
+   */
   public static BlobData deserializeBlob(InputStream stream) throws IOException, MessageFormatException {
     return deserializeAndGetBlobWithVersion(stream).getBlobData();
   }

--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageFormatSend.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageFormatSend.java
@@ -22,6 +22,7 @@ import com.github.ambry.store.StoreKeyFactory;
 import com.github.ambry.utils.AbstractByteBufHolder;
 import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.ByteBufferOutputStream;
+import com.github.ambry.utils.NettyByteBufDataInputStream;
 import com.github.ambry.utils.SystemTime;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
@@ -129,7 +130,7 @@ public class MessageFormatSend extends AbstractByteBufHolder<MessageFormatSend> 
           // If we can successfully deserialize BlobAll, then the message content is correct
           try {
             ByteBuf messageData = readSet.getPrefetchedData(i).duplicate();
-            MessageFormatRecord.deserializeBlobAll(new ByteBufInputStream(messageData), storeKeyFactory);
+            MessageFormatRecord.deserializeBlobAll(new NettyByteBufDataInputStream(messageData), storeKeyFactory);
           } catch (Exception e) {
             metrics.messageFormatExceptionCount.inc();
             logger.error("Failed to deserialize the BlobAll from message format send for StoreKey {}.", storeKey, e);
@@ -230,7 +231,7 @@ public class MessageFormatSend extends AbstractByteBufHolder<MessageFormatSend> 
         data.release();
       }
       if (!(e instanceof MessageFormatException)) {
-        logger.trace("Error when calculating offsets", e);
+        logger.error("Error when calculating offsets", e);
         throw new MessageFormatException("IOError when calculating offsets ", e, MessageFormatErrorCodes.IO_Error);
       } else {
         throw (MessageFormatException) e;

--- a/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
@@ -880,9 +880,14 @@ class GetBlobOperation extends GetOperation {
             routerMetrics.getDataChunkLatencyMs.update(System.currentTimeMillis() - initializedTimeMs);
             ByteBuf decryptedContent = result.getDecryptedBlobContent();
             ByteBuf decompressedContent = decompressContent(decryptedContent);
+            // If the decompressed content is valid, don't use decryptedContent anymore, so we release it.
+            // If the decompressed content is null, which means the operation failed, just release the decryptedContent.
+            decryptedContent.release();
             if (decompressedContent != null) {
               chunkIndexToBuf.put(chunkIndex, filterChunkToRange(decompressedContent));
               numChunksRetrieved.incrementAndGet();
+            } else {
+              progressTracker.setCryptoJobFailed();
             }
           } else {
             // only in maybeReleaseDecryptionResultBuffer() will result be set to null, this means the bytebuf has been
@@ -914,12 +919,12 @@ class GetBlobOperation extends GetOperation {
      */
     protected ByteBuf decompressContent(ByteBuf sourceBuffer) {
       if (!isChunkCompressed) {
-        // Blob is not compressed.  Return source buffer.
-        return sourceBuffer;
+        // Blob is not compressed.  Return source buffer and increase the counter.
+        return sourceBuffer.retain();
       }
 
       try {
-        return decompressionService.decompress(sourceBuffer, routerConfig.routerMaxPutChunkSizeBytes, true);
+        return decompressionService.decompress(sourceBuffer.duplicate(), routerConfig.routerMaxPutChunkSizeBytes, true);
       } catch (Exception ex) {
         // Note: No need to emit metrics here because decompress() already emits failure metrics.
         logger.error("Failed to decompress chunk data for chunkBlobId " + chunkBlobId + " due to exception.", ex);
@@ -927,8 +932,6 @@ class GetBlobOperation extends GetOperation {
             RouterErrorCode.UnexpectedInternalError));
         setOperationCompleted();
         return null;
-      } finally {
-        sourceBuffer.release();
       }
     }
 
@@ -1112,25 +1115,25 @@ class GetBlobOperation extends GetOperation {
         ByteBuffer encryptionKey = messageMetadata == null ? null : messageMetadata.getEncryptionKey();
         ByteBuf chunkBuf = blobData.content();
         this.isChunkCompressed = blobData.isCompressed();
+        // We are going to send this chunkBuf later back to the router, so increase the counter here
+        chunkBuf.retain();
 
-        try {
-          boolean launchedJob = maybeLaunchCryptoJob(chunkBuf, null, encryptionKey, chunkBlobId);
-          if (!launchedJob) {
-            if (chunkIndex == 0) {
-              routerMetrics.getFirstDataChunkLatencyMs.update(System.currentTimeMillis() - submissionTimeMs);
-            }
-            routerMetrics.getDataChunkLatencyMs.update(System.currentTimeMillis() - initializedTimeMs);
-            ByteBuf decompressedContent = decompressContent(chunkBuf.retainedDuplicate());
-            if (decompressedContent != null) {
-              chunkIndexToBuf.put(chunkIndex, filterChunkToRange(decompressedContent));
-              numChunksRetrieved.incrementAndGet();
-            }
+        boolean launchedJob = maybeLaunchCryptoJob(chunkBuf, null, encryptionKey, chunkBlobId);
+        if (!launchedJob) {
+          if (chunkIndex == 0) {
+            routerMetrics.getFirstDataChunkLatencyMs.update(System.currentTimeMillis() - submissionTimeMs);
           }
-
-          successfullyDeserialized = true;
-        } finally {
-          ReferenceCountUtil.safeRelease(chunkBuf);
+          routerMetrics.getDataChunkLatencyMs.update(System.currentTimeMillis() - initializedTimeMs);
+          ByteBuf decompressedContent = decompressContent(chunkBuf);
+          // If the decompressed content is valid, don't use chunkBuf anymore, so we release it.
+          // If the decompressed content is null, which means the operation failed, just release the chunkBuf.
+          chunkBuf.release();
+          if (decompressedContent != null) {
+            chunkIndexToBuf.put(chunkIndex, filterChunkToRange(decompressedContent));
+            numChunksRetrieved.incrementAndGet();
+          }
         }
+        successfullyDeserialized = true;
       } else {
         // If successTarget > 1, then content reconciliation may have to be done. For now, ignore subsequent responses.
       }
@@ -1240,7 +1243,7 @@ class GetBlobOperation extends GetOperation {
         decryptCallbackResultInfo = new DecryptCallBackResultInfo();
         progressTracker.initializeCryptoJobTracker(CryptoJobType.DECRYPTION);
         decryptJobMetricsTracker.onJobSubmission();
-        cryptoJobHandler.submitJob(new DecryptJob(targetBlobId, encryptionKey, dataBuf.retainedDuplicate(),
+        cryptoJobHandler.submitJob(new DecryptJob(targetBlobId, encryptionKey, dataBuf.duplicate(),
             userMetadata != null ? ByteBuffer.wrap(userMetadata) : null, cryptoService, kms, options.getBlobOptions,
             decryptJobMetricsTracker, (DecryptJob.DecryptJobResult result, Exception exception) -> {
           routerMetrics.decryptTimeMs.update(System.currentTimeMillis() - startTimeMs);
@@ -1582,8 +1585,8 @@ class GetBlobOperation extends GetOperation {
               routerMetrics.getFirstDataChunkLatencyMs.update(System.currentTimeMillis() - submissionTimeMs);
               routerMetrics.getDataChunkLatencyMs.update(System.currentTimeMillis() - initializedTimeMs);
               ByteBuf decompressedContent = decompressContent(decryptedBlobContent);
+              decryptedBlobContent.release();
               if (decompressedContent == null) {
-                ReferenceCountUtil.safeRelease(decryptedBlobContent);
                 progressTracker.setCryptoJobFailed();
               } else {
                 totalSize = decompressedContent.readableBytes();
@@ -1594,7 +1597,6 @@ class GetBlobOperation extends GetOperation {
                   logger.trace("BlobContent available to process for simple blob {}", blobId);
                 } else {
                   ReferenceCountUtil.safeRelease(decompressedContent);
-                  ReferenceCountUtil.safeRelease(decryptedBlobContent);
                   progressTracker.setCryptoJobFailed();
                 }
               }
@@ -1753,69 +1755,65 @@ class GetBlobOperation extends GetOperation {
     private void handleMetadataBlob(BlobData blobData, byte[] userMetadata, ByteBuffer encryptionKey)
         throws IOException, MessageFormatException {
       ByteBuf serializedMetadataContent = blobData.content();
+      compositeBlobInfo =
+          MetadataContentSerDe.deserializeMetadataContentRecord(serializedMetadataContent.nioBuffer(), blobIdFactory);
+      totalSize = compositeBlobInfo.getTotalSize();
+      chunkMetadataList = compositeBlobInfo.getChunkMetadataList();
+      boolean rangeResolutionFailure = false;
       try {
-        compositeBlobInfo =
-            MetadataContentSerDe.deserializeMetadataContentRecord(serializedMetadataContent.nioBuffer(), blobIdFactory);
-        totalSize = compositeBlobInfo.getTotalSize();
-        chunkMetadataList = compositeBlobInfo.getChunkMetadataList();
-        boolean rangeResolutionFailure = false;
-        try {
-          long rangeTotalSize = totalSize;
-          if (options.getBlobOptions.hasBlobSegmentIdx()) {
-            int requestedSegment = options.getBlobOptions.getBlobSegmentIdx();
-            if (requestedSegment < 0 || requestedSegment >= chunkMetadataList.size()) {
-              throw new IllegalArgumentException(
-                  "Bad segment number: " + requestedSegment + ", num of keys: " + chunkMetadataList.size());
-            }
-            chunkMetadataList = chunkMetadataList.subList(requestedSegment, requestedSegment + 1);
-            rangeTotalSize = chunkMetadataList.get(0).getSize();
+        long rangeTotalSize = totalSize;
+        if (options.getBlobOptions.hasBlobSegmentIdx()) {
+          int requestedSegment = options.getBlobOptions.getBlobSegmentIdx();
+          if (requestedSegment < 0 || requestedSegment >= chunkMetadataList.size()) {
+            throw new IllegalArgumentException(
+                "Bad segment number: " + requestedSegment + ", num of keys: " + chunkMetadataList.size());
           }
-          if (options.getBlobOptions.getRange() != null) {
-            resolvedByteRange = options.getBlobOptions.getRange().toResolvedByteRange(rangeTotalSize);
-            // Get only the chunks within the range.
-            if (!options.getBlobOptions.hasBlobSegmentIdx()) {
-              chunkMetadataList = compositeBlobInfo.getStoreKeysInByteRange(resolvedByteRange.getStartOffset(),
-                  resolvedByteRange.getEndOffset());
-            }
-          }
-        } catch (IllegalArgumentException e) {
-          onInvalidRange(e);
-          rangeResolutionFailure = true;
+          chunkMetadataList = chunkMetadataList.subList(requestedSegment, requestedSegment + 1);
+          rangeTotalSize = chunkMetadataList.get(0).getSize();
         }
-        if (!rangeResolutionFailure) {
-          if (options.getChunkIdsOnly || getOperationFlag() == MessageFormatFlags.Blob || encryptionKey == null) {
-            initializeDataChunks();
-          } else {
-            // if blob is encrypted, then decryption is required only in case of GetBlobInfo and GetBlobAll (since user-metadata
-            // is expected to be encrypted). In case of GetBlob, Metadata blob does not need any decryption even if BlobProperties says so
-            decryptCallbackResultInfo = new DecryptCallBackResultInfo();
-            progressTracker.initializeCryptoJobTracker(CryptoJobType.DECRYPTION);
-            decryptJobMetricsTracker.onJobSubmission();
-            logger.trace("Submitting decrypt job for Metadata chunk {}", blobId);
-            long startTimeMs = System.currentTimeMillis();
-            cryptoJobHandler.submitJob(
-                new DecryptJob(blobId, encryptionKey, null, ByteBuffer.wrap(userMetadata), cryptoService, kms,
-                    options.getBlobOptions, decryptJobMetricsTracker,
-                    (DecryptJob.DecryptJobResult result, Exception exception) -> {
-                      routerMetrics.decryptTimeMs.update(System.currentTimeMillis() - startTimeMs);
-                      if (isOperationComplete() || operationException.get() != null) {
-                        if (result != null && result.getDecryptedBlobContent() != null) {
-                          ReferenceCountUtil.safeRelease(result.getDecryptedBlobContent());
-                        }
-                      } else {
-                        decryptJobMetricsTracker.onJobCallbackProcessingStart();
-                        logger.trace(
-                            "Handling decrypt job call back for Metadata chunk {} to set decrypt callback results",
-                            blobId);
-                        decryptCallbackResultInfo.setResultAndException(result, exception);
-                        routerCallback.onPollReady();
-                        decryptJobMetricsTracker.onJobCallbackProcessingComplete();
+        if (options.getBlobOptions.getRange() != null) {
+          resolvedByteRange = options.getBlobOptions.getRange().toResolvedByteRange(rangeTotalSize);
+          // Get only the chunks within the range.
+          if (!options.getBlobOptions.hasBlobSegmentIdx()) {
+            chunkMetadataList = compositeBlobInfo.getStoreKeysInByteRange(resolvedByteRange.getStartOffset(),
+                resolvedByteRange.getEndOffset());
+          }
+        }
+      } catch (IllegalArgumentException e) {
+        onInvalidRange(e);
+        rangeResolutionFailure = true;
+      }
+      if (!rangeResolutionFailure) {
+        if (options.getChunkIdsOnly || getOperationFlag() == MessageFormatFlags.Blob || encryptionKey == null) {
+          initializeDataChunks();
+        } else {
+          // if blob is encrypted, then decryption is required only in case of GetBlobInfo and GetBlobAll (since user-metadata
+          // is expected to be encrypted). In case of GetBlob, Metadata blob does not need any decryption even if BlobProperties says so
+          decryptCallbackResultInfo = new DecryptCallBackResultInfo();
+          progressTracker.initializeCryptoJobTracker(CryptoJobType.DECRYPTION);
+          decryptJobMetricsTracker.onJobSubmission();
+          logger.trace("Submitting decrypt job for Metadata chunk {}", blobId);
+          long startTimeMs = System.currentTimeMillis();
+          cryptoJobHandler.submitJob(
+              new DecryptJob(blobId, encryptionKey, null, ByteBuffer.wrap(userMetadata), cryptoService, kms,
+                  options.getBlobOptions, decryptJobMetricsTracker,
+                  (DecryptJob.DecryptJobResult result, Exception exception) -> {
+                    routerMetrics.decryptTimeMs.update(System.currentTimeMillis() - startTimeMs);
+                    if (isOperationComplete() || operationException.get() != null) {
+                      if (result != null && result.getDecryptedBlobContent() != null) {
+                        ReferenceCountUtil.safeRelease(result.getDecryptedBlobContent());
                       }
-                    }));
-          }
+                    } else {
+                      decryptJobMetricsTracker.onJobCallbackProcessingStart();
+                      logger.trace(
+                          "Handling decrypt job call back for Metadata chunk {} to set decrypt callback results",
+                          blobId);
+                      decryptCallbackResultInfo.setResultAndException(result, exception);
+                      routerCallback.onPollReady();
+                      decryptJobMetricsTracker.onJobCallbackProcessingComplete();
+                    }
+                  }));
         }
-      } finally {
-        ReferenceCountUtil.safeRelease(serializedMetadataContent);
       }
     }
 
@@ -1847,33 +1845,35 @@ class GetBlobOperation extends GetOperation {
      * @param encryptionKey encryption key for the blob. Could be null for non encrypted blob.
      */
     private void handleSimpleBlob(BlobData blobData, byte[] userMetadata, ByteBuffer encryptionKey) {
-      try {
-        ByteBuf chunkBuf = blobData.content();
-        chunkIdIterator = null;
-        numChunksTotal = 0;
-        dataChunks = null;
-        if (!options.getChunkIdsOnly) {
-          chunkIndex = 0;
-          numChunksTotal = 1;
-          boolean launchedJob = maybeLaunchCryptoJob(chunkBuf, userMetadata, encryptionKey, blobId);
-          if (!launchedJob) {
-            routerMetrics.getFirstDataChunkLatencyMs.update(System.currentTimeMillis() - submissionTimeMs);
-            routerMetrics.getDataChunkLatencyMs.update(System.currentTimeMillis() - initializedTimeMs);
+      ByteBuf chunkBuf = blobData.content();
 
-            ByteBuf decompressedContent = decompressContent(chunkBuf.retainedDuplicate());
-            if (decompressedContent != null) {
-              totalSize = decompressedContent.readableBytes();
-              if (!resolveRange(totalSize)) {
-                chunkIndexToBuf.put(0, filterChunkToRange(decompressedContent));
-                numChunksRetrieved.set(1);
-              } else {
-                decompressedContent.release();
-              }
+      chunkIdIterator = null;
+      numChunksTotal = 0;
+      dataChunks = null;
+      if (!options.getChunkIdsOnly) {
+        // We are going to send this chunkBuf later back to the router, so increase the counter here
+        chunkBuf.retain();
+        chunkIndex = 0;
+        numChunksTotal = 1;
+        boolean launchedJob = maybeLaunchCryptoJob(chunkBuf, userMetadata, encryptionKey, blobId);
+        if (!launchedJob) {
+          routerMetrics.getFirstDataChunkLatencyMs.update(System.currentTimeMillis() - submissionTimeMs);
+          routerMetrics.getDataChunkLatencyMs.update(System.currentTimeMillis() - initializedTimeMs);
+
+          ByteBuf decompressedContent = decompressContent(chunkBuf);
+          // If the decompressed content is valid, don't use chunkBuf anymore, so we release it.
+          // If the decompressed content is null, which means the operation failed, just release the chunkBuf.
+          chunkBuf.release();
+          if (decompressedContent != null) {
+            totalSize = decompressedContent.readableBytes();
+            if (!resolveRange(totalSize)) {
+              chunkIndexToBuf.put(0, filterChunkToRange(decompressedContent));
+              numChunksRetrieved.set(1);
+            } else {
+              decompressedContent.release();
             }
           }
         }
-      } finally {
-        ReferenceCountUtil.safeRelease(blobData);
       }
     }
 

--- a/ambry-server/src/integration-test/java/com/github/ambry/server/Http2NetworkClientTest.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/Http2NetworkClientTest.java
@@ -171,6 +171,7 @@ public class Http2NetworkClientTest {
     DataInputStream dis = new NettyByteBufDataInputStream(responseInfos.get(0).content());
     PutResponse putResponse = PutResponse.readFrom(dis);
     assertEquals("No error expected.", ServerErrorCode.No_Error, putResponse.getError());
+    responseInfos.get(0).release();
 
     // Get the blob
     // get blob properties
@@ -210,8 +211,9 @@ public class Http2NetworkClientTest {
     byte[] userMetadataOutput = blobAll.getBlobInfo().getUserMetadata();
     assertArrayEquals(usermetadata, userMetadataOutput);
     // verify content
-    byte[] actualBlobData = getBlobDataAndRelease(blobAll.getBlobData());
+    byte[] actualBlobData = getBlobData(blobAll.getBlobData());
     assertArrayEquals("Content mismatch.", data, actualBlobData);
+    responseInfos.get(0).release();
   }
 
   @Test

--- a/ambry-server/src/integration-test/java/com/github/ambry/server/ServerTestUtil.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/ServerTestUtil.java
@@ -171,6 +171,13 @@ import static org.junit.Assert.*;
 final class ServerTestUtil {
   private static final QuotaChargeCallback QUOTA_CHARGE_EVENT_LISTENER = QuotaTestUtils.createTestQuotaChargeCallback();
 
+  static byte[] getBlobData(BlobData blobData) {
+    byte[] actualBlobData = new byte[(int) blobData.getSize()];
+    ByteBuf buffer = blobData.content();
+    buffer.readBytes(actualBlobData);
+    return actualBlobData;
+  }
+
   static byte[] getBlobDataAndRelease(BlobData blobData) {
     byte[] actualBlobData = new byte[(int) blobData.getSize()];
     ByteBuf buffer = blobData.content();
@@ -517,7 +524,8 @@ final class ServerTestUtil {
       assertEquals(new String(adminResponseWithContent.getContent()), ServerErrorCode.No_Error,
           adminResponseWithContent.getError());
       jsonBytes = adminResponseWithContent.getContent();
-      messages = objectMapper.readValue(jsonBytes, new TypeReference<Map<String, MessageInfo>>() {});
+      messages = objectMapper.readValue(jsonBytes, new TypeReference<Map<String, MessageInfo>>() {
+      });
       // We should have one message info
       assertEquals(1, messages.size());
       MessageInfo deleteRecordInfo = messages.values().stream().findFirst().get();
@@ -2662,35 +2670,50 @@ final class ServerTestUtil {
 
       short blobIdVersion = CommonTestUtils.getCurrentBlobIdVersion();
       BlobId blobId1 = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, clusterMap.getLocalDatacenterId(),
-          properties.getAccountId(), properties.getContainerId(), partitionId, testEncryption, BlobId.BlobDataType.DATACHUNK);
+          properties.getAccountId(), properties.getContainerId(), partitionId, testEncryption,
+          BlobId.BlobDataType.DATACHUNK);
       BlobId blobId2 = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, clusterMap.getLocalDatacenterId(),
-          properties.getAccountId(), properties.getContainerId(), partitionId, testEncryption, BlobId.BlobDataType.DATACHUNK);
+          properties.getAccountId(), properties.getContainerId(), partitionId, testEncryption,
+          BlobId.BlobDataType.DATACHUNK);
       BlobId blobId3 = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, clusterMap.getLocalDatacenterId(),
-          properties.getAccountId(), properties.getContainerId(), partitionId, testEncryption, BlobId.BlobDataType.DATACHUNK);
+          properties.getAccountId(), properties.getContainerId(), partitionId, testEncryption,
+          BlobId.BlobDataType.DATACHUNK);
       BlobId blobId4 = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, clusterMap.getLocalDatacenterId(),
-          properties.getAccountId(), properties.getContainerId(), partitionId, testEncryption, BlobId.BlobDataType.DATACHUNK);
+          properties.getAccountId(), properties.getContainerId(), partitionId, testEncryption,
+          BlobId.BlobDataType.DATACHUNK);
       BlobId blobId5 = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, clusterMap.getLocalDatacenterId(),
-          properties.getAccountId(), properties.getContainerId(), partitionId, testEncryption, BlobId.BlobDataType.DATACHUNK);
+          properties.getAccountId(), properties.getContainerId(), partitionId, testEncryption,
+          BlobId.BlobDataType.DATACHUNK);
       BlobId blobId6 = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, clusterMap.getLocalDatacenterId(),
-          properties.getAccountId(), properties.getContainerId(), partitionId, testEncryption, BlobId.BlobDataType.DATACHUNK);
+          properties.getAccountId(), properties.getContainerId(), partitionId, testEncryption,
+          BlobId.BlobDataType.DATACHUNK);
       BlobId blobId7 = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, clusterMap.getLocalDatacenterId(),
-          properties.getAccountId(), properties.getContainerId(), partitionId, testEncryption, BlobId.BlobDataType.DATACHUNK);
+          properties.getAccountId(), properties.getContainerId(), partitionId, testEncryption,
+          BlobId.BlobDataType.DATACHUNK);
       BlobId blobId8 = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, clusterMap.getLocalDatacenterId(),
-          properties.getAccountId(), properties.getContainerId(), partitionId, testEncryption, BlobId.BlobDataType.DATACHUNK);
+          properties.getAccountId(), properties.getContainerId(), partitionId, testEncryption,
+          BlobId.BlobDataType.DATACHUNK);
       BlobId blobId9 = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, clusterMap.getLocalDatacenterId(),
-          properties.getAccountId(), properties.getContainerId(), partitionId, testEncryption, BlobId.BlobDataType.DATACHUNK);
+          properties.getAccountId(), properties.getContainerId(), partitionId, testEncryption,
+          BlobId.BlobDataType.DATACHUNK);
       BlobId blobId10 = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, clusterMap.getLocalDatacenterId(),
-          properties.getAccountId(), properties.getContainerId(), partitionId, testEncryption, BlobId.BlobDataType.DATACHUNK);
+          properties.getAccountId(), properties.getContainerId(), partitionId, testEncryption,
+          BlobId.BlobDataType.DATACHUNK);
       BlobId blobId11 = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, clusterMap.getLocalDatacenterId(),
-          properties.getAccountId(), properties.getContainerId(), partitionId, testEncryption, BlobId.BlobDataType.DATACHUNK);
+          properties.getAccountId(), properties.getContainerId(), partitionId, testEncryption,
+          BlobId.BlobDataType.DATACHUNK);
       BlobId blobId12 = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, clusterMap.getLocalDatacenterId(),
-          properties.getAccountId(), properties.getContainerId(), partitionId, testEncryption, BlobId.BlobDataType.DATACHUNK);
+          properties.getAccountId(), properties.getContainerId(), partitionId, testEncryption,
+          BlobId.BlobDataType.DATACHUNK);
       BlobId blobId13 = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, clusterMap.getLocalDatacenterId(),
-          properties.getAccountId(), properties.getContainerId(), partitionId, testEncryption, BlobId.BlobDataType.DATACHUNK);
+          properties.getAccountId(), properties.getContainerId(), partitionId, testEncryption,
+          BlobId.BlobDataType.DATACHUNK);
       BlobId blobId14 = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, clusterMap.getLocalDatacenterId(),
-          properties.getAccountId(), properties.getContainerId(), partitionId, testEncryption, BlobId.BlobDataType.DATACHUNK);
+          properties.getAccountId(), properties.getContainerId(), partitionId, testEncryption,
+          BlobId.BlobDataType.DATACHUNK);
       BlobId blobId15 = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, clusterMap.getLocalDatacenterId(),
-          properties.getAccountId(), properties.getContainerId(), partitionId, testEncryption, BlobId.BlobDataType.DATACHUNK);
+          properties.getAccountId(), properties.getContainerId(), partitionId, testEncryption,
+          BlobId.BlobDataType.DATACHUNK);
 
       Port sourcePort = new Port(sourceDataNode.getHttp2Port(), PortType.HTTP2);
       Port targetPort = new Port(targetDataNode.getHttp2Port(), PortType.HTTP2);
@@ -2992,14 +3015,16 @@ final class ServerTestUtil {
       undeleteBlob(sourceChannel, blobId10, cluster.time.milliseconds(), (short) 1);
       // create blob16 on the sourceDataNode
       BlobId blobId16 = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, clusterMap.getLocalDatacenterId(),
-          properties.getAccountId(), properties.getContainerId(), partitionId, testEncryption, BlobId.BlobDataType.DATACHUNK);
+          properties.getAccountId(), properties.getContainerId(), partitionId, testEncryption,
+          BlobId.BlobDataType.DATACHUNK);
       putRequest = new PutRequest(1, "client1", blobId16, properties, ByteBuffer.wrap(userMetadata),
           Unpooled.wrappedBuffer(data), properties.getBlobSize(), BlobType.DataBlob,
           testEncryption ? ByteBuffer.wrap(encryptionKey) : null);
       putBlob(putRequest, sourceChannel, ServerErrorCode.No_Error);
       // create blob17 on the targetDataNode
       BlobId blobId17 = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, clusterMap.getLocalDatacenterId(),
-          properties.getAccountId(), properties.getContainerId(), partitionId, testEncryption, BlobId.BlobDataType.DATACHUNK);
+          properties.getAccountId(), properties.getContainerId(), partitionId, testEncryption,
+          BlobId.BlobDataType.DATACHUNK);
       putRequest = new PutRequest(1, "client1", blobId17, properties, ByteBuffer.wrap(userMetadata),
           Unpooled.wrappedBuffer(data), properties.getBlobSize(), BlobType.DataBlob,
           testEncryption ? ByteBuffer.wrap(encryptionKey) : null);
@@ -3807,7 +3832,8 @@ final class ServerTestUtil {
           encryptionKey, clusterMap, blobIdFactory, testEncryption);
       checkTtlUpdateStatus(targetChannel, clusterMap, blobIdFactory, blobId, data, true, Utils.Infinite_Time);
       // the TtlUpdate Operation Time will be same as the PutBlob time since we apply TtlUpdate from the GetRequest.
-      checkTtlUpdateRecord(targetChannel, clusterMap, blobId, propertiesWithTtl.getCreationTimeInMs(), Utils.Infinite_Time);
+      checkTtlUpdateRecord(targetChannel, clusterMap, blobId, propertiesWithTtl.getCreationTimeInMs(),
+          Utils.Infinite_Time);
       cluster.time.sleep(1000);
 
       // 7. On the sourceDatanode blob is ttlUpdated. On the targetDataNode, putBlob.
@@ -3926,7 +3952,8 @@ final class ServerTestUtil {
           encryptionKey, clusterMap, blobIdFactory, testEncryption);
       // The TtlUpdate and Delete operation is same as the source replica's PutBlob creation time.
       // It's not same as the source replica's TtlUpdate or Delete operation time. But it's ok.
-      checkTtlUpdateRecord(targetChannel, clusterMap, blobId, propertiesWithTtl.getCreationTimeInMs(), Utils.Infinite_Time);
+      checkTtlUpdateRecord(targetChannel, clusterMap, blobId, propertiesWithTtl.getCreationTimeInMs(),
+          Utils.Infinite_Time);
       checkDeleteRecord(targetChannel, clusterMap, blobId, propertiesWithTtl.getCreationTimeInMs());
       cluster.time.sleep(1000);
 
@@ -3954,7 +3981,8 @@ final class ServerTestUtil {
       replicateDeleteBlob(targetChannel, blobId, sourceDataNode, delOperationTime, ServerErrorCode.No_Error);
       getBlobAndVerify(blobId, targetChannel, ServerErrorCode.Blob_Deleted, propertiesWithTtl, userMetadata, data,
           encryptionKey, clusterMap, blobIdFactory, testEncryption);
-      checkDeleteRecord(targetChannel, clusterMap, blobId, delOperationTime); // should be delOperationTime not operationTime
+      checkDeleteRecord(targetChannel, clusterMap, blobId,
+          delOperationTime); // should be delOperationTime not operationTime
       cluster.time.sleep(1000);
 
       // 12. On the sourceDataNode, the blob is deleted. On the targetDataNode, it's ttlUpdated.
@@ -4164,8 +4192,8 @@ final class ServerTestUtil {
           channel = thirdChannel;
         }
 
-        getBlobAndVerify(blobId1, channel, ServerErrorCode.No_Error, propertiesWithTtl, userMetadata, data, encryptionKey,
-            clusterMap, blobIdFactory, testEncryption, GetOption.None);
+        getBlobAndVerify(blobId1, channel, ServerErrorCode.No_Error, propertiesWithTtl, userMetadata, data,
+            encryptionKey, clusterMap, blobIdFactory, testEncryption, GetOption.None);
 
         getBlobAndVerify(blobId2, channel, ServerErrorCode.No_Error, propertiesWithTtl, userMetadata, data,
             encryptionKey, clusterMap, blobIdFactory, testEncryption);
@@ -4831,8 +4859,8 @@ final class ServerTestUtil {
     releaseNettyBufUnderneathStream(stream);
   }
 
-  static void checkTtlUpdateRecord(ConnectedChannel channel, ClusterMap clusterMap, BlobId blobId, long expectedOperationTime,
-      long expectedExpiryTimeMs) throws IOException {
+  static void checkTtlUpdateRecord(ConnectedChannel channel, ClusterMap clusterMap, BlobId blobId,
+      long expectedOperationTime, long expectedExpiryTimeMs) throws IOException {
     // Use BlobIndexAdminRequest to verify we have the right TtlUpdate record
     BlobIndexAdminRequest blobIndexAdminRequest = new BlobIndexAdminRequest(blobId,
         new AdminRequest(AdminRequestOrResponseType.BlobIndex, blobId.getPartition(), 1, "clientid2"));
@@ -4844,7 +4872,9 @@ final class ServerTestUtil {
     byte[] jsonBytes = adminResponseWithContent.getContent();
     ObjectMapper objectMapper = new ObjectMapper();
     StoreKeyJacksonConfig.setupObjectMapper(objectMapper, new BlobIdFactory(clusterMap));
-    Map<String, MessageInfo> messages = objectMapper.readValue(jsonBytes, new TypeReference<Map<String, MessageInfo>>() {});
+    Map<String, MessageInfo> messages =
+        objectMapper.readValue(jsonBytes, new TypeReference<Map<String, MessageInfo>>() {
+        });
     // find the TtlUpdate record
     MessageInfo ttlUpdateRecord = null;
     for (MessageInfo mg : messages.values()) {
@@ -5073,9 +5103,8 @@ final class ServerTestUtil {
       } else if (channel.getRemoteHost().equals(targetDataNode.getHostname())
           && channel.getRemotePort() == targetDataNode.getPortToConnectTo().getPort()) {
         targetChannel = channel;
-      } else if (channel.getRemoteHost().equals(thirdDataNode.getHostname()) && channel.getRemotePort() == thirdDataNode
-          .getPortToConnectTo()
-          .getPort()) {
+      } else if (channel.getRemoteHost().equals(thirdDataNode.getHostname())
+          && channel.getRemotePort() == thirdDataNode.getPortToConnectTo().getPort()) {
         thirdChannel = channel;
       }
     }

--- a/ambry-server/src/integration-test/java/com/github/ambry/server/ServerTestUtil.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/ServerTestUtil.java
@@ -178,17 +178,6 @@ final class ServerTestUtil {
     return actualBlobData;
   }
 
-  static byte[] getBlobDataAndRelease(BlobData blobData) {
-    byte[] actualBlobData = new byte[(int) blobData.getSize()];
-    ByteBuf buffer = blobData.content();
-    try {
-      buffer.readBytes(actualBlobData);
-    } finally {
-      buffer.release();
-    }
-    return actualBlobData;
-  }
-
   static void endToEndTest(Port targetPort, String routerDatacenter, MockCluster cluster, SSLConfig clientSSLConfig,
       SSLSocketFactory clientSSLSocketFactory, Properties routerProps, boolean testEncryption) {
     try {
@@ -411,7 +400,7 @@ final class ServerTestUtil {
       GetResponse resp4 = GetResponse.readFrom(stream, clusterMap);
       responseStream = resp4.getInputStream();
       BlobAll blobAll = MessageFormatRecord.deserializeBlobAll(responseStream, blobIdFactory);
-      byte[] actualBlobData = getBlobDataAndRelease(blobAll.getBlobData());
+      byte[] actualBlobData = getBlobData(blobAll.getBlobData());
       // verify content
       assertArrayEquals("Content mismatch.", data, actualBlobData);
       if (testEncryption) {
@@ -678,7 +667,7 @@ final class ServerTestUtil {
       resp1 = GetResponse.readFrom(stream, clusterMap);
       responseStream = resp1.getInputStream();
       blobAll = MessageFormatRecord.deserializeBlobAll(responseStream, blobIdFactory);
-      actualBlobData = getBlobDataAndRelease(blobAll.getBlobData());
+      actualBlobData = getBlobData(blobAll.getBlobData());
       assertArrayEquals("Content mismatch.", data, actualBlobData);
       releaseNettyBufUnderneathStream(stream);
       // undelete a not-deleted blob should return fail
@@ -718,7 +707,7 @@ final class ServerTestUtil {
       resp1 = GetResponse.readFrom(stream, clusterMap);
       responseStream = resp1.getInputStream();
       blobAll = MessageFormatRecord.deserializeBlobAll(responseStream, blobIdFactory);
-      actualBlobData = getBlobDataAndRelease(blobAll.getBlobData());
+      actualBlobData = getBlobData(blobAll.getBlobData());
       assertArrayEquals("Content mismatch", data, actualBlobData);
       releaseNettyBufUnderneathStream(stream);
       // Bounce servers to make them read the persisted token file.
@@ -733,7 +722,7 @@ final class ServerTestUtil {
       resp1 = GetResponse.readFrom(stream, clusterMap);
       responseStream = resp1.getInputStream();
       blobAll = MessageFormatRecord.deserializeBlobAll(responseStream, blobIdFactory);
-      actualBlobData = getBlobDataAndRelease(blobAll.getBlobData());
+      actualBlobData = getBlobData(blobAll.getBlobData());
       assertArrayEquals("Content mismatch", data, actualBlobData);
       releaseNettyBufUnderneathStream(stream);
       channel.disconnect();
@@ -1035,7 +1024,7 @@ final class ServerTestUtil {
         resp = GetResponse.readFrom(stream, clusterMap);
         try {
           BlobData blobData = MessageFormatRecord.deserializeBlob(resp.getInputStream());
-          byte[] blobout = getBlobDataAndRelease(blobData);
+          byte[] blobout = getBlobData(blobData);
           assertArrayEquals(data, blobout);
           if (testEncryption) {
             assertNotNull("MessageMetadata should not have been null",
@@ -1063,7 +1052,7 @@ final class ServerTestUtil {
               getExpiryTimeMs(blobAll.getBlobInfo().getBlobProperties()));
           assertEquals("Expiration time mismatch (MessageInfo)", expectedExpiryTimeMs,
               resp.getPartitionResponseInfoList().get(0).getMessageInfoList().get(0).getExpirationTimeInMs());
-          byte[] blobout = getBlobDataAndRelease(blobAll.getBlobData());
+          byte[] blobout = getBlobData(blobAll.getBlobData());
           assertArrayEquals(data, blobout);
           if (testEncryption) {
             assertNotNull("EncryptionKey should not ne null", blobAll.getBlobEncryptionKey());
@@ -1265,7 +1254,7 @@ final class ServerTestUtil {
       } else {
         try {
           BlobData blobData = MessageFormatRecord.deserializeBlob(resp.getInputStream());
-          byte[] blobout = getBlobDataAndRelease(blobData);
+          byte[] blobout = getBlobData(blobData);
           assertArrayEquals(data, blobout);
           if (testEncryption) {
             assertNotNull("MessageMetadata should not have been null",
@@ -1295,7 +1284,7 @@ final class ServerTestUtil {
       } else {
         try {
           BlobAll blobAll = MessageFormatRecord.deserializeBlobAll(resp.getInputStream(), blobIdFactory);
-          byte[] blobout = getBlobDataAndRelease(blobAll.getBlobData());
+          byte[] blobout = getBlobData(blobAll.getBlobData());
           assertArrayEquals(data, blobout);
           if (testEncryption) {
             assertNotNull("EncryptionKey should not ne null", blobAll.getBlobEncryptionKey());
@@ -1403,7 +1392,7 @@ final class ServerTestUtil {
       } else {
         try {
           BlobData blobData = MessageFormatRecord.deserializeBlob(resp.getInputStream());
-          byte[] blobout = getBlobDataAndRelease(blobData);
+          byte[] blobout = getBlobData(blobData);
           assertArrayEquals(data, blobout);
           if (testEncryption) {
             assertNotNull("MessageMetadata should not have been null",
@@ -1431,7 +1420,7 @@ final class ServerTestUtil {
       } else {
         try {
           BlobAll blobAll = MessageFormatRecord.deserializeBlobAll(resp.getInputStream(), blobIdFactory);
-          byte[] blobout = getBlobDataAndRelease(blobAll.getBlobData());
+          byte[] blobout = getBlobData(blobAll.getBlobData());
           assertArrayEquals(data, blobout);
           if (testEncryption) {
             assertNotNull("EncryptionKey should not ne null", blobAll.getBlobEncryptionKey());
@@ -1485,7 +1474,7 @@ final class ServerTestUtil {
         assertFalse(info.isDeleted());
         try {
           BlobAll blobAll = MessageFormatRecord.deserializeBlobAll(resp.getInputStream(), blobIdFactory);
-          byte[] blobout = getBlobDataAndRelease(blobAll.getBlobData());
+          byte[] blobout = getBlobData(blobAll.getBlobData());
           assertArrayEquals(data, blobout);
           if (testEncryption) {
             assertNotNull("EncryptionKey should not ne null", blobAll.getBlobEncryptionKey());
@@ -1530,7 +1519,7 @@ final class ServerTestUtil {
         assertTrue(info.isDeleted());
         try {
           BlobAll blobAll = MessageFormatRecord.deserializeBlobAll(resp.getInputStream(), blobIdFactory);
-          byte[] blobout = getBlobDataAndRelease(blobAll.getBlobData());
+          byte[] blobout = getBlobData(blobAll.getBlobData());
           assertArrayEquals(data, blobout);
           if (testEncryption) {
             assertNotNull("EncryptionKey should not ne null", blobAll.getBlobEncryptionKey());
@@ -1729,7 +1718,7 @@ final class ServerTestUtil {
     GetResponse resp2 = GetResponse.readFrom(stream, clusterMap);
     InputStream responseStream = resp2.getInputStream();
     BlobAll blobAll = MessageFormatRecord.deserializeBlobAll(responseStream, blobIdFactory);
-    byte[] actualBlobData = getBlobDataAndRelease(blobAll.getBlobData());
+    byte[] actualBlobData = getBlobData(blobAll.getBlobData());
     assertArrayEquals("Content mismatch.", data, actualBlobData);
     releaseNettyBufUnderneathStream(stream);
     // delete a blob on a restarted store , which should succeed
@@ -1938,7 +1927,7 @@ final class ServerTestUtil {
       GetResponse resp3 = GetResponse.readFrom(stream, clusterMap);
       try {
         BlobData blobData = MessageFormatRecord.deserializeBlob(resp3.getInputStream());
-        byte[] blobout = getBlobDataAndRelease(blobData);
+        byte[] blobout = getBlobData(blobData);
         assertArrayEquals(dataList.get(0), blobout);
         if (testEncryption) {
           assertNotNull("MessageMetadata should not have been null",
@@ -1962,7 +1951,7 @@ final class ServerTestUtil {
       GetResponse resp4 = GetResponse.readFrom(stream, clusterMap);
       try {
         BlobAll blobAll = MessageFormatRecord.deserializeBlobAll(resp4.getInputStream(), blobIdFactory);
-        byte[] blobout = getBlobDataAndRelease(blobAll.getBlobData());
+        byte[] blobout = getBlobData(blobAll.getBlobData());
         assertArrayEquals(dataList.get(0), blobout);
         if (testEncryption) {
           assertNotNull("MessageMetadata should not have been null", blobAll.getBlobEncryptionKey());
@@ -4590,7 +4579,7 @@ final class ServerTestUtil {
     GetResponse resp = GetResponse.readFrom(stream, clusterMap);
     assertEquals(ServerErrorCode.No_Error, resp.getError());
     BlobData blobData = MessageFormatRecord.deserializeBlob(resp.getInputStream());
-    byte[] blobout = getBlobDataAndRelease(blobData);
+    byte[] blobout = getBlobData(blobData);
     assertArrayEquals(dataToCheck, blobout);
     if (encryptionKey != null) {
       assertNotNull("EncryptionKey should not have been null",
@@ -4641,7 +4630,7 @@ final class ServerTestUtil {
     assertArrayEquals(expectedUserMetadata, userMetadataOutput);
 
     // verify the content
-    byte[] actualBlobData = getBlobDataAndRelease(blobAll.getBlobData());
+    byte[] actualBlobData = getBlobData(blobAll.getBlobData());
     assertArrayEquals("Content mismatch.", expectedData, actualBlobData);
     if (testEncryption) {
       assertNotNull("EncryptionKey should not ne null", blobAll.getBlobEncryptionKey());
@@ -4850,7 +4839,7 @@ final class ServerTestUtil {
     response = GetResponse.readFrom(stream, clusterMap);
     InputStream responseStream = response.getInputStream();
     BlobAll blobAll = MessageFormatRecord.deserializeBlobAll(responseStream, storeKeyFactory);
-    byte[] actualBlobData = getBlobDataAndRelease(blobAll.getBlobData());
+    byte[] actualBlobData = getBlobData(blobAll.getBlobData());
     assertArrayEquals("Content mismatch.", expectedBlobData, actualBlobData);
     messageInfo = response.getPartitionResponseInfoList().get(0).getMessageInfoList().get(0);
     assertEquals("Blob ID not as expected", blobId, messageInfo.getStoreKey());

--- a/ambry-utils/src/main/java/com/github/ambry/utils/Utils.java
+++ b/ambry-utils/src/main/java/com/github/ambry/utils/Utils.java
@@ -409,7 +409,7 @@ public class Utils {
       ByteBuf nettyByteBuf = ((NettyByteBufDataInputStream) inputStream).getBuffer();
       // construct a java.nio.ByteBuffer to create a ByteBufferInputStream
       int startIndex = nettyByteBuf.readerIndex();
-      output = nettyByteBuf.retainedSlice(startIndex, dataSize);
+      output = nettyByteBuf.slice(startIndex, dataSize);
       crcStream.updateCrc(output.nioBuffer());
       nettyByteBuf.readerIndex(startIndex + dataSize);
     } else {


### PR DESCRIPTION
## Summary
When using NettyByteBufDataInputStream, we would increase the refCnt when calling readNettyByteBufFromCrcInputStream in Utils class. This is a bad design as an utility function should never increase the reference counter. It's very hard to know that refCnt is changed here. 

This PR would fix that.
