### PR TITLE
Fix ambry server infinity stacktrace when netty channel is closed by exception

### DIFF
--- a/ambry-network/src/main/java/com/github/ambry/network/http2/AmbryNetworkRequestHandler.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/AmbryNetworkRequestHandler.java
@@ -68,7 +68,7 @@ public class AmbryNetworkRequestHandler extends SimpleChannelInboundHandler<Full
   public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
     http2ServerMetrics.http2StreamExceptionCount.inc();
     logger.warn("Exception caught in AmbryNetworkRequestHandler, cause: ", cause);
-    ctx.channel().close();
+    ctx.fireExceptionCaught(cause);
   }
 
   /**


### PR DESCRIPTION
## Summary
When there is an exception in storage server netty layer, it will close the channel, which would try to flush any bytes on the channel, which would then trigger the exception again, and then calling the handler to close the channel again. Then we are trapped in an infinite stack traces. 

Unfortunately, jvm doesn't kill the process when this happens, so the ambry-server process is returning healthy to health checker while refusing to serve any requests.

This PR fixes that. 

## Test
unit test