### PR TITLE
Include leaderless replicas for GET replication requests

### DIFF
--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
@@ -14,6 +14,7 @@
 package com.github.ambry.replication;
 
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.clustermap.AmbryPartition;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.ClusterMapChangeListener;
 import com.github.ambry.clustermap.ClusterParticipant;
@@ -695,6 +696,14 @@ public abstract class ReplicationEngine implements ReplicationAPI {
       } finally {
         rwLockForLeaderReplicaUpdates.readLock().unlock();
       }
+    }
+
+    /**
+     * @param partition partition id
+     * @return true if this partition doesn't have any leader in local data center.
+     */
+    public boolean isLeaderLessPartition(PartitionId partition) {
+      return partition.getReplicaIdsByState(ReplicaState.LEADER, dataNodeId.getDatacenterName()).isEmpty();
     }
 
     /**


### PR DESCRIPTION
During leader-based replication, we only include leaders for fetching actual data. For non-leaders, we wait for 2 minutes hoping that the data would be fetched via intra-colo replication. This causes issue of very slow replication if leader is missing. To avoid that, we are fetching data for replicas without any leaders in this PR.