### PR TITLE
Add a configuration to ignore all downward state transition

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
@@ -351,6 +351,11 @@ public class ClusterMapConfig {
   @Default("60 * 1000")
   public final long clustermapDistributedLockLeaseTimeoutInMs;
 
+  public static final String IGNORE_DOWNWARD_STATE_TRANSITION = "clustermap.ignore.downward.state.transition";
+  @Config(IGNORE_DOWNWARD_STATE_TRANSITION)
+  @Default("false")
+  public final boolean clusterMapIgnoreDownwardStateTransition;
+
   public ClusterMapConfig(VerifiableProperties verifiableProperties) {
     clusterMapFixedTimeoutDatanodeErrorThreshold =
         verifiableProperties.getIntInRange("clustermap.fixedtimeout.datanode.error.threshold", 3, 1, 100);
@@ -429,5 +434,6 @@ public class ClusterMapConfig {
     clustermapDefaultReplicaCapacityInBytes =
         verifiableProperties.getLongInRange("clustermap.default.replica.capacity.in.bytes", 384L * 1024 * 1024 * 1024,
             0, Long.MAX_VALUE);
+    clusterMapIgnoreDownwardStateTransition = verifiableProperties.getBoolean(IGNORE_DOWNWARD_STATE_TRANSITION, false);
   }
 }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryPartitionStateModel.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryPartitionStateModel.java
@@ -143,9 +143,12 @@ public class AmbryPartitionStateModel extends StateModel {
   public void onBecomeInactiveFromStandby(Message message, NotificationContext context) {
     boolean shouldTransition = shouldTransition(message);
     String partitionName = message.getPartitionName();
-    logger.info("Partition {} in resource {} is becoming INACTIVE from STANDBY, Should Transition? {}", partitionName,
-        message.getResourceName(), shouldTransition);
-    if (clusterMapConfig.clustermapEnableStateModelListener && shouldTransition) {
+    logger.info(
+        "Partition {} in resource {} is becoming INACTIVE from STANDBY, Should Transition? {} Ignore downward state transition? {}",
+        partitionName, message.getResourceName(), shouldTransition,
+        clusterMapConfig.clusterMapIgnoreDownwardStateTransition);
+    if (clusterMapConfig.clustermapEnableStateModelListener && shouldTransition
+        && !clusterMapConfig.clusterMapIgnoreDownwardStateTransition) {
       partitionStateChangeListener.onPartitionBecomeInactiveFromStandby(partitionName);
     }
   }
@@ -154,9 +157,12 @@ public class AmbryPartitionStateModel extends StateModel {
   public void onBecomeOfflineFromInactive(Message message, NotificationContext context) {
     boolean shouldTransition = shouldTransition(message);
     String partitionName = message.getPartitionName();
-    logger.info("Partition {} in resource {} is becoming OFFLINE from INACTIVE, Should Transition? {}", partitionName,
-        message.getResourceName(), shouldTransition);
-    if (clusterMapConfig.clustermapEnableStateModelListener && shouldTransition) {
+    logger.info(
+        "Partition {} in resource {} is becoming OFFLINE from INACTIVE, Should Transition? {} Ignore downward state transition? {}",
+        partitionName, message.getResourceName(), shouldTransition,
+        clusterMapConfig.clusterMapIgnoreDownwardStateTransition);
+    if (clusterMapConfig.clustermapEnableStateModelListener && shouldTransition
+        && !clusterMapConfig.clusterMapIgnoreDownwardStateTransition) {
       partitionStateChangeListener.onPartitionBecomeOfflineFromInactive(partitionName);
     }
   }
@@ -165,9 +171,12 @@ public class AmbryPartitionStateModel extends StateModel {
   public void onBecomeDroppedFromOffline(Message message, NotificationContext context) {
     boolean shouldTransition = shouldTransition(message);
     String partitionName = message.getPartitionName();
-    logger.info("Partition {} in resource {} is becoming DROPPED from OFFLINE, Should Transition? {}", partitionName,
-        message.getResourceName(), shouldTransition);
-    if (clusterMapConfig.clustermapEnableStateModelListener && shouldTransition) {
+    logger.info(
+        "Partition {} in resource {} is becoming DROPPED from OFFLINE, Should Transition? {} Ignore downward state transition? {}",
+        partitionName, message.getResourceName(), shouldTransition,
+        clusterMapConfig.clusterMapIgnoreDownwardStateTransition);
+    if (clusterMapConfig.clustermapEnableStateModelListener && shouldTransition
+        && !clusterMapConfig.clusterMapIgnoreDownwardStateTransition) {
       partitionStateChangeListener.onPartitionBecomeDroppedFromOffline(partitionName);
     }
   }


### PR DESCRIPTION
## Summary
Adding a configuration to AmbryPartitionStateModel to ignore downward state transition.