### PR TITLE
Replicate from all replicas if the partition doesn't have a leader

### DIFF
--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
@@ -14,6 +14,7 @@
 package com.github.ambry.replication;
 
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.clustermap.AmbryPartition;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.ClusterMapChangeListener;
 import com.github.ambry.clustermap.ClusterParticipant;
@@ -695,6 +696,14 @@ public abstract class ReplicationEngine implements ReplicationAPI {
       } finally {
         rwLockForLeaderReplicaUpdates.readLock().unlock();
       }
+    }
+
+    /**
+     * @param partition partition id
+     * @return true if this partition doesn't have any leader in local data center.
+     */
+    public boolean isLeaderLessPartition(PartitionId partition) {
+      return partition.getReplicaIdsByState(ReplicaState.LEADER, dataNodeId.getDatacenterName()).isEmpty();
     }
 
     /**

--- a/ambry-replication/src/test/java/com/github/ambry/replication/LeaderBasedReplicationTest.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/LeaderBasedReplicationTest.java
@@ -403,6 +403,114 @@ public class LeaderBasedReplicationTest extends ReplicationTestHelper {
   }
 
   /**
+   * Test replication for leader less partitions.
+   */
+  @Test
+  public void missingLeadersReplicationTest() throws Exception {
+    int batchSize = 4;
+
+    Map<DataNodeId, MockHost> hosts = new HashMap<>();
+    hosts.put(remoteNodeInLocalDC, remoteHostInLocalDC);
+    hosts.put(remoteNodeInRemoteDC, remoteHostInRemoteDC);
+    MockNetworkClientFactory mockNetworkClientFactory = new MockNetworkClientFactory(hosts, clusterMap, batchSize,
+        new MockFindTokenHelper(new BlobIdFactory(clusterMap), replicationConfig));
+    Pair<StorageManager, ReplicationManager> managers =
+        createStorageManagerAndReplicationManager(clusterMap, clusterMapConfig, mockHelixParticipant,
+            mockNetworkClientFactory);
+    StorageManager storageManager = managers.getFirst();
+    MockReplicationManager replicationManager = (MockReplicationManager) managers.getSecond();
+
+    // 1. Set mock local stores on all remoteReplicaInfos which will used during replication.
+    for (PartitionId partitionId : replicationManager.partitionToPartitionInfo.keySet()) {
+      localHost.addStore(partitionId, null);
+      Store localStore = localHost.getStore(partitionId);
+      localStore.start();
+      List<RemoteReplicaInfo> remoteReplicaInfos =
+          replicationManager.partitionToPartitionInfo.get(partitionId).getRemoteReplicaInfos();
+      remoteReplicaInfos.forEach(remoteReplicaInfo -> remoteReplicaInfo.setLocalStore(localStore));
+    }
+
+    //2. Add put messages to all partitions on remote hosts in local dc and remote dc
+    List<PartitionId> partitionIds = clusterMap.getWritablePartitionIds(null);
+    PartitionId leaderLessPartition = null;
+    for (PartitionId partitionId : partitionIds) {
+      addPutMessagesToReplicasOfPartition(partitionId, Arrays.asList(remoteHostInLocalDC, remoteHostInRemoteDC),
+          batchSize);
+      if (leaderLessPartition == null) {
+        // Have 1 leader-less partition
+        leaderLessPartition = partitionId;
+        for (ReplicaId replicaId : ((MockPartitionId) partitionId).getReplicaIds()) {
+          ((MockPartitionId) partitionId).setReplicaState(replicaId, ReplicaState.STANDBY);
+        }
+      }
+    }
+
+    // 3. Issue STs for leaders
+    List<? extends ReplicaId> replicaIds = clusterMap.getReplicaIds(replicationManager.dataNodeId);
+    for (ReplicaId replicaId : replicaIds) {
+      MockReplicaId mockReplicaId = (MockReplicaId) replicaId;
+      if (mockReplicaId.getReplicaState() == ReplicaState.LEADER) {
+        MockPartitionId mockPartitionId = (MockPartitionId) replicaId.getPartitionId();
+        mockHelixParticipant.onPartitionBecomeLeaderFromStandby(mockPartitionId.toPathString());
+      }
+    }
+
+    // 4. Replicate with host in remote dc.
+    ReplicaThread crossColoReplicaThread = replicationManager.dataNodeIdToReplicaThread.get(remoteNodeInRemoteDC);
+    crossColoReplicaThread.replicate();
+
+    // 5. Verification 1: Check metadata requests are sent to both leader and standby replicas.
+    List<RemoteReplicaInfo> remoteReplicaInfosForRemoteDC =
+        crossColoReplicaThread.getRemoteReplicaInfos().get(remoteNodeInRemoteDC);
+    List<ReplicaThread.ExchangeMetadataResponse> exchangeMetadataResponseList =
+        crossColoReplicaThread.getExchangeMetadataResponsesInEachCycle().get(remoteNodeInRemoteDC);
+    assertEquals("Response should contain a response for each replica", remoteReplicaInfosForRemoteDC.size(),
+        exchangeMetadataResponseList.size());
+
+    // 6. Verification 2: Check missing messages size equals to the min{batch size, number of PUT messages} placed on remote hosts
+    for (ReplicaThread.ExchangeMetadataResponse exchangeMetadataResponse : exchangeMetadataResponseList) {
+      assertEquals("mismatch in number of missing messages", batchSize,
+          exchangeMetadataResponse.missingStoreMessages.size());
+    }
+
+    // 7. Verification 3: Verify that the remote token will be moved for leader replicas and 1 leader less replica.
+    Set<ReplicaId> expectedLeaderReplicaIds =
+        getRemoteLeaderReplicasWithLeaderPartitionsOnLocalNode(clusterMap, replicationManager.dataNodeId,
+            remoteNodeInRemoteDC);
+    for (int i = 0; i < remoteReplicaInfosForRemoteDC.size(); i++) {
+      if (expectedLeaderReplicaIds.contains(remoteReplicaInfosForRemoteDC.get(i).getReplicaId())) {
+        assertEquals("Remote token must have been updated for leader replicas",
+            remoteReplicaInfosForRemoteDC.get(i).getToken(), exchangeMetadataResponseList.get(i).remoteToken);
+      } else if (remoteReplicaInfosForRemoteDC.get(i).getReplicaId().getPartitionId().equals(leaderLessPartition)) {
+        assertEquals("Remote token must have been updated for leader-less replicas",
+            remoteReplicaInfosForRemoteDC.get(i).getToken(), exchangeMetadataResponseList.get(i).remoteToken);
+      } else {
+        assertThat("Remote token must not move forward for standby replicas until missing keys are fetched",
+            remoteReplicaInfosForRemoteDC.get(i).getToken(), not(exchangeMetadataResponseList.get(i).remoteToken));
+        assertEquals("Missing keys in metadata response must be stored for standby replicas",
+            remoteReplicaInfosForRemoteDC.get(i).getExchangeMetadataResponse().missingStoreMessages.size(),
+            exchangeMetadataResponseList.get(i).missingStoreMessages.size());
+      }
+    }
+
+    // 8. Replicate with host in local dc so that missing messages in standby are fetched from local dc
+    ReplicaThread intraColoReplicaThread = replicationManager.dataNodeIdToReplicaThread.get(remoteNodeInLocalDC);
+    intraColoReplicaThread.replicate();
+
+    // 9. Replicate again with remote dc. This should process missing keys for standby replicas from previous metadata exchange
+    crossColoReplicaThread.replicate();
+
+    // 10. Verification 4: Remote token for all cross-colo replicas (leader and standby) should have moved forward now
+    // as the missing keys for standbys are received via intra-dc replication.
+    for (int i = 0; i < exchangeMetadataResponseList.size(); i++) {
+      assertEquals("mismatch in remote token set for cross colo replicas",
+          remoteReplicaInfosForRemoteDC.get(i).getToken(), (exchangeMetadataResponseList.get(i).remoteToken));
+    }
+
+    storageManager.shutdown();
+  }
+
+  /**
    * Test leader based replication to verify remote token is caught up for standby replicas and updated token is used
    * when their state transitions to leader.
    * @throws Exception


### PR DESCRIPTION
When there is no leader for a partition, replication is very slow since we wait for 2 mins in each replication cycle before issuing GET requests. To avoid this, replicate from all remote replicas when we detect that a partition doesn't have a leader.