### PR TITLE
Fix helix-vcr tool to parse namespaces

### DIFF
--- a/ambry-tools/src/main/java/com/github/ambry/clustermap/HelixVcrPopulateTool.java
+++ b/ambry-tools/src/main/java/com/github/ambry/clustermap/HelixVcrPopulateTool.java
@@ -61,7 +61,7 @@ public class HelixVcrPopulateTool {
 
     String[] destZkAndCluster = options.valueOf(destOpt).split(HelixVcrUtil.SEPARATOR);
     if (destZkAndCluster.length != 3) {
-      errorAndExit("dest argument must have form 'zkString/clusterName'");
+      errorAndExit("dest argument must have form 'zkString/namespace/clusterName'");
     }
     String destZkString = destZkAndCluster[0];
     String destClusterName = destZkAndCluster[1];
@@ -89,7 +89,7 @@ public class HelixVcrPopulateTool {
       if (options.has(srcOpt)) {
         String[] srcZkAndCluster = options.valueOf(srcOpt).split(SEPARATOR);
         if (srcZkAndCluster.length != 3) {
-          errorAndExit("src argument must have form 'zkString/clusterName'");
+          errorAndExit("src argument must have form 'zkString/namespace/clusterName'");
         }
         String srcZkString = srcZkAndCluster[0];
         String srcClusterName = srcZkAndCluster[1];

--- a/ambry-tools/src/main/java/com/github/ambry/clustermap/HelixVcrPopulateTool.java
+++ b/ambry-tools/src/main/java/com/github/ambry/clustermap/HelixVcrPopulateTool.java
@@ -60,7 +60,7 @@ public class HelixVcrPopulateTool {
     OptionSet options = parser.parse(args);
 
     String[] destZkAndCluster = options.valueOf(destOpt).split(HelixVcrUtil.SEPARATOR);
-    if (destZkAndCluster.length != 2) {
+    if (destZkAndCluster.length != 3) {
       errorAndExit("dest argument must have form 'zkString/clusterName'");
     }
     String destZkString = destZkAndCluster[0];
@@ -88,7 +88,7 @@ public class HelixVcrPopulateTool {
       boolean dryRun = options.has(dryRunOpt);
       if (options.has(srcOpt)) {
         String[] srcZkAndCluster = options.valueOf(srcOpt).split(SEPARATOR);
-        if (srcZkAndCluster.length != 2) {
+        if (srcZkAndCluster.length != 3) {
           errorAndExit("src argument must have form 'zkString/clusterName'");
         }
         String srcZkString = srcZkAndCluster[0];


### PR DESCRIPTION
Helix/ZK pathnames have 3 parts: zk_conn_string/namespace/znode. But the tool is old and expects only 2 parts.
This patch fixes that.