### PR TITLE
Fail storage manager when too many disk failed

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/clustermap/DataNodeId.java
+++ b/ambry-api/src/main/java/com/github/ambry/clustermap/DataNodeId.java
@@ -14,6 +14,7 @@
 package com.github.ambry.clustermap;
 
 import com.github.ambry.network.Port;
+import java.util.List;
 
 
 /**
@@ -104,6 +105,12 @@ public interface DataNodeId extends Resource, Comparable<DataNodeId> {
    * @return the xid associated with this node.
    */
   long getXid();
+
+  /**
+   * Return a list of {@link DiskId}s from this data node.
+   * @return
+   */
+  List<DiskId> getDiskIds();
 
   @Override
   default int compareTo(DataNodeId o) {

--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -583,6 +583,17 @@ public class StoreConfig {
   public static final String storeDiskCapacityReportingPercentageName = "store.disk.capacity.reporting.percentage";
 
   /**
+   * The threshold of disk failures to terminate the process. If we have 10 disks and the threshold is 0.8, then when
+   * there are 9, or 10 disks failed to start, or marked as unavailable, we would fail the initialization of the
+   * storage manager, thus, kill the process. By default, the threshold is 1, which means we don't fail the process even
+   * when all the disks failed.
+   */
+  @Config(storeThresholdOfDiskFailuresToTerminateName)
+  public final float storeThresholdOfDiskFailuresToTerminate;
+  public static final String storeThresholdOfDiskFailuresToTerminateName =
+      "store.threshold.of.disk.failures.to.terminate";
+
+  /**
    * True to remove all the unexpected directories when the current node is in FULL AUTO.
    */
   @Config(storeRemoveUnexpectedDirsInFullAutoName)
@@ -745,6 +756,8 @@ public class StoreConfig {
     }
     storeDiskCapacityReportingPercentage =
         verifiableProperties.getIntInRange(storeDiskCapacityReportingPercentageName, 95, 0, 100);
+    storeThresholdOfDiskFailuresToTerminate =
+        verifiableProperties.getFloatInRange(storeThresholdOfDiskFailuresToTerminateName, 1.0f, 0.0f, 1.0f);
     storeRemoveUnexpectedDirsInFullAuto =
         verifiableProperties.getBoolean(storeRemoveUnexpectedDirsInFullAutoName, false);
   }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryServerDataNode.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryServerDataNode.java
@@ -19,6 +19,7 @@ import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.network.Port;
 import com.github.ambry.network.PortType;
 import com.github.ambry.utils.Utils;
+import java.util.ArrayList;
 import java.util.List;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -82,6 +83,11 @@ class AmbryServerDataNode extends AmbryDataNode {
   @Override
   public long getXid() {
     return xid;
+  }
+
+  @Override
+  public List<DiskId> getDiskIds() {
+    return new ArrayList<>(clusterManagerQueryHelper.getDisks(this));
   }
 
   @Override

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/CloudDataNode.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/CloudDataNode.java
@@ -18,6 +18,7 @@ import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.network.Port;
 import com.github.ambry.network.PortType;
 import com.github.ambry.utils.Utils;
+import java.util.Collections;
 import java.util.List;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -146,6 +147,11 @@ public class CloudDataNode implements DataNodeId {
   @Override
   public long getXid() {
     return 0;
+  }
+
+  @Override
+  public List<DiskId> getDiskIds() {
+    return Collections.EMPTY_LIST;
   }
 
   @Override

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/CloudServiceDataNode.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/CloudServiceDataNode.java
@@ -17,6 +17,8 @@ package com.github.ambry.clustermap;
 
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.network.Port;
+import java.util.Collections;
+import java.util.List;
 import org.json.JSONObject;
 
 import static com.github.ambry.clustermap.ClusterMapSnapshotConstants.*;
@@ -53,6 +55,11 @@ class CloudServiceDataNode extends AmbryDataNode {
   @Override
   public String getRackId() {
     return null;
+  }
+
+  @Override
+  public List<DiskId> getDiskIds() {
+    return Collections.EMPTY_LIST;
   }
 
   @Override

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DataNode.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DataNode.java
@@ -227,6 +227,11 @@ class DataNode implements DataNodeId {
   }
 
   @Override
+  public List<DiskId> getDiskIds() {
+    return new ArrayList<>(disks);
+  }
+
+  @Override
   public JSONObject getSnapshot() {
     JSONObject snapshot = new JSONObject();
     snapshot.put(DATA_NODE_HOSTNAME, getHostname());

--- a/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
@@ -84,7 +84,7 @@ public class DiskManager {
   private final List<String> unexpectedDirs = new ArrayList<>();
   private final AccountService accountService;
   private final DiskManagerConfig diskManagerConfig;
-  private boolean running = false;
+  private volatile boolean running = false;
   private DiskHealthStatus diskHealthStatus;
   private final DiskHealthCheck diskHealthCheck;
   // Have a dedicated scheduler for persisting index segments to ensure index segments are always persisted
@@ -282,6 +282,14 @@ public class DiskManager {
       rwLock.readLock().unlock();
       metrics.diskShutdownTimeMs.update(time.milliseconds() - startTimeMs);
     }
+  }
+
+  /**
+   * Return true is the disk manager is running.
+   * @return True when the disk manager is running.
+   */
+  boolean isRunning() {
+    return running;
   }
 
   /**

--- a/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockDataNodeId.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockDataNodeId.java
@@ -166,6 +166,15 @@ public class MockDataNodeId implements DataNodeId {
   }
 
   @Override
+  public List<DiskId> getDiskIds() {
+    List<DiskId> disks = new ArrayList<>();
+    for (String mountPath : mountPaths) {
+      disks.add(new MockDiskId(this, mountPath));
+    }
+    return disks;
+  }
+
+  @Override
   public JSONObject getSnapshot() {
     JSONObject snapshot = new JSONObject();
     snapshot.put(DATA_NODE_HOSTNAME, getHostname());


### PR DESCRIPTION
## Summary
Fail the initialization of StorageManager when there are too many disks fail to start or marked as unavailable. If enough disks fail to start up, there is no way ambry-server would be able to function. Then just fail the ambry-server so the helix would move all the replicas out sometime.

## Test
Unit test