### PR TITLE
Check if a disk has any store before treating it as failure

### DIFF
--- a/ambry-store/src/main/java/com/github/ambry/store/CompactionManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/CompactionManager.java
@@ -314,7 +314,9 @@ class CompactionManager {
                   if (triggers.contains(Trigger.PERIODIC)) {
                     // If compaction is not run on some of stores, wait time should be reduced.
                     // The max time to reduce is waitTimeMs / 2;
-                    long compensation = waitTimeMs / 2 * storesNoCompaction / stores.size();
+                    long compensation =
+                        storesNoCompaction != 0 && stores.size() > 0 ? waitTimeMs / 2 * storesNoCompaction
+                            / stores.size() : 0;
                     long actualWaitTimeMs = expectedNextCheckTime - compensation - time.milliseconds();
                     logger.trace("Going to wait for {} ms in compaction thread at {}", actualWaitTimeMs, mountPath);
                     time.await(waitCondition, actualWaitTimeMs);

--- a/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
@@ -578,6 +578,19 @@ public class DiskManager {
   }
 
   /**
+   * Check if this disk has any stores on it.
+   * @return
+   */
+  boolean hasAnyStore() {
+    rwLock.readLock().lock();
+    try {
+      return !stores.isEmpty();
+    } finally {
+      rwLock.readLock().unlock();
+    }
+  }
+
+  /**
    * @return unexpected directories on this disk.
    */
   List<String> getUnexpectedDirs() {


### PR DESCRIPTION
When the disk is empty, the current disk failure handler would just treat this disk as a failure and mark this disk as unavailable. This is wrong, this PR fixes it.

