### PR TITLE
Add account name and container name in the ContainerBlobsResource and AccountBlobsResource

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/account/AccountBlobsResource.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/AccountBlobsResource.java
@@ -16,6 +16,7 @@ package com.github.ambry.account;
 public class AccountBlobsResource implements AclService.Resource {
   public static final String RESOURCE_TYPE = "AccountBlobs";
   private final String resourceId;
+  private final String accountName;
 
   /**
    * Construct the resource from an account.
@@ -23,6 +24,7 @@ public class AccountBlobsResource implements AclService.Resource {
    */
   public AccountBlobsResource(Account account) {
     resourceId = String.valueOf(account.getId());
+    accountName = account.getName();
   }
 
   /**
@@ -41,6 +43,14 @@ public class AccountBlobsResource implements AclService.Resource {
   @Override
   public String getResourceId() {
     return resourceId;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String getResourceDetail() {
+    return RESOURCE_TYPE + ":AccountName:" + accountName;
   }
 
   @Override

--- a/ambry-api/src/main/java/com/github/ambry/account/AclService.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/AclService.java
@@ -94,5 +94,12 @@ public interface AclService<P> extends Closeable {
      * implementing {@link AclService}.
      */
     String getResourceId();
+
+    /**
+     * @return A detailed string for this specific resource. The returned string is not safe for URL.
+     */
+    default String getResourceDetail() {
+      return this.toString();
+    }
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/account/ContainerBlobsResource.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/ContainerBlobsResource.java
@@ -23,6 +23,9 @@ public class ContainerBlobsResource implements AclService.Resource {
   private static final String SEPARATOR = "_";
 
   private final String resourceId;
+  private final short accountId;
+  private final String accountName;
+  private final String containerName;
 
   /**
    * Construct the resource from a container.
@@ -30,6 +33,21 @@ public class ContainerBlobsResource implements AclService.Resource {
    */
   public ContainerBlobsResource(Container container) {
     resourceId = container.getParentAccountId() + SEPARATOR + container.getId();
+    accountId = container.getParentAccountId();
+    accountName = null;
+    containerName = container.getName();
+  }
+
+  /**
+   * Construct the resource from an Account and a Container. Account will provide account name in detail
+   * @param account The {@link Account}.
+   * @param container The {@link Container}.
+   */
+  public ContainerBlobsResource(Account account, Container container) {
+    resourceId = container.getParentAccountId() + SEPARATOR + container.getId();
+    accountId = container.getParentAccountId();
+    accountName = account.getName();
+    containerName = container.getName();
   }
 
   /**
@@ -48,6 +66,13 @@ public class ContainerBlobsResource implements AclService.Resource {
   @Override
   public String getResourceId() {
     return resourceId;
+  }
+
+  @Override
+  public String getResourceDetail() {
+    String detail = (accountName == null ? "AccountId:" + accountId : "AccountName:" + accountName) + "|ContainerName:"
+        + containerName;
+    return RESOURCE_TYPE + ":" + detail;
   }
 
   @Override


### PR DESCRIPTION
## Summary

Adding a new method to AclResource to return the detail of the resource, so we can return the account name and container name in the http response header back to client.

## Test
./gradlew allJar