### PR TITLE
Print out stack track on ReplicaThread calling getBootstrapReplica

### DIFF
--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
@@ -834,6 +834,11 @@ public class HelixClusterManager implements ClusterMap {
         bootstrapReplica = new AmbryServerReplica(clusterMapConfig, currentPartition, targetDisk, true, replicaCapacity,
             ReplicaSealStatus.NOT_SEALED);
         logger.info("Created bootstrap replica {} for Partition {}", bootstrapReplica, partitionIdStr);
+        Thread currentThread = Thread.currentThread();
+        // TODO: Remove this code after figuring out why ReplicaThread is calling this method.
+        if (currentThread.getName().contains("ReplicaThread")) {
+          logger.error("Method invocation in wrong thread {}", currentThread.getName(), new Exception(""));
+        }
       } catch (Exception e) {
         logger.error("Failed to create bootstrap replica for partition {} on {} due to exception: ", partitionIdStr,
             instanceName, e);


### PR DESCRIPTION
## Summary

We are seeing getBootstrapReplica being called in ReplicaThread somehow. And we can't figure out how it's been called. This PR adds a stacktrace  for that. Will remove it when we know the call chain.

