### PR TITLE
Update the BlobPropertiesSerDe version so that reserved metadata id can be saved to the storage nodes.

### DIFF
--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/BlobPropertiesSerDe.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/BlobPropertiesSerDe.java
@@ -38,7 +38,7 @@ public class BlobPropertiesSerDe {
   private static final int CREATION_TIME_FIELD_SIZE_IN_BYTES = Long.BYTES;
   private static final int BLOB_SIZE_FIELD_SIZE_IN_BYTES = Long.BYTES;
   private static final int ENCRYPTED_FIELD_SIZE_IN_BYTES = Byte.BYTES;
-  public static short CURRENT_VERSION = VERSION_4;
+  public static short CURRENT_VERSION = VERSION_5;
 
   public static int getBlobPropertiesSerDeSize(BlobProperties properties) {
     int size = VERSION_FIELD_SIZE_IN_BYTES + TTL_FIELD_SIZE_IN_BYTES + PRIVATE_FIELD_SIZE_IN_BYTES


### PR DESCRIPTION
This will enable reserved metadata ids to be persisted on the server nodes along with the blob properties.