### PR TITLE
Fix NPE in helix cluster manager

### DIFF
--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PropertyStoreToDataNodeConfigAdapter.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PropertyStoreToDataNodeConfigAdapter.java
@@ -177,7 +177,7 @@ class PropertyStoreToDataNodeConfigAdapter implements DataNodeConfigSource {
 
     private Iterable<DataNodeConfig> lazyIterable(Collection<ZNRecord> records) {
       return records == null || records.isEmpty() ? Collections.emptyList()
-          : () -> records.stream().map(converter::convert).filter(Objects::nonNull).iterator();
+          : () -> records.stream().filter(Objects::nonNull).map(converter::convert).filter(Objects::nonNull).iterator();
     }
 
     /**


### PR DESCRIPTION
When hosts are removed from cluster, it looks like there is some race condition in helix callbacks which causes the hosts to be present under /DataNodeConfigs but their znode itself is missing. This causes the in-memory cluster map to be incomplete.

```
2023/11/14 21:21:32.948 ERROR [HelixClusterManager] [pool-18-thread-1] [ambry-server] [] Exception occurred at runtime when handling data node config changes from helix cluster Ambry-prod in datacenter prod-ltx1: 
java.lang.NullPointerException: null
        at com.github.ambry.clustermap.ClusterMapUtils.getSchemaVersion(ClusterMapUtils.java:309) ~[com.github.ambry.ambry-clustermap-0.4.247.jar:?]
        at com.github.ambry.clustermap.PropertyStoreToDataNodeConfigAdapter$Converter.convert(PropertyStoreToDataNodeConfigAdapter.java:261) ~[com.github.ambry.ambry-clustermap-0.4.247.jar:?]
        at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195) ~[?:?]
        at java.util.ArrayList$ArrayListSpliterator.tryAdvance(ArrayList.java:1632) ~[?:?]
        at java.util.stream.StreamSpliterators$WrappingSpliterator.lambda$initPartialTraversalState$0(StreamSpliterators.java:294) ~[?:?]
        at java.util.stream.StreamSpliterators$AbstractWrappingSpliterator.fillBuffer(StreamSpliterators.java:206) ~[?:?]
        at java.util.stream.StreamSpliterators$AbstractWrappingSpliterator.doAdvance(StreamSpliterators.java:169) ~[?:?]
        at java.util.stream.StreamSpliterators$WrappingSpliterator.tryAdvance(StreamSpliterators.java:300) ~[?:?]
        at java.util.Spliterators$1Adapter.hasNext(Spliterators.java:681) ~[?:?]
        at com.github.ambry.clustermap.HelixClusterManager$HelixClusterChangeHandler.addOrUpdateInstanceInfos(HelixClusterManager.java:1810) ~[com.github.ambry.ambry-clustermap-0.4.247.jar:?]
        at com.github.ambry.clustermap.HelixClusterManager$HelixClusterChangeHandler.handleDataNodeConfigChange(HelixClusterManager.java:1497) ~[com.github.ambry.ambry-clustermap-0.4.247.jar:?]
        at com.github.ambry.clustermap.HelixAggregatedViewClusterInitializer$1.onDataNodeConfigChange(HelixAggregatedViewClusterInitializer.java:225) ~[com.github.ambry.ambry-clustermap-0.4.247.jar:?]
        at com.github.ambry.clustermap.PropertyStoreToDataNodeConfigAdapter$Subscription.initializeIfNeeded(PropertyStoreToDataNodeConfigAdapter.java:228) ~[com.github.ambry.ambry-clustermap-0.4.247.jar:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
        at java.lang.Thread.run(Thread.java:834) [?:?]
```

Adding null checks to prevent this.