### PR TITLE
[vcr-2.0] Use azure-sdk-bom to manage azure libs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -486,6 +486,7 @@ project(':ambry-cloud') {
             project(':ambry-server')
 
         // use compile to include these jars during compile-time and make it avlb for ambry-tools
+        // https://mvnrepository.com/artifact/com.azure/azure-sdk-bom
         compile platform("com.azure:azure-sdk-bom:$azureSdkBom")
         compile "com.azure:azure-cosmos"
         compile "com.azure:azure-identity"

--- a/build.gradle
+++ b/build.gradle
@@ -484,13 +484,17 @@ project(':ambry-cloud') {
             project(':ambry-replication'),
             project(':ambry-rest'),
             project(':ambry-server')
-        compile "com.azure:azure-storage-blob:$azureStorageBlobVersion"
-        compile "com.azure:azure-storage-blob-batch:$azureStorageBlobBatchVersion"
-        compile "com.azure:azure-identity:$azureIdentityVersion"
-        compile "com.azure:azure-security-keyvault-secrets:$azureSecurityKeyvaultSecretsVersion"
+
+        // use compile to include these jars during compile-time and make it avlb for ambry-tools
+        compile platform("com.azure:azure-sdk-bom:$azureSdkBom")
+        compile "com.azure:azure-cosmos"
+        compile "com.azure:azure-identity"
+        compile "com.azure:azure-security-keyvault-secrets"
+        compile "com.azure:azure-storage-blob"
+        compile "com.azure:azure-storage-blob-batch"
+
         compile "io.dropwizard.metrics:metrics-core:$metricsVersion"
         compile "io.dropwizard.metrics:metrics-jmx:$metricsVersion"
-        compile "com.azure:azure-cosmos:$azureCosmosDbAsyncVersion"
         compile "com.microsoft.azure:msal4j:$azureMsal4jVersion"
         compile "org.apache.helix:helix-lock:$helixVersion"
         testCompile project(':ambry-router')

--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -8,6 +8,7 @@
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 // CONDITIONS OF ANY KIND, either express or implied.
 ext {
+    azureSdkBom = "1.2.17"
     junitVersion = "4.8.1"
     slf4jVersion = "1.7.35"
     joptSimpleVersion = "4.9"
@@ -23,13 +24,8 @@ ext {
     helixVersion = "1.1.0"
     jacksonVersion = "2.10.2"
     jaydioVersion = "0.1"
-    azureStorageBlobVersion = "12.15.0"
-    azureStorageBlobBatchVersion = "12.12.0"
-    azureCosmosDbAsyncVersion = "4.39.0"
     azureMsal4jVersion="1.7.1"
     azureMsalClientCredentialVersion="1.0.0"
-    azureIdentityVersion= "1.3.6"
-    azureSecurityKeyvaultSecretsVersion="4.2.2"
     conscryptVersion = "2.2.1"
     jimFsVersion = "1.1"
     mysqlConnectorVersion = "8.0.21"


### PR DESCRIPTION
Issue: https://github.com/Azure/azure-sdk-for-java/issues/37223
Ref: https://devblogs.microsoft.com/azure-sdk/dependency-management-for-java/

MSFT recommends using azure-sdk-bom to manage azure dependencies instead of us pulling in specific versions. Azure SDK BOM automatically pulls in right versions, so we don't have to specify them.
