### PR TITLE
[Compaction] Configure multiple compaction threads per-disk

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -608,7 +608,15 @@ public class StoreConfig {
   public static final String storeRemoveDirectoryAndRestartBlobStoreName =
       "store.remove.directory.and.restart.blob.store";
 
+  /**
+   * True to remove all the files under the partition directory and restart the blob store when blob store fails to start.
+   */
+  public static final int DEFAULT_NUM_COMPACTION_EXECUTORS = 1;
+  public static final String NUM_COMPACTION_EXECUTORS = "num.compaction.executors";
+  @Config(NUM_COMPACTION_EXECUTORS)
+  public final int numCompactionExecutors;
   public StoreConfig(VerifiableProperties verifiableProperties) {
+    numCompactionExecutors = verifiableProperties.getString(NUM_COMPACTION_EXECUTORS, DEFAULT_NUM_COMPACTION_EXECUTORS);
     storeKeyFactory = verifiableProperties.getString("store.key.factory", "com.github.ambry.commons.BlobIdFactory");
     storeDataFlushIntervalSeconds = verifiableProperties.getLong("store.data.flush.interval.seconds", 60);
     storeIndexMaxMemorySizeBytes = verifiableProperties.getInt("store.index.max.memory.size.bytes", 20 * 1024 * 1024);

--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -616,7 +616,7 @@ public class StoreConfig {
   @Config(NUM_COMPACTION_EXECUTORS)
   public final int numCompactionExecutors;
   public StoreConfig(VerifiableProperties verifiableProperties) {
-    numCompactionExecutors = verifiableProperties.getString(NUM_COMPACTION_EXECUTORS, DEFAULT_NUM_COMPACTION_EXECUTORS);
+    numCompactionExecutors = verifiableProperties.getInt(NUM_COMPACTION_EXECUTORS, DEFAULT_NUM_COMPACTION_EXECUTORS);
     storeKeyFactory = verifiableProperties.getString("store.key.factory", "com.github.ambry.commons.BlobIdFactory");
     storeDataFlushIntervalSeconds = verifiableProperties.getLong("store.data.flush.interval.seconds", 60);
     storeIndexMaxMemorySizeBytes = verifiableProperties.getInt("store.index.max.memory.size.bytes", 20 * 1024 * 1024);

--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -609,7 +609,7 @@ public class StoreConfig {
       "store.remove.directory.and.restart.blob.store";
 
   /**
-   * True to remove all the files under the partition directory and restart the blob store when blob store fails to start.
+   * Number of compaction executors
    */
   public static final int DEFAULT_NUM_COMPACTION_EXECUTORS = 1;
   public static final String NUM_COMPACTION_EXECUTORS = "num.compaction.executors";

--- a/ambry-store/src/main/java/com/github/ambry/store/CompactionManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/CompactionManager.java
@@ -132,7 +132,7 @@ class CompactionManager {
       Thread compactionThread = compactionExecutor.getCompactionThread();
       if (compactionThread != null) {
         try {
-          compactionThread.join(2000);
+          compactionThread.join(10000);
         } catch (InterruptedException e) {
           metrics.compactionManagerTerminateErrorCount.inc();
           logger.error("Compaction thread join wait for {} was interrupted", mountPath);

--- a/ambry-store/src/main/java/com/github/ambry/store/CompactionManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/CompactionManager.java
@@ -132,7 +132,7 @@ class CompactionManager {
       Thread compactionThread = compactionExecutor.getCompactionThread();
       if (compactionThread != null) {
         try {
-          compactionThread.join(10000);
+          compactionThread.join(2000);
         } catch (InterruptedException e) {
           metrics.compactionManagerTerminateErrorCount.inc();
           logger.error("Compaction thread join wait for {} was interrupted", mountPath);

--- a/ambry-store/src/main/java/com/github/ambry/store/CompactionManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/CompactionManager.java
@@ -185,7 +185,8 @@ class CompactionManager {
    * @return {@code true} if store is removed successfully. {@code false} if not.
    */
   boolean removeBlobStore(BlobStore store) {
-    CompactionExecutor compactionExecutor = storeCompactionExecutorMap.get(store);
+    CompactionExecutor compactionExecutor =
+        storeCompactionExecutorMap.computeIfAbsent(store, key -> getCompactionExecutorForStore());
     if (compactionExecutor == null) {
       stores.remove(store);
       return true;

--- a/ambry-store/src/main/java/com/github/ambry/store/CompactionManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/CompactionManager.java
@@ -432,7 +432,7 @@ class CompactionManager {
       } finally {
         lock.unlock();
       }
-      logger.info("Disabled compaction thread for {}", mountPath);
+      logger.info("Disabled compaction thread {} for {}", compactionThread.getName(), mountPath);
     }
 
     /**

--- a/ambry-store/src/main/java/com/github/ambry/store/CompactionManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/CompactionManager.java
@@ -106,7 +106,7 @@ class CompactionManager {
   void enable() {
     int threadIdx = 0;
     for (CompactionExecutor compactionExecutor : compactionExecutors) {
-      String threadName = THREAD_NAME_PREFIX + mountPath + String.format("_%s", threadIdx);
+      String threadName = THREAD_NAME_PREFIX + mountPath + String.format("-%s", threadIdx);
       Thread compactionThread = Utils.newThread(threadName, compactionExecutor, true);
       threadIdx += 1;
       compactionThread.setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {

--- a/ambry-store/src/main/java/com/github/ambry/store/CompactionManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/CompactionManager.java
@@ -432,7 +432,8 @@ class CompactionManager {
       } finally {
         lock.unlock();
       }
-      logger.info("Disabled compaction thread {} for {}", compactionThread.getName(), mountPath);
+      logger.info("Disabled compaction thread {} for {}", compactionThread == null ? "" : compactionThread.getName(),
+          mountPath);
     }
 
     /**

--- a/ambry-store/src/test/java/com/github/ambry/store/CompactionManagerTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CompactionManagerTest.java
@@ -31,6 +31,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import org.junit.After;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import static org.junit.Assert.*;
 
@@ -38,6 +40,7 @@ import static org.junit.Assert.*;
 /**
  * Unit tests {@link CompactionManager}.
  */
+@RunWith(Parameterized.class)
 public class CompactionManagerTest {
   private static final String MOUNT_PATH = "/tmp/";
   private static final String ALL_COMPACTION_TRIGGERS = "Periodic,Admin";
@@ -49,9 +52,19 @@ public class CompactionManagerTest {
   private CompactionManager compactionManager;
 
   /**
+   * Number of compaction executors
+   * @return Number of compaction executors
+   */
+  @Parameterized.Parameters
+  public static List<Integer> data() {
+    return Arrays.asList(1, 2, 3);
+  }
+
+  /**
    * Instantiates {@link CompactionManagerTest} with the required cast
    */
-  public CompactionManagerTest() {
+  public CompactionManagerTest(int numCompactionExecutors) {
+    properties.setProperty(StoreConfig.NUM_COMPACTION_EXECUTORS, String.valueOf(numCompactionExecutors));
     config = new StoreConfig(new VerifiableProperties(properties));
     MetricRegistry metricRegistry = new MetricRegistry();
     StoreMetrics metrics = new StoreMetrics(metricRegistry);


### PR DESCRIPTION
This patch allows configuring the number of compaction executors per disk. Prior to this, we had only one thread per disk chugging along many data partitions on the disk. This task can be sped up by adding more threads to do the job. Each thread works on a subset of data partitions on a disk independent of other threads. The only shared resource is disk IOs.