### PR TITLE
PutBlob, add one option: skipCompositeChunk.

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com/github/ambry/rest/RestUtils.java
@@ -913,7 +913,7 @@ public class RestUtils {
    * @return {@code true} if the request is a S3 API request.
    */
   public static boolean isS3Request(RestRequest restRequest) {
-    return restRequest.getArgs().containsKey(S3_REQUEST);
+    return restRequest != null && restRequest.getArgs().containsKey(S3_REQUEST);
   }
 
   /**

--- a/ambry-api/src/main/java/com/github/ambry/router/PutBlobOptions.java
+++ b/ambry-api/src/main/java/com/github/ambry/router/PutBlobOptions.java
@@ -27,6 +27,7 @@ public class PutBlobOptions {
   private final boolean chunkUpload;
   private final long maxUploadSize;
   private final RestRequest restRequest;
+  private final boolean skipCompositeChunk;
 
   /**
    * @param chunkUpload {@code true} to indicate that the {@code putBlob()} call is for a single data chunk of a
@@ -38,6 +39,21 @@ public class PutBlobOptions {
     this.chunkUpload = chunkUpload;
     this.maxUploadSize = maxUploadSize;
     this.restRequest = restRequest;
+    this.skipCompositeChunk = false;
+  }
+
+  /**
+   * @param chunkUpload {@code true} to indicate that the {@code putBlob()} call is for a single data chunk of a
+   *                    stitched blob.
+   * @param maxUploadSize the max size of the uploaded blob in bytes. To be enforced by the router. Can be null.
+   * @param restRequest The {@link RestRequest} that triggered this put operation.
+   * @param skipCompositeChunk if true, don't generate composite blob, and return data chunk info in string.
+   */
+  public PutBlobOptions(boolean chunkUpload, long maxUploadSize, RestRequest restRequest, boolean skipCompositeChunk) {
+    this.chunkUpload = chunkUpload;
+    this.maxUploadSize = maxUploadSize;
+    this.restRequest = restRequest;
+    this.skipCompositeChunk = skipCompositeChunk;
   }
 
   /**
@@ -62,6 +78,13 @@ public class PutBlobOptions {
     return restRequest;
   }
 
+  /**
+   * @return the skipCompositeChunk
+   */
+  public boolean skipCompositeChunk() {
+    return skipCompositeChunk;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -73,17 +96,17 @@ public class PutBlobOptions {
 
     PutBlobOptions options = (PutBlobOptions) o;
     return chunkUpload == options.chunkUpload && maxUploadSize == options.maxUploadSize && Objects.equals(restRequest,
-        options.restRequest);
+        options.restRequest) && (skipCompositeChunk == options.skipCompositeChunk);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(chunkUpload, maxUploadSize, restRequest);
+    return Objects.hash(chunkUpload, maxUploadSize, restRequest, skipCompositeChunk);
   }
 
   @Override
   public String toString() {
     return "PutBlobOptions{" + "chunkUpload=" + chunkUpload + ", maxUploadSize=" + maxUploadSize + ", restRequest="
-        + restRequest + '}';
+        + restRequest + ", skipCompositeChunk=" + skipCompositeChunk + "}";
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/router/PutBlobOptionsBuilder.java
+++ b/ambry-api/src/main/java/com/github/ambry/router/PutBlobOptionsBuilder.java
@@ -25,6 +25,7 @@ public class PutBlobOptionsBuilder {
   private boolean chunkUpload = false;
   private long maxUploadSize = Long.MAX_VALUE;
   private RestRequest restRequest = null;
+  private boolean skipCompositeChunk = false;
 
   /**
    * @param chunkUpload {@code true} to indicate that this is an upload of a data chunk of a stitched upload.
@@ -54,9 +55,18 @@ public class PutBlobOptionsBuilder {
   }
 
   /**
+   * @param skipCompositeChunk: if true, skip the composite chunk.
+   * @return this builder.
+   */
+  public PutBlobOptionsBuilder skipCompositeChunk(boolean skipCompositeChunk) {
+    this.skipCompositeChunk = skipCompositeChunk;
+    return this;
+  }
+
+  /**
    * @return the {@link PutBlobOptions} built.
    */
   public PutBlobOptions build() {
-    return new PutBlobOptions(chunkUpload, maxUploadSize, restRequest);
+    return new PutBlobOptions(chunkUpload, maxUploadSize, restRequest, skipCompositeChunk);
   }
 }

--- a/ambry-api/src/test/java/com/github/ambry/router/PutBlobOptionsTest.java
+++ b/ambry-api/src/test/java/com/github/ambry/router/PutBlobOptionsTest.java
@@ -59,7 +59,7 @@ public class PutBlobOptionsTest {
     assertEquals("PutBlobOptions should be equal", a, b);
     assertEquals("PutBlobOptions hashcodes should be equal", a.hashCode(), b.hashCode());
     assertEquals("toString output not as expected",
-        "PutBlobOptions{chunkUpload=true, maxUploadSize=3, restRequest=null}", a.toString());
+        "PutBlobOptions{chunkUpload=true, maxUploadSize=3, restRequest=null, skipCompositeChunk=false}", a.toString());
     b = new PutBlobOptionsBuilder().chunkUpload(false).maxUploadSize(3).build();
     assertThat("PutBlobOptions should not be equal.", a, not(b));
   }

--- a/ambry-router/src/main/java/com/github/ambry/router/PutBlobMetaInfo.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/PutBlobMetaInfo.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.ambry.utils.Pair;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -73,7 +74,7 @@ public class PutBlobMetaInfo {
    * @return the list of chunk with blob id and blob size
    */
   public List<Pair<String, Long>> getOrderedChunkIdSizeList() {
-    return orderedChunkIdSizeList;
+    return Collections.unmodifiableList(orderedChunkIdSizeList);
   }
 
   /**

--- a/ambry-router/src/main/java/com/github/ambry/router/PutBlobMetaInfo.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/PutBlobMetaInfo.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2024 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package com.github.ambry.router;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.ambry.utils.Pair;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+
+/**
+ * This class holds information about the data chunk list or other metadata of the PutOperation
+ * It contains a list of key size pair for the blob's data chunks, reserved metadata etc.
+ */
+public class PutBlobMetaInfo {
+  private static final String BLOB = "blob";
+  private static final String SIZE = "size";
+  private static final String CHUNKS = "chunks";
+  private static final String RESERVED_METADATA_CHUNK_ID = "reservedMetadataChunkId";
+
+  // reserved metadata chunk id
+  private final String reservedMetadataChunkId;
+  // the list of data chunk pairs <blob id, blob size> in order
+  private final List<Pair<String, Long>> orderedChunkIdSizeList;
+  // TODO [S3] Do we need ttl or sessionId?
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+
+  /**
+   * Construct a {@link PutBlobMetaInfo} object.
+   * @param orderedChunkIdSizeList list of store keys and the size of the data content they reference
+   * @param reservedMetadataChunkId the id of the reserved metadata chunk
+   */
+  public PutBlobMetaInfo(List<Pair<String, Long>> orderedChunkIdSizeList, String reservedMetadataChunkId) {
+    this.orderedChunkIdSizeList = orderedChunkIdSizeList;
+    this.reservedMetadataChunkId = reservedMetadataChunkId;
+  }
+
+  /**
+   * Get the reserved metadata chunk id
+   * @return the chunk id
+   */
+  public String getReservedMetadataChunkId() {
+    return reservedMetadataChunkId;
+  }
+
+  /**
+   * Get the number of chunks
+   * @return the chunk number
+   */
+  public int getChunkNumber() {
+    return orderedChunkIdSizeList.size();
+  }
+
+  /**
+   * Get the chunk list
+   * @return the list of chunk with blob id and blob size
+   */
+  public List<Pair<String, Long>> getOrderedChunkIdSizeList() {
+    return orderedChunkIdSizeList;
+  }
+
+  /**
+   * Serialize a {@link PutBlobMetaInfo} object to a JSON string
+   * @param metaInfo the {@link PutBlobMetaInfo}
+   * @return the JSON string representation of the object
+   */
+  public static String serialize(PutBlobMetaInfo metaInfo) {
+    JSONObject rootObject = new JSONObject();
+
+    // The order of elements in JSON arrays is preserved.
+    // https://www.rfc-editor.org/rfc/rfc7159.html
+    // An object is an unordered collection of zero or more name/value pairs
+    // An array is an ordered sequence of zero or more values.
+    JSONArray chunks = new JSONArray();
+    for (Pair<String, Long> blobAndSize : metaInfo.orderedChunkIdSizeList) {
+      chunks.put(new JSONObject().put(BLOB, blobAndSize.getFirst()).put(SIZE, blobAndSize.getSecond()));
+    }
+    rootObject.put(CHUNKS, chunks);
+    rootObject.put(RESERVED_METADATA_CHUNK_ID, metaInfo.reservedMetadataChunkId);
+
+    return rootObject.toString();
+  }
+
+  /**
+   * Deserialize a JSON string to a {@link PutBlobMetaInfo} object.
+   * @param metaInfo the JSON string representation of the object
+   * @return the {@link PutBlobMetaInfo}
+   */
+  public static PutBlobMetaInfo deserialize(String metaInfo) throws IOException {
+    List<Pair<String, Long>> orderedChunkIdSizeList = new ArrayList<>();
+
+    JsonNode rootNode;
+    try {
+      rootNode = objectMapper.readTree(metaInfo);
+    } catch (JsonProcessingException e) {
+      throw new IOException("Not expected JSON content " + metaInfo + e.getMessage());
+    }
+
+    // loop all the data chunks
+    JsonNode jsonNode = rootNode.get(CHUNKS);
+    if (jsonNode.isArray()) {
+      for (final JsonNode objNode : jsonNode) {
+        String blobId = objNode.get(BLOB).textValue();
+        Long chunkSizeBytes = objNode.get(SIZE).longValue();
+        orderedChunkIdSizeList.add(new Pair<>(blobId, chunkSizeBytes));
+      }
+    } else {
+      throw new IOException("Not expected JSON content " + metaInfo);
+    }
+
+    jsonNode = rootNode.get(RESERVED_METADATA_CHUNK_ID);
+    String metaBlobId = jsonNode.textValue();
+    return new PutBlobMetaInfo(orderedChunkIdSizeList, metaBlobId);
+  }
+
+  @Override
+  public String toString() {
+    return PutBlobMetaInfo.serialize(this);
+  }
+}

--- a/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
@@ -2104,6 +2104,7 @@ class PutOperation {
 
       if (options.skipCompositeChunk()) {
         // close the request as the single blob. we don't generate the composite blob.
+        // we set first chunk id to the blobid since it's not supposed to be null. But we return putBlobMetaInfo only.
         blobId = (BlobId) indexToChunkIdsAndChunkSizes.get(0).getFirst();
         state = ChunkState.Complete;
         setOperationCompleted();
@@ -2117,7 +2118,7 @@ class PutOperation {
             .collect(Collectors.toList()));
         PutBlobMetaInfo putBlobMetaInfoObj = new PutBlobMetaInfo(orderedChunkList, reservedMetadataChunkId.getID());
         putBlobMetaInfo = PutBlobMetaInfo.serialize(putBlobMetaInfoObj);
-        logger.info("S3 5MB : finalizeMetadataChunk orderedChunkIdList is {} {}", indexToChunkIdsAndChunkSizes,
+        logger.debug("S3 5MB : finalizeMetadataChunk orderedChunkIdList is {} {}", indexToChunkIdsAndChunkSizes,
             putBlobMetaInfo);
       } else if (isStitchOperation() || getNumDataChunks() > 1) {
         ByteBuffer serialized = null;

--- a/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
@@ -946,7 +946,7 @@ class PutOperation {
   String getBlobIdString() {
     // we call getBlobIdString to set the return result of FutureResult<String>
     // when skipCompositeChunk is true, we don't generate composite blob, we return {@link PutBlobMetaInfo}
-    if (options != null && options.skipCompositeChunk()) {
+    if (options.skipCompositeChunk()) {
       return putBlobMetaInfo;
     } else {
       return blobId == null ? null : blobId.getID();

--- a/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
@@ -44,6 +44,7 @@ import com.github.ambry.quota.QuotaException;
 import com.github.ambry.quota.QuotaUtils;
 import com.github.ambry.rest.NettyRequest;
 import com.github.ambry.rest.RestRequest;
+import com.github.ambry.rest.RestUtils;
 import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.store.StoreKey;
 import com.github.ambry.utils.Pair;
@@ -157,6 +158,8 @@ class PutOperation {
   private volatile boolean operationCompleted = false;
   // the blob id of the overall blob. This will be set if and when the operation is successful.
   private BlobId blobId;
+
+  private String putBlobMetaInfo = null;
   // the cause for failure of this operation. This will be set if and when the operation encounters an irrecoverable
   // failure.
   private final AtomicReference<Exception> operationException = new AtomicReference<Exception>();
@@ -359,7 +362,8 @@ class PutOperation {
     }
     Exception exception = null;
     try {
-      if (options.isChunkUpload() && options.getMaxUploadSize() > routerConfig.routerMaxPutChunkSizeBytes) {
+      if (options.isChunkUpload() && options.getMaxUploadSize() > routerConfig.routerMaxPutChunkSizeBytes
+          && !RestUtils.isS3Request(restRequest)) {
         exception = new RouterException("Invalid max upload size for chunk upload: " + options.getMaxUploadSize(),
             RouterErrorCode.InvalidPutArgument);
       } else if (isStitchOperation()) {
@@ -601,10 +605,12 @@ class PutOperation {
       setOperationCompleted();
     }
     long operationLatencyMs = time.milliseconds() - chunk.chunkFillCompleteAtMs;
-    if (chunk.chunkBlobProperties.isEncrypted()) {
-      routerMetrics.putEncryptedChunkOperationLatencyMs.update(operationLatencyMs);
-    } else {
-      routerMetrics.putChunkOperationLatencyMs.update(operationLatencyMs, TimeUnit.MILLISECONDS);
+    if (chunk.chunkBlobProperties != null) {
+      if (chunk.chunkBlobProperties.isEncrypted()) {
+        routerMetrics.putEncryptedChunkOperationLatencyMs.update(operationLatencyMs);
+      } else {
+        routerMetrics.putChunkOperationLatencyMs.update(operationLatencyMs, TimeUnit.MILLISECONDS);
+      }
     }
     chunk.clear();
   }
@@ -938,7 +944,13 @@ class PutOperation {
    * @return the blobId if the operation is successful; null otherwise.
    */
   String getBlobIdString() {
-    return blobId == null ? null : blobId.getID();
+    // we call getBlobIdString to set the return result of FutureResult<String>
+    // when skipCompositeChunk is true, we don't generate composite blob, we return {@link PutBlobMetaInfo}
+    if (options != null && options.skipCompositeChunk()) {
+      return putBlobMetaInfo;
+    } else {
+      return blobId == null ? null : blobId.getID();
+    }
   }
 
   /**
@@ -2089,7 +2101,25 @@ class PutOperation {
               passedInBlobProperties.getAccountId(), passedInBlobProperties.getContainerId(),
               passedInBlobProperties.isEncrypted(), passedInBlobProperties.getExternalAssetTag(),
               passedInBlobProperties.getContentEncoding(), passedInBlobProperties.getFilename(), null);
-      if (isStitchOperation() || getNumDataChunks() > 1) {
+
+      if (options.skipCompositeChunk()) {
+        // close the request as the single blob. we don't generate the composite blob.
+        blobId = (BlobId) indexToChunkIdsAndChunkSizes.get(0).getFirst();
+        state = ChunkState.Complete;
+        setOperationCompleted();
+
+        // now generate the PutBlobMetaInfo which includes the data chunk list
+        // values returned are in the right order as TreeMap returns them in key-order.
+        // .stream.map.collect is supposed to return in order
+        List<Pair<String, Long>> orderedChunkList = new ArrayList<>(indexToChunkIdsAndChunkSizes.values()
+            .stream()
+            .map(p -> new Pair<>(p.getFirst().toString(), p.getSecond()))
+            .collect(Collectors.toList()));
+        PutBlobMetaInfo putBlobMetaInfoObj = new PutBlobMetaInfo(orderedChunkList, reservedMetadataChunkId.getID());
+        putBlobMetaInfo = PutBlobMetaInfo.serialize(putBlobMetaInfoObj);
+        logger.info("S3 5MB : finalizeMetadataChunk orderedChunkIdList is {} {}", indexToChunkIdsAndChunkSizes,
+            putBlobMetaInfo);
+      } else if (isStitchOperation() || getNumDataChunks() > 1) {
         ByteBuffer serialized = null;
         // values returned are in the right order as TreeMap returns them in key-order.
         if (routerConfig.routerMetadataContentVersion == MessageFormatRecord.Metadata_Content_Version_V2) {

--- a/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTest.java
@@ -87,6 +87,7 @@ import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 import javax.sql.DataSource;
 import org.json.JSONObject;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -129,6 +130,11 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
   @BeforeClass
   public static void setup() throws Exception {
     repairDb = createRepairRequestsConnection("DC3", staticMockTime);
+  }
+
+  @AfterClass
+  public static void tearDown() {
+    repairDb.close();
   }
 
   @Parameterized.Parameters
@@ -598,49 +604,45 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
    */
   @Test
   public void testS3PartUpload() throws Exception {
-    for (int chunkNumber = 1; chunkNumber < 10; chunkNumber++) {
-      // composite blob with "chunkNumber" of data chunks
-      maxPutChunkSize = PUT_CONTENT_SIZE / chunkNumber;
-      if (PUT_CONTENT_SIZE % maxPutChunkSize != 0) {
-        maxPutChunkSize++;
+    int chunkNumber = 9;
+    // composite blob with "chunkNumber" of data chunks
+    maxPutChunkSize = PUT_CONTENT_SIZE / chunkNumber;
+    if (PUT_CONTENT_SIZE % maxPutChunkSize != 0) {
+      maxPutChunkSize++;
+    }
+    setRouter();
+    setOperationParams();
+
+    // set skipCompositeChunk to true
+    PutBlobOptions putBlobOptions = new PutBlobOptionsBuilder().skipCompositeChunk(true).build();
+    String compositeBlobInfo = router.putBlob(putBlobProperties, putUserMetadata, putChannel, putBlobOptions)
+        .get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    PutBlobMetaInfo metaInfo = PutBlobMetaInfo.deserialize(compositeBlobInfo);
+
+    // verify the PutBlobMetaInfo
+    Assert.assertEquals(chunkNumber, metaInfo.getChunkNumber());
+    // verify the content, one data chunk after another
+    List<Pair<String, Long>> chunks = metaInfo.getOrderedChunkIdSizeList();
+    int chunkSize = maxPutChunkSize;
+    for (int i = 0; i < chunkNumber; i++) {
+      GetBlobResult chunkResult =
+          router.getBlob(chunks.get(i).getFirst(), new GetBlobOptionsBuilder().build(), null, null).get();
+      // last chunk
+      if (i == chunkNumber - 1) {
+        chunkSize = PUT_CONTENT_SIZE - maxPutChunkSize * i;
       }
-      MockServerLayout layout = new MockServerLayout(mockClusterMap);
-      String localDcName = "DC3";
-      setRouter(getNonBlockingRouterPropertiesForRepairRequests(localDcName, true, false), layout,
-          new LoggingNotificationSystem());
-      setOperationParams();
 
-      // set skipCompositeChunk to true
-      PutBlobOptions putBlobOptions = new PutBlobOptionsBuilder().skipCompositeChunk(true).build();
-      String compositeBlobInfo = router.putBlob(putBlobProperties, putUserMetadata, putChannel, putBlobOptions)
-          .get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-      PutBlobMetaInfo metaInfo = PutBlobMetaInfo.deserialize(compositeBlobInfo);
+      // verify data content
+      RetainingAsyncWritableChannel retainingAsyncWritableChannel = new RetainingAsyncWritableChannel();
+      chunkResult.getBlobDataChannel().readInto(retainingAsyncWritableChannel, null).get();
+      InputStream input = retainingAsyncWritableChannel.consumeContentAsInputStream();
+      retainingAsyncWritableChannel.close();
+      Assert.assertEquals(chunkSize, input.available());
+      byte[] readContent = Utils.readBytesFromStream(input, chunkSize);
+      input.close();
 
-      // verify the PutBlobMetaInfo
-      Assert.assertEquals(chunkNumber, metaInfo.getChunkNumber());
-      // verify the content, one data chunk after another
-      List<Pair<String, Long>> chunks = metaInfo.getOrderedChunkIdSizeList();
-      int chunkSize = maxPutChunkSize;
-      for (int i = 0; i < chunkNumber; i++) {
-        GetBlobResult chunkResult =
-            router.getBlob(chunks.get(i).getFirst(), new GetBlobOptionsBuilder().build(), null, null).get();
-        // last chunk
-        if (i == chunkNumber - 1) {
-          chunkSize = PUT_CONTENT_SIZE - maxPutChunkSize * i;
-        }
-
-        // verify data content
-        RetainingAsyncWritableChannel retainingAsyncWritableChannel = new RetainingAsyncWritableChannel();
-        chunkResult.getBlobDataChannel().readInto(retainingAsyncWritableChannel, null).get();
-        InputStream input = retainingAsyncWritableChannel.consumeContentAsInputStream();
-        retainingAsyncWritableChannel.close();
-        Assert.assertEquals(chunkSize, input.available());
-        byte[] readContent = Utils.readBytesFromStream(input, chunkSize);
-        input.close();
-
-        byte[] originSlice = Arrays.copyOfRange(putContent, i * maxPutChunkSize, i * maxPutChunkSize + chunkSize);
-        Assert.assertArrayEquals(originSlice, readContent);
-      }
+      byte[] originSlice = Arrays.copyOfRange(putContent, i * maxPutChunkSize, i * maxPutChunkSize + chunkSize);
+      Assert.assertArrayEquals(originSlice, readContent);
     }
   }
 


### PR DESCRIPTION
PutBlob, we add one option: skipCompositeChunk.
When it's true, we don't generate the composite blob.
And then we return serialized PutBlobMetaInfo string instead of the composite blob id.


