### PR TITLE
Use clustermap to avoid state transitions from old resource

### DIFF
--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryPartitionStateModel.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryPartitionStateModel.java
@@ -78,7 +78,7 @@ public class AmbryPartitionStateModel extends StateModel {
     StateModelParser parser = new StateModelParser();
     _currentState = parser.getInitialState(AmbryPartitionStateModel.class);
     this.partitionNameToResourceName = partitionNameToResourceName;
-    this.clusterManager = clusterManager;
+    this.clusterManager = Objects.requireNonNull(clusterManager, "Clustermap is missing");
   }
 
   @Transition(to = "BOOTSTRAP", from = "OFFLINE")

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryPartitionStateModel.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryPartitionStateModel.java
@@ -15,6 +15,7 @@ package com.github.ambry.clustermap;
 
 import com.github.ambry.config.ClusterMapConfig;
 import java.util.Objects;
+import java.util.Set;
 import org.apache.helix.NotificationContext;
 import org.apache.helix.model.Message;
 import org.apache.helix.participant.statemachine.StateModel;
@@ -32,19 +33,19 @@ import org.slf4j.LoggerFactory;
  *
  * In doing so, we should inevitably 1. duplicate all the partition ids with a different resource 2. remove the old
  * resources.  The issue is that resource doesn't really matter in Ambry. Resource is a structure required by Helix.
- * Ambry has a flatter structure. This structure starts with a cluster. Under this cluster, it has partitions. If we
+ * Ambry has a flat structure. This structure starts with a cluster. Under this cluster, it has partitions. If we
  * duplicate all the partition ids with different resources, we would force these partitions to go through state
  * transition twice. And by removing the old resource, we would effectively force all the partitions to go through
  * downward transition to DROPPED state. We have to make sure that frontend and server would be able to deal with both
  * situations.
  *
  * Current resource names are all numeric numbers starting from 0. The new resource names will be numeric numbers as
- * well, but it will be starting from a much higher number, like 1000. So we can easily find the new resource by just
+ * well, but it will be starting from a much higher number, like 10000. So we can easily find the new resource by just
  * comparing the resource names.
  *
  * When we eventually remove old resources, all the partition ids under those resourced would have to go through state
  * transition to become DROPPED in the end. A dropped partition means all the data will be removed, we don't want any
- * of the partition to remove data. So in state transition, we have to make sure after we add new resources, the state
+ * partition to remove data. So in state transition, we have to make sure after we add new resources, the state
  * transition messages from the old resources would be ignored and won't take effect anymore.
  *
  * Since in server we honor new resource over the old resource, we have to do the same thing in the clustermap.
@@ -56,6 +57,22 @@ import org.slf4j.LoggerFactory;
  * to be leader in different transition, then we would have multiple leaders. But this is fine, since replication manager
  * use this leader pair information for cross-colo replication. The worst case is that we have more than one replicas doing
  * cross-colo data replication.
+ *
+ * In order to make sure we don't allow state transition messages for old resource to go through, we will leverage clustermap.
+ * When new resources are created, clustermap would receive this update and replace the resource name for all the partitions.
+ * StateModel has to compare the resource name in transition messages with the resource name in clustermap. Here are the
+ * four cases StateModel has to deal with.
+ * 1. New resources are created, but clustermap hasn't updated the resources yet
+ * 2. New resources are created, and clustermap has the up-to-date resources
+ * 3. Old resources are removed
+ * 4. Hosts that were unavailable when old resources were removed, now is waking up and deal with state transition messages
+ *    for both new and old resources.
+ *
+ * For case 1, if the resource name from transition message is greater than the resource name from clustermap, then allow the transition
+ * For case 2, resource name from transition message is included in the clustermap.
+ * For case 3, resource name from transition message should be less than the resource name from clustermap, so don't allow the transition
+ * For case 4. clustermap has the new resource name, and old resource name is less than the new ones, so don't allow the transition
+ *             for old resource names, but allow transition for new resource names.
  */
 @StateModelInfo(initialState = "OFFLINE", states = {"BOOTSTRAP", "LEADER", "STANDBY", "INACTIVE"})
 public class AmbryPartitionStateModel extends StateModel {
@@ -193,15 +210,21 @@ public class AmbryPartitionStateModel extends StateModel {
   boolean shouldTransition(Message message) {
     String resourceName = message.getResourceName();
     String partitionName = message.getPartitionName();
-    String resourceNameToCompare = clusterManager.getResourceForPartitionInLocalDc(partitionName);
-    if (resourceNameToCompare == null) {
+    Set<String> resourceNamesToCompare = clusterManager.getResourceForPartitionInLocalDc(partitionName);
+    if (resourceNamesToCompare == null || resourceNamesToCompare.isEmpty()) {
       // this is a new partition, clustermap didn't get the update yet, then just allow transition.
       return true;
     }
-    // The resource from clustermap is lower than or equals to the resource name in the message,
-    // just allow it.
-    // If the resource from clustermap is greater than the resource name in the message, then this transition message
-    // was fired for the old resources.
-    return Integer.valueOf(resourceNameToCompare) <= Integer.valueOf(resourceName));
+    if (resourceNamesToCompare.contains(resourceName)) {
+      // Resource name is one of the legit resource in clustermap.
+      return true;
+    }
+    // If the resource name is lower than all the resource names in the clustermap, then don't allow it.
+    for (String resourceNameToCompare : resourceNamesToCompare) {
+      if (Integer.valueOf(resourceNameToCompare) < Integer.valueOf(resourceName)) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryStateModelFactory.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryStateModelFactory.java
@@ -14,7 +14,6 @@
 package com.github.ambry.clustermap;
 
 import com.github.ambry.config.ClusterMapConfig;
-import java.util.concurrent.ConcurrentHashMap;
 import org.apache.helix.model.LeaderStandbySMD;
 import org.apache.helix.participant.statemachine.StateModel;
 import org.apache.helix.participant.statemachine.StateModelFactory;
@@ -27,7 +26,6 @@ class AmbryStateModelFactory extends StateModelFactory<StateModel> {
   private final ClusterMapConfig clustermapConfig;
   private final HelixClusterManager clusterManager;
   private final PartitionStateChangeListener partitionStateChangeListener;
-  private final ConcurrentHashMap<String, String> partitionNameToResourceName = new ConcurrentHashMap<>();
 
   AmbryStateModelFactory(ClusterMapConfig clusterMapConfig, PartitionStateChangeListener partitionStateChangeListener,
       HelixClusterManager clusterManager) {
@@ -49,7 +47,7 @@ class AmbryStateModelFactory extends StateModelFactory<StateModel> {
       case AmbryStateModelDefinition.AMBRY_LEADER_STANDBY_MODEL:
         stateModelToReturn =
             new AmbryPartitionStateModel(resourceName, partitionName, partitionStateChangeListener, clustermapConfig,
-                partitionNameToResourceName, clusterManager);
+                clusterManager);
         break;
       case LeaderStandbySMD.name:
         stateModelToReturn = new DefaultLeaderStandbyStateModel();

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryStateModelFactory.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryStateModelFactory.java
@@ -25,12 +25,15 @@ import org.apache.helix.participant.statemachine.StateModelFactory;
  */
 class AmbryStateModelFactory extends StateModelFactory<StateModel> {
   private final ClusterMapConfig clustermapConfig;
+  private final HelixClusterManager clusterManager;
   private final PartitionStateChangeListener partitionStateChangeListener;
   private final ConcurrentHashMap<String, String> partitionNameToResourceName = new ConcurrentHashMap<>();
 
-  AmbryStateModelFactory(ClusterMapConfig clusterMapConfig, PartitionStateChangeListener partitionStateChangeListener) {
+  AmbryStateModelFactory(ClusterMapConfig clusterMapConfig, PartitionStateChangeListener partitionStateChangeListener,
+      HelixClusterManager clusterManager) {
     this.clustermapConfig = clusterMapConfig;
     this.partitionStateChangeListener = partitionStateChangeListener;
+    this.clusterManager = clusterManager;
   }
 
   /**
@@ -46,7 +49,7 @@ class AmbryStateModelFactory extends StateModelFactory<StateModel> {
       case AmbryStateModelDefinition.AMBRY_LEADER_STANDBY_MODEL:
         stateModelToReturn =
             new AmbryPartitionStateModel(resourceName, partitionName, partitionStateChangeListener, clustermapConfig,
-                partitionNameToResourceName);
+                partitionNameToResourceName, clusterManager);
         break;
       case LeaderStandbySMD.name:
         stateModelToReturn = new DefaultLeaderStandbyStateModel();

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterAgentsFactory.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterAgentsFactory.java
@@ -85,7 +85,8 @@ public class HelixClusterAgentsFactory implements ClusterAgentsFactory {
         boolean isSoleParticipant = zkConnectStrs.size() == 1;
         for (String zkConnectStr : zkConnectStrs) {
           helixParticipants.add(
-              new HelixParticipant(clusterMapConfig, helixFactory, metricRegistry, zkConnectStr, isSoleParticipant));
+              new HelixParticipant(getClusterMap(), clusterMapConfig, helixFactory, metricRegistry, zkConnectStr,
+                  isSoleParticipant));
         }
       } catch (JSONException e) {
         throw new IOException("Received JSON exception while parsing ZKInfo json string", e);

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
@@ -671,7 +671,7 @@ public class HelixClusterManager implements ClusterMap {
     return dcToDcInfo.get(clusterMapConfig.clusterMapDatacenterName).dcZkInfo.getZkConnectStrs().get(0);
   }
 
-  public String getResourceForPartitionInLocalDc(String partitionName) {
+  public Set<String> getResourceForPartitionInLocalDc(String partitionName) {
     return partitionToResourceNameByDc.get(clusterMapConfig.clusterMapDatacenterName).get(partitionName);
   }
 

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
@@ -671,6 +671,10 @@ public class HelixClusterManager implements ClusterMap {
     return dcToDcInfo.get(clusterMapConfig.clusterMapDatacenterName).dcZkInfo.getZkConnectStrs().get(0);
   }
 
+  public String getResourceForPartitionInLocalDc(String partitionName) {
+    return partitionToResourceNameByDc.get(clusterMapConfig.clusterMapDatacenterName).get(partitionName);
+  }
+
   /**
    * Add partition if it's not present in cluster-wide partition map and also update cluster-wide allocated usable
    * capacity. If the partition already exists, skip addition and return current partition.

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
@@ -62,6 +62,7 @@ import static com.github.ambry.clustermap.StateTransitionException.TransitionErr
 public class HelixParticipant implements ClusterParticipant, PartitionStateChangeListener {
   public static final String DISK_KEY = "DISK";
   protected final HelixParticipantMetrics participantMetrics;
+  private final HelixClusterManager clusterManager;
   private final String clusterName;
   private final String zkConnectStr;
   private final Object helixAdministrationLock = new Object();
@@ -88,9 +89,10 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
    * @param zkConnectStr the address identifying the zk service which this participant interacts with.
    * @param isSoleParticipant whether this is the sole participant on current node.
    */
-  public HelixParticipant(ClusterMapConfig clusterMapConfig, HelixFactory helixFactory, MetricRegistry metricRegistry,
-      String zkConnectStr, boolean isSoleParticipant) {
+  public HelixParticipant(HelixClusterManager clusterManager, ClusterMapConfig clusterMapConfig,
+      HelixFactory helixFactory, MetricRegistry metricRegistry, String zkConnectStr, boolean isSoleParticipant) {
     this.clusterMapConfig = clusterMapConfig;
+    this.clusterManager = clusterManager;
     this.zkConnectStr = zkConnectStr;
     this.metricRegistry = metricRegistry;
     participantMetrics =
@@ -137,7 +139,7 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
         clusterMapConfig.clustermapStateModelDefinition);
     StateMachineEngine stateMachineEngine = manager.getStateMachineEngine();
     stateMachineEngine.registerStateModelFactory(clusterMapConfig.clustermapStateModelDefinition,
-        new AmbryStateModelFactory(clusterMapConfig, this));
+        new AmbryStateModelFactory(clusterMapConfig, this, clusterManager));
     registerStatsReportAggregationTasks(stateMachineEngine, ambryStatsReports, accountStatsStore, callback);
     try {
       // register server as a participant

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/AmbryReplicaSyncUpManagerTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/AmbryReplicaSyncUpManagerTest.java
@@ -24,7 +24,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -85,7 +84,7 @@ public class AmbryReplicaSyncUpManagerTest {
     mockHelixParticipant.replicaSyncUpService = replicaSyncUpService;
     stateModel =
         new AmbryPartitionStateModel(RESOURCE_NAME, partition.toPathString(), mockHelixParticipant, clusterMapConfig,
-            new ConcurrentHashMap<>(), mock(HelixClusterManager.class));
+            mock(HelixClusterManager.class));
     mockMessage = Mockito.mock(Message.class);
     when(mockMessage.getPartitionName()).thenReturn(partition.toPathString());
     when(mockMessage.getResourceName()).thenReturn(RESOURCE_NAME);

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/AmbryReplicaSyncUpManagerTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/AmbryReplicaSyncUpManagerTest.java
@@ -85,7 +85,7 @@ public class AmbryReplicaSyncUpManagerTest {
     mockHelixParticipant.replicaSyncUpService = replicaSyncUpService;
     stateModel =
         new AmbryPartitionStateModel(RESOURCE_NAME, partition.toPathString(), mockHelixParticipant, clusterMapConfig,
-            new ConcurrentHashMap<>());
+            new ConcurrentHashMap<>(), mock(HelixClusterManager.class));
     mockMessage = Mockito.mock(Message.class);
     when(mockMessage.getPartitionName()).thenReturn(partition.toPathString());
     when(mockMessage.getResourceName()).thenReturn(RESOURCE_NAME);

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/AmbryStateModelFactoryTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/AmbryStateModelFactoryTest.java
@@ -24,8 +24,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixManager;
 import org.apache.helix.model.InstanceConfig;
@@ -162,9 +160,11 @@ public class AmbryStateModelFactoryTest {
     Message mockMessage = Mockito.mock(Message.class);
     when(mockMessage.getPartitionName()).thenReturn(partitionName);
     when(mockMessage.getResourceName()).thenReturn(resourceName);
+    HelixClusterManager clusterManager = mock(HelixClusterManager.class);
+    // The cluster map returns resource name
+    when(clusterManager.getResourceForPartitionInLocalDc(anyString())).thenReturn(Collections.singleton(resourceName));
     AmbryPartitionStateModel stateModel =
-        new AmbryPartitionStateModel(resourceName, partitionName, mockHelixParticipant, config,
-            new ConcurrentHashMap<>(), mock(HelixClusterManager.class));
+        new AmbryPartitionStateModel(resourceName, partitionName, mockHelixParticipant, config, clusterManager);
     mockHelixParticipant.setInitialLocalPartitions(new HashSet<>(Collections.singletonList(partitionName)));
     assertStateCount(Arrays.asList("offline"), Arrays.asList(1), metricRegistry);
 
@@ -249,25 +249,26 @@ public class AmbryStateModelFactoryTest {
     Message newMockMessage = Mockito.mock(Message.class);
     when(newMockMessage.getPartitionName()).thenReturn(partitionName);
     when(newMockMessage.getResourceName()).thenReturn(newResourceName);
-    ConcurrentMap<String, String> partitionToResource = new ConcurrentHashMap<>();
 
+    HelixClusterManager clusterManager = mock(HelixClusterManager.class);
+
+    // Test case 1. clustermap returns the newResourceName when retrieving resource name for partition
+    when(clusterManager.getResourceForPartitionInLocalDc(anyString())).thenReturn(
+        Collections.singleton(newResourceName));
     AmbryPartitionStateModel stateModel =
-        new AmbryPartitionStateModel(resourceName, partitionName, mockHelixParticipant, config, partitionToResource,
-            mock(HelixClusterManager.class));
-
+        new AmbryPartitionStateModel(resourceName, partitionName, mockHelixParticipant, config, clusterManager);
     AmbryPartitionStateModel newStateModel =
-        new AmbryPartitionStateModel(newResourceName, partitionName, mockHelixParticipant, config, partitionToResource,
-            mock(HelixClusterManager.class));
+        new AmbryPartitionStateModel(newResourceName, partitionName, mockHelixParticipant, config, clusterManager);
 
     // resource move to bootstrap then new resource start transition
     mockHelixParticipant.setInitialLocalPartitions(new HashSet<>(Collections.singletonList(partitionName)));
     assertStateCount(Arrays.asList("offline"), Arrays.asList(1), metricRegistry);
-    // resource: OFFLINE -> BOOTSTRAP, should work
+    // resource: OFFLINE -> BOOTSTRAP, shouldn't work, partition belongs to new resource name
     stateModel.onBecomeBootstrapFromOffline(mockMessage, null);
-    assertStateCount(Arrays.asList("offline", "bootstrap"), Arrays.asList(0, 1), metricRegistry);
-    // resource: BOOTSTRAP -> STANDBY, should work
+    assertStateCount(Arrays.asList("offline", "bootstrap"), Arrays.asList(1, 0), metricRegistry);
+    // resource: BOOTSTRAP -> STANDBY, shouldn't work, partition belongs to new resource name
     stateModel.onBecomeStandbyFromBootstrap(mockMessage, null);
-    assertStateCount(Arrays.asList("offline", "bootstrap", "standby"), Arrays.asList(0, 0, 1), metricRegistry);
+    assertStateCount(Arrays.asList("offline", "bootstrap", "standby"), Arrays.asList(1, 0, 0), metricRegistry);
     // new resource: OFFLINE -> BOOTSTRAP, should work
     newStateModel.onBecomeBootstrapFromOffline(newMockMessage, null);
     assertStateCount(Arrays.asList("offline", "bootstrap", "standby"), Arrays.asList(0, 1, 0), metricRegistry);
@@ -337,11 +338,74 @@ public class AmbryStateModelFactoryTest {
     // call reset method again to mock the case where same partition is reset multiple times during zk disconnection or shutdown
     newStateModel.reset();
     assertStateCount(Arrays.asList("offline"), Arrays.asList(1), metricRegistry);
+
+    // Test case 2. clustermap returns the old resourceName when retrieving resource name for partition.
+    when(clusterManager.getResourceForPartitionInLocalDc(anyString())).thenReturn(Collections.singleton(resourceName));
+    stateModel =
+        new AmbryPartitionStateModel(resourceName, partitionName, mockHelixParticipant, config, clusterManager);
+    newStateModel =
+        new AmbryPartitionStateModel(newResourceName, partitionName, mockHelixParticipant, config, clusterManager);
+
+    // resource move to bootstrap then new resource start transition
+    mockHelixParticipant.setInitialLocalPartitions(new HashSet<>(Collections.singletonList(partitionName)));
+    // resource: OFFLINE -> BOOTSTRAP, should work
+    stateModel.onBecomeBootstrapFromOffline(mockMessage, null);
+    assertStateCount(Arrays.asList("offline", "bootstrap"), Arrays.asList(0, 1), metricRegistry);
+    // resource: BOOTSTRAP -> STANDBY, should work
+    stateModel.onBecomeStandbyFromBootstrap(mockMessage, null);
+    assertStateCount(Arrays.asList("offline", "bootstrap", "standby"), Arrays.asList(0, 0, 1), metricRegistry);
+    // resource: STANDBY -> LEADER, should work
+    stateModel.onBecomeLeaderFromStandby(mockMessage, null);
+    assertStateCount(Arrays.asList("offline", "bootstrap", "standby", "leader"), Arrays.asList(0, 0, 0, 1),
+        metricRegistry);
+
+    // new resource: OFFLINE -> BOOTSTRAP, should work
+    newStateModel.onBecomeBootstrapFromOffline(newMockMessage, null);
+    assertStateCount(Arrays.asList("offline", "bootstrap", "standby", "leader"), Arrays.asList(0, 1, 0, 0),
+        metricRegistry);
+    // new resource: BOOTSTRAP -> STANDBY, should work
+    newStateModel.onBecomeStandbyFromBootstrap(newMockMessage, null);
+    assertStateCount(Arrays.asList("offline", "bootstrap", "standby", "leader"), Arrays.asList(0, 0, 1, 0),
+        metricRegistry);
+    // new resource: STANDBY -> LEADER, should work
+    newStateModel.onBecomeLeaderFromStandby(newMockMessage, null);
+    assertStateCount(Arrays.asList("offline", "bootstrap", "standby", "leader"), Arrays.asList(0, 0, 0, 1),
+        metricRegistry);
+    // new resource: LEADER -> STANDBY, should work
+    newStateModel.onBecomeStandbyFromLeader(newMockMessage, null);
+    assertStateCount(Arrays.asList("offline", "bootstrap", "standby", "leader"), Arrays.asList(0, 0, 1, 0),
+        metricRegistry);
+    // new resource: STANDBY -> INACTIVE, should work
+    newStateModel.onBecomeInactiveFromStandby(newMockMessage, null);
+    assertStateCount(Arrays.asList("offline", "standby", "inactive"), Arrays.asList(0, 0, 1), metricRegistry);
+    // new resource: INACTIVE -> OFFLINE, should work
+    newStateModel.onBecomeOfflineFromInactive(newMockMessage, null);
+    assertStateCount(Arrays.asList("offline", "inactive"), Arrays.asList(1, 0), metricRegistry);
+    // new resource: OFFLINE -> DROPPED, should work
+    disabledPartitionSet.add(partitionName);
+    newStateModel.onBecomeDroppedFromOffline(newMockMessage, null);
+    assertStateCount(Arrays.asList("offline"), Arrays.asList(0), metricRegistry);
+    assertEquals("Dropped count should be updated", 3, participantMetrics.partitionDroppedCount.getCount());
+    assertTrue("Partition should be removed from disabled partition set", disabledPartitionSet.isEmpty());
+    assertEquals("Mismatch in enabled partition", partitionName, enabledPartitionSet.iterator().next());
+    // new resource: ERROR -> DROPPED, should work
+    newStateModel.onBecomeDroppedFromError(newMockMessage, null);
+    assertEquals("Dropped count should be updated", 4, participantMetrics.partitionDroppedCount.getCount());
+    // new resource: ERROR -> OFFLINE (this occurs when we use Helix API to reset certain partition in ERROR state)
+    newStateModel.onBecomeOfflineFromError(newMockMessage, null);
+    assertStateCount(Arrays.asList("offline"), Arrays.asList(1), metricRegistry);
+    // reset method
+    newStateModel.reset();
+    assertStateCount(Arrays.asList("offline"), Arrays.asList(1), metricRegistry);
+    // call reset method again to mock the case where same partition is reset multiple times during zk disconnection or shutdown
+    newStateModel.reset();
+    assertStateCount(Arrays.asList("offline"), Arrays.asList(1), metricRegistry);
+
     MockHelixManagerFactory.overrideGetHelixManager = false;
   }
 
   @Test
-  public void testDuplicatePartitionIdsWithClustermap() {
+  public void testMultipleResourceNamesFromClusterMap() {
     assumeTrue(stateModelDef.equals(ClusterMapConfig.AMBRY_STATE_MODEL_DEF));
     MetricRegistry metricRegistry = new MetricRegistry();
     MockHelixParticipant.metricRegistry = metricRegistry;
@@ -380,35 +444,34 @@ public class AmbryStateModelFactoryTest {
     Message newMockMessage = Mockito.mock(Message.class);
     when(newMockMessage.getPartitionName()).thenReturn(partitionName);
     when(newMockMessage.getResourceName()).thenReturn(newResourceName);
-    ConcurrentMap<String, String> partitionToResource = new ConcurrentHashMap<>();
     HelixClusterManager clusterManager = mock(HelixClusterManager.class);
     // The cluster map returns new resource name
-    when(clusterManager.getResourceForPartitionInLocalDc(anyString())).thenReturn(newResourceName);
+    when(clusterManager.getResourceForPartitionInLocalDc(anyString())).thenReturn(
+        new HashSet<>(Arrays.asList(resourceName, newResourceName)));
 
     AmbryPartitionStateModel stateModel =
-        new AmbryPartitionStateModel(resourceName, partitionName, mockHelixParticipant, config, partitionToResource,
-            clusterManager);
-
+        new AmbryPartitionStateModel(resourceName, partitionName, mockHelixParticipant, config, clusterManager);
     AmbryPartitionStateModel newStateModel =
-        new AmbryPartitionStateModel(newResourceName, partitionName, mockHelixParticipant, config, partitionToResource,
-            clusterManager);
+        new AmbryPartitionStateModel(newResourceName, partitionName, mockHelixParticipant, config, clusterManager);
 
     // resource move to bootstrap then new resource start transition
     mockHelixParticipant.setInitialLocalPartitions(new HashSet<>(Collections.singletonList(partitionName)));
     assertStateCount(Arrays.asList("offline"), Arrays.asList(1), metricRegistry);
-    // resource: OFFLINE -> BOOTSTRAP, should not work, since the cluster map return new resource name for this partition
+    // resource: OFFLINE -> BOOTSTRAP, should work
     stateModel.onBecomeBootstrapFromOffline(mockMessage, null);
-    assertStateCount(Arrays.asList("offline", "bootstrap"), Arrays.asList(1, 0), metricRegistry);
-    // resource: BOOTSTRAP -> STANDBY, should not work
+    assertStateCount(Arrays.asList("offline", "bootstrap"), Arrays.asList(0, 1), metricRegistry);
+    // resource: BOOTSTRAP -> STANDBY, should work
     stateModel.onBecomeStandbyFromBootstrap(mockMessage, null);
-    assertStateCount(Arrays.asList("offline", "bootstrap", "standby"), Arrays.asList(1, 0, 0), metricRegistry);
+    assertStateCount(Arrays.asList("offline", "bootstrap", "standby"), Arrays.asList(0, 0, 1), metricRegistry);
     // new resource: OFFLINE -> BOOTSTRAP, should work
     newStateModel.onBecomeBootstrapFromOffline(newMockMessage, null);
     assertStateCount(Arrays.asList("offline", "bootstrap", "standby"), Arrays.asList(0, 1, 0), metricRegistry);
 
-    // resource: OFFLINE -> DROPPED, should not work
+    // resource: OFFLINE -> DROPPED, should work
     stateModel.onBecomeDroppedFromOffline(mockMessage, null);
-    assertStateCount(Arrays.asList("offline", "bootstrap", "standby"), Arrays.asList(0, 1, 0), metricRegistry);
+    assertStateCount(Arrays.asList("offline", "bootstrap", "standby"), Arrays.asList(0, 0, 0), metricRegistry);
+    assertEquals("Dropped count should be updated", 1, participantMetrics.partitionDroppedCount.getCount());
+
     MockHelixManagerFactory.overrideGetHelixManager = false;
   }
 

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixParticipantTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixParticipantTest.java
@@ -432,7 +432,7 @@ public class HelixParticipantTest {
     props.setProperty("clustermap.dcs.zk.connect.strings", "");
     clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
     try {
-      new HelixClusterAgentsFactory(clusterMapConfig, new MetricRegistry()).getClusterParticipants();
+      new HelixClusterAgentsFactoryWithMockClusterMap(clusterMapConfig, new MetricRegistry()).getClusterParticipants();
       fail("Instantiation should have failed");
     } catch (IOException e) {
       // OK
@@ -457,8 +457,8 @@ public class HelixParticipantTest {
     props.setProperty("clustermap.dcs.zk.connect.strings", jsonObject.toString(2));
     ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
     try {
-      List<ClusterParticipant> participants =
-          new HelixClusterAgentsFactory(clusterMapConfig, helixManagerFactory).getClusterParticipants();
+      List<ClusterParticipant> participants = new HelixClusterAgentsFactoryWithMockClusterMap(clusterMapConfig,
+          helixManagerFactory).getClusterParticipants();
       assertEquals("Number of participants is not expected", 2, participants.size());
     } catch (Exception e) {
       throw e;
@@ -511,7 +511,8 @@ public class HelixParticipantTest {
 
     DataNodeConfig.DiskConfig diskConfig = dataNodeConfig.getDiskConfigs().values().iterator().next();
     String existingReplicaName = diskConfig.getReplicaConfigs().keySet().iterator().next();
-    PartitionId correspondingPartition = testPartitionLayout.getPartitionLayout().getPartitions(null)
+    PartitionId correspondingPartition = testPartitionLayout.getPartitionLayout()
+        .getPartitions(null)
         .stream()
         .filter(p -> p.toPathString().equals(existingReplicaName))
         .findFirst()
@@ -1089,5 +1090,20 @@ public class HelixParticipantTest {
   private void listIsExpectedSize(List<String> list, int expectedSize, String listName) {
     assertNotNull(listName + " is null", list);
     assertEquals(listName + " doesn't have the expected size " + expectedSize, expectedSize, list.size());
+  }
+
+  private static class HelixClusterAgentsFactoryWithMockClusterMap extends HelixClusterAgentsFactory {
+    public HelixClusterAgentsFactoryWithMockClusterMap(ClusterMapConfig config, HelixFactory helixFactory) {
+      super(config, helixFactory);
+    }
+
+    public HelixClusterAgentsFactoryWithMockClusterMap(ClusterMapConfig config, MetricRegistry metricRegistry) {
+      super(config, metricRegistry);
+    }
+
+    @Override
+    public HelixClusterManager getClusterMap() throws IOException {
+      return mock(HelixClusterManager.class);
+    }
   }
 }

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixParticipantTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixParticipantTest.java
@@ -170,8 +170,9 @@ public class HelixParticipantTest {
     //setup HelixParticipant and dependencies
     ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
     String instanceName = ClusterMapUtils.getInstanceName("localhost", clusterMapConfig.clusterMapPort);
-    HelixParticipant helixParticipant = new HelixParticipant(clusterMapConfig, new HelixFactory(), new MetricRegistry(),
-        getDefaultZkConnectStr(clusterMapConfig), true);
+    HelixParticipant helixParticipant =
+        new HelixParticipant(mock(HelixClusterManager.class), clusterMapConfig, new HelixFactory(),
+            new MetricRegistry(), getDefaultZkConnectStr(clusterMapConfig), true);
     ZKHelixAdmin helixAdmin = new ZKHelixAdmin("localhost:" + zkInfo.getPort());
     DataNodeConfig dataNodeConfig = getDataNodeConfigInHelix(helixAdmin, instanceName);
 
@@ -316,8 +317,9 @@ public class HelixParticipantTest {
     //setup HelixParticipant, HelixParticipantDummy and dependencies
     ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
     String instanceName = ClusterMapUtils.getInstanceName("localhost", clusterMapConfig.clusterMapPort);
-    HelixParticipant helixParticipant = new HelixParticipant(clusterMapConfig, new HelixFactory(), new MetricRegistry(),
-        getDefaultZkConnectStr(clusterMapConfig), true);
+    HelixParticipant helixParticipant =
+        new HelixParticipant(mock(HelixClusterManager.class), clusterMapConfig, new HelixFactory(),
+            new MetricRegistry(), getDefaultZkConnectStr(clusterMapConfig), true);
     ZKHelixAdmin helixAdmin = new ZKHelixAdmin("localhost:" + zkInfo.getPort());
     DataNodeConfig dataNodeConfig = getDataNodeConfigInHelix(helixAdmin, instanceName);
 
@@ -406,8 +408,8 @@ public class HelixParticipantTest {
     ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
     helixManagerFactory.getHelixManager(InstanceType.PARTICIPANT).beBad = true;
     HelixParticipant helixParticipant =
-        new HelixParticipant(clusterMapConfig, helixManagerFactory, new MetricRegistry(),
-            getDefaultZkConnectStr(clusterMapConfig), true);
+        new HelixParticipant(mock(HelixClusterManager.class), clusterMapConfig, helixManagerFactory,
+            new MetricRegistry(), getDefaultZkConnectStr(clusterMapConfig), true);
     try {
       helixParticipant.participate(Collections.emptyList(), null, null);
       fail("Participation should have failed");
@@ -419,7 +421,7 @@ public class HelixParticipantTest {
     props.setProperty("clustermap.cluster.name", "");
     clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
     try {
-      new HelixParticipant(clusterMapConfig, helixManagerFactory, new MetricRegistry(),
+      new HelixParticipant(mock(HelixClusterManager.class), clusterMapConfig, helixManagerFactory, new MetricRegistry(),
           getDefaultZkConnectStr(clusterMapConfig), true);
       fail("Instantiation should have failed");
     } catch (IllegalStateException e) {
@@ -473,8 +475,9 @@ public class HelixParticipantTest {
   @Test
   public void testHelixParticipant() throws Exception {
     ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
-    HelixParticipant participant = new HelixParticipant(clusterMapConfig, helixManagerFactory, new MetricRegistry(),
-        getDefaultZkConnectStr(clusterMapConfig), true);
+    HelixParticipant participant =
+        new HelixParticipant(mock(HelixClusterManager.class), clusterMapConfig, helixManagerFactory,
+            new MetricRegistry(), getDefaultZkConnectStr(clusterMapConfig), true);
     assertTrue(helixManagerFactory.getHelixManager(InstanceType.SPECTATOR).isConnected());
     assertFalse(helixManagerFactory.getHelixManager(InstanceType.PARTICIPANT).isConnected());
 
@@ -497,8 +500,9 @@ public class HelixParticipantTest {
     // override some props for current test
     props.setProperty("clustermap.update.datanode.info", Boolean.toString(true));
     ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
-    HelixParticipant participant = new HelixParticipant(clusterMapConfig, new HelixFactory(), new MetricRegistry(),
-        getDefaultZkConnectStr(clusterMapConfig), true);
+    HelixParticipant participant =
+        new HelixParticipant(mock(HelixClusterManager.class), clusterMapConfig, new HelixFactory(),
+            new MetricRegistry(), getDefaultZkConnectStr(clusterMapConfig), true);
     participant.markDisablePartitionComplete();
     // create InstanceConfig for local node. Also, put existing replica into sealed list
     String instanceName = ClusterMapUtils.getInstanceName("localhost", clusterMapConfig.clusterMapPort);
@@ -507,8 +511,7 @@ public class HelixParticipantTest {
 
     DataNodeConfig.DiskConfig diskConfig = dataNodeConfig.getDiskConfigs().values().iterator().next();
     String existingReplicaName = diskConfig.getReplicaConfigs().keySet().iterator().next();
-    PartitionId correspondingPartition = testPartitionLayout.getPartitionLayout()
-        .getPartitions(null)
+    PartitionId correspondingPartition = testPartitionLayout.getPartitionLayout().getPartitions(null)
         .stream()
         .filter(p -> p.toPathString().equals(existingReplicaName))
         .findFirst()
@@ -579,8 +582,9 @@ public class HelixParticipantTest {
 
     props.setProperty("clustermap.update.datanode.info", Boolean.toString(true));
     ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
-    HelixParticipant participant = new HelixParticipant(clusterMapConfig, new HelixFactory(), new MetricRegistry(),
-        getDefaultZkConnectStr(clusterMapConfig), true);
+    HelixParticipant participant =
+        new HelixParticipant(mock(HelixClusterManager.class), clusterMapConfig, new HelixFactory(),
+            new MetricRegistry(), getDefaultZkConnectStr(clusterMapConfig), true);
     participant.markDisablePartitionComplete();
     // create InstanceConfig for local node. Also, put existing replica into sealed list
     String instanceName = ClusterMapUtils.getInstanceName("localhost", clusterMapConfig.clusterMapPort);
@@ -656,8 +660,9 @@ public class HelixParticipantTest {
   public void testUpdateDiskCapacity() throws Exception {
     ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
     String instanceName = ClusterMapUtils.getInstanceName("localhost", clusterMapConfig.clusterMapPort);
-    HelixParticipant helixParticipant = new HelixParticipant(clusterMapConfig, new HelixFactory(), new MetricRegistry(),
-        getDefaultZkConnectStr(clusterMapConfig), true);
+    HelixParticipant helixParticipant =
+        new HelixParticipant(mock(HelixClusterManager.class), clusterMapConfig, new HelixFactory(),
+            new MetricRegistry(), getDefaultZkConnectStr(clusterMapConfig), true);
     HelixAdmin helixAdmin = helixParticipant.getHelixAdmin();
     InstanceConfig instanceConfig = helixAdmin.getInstanceConfig(clusterName, instanceName);
     // By default, there is no disk capacity
@@ -683,8 +688,9 @@ public class HelixParticipantTest {
     assumeTrue(dataNodeConfigSourceType == DataNodeConfigSourceType.PROPERTY_STORE);
     ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
     String instanceName = ClusterMapUtils.getInstanceName("localhost", clusterMapConfig.clusterMapPort);
-    HelixParticipant helixParticipant = new HelixParticipant(clusterMapConfig, new HelixFactory(), new MetricRegistry(),
-        getDefaultZkConnectStr(clusterMapConfig), true);
+    HelixParticipant helixParticipant =
+        new HelixParticipant(mock(HelixClusterManager.class), clusterMapConfig, new HelixFactory(),
+            new MetricRegistry(), getDefaultZkConnectStr(clusterMapConfig), true);
     HelixAdmin helixAdmin = helixParticipant.getHelixAdmin();
     DataNodeConfig dataNodeConfig = getDataNodeConfigInHelix(helixAdmin, instanceName);
     // by default, all disks are available
@@ -754,8 +760,9 @@ public class HelixParticipantTest {
     assumeTrue(stateModelDef.equals(ClusterMapConfig.AMBRY_STATE_MODEL_DEF));
     ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
     MetricRegistry metricRegistry = new MetricRegistry();
-    HelixParticipant helixParticipant = new HelixParticipant(clusterMapConfig, new HelixFactory(), metricRegistry,
-        getDefaultZkConnectStr(clusterMapConfig), true);
+    HelixParticipant helixParticipant =
+        new HelixParticipant(mock(HelixClusterManager.class), clusterMapConfig, new HelixFactory(), metricRegistry,
+            getDefaultZkConnectStr(clusterMapConfig), true);
     // participate
     helixParticipant.participate(Collections.emptyList(), null, null);
     HelixManager manager = helixParticipant.getHelixManager();
@@ -813,8 +820,9 @@ public class HelixParticipantTest {
     assumeTrue(stateModelDef.equals(ClusterMapConfig.AMBRY_STATE_MODEL_DEF));
     ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
     MetricRegistry metricRegistry = new MetricRegistry();
-    HelixParticipant helixParticipant = new HelixParticipant(clusterMapConfig, new HelixFactory(), metricRegistry,
-        getDefaultZkConnectStr(clusterMapConfig), true);
+    HelixParticipant helixParticipant =
+        new HelixParticipant(mock(HelixClusterManager.class), clusterMapConfig, new HelixFactory(), metricRegistry,
+            getDefaultZkConnectStr(clusterMapConfig), true);
 
     // Mock a state change listener to throw an exception
     PartitionStateChangeListener listener = mock(PartitionStateChangeListener.class);
@@ -867,8 +875,9 @@ public class HelixParticipantTest {
   public void testDistributedLock() throws Exception {
     ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
     MetricRegistry metricRegistry = new MetricRegistry();
-    HelixParticipant helixParticipant = new HelixParticipant(clusterMapConfig, new HelixFactory(), metricRegistry,
-        getDefaultZkConnectStr(clusterMapConfig), true);
+    HelixParticipant helixParticipant =
+        new HelixParticipant(mock(HelixClusterManager.class), clusterMapConfig, new HelixFactory(), metricRegistry,
+            getDefaultZkConnectStr(clusterMapConfig), true);
 
     // By default, helix library would use shared zookeeper connection
     DistributedLock lock1 = helixParticipant.getDistributedLock("TestDistributedLock", "for testing");
@@ -903,10 +912,12 @@ public class HelixParticipantTest {
   public void testMaintenanceMode() throws Exception {
     ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
     MetricRegistry metricRegistry = new MetricRegistry();
-    HelixParticipant helixParticipant = new HelixParticipant(clusterMapConfig, new HelixFactory(), metricRegistry,
-        getDefaultZkConnectStr(clusterMapConfig), true);
-    HelixParticipant helixParticipant2 = new HelixParticipant(clusterMapConfig, new HelixFactory(), metricRegistry,
-        getDefaultZkConnectStr(clusterMapConfig), true);
+    HelixParticipant helixParticipant =
+        new HelixParticipant(mock(HelixClusterManager.class), clusterMapConfig, new HelixFactory(), metricRegistry,
+            getDefaultZkConnectStr(clusterMapConfig), true);
+    HelixParticipant helixParticipant2 =
+        new HelixParticipant(mock(HelixClusterManager.class), clusterMapConfig, new HelixFactory(), metricRegistry,
+            getDefaultZkConnectStr(clusterMapConfig), true);
 
     try {
       helixParticipant.exitMaintenanceMode();

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixParticipant.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixParticipant.java
@@ -89,7 +89,7 @@ public class MockHelixParticipant extends HelixParticipant {
   }
 
   public MockHelixParticipant(ClusterMapConfig clusterMapConfig, HelixFactory helixFactory) {
-    super(clusterMapConfig, helixFactory, metricRegistry,
+    super(mock(HelixClusterManager.class), clusterMapConfig, helixFactory, metricRegistry,
         parseDcJsonAndPopulateDcInfo(clusterMapConfig.clusterMapDcsZkConnectStrings).get(
             clusterMapConfig.clusterMapDatacenterName).getZkConnectStrs().get(0), true);
   }

--- a/ambry-store/src/test/java/com/github/ambry/store/StorageManagerTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/StorageManagerTest.java
@@ -1312,9 +1312,10 @@ public class StorageManagerTest {
         DataNodeConfigSourceType.PROPERTY_STORE, false, 1000);
 
     String instanceName = ClusterMapUtils.getInstanceName("localhost", clusterMapConfig.clusterMapPort);
-    HelixParticipant helixParticipant = new HelixParticipant(clusterMapConfig, new HelixFactory(), metricRegistry,
-        parseDcJsonAndPopulateDcInfo(clusterMapConfig.clusterMapDcsZkConnectStrings).get(
-            clusterMapConfig.clusterMapDatacenterName).getZkConnectStrs().get(0), true);
+    HelixParticipant helixParticipant =
+        new HelixParticipant(mock(HelixClusterManager.class), clusterMapConfig, new HelixFactory(), metricRegistry,
+            parseDcJsonAndPopulateDcInfo(clusterMapConfig.clusterMapDcsZkConnectStrings).get(
+                clusterMapConfig.clusterMapDatacenterName).getZkConnectStrs().get(0), true);
     // Mock a state change listener to throw an exception
     PartitionStateChangeListener listener = mock(PartitionStateChangeListener.class);
     doThrow(new StateTransitionException("error", StateTransitionException.TransitionErrorCode.BootstrapFailure)).when(
@@ -1690,7 +1691,7 @@ public class StorageManagerTest {
      *                              go through standard workflow in the method.
      */
     MockClusterParticipant(Boolean setSealStateReturnVal, Boolean setStopStateReturnVal) {
-      super(clusterMapConfig, new MockHelixManagerFactory(), new MetricRegistry(),
+      super(mock(HelixClusterManager.class), clusterMapConfig, new MockHelixManagerFactory(), new MetricRegistry(),
           parseDcJsonAndPopulateDcInfo(clusterMapConfig.clusterMapDcsZkConnectStrings).get(
               clusterMapConfig.clusterMapDatacenterName).getZkConnectStrs().get(0), true);
       this.setSealStateReturnVal = setSealStateReturnVal;

--- a/ambry-tools/src/integration-test/java/com/github/ambry/clustermap/HelixBootstrapUpgradeToolTest.java
+++ b/ambry-tools/src/integration-test/java/com/github/ambry/clustermap/HelixBootstrapUpgradeToolTest.java
@@ -55,6 +55,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.mockito.Mockito;
 
 import static com.github.ambry.clustermap.ClusterMapUtils.*;
 import static com.github.ambry.clustermap.DataNodeConfigSourceType.*;
@@ -1182,8 +1183,9 @@ public class HelixBootstrapUpgradeToolTest {
     props.setProperty("clustermap.retry.disable.partition.completion.backoff.ms", Integer.toString(100));
     props.setProperty("clustermap.data.node.config.source.type", dataNodeConfigSourceType.name());
     ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
-    HelixParticipant helixParticipant = new HelixParticipant(clusterMapConfig, new HelixFactory(), new MetricRegistry(),
-        "localhost:" + zkInfo.getPort(), true);
+    HelixParticipant helixParticipant =
+        new HelixParticipant(Mockito.mock(HelixClusterManager.class), clusterMapConfig, new HelixFactory(),
+            new MetricRegistry(), "localhost:" + zkInfo.getPort(), true);
     PropertyStoreToDataNodeConfigAdapter propertyStoreAdapter =
         dataNodeConfigSourceType == DataNodeConfigSourceType.INSTANCE_CONFIG ? null
             : new PropertyStoreToDataNodeConfigAdapter("localhost:" + zkInfo.getPort(), clusterMapConfig);


### PR DESCRIPTION
When reconstructing resources, if some hosts are down, and when they wake up, they would receive state transition messages for the old resources, which is to drop partitions. At the time, if the message of old resources comes before the message of new resources, ambry would drop those partitions. This is not good.

This PR fixes that by relying clustermap to provide the resource for a partition. If the resource provided by the clustermap is higher than the resource from the message, we would ignore this transition.