### PR TITLE
Reverting starting of index persistor thread when recovering index segments - PR https://github.com/linkedin/ambry/pull/2623

### DIFF
--- a/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
@@ -266,16 +266,6 @@ class PersistentIndex {
         cleanShutdownFile.delete();
       }
 
-      // Schedule index persistor before recovering index so that index segments are persisted as they are being recovered
-      if (scheduler != null) {
-        // start scheduler thread to persist index in the background
-        persistorTask = scheduler.scheduleAtFixedRate(persistor,
-            config.storeDataFlushDelaySeconds + new Random().nextInt(Time.SecsPerMin),
-            config.storeDataFlushIntervalSeconds, TimeUnit.SECONDS);
-      } else {
-        persistorTask = null;
-      }
-
       if (recovery != null) {
         recover(recovery);
       }
@@ -302,6 +292,15 @@ class PersistentIndex {
         metrics.initializeHardDeleteMetric(storeId, hardDeleter, this);
       } else {
         hardDeleter = null;
+      }
+
+      if (scheduler != null) {
+        // start scheduler thread to persist index in the background
+        persistorTask = scheduler.scheduleAtFixedRate(persistor,
+            config.storeDataFlushDelaySeconds + new Random().nextInt(Time.SecsPerMin),
+            config.storeDataFlushIntervalSeconds, TimeUnit.SECONDS);
+      } else {
+        persistorTask = null;
       }
 
       if (hardDelete != null && config.storeEnableHardDelete) {


### PR DESCRIPTION
We have changed to start index persistor thread in background when recovering index segments. But, some of the data structures (the last offset of a log segment) are not correctly populated while recovery. This causes exception as below

```
LogEndOffset Name = [1215_0] Offset = [18] before flush cannot be less than currentEndOffSet of index Name = [1215_0] Offset = [624188832]
at com.github.ambry.store.PersistentIndex$IndexPersistor. write (PersistentIndex.java:2616)
at com.github.ambry.store.PersistentIndex$IndexPersistor. run (PersistentIndex.java:2665)
at java.util.concurrent.Executors$RunnableAdapter. call (Executors.java:515)
at java.util.concurrent.FutureTask. runAndReset (FutureTask.java:305)
at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask. run (ScheduledThreadPoolExecutor.java:305)
at java.util.concurrent.ThreadPoolExecutor. runWorker (ThreadPoolExecutor.java:1128)
at java.util.concurrent.ThreadPoolExecutor$Worker. run (ThreadPoolExecutor.java:628)
at java.lang.Thread. run (Thread.java:834)
```

Reverting back the fix for now 