### PR TITLE
Filter out DNS fields from certificate in public access log

### DIFF
--- a/ambry-rest/src/main/java/com/github/ambry/rest/PublicAccessLogHandler.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/PublicAccessLogHandler.java
@@ -26,10 +26,12 @@ import io.netty.handler.ssl.SslHandler;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
 import javax.net.ssl.SSLEngine;
 import javax.security.auth.x500.X500Principal;
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.StringMapMessage;
 
 
@@ -38,6 +40,7 @@ import org.apache.logging.log4j.message.StringMapMessage;
  * {@link PublicAccessLogger} assists in logging the required information
  */
 public class PublicAccessLogHandler extends ChannelDuplexHandler {
+  private static final int SAN_DNS_FIELD_ID = 2;
   private final PublicAccessLogger publicAccessLogger;
   private final NettyMetrics nettyMetrics;
   private long requestArrivalTimeInMs;
@@ -247,11 +250,25 @@ public class PublicAccessLogHandler extends ChannelDuplexHandler {
             for (Certificate certificate : sslEngine.getSession().getPeerCertificates()) {
               if (certificate instanceof X509Certificate) {
                 X500Principal principal = ((X509Certificate) certificate).getSubjectX500Principal();
-                Collection subjectAlternativeNames = ((X509Certificate) certificate).getSubjectAlternativeNames();
+
                 sslLogMessage.append(", [principal=").append(principal).append("]");
                 structuredLogMessage.put("principal", principal.toString());
-                sslLogMessage.append(", [san=").append(subjectAlternativeNames).append("]");
-                structuredLogMessage.put("san", String.valueOf(subjectAlternativeNames));
+                Collection<List<?>> subjectAlternativeNames =
+                    ((X509Certificate) certificate).getSubjectAlternativeNames();
+                if (subjectAlternativeNames == null || subjectAlternativeNames.isEmpty()) {
+                  continue;
+                }
+                /*
+                 * https://docs.oracle.com/javase/7/docs/api/java/security/cert/X509Certificate.html#getSubjectAlternativeNames()
+                 * For getSubjectAlternativeNames, a Collection is returned with an entry representing each GeneralName included in the extension.
+                 * Each entry is a List whose first entry is an Integer (the name type, 0-8) and whose second entry is a String or a byte array.
+                 * */
+                // here we filter out dns field and value, we don't need those values in public access log.
+                List<List<?>> sans = subjectAlternativeNames.stream()
+                    .filter(p -> (Integer) p.get(0) != SAN_DNS_FIELD_ID)
+                    .collect(Collectors.toList());
+                sslLogMessage.append(", [san=").append(sans).append("]");
+                structuredLogMessage.put("san", String.valueOf(sans));
               }
             }
           }

--- a/ambry-rest/src/test/java/com/github/ambry/rest/PublicAccessLogHandlerTest.java
+++ b/ambry-rest/src/test/java/com/github/ambry/rest/PublicAccessLogHandlerTest.java
@@ -32,10 +32,12 @@ import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.stream.Collectors;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
 import org.junit.Assert;
@@ -280,7 +282,11 @@ public class PublicAccessLogHandlerTest {
     subString = "SSL ([used=" + sslUsed + "]";
     if (sslUsed) {
       subString += ", [principal=" + PEER_CERT.getSubjectX500Principal() + "]";
-      subString += ", [san=" + PEER_CERT.getSubjectAlternativeNames() + "]";
+      Collection<List<?>> sans = PEER_CERT.getSubjectAlternativeNames();
+      if (sans != null && !sans.isEmpty()) {
+        sans = sans.stream().filter(p -> (Integer) p.get(0) != 2).collect(Collectors.toList());
+      }
+      subString += ", [san=" + sans + "]";
     }
     subString += ")";
     Assert.assertTrue("Public Access log entry doesn't have SSL info set correctly", lastLogEntry.contains(subString));


### PR DESCRIPTION
## Summary

We are filtering out all the DNS fields from certificate in the public access log. We don't need those information.