### PR TITLE
Add file path in the crc error log for given store key

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/store/MessageReadSet.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/MessageReadSet.java
@@ -13,8 +13,8 @@
  */
 package com.github.ambry.store;
 
-import com.github.ambry.router.AsyncWritableChannel;
 import com.github.ambry.commons.Callback;
+import com.github.ambry.router.AsyncWritableChannel;
 import io.netty.buffer.ByteBuf;
 import java.io.IOException;
 import java.nio.channels.WritableByteChannel;
@@ -81,4 +81,13 @@ public interface MessageReadSet {
    * @return The prefetched data.
    */
   ByteBuf getPrefetchedData(int index);
+
+  /**
+   * Return the data source for this message read set.
+   * @param index The index into the message set.
+   * @return The data source for the data identified by the given index.
+   */
+  default String getDataSource(int index) {
+    return "DataSourceUnknown";
+  }
 }

--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageFormatSend.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageFormatSend.java
@@ -133,7 +133,9 @@ public class MessageFormatSend extends AbstractByteBufHolder<MessageFormatSend> 
             MessageFormatRecord.deserializeBlobAll(new NettyByteBufDataInputStream(messageData), storeKeyFactory);
           } catch (Exception e) {
             metrics.messageFormatExceptionCount.inc();
-            logger.error("Failed to deserialize the BlobAll from message format send for StoreKey {}.", storeKey, e);
+            logger.error(
+                "Failed to deserialize the BlobAll from message format send for StoreKey {}. The data source for this key is {}",
+                storeKey, readSet.getDataSource(i), e);
           }
 
           if (flag == MessageFormatFlags.All) {

--- a/ambry-store/src/main/java/com/github/ambry/store/StoreMessageReadSet.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StoreMessageReadSet.java
@@ -291,6 +291,11 @@ class StoreMessageReadSet implements MessageReadSet {
     return readOptions.get(index).getPrefetchedData();
   }
 
+  @Override
+  public String getDataSource(int index) {
+    return readOptions.get(index).getFile().getAbsolutePath();
+  }
+
   /**
    * Interface to call after dealing with IO operation in the {@link StoreMessageReadSet}.
    */


### PR DESCRIPTION
## Summary
Adding the file path in the crc error log so we can easily identify the disk. CRC error can be caused by failed disk. This log message make identity the disk easier. 