### PR TITLE
Fix the helix tool to return number of replicas from ideal state for FULL AUTO resources

### DIFF
--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeUtil.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeUtil.java
@@ -2866,6 +2866,9 @@ public class HelixBootstrapUpgradeUtil {
   }
 
   private int numReplicasForIdealState(String dcName, IdealState state) {
+    if (isIdealStateInFullAuto(state)) {
+      return Integer.valueOf(state.getReplicas());
+    }
     int numReplicaToCompare = -1;
     String partitionToCompare = null;
     for (String partition : state.getPartitionSet()) {

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeUtil.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeUtil.java
@@ -3189,4 +3189,3 @@ public class HelixBootstrapUpgradeUtil {
     }
   }
 }
-

--- a/ambry-tools/src/integration-test/java/com/github/ambry/clustermap/HelixBootstrapUpgradeToolTest.java
+++ b/ambry-tools/src/integration-test/java/com/github/ambry/clustermap/HelixBootstrapUpgradeToolTest.java
@@ -934,6 +934,8 @@ public class HelixBootstrapUpgradeToolTest {
     ZKHelixAdmin admin = new ZKHelixAdmin("localhost:" + zkInfo.getPort());
     IdealState idealState = admin.getResourceIdealState(clusterName, String.valueOf(resourceId));
     idealState.setRebalanceMode(IdealState.RebalanceMode.FULL_AUTO);
+    int replicaCount = idealState.getPreferenceLists().entrySet().iterator().next().getValue().size();
+    idealState.setReplicas(String.valueOf(replicaCount));
     admin.setResourceIdealState(clusterName, String.valueOf(resourceId), idealState);
     admin.close();
   }


### PR DESCRIPTION
## Summary

To get the number of replicas of a FULL AUTO resource, let's just use the "Replicas" simple field from ideal state.