### PR TITLE
Delete all the unexpected directories in ambry-server when current node is in FULL AUTO

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -582,8 +582,14 @@ public class StoreConfig {
   public final int storeDiskCapacityReportingPercentage;
   public static final String storeDiskCapacityReportingPercentageName = "store.disk.capacity.reporting.percentage";
 
-  public StoreConfig(VerifiableProperties verifiableProperties) {
+  /**
+   * True to remove all the unexpected directories when the current node is in FULL AUTO.
+   */
+  @Config(storeRemoveUnexpectedDirsInFullAutoName)
+  public final boolean storeRemoveUnexpectedDirsInFullAuto;
+  public static final String storeRemoveUnexpectedDirsInFullAutoName = "store.remove.unexpected.dirs.in.full.auto";
 
+  public StoreConfig(VerifiableProperties verifiableProperties) {
     storeKeyFactory = verifiableProperties.getString("store.key.factory", "com.github.ambry.commons.BlobIdFactory");
     storeDataFlushIntervalSeconds = verifiableProperties.getLong("store.data.flush.interval.seconds", 60);
     storeIndexMaxMemorySizeBytes = verifiableProperties.getInt("store.index.max.memory.size.bytes", 20 * 1024 * 1024);
@@ -734,9 +740,12 @@ public class StoreConfig {
             Integer.MAX_VALUE);
     if (storeDiskFailureHandlerRetryLockBackoffTimeInSeconds > storeDiskFailureHandlerTaskIntervalInSeconds) {
       throw new IllegalStateException("Retry lock backoff time should be shorter than task interval: "
-          + storeDiskFailureHandlerRetryLockBackoffTimeInSeconds + " < " + storeDiskFailureHandlerTaskIntervalInSeconds);
+          + storeDiskFailureHandlerRetryLockBackoffTimeInSeconds + " < "
+          + storeDiskFailureHandlerTaskIntervalInSeconds);
     }
     storeDiskCapacityReportingPercentage =
         verifiableProperties.getIntInRange(storeDiskCapacityReportingPercentageName, 95, 0, 100);
+    storeRemoveUnexpectedDirsInFullAuto =
+        verifiableProperties.getBoolean(storeRemoveUnexpectedDirsInFullAutoName, false);
   }
 }

--- a/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
@@ -620,6 +620,26 @@ public class DiskManager {
     }
   }
 
+  /**
+   * Try to remove all unexpected directories.
+   */
+  void tryRemoveAllUnexpectedDirs() {
+    for (String unexpectedDir : unexpectedDirs) {
+      String[] segments = unexpectedDir.split(File.separator);
+      if (segments.length > 1) {
+        String partitionName = segments[segments.length - 1];
+        try {
+          File dirToDelete = new File(unexpectedDir);
+          Utils.deleteFileOrDirectory(dirToDelete);
+          logger.info("Removed directory {}", unexpectedDir);
+          diskSpaceAllocator.deleteAllSegmentsForStoreIds(Collections.singletonList(partitionName));
+        } catch (Exception e) {
+          logger.error("Failed to delete directory for partition {}", partitionName, e);
+        }
+      }
+    }
+  }
+
   public DiskHealthStatus getDiskHealthStatus() {
     return diskHealthStatus;
   }
@@ -722,7 +742,8 @@ public class DiskManager {
         }
       } catch (Exception e) {
         diskHealthStatus = DiskHealthStatus.CREATE_EXCEPTION;
-        logger.error("Exception occurred when creating a file/directory for disk healthcheck {}", disk.getMountPath(), e);
+        logger.error("Exception occurred when creating a file/directory for disk healthcheck {}", disk.getMountPath(),
+            e);
       }
       return null;
     }

--- a/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
@@ -161,12 +161,21 @@ public class DiskManager {
    * Starts all the stores on this disk.
    * @throws InterruptedException
    */
-  void start() throws InterruptedException {
+  void start(boolean shouldRemoveUnexpectedDirs) throws InterruptedException {
     long startTimeMs = time.milliseconds();
     final AtomicInteger numStoreFailures = new AtomicInteger(0);
     rwLock.readLock().lock();
     try {
       checkMountPathAccessible();
+      // Report unrecognized directories before trying to satisfy disk space requirements.
+      reportUnrecognizedDirs();
+      if (shouldRemoveUnexpectedDirs) {
+        // Try to remove all the unexpected directories before starting any blob store.
+        // If the disk is near full because of the unexpected directoires, then blob store
+        // might not be able to start since each blob store would request at least one log
+        // segment.
+        tryRemoveAllUnexpectedDirs();
+      }
 
       List<Thread> startupThreads = new ArrayList<>();
       for (final Map.Entry<PartitionId, BlobStore> partitionAndStore : stores.entrySet()) {
@@ -205,7 +214,6 @@ public class DiskManager {
       }
       diskSpaceAllocator.initializePool(requirementsList);
       compactionManager.enable();
-      reportUnrecognizedDirs();
       running = true;
       if (diskHealthCheck.isEnabled()) {
         logger.info("Starting Disk Healthchecker");
@@ -624,6 +632,7 @@ public class DiskManager {
    * Try to remove all unexpected directories.
    */
   void tryRemoveAllUnexpectedDirs() {
+    logger.info("Removing unexpected directories: {}", unexpectedDirs);
     for (String unexpectedDir : unexpectedDirs) {
       String[] segments = unexpectedDir.split(File.separator);
       if (segments.length > 1) {

--- a/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
@@ -376,6 +376,10 @@ public class StorageManager implements StoreManager {
         logger.error("Error while starting the new DiskManager for {}", disk.getMountPath(), e);
         return null;
       }
+
+      if (clusterMap.isDataNodeInFullAutoMode(currentNode) && storeConfig.storeRemoveUnexpectedDirsInFullAuto) {
+        newDiskManager.tryRemoveAllUnexpectedDirs();
+      }
       return newDiskManager;
     });
   }
@@ -488,6 +492,15 @@ public class StorageManager implements StoreManager {
     File bootstrapFile = new File(replica.getReplicaPath(), BlobStore.BOOTSTRAP_FILE_NAME);
     if (!bootstrapFile.exists()) {
       bootstrapFile.createNewFile();
+    }
+  }
+
+  /**
+   * Delete all unexpected directories in all disks
+   */
+  private void maybeDeleteUnexpectedDirectories() {
+    if (clusterMap.isDataNodeInFullAutoMode(currentNode) && storeConfig.storeRemoveUnexpectedDirsInFullAuto) {
+      diskToDiskManager.values().forEach(disk -> disk.tryRemoveAllUnexpectedDirs());
     }
   }
 


### PR DESCRIPTION
## Summary 

Delete all the unexpected directories in ambry-server when the current node is in FULL AUTO. So when facing disk mismount issues, we can still move on from initialization in ambry-server.

## Test
unit test