### PR TITLE
Fix a NPE in getReplicaIdsByState

### DIFF
--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
@@ -1276,7 +1276,12 @@ public class HelixClusterManager implements ClusterMap {
       if (externalView == null) {
         return false;
       }
-      return externalView.getStateMap(partitionName).values().stream().anyMatch(instance -> {
+      Map<String, String> stateMap = externalView.getStateMap(partitionName);
+      if (stateMap == null || stateMap.isEmpty()) {
+        return false;
+      }
+      // state map is a map from instance to state
+      return stateMap.keySet().stream().anyMatch(instance -> {
         AmbryDataNode dataNode = instanceNameToAmbryDataNode.get(instance);
         return dataNode != null && dataNode.getDatacenterName().equals(dcName);
       });


### PR DESCRIPTION
## Summary

When new resource is created for the exiting partitions, the ideal state would have this partition before the external view. So checking if the new external view has any replica of this partition has to make sure that partition state map really exist. If it does not exist, then we just have to return false right away.

## Test
./gradlew build