### PR TITLE
Fix some logic in SimpleOperationTracker

### DIFF
--- a/ambry-router/src/test/java/com/github/ambry/router/GetBlobInfoOperationTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/GetBlobInfoOperationTest.java
@@ -502,11 +502,11 @@ public class GetBlobInfoOperationTest {
   }
 
   /**
-   * Test the case when some of the replicas in originating DC are unavailable, we should return AmbryUnavailable.
+   * Test the case when all replicas in originating DC return NOT_FOUND, we should return BlobDoesNotExist.
    * @throws Exception
    */
   @Test
-  public void testOrigDcUnavailability() throws Exception {
+  public void testOrigDcNotExist() throws Exception {
     correlationIdToGetOperation.clear();
 
     // Default all replicas to return not found.
@@ -539,9 +539,9 @@ public class GetBlobInfoOperationTest {
     requestRegistrationCallback.setRequestsToSend(new ArrayList<>());
     completeOp(op);
 
-    // error code should be Unavailability
+    // error code should be NOT_FOUND, since all replicas return NOT_FOUND
     RouterException routerException = (RouterException) op.getOperationException();
-    Assert.assertEquals(RouterErrorCode.AmbryUnavailable, routerException.getErrorCode());
+    Assert.assertEquals(RouterErrorCode.BlobDoesNotExist, routerException.getErrorCode());
   }
 
   /**

--- a/ambry-router/src/test/java/com/github/ambry/router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/GetBlobOperationTest.java
@@ -868,11 +868,11 @@ public class GetBlobOperationTest {
   }
 
   /**
-   * Test the case when some of the replicas in originating DC are unavailable, we should return AmbryUnavailable.
+   * Test the case when all replicas in originating DC return NOT_FOUND, we should return BlobDoesNotExist.
    * @throws Exception
    */
   @Test
-  public void testOrigDcUnavailability() throws Exception {
+  public void testOrigDcNotExist() throws Exception {
     doPut();
 
     // Default all replicas to return not found.
@@ -898,7 +898,7 @@ public class GetBlobOperationTest {
     serversInLocalDc.get(1).setServerErrorForAllRequests(ServerErrorCode.Blob_Not_Found);
     serversInLocalDc.get(2).setServerErrorForAllRequests(ServerErrorCode.Blob_Not_Found);
 
-    getErrorCodeChecker.testAndAssert(RouterErrorCode.AmbryUnavailable);
+    getErrorCodeChecker.testAndAssert(RouterErrorCode.BlobDoesNotExist);
   }
 
   /**

--- a/ambry-router/src/test/java/com/github/ambry/router/OperationTrackerTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/OperationTrackerTest.java
@@ -678,8 +678,7 @@ public class OperationTrackerTest {
       inflightReplica = inflightReplicas.poll();
       assertEquals("The request should be sent to dc-1 with most replicas", "dc-1",
           inflightReplica.getDataNodeId().getDatacenterName());
-      // we deliberately make all replicas in dc-1 return Not_Found to verify that operation won't terminate on not found
-      ot.onResponse(inflightReplica, TrackedRequestFinalState.NOT_FOUND);
+      ot.onResponse(inflightReplica, i != 2 ? TrackedRequestFinalState.NOT_FOUND : TrackedRequestFinalState.FAILURE);
       assertFalse("Operation should not be done yet", ot.isDone());
     }
     // the last request should go to dc-2 and this time we make it succeed
@@ -1080,7 +1079,7 @@ public class OperationTrackerTest {
     ot.onResponse(inflightReplicas.poll(), TrackedRequestFinalState.NOT_FOUND);
     ot.onResponse(inflightReplicas.poll(), TrackedRequestFinalState.NOT_FOUND);
     assertFalse("Operation should not succeed", ot.hasSucceeded());
-    assertFalse("Operation should not fail on NOT_FOUND", ot.hasFailedOnNotFound());
+    assertTrue("Operation should fail on NOT_FOUND since all replicas return NOT_FOUND", ot.hasFailedOnNotFound());
     assertTrue("Operation should have some unavailability", ot.hasSomeUnavailability());
     assertTrue("Operation should be done", ot.isDone());
 
@@ -1160,7 +1159,7 @@ public class OperationTrackerTest {
     ot.onResponse(inflightReplicas.poll(), TrackedRequestFinalState.NOT_FOUND);
     ot.onResponse(inflightReplicas.poll(), TrackedRequestFinalState.NOT_FOUND);
     assertFalse("Operation should not succeed", ot.hasSucceeded());
-    assertFalse("Operation should not fail on NOT_FOUND", ot.hasFailedOnNotFound());
+    assertTrue("Operation should fail on NOT_FOUND since all replicas return NOT_FOUND", ot.hasFailedOnNotFound());
     assertTrue("Operation should have some unavailability", ot.hasSomeUnavailability());
     assertTrue("Operation should be done", ot.isDone());
   }


### PR DESCRIPTION
## Summary

This PR changes some logic in SimpleOperationTracker as well as removing some unused RouterConfig and unit test

1. Return NOT_FOUND if all replicas return NOT_FOUND even if we have bootstrap replicas.
2. Add a new configuration to only require two NOT_FOUND in originating DC to return NOT_FOUND. 
3. Remove some unused configurations from RouterConfig.

## Detail

We used to treat bootstrap replicas as unavailable replicas when it returns NOT_FOUND. But when all the other replicas return NOT_FOUND, bootstrap replicas will eventually return NOT_FOUND for sure, since it gets blob content from other replicas. This PR would count the number of NOT_FOUND response and when it's the same as the total number of replicas, we just return NOT_FOUND even if there are bootstrap replicas in originating DC.

This PR also adds a new configuration to only require two NOT_FOUND response in originating DC to return NOT_FOUND. In FULL AUTO, a host can become unavailable and some time later, helix would start a new bootstrap replica somewhere else. In this case, we would have 4 replicas in originating DC, 1 leader, 1 standby, 1 bootstrap and 1 unavailable. When blob id doesn't exist, leader and standby and bootstrap would all return NOT_FOUND, but we would treat bootstrap as unavailable. In this case, we don't return NOT_FOUND since we only tolerate one unavailable replicas. This PR would change that. The reason why this is reasonable is that PutOperation would always make sure it succeeds on N-1 replicas. So if we have 2 leader/standby replicas returning NOT_FOUND, we can return NOT_FOUND.

## Test
Unit test