### PR TITLE
[vcr-2.0] Remove concurrent update errors

### DIFF
--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudRequestAgent.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudRequestAgent.java
@@ -94,7 +94,8 @@ public class CloudRequestAgent {
       } else {
         // Either not retryable or exhausted attempts.
         Throwable t = cse.getCause();
-        Set<StoreErrorCodes> errorCodes = new HashSet<>(Arrays.asList(StoreErrorCodes.Already_Updated));
+        Set<StoreErrorCodes> errorCodes = new HashSet<>(Arrays.asList(StoreErrorCodes.Already_Updated,
+            StoreErrorCodes.ID_Deleted, StoreErrorCodes.Life_Version_Conflict, StoreErrorCodes.ID_Undeleted));
         if (t instanceof StoreException && errorCodes.contains(((StoreException)t).getErrorCode())) {
           // Not very useful to log error here as they are printed in several other places
           logger.trace("{} failed partition {} statusCode {} cause {} made {} attempts.", actionName, partitionPath,


### PR DESCRIPTION
As VCR catches up with all replicas and approaches current time, it starts getting the same updates from all replicas. Multiple VCR threads send the same request to cloud and hit concurrent-update error. The metrics emitted and log messages printed are not really useful as they do not indicate a real issue. This patch removes those metrics and converts the log msgs to a trace msgs.