### PR TITLE
Warning when the number of replicas are decreased

### DIFF
--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeUtil.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeUtil.java
@@ -2005,6 +2005,9 @@ public class HelixBootstrapUpgradeUtil {
                 dryRun ? "No action as dry run" : "Updating Helix using static",
                 String.join(",", instanceSetInHelix), String.join(",", instanceSetInStatic));
             // @formatter:on
+            if (instanceSetInStatic.size() < instanceSetInHelix.size()) {
+              warning("*****STOP STOP STOP*****: New instance set has less replicas than what is in helix");
+            }
             if (!dryRun) {
               ArrayList<String> newInstances = new ArrayList<>(instanceSetInStatic);
               Collections.shuffle(newInstances);


### PR DESCRIPTION
Print out some warning if the number of replicas from the static clustermap is less than the number of replicas in helix.