### PR TITLE
[vcr-2.0] Trying a FIXED retry policy

### DIFF
--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/StorageClient.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/StorageClient.java
@@ -441,7 +441,7 @@ public abstract class StorageClient implements AzureStorageClient {
       Integer tryTimeoutInSeconds =
           Math.toIntExact(Math.max(1, TimeUnit.MILLISECONDS.toSeconds(cloudConfig.cloudRequestTimeout)));
       RequestRetryOptions retryOptions =
-          new RequestRetryOptions(null, null, tryTimeoutInSeconds,
+          new RequestRetryOptions(RetryPolicyType.FIXED, null, tryTimeoutInSeconds,
               null, null, null);
       return buildBlobServiceSyncClient(client, new ConfigurationBuilder().build(), retryOptions, azureCloudConfig);
     } catch (MalformedURLException | InterruptedException | ExecutionException ex) {


### PR DESCRIPTION
We are receiving a lot of 503 errors frm Azure. Let's try a simple FIXED backoff policy to retry requests to Azure Storage. The fixed-policy has a 30 second delay. The default was exponential policy with 4s, 12s, 36s, and 60s delays.