### PR TITLE
[vcr-2.0] Remove redundant metadata

### DIFF
--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestinationSync.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestinationSync.java
@@ -456,8 +456,7 @@ public class AzureCloudDestinationSync implements CloudDestination {
           if cloudLifeVersion == replicaLifeVersion && deleteTime absent in cloudMetatadata, then something is wrong. Throw Life_Version_Conflict.
           if cloudLifeVersion == replicaLifeVersion && deleteTime != -1, then something is wrong. Throw Life_Version_Conflict.
          */
-        if (cloudlifeVersion == lifeVersion && cloudMetadata.containsKey(CloudBlobMetadata.FIELD_DELETION_TIME)
-            && Long.parseLong(cloudMetadata.get(CloudBlobMetadata.FIELD_DELETION_TIME)) == Utils.Infinite_Time) {
+        if (cloudlifeVersion == lifeVersion && !cloudMetadata.containsKey(CloudBlobMetadata.FIELD_DELETION_TIME)) {
           String error = String.format("Failed to undelete blob %s as it is undeleted in cloud", blobIdStr);
           logger.trace(error);
           throw AzureCloudDestination.toCloudStorageException(error, new StoreException(error, StoreErrorCodes.ID_Undeleted), null);


### PR DESCRIPTION
We identify permanent blobs in two different ways.

1. A lack of expiration-time means the blob is permanent
2. expiration = -1 also means the blob is permanent

Similarly, in case of deletion
1. A lack of deletion-time means the blob  must not be purged from cloud. 
2. A deletion-time = -1 also means the blob must not be purged from cloud.

This distinction is not useful anywhere and not used at all during compaction or recovery.
It would be clearer if we just remove the deletion-time field from metadata to indicate the blob must not be purged, and remove expiration-time to indicate blob is permanent.
