### PR TITLE
Fix mock restRequest

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com/github/ambry/rest/RestUtils.java
@@ -386,7 +386,7 @@ public class RestUtils {
    * Ambry specific keys used internally in a {@link RestRequest}.
    */
   public static final class InternalKeys {
-    private static final String KEY_PREFIX = "ambry-internal-key-";
+    public static final String KEY_PREFIX = "ambry-internal-key-";
 
     /**
      * The key for the target {@link com.github.ambry.account.Account} indicated by the request.

--- a/ambry-test-utils/src/main/java/com/github/ambry/rest/MockRestRequest.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/rest/MockRestRequest.java
@@ -437,10 +437,13 @@ public class MockRestRequest implements RestRequest {
    */
   private void addOrUpdateArgNoDecoding(String key, Object value) throws UnsupportedEncodingException {
     if (value != null && value instanceof String) {
-      CharsetEncoder encoder = StandardCharsets.US_ASCII.newEncoder();
-      if (!encoder.canEncode(key) || !encoder.canEncode((String) value)) {
-        throw new IllegalArgumentException(
-            "Key " + key + " or Value " + value + "is not valid, since they are not all ascii");
+      if (!key.startsWith(RestUtils.InternalKeys.KEY_PREFIX)) {
+        // For any key rather than ambry internal key, value should be all ascii.
+        CharsetEncoder encoder = StandardCharsets.US_ASCII.newEncoder();
+        if (!encoder.canEncode(key) || !encoder.canEncode((String) value)) {
+          throw new IllegalArgumentException(
+              "Key " + key + " or Value " + value + "is not valid, since they are not all ascii");
+        }
       }
       String valueStr = (String) value;
       StringBuilder sb;


### PR DESCRIPTION
In MockRestRequest header, if the key is ambry internal key, don't throw any exception when the value is not all ascii.