### PR TITLE
[vcr-2.0] Fix cloud compaction sched

### DIFF
--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicationManager.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicationManager.java
@@ -278,7 +278,7 @@ public class VcrReplicationManager extends ReplicationEngine {
     if (cloudConfig.cloudBlobCompactionEnabled && cloudStorageCompactor != null) {
       logger.info("[COMPACT] Waiting {} seconds to populate partitions for compaction", cloudConfig.cloudBlobCompactionStartupDelaySecs);
       cloudCompactionScheduler.scheduleWithFixedDelay(cloudStorageCompactor, cloudConfig.cloudBlobCompactionStartupDelaySecs,
-          cloudConfig.cloudBlobCompactionIntervalHours, TimeUnit.HOURS);
+          TimeUnit.HOURS.toSeconds(cloudConfig.cloudBlobCompactionIntervalHours), TimeUnit.SECONDS);
     }
 
     // Schedule thread to purge blobs belonging to deprecated containers for this VCR's partitions


### PR DESCRIPTION
The start-up delay for cloud compaction is meant to be in seconds but was taken in as number of hours due to TimeUnit.Hours. As a result, 300 was treated as number of hours for startup-delay instead of 300 seconds. And that is why we didn't see compaction running soon.