### PR TITLE
Fix NPE in getReplicaIdsByState when partition only exist in one DC

### DIFF
--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
@@ -1229,6 +1229,10 @@ public class HelixClusterManager implements ClusterMap {
       String partitionName = partition.toPathString();
       for (String dc : dcs) {
         Set<String> resourceNames = partitionToResourceNameByDc.get(dc).get(partitionName);
+        if (resourceNames == null) {
+          // For newly created partitions, we might not able to find resources in other DCs
+          continue;
+        }
         RoutingTableSnapshot routingTableSnapshot =
             clusterMapConfig.clusterMapUseAggregatedView ? globalRoutingTableSnapshotRef.get()
                 : dcToRoutingTableSnapshotRef.get(dc).get();


### PR DESCRIPTION
## Summary

When creating new partitions, we create them in on DC first and make sure they are working, then move on to other DCs. This would put cluster in a state where some partitions only exist in one DC and not in other DCs. 

This PR fixes an NPE issue in getReplicaIdsByState when partitions are newly created in only one DC.
