### PR TITLE
Support deleted_ts for auto_purge

### DIFF
--- a/ambry-account/src/main/resources/AccountSchema.ddl
+++ b/ambry-account/src/main/resources/AccountSchema.ddl
@@ -57,6 +57,7 @@ CREATE TABLE IF NOT EXISTS Datasets (
     retentionTimeInSeconds BIGINT DEFAULT NULL,
     userTags JSON DEFAULT NULL,
     lastModifiedTime DATETIME(3) NOT NULL,
+    deleted_ts DATETIME(6) DEFAULT NULL,
     delete_ts DATETIME(6) DEFAULT NULL,
     PRIMARY KEY (accountId, containerId, datasetName)
 )
@@ -71,6 +72,7 @@ CREATE TABLE IF NOT EXISTS DatasetVersions (
     creationTime DATETIME(3) NOT NULL,
     lastModifiedTime DATETIME(3) NOT NULL,
     delete_ts DATETIME(6) DEFAULT NULL,
+    deleted_ts DATETIME(6) DEFAULT NULL,
     PRIMARY KEY (accountId, containerId, datasetName, version)
 )
 CHARACTER SET utf8 COLLATE utf8_bin;

--- a/ambry-utils/src/main/java/com/github/ambry/utils/Utils.java
+++ b/ambry-utils/src/main/java/com/github/ambry/utils/Utils.java
@@ -1500,6 +1500,17 @@ public class Utils {
   }
 
   /**
+   * Get the latest timestamp, and if one of the timestamp is null, return the non-null timestamp.
+   */
+  public static Timestamp getLatestTimeStamp(Timestamp timestamp1, Timestamp timestamp2) {
+    if (compareTimestamp(timestamp1, timestampToMs(timestamp2)) > 0) {
+      return timestamp1;
+    } else {
+      return timestamp2;
+    }
+  }
+
+  /**
    * @param timestamp a {@link Timestamp}, can be null.
    * @return the milliseconds since the epoch if {@code timestamp} is non-null, or {@link Utils#Infinite_Time} if null.
    */


### PR DESCRIPTION
Due to previously we have delete_ts, but auto_purge only recognize deleted_ts, so we have to do this migration.
1. Add one more column for deleted_ts.
2. update the logic in our frontend to write to both deleted_ts and delete_ts, and read the max(deleted_ts, delete_ts)
3. Do one time migration to migrate all delete_ts to deleted_ts if it's null.
4. Delete the delete_ts column after migration is done.
**This pr is to support step2, and need to be merged once step1 is done.**

The pr has three major changes:
1.When update the delete_ts, we will also update same value for deleted_ts.
2.Since we do step1, so when we get the delete_ts and deleted_ts, there will be two cases
    2.1 delete_ts has value and deleted_ts is null.
    2.2 delete_ts has same value(or null) as deleted_ts.
So calling the COALESCE(%2$s, %8$s) will get the real delete timestamp we want as it will return the first non-null value.
3.when we use select, we get both delete_ts and deleted_ts and use below cmd to get the latest timestamp, as it will return the first non-null value as well.
`deletionTime = getLatestTimeStamp(resultSet.getTimestamp(DELETE_TS), resultSet.getTimestamp(DELETED_TS))`

