### PR TITLE
[vcr-2.0] Remove unused recentBlobCache

### DIFF
--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobStore.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobStore.java
@@ -385,7 +385,7 @@ public class CloudBlobStore implements Store {
       try {
         cloudDestination.uploadBlobs((MessageFormatWriteSet) messageSetToWrite);
       } catch (CloudStorageException e) {
-        throw new RuntimeException(e);
+        throw new StoreException(e, StoreErrorCodes.IOError);
       }
       return;
     }

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudDestination.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudDestination.java
@@ -15,6 +15,7 @@ package com.github.ambry.cloud;
 
 import com.github.ambry.account.Container;
 import com.github.ambry.commons.BlobId;
+import com.github.ambry.messageformat.MessageFormatWriteSet;
 import com.github.ambry.replication.FindToken;
 import java.io.Closeable;
 import java.io.InputStream;
@@ -41,6 +42,9 @@ public interface CloudDestination extends Closeable {
    */
   boolean uploadBlob(BlobId blobId, long inputLength, CloudBlobMetadata cloudBlobMetadata, InputStream blobInputStream)
       throws CloudStorageException;
+  default boolean uploadBlobs(MessageFormatWriteSet messageSetToWrite) throws CloudStorageException {
+    throw new UnsupportedOperationException("uploadBlobs is not be implemented");
+  }
 
   /**
    * Upload blob to the cloud destination asynchronously.

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicationManager.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicationManager.java
@@ -51,7 +51,6 @@ import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
@@ -59,7 +58,6 @@ import org.apache.helix.lock.DistributedLock;
 import org.apache.helix.lock.LockScope;
 import org.apache.helix.lock.helix.HelixLockScope;
 import org.apache.helix.lock.helix.ZKDistributedNonblockingLock;
-import org.checkerframework.checker.units.qual.A;
 
 
 /**
@@ -84,8 +82,6 @@ public class VcrReplicationManager extends ReplicationEngine {
   private final HelixVcrUtil.VcrHelixConfig vcrHelixConfig;
   private DistributedLock vcrUpdateDistributedLock = null;
 
-  private AtomicInteger numPartitionsAssigned;
-
   public VcrReplicationManager(CloudConfig cloudConfig, ReplicationConfig replicationConfig,
       ClusterMapConfig clusterMapConfig, StoreConfig storeConfig, StoreManager storeManager,
       StoreKeyFactory storeKeyFactory, ClusterMap clusterMap, VcrClusterParticipant vcrClusterParticipant,
@@ -96,7 +92,6 @@ public class VcrReplicationManager extends ReplicationEngine {
         vcrClusterParticipant.getCurrentDataNodeId(), Collections.emptyList(), networkClientFactory,
         vcrMetrics.getMetricRegistry(), requestNotification, storeKeyConverterFactory, transformerClassName, null,
         storeManager, null, true);
-    this.numPartitionsAssigned = new AtomicInteger(0);
     this.cloudConfig = cloudConfig;
     this.vcrClusterParticipant = vcrClusterParticipant;
     this.vcrMetrics = vcrMetrics;
@@ -277,12 +272,6 @@ public class VcrReplicationManager extends ReplicationEngine {
     if (partitionToPartitionInfo.containsKey(partitionId)) {
       throw new ReplicationException("Partition " + partitionId + " already exists on " + dataNodeId);
     }
-    int numPartitions = numPartitionsAssigned.incrementAndGet();
-    if (numPartitions > 1600) {
-      logger.info("|snkt| Not backing up partition-{} #{}", partitionId.getId(), numPartitions);
-      return;
-    }
-    logger.info("|snkt| Backing up partition-{} #{}", partitionId.getId(), numPartitions);
     ReplicaId cloudReplica = new CloudReplica(partitionId, vcrClusterParticipant.getCurrentDataNodeId());
     if (!storeManager.addBlobStore(cloudReplica)) {
       logger.error("Can't start cloudstore for replica {}", cloudReplica);


### PR DESCRIPTION
Final planned fix for backup system 2.0.

We do not use the `recentBlobCache` for VCR 2.0 and setting the `maxCacheLimit` to 0 doesn't achieve that. The code still creates the `recentBlobCache` with a hardcoded initial size of 1000 entries (`cacheInitialCapacity`). This patch just completely removes the `recentBlobCache`. It is an incomplete and untested legacy remnant that gives erroneous results.

There are couple of other improvements. For a PUT with no encryption, it is better to just pass the blob's un-encrypted inputStream to azure-sdk instead of creating an in-memory copy and passing that to azure-sdk. The SDK will handle retries.

Lastly, this patch replaces the deprecated `download` with recommended `downloadStream`