### PR TITLE
Search duplicate resources in clustermap when partition cant be found in given resource

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
@@ -351,16 +351,6 @@ public class ClusterMapConfig {
   @Default("60 * 1000")
   public final long clustermapDistributedLockLeaseTimeoutInMs;
 
-  public static final String SEARCH_RESOURCE_FOR_PARTITION_IN_EXTERNAL_VIEW =
-      "clustermap.search.resource.for.partition.in.external.view";
-  /**
-   * True to search resource in external view for a given partition id when the resource in ideal state doesn't have
-   * the given partition id.
-   */
-  @Config(SEARCH_RESOURCE_FOR_PARTITION_IN_EXTERNAL_VIEW)
-  @Default("false")
-  public final boolean clustermapSearchResourceForPartitionInExternalView;
-
   public ClusterMapConfig(VerifiableProperties verifiableProperties) {
     clusterMapFixedTimeoutDatanodeErrorThreshold =
         verifiableProperties.getIntInRange("clustermap.fixedtimeout.datanode.error.threshold", 3, 1, 100);
@@ -439,7 +429,5 @@ public class ClusterMapConfig {
     clustermapDefaultReplicaCapacityInBytes =
         verifiableProperties.getLongInRange("clustermap.default.replica.capacity.in.bytes", 384L * 1024 * 1024 * 1024,
             0, Long.MAX_VALUE);
-    clustermapSearchResourceForPartitionInExternalView =
-        verifiableProperties.getBoolean(SEARCH_RESOURCE_FOR_PARTITION_IN_EXTERNAL_VIEW, false);
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
@@ -351,6 +351,16 @@ public class ClusterMapConfig {
   @Default("60 * 1000")
   public final long clustermapDistributedLockLeaseTimeoutInMs;
 
+  public static final String SEARCH_RESOURCE_FOR_PARTITION_IN_EXTERNAL_VIEW =
+      "clustermap.search.resource.for.partition.in.external.view";
+  /**
+   * True to search resource in external view for a given partition id when the resource in ideal state doesn't have
+   * the given partition id.
+   */
+  @Config(SEARCH_RESOURCE_FOR_PARTITION_IN_EXTERNAL_VIEW)
+  @Default("false")
+  public final boolean clustermapSearchResourceForPartitionInExternalView;
+
   public ClusterMapConfig(VerifiableProperties verifiableProperties) {
     clusterMapFixedTimeoutDatanodeErrorThreshold =
         verifiableProperties.getIntInRange("clustermap.fixedtimeout.datanode.error.threshold", 3, 1, 100);
@@ -429,5 +439,7 @@ public class ClusterMapConfig {
     clustermapDefaultReplicaCapacityInBytes =
         verifiableProperties.getLongInRange("clustermap.default.replica.capacity.in.bytes", 384L * 1024 * 1024 * 1024,
             0, Long.MAX_VALUE);
+    clustermapSearchResourceForPartitionInExternalView =
+        verifiableProperties.getBoolean(SEARCH_RESOURCE_FOR_PARTITION_IN_EXTERNAL_VIEW, false);
   }
 }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManagerMetrics.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManagerMetrics.java
@@ -53,6 +53,9 @@ class HelixClusterManagerMetrics {
   public Gauge<Long> helixClusterManagerRemoteInstantiationFailed;
   public Gauge<Long> helixClusterManagerCurrentXid;
   public final Timer routingTableQueryTime;
+  public final Counter resourceNameMismatchCount;
+  public final Counter resourceNameCacheHitCount;
+  public final Counter resourceNameCacheMissCount;
 
   /**
    * Metrics for the {@link HelixClusterManager}
@@ -95,6 +98,12 @@ class HelixClusterManagerMetrics {
     routingTableQueryTime = registry.timer(MetricRegistry.name(HelixClusterManager.class, "routingTableQueryTime"));
     instanceDeleteTriggerCount =
         registry.counter(MetricRegistry.name(HelixClusterManager.class, "instanceDeleteTriggerCount"));
+    resourceNameMismatchCount =
+        registry.counter(MetricRegistry.name(HelixClusterManager.class, "resourceNameMismatchCount"));
+    resourceNameCacheHitCount =
+        registry.counter(MetricRegistry.name(HelixClusterManager.class, "resourceNameCacheHitCount"));
+    resourceNameCacheMissCount =
+        registry.counter(MetricRegistry.name(HelixClusterManager.class, "resourceNameCacheMissCount"));
   }
 
   void initializeInstantiationMetric(final boolean instantiated, final long instantiationExceptionCount) {

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManagerMetrics.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManagerMetrics.java
@@ -54,8 +54,6 @@ class HelixClusterManagerMetrics {
   public Gauge<Long> helixClusterManagerCurrentXid;
   public final Timer routingTableQueryTime;
   public final Counter resourceNameMismatchCount;
-  public final Counter resourceNameCacheHitCount;
-  public final Counter resourceNameCacheMissCount;
 
   /**
    * Metrics for the {@link HelixClusterManager}
@@ -100,10 +98,6 @@ class HelixClusterManagerMetrics {
         registry.counter(MetricRegistry.name(HelixClusterManager.class, "instanceDeleteTriggerCount"));
     resourceNameMismatchCount =
         registry.counter(MetricRegistry.name(HelixClusterManager.class, "resourceNameMismatchCount"));
-    resourceNameCacheHitCount =
-        registry.counter(MetricRegistry.name(HelixClusterManager.class, "resourceNameCacheHitCount"));
-    resourceNameCacheMissCount =
-        registry.counter(MetricRegistry.name(HelixClusterManager.class, "resourceNameCacheMissCount"));
   }
 
   void initializeInstantiationMetric(final boolean instantiated, final long instantiationExceptionCount) {

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/ClusterChangeHandlerTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/ClusterChangeHandlerTest.java
@@ -735,7 +735,11 @@ public class ClusterChangeHandlerTest {
     List<String> newInstances = new ArrayList<>();
     Iterator<String> iter = allInstances.iterator();
     for (int i = 0; i < 3; i++) {
-      newInstances.add(iter.next());
+      String instanceName = iter.next();
+      // Don't add self instance, self instance requires partition override
+      if (!instanceName.equals(selfInstanceName)) {
+        newInstances.add(instanceName);
+      }
     }
 
     // create new resource for this partition with different instance set
@@ -766,9 +770,10 @@ public class ClusterChangeHandlerTest {
               replicaId.getPartitionId().getPartitionClass()));
       instanceConfig = converter.convert(datanodeConfig);
       localMockHelixAdmin.setInstanceConfig(clusterNameStatic, instance, instanceConfig);
+      System.out.println(
+          "---------------- adding replica " + replicaId.getPartitionId().getId() + " to instance " + instance);
     }
     helixCluster.triggerInstanceConfigChangeNotification();
-    Thread.sleep(1000);
 
     List<AmbryReplica> replicas = helixClusterManager.getManagerQueryHelper()
         .getReplicaIdsByState(new AmbryPartition(Long.parseLong(partitionName), null, null), ReplicaState.LEADER,


### PR DESCRIPTION
## Summary

In helix, when we add new resources to ideal state, it will take some time to populate that information to aggregated external view. Within this time, helix cluster manager would know the resources for partitions, but getReplicaIdsByState would fail because the routing table hasn't updated yet. 

This PR would fix this issue by searching in old resources to find the replica ids.

## Test
Unit test