### PR TITLE
Start ReplicationManager with empty replicas

### DIFF
--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationManager.java
@@ -148,10 +148,7 @@ public class ReplicationManager extends ReplicationEngine {
       for (String mountPath : mountPathToPartitionInfos.keySet()) {
         retrieveReplicaTokensAndPersistIfNecessary(mountPath);
       }
-      if (replicaThreadPoolByDc.size() == 0) {
-        logger.warn("Number of data centers to replicate from is 0, not starting any replica threads");
-        return;
-      }
+
       // valid for replication manager.
       replicationMetrics.trackReplicationDisabledPartitions(replicaThreadPoolByDc);
 
@@ -175,6 +172,14 @@ public class ReplicationManager extends ReplicationEngine {
     } finally {
       startupLatch.countDown();
     }
+  }
+
+  /**
+   * Checks if replication manager started successfully. Only used in tests
+   * @return {@code true} if replication manager started successfully.
+   */
+  boolean isStarted() {
+    return started;
   }
 
   @Override

--- a/ambry-replication/src/test/java/com/github/ambry/replication/ReplicationTestHelper.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/ReplicationTestHelper.java
@@ -283,7 +283,8 @@ public class ReplicationTestHelper {
     MockReplicationManager replicationManager =
         new MockReplicationManager(replicationConfig, clusterMapConfig, storeConfig, storageManager, clusterMap,
             dataNodeId, storeKeyConverterFactory, clusterParticipant, mockNetworkClientFactory,
-            mockNetworkClientFactory.getFindTokenHelper(), BlobIdTransformer.class.getName(), storeKeyFactory, time);
+            mockNetworkClientFactory.getFindTokenHelper(), BlobIdTransformer.class.getName(), storeKeyFactory, time,
+            null);
 
     return new Pair<>(storageManager, replicationManager);
   }

--- a/ambry-server/src/test/java/com/github/ambry/server/StatsManagerTest.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/StatsManagerTest.java
@@ -522,7 +522,7 @@ public class StatsManagerTest {
     storeKeyConverterFactory.setConversionMap(new HashMap<>());
     MockReplicationManager mockReplicationManager =
         new MockReplicationManager(replicationConfig, clusterMapConfig, storeConfig, storageManager, clusterMap,
-            currentNode, storeKeyConverterFactory, mockHelixParticipant);
+            currentNode, storeKeyConverterFactory, mockHelixParticipant, null);
     MockStatsManager mockStatsManager =
         new MockStatsManager(storageManager, mockClusterMap, localReplicas, new MetricRegistry(), statsManagerConfig,
             mockHelixParticipant, dataNodeId);


### PR DESCRIPTION
Currently ReplicationManager is not started correctly (i.e. `started` variable is not set and `ReplicaTokenPersistor` thread is not scheduled) if there are no replicas assigned to the host at boot up. In FullAuto, a new node joining the cluster always has 0 replicas assigned to it initially. 

To fix this, we need to remove below condition in `ReplicationManager.start()` method.
```
if (replicaThreadPoolByDc.size() == 0) {
        logger.warn("Number of data centers to replicate from is 0, not starting any replica threads");
        return;
      }
```