### PR TITLE
Fix ConnectionTimeoutException

### DIFF
--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AccountStorageStatsIterator.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AccountStorageStatsIterator.java
@@ -1,0 +1,43 @@
+package com.github.ambry.clustermap;
+
+import com.github.ambry.accountstats.AccountStatsStore;
+import com.github.ambry.config.ClusterMapConfig;
+import com.github.ambry.server.HostAccountStorageStatsWrapper;
+import com.github.ambry.utils.Pair;
+import java.util.Iterator;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class AccountStorageStatsIterator implements Iterator<Pair<String, HostAccountStorageStatsWrapper>> {
+
+  private static final Logger logger = LoggerFactory.getLogger(AccountStorageStatsIterator.class);
+  private final Iterator<String> instances;
+  private final AccountStatsStore accountStatsStore;
+  private final ClusterMapConfig clusterMapConfig;
+
+  public AccountStorageStatsIterator(List<String> instances, AccountStatsStore accountStatsStore, ClusterMapConfig clusterMapConfig) {
+    this.instances = instances.iterator();
+    this.accountStatsStore = accountStatsStore;
+    this.clusterMapConfig = clusterMapConfig;
+  }
+
+  @Override
+  public boolean hasNext() {
+    return instances.hasNext();
+  }
+
+  @Override
+  public Pair<String, HostAccountStorageStatsWrapper> next() {
+    String hostname = instances.next();
+    try {
+      Pair<String, Integer> hostNameAndPort = TaskUtils.getHostNameAndPort(hostname, clusterMapConfig.clusterMapPort);
+      return new Pair<>(hostname,
+          accountStatsStore.queryHostAccountStorageStatsByHost(hostNameAndPort.getFirst(), hostNameAndPort.getSecond()));
+    } catch (Exception e) {
+      logger.error("Failed to get account storage stats for {}", hostname);
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PartitionClassStorageStatsIterator.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PartitionClassStorageStatsIterator.java
@@ -1,0 +1,51 @@
+package com.github.ambry.clustermap;
+
+import com.github.ambry.accountstats.AccountStatsStore;
+import com.github.ambry.config.ClusterMapConfig;
+import com.github.ambry.server.HostPartitionClassStorageStatsWrapper;
+import com.github.ambry.utils.Pair;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class PartitionClassStorageStatsIterator implements
+                                                Iterator<Pair<String, HostPartitionClassStorageStatsWrapper>> {
+
+  private static final Logger logger = LoggerFactory.getLogger(PartitionClassStorageStatsIterator.class);
+  private final Iterator<String> instances;
+  private final Map<String, Set<Integer>> partitionNameAndIds;
+  private final AccountStatsStore accountStatsStore;
+  private final ClusterMapConfig clusterMapConfig;
+
+
+  public PartitionClassStorageStatsIterator(List<String> instances, AccountStatsStore accountStatsStore, ClusterMapConfig clusterMapConfig) throws Exception {
+    this.instances = instances.iterator();
+    this.partitionNameAndIds = accountStatsStore.queryPartitionNameAndIds();
+    this.accountStatsStore = accountStatsStore;
+    this.clusterMapConfig = clusterMapConfig;
+  }
+
+  @Override
+  public boolean hasNext() {
+    return instances.hasNext();
+  }
+
+  @Override
+  public Pair<String, HostPartitionClassStorageStatsWrapper> next() {
+    String hostname = instances.next();
+    try {
+      Pair<String, Integer> hostNameAndPort = TaskUtils.getHostNameAndPort(hostname, clusterMapConfig.clusterMapPort);
+      return new Pair<>(hostname,
+          accountStatsStore.queryHostPartitionClassStorageStatsByHost(
+              hostNameAndPort.getFirst(), hostNameAndPort.getSecond(), partitionNameAndIds));
+    } catch (Exception e) {
+      logger.error("Failed to get partition storage stats for {}", hostname);
+      throw new RuntimeException(e);
+    }
+  }
+
+}

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/TaskUtils.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/TaskUtils.java
@@ -1,0 +1,22 @@
+package com.github.ambry.clustermap;
+
+import com.github.ambry.utils.Pair;
+
+
+public class TaskUtils {
+
+  protected static Pair<String, Integer> getHostNameAndPort(String instanceName, int defaultPort) {
+    String hostname = instanceName;
+    int port = defaultPort;
+    int ind = instanceName.lastIndexOf("_");
+    if (ind != -1) {
+      try {
+        port = Short.valueOf(instanceName.substring(ind + 1));
+        hostname = instanceName.substring(0, ind);
+      } catch (NumberFormatException e) {
+        // String after "_" is not a port number, then the hostname should be the instanceName
+      }
+    }
+    return new Pair<>(hostname, port);
+  }
+}


### PR DESCRIPTION
The frontends are timing out connecting to servers because servers are busy with GC. The GC pause is 3-second long because JVM is busy releasing memory consumed by StatsAggregator. The aggregator fetches results for all accounts, containers and partitions to store it in a giant map, which consumed close to 10GB of heap.

This patch fixes this issue by not buffering those stats. Instead it fetches each stat and immediately processes it without saving it for further use.