### PR TITLE
Swallow all exceptions for background deleter.

### DIFF
--- a/ambry-router/src/main/java/com/github/ambry/router/DeleteOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/DeleteOperation.java
@@ -472,7 +472,7 @@ class DeleteOperation {
             // We may hit AmbryUnavailable or other exceptions.
             // Since we don't do any further thing for it anyway, swallow the exception.
             // Just emit with metrics and log error message
-            routerMetrics.backgroundDeleterNotAvailableCount.inc();
+            routerMetrics.backgroundDeleterExceptionCount.inc();
             logger.error("Background deleter hit exception {} {}", blobId, code);
           }
           operationException.set(null);

--- a/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterMetrics.java
@@ -133,7 +133,7 @@ public class NonBlockingRouterMetrics {
   public final Counter offlineRepairOnTtlUpdateCount;
   public final Counter offlineRepairOnTtlUpdateErrorCount;
   public final Counter backgroundDeleterNotFoundCount;
-  public final Counter backgroundDeleterNotAvailableCount;
+  public final Counter backgroundDeleterExceptionCount;
   public final Counter operationAbortCount;
   public final Counter routerRequestErrorCount;
 
@@ -484,8 +484,8 @@ public class NonBlockingRouterMetrics {
         metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "OfflineRepairOnTtlUpdateErrorCount"));
     backgroundDeleterNotFoundCount =
         metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "BackgroundDeleterNotFoundCount"));
-    backgroundDeleterNotAvailableCount =
-        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "BackgroundDeleterNotAvailableCount"));
+    backgroundDeleterExceptionCount =
+        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "BackgroundDeleterExceptionCount"));
 
     // Performance metrics for operation managers.
     putManagerPollTimeMs = metricRegistry.histogram(MetricRegistry.name(PutManager.class, "PutManagerPollTimeMs"));

--- a/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterMetrics.java
@@ -133,6 +133,7 @@ public class NonBlockingRouterMetrics {
   public final Counter offlineRepairOnTtlUpdateCount;
   public final Counter offlineRepairOnTtlUpdateErrorCount;
   public final Counter backgroundDeleterNotFoundCount;
+  public final Counter backgroundDeleterNotAvailableCount;
   public final Counter operationAbortCount;
   public final Counter routerRequestErrorCount;
 
@@ -483,6 +484,8 @@ public class NonBlockingRouterMetrics {
         metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "OfflineRepairOnTtlUpdateErrorCount"));
     backgroundDeleterNotFoundCount =
         metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "BackgroundDeleterNotFoundCount"));
+    backgroundDeleterNotAvailableCount =
+        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "BackgroundDeleterNotAvailableCount"));
 
     // Performance metrics for operation managers.
     putManagerPollTimeMs = metricRegistry.histogram(MetricRegistry.name(PutManager.class, "PutManagerPollTimeMs"));


### PR DESCRIPTION
For background deleter, we swallow any exception including server unavailable. 