### PR TITLE
Remove blob store directory when it can't start

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -601,11 +601,12 @@ public class StoreConfig {
   public static final String storeRemoveUnexpectedDirsInFullAutoName = "store.remove.unexpected.dirs.in.full.auto";
 
   /**
-   * True to remove all the files for a partition and restart the blob store when blob store fails to start.
+   * True to remove all the files under the partition directory and restart the blob store when blob store fails to start.
    */
-  @Config(storeWipeAndRestartBlobStoreName)
-  public final boolean storeWipeAndRestartBlobStore;
-  public static final String storeWipeAndRestartBlobStoreName = "store.wipe.and.restart.blob.store";
+  @Config(storeRemoveDirectoryAndRestartBlobStoreName)
+  public final boolean storeRemoveDirectoryAndRestartBlobStore;
+  public static final String storeRemoveDirectoryAndRestartBlobStoreName =
+      "store.remove.directory.and.restart.blob.store";
 
   public StoreConfig(VerifiableProperties verifiableProperties) {
     storeKeyFactory = verifiableProperties.getString("store.key.factory", "com.github.ambry.commons.BlobIdFactory");
@@ -767,6 +768,7 @@ public class StoreConfig {
         verifiableProperties.getFloatInRange(storeThresholdOfDiskFailuresToTerminateName, 1.0f, 0.0f, 1.0f);
     storeRemoveUnexpectedDirsInFullAuto =
         verifiableProperties.getBoolean(storeRemoveUnexpectedDirsInFullAutoName, false);
-    storeWipeAndRestartBlobStore = verifiableProperties.getBoolean(storeWipeAndRestartBlobStoreName, false);
+    storeRemoveDirectoryAndRestartBlobStore =
+        verifiableProperties.getBoolean(storeRemoveDirectoryAndRestartBlobStoreName, false);
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -600,6 +600,13 @@ public class StoreConfig {
   public final boolean storeRemoveUnexpectedDirsInFullAuto;
   public static final String storeRemoveUnexpectedDirsInFullAutoName = "store.remove.unexpected.dirs.in.full.auto";
 
+  /**
+   * True to remove all the files for a partition and restart the blob store when blob store fails to start.
+   */
+  @Config(storeWipeAndRestartBlobStoreName)
+  public final boolean storeWipeAndRestartBlobStore;
+  public static final String storeWipeAndRestartBlobStoreName = "store.wipe.and.restart.blob.store";
+
   public StoreConfig(VerifiableProperties verifiableProperties) {
     storeKeyFactory = verifiableProperties.getString("store.key.factory", "com.github.ambry.commons.BlobIdFactory");
     storeDataFlushIntervalSeconds = verifiableProperties.getLong("store.data.flush.interval.seconds", 60);
@@ -760,5 +767,6 @@ public class StoreConfig {
         verifiableProperties.getFloatInRange(storeThresholdOfDiskFailuresToTerminateName, 1.0f, 0.0f, 1.0f);
     storeRemoveUnexpectedDirsInFullAuto =
         verifiableProperties.getBoolean(storeRemoveUnexpectedDirsInFullAutoName, false);
+    storeWipeAndRestartBlobStore = verifiableProperties.getBoolean(storeWipeAndRestartBlobStoreName, false);
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/store/StoreErrorCodes.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/StoreErrorCodes.java
@@ -41,5 +41,9 @@ public enum StoreErrorCodes {
   ID_Undeleted,
   ID_Deleted_Permanently,
   // TODO Efficient_Metadata_Operations_TODO : ID_Purged error should be handled in all of the store's methods.
-  ID_Purged
+  ID_Purged,
+  Log_File_Format_Error,
+  Index_File_Format_Error,
+  Log_End_Offset_Error,
+  Index_Recovery_Error
 }

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -388,6 +388,10 @@ public class BlobStore implements Store {
     return this.replicaId;
   }
 
+  String getDataDir() {
+    return dataDir;
+  }
+
   /**
    * Checks the state of the messages in the given {@link MessageWriteSet} in the given {@link FileSpan}.
    * @param messageSetToWrite Non-empty set of messages to write to the store.

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -64,7 +64,7 @@ public class BlobStore implements Store {
   static final String SEPARATOR = "_";
   static final String BOOTSTRAP_FILE_NAME = "bootstrap_in_progress";
   static final String DECOMMISSION_FILE_NAME = "decommission_in_progress";
-  private final static String LockFile = ".lock";
+  final static String LockFile = ".lock";
 
   private final String storeId;
   private final String dataDir;

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -305,6 +305,14 @@ public class BlobStore implements Store {
         }
         enableReplicaIfNeeded();
       } catch (Exception e) {
+        if (fileLock != null) {
+          // Release the file lock
+          try {
+            fileLock.unlock();
+          } catch (Exception lockException) {
+            logger.error("Failed to unlock file lock for dir " + dataDir, lockException);
+          }
+        }
         metrics.storeStartFailure.inc();
         throw new StoreException("Error while starting store for dir " + dataDir, e,
             StoreErrorCodes.Initialization_Error);

--- a/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
@@ -243,6 +243,14 @@ public class DiskManager {
     }
   }
 
+  /**
+   * Maybe recover the blob stores that failed to start. The configuration has to be set to true and the number
+   * of failed blob stores are not the same as the total number on the disk, then we would try to recover each
+   * blob store. We only recover the blob store if the exception thrown in the start method is StoreException and
+   * the store error code is one of the recoverable error codes.
+   * @param numStoreFailures
+   * @param startExceptions
+   */
   void maybeRecoverBlobStores(int numStoreFailures, Map<PartitionId, Exception> startExceptions) {
     if (!storeConfig.storeRemoveDirectoryAndRestartBlobStore || numStoreFailures == stores.size()) {
       return;

--- a/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
@@ -244,7 +244,7 @@ public class DiskManager {
   }
 
   void maybeRecoverBlobStores(int numStoreFailures, Map<PartitionId, Exception> startExceptions) {
-    if (!storeConfig.storeRemoveDirectoryAndRestartBlobStore || numStoreFailures != stores.size()) {
+    if (!storeConfig.storeRemoveDirectoryAndRestartBlobStore || numStoreFailures == stores.size()) {
       return;
     }
     for (Map.Entry<PartitionId, BlobStore> entry : stores.entrySet()) {

--- a/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
@@ -200,7 +200,7 @@ public class DiskManager {
       }
       if (numStoreFailures.get() > 0) {
         logger.error("Could not start {} out of {} stores on the disk {}", numStoreFailures.get(), stores.size(), disk);
-        if (storeConfig.storeWipeAndRestartBlobStore) {
+        if (storeConfig.storeWipeAndRestartBlobStore && numStoreFailures.get() != stores.size()) {
           for (Map.Entry<PartitionId, BlobStore> entry : stores.entrySet()) {
             BlobStore store = entry.getValue();
             if (store.isStarted()) {

--- a/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
@@ -203,7 +203,7 @@ public class DiskManager {
         if (storeConfig.storeWipeAndRestartBlobStore && numStoreFailures.get() != stores.size()) {
           for (Map.Entry<PartitionId, BlobStore> entry : stores.entrySet()) {
             BlobStore store = entry.getValue();
-            if (store.isStarted()) {
+            if (store.isStarted() || stoppedReplicas.contains(entry.getKey().toPathString())) {
               continue;
             }
             // 1. wipe out the blob store directory

--- a/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
@@ -17,7 +17,6 @@ import com.codahale.metrics.Timer;
 import com.github.ambry.config.StoreConfig;
 import com.github.ambry.replication.FindToken;
 import com.github.ambry.replication.FindTokenType;
-import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
 import java.io.File;
@@ -449,8 +448,9 @@ class PersistentIndex {
             deleteExpectedKeys.add(info.getStoreKey());
           }
         } else if (value != null) {
-          throw new StoreException("Illegal message state during recovery. Duplicate PUT record",
-              StoreErrorCodes.Initialization_Error);
+          throw new StoreException(
+              "Illegal message state during recovery. Duplicate PUT record for " + info.getStoreKey(),
+              StoreErrorCodes.Index_Recovery_Error);
         } else {
           // create a new entry in the index
           IndexValue newValue = new IndexValue(info.getSize(), runningOffset, IndexValue.FLAGS_DEFAULT_VALUE,
@@ -469,7 +469,7 @@ class PersistentIndex {
     }
     if (deleteExpectedKeys.size() > 0) {
       throw new StoreException("Deletes were expected for some keys but were not encountered: " + deleteExpectedKeys,
-          StoreErrorCodes.Initialization_Error);
+          StoreErrorCodes.Index_Recovery_Error);
     }
     if (recoveryOccurred) {
       metrics.nonzeroMessageRecovery.inc();

--- a/ambry-store/src/test/java/com/github/ambry/store/IndexTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/IndexTest.java
@@ -1081,16 +1081,16 @@ public class IndexTest {
     // recovery info contains a PUT for a key that already exists
     MessageInfo info = new MessageInfo(state.liveKeys.iterator().next(), CuratedLogIndexState.PUT_RECORD_SIZE,
         Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM), Utils.Infinite_Time);
-    doRecoveryFailureTest(info, StoreErrorCodes.Initialization_Error);
+    doRecoveryFailureTest(info, StoreErrorCodes.Index_Recovery_Error);
     // recovery info contains a PUT for a key that has been deleted
     info = new MessageInfo(state.deletedKeys.iterator().next(), CuratedLogIndexState.PUT_RECORD_SIZE,
         Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM), Utils.Infinite_Time);
-    doRecoveryFailureTest(info, StoreErrorCodes.Initialization_Error);
+    doRecoveryFailureTest(info, StoreErrorCodes.Index_Recovery_Error);
     // recovery info contains a Ttl Update for a key that does not exist and there is no delete info that follows
     MockId nonExistentId = state.getUniqueId();
     info = new MessageInfo(nonExistentId, CuratedLogIndexState.TTL_UPDATE_RECORD_SIZE, false, true,
         nonExistentId.getAccountId(), nonExistentId.getContainerId(), state.time.milliseconds());
-    doRecoveryFailureTest(info, StoreErrorCodes.Initialization_Error);
+    doRecoveryFailureTest(info, StoreErrorCodes.Index_Recovery_Error);
     // recovery info contains a Ttl Update for a key that is already Ttl updated
     MockId updatedId = null;
     for (MockId id : state.ttlUpdatedKeys) {
@@ -1117,7 +1117,7 @@ public class IndexTest {
     // recovery info that contains a PUT beyond the end offset of the log segment
     info = new MessageInfo(state.getUniqueId(), CuratedLogIndexState.PUT_RECORD_SIZE,
         Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM), Utils.Infinite_Time);
-    doRecoveryFailureTest(info, StoreErrorCodes.Index_Creation_Failure);
+    doRecoveryFailureTest(info, StoreErrorCodes.Log_End_Offset_Error);
   }
 
   /**

--- a/ambry-store/src/test/java/com/github/ambry/store/LogSegmentTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/LogSegmentTest.java
@@ -36,6 +36,7 @@ import java.util.Properties;
 import java.util.Random;
 import java.util.Set;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -225,8 +226,9 @@ public class LogSegmentTest {
         try {
           segment.setEndOffset(offset);
           fail("Setting log end offset an invalid offset [" + offset + "] should have failed");
-        } catch (IllegalArgumentException e) {
+        } catch (StoreException e) {
           // expected. Nothing to do.
+          Assert.assertEquals(StoreErrorCodes.Log_End_Offset_Error, e.getErrorCode());
         }
       }
     } finally {
@@ -587,8 +589,9 @@ public class LogSegmentTest {
     try {
       new LogSegment(name, file, config, metrics);
       fail("Construction should have failed because version is unknown");
-    } catch (IllegalArgumentException e) {
+    } catch (StoreException e) {
       // expected. Nothing to do.
+      Assert.assertEquals(StoreErrorCodes.Log_File_Format_Error, e.getErrorCode());
     }
 
     // bad CRC
@@ -599,8 +602,9 @@ public class LogSegmentTest {
     try {
       new LogSegment(name, file, config, metrics);
       fail("Construction should have failed because crc check should have failed");
-    } catch (IllegalStateException e) {
+    } catch (StoreException e) {
       // expected. Nothing to do.
+      Assert.assertEquals(StoreErrorCodes.Log_File_Format_Error, e.getErrorCode());
     }
     closeSegmentAndDeleteFile(segment);
   }

--- a/ambry-store/src/test/java/com/github/ambry/store/StorageManagerTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/StorageManagerTest.java
@@ -57,8 +57,10 @@ import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
 import java.io.File;
 import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1099,6 +1101,116 @@ public class StorageManagerTest {
   }
 
   /**
+   * Test the case where the blob store can't get started and we need to remove the directory and then restart the blobstore.
+   * @throws Exception
+   */
+  @Test
+  public void storeRemoveDirectoryAndRestartTest() throws Exception {
+    // Make sure that we use segmented log files
+    generateConfigs(true, false);
+    MockDataNodeId dataNode = clusterMap.getDataNodes().get(0);
+    ReplicaId replica = clusterMap.getReplicaIds(dataNode).get(0);
+    ReplicaId goodReplica = clusterMap.getReplicaIds(dataNode).get(1);
+    // Just start the storage manager and this will make sure all the replicas' directories are created
+    // and the first log segment file is also created for each replica.
+    StorageManager storageManager = createStorageManager(dataNode, metricRegistry, null);
+    storageManager.start();
+    // Both replicas should have blobstore returned
+    assertNotNull(storageManager.getStore(replica.getPartitionId(), false));
+    assertNotNull(storageManager.getStore(goodReplica.getPartitionId(), false));
+
+    File file = getFileLogSegment(replica);
+    assertTrue("First log segment file should exist " + file.getAbsolutePath(), file.exists());
+
+    // Now shutdown the storage manager and modify the first log segment by truncating the size to half.
+    // This will break the log segment file header
+    storageManager.shutdown();
+    corruptFirstLogSegment(replica);
+
+    // Now restart the storage manager
+    storageManager = createStorageManager(dataNode, metricRegistry, null);
+    storageManager.start();
+    assertEquals(1,
+        getCounterValue(metricRegistry.getCounters(), DiskManager.class.getName(), "TotalStoreStartFailures"));
+    // bad replica is not started, but the good replica is
+    assertNull(storageManager.getStore(replica.getPartitionId(), false));
+    assertNotNull(storageManager.getStore(goodReplica.getPartitionId(), false));
+
+    storageManager.shutdown();
+
+    // Now enable the feature to remove directory and restart blob store
+    generateConfigs(true, false, false, 2, true);
+    storageManager = createStorageManager(dataNode, metricRegistry, null);
+    storageManager.start();
+
+    // Getting blob stores for both replicas should both result in not null
+    assertNotNull(storageManager.getStore(replica.getPartitionId(), false));
+    assertNotNull(storageManager.getStore(goodReplica.getPartitionId(), false));
+    storageManager.shutdown();
+  }
+
+  @Test
+  public void storeRemoveDirectoryAndRestartTestWithDiskFailure() throws Exception {
+    MockDataNodeId dataNode = clusterMap.getDataNodes().get(0);
+    List<ReplicaId> replicas = clusterMap.getReplicaIds(dataNode);
+    List<String> mountPaths = dataNode.getMountPaths();
+    String badDiskMountPath = mountPaths.get(RANDOM.nextInt(mountPaths.size()));
+    List<ReplicaId> badReplicas =
+        replicas.stream().filter(r -> r.getMountPath().equals(badDiskMountPath)).collect(Collectors.toList());
+
+    generateConfigs(true, false, false, 2, true);
+    StorageManager storageManager = createStorageManager(dataNode, metricRegistry, null);
+    storageManager.start();
+    storageManager.shutdown();
+
+    // Now corrupt all the replicas on the disk except for the last one
+    // So we will remove the bad directories and restart blob stores
+    for (ReplicaId replica : badReplicas.subList(0, badReplicas.size() - 1)) {
+      corruptFirstLogSegment(replica);
+    }
+    storageManager = createStorageManager(dataNode, metricRegistry, null);
+    storageManager.start();
+    // All replicas should have its blob store
+    for (ReplicaId replica : badReplicas) {
+      assertNotNull(storageManager.getStore(replica.getPartitionId(), false));
+    }
+    storageManager.shutdown();
+
+    // Now corrupt all the replicas on the disk
+    for (ReplicaId replica : badReplicas) {
+      corruptFirstLogSegment(replica);
+    }
+    storageManager = createStorageManager(dataNode, metricRegistry, null);
+    storageManager.start();
+    // All replicas should not have its blob store
+    for (ReplicaId replica : badReplicas) {
+      assertNull(storageManager.getStore(replica.getPartitionId(), false));
+    }
+    storageManager.shutdown();
+  }
+
+  @Test
+  public void storeRemoveDirectoryAndRestartTestWithStoppedReplica() throws Exception {
+    generateConfigs(true, false, false, 2, true);
+    MockDataNodeId dataNode = clusterMap.getDataNodes().get(0);
+    ReplicaId replica = clusterMap.getReplicaIds(dataNode).get(0);
+
+    // Start a storage manager so the replica's first log segment would be created
+    StorageManager storageManager = createStorageManager(dataNode, metricRegistry, null);
+    storageManager.start();
+    storageManager.shutdown();
+
+    ClusterParticipant mockParticipant = new MockClusterParticipant();
+    mockParticipant.setReplicaStoppedState(Collections.singletonList(replica), true);
+    // The first log segment is corrupted, but this replica is also in stopped replicas list, it will not be restarted
+    corruptFirstLogSegment(replica);
+    storageManager = createStorageManager(dataNode, metricRegistry, Collections.singletonList(mockParticipant));
+    storageManager.start();
+    assertNull(storageManager.getStore(replica.getPartitionId(), false));
+    storageManager.shutdown();
+  }
+
+  /**
    * Test that stores on a disk are inaccessible if the {@link DiskSpaceAllocator} fails to start.
    * @throws Exception
    */
@@ -1262,7 +1374,7 @@ public class StorageManagerTest {
    */
   @Test
   public void unrecognizedDirsRemovalTest() throws Exception {
-    generateConfigs(true, false, true, 2);
+    generateConfigs(true, false, true, 2, false);
     MockDataNodeId dataNode = clusterMap.getDataNodes().get(0);
     List<ReplicaId> replicas = clusterMap.getReplicaIds(dataNode);
     try {
@@ -1415,7 +1527,7 @@ public class StorageManagerTest {
    */
   @Test
   public void replicaFromOfflineToBootstrapFailureRetryWithDiskSpaceRequirementTest() throws Exception {
-    generateConfigs(true, false, false, 4);
+    generateConfigs(true, false, false, 4, false);
     MockClusterMap spyClusterMap = spy(clusterMap);
     MockDataNodeId localNode = spyClusterMap.getDataNodes().get(0);
     List<ReplicaId> localReplicas = spyClusterMap.getReplicaIds(localNode);
@@ -1998,9 +2110,10 @@ public class StorageManagerTest {
    * @param updateInstanceConfig whether to update InstanceConfig in Helix
    * @param removeUnexpectedDirs {@code true} to remove unexpectedd directories when current node is in FULL AUTO
    * @param numSegment the number of log segment files to create
+   * @parem removeDirectoryAndRestart {@code true} to remove directory of a blob store and restart it when it failes to start
    */
   private void generateConfigs(boolean segmentedLog, boolean updateInstanceConfig, boolean removeUnexpectedDirs,
-      int numSegment) {
+      int numSegment, boolean removeDirectoryAndRestart) {
     List<com.github.ambry.utils.TestUtils.ZkInfo> zkInfoList = new ArrayList<>();
     zkInfoList.add(new com.github.ambry.utils.TestUtils.ZkInfo(null, "DC0", (byte) 0, 2199, false));
     JSONObject zkJson = constructZkLayoutJSON(zkInfoList);
@@ -2023,6 +2136,8 @@ public class StorageManagerTest {
       long replicaCapacity = clusterMap.getAllPartitionIds(null).get(0).getReplicaIds().get(0).getCapacityInBytes();
       properties.put("store.segment.size.in.bytes", Long.toString(replicaCapacity / numSegment));
     }
+    properties.setProperty(StoreConfig.storeRemoveDirectoryAndRestartBlobStoreName,
+        String.valueOf(removeDirectoryAndRestart));
     VerifiableProperties vProps = new VerifiableProperties(properties);
     diskManagerConfig = new DiskManagerConfig(vProps);
     storeConfig = new StoreConfig(vProps);
@@ -2035,7 +2150,7 @@ public class StorageManagerTest {
    * @param updateInstanceConfig whether to update InstanceConfig in Helix
    */
   private void generateConfigs(boolean segmentedLog, boolean updateInstanceConfig) {
-    generateConfigs(segmentedLog, updateInstanceConfig, false, 2);
+    generateConfigs(segmentedLog, updateInstanceConfig, false, 2, false);
   }
 
   // unrecognizedDirsOnDiskTest() helpers
@@ -2067,6 +2182,17 @@ public class StorageManagerTest {
       createdDirs.add(createdDir);
     }
     return new Pair<>(createdFiles, createdDirs);
+  }
+
+  private File getFileLogSegment(ReplicaId replica) {
+    return Paths.get(replica.getReplicaPath(), LogSegmentName.fromPositionAndGeneration(0, 0).toFilename()).toFile();
+  }
+
+  private void corruptFirstLogSegment(ReplicaId replica) throws Exception {
+    File file = getFileLogSegment(replica);
+    FileChannel fileChannel = new RandomAccessFile(file, "rw").getChannel();
+    fileChannel.truncate(fileChannel.size() / 2);
+    fileChannel.close();
   }
 
   /**

--- a/ambry-store/src/test/java/com/github/ambry/store/StorageManagerTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/StorageManagerTest.java
@@ -1222,7 +1222,6 @@ public class StorageManagerTest {
     storageManager.start();
     storageManager.shutdown();
 
-    // Case 1. File lock is already locked
     // Now find the lock file in the blob store and lock this file
     FileLock fileLock = new FileLock(new File(replica.getReplicaPath(), BlobStore.LockFile));
     Assert.assertTrue(fileLock.tryLock());
@@ -1233,14 +1232,6 @@ public class StorageManagerTest {
     assertNull(storageManager.getStore(replica.getPartitionId(), false));
     storageManager.shutdown();
     fileLock.destroy();
-
-    // Case 2. Directory is read only
-    new File(replica.getReplicaPath()).setReadable(false);
-    storageManager = createStorageManager(dataNode, metricRegistry, null);
-    storageManager.start();
-    assertNull(storageManager.getStore(replica.getPartitionId(), false));
-    storageManager.shutdown();
-    new File(replica.getReplicaPath()).setReadable(true);
   }
 
   /**

--- a/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockClusterMap.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockClusterMap.java
@@ -564,7 +564,7 @@ public class MockClusterMap implements ClusterMap {
       if (f.isDirectory()) {
         File[] children = f.listFiles();
         if (children == null) {
-          throw new IOException("Error listing files of the directory");
+          throw new IOException("Error listing files of the directory " + f.getAbsolutePath());
         }
         for (File c : children) {
           deleteFileOrDirectory(c);

--- a/ambry-utils/src/main/java/com/github/ambry/utils/Utils.java
+++ b/ambry-utils/src/main/java/com/github/ambry/utils/Utils.java
@@ -1192,6 +1192,24 @@ public class Utils {
   }
 
   /**
+   * Find the deepest Throwable in the chain of the throwables of the given class.
+   * @param throwable
+   * @param clazz
+   * @param <T>
+   * @return
+   */
+  public static <T extends Throwable> T getRootCause(Throwable throwable, Class<T> clazz) {
+    T result = null;
+    while (throwable != null) {
+      if (clazz.isInstance(throwable)) {
+        result = (T) throwable;
+      }
+      throwable = throwable.getCause();
+    }
+    return result;
+  }
+
+  /**
    * Convert ms to nearest second(floor) and back to ms to get the approx value in ms if not for
    * {@link Utils#Infinite_Time}.
    * @param timeInMs the time in ms that needs to be converted


### PR DESCRIPTION
## Summary

When a blob store can't start (while some other blob stores can start), we currently just mark this blob store as down and don't do anything about it. This error would require human intervention. Someone has to go to ambry server host, stop jvm process and remove the replica directory and then restart the process and hope replication would work to restore all the blobs.

This PR tries to automate this process by removing the blob store directory and recreate a new one.

