### PR TITLE
[S3 API] Remove Ambry header from response

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/rest/RestResponseChannel.java
+++ b/ambry-api/src/main/java/com/github/ambry/rest/RestResponseChannel.java
@@ -116,7 +116,7 @@ public interface RestResponseChannel extends AsyncWritableChannel {
   public Object getHeader(String headerName);
 
   /**
-   * Get the list of headers
+   * Get the readonly list of headers
    * @return the names of headers.
    */
   public List<String> getHeaders();

--- a/ambry-api/src/main/java/com/github/ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com/github/ambry/rest/RestUtils.java
@@ -65,6 +65,11 @@ public class RestUtils {
   public static final String STITCH = "STITCH";
 
   /**
+   * prefix for all Ambry specific heaeders
+   */
+  public static final String AMBRY_HEADER_PREFIX = "x-ambry-";
+
+  /**
    * Ambry specific HTTP headers.
    */
   public static final class Headers {

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbryUrlSigningService.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbryUrlSigningService.java
@@ -32,6 +32,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
+import static com.github.ambry.rest.RestUtils.*;
 
 
 /**
@@ -42,7 +43,6 @@ import java.util.UUID;
  * See https://github.com/linkedin/ambry/issues/788
  */
 public class AmbryUrlSigningService implements UrlSigningService {
-  static final String AMBRY_PARAMETERS_PREFIX = "x-ambry-";
   private static final String LINK_EXPIRY_TIME = "et";
   private static final String ENDPOINT_SUFFIX = "/";
   private static final String QUERY_STRING_START = "?";
@@ -135,7 +135,7 @@ public class AmbryUrlSigningService implements UrlSigningService {
     for (Map.Entry<String, Object> entry : args.entrySet()) {
       String name = entry.getKey();
       Object value = entry.getValue();
-      if (name.regionMatches(true, 0, AMBRY_PARAMETERS_PREFIX, 0, AMBRY_PARAMETERS_PREFIX.length())
+      if (name.regionMatches(true, 0, AMBRY_HEADER_PREFIX, 0, AMBRY_HEADER_PREFIX.length())
           && value instanceof String) {
         switch (name) {
           case RestUtils.Headers.URL_TTL:

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3BaseHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3BaseHandler.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2024 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ */
+package com.github.ambry.frontend.s3;
+
+import com.github.ambry.commons.Callback;
+import com.github.ambry.frontend.Operations;
+import com.github.ambry.rest.RequestPath;
+import com.github.ambry.rest.RestRequest;
+import com.github.ambry.rest.RestResponseChannel;
+import com.github.ambry.rest.RestServiceException;
+import com.github.ambry.router.ReadableStreamChannel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.github.ambry.rest.RestUtils.InternalKeys.*;
+
+/**
+ * Base class for all S3 handle classes that provides crosscutting functionality such as
+ * logging and response header handling
+ *
+ * @param <R> the type of the result the object in callbacks. It is {@link Void} for requests that don't
+ *           require a response body, otherwise it is {@link ReadableStreamChannel}.
+ */
+abstract public class S3BaseHandler<R> {
+  private static final Logger LOGGER = LoggerFactory.getLogger(S3BaseHandler.class);
+  public static final String AMBRY_PARAMETERS_PREFIX = "x-ambry-";
+
+  /**
+   * Handles the S3 request and construct the response.
+   * @param restRequest the {@link RestRequest} that contains the request parameters and body.
+   * @param restResponseChannel the {@link RestResponseChannel} where headers should be set.
+   * @param callback the {@link Callback} to invoke when the response is ready (or if there is an exception).
+   * @throws RestServiceException exception when the processing fails
+   */
+  abstract protected void doHandle(RestRequest restRequest, RestResponseChannel restResponseChannel,
+      Callback<R> callback) throws RestServiceException;
+
+  /**
+   * Process the request and construct the response, internally the invocation is delegated
+   * to method {@link #doHandle(RestRequest, RestResponseChannel, Callback)}
+   *
+   * @param restRequest the {@link RestRequest} that contains the request parameters and body.
+   * @param restResponseChannel the {@link RestResponseChannel} where headers should be set.
+   * @param callback the {@link Callback} to invoke when the response is ready (or if there is an exception).
+   * @throws RestServiceException exception when the processing fails
+   */
+  public void handle(RestRequest restRequest, RestResponseChannel restResponseChannel,
+      Callback<R> callback) throws RestServiceException {
+    String path = ((RequestPath) restRequest.getArgs().get(REQUEST_PATH)).getOperationOrBlobId(true);
+    if (!path.startsWith(Operations.NAMED_BLOB)) {
+      throw new RuntimeException("S3 request handler can only handle named blob requests");
+    }
+
+    String action = getClass().getSimpleName()
+        .replace("S3", "")
+        .replace("Handler", "");
+    LOGGER.debug("{} {}", action, path);
+
+    doHandle(restRequest, restResponseChannel, (result, exception) -> {
+      if (exception != null) {
+        callback.onCompletion(null, exception);
+      } else try {
+        removeAmbryHeaders(restResponseChannel);
+        callback.onCompletion(result, null);
+      } catch (Exception e) {
+        callback.onCompletion(null, e);
+      }
+    });
+  }
+
+  private void removeAmbryHeaders(RestResponseChannel restResponseChannel) {
+    restResponseChannel.getHeaders().stream()
+        .filter(header -> header.startsWith(AMBRY_PARAMETERS_PREFIX))
+        .forEach(restResponseChannel::removeHeader);
+  }
+}

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3BaseHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3BaseHandler.java
@@ -24,6 +24,7 @@ import com.github.ambry.router.ReadableStreamChannel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.github.ambry.rest.RestUtils.*;
 import static com.github.ambry.rest.RestUtils.InternalKeys.*;
 
 /**
@@ -35,12 +36,12 @@ import static com.github.ambry.rest.RestUtils.InternalKeys.*;
  */
 abstract public class S3BaseHandler<R> {
   private static final Logger LOGGER = LoggerFactory.getLogger(S3BaseHandler.class);
-  public static final String AMBRY_PARAMETERS_PREFIX = "x-ambry-";
 
   /**
    * Handles the S3 request and construct the response.
-   * @param restRequest the {@link RestRequest} that contains the request parameters and body.
-   * @param restResponseChannel the {@link RestResponseChannel} where headers should be set.
+   *
+   * @param restRequest the {@link RestRequest} that contains the request headers and body.
+   * @param restResponseChannel the {@link RestResponseChannel} that contains the response headers and body.
    * @param callback the {@link Callback} to invoke when the response is ready (or if there is an exception).
    * @throws RestServiceException exception when the processing fails
    */
@@ -49,10 +50,11 @@ abstract public class S3BaseHandler<R> {
 
   /**
    * Process the request and construct the response, internally the invocation is delegated
-   * to method {@link #doHandle(RestRequest, RestResponseChannel, Callback)}
+   * to method {@link #doHandle(RestRequest, RestResponseChannel, Callback)}, which is
+   * implemented by subclasses.
    *
-   * @param restRequest the {@link RestRequest} that contains the request parameters and body.
-   * @param restResponseChannel the {@link RestResponseChannel} where headers should be set.
+   * @param restRequest the {@link RestRequest} that contains the request headers and body.
+   * @param restResponseChannel the {@link RestResponseChannel} that contains the response headers and body.
    * @param callback the {@link Callback} to invoke when the response is ready (or if there is an exception).
    * @throws RestServiceException exception when the processing fails
    */
@@ -82,7 +84,7 @@ abstract public class S3BaseHandler<R> {
 
   private void removeAmbryHeaders(RestResponseChannel restResponseChannel) {
     restResponseChannel.getHeaders().stream()
-        .filter(header -> header.startsWith(AMBRY_PARAMETERS_PREFIX))
+        .filter(header -> header.startsWith(AMBRY_HEADER_PREFIX))
         .forEach(restResponseChannel::removeHeader);
   }
 }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3DeleteHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3DeleteHandler.java
@@ -16,8 +16,6 @@ package com.github.ambry.frontend.s3;
 
 import com.github.ambry.commons.Callback;
 import com.github.ambry.frontend.DeleteBlobHandler;
-import com.github.ambry.frontend.Operations;
-import com.github.ambry.rest.RequestPath;
 import com.github.ambry.rest.ResponseStatus;
 import com.github.ambry.rest.RestRequest;
 import com.github.ambry.rest.RestResponseChannel;
@@ -25,13 +23,11 @@ import com.github.ambry.rest.RestServiceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static com.github.ambry.rest.RestUtils.InternalKeys.*;
-
 
 /**
  * Handler to handle all the S3 DELETE requests
  */
-public class S3DeleteHandler {
+public class S3DeleteHandler extends S3BaseHandler<Void> {
   private static final Logger LOGGER = LoggerFactory.getLogger(S3DeleteHandler.class);
   private S3DeleteObjectHandler objectHandler;
 
@@ -53,23 +49,9 @@ public class S3DeleteHandler {
    * @param callback the {@link Callback} to invoke when the response is ready (or if there is an exception).
    * @throws RestServiceException exception when the processing fails
    */
-  public void handle(RestRequest restRequest, RestResponseChannel restResponseChannel, Callback<Void> callback)
+  protected void doHandle(RestRequest restRequest, RestResponseChannel restResponseChannel, Callback<Void> callback)
       throws RestServiceException {
-    String path = ((RequestPath) restRequest.getArgs().get(REQUEST_PATH)).getOperationOrBlobId(true);
-    LOGGER.debug("Delete {}", path);
-
-    if (!path.startsWith(Operations.NAMED_BLOB)) {
-      throw new RuntimeException("S3DeleteHandler only handles named blob requests");
-    }
-
-    Callback<Void> wrappedCallback = (result, exception) -> {
-
-      // TODO [S3]: remove x-ambry- headers
-
-      callback.onCompletion(result, exception);
-    };
-
-    objectHandler.handle(restRequest, restResponseChannel, wrappedCallback);
+    objectHandler.handle(restRequest, restResponseChannel, callback);
   }
 
   private class S3DeleteObjectHandler {

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3PutHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3PutHandler.java
@@ -29,8 +29,7 @@ import static com.github.ambry.rest.RestUtils.*;
  * Handles S3 requests for uploading blobs.
  * API reference: <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html">...</a>
  */
-public class S3PutHandler {
-  public static final String AMBRY_PARAMETERS_PREFIX = "x-ambry-";
+public class S3PutHandler extends S3BaseHandler<Void> {
   private final NamedBlobPutHandler namedBlobPutHandler;
 
   /**
@@ -47,7 +46,8 @@ public class S3PutHandler {
    * @param restResponseChannel the {@link RestResponseChannel} where headers should be set.
    * @param callback the {@link Callback} to invoke when the response is ready (or if there is an exception).
    */
-  public void handle(RestRequest restRequest, RestResponseChannel restResponseChannel, Callback<Void> callback) {
+  @Override
+  protected void doHandle(RestRequest restRequest, RestResponseChannel restResponseChannel, Callback<Void> callback) {
 
     // 1. Add headers required by Ambry. These become the blob properties.
     try {
@@ -64,12 +64,6 @@ public class S3PutHandler {
     // 2. Upload the blob by following named blob PUT path
     namedBlobPutHandler.handle(restRequest, restResponseChannel, (result, exception) -> {
       try {
-        // Remove any Ambry specific headers in response
-        for (String headerName : restResponseChannel.getHeaders()) {
-          if (headerName.startsWith(AMBRY_PARAMETERS_PREFIX)) {
-            restResponseChannel.removeHeader(headerName);
-          }
-        }
         if (exception == null && restResponseChannel.getStatus() == ResponseStatus.Created) {
           // Set the response status to 200 since Ambry named blob PUT has response as 201.
           restResponseChannel.setStatus(ResponseStatus.Ok);

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/AmbryUrlSigningServiceTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/AmbryUrlSigningServiceTest.java
@@ -44,6 +44,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import static com.github.ambry.rest.RestUtils.*;
 import static org.junit.Assert.*;
 
 
@@ -59,7 +60,7 @@ public class AmbryUrlSigningServiceTest {
   private static final long MAX_URL_TTL_SECS = 60 * 60;
   private static final long CHUNK_UPLOAD_INITIAL_CHUNK_TTL_SECS = 24 * 1024 * 1024;
   private static final long CHUNK_UPLOAD_MAX_CHUNK_SIZE = 4 * 1024 * 1024;
-  private static final String RANDOM_AMBRY_HEADER = AmbryUrlSigningService.AMBRY_PARAMETERS_PREFIX + "random";
+  private static final String RANDOM_AMBRY_HEADER = AMBRY_HEADER_PREFIX + "random";
   private final ClusterMap mockClusterMap;
   private final boolean isReservedMetadataEnabled;
 

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/S3BaseHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/S3BaseHandlerTest.java
@@ -30,6 +30,7 @@ import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 
+import static com.github.ambry.rest.RestUtils.*;
 import static org.junit.Assert.*;
 
 
@@ -46,6 +47,7 @@ public class S3BaseHandlerTest {
       @Override
       protected void doHandle(RestRequest restRequest, RestResponseChannel restResponseChannel, Callback callback) {
         restResponseChannel.setHeader("x-ambry-foo", "foo");
+        restResponseChannel.setHeader("x-ambry-bar", "bar");
         // Verify that the response has Ambry headers
         assertTrue("Failed to set Ambry header", hasAmbryHeaders(restResponseChannel));
         callback.onCompletion(null, null);
@@ -70,6 +72,6 @@ public class S3BaseHandlerTest {
 
   private boolean hasAmbryHeaders(RestResponseChannel restResponseChannel) {
     return restResponseChannel.getHeaders().stream()
-        .anyMatch(header -> header.startsWith(S3BaseHandler.AMBRY_PARAMETERS_PREFIX));
+        .anyMatch(header -> header.startsWith(AMBRY_HEADER_PREFIX));
   }
 }

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/S3BaseHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/S3BaseHandlerTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2024 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ */
+package com.github.ambry.frontend;
+
+import com.github.ambry.commons.Callback;
+import com.github.ambry.commons.CommonTestUtils;
+import com.github.ambry.config.FrontendConfig;
+import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.frontend.s3.S3BaseHandler;
+import com.github.ambry.rest.MockRestResponseChannel;
+import com.github.ambry.rest.RequestPath;
+import com.github.ambry.rest.RestMethod;
+import com.github.ambry.rest.RestRequest;
+import com.github.ambry.rest.RestResponseChannel;
+import com.github.ambry.rest.RestUtils;
+import java.util.Properties;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+public class S3BaseHandlerTest {
+  private FrontendConfig frontendConfig;
+  @Test
+  public void removeAmbryHeadersTest() throws Exception {
+    RestResponseChannel restResponseChannel = new MockRestResponseChannel();
+    RestRequest request = FrontendRestRequestServiceTest.createRestRequest(
+        RestMethod.HEAD, "/s3/account/key", new JSONObject(), null);
+    request.setArg(RestUtils.InternalKeys.REQUEST_PATH,
+        RequestPath.parse(request, frontendConfig.pathPrefixesToRemove, "ambry-test"));
+    S3BaseHandler<Void> s3BaseHandler = new S3BaseHandler() {
+      @Override
+      protected void doHandle(RestRequest restRequest, RestResponseChannel restResponseChannel, Callback callback) {
+        restResponseChannel.setHeader("x-ambry-foo", "foo");
+        // Verify that the response has Ambry headers
+        assertTrue("Failed to set Ambry header", hasAmbryHeaders(restResponseChannel));
+        callback.onCompletion(null, null);
+      }
+    };
+    // Process the request
+    s3BaseHandler.handle(request, restResponseChannel, (r, e) -> {
+      // Verify that the response doesn't have Ambry headers
+      assertNull("Result isn't null", r);
+      assertNull("Error happened during request handling", e);
+      assertFalse("Ambry header not removed", hasAmbryHeaders(restResponseChannel));
+    });
+  }
+
+  @Before
+  public void setup() {
+    Properties properties = new Properties();
+    CommonTestUtils.populateRequiredRouterProps(properties);
+    VerifiableProperties verifiableProperties = new VerifiableProperties(properties);
+    frontendConfig = new FrontendConfig(verifiableProperties);
+  }
+
+  private boolean hasAmbryHeaders(RestResponseChannel restResponseChannel) {
+    return restResponseChannel.getHeaders().stream()
+        .anyMatch(header -> header.startsWith(S3BaseHandler.AMBRY_PARAMETERS_PREFIX));
+  }
+}

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/S3HeadHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/S3HeadHandlerTest.java
@@ -36,7 +36,6 @@ import com.github.ambry.rest.RestResponseChannel;
 import com.github.ambry.rest.RestUtils;
 import com.github.ambry.router.FutureResult;
 import com.github.ambry.router.InMemoryRouter;
-import com.github.ambry.router.ReadableStreamChannel;
 import com.github.ambry.utils.TestUtils;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -82,7 +81,7 @@ public class S3HeadHandlerTest {
     String uri = String.format("/s3/%s/", account.getName());
     RestRequest request = FrontendRestRequestServiceTest.createRestRequest(RestMethod.HEAD, uri, new JSONObject(), null);
     RestResponseChannel restResponseChannel = new MockRestResponseChannel();
-    FutureResult<ReadableStreamChannel> futureResult = new FutureResult<>();
+    FutureResult<Void> futureResult = new FutureResult<>();
     request.setArg(RestUtils.InternalKeys.REQUEST_PATH,
         RequestPath.parse(request, frontendConfig.pathPrefixesToRemove, "ambry-test"));
     s3HeadHandler.handle(request, restResponseChannel, futureResult::done);
@@ -98,7 +97,7 @@ public class S3HeadHandlerTest {
     String uri = String.format("/s3/%s/%s", account.getName(), KEY_NAME);
     RestRequest request = FrontendRestRequestServiceTest.createRestRequest(RestMethod.HEAD, uri, new JSONObject(), null);
     RestResponseChannel restResponseChannel = new MockRestResponseChannel();
-    FutureResult<ReadableStreamChannel> futureResult = new FutureResult<>();
+    FutureResult<Void> futureResult = new FutureResult<>();
     request.setArg(RestUtils.InternalKeys.REQUEST_PATH,
         RequestPath.parse(request, frontendConfig.pathPrefixesToRemove, CLUSTER_NAME));
     s3HeadHandler.handle(request, restResponseChannel, futureResult::done);
@@ -120,7 +119,7 @@ public class S3HeadHandlerTest {
     String uri = String.format("/s3/%s/%s", account.getName(), KEY_NAME);
     RestRequest request = FrontendRestRequestServiceTest.createRestRequest(RestMethod.HEAD, uri, new JSONObject(), null);
     RestResponseChannel restResponseChannel = new MockRestResponseChannel();
-    FutureResult<ReadableStreamChannel> futureResult = new FutureResult<>();
+    FutureResult<Void> futureResult = new FutureResult<>();
     request.setArg(RestUtils.InternalKeys.REQUEST_PATH,
         RequestPath.parse(request, frontendConfig.pathPrefixesToRemove, CLUSTER_NAME));
     request.setArg(RestUtils.Headers.RANGE, String.format("bytes=%d-%d", BEG, END));

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/S3PutHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/S3PutHandlerTest.java
@@ -102,11 +102,6 @@ public class S3PutHandlerTest {
     String blobId = (String) restResponseChannel.getHeader(RestUtils.Headers.LOCATION);
     assertEquals("Mismatch on response status", ResponseStatus.Ok, restResponseChannel.getStatus());
     assertNotNull("Location header must be present", blobId);
-    // Verify ambry specific headers are removed in response
-    for (String headerName : restResponseChannel.getHeaders()) {
-      assertFalse("Ambry specific response header " + headerName + "must not be present.",
-          headerName.startsWith(AMBRY_PARAMETERS_PREFIX));
-    }
 
     // 3. Verify blob name exists in named blob DB
     NamedBlobRecord namedBlobRecord = namedBlobDb.get(accountName, containerName, blobName).get();

--- a/ambry-rest/src/main/java/com/github/ambry/rest/NettyResponseChannel.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/NettyResponseChannel.java
@@ -51,6 +51,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.EnumMap;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
@@ -361,7 +362,8 @@ class NettyResponseChannel implements RestResponseChannel {
     if (response == null) {
       response = responseMetadata;
     }
-    return new ArrayList<>(response.headers().names());
+    return Collections.unmodifiableList(
+        new ArrayList<>(response.headers().names()));
   }
 
   /**

--- a/ambry-rest/src/main/java/com/github/ambry/rest/NoOpResponseChannel.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/NoOpResponseChannel.java
@@ -18,6 +18,7 @@ import com.github.ambry.router.FutureResult;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -77,7 +78,8 @@ public class NoOpResponseChannel implements RestResponseChannel{
 
   @Override
   public List<String> getHeaders() {
-    return new ArrayList<>(headers.keySet());
+    return Collections.unmodifiableList(
+        new ArrayList<>(headers.keySet()));
   }
 
   @Override

--- a/ambry-test-utils/src/main/java/com/github/ambry/rest/MockRestResponseChannel.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/rest/MockRestResponseChannel.java
@@ -218,7 +218,7 @@ public class MockRestResponseChannel implements RestResponseChannel {
     } catch (JSONException e) {
       throw new IllegalStateException(e);
     }
-    return headers;
+    return Collections.unmodifiableList(headers);
   }
 
   @Override

--- a/ambry-tools/src/main/java/com/github/ambry/tools/perf/rest/PerfNioServer.java
+++ b/ambry-tools/src/main/java/com/github/ambry/tools/perf/rest/PerfNioServer.java
@@ -438,7 +438,8 @@ class PerfNioServer implements NioServer {
 
     @Override
     public List<String> getHeaders() {
-      return new ArrayList<>(headers.keySet());
+      return Collections.unmodifiableList(
+          new ArrayList<>(headers.keySet()));
     }
 
     @Override


### PR DESCRIPTION
Changes introduced in this PR are
* Introduced base class S3BaseHandler, which allows pre- and post-processing
* Added post-processing to remove Ambry header from response right before invoking the final callback
* Some basic erroring checking and logging