### PR TITLE
[S3 API] Added HEAD handlers for S3 bucket and object

### DIFF
--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendUtils.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendUtils.java
@@ -13,8 +13,6 @@
  */
 package com.github.ambry.frontend;
 
-import com.github.ambry.account.AccountServiceException;
-import com.github.ambry.account.Dataset;
 import com.github.ambry.account.DatasetVersionRecord;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.commons.BlobId;
@@ -38,7 +36,6 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.Objects;
 import org.json.JSONObject;
 import org.json.JSONTokener;
 import org.slf4j.Logger;
@@ -90,8 +87,8 @@ public class FrontendUtils {
    * @param finalCallback the final callback to call once the chain is complete or if it is interrupted
    * @return the {@link Callback} returned by {@link CallbackUtils#chainCallback}.
    */
-  static <T, V> Callback<T> buildCallback(AsyncOperationTracker.Metrics metrics, ThrowingConsumer<T> successAction,
-      String context, Logger logger, Callback<V> finalCallback) {
+  public static <T, V> Callback<T> buildCallback(AsyncOperationTracker.Metrics metrics,
+      ThrowingConsumer<T> successAction, String context, Logger logger, Callback<V> finalCallback) {
     AsyncOperationTracker tracker = new AsyncOperationTracker(context, logger, metrics);
     return CallbackUtils.chainCallback(tracker, finalCallback, successAction);
   }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/HeadBlobHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/HeadBlobHandler.java
@@ -65,7 +65,7 @@ public class HeadBlobHandler {
     this.quotaManager = quotaManager;
   }
 
-  void handle(RestRequest restRequest, RestResponseChannel restResponseChannel, Callback<Void> callback)
+  public void handle(RestRequest restRequest, RestResponseChannel restResponseChannel, Callback<Void> callback)
       throws RestServiceException {
     // named blob requests have their account/container in the URI, so checks can be done prior to ID conversion.
     if (getRequestPath(restRequest).matchesOperation(Operations.NAMED_BLOB)) {

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3HeadHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3HeadHandler.java
@@ -81,7 +81,7 @@ public class S3HeadHandler {
 
     Callback<ReadableStreamChannel> wrappedCallback = (result, exception) -> {
 
-      // TODO: remove x-ambry- headers
+      // TODO [S3]: remove x-ambry- headers
 
       callback.onCompletion(result, exception);
     };
@@ -168,7 +168,7 @@ public class S3HeadHandler {
     private void handle(RestRequest restRequest, RestResponseChannel restResponseChannel,
         Callback<ReadableStreamChannel> callback) throws RestServiceException {
 
-      // TODO: implement PartNumber handling
+      // TODO [S3]: implement PartNumber handling
 
       headBlobHandler.handle(restRequest, restResponseChannel,
           ((result, exception) -> callback.onCompletion(null, exception)));

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3HeadHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3HeadHandler.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2024 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ */
+package com.github.ambry.frontend.s3;
+
+import com.github.ambry.account.AccountService;
+import com.github.ambry.account.AccountServiceException;
+import com.github.ambry.account.Container;
+import com.github.ambry.commons.Callback;
+import com.github.ambry.frontend.FrontendMetrics;
+import com.github.ambry.frontend.HeadBlobHandler;
+import com.github.ambry.frontend.NamedBlobPath;
+import com.github.ambry.frontend.Operations;
+import com.github.ambry.frontend.SecurityService;
+import com.github.ambry.rest.RequestPath;
+import com.github.ambry.rest.RestRequest;
+import com.github.ambry.rest.RestResponseChannel;
+import com.github.ambry.rest.RestServiceErrorCode;
+import com.github.ambry.rest.RestServiceException;
+import com.github.ambry.rest.RestUtils;
+import com.github.ambry.router.ReadableStreamChannel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.github.ambry.frontend.FrontendUtils.*;
+import static com.github.ambry.rest.RestUtils.*;
+import static com.github.ambry.rest.RestUtils.InternalKeys.*;
+
+
+/**
+ * Handler to handle all the S3 HEAD requests
+ */
+public class S3HeadHandler {
+  private static final Logger LOGGER = LoggerFactory.getLogger(S3HeadHandler.class);
+  private final S3HeadBucketHandler bucketHandler;
+  private final S3HeadObjectHandler objectHandler;
+
+  /**
+   * Construct a handler for handling S3 HEAD requests.
+   *
+   * @param headBlobHandler the generic head request handler delegated to by the underlying head object handler.
+   * @param securityService the {@link SecurityService} to use.
+   * @param metrics the {@link FrontendMetrics} to use.
+   * @param accountService the {@link AccountService} to use.
+   */
+  public S3HeadHandler(HeadBlobHandler headBlobHandler, SecurityService securityService,
+      FrontendMetrics metrics, AccountService accountService) {
+    this.bucketHandler = new S3HeadBucketHandler(securityService, metrics, accountService);
+    this.objectHandler = new S3HeadObjectHandler(headBlobHandler);
+  }
+
+  /**
+   * Process the request and construct the response according to the
+   * <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html">HeadOjbect spec</a> and
+   * <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadBucket.html">BucketObject spec</a>
+   *
+   * @param restRequest the {@link RestRequest} that contains the request parameters and body.
+   * @param restResponseChannel the {@link RestResponseChannel} where headers should be set.
+   * @param callback the {@link Callback} to invoke when the response is ready (or if there is an exception).
+   * @throws RestServiceException exception when the processing fails
+   */
+  public void handle(RestRequest restRequest, RestResponseChannel restResponseChannel,
+      Callback<ReadableStreamChannel> callback) throws RestServiceException {
+    String path = ((RequestPath) restRequest.getArgs().get(REQUEST_PATH)).getOperationOrBlobId(true);
+    LOGGER.debug("Head {}", path);
+
+    if (!path.startsWith(Operations.NAMED_BLOB)) {
+      throw new RuntimeException("S3HeadHandler only handles named blob requests");
+    }
+
+    Callback<ReadableStreamChannel> wrappedCallback = (result, exception) -> {
+
+      // TODO: remove x-ambry- headers
+
+      callback.onCompletion(result, exception);
+    };
+
+    if (path.split("/").length <= 3) {
+      bucketHandler.handle(restRequest, restResponseChannel, wrappedCallback);
+    } else {
+      objectHandler.handle(restRequest, restResponseChannel, wrappedCallback);
+    }
+  }
+
+  private class S3HeadBucketHandler {
+    private final Logger LOGGER = LoggerFactory.getLogger(S3HeadBucketHandler.class);
+    private final SecurityService securityService;
+    private final FrontendMetrics metrics;
+    private final AccountService accountService;
+
+    private S3HeadBucketHandler(SecurityService securityService, FrontendMetrics metrics,
+        AccountService accountService) {
+      this.securityService = securityService;
+      this.metrics = metrics;
+      this.accountService = accountService;
+    }
+
+    private void handle(RestRequest restRequest, RestResponseChannel restResponseChannel,
+        Callback<ReadableStreamChannel> callback) {
+      if (!getRequestPath(restRequest).matchesOperation(Operations.NAMED_BLOB)) {
+        throw new RuntimeException("S3HeadBucketHandler should only handle named blob requests");
+      }
+      new CallbackChain(restRequest, restResponseChannel, callback).start();
+    }
+
+    private class CallbackChain {
+      private final RestRequest restRequest;
+      private final RestResponseChannel restResponseChannel;
+      private final Callback<ReadableStreamChannel> finalCallback;
+
+      private CallbackChain(RestRequest restRequest, RestResponseChannel restResponseChannel,
+          Callback<ReadableStreamChannel> finalCallback) {
+        this.restRequest = restRequest;
+        this.restResponseChannel = restResponseChannel;
+        this.finalCallback = finalCallback;
+      }
+
+      private void start() {
+        restRequest.setArg(RestUtils.InternalKeys.KEEP_ALIVE_ON_ERROR_HINT, true);
+        securityService.processRequest(restRequest, securityProcessRequestCallback());
+      }
+
+      private Callback<Void> securityProcessRequestCallback() {
+        return buildCallback(metrics.headBlobSecurityProcessRequestMetrics,
+            result -> securityService.postProcessRequest(restRequest, securityPostProcessRequestCallback()),
+            restRequest.getUri(), LOGGER, null);
+      }
+
+      private Callback<Void> securityPostProcessRequestCallback() {
+        return buildCallback(metrics.getAccountsSecurityPostProcessRequestMetrics, securityCheckResult -> {
+          RequestPath requestPath = (RequestPath) restRequest.getArgs().get(REQUEST_PATH);
+          // Build a dummy blob path to get the account and container name
+          String dummyBlobPath = requestPath.getOperationOrBlobId(true) + "/dummy";
+          NamedBlobPath namedBlobPath = NamedBlobPath.parse(dummyBlobPath, restRequest.getArgs());
+          String accountName = namedBlobPath.getAccountName();
+          String containerName = namedBlobPath.getContainerName();
+          try {
+            Container container = accountService.getContainerByName(accountName, containerName);
+            if (container == null) {
+              throw new RestServiceException(
+                  String.format("Container %s in account %s not found", containerName, accountName),
+                  RestServiceErrorCode.NotFound);
+            }
+          } catch (AccountServiceException e) {
+            throw new RestServiceException(
+                String.format("Failed to get container %s from account %s", containerName, accountName),
+                RestServiceErrorCode.getRestServiceErrorCode(e.getErrorCode()));
+          }
+          finalCallback.onCompletion(null, null);
+        }, restRequest.getUri(), LOGGER, finalCallback);
+      }
+    }
+  }
+
+  private class S3HeadObjectHandler {
+    private final HeadBlobHandler headBlobHandler;
+    private S3HeadObjectHandler(HeadBlobHandler headBlobHandler) {
+      this.headBlobHandler = headBlobHandler;
+    }
+    private void handle(RestRequest restRequest, RestResponseChannel restResponseChannel,
+        Callback<ReadableStreamChannel> callback) throws RestServiceException {
+
+      // TODO: implement PartNumber handling
+
+      headBlobHandler.handle(restRequest, restResponseChannel,
+          ((result, exception) -> callback.onCompletion(null, exception)));
+    }
+  }
+}

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3HeadHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3HeadHandler.java
@@ -62,7 +62,7 @@ public class S3HeadHandler {
 
   /**
    * Process the request and construct the response according to the
-   * <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html">HeadOjbect spec</a> and
+   * <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html">HeadObject spec</a> and
    * <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadBucket.html">BucketObject spec</a>
    *
    * @param restRequest the {@link RestRequest} that contains the request parameters and body.

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3HeadHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3HeadHandler.java
@@ -86,7 +86,7 @@ public class S3HeadHandler {
       callback.onCompletion(result, exception);
     };
 
-    if (path.split("/").length <= 3) {
+    if (isHeadBucketRequest(path)) {
       bucketHandler.handle(restRequest, restResponseChannel, wrappedCallback);
     } else {
       objectHandler.handle(restRequest, restResponseChannel, wrappedCallback);
@@ -108,9 +108,6 @@ public class S3HeadHandler {
 
     private void handle(RestRequest restRequest, RestResponseChannel restResponseChannel,
         Callback<ReadableStreamChannel> callback) {
-      if (!getRequestPath(restRequest).matchesOperation(Operations.NAMED_BLOB)) {
-        throw new RuntimeException("S3HeadBucketHandler should only handle named blob requests");
-      }
       new CallbackChain(restRequest, restResponseChannel, callback).start();
     }
 
@@ -176,5 +173,9 @@ public class S3HeadHandler {
       headBlobHandler.handle(restRequest, restResponseChannel,
           ((result, exception) -> callback.onCompletion(null, exception)));
     }
+  }
+
+  private boolean isHeadBucketRequest(String path) {
+    return path.split("/").length <= 3;
   }
 }

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/S3HeadHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/S3HeadHandlerTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2024 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ */
+package com.github.ambry.frontend;
+
+import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.account.Account;
+import com.github.ambry.account.Container;
+import com.github.ambry.account.ContainerBuilder;
+import com.github.ambry.account.InMemAccountService;
+import com.github.ambry.clustermap.MockClusterMap;
+import com.github.ambry.commons.CommonTestUtils;
+import com.github.ambry.config.FrontendConfig;
+import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.frontend.s3.S3HeadHandler;
+import com.github.ambry.named.NamedBlobDb;
+import com.github.ambry.named.NamedBlobDbFactory;
+import com.github.ambry.quota.QuotaTestUtils;
+import com.github.ambry.rest.MockRestResponseChannel;
+import com.github.ambry.rest.RequestPath;
+import com.github.ambry.rest.ResponseStatus;
+import com.github.ambry.rest.RestMethod;
+import com.github.ambry.rest.RestRequest;
+import com.github.ambry.rest.RestResponseChannel;
+import com.github.ambry.rest.RestUtils;
+import com.github.ambry.router.FutureResult;
+import com.github.ambry.router.InMemoryRouter;
+import com.github.ambry.router.ReadableStreamChannel;
+import com.github.ambry.utils.TestUtils;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.Properties;
+import org.json.JSONObject;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+public class S3HeadHandlerTest {
+  private static final InMemAccountService ACCOUNT_SERVICE = new InMemAccountService(false, true);
+  private static final String SERVICE_ID = "test-app";
+  private static final String CONTENT_TYPE = "text/plain";
+  private static final String OWNER_ID = "tester";
+  private static final String CLUSTER_NAME = "ambry-test";
+  private static final String NAMED_BLOB_PREFIX = "/named";
+  private static final String S3_PREFIX = "/s3";
+  private static final String PREFIX = "directory-name";
+  private static final String KEY_NAME = String.format("%s/%s", PREFIX, "key_name");
+  private final Account account;
+  private final Container container;
+  private FrontendConfig frontendConfig;
+  private NamedBlobPutHandler namedBlobPutHandler;
+  private S3HeadHandler s3HeadHandler;
+
+  public S3HeadHandlerTest() throws Exception {
+    account = ACCOUNT_SERVICE.createAndAddRandomAccount();
+    container = new ContainerBuilder().setName(Container.DEFAULT_S3_CONTAINER_NAME)
+        .setId((short) 10)
+        .setParentAccountId(account.getId())
+        .setStatus(Container.ContainerStatus.ACTIVE)
+        .setNamedBlobMode(Container.NamedBlobMode.OPTIONAL)
+        .build();
+    account.updateContainerMap(Collections.singletonList(container));
+    setup();
+    putABlob();
+  }
+
+  @Test
+  public void headBucketTest() throws Exception {
+    // 1. Head the bucket with range
+    String uri = String.format("/s3/%s/", account.getName());
+    RestRequest request = FrontendRestRequestServiceTest.createRestRequest(RestMethod.HEAD, uri, new JSONObject(), null);
+    RestResponseChannel restResponseChannel = new MockRestResponseChannel();
+    FutureResult<ReadableStreamChannel> futureResult = new FutureResult<>();
+    request.setArg(RestUtils.InternalKeys.REQUEST_PATH,
+        RequestPath.parse(request, frontendConfig.pathPrefixesToRemove, "ambry-test"));
+    s3HeadHandler.handle(request, restResponseChannel, futureResult::done);
+
+    // 2. Verify results
+    assertNull(futureResult.get());
+    assertEquals("Mismatch on status", ResponseStatus.Ok, restResponseChannel.getStatus());
+  }
+
+  @Test
+  public void headObjectTest() throws Exception {
+    // 1. Head the object with range
+    String uri = String.format("%s/%s/%s", S3_PREFIX, account.getName(), KEY_NAME);
+    RestRequest request = FrontendRestRequestServiceTest.createRestRequest(RestMethod.HEAD, uri, new JSONObject(), null);
+    RestResponseChannel restResponseChannel = new MockRestResponseChannel();
+    FutureResult<ReadableStreamChannel> futureResult = new FutureResult<>();
+    request.setArg(RestUtils.InternalKeys.REQUEST_PATH,
+        RequestPath.parse(request, frontendConfig.pathPrefixesToRemove, CLUSTER_NAME));
+    request.setArg(RestUtils.Headers.RANGE, "bytes=200-299");
+    s3HeadHandler.handle(request, restResponseChannel, futureResult::done);
+
+    // 2. Verify results
+    assertNull(futureResult.get());
+    assertEquals("Mismatch on status", ResponseStatus.PartialContent, restResponseChannel.getStatus());
+    assertEquals("Mismatch in content type", "text/plain",
+        restResponseChannel.getHeader(RestUtils.Headers.CONTENT_TYPE));
+    assertEquals("Mismatch in content length", 100,
+        Integer.parseInt(restResponseChannel.getHeader(RestUtils.Headers.CONTENT_LENGTH).toString()));
+    assertEquals("Mismatch in accept range", "bytes",
+        restResponseChannel.getHeader(RestUtils.Headers.ACCEPT_RANGES));
+    assertEquals("Mismatch in content range", "bytes 200-299/1024",
+        restResponseChannel.getHeader(RestUtils.Headers.CONTENT_RANGE));
+  }
+
+  @Test
+  public void headObjectWithRangeTest() throws Exception {
+    // 1. Head the object with range
+    String uri = String.format("%s/%s/%s", S3_PREFIX, account.getName(), KEY_NAME);
+    RestRequest request = FrontendRestRequestServiceTest.createRestRequest(RestMethod.HEAD, uri, new JSONObject(), null);
+    RestResponseChannel restResponseChannel = new MockRestResponseChannel();
+    FutureResult<ReadableStreamChannel> futureResult = new FutureResult<>();
+    request.setArg(RestUtils.InternalKeys.REQUEST_PATH,
+        RequestPath.parse(request, frontendConfig.pathPrefixesToRemove, CLUSTER_NAME));
+    request.setArg(RestUtils.Headers.RANGE, "bytes=200-299");
+    s3HeadHandler.handle(request, restResponseChannel, futureResult::done);
+
+    // 2. Verify results
+    assertNull(futureResult.get());
+    assertEquals("Mismatch on status", ResponseStatus.PartialContent, restResponseChannel.getStatus());
+    assertEquals("Mismatch in content type", "text/plain",
+        restResponseChannel.getHeader(RestUtils.Headers.CONTENT_TYPE));
+    assertEquals("Mismatch in accept range", "bytes",
+        restResponseChannel.getHeader(RestUtils.Headers.ACCEPT_RANGES));
+    assertEquals("Mismatch in content length", 100,
+        Integer.parseInt(restResponseChannel.getHeader(RestUtils.Headers.CONTENT_LENGTH).toString()));
+    assertEquals("Mismatch in content range", "bytes 200-299/1024",
+        restResponseChannel.getHeader(RestUtils.Headers.CONTENT_RANGE));
+  }
+
+  private void setup() throws Exception {
+    Properties properties = new Properties();
+    CommonTestUtils.populateRequiredRouterProps(properties);
+    VerifiableProperties verifiableProperties = new VerifiableProperties(properties);
+    frontendConfig = new FrontendConfig(verifiableProperties);
+    FrontendMetrics metrics = new FrontendMetrics(new MetricRegistry(), frontendConfig);
+    InMemoryRouter router = new InMemoryRouter(verifiableProperties, new MockClusterMap());
+    AccountAndContainerInjector injector = new AccountAndContainerInjector(ACCOUNT_SERVICE, metrics, frontendConfig);
+    IdSigningService idSigningService = new AmbryIdSigningService();
+    AmbrySecurityServiceFactory securityServiceFactory = new AmbrySecurityServiceFactory(verifiableProperties,
+        new MockClusterMap(), ACCOUNT_SERVICE, null, idSigningService, injector,
+        QuotaTestUtils.createDummyQuotaManager());
+    SecurityService securityService = securityServiceFactory.getSecurityService();
+    NamedBlobDbFactory namedBlobDbFactory =
+        new TestNamedBlobDbFactory(verifiableProperties, new MetricRegistry(), ACCOUNT_SERVICE);
+    NamedBlobDb namedBlobDb = namedBlobDbFactory.getNamedBlobDb();
+    AmbryIdConverterFactory ambryIdConverterFactory =
+        new AmbryIdConverterFactory(verifiableProperties, new MetricRegistry(), idSigningService, namedBlobDb);
+    namedBlobPutHandler = new NamedBlobPutHandler(securityService, namedBlobDb,
+        ambryIdConverterFactory.getIdConverter(), idSigningService, router, injector, frontendConfig, metrics,
+        CLUSTER_NAME, QuotaTestUtils.createDummyQuotaManager(), ACCOUNT_SERVICE, null);
+    HeadBlobHandler headBlobHandler = new HeadBlobHandler(frontendConfig, router,
+        securityService, ambryIdConverterFactory.getIdConverter(), injector,
+        metrics, new MockClusterMap(), QuotaTestUtils.createDummyQuotaManager());
+    s3HeadHandler = new S3HeadHandler(headBlobHandler, securityService, metrics, ACCOUNT_SERVICE);
+  }
+
+  private void putABlob() throws Exception {
+    String requestPath = String.format("%s/%s/%s/%s",
+        NAMED_BLOB_PREFIX, account.getName(), container.getName(), KEY_NAME);
+    JSONObject headers = new JSONObject();
+    FrontendRestRequestServiceTest.setAmbryHeadersForPut(headers, TestUtils.TTL_SECS, container.isCacheable(),
+        SERVICE_ID, CONTENT_TYPE, OWNER_ID, null, null, null);
+    byte[] content = TestUtils.getRandomBytes(1024);
+    RestRequest request = FrontendRestRequestServiceTest.createRestRequest(RestMethod.PUT, requestPath, headers,
+        new LinkedList<>(Arrays.asList(ByteBuffer.wrap(content), null)));
+    request.setArg(RestUtils.InternalKeys.REQUEST_PATH,
+        RequestPath.parse(request, frontendConfig.pathPrefixesToRemove, CLUSTER_NAME));
+    RestResponseChannel restResponseChannel = new MockRestResponseChannel();
+    FutureResult<Void> putResult = new FutureResult<>();
+    namedBlobPutHandler.handle(request, restResponseChannel, putResult::done);
+    putResult.get();
+  }
+}


### PR DESCRIPTION
This PR contains the implementation of two S3 HEAD handler
 - HEAD Bucket according to [AWS specification](https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadBucket.html)
 - HEAD Object according to [AWS specification](https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html)
