### PR TITLE
Clean up directories on disk if a bootstrap replica failed

### DIFF
--- a/ambry-store/src/main/java/com/github/ambry/store/DiskSpaceAllocator.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/DiskSpaceAllocator.java
@@ -569,7 +569,7 @@ class DiskSpaceAllocator {
    * @return the created file.
    * @throws IOException if the file could not be created, or if an error occurred during the fallocate call.
    */
-  private File createReserveFile(long sizeInBytes, File dir) throws IOException {
+  File createReserveFile(long sizeInBytes, File dir) throws IOException {
     File fileSizeDir = prepareDirectory(new File(dir, FILE_SIZE_DIR_PREFIX + sizeInBytes));
     File reserveFile;
     do {


### PR DESCRIPTION
## Summary

When storage manage fails adding a bootstrap replica, we might leave some of the blob store files on disk for the failed replica. These files includes the initial log segment file, the reserved files etc.. This PR removes those files.

## Test
Unit test