### PR TITLE
[vcr-2.0] Align new metric names with old ones

### DIFF
--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureMetrics.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureMetrics.java
@@ -167,17 +167,17 @@ public class AzureMetrics {
         registry.counter(MetricRegistry.name(AzureCloudDestination.class, BLOB_UPLOAD_REQUEST_COUNT));
     blobUploadSuccessCount =
         registry.counter(MetricRegistry.name(AzureCloudDestination.class, BLOB_UPLOAD_SUCCESS_COUNT));
-    blobUploadSuccessRate = registry.meter(MetricRegistry.name(AzureCloudDestinationSync.class, BLOB_UPLOAD_SUCCESS_RATE));
-    blobUpdateDeleteTimeLatency = registry.timer(MetricRegistry.name(AzureCloudDestinationSync.class, BLOB_UPDATE_DELETE_TIME_LATENCY));
-    blobUpdateDeleteTimeSucessRate = registry.meter(MetricRegistry.name(AzureCloudDestinationSync.class, BLOB_UPDATE_DELETE_TIME_SUCCESS_RATE));
-    blobUpdateDeleteTimeErrorCount = registry.counter(MetricRegistry.name(AzureCloudDestinationSync.class, BLOB_UPDATE_DELETE_TIME_ERROR_COUNT));
-    blobUndeleteLatency = registry.timer(MetricRegistry.name(AzureCloudDestinationSync.class, BLOB_UNDELETE_LATENCY));
-    blobUndeleteSucessRate = registry.meter(MetricRegistry.name(AzureCloudDestinationSync.class, BLOB_UNDELETE_SUCCESS_RATE));
-    blobUndeleteErrorCount = registry.counter(MetricRegistry.name(AzureCloudDestinationSync.class, BLOB_UNDELETE_ERROR_COUNT));
-    blobUpdateTTLLatency = registry.timer(MetricRegistry.name(AzureCloudDestinationSync.class, BLOB_UPDATE_TTL_LATENCY));
-    blobUpdateTTLSucessRate = registry.meter(MetricRegistry.name(AzureCloudDestinationSync.class, BLOB_UPDATE_TTL_SUCCESS_RATE));
-    blobUpdateTTLErrorCount = registry.counter(MetricRegistry.name(AzureCloudDestinationSync.class, BLOB_UPDATE_TTL_ERROR_COUNT));
-    blobUploadErrorCount = registry.counter(MetricRegistry.name(AzureCloudDestinationSync.class, BLOB_UPLOAD_ERROR_COUNT));
+    blobUploadSuccessRate = registry.meter(MetricRegistry.name(AzureCloudDestination.class, BLOB_UPLOAD_SUCCESS_RATE));
+    blobUpdateDeleteTimeLatency = registry.timer(MetricRegistry.name(AzureCloudDestination.class, BLOB_UPDATE_DELETE_TIME_LATENCY));
+    blobUpdateDeleteTimeSucessRate = registry.meter(MetricRegistry.name(AzureCloudDestination.class, BLOB_UPDATE_DELETE_TIME_SUCCESS_RATE));
+    blobUpdateDeleteTimeErrorCount = registry.counter(MetricRegistry.name(AzureCloudDestination.class, BLOB_UPDATE_DELETE_TIME_ERROR_COUNT));
+    blobUndeleteLatency = registry.timer(MetricRegistry.name(AzureCloudDestination.class, BLOB_UNDELETE_LATENCY));
+    blobUndeleteSucessRate = registry.meter(MetricRegistry.name(AzureCloudDestination.class, BLOB_UNDELETE_SUCCESS_RATE));
+    blobUndeleteErrorCount = registry.counter(MetricRegistry.name(AzureCloudDestination.class, BLOB_UNDELETE_ERROR_COUNT));
+    blobUpdateTTLLatency = registry.timer(MetricRegistry.name(AzureCloudDestination.class, BLOB_UPDATE_TTL_LATENCY));
+    blobUpdateTTLSucessRate = registry.meter(MetricRegistry.name(AzureCloudDestination.class, BLOB_UPDATE_TTL_SUCCESS_RATE));
+    blobUpdateTTLErrorCount = registry.counter(MetricRegistry.name(AzureCloudDestination.class, BLOB_UPDATE_TTL_ERROR_COUNT));
+    blobUploadErrorCount = registry.counter(MetricRegistry.name(AzureCloudDestination.class, BLOB_UPLOAD_ERROR_COUNT));
     blobDownloadRequestCount =
         registry.counter(MetricRegistry.name(AzureCloudDestination.class, BLOB_DOWNLOAD_REQUEST_COUNT));
     blobDownloadSuccessCount =


### PR DESCRIPTION
The closed-source Ambry expects metrics
to start with com.github.ambry.cloud.azure.AzureCloudDestination.

It doesn't matter which class uses them so long as the names registered in the open-source code match what is expected in the closed-source code.