### PR TITLE
[vcr-2.0] Check delete-status during compaction

### DIFF
--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestinationSync.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestinationSync.java
@@ -756,9 +756,6 @@ public class AzureCloudDestinationSync implements CloudDestination {
               vcrMetrics.blobCompactionRate.mark();
               break;
             case HttpStatus.SC_NOT_FOUND:
-              logger.trace("[COMPACT] Tried to erase blob {} not found in Azure blob storage, reason = {}, status {}", blobItem.getName(),
-                  eraseReason, response.getStatusCode());
-              break;
             default:
               // Just increment a counter and set an alert on it. No need to throw an error and fail the thread.
               vcrMetrics.compactionFailureCount.inc();

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestinationSync.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestinationSync.java
@@ -30,6 +30,7 @@ import com.azure.storage.blob.models.BlobProperties;
 import com.azure.storage.blob.models.BlobRequestConditions;
 import com.azure.storage.blob.models.BlobStorageException;
 import com.azure.storage.blob.models.BlockBlobItem;
+import com.azure.storage.blob.models.DeleteSnapshotsOptionType;
 import com.azure.storage.blob.models.ListBlobsOptions;
 import com.azure.storage.blob.options.BlobParallelUploadOptions;
 import com.codahale.metrics.MetricRegistry;
@@ -59,6 +60,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -69,6 +71,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -739,14 +742,30 @@ public class AzureCloudDestinationSync implements CloudDestination {
       if (eraseBlob) {
         if (cloudConfig.cloudCompactionDryRunEnabled) {
           logger.trace("[DRY-RUN][COMPACT] Can erase blob {} from Azure blob storage because {}", blobItem.getName(), eraseReason);
+          numBlobsPurged += 1;
         } else {
           Timer.Context storageTimer = azureMetrics.blobCompactionLatency.time();
-          logger.trace("[COMPACT] Erasing blob {} from Azure blob storage because {}", blobItem.getName(), eraseReason);
-          blobContainerClient.getBlobClient(blobItem.getName()).delete();
+          Response<Void> response = blobContainerClient.getBlobClient(blobItem.getName())
+              .deleteWithResponse(DeleteSnapshotsOptionType.INCLUDE, null, null, null);
           storageTimer.stop();
-          vcrMetrics.blobCompactionRate.mark();
+          switch (response.getStatusCode()) {
+            case HttpStatus.SC_ACCEPTED:
+              logger.trace("[COMPACT] Erased blob {} from Azure blob storage, reason = {}, status = {}", blobItem.getName(),
+                  eraseReason, response.getStatusCode());
+              numBlobsPurged += 1;
+              vcrMetrics.blobCompactionRate.mark();
+              break;
+            case HttpStatus.SC_NOT_FOUND:
+              logger.trace("[COMPACT] Tried to erase blob {} not found in Azure blob storage, reason = {}, status {}", blobItem.getName(),
+                  eraseReason, response.getStatusCode());
+              break;
+            default:
+              // Just increment a counter and set an alert on it. No need to throw an error and fail the thread.
+              vcrMetrics.compactionFailureCount.inc();
+              logger.error("[COMPACT] Failed to erase blob {} from Azure blob storage with status {}", blobItem.getName(),
+                  response.getStatusCode());
+          }
         }
-        numBlobsPurged += 1;
       } else {
         logger.trace("[COMPACT] Cannot erase blob {} from Azure blob storage because condition not met: {}", blobItem.getName(), eraseReason);
       }

--- a/ambry-cloud/src/test/java/com/github/ambry/cloud/CloudBlobStoreTest.java
+++ b/ambry-cloud/src/test/java/com/github/ambry/cloud/CloudBlobStoreTest.java
@@ -342,10 +342,10 @@ public class CloudBlobStoreTest {
     // Return error when compaction tries to delete blobs and check nothing is deleted
     when(mockResponse.getStatusCode()).thenReturn(HttpStatus.SC_NOT_FOUND);
     assertEquals(0, spyDest.compactPartition(String.valueOf(partitionId.getId())));
-    assertEquals(0, vcrMetrics.compactionFailureCount.getCount());
+    assertEquals(numBlobs, vcrMetrics.compactionFailureCount.getCount());
     when(mockResponse.getStatusCode()).thenReturn(HttpStatus.SC_INTERNAL_SERVER_ERROR);
     assertEquals(0, spyDest.compactPartition(String.valueOf(partitionId.getId())));
-    assertEquals(numBlobs, vcrMetrics.compactionFailureCount.getCount());
+    assertEquals(numBlobs * 2, vcrMetrics.compactionFailureCount.getCount());
     // Check blob exists
     assertEquals(0, vcrMetrics.blobCompactionRate.getCount());
     when(spyContainerClient.getBlobClient(any())).thenCallRealMethod();


### PR DESCRIPTION
Adds a fix to eliminate all snapshots of a blob during compaction and a minor improvement to avoid any unnecessary 404 errors.