### PR TITLE
Handling the case where a partition has no replicas

### DIFF
--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
@@ -1187,7 +1187,15 @@ public class HelixClusterManager implements ClusterMap {
      */
     @Override
     public List<AmbryReplica> getReplicaIdsForPartition(AmbryPartition partition) {
-      return new ArrayList<>(ambryPartitionToAmbryReplicas.get(partition));
+      Set<AmbryReplica> replicas = ambryPartitionToAmbryReplicas.get(partition);
+
+      if (replicas == null) {
+        // Returns an empty list if the partition does not exist
+        logger.error("Partition {} has no replicas", partition.getId());
+        return Collections.emptyList();
+      }
+
+      return new ArrayList<>(replicas);
     }
 
     @Override


### PR DESCRIPTION
## Summary
Given the case where a partition has no replicas, such as when a new partition is being created, we would want to return an empty list to reflect that.

Currently, when we are attempting to add a blob store to a datanode, we end up `refreshPeerReplicaTokens` -> `getPeerReplicaIds` -> `getReplicaIds` -> `getReplicaIdsForPartition` which ultimately raise a null pointer pointer exception when the partition doesn't exist 