### PR TITLE
Fix blob names with "+" in signed url

### DIFF
--- a/ambry-api/src/test/java/com/github/ambry/rest/RequestPathTest.java
+++ b/ambry-api/src/test/java/com/github/ambry/rest/RequestPathTest.java
@@ -205,9 +205,11 @@ public class RequestPathTest {
     Map<String, String> blobNamePairs = Stream.of(
             new String[][]{{"/named/account/container/blobname", "/named/account/container/blobname"},
                 {"/named/account/container/test%20123.json", "/named/account/container/test 123.json"},
+                {"/named/account/container/test+123.json", "/named/account/container/test 123.json"},
+                {"/named/account/container/test%2B123.json", "/named/account/container/test+123.json"},
                 {"/named/account/container/donne%CC%81es_2.xls", "/named/account/container/données_2.xls"},
                 {"/named/account/container/%E6%96%87%E4%BB%B6.txt", "/named/account/container/文件.txt"},
-                {"%2Fnamed%2Faccount%2Fcontainer%2Ffilename.json", "/named/account/container/filename.json"},
+                {"/named%2Faccount%2Fcontainer%2Ffilename.json", "/named/account/container/filename.json"},
                 {"/named/account/container/%2Fa%2Fb%2Fc%2Fd.txt", "/named/account/container//a/b/c/d.txt"}})
         .collect(Collectors.toMap(d -> d[0], d -> d[1]));
     for (Map.Entry<String, String> namePairs : blobNamePairs.entrySet()) {

--- a/ambry-api/src/test/java/com/github/ambry/rest/RestUtilsTest.java
+++ b/ambry-api/src/test/java/com/github/ambry/rest/RestUtilsTest.java
@@ -29,7 +29,9 @@ import com.github.ambry.utils.Utils;
 import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
 import java.net.URLDecoder;
+import java.net.URLEncoder;
 import java.nio.ByteBuffer;
+import java.nio.charset.CharsetEncoder;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
@@ -111,10 +113,18 @@ public class RestUtilsTest {
    * @param userMetadata {@link Map} which has the new entries that has to be added
    * @throws org.json.JSONException
    */
-  public static void setUserMetadataHeaders(JSONObject headers, Map<String, String> userMetadata) throws JSONException {
+  public static void setUserMetadataHeaders(JSONObject headers, Map<String, String> userMetadata) throws Exception {
     if (userMetadata != null) {
+      CharsetEncoder encoder = StandardCharsets.US_ASCII.newEncoder();
       for (String key : userMetadata.keySet()) {
-        headers.put(key, userMetadata.get(key));
+        String value = userMetadata.get(key);
+        if (encoder.canEncode(value)) {
+          headers.put(key, userMetadata.get(key));
+        } else {
+          String newKey = key.replaceFirst(RestUtils.Headers.USER_META_DATA_HEADER_PREFIX,
+              RestUtils.Headers.USER_META_DATA_ENCODED_HEADER_PREFIX);
+          headers.put(newKey, URLEncoder.encode(value, StandardCharsets.UTF_8.name()));
+        }
       }
     }
   }

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/AmbrySecurityServiceTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/AmbrySecurityServiceTest.java
@@ -187,8 +187,18 @@ public class AmbrySecurityServiceTest {
         Assert.assertEquals("Should be a bad request", RestServiceErrorCode.BadRequest, rse.getErrorCode());
       }
     }
+
+    // verify blob id is encoded in signed url
+    String encodedBlobName = URLEncoder.encode("/named/account/container/données", StandardCharsets.UTF_8.name());
+    String url = "https://localhost:1717/?" + RestUtils.Headers.BLOB_ID + "=" + encodedBlobName;
+    RestRequest restRequest = createRestRequest(RestMethod.GET, url, null);
+    URL_SIGNING_SERVICE_FACTORY.isRequestSigned = true;
+    URL_SIGNING_SERVICE_FACTORY.verifySignedRequestException = null;
+    securityService.preProcessRequest(restRequest).get();
+    Assert.assertEquals(encodedBlobName, restRequest.getArgs().get(RestUtils.Headers.BLOB_ID));
+
     // verify request args regarding to tracking is set accordingly
-    RestRequest restRequest = createRestRequest(RestMethod.GET, "/", null);
+    restRequest = createRestRequest(RestMethod.GET, "/", null);
     securityService.preProcessRequest(restRequest).get();
     Assert.assertTrue("The arg with key: ambry-internal-keys-send-tracking-info should be set to true",
         (Boolean) restRequest.getArgs().get(RestUtils.InternalKeys.SEND_TRACKING_INFO));
@@ -199,7 +209,7 @@ public class AmbrySecurityServiceTest {
         new AmbrySecurityService(frontendConfig, new FrontendMetrics(new MetricRegistry(), frontendConfig),
             URL_SIGNING_SERVICE_FACTORY.getUrlSigningService(), hostLevelThrottler, QUOTA_MANAGER);
     restRequest = createRestRequest(RestMethod.GET, "/", null);
-    securityServiceWithTrackingDisabled.preProcessRequest(restRequest);
+    securityServiceWithTrackingDisabled.preProcessRequest(restRequest).get();
     Assert.assertFalse("The arg with key: ambry-internal-keys-send-tracking-info should be set to false",
         (Boolean) restRequest.getArgs().get(RestUtils.InternalKeys.SEND_TRACKING_INFO));
   }


### PR DESCRIPTION
Fix an issue in signed url with blob name. This issue goes like this

client is trying to create a signed url to download named blob: /named/account/container/test+123.json
client is putting x-ambry-blob-id:/named/account/container/test%2B123.json in the header
Ambry-frontend sees this blob id and create a signed url (localhost:1718/?x-ambry-blob-id:%2Fnamed%2Faccount%2Fcontainer%2Ftest%2B123.json)
client use this signed url to download this named blob, since the blob name is in the query parameter, not header, it will be decode back to x-ambry-blob-id: /named/account/container/test+123.json and put it in the header
When RequestPath.parse try to use UrlDecoder to decode this blob name, it converts the blob name to "test 123.json" with a space.
This PR would reencode the named blob and put it in the restRequest before the RequestPath.parse.