### PR TITLE
Add metrics to get the time taken for deserializing and validating signed ids for named blob stitch puts

### DIFF
--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendMetrics.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendMetrics.java
@@ -170,6 +170,7 @@ public class FrontendMetrics {
   public final Histogram blobPropsBuildTimeInMs;
   // NAMED BLOB PUT
   public final Histogram blobPropsBuildForNameBlobPutTimeInMs;
+  public final Histogram namedBlobPutGetChunksToStitchTimeInMs;
 
   // OPTIONS
   public final Histogram optionsPreProcessingTimeInMs;
@@ -353,6 +354,7 @@ public class FrontendMetrics {
         new RestRequestMetricsGroup(UndeleteHandler.class, "UndeleteBlob", false, metricRegistry, frontendConfig);
     putBlobMetricsGroup =
         new RestRequestMetricsGroup(NamedBlobPutHandler.class, "PutBlob", false, metricRegistry, frontendConfig);
+
 
     // AsyncOperationTracker.Metrics instances
     postSecurityProcessRequestMetrics =
@@ -540,6 +542,8 @@ public class FrontendMetrics {
     // NAMEDBLOBPUT
     blobPropsBuildForNameBlobPutTimeInMs = metricRegistry.histogram(
         MetricRegistry.name(FrontendRestRequestService.class, "blobPropsBuildForNameBlobPutTimeInMs"));
+    namedBlobPutGetChunksToStitchTimeInMs = metricRegistry.histogram(
+        MetricRegistry.name(FrontendRestRequestService.class, "NamedBlobPutGetChunksToStitchTimeInMs"));
     // OPTIONS
     optionsPreProcessingTimeInMs =
         metricRegistry.histogram(MetricRegistry.name(FrontendRestRequestService.class, "OptionsPreProcessingTimeInMs"));

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
@@ -455,6 +455,7 @@ public class NamedBlobPutHandler {
      */
     List<ChunkInfo> getChunksToStitch(BlobProperties stitchedBlobProperties, JSONObject stitchRequestJson)
         throws RestServiceException {
+      long getChunksToStitchStartTime = System.currentTimeMillis();
       String reservedMetadataBlobId = null;
       List<String> signedChunkIds = StitchRequestSerDe.fromJson(stitchRequestJson);
       if (signedChunkIds.isEmpty()) {
@@ -493,6 +494,11 @@ public class NamedBlobPutHandler {
       }
       //the actual blob size for stitched blob is the sum of all the chunk sizes
       restResponseChannel.setHeader(RestUtils.Headers.BLOB_SIZE, totalStitchedBlobSize);
+      long getChunksToStitchTimeInMs = System.currentTimeMillis() - getChunksToStitchStartTime;
+      frontendMetrics.namedBlobPutGetChunksToStitchTimeInMs.update(getChunksToStitchTimeInMs);
+      if (getChunksToStitchTimeInMs > 10000) {
+        LOGGER.warn("getChunksToStitch took {} ms for {} chunks", getChunksToStitchTimeInMs, signedChunkIds.size());
+      }
       return chunksToStitch;
     }
 


### PR DESCRIPTION
For very large blobs, the number of chunks to deserialize and validate can be very very high (~250000 for 1TiB blob). This metrics tracks the time taken for deserialization and validation of stitch blob uploads.