### PR TITLE
[S3 API] Fixed possible hang in S3ListHandlerTest

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/commons/CallbackUtils.java
+++ b/ambry-api/src/main/java/com/github/ambry/commons/CallbackUtils.java
@@ -15,8 +15,11 @@
 
 package com.github.ambry.commons;
 
+import com.github.ambry.rest.RestServiceErrorCode;
+import com.github.ambry.rest.RestServiceException;
 import com.github.ambry.utils.AsyncOperationTracker;
 import com.github.ambry.utils.ThrowingConsumer;
+import com.github.ambry.utils.ThrowingFunction;
 import com.github.ambry.utils.Utils;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -49,9 +52,10 @@ public class CallbackUtils {
         if (exception == null && successAction != null) {
           successAction.accept(result);
         }
-      } catch (Exception e) {
+      } catch (Throwable t) {
         asyncOperationTracker.markCallbackProcessingError();
-        exception = e;
+        exception = t instanceof Exception ? (Exception) t
+            : new RestServiceException(t, RestServiceErrorCode.InternalServerError);
       } finally {
         if (exception != null && failureCallback != null) {
           failureCallback.onCompletion(null, exception);
@@ -86,6 +90,58 @@ public class CallbackUtils {
         future.completeExceptionally(exception);
       } else {
         future.complete(result);
+      }
+    };
+  }
+
+  /**
+   * Create a {@link Callback} that invokes the preAction and then the callback with error handling.
+   * It is meant to be a part of multi-step callback chain and handle intermediate failures in a consistent way.
+   * @param <T> the input and result type for the callback.
+   * @param callback the callback to call after the preAction.
+   * @param preAction the optional action to take before the callback is called.
+   * @return the managed {@link Callback}.
+   */
+  public static <T> Callback<T> chainCallback(Callback<T> callback, ThrowingFunction<T, T> preAction) {
+    return chainCallbackInternal(callback, preAction);
+  }
+
+  /**
+   * Create a {@link Callback} that invokes the preAction and then the callback with error handling.
+   * It is meant to be a part of multi-step callback chain and handle intermediate failures in a consistent way.
+   * @param <T> the input type for the callback accepts.
+   * @param callback the callback to call after the preAction.
+   * @param preAction the optional action to take before the callback is called.
+   * @return the managed {@link Callback}.
+   */
+  public static <T> Callback<T> chainCallback(Callback<T> callback, ThrowingConsumer<T> preAction) {
+    return chainCallbackInternal(callback, preAction);
+  }
+
+  private static <T> Callback<T> chainCallbackInternal(Callback<T> finalCallback, Object preAction) {
+    return (result, exception) -> {
+      try {
+        if (exception == null && preAction != null) {
+          if (preAction instanceof ThrowingFunction) {
+            result = ((ThrowingFunction<T, T>) preAction).apply(result);
+          } else if (preAction instanceof ThrowingConsumer) {
+            ((ThrowingConsumer<T>) preAction).accept(result);
+          } else {
+            throw new RestServiceException("Unknown preAction type " + preAction.getClass().getName(),
+                RestServiceErrorCode.InternalServerError);
+          }
+        }
+      }
+      catch (Throwable t) {
+        exception = t instanceof Exception ? (Exception) t
+            : new RestServiceException(t, RestServiceErrorCode.InternalServerError);
+      }
+      finally {
+        if (exception == null) {
+          finalCallback.onCompletion(result, null);
+        } else {
+          finalCallback.onCompletion(null, exception);
+        }
       }
     };
   }

--- a/ambry-api/src/main/java/com/github/ambry/commons/CallbackUtils.java
+++ b/ambry-api/src/main/java/com/github/ambry/commons/CallbackUtils.java
@@ -137,9 +137,8 @@ public class CallbackUtils {
             : new RestServiceException(t, RestServiceErrorCode.InternalServerError);
       }
       finally {
-        if (exception == null) {
-          finalCallback.onCompletion(result, null);
-        } else {
+        // Note: we don't call the finalCallback in success case
+        if (exception != null) {
           finalCallback.onCompletion(null, exception);
         }
       }

--- a/ambry-api/src/test/java/com/github/ambry/commons/CallbackUtilsTest.java
+++ b/ambry-api/src/test/java/com/github/ambry/commons/CallbackUtilsTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2024 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ */
+package com.github.ambry.commons;
+
+import com.github.ambry.rest.RestServiceException;
+import com.github.ambry.utils.ThrowingFunction;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+/**
+ * Tests for {@link CallbackUtils}.
+ */
+public class CallbackUtilsTest {
+  @Test
+  public void chainCallbackWithThrowableConsumerTest() {
+    String theResult = "result";
+    Exception theException = new Exception();
+    Error theError = new Error();
+
+    // Test with a successful action, result should be passed to the callback
+    CallbackUtils.chainCallback((result, exception) -> {
+      Assert.assertSame(theResult, result);
+      Assert.assertNull(exception);
+    }, (result) -> {
+      // Do nothing
+    }).onCompletion(theResult, null);
+
+    // Test with preAction throwing an exception, original exception should be passed to the callback
+    CallbackUtils.chainCallback((result, exception) -> {
+      Assert.assertNull(result);
+      Assert.assertSame(theException, exception);
+    }, (ThrowingFunction<Object, Object>) (result) -> {
+      throw theException;
+    }).onCompletion(theResult, null);
+
+    // Test with preAction throwing an error, original exception should be wrapped in a RestServiceException
+    // and passed to the callback
+    CallbackUtils.chainCallback((result, exception) -> {
+      Assert.assertNull(result);
+      Assert.assertTrue(exception instanceof RestServiceException);
+      Assert.assertSame(exception.getCause(), theError);
+    }, (ThrowingFunction<Object, Object>) (result) -> {
+      throw theError;
+    }).onCompletion(theResult, null);
+  }
+
+  @Test
+  public void chainCallbackWithThrowableFunctionTest() {
+    String result1 = "result1";
+    String result2 = "result2";
+
+    // Test with a successful action, returned result from preAction should be passed to the callback
+    CallbackUtils.chainCallback((result, exception) -> {
+      Assert.assertNotSame(result1, result);
+      Assert.assertSame(result2, result);
+      Assert.assertNull(exception);
+    }, (result) -> {
+      return result2;
+    }).onCompletion(result1, null);
+  }
+}

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendMetrics.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendMetrics.java
@@ -18,6 +18,9 @@ import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.config.FrontendConfig;
+import com.github.ambry.frontend.s3.S3DeleteHandler;
+import com.github.ambry.frontend.s3.S3ListHandler;
+import com.github.ambry.frontend.s3.S3PutHandler;
 import com.github.ambry.utils.AsyncOperationTracker;
 
 
@@ -155,6 +158,10 @@ public class FrontendMetrics {
   public final AsyncOperationTracker.Metrics deleteSecurityPostProcessRequestMetrics;
 
   public final AsyncOperationTracker.Metrics deleteDatasetOutOfRetentionRequestMetrics;
+
+  public final AsyncOperationTracker.Metrics s3DeleteHandleMetrics;
+  public final AsyncOperationTracker.Metrics s3ListHandleMetrics;
+  public final AsyncOperationTracker.Metrics s3PutHandleMetrics;
 
   // Rates
   // AmbrySecurityService
@@ -480,6 +487,13 @@ public class FrontendMetrics {
 
     deleteDatasetOutOfRetentionRequestMetrics =
         new AsyncOperationTracker.Metrics(NamedBlobPutHandler.class, "RetentionRequest", metricRegistry);
+
+    s3DeleteHandleMetrics =
+        new AsyncOperationTracker.Metrics(S3DeleteHandler.class, "S3Handle", metricRegistry);
+    s3ListHandleMetrics =
+        new AsyncOperationTracker.Metrics(S3ListHandler.class, "S3Handle", metricRegistry);
+    s3PutHandleMetrics =
+        new AsyncOperationTracker.Metrics(S3PutHandler.class, "S3Handle", metricRegistry);
 
     getStatsReportSecurityProcessRequestMetrics =
         new AsyncOperationTracker.Metrics(GetStatsReportHandler.class, "SecurityProcessRequest", metricRegistry);

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestService.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestService.java
@@ -227,15 +227,15 @@ class FrontendRestRequestService implements RestRequestService {
     postAccountsHandler = new PostAccountsHandler(securityService, accountService, frontendConfig, frontendMetrics);
     postDatasetsHandler = new PostDatasetsHandler(securityService, accountService, frontendConfig, frontendMetrics,
         accountAndContainerInjector);
-    s3DeleteHandler = new S3DeleteHandler(deleteBlobHandler);
+    s3DeleteHandler = new S3DeleteHandler(deleteBlobHandler, frontendMetrics);
     s3HeadHandler = new S3HeadHandler(headBlobHandler, securityService, frontendMetrics, accountService);
-    s3ListHandler = new S3ListHandler(namedBlobListHandler);
+    s3ListHandler = new S3ListHandler(namedBlobListHandler, frontendMetrics);
     s3HeadHandler = new S3HeadHandler(headBlobHandler, securityService, frontendMetrics, accountService);
     s3MultipartUploadHandler =
         new S3MultipartUploadHandler(securityService, frontendMetrics, namedBlobPutHandler, accountAndContainerInjector,
             frontendConfig, namedBlobDb, idConverter, router, quotaManager);
     s3PostHandler = new S3PostHandler(s3MultipartUploadHandler);
-    s3PutHandler = new S3PutHandler(namedBlobPutHandler, s3MultipartUploadHandler);
+    s3PutHandler = new S3PutHandler(namedBlobPutHandler, s3MultipartUploadHandler, frontendMetrics);
     namedBlobsCleanupRunner = new NamedBlobsCleanupRunner(router, namedBlobDb);
     if (frontendConfig.enableNamedBlobCleanupTask) {
       namedBlobsCleanupScheduler = Utils.newScheduler(1, "named-blobs-cleanup-", false);

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3BaseHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3BaseHandler.java
@@ -68,13 +68,11 @@ abstract public class S3BaseHandler<R> {
         throw new RuntimeException("S3 request handler can only handle named blob requests");
       }
 
-      String action = getClass().getSimpleName()
-          .replace("S3", "")
-          .replace("Handler", "");
-      LOGGER.debug("{} {}", action, path);
+      LOGGER.debug("{} {}", restRequest.getRestMethod(), path);
 
       doHandle(restRequest, restResponseChannel, CallbackUtils.chainCallback(callback, (r) -> {
         removeAmbryHeaders(restResponseChannel);
+        callback.onCompletion(r, null);
       }));
     }
     catch (Throwable t) {

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3DeleteHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3DeleteHandler.java
@@ -33,7 +33,7 @@ import static com.github.ambry.frontend.FrontendUtils.*;
  */
 public class S3DeleteHandler extends S3BaseHandler<Void> {
 
-  private S3DeleteObjectHandler objectHandler;
+  private final S3DeleteObjectHandler objectHandler;
   private final FrontendMetrics metrics;
 
   /**

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3DeleteHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3DeleteHandler.java
@@ -15,12 +15,17 @@
 package com.github.ambry.frontend.s3;
 
 import com.github.ambry.commons.Callback;
-import com.github.ambry.commons.CallbackUtils;
 import com.github.ambry.frontend.DeleteBlobHandler;
+import com.github.ambry.frontend.FrontendMetrics;
 import com.github.ambry.rest.ResponseStatus;
 import com.github.ambry.rest.RestRequest;
 import com.github.ambry.rest.RestResponseChannel;
 import com.github.ambry.rest.RestServiceException;
+import com.github.ambry.utils.ThrowingConsumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.github.ambry.frontend.FrontendUtils.*;
 
 
 /**
@@ -29,13 +34,15 @@ import com.github.ambry.rest.RestServiceException;
 public class S3DeleteHandler extends S3BaseHandler<Void> {
 
   private S3DeleteObjectHandler objectHandler;
+  private final FrontendMetrics metrics;
 
   /**
    * Construct a handler for handling S3 DELETE requests.
    *
    * @param deleteBlobHandler the generic {@link DeleteBlobHandler} delegated to by the underlying delete object handler.
    */
-  public S3DeleteHandler(DeleteBlobHandler deleteBlobHandler) {
+  public S3DeleteHandler(DeleteBlobHandler deleteBlobHandler, FrontendMetrics metrics) {
+    this.metrics = metrics;
     this.objectHandler = new S3DeleteObjectHandler(deleteBlobHandler);
   }
 
@@ -54,17 +61,21 @@ public class S3DeleteHandler extends S3BaseHandler<Void> {
   }
 
   private class S3DeleteObjectHandler {
+    private final Logger LOGGER = LoggerFactory.getLogger(S3DeleteObjectHandler.class);
     private final DeleteBlobHandler deleteBlobHandler;
 
     private S3DeleteObjectHandler(DeleteBlobHandler deleteBlobHandler) {
       this.deleteBlobHandler = deleteBlobHandler;
     }
 
-    private void handle(RestRequest restRequest, RestResponseChannel restResponseChannel, Callback<Void> callback)
+    private void handle(RestRequest restRequest, RestResponseChannel restResponseChannel, Callback<Void> finalCallback)
         throws RestServiceException {
-      deleteBlobHandler.handle(restRequest, restResponseChannel, CallbackUtils.chainCallback(callback, (result) -> {
+      ThrowingConsumer<Void> successAction = (r) -> {
         restResponseChannel.setStatus(ResponseStatus.NoContent);
-      }));
+        finalCallback.onCompletion(null, null);
+      };
+      deleteBlobHandler.handle(restRequest, restResponseChannel, buildCallback(metrics.s3DeleteHandleMetrics,
+          successAction, restRequest.getUri(), LOGGER, finalCallback));
     }
   }
 }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3DeleteHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3DeleteHandler.java
@@ -15,20 +15,19 @@
 package com.github.ambry.frontend.s3;
 
 import com.github.ambry.commons.Callback;
+import com.github.ambry.commons.CallbackUtils;
 import com.github.ambry.frontend.DeleteBlobHandler;
 import com.github.ambry.rest.ResponseStatus;
 import com.github.ambry.rest.RestRequest;
 import com.github.ambry.rest.RestResponseChannel;
 import com.github.ambry.rest.RestServiceException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
  * Handler to handle all the S3 DELETE requests
  */
 public class S3DeleteHandler extends S3BaseHandler<Void> {
-  private static final Logger LOGGER = LoggerFactory.getLogger(S3DeleteHandler.class);
+
   private S3DeleteObjectHandler objectHandler;
 
   /**
@@ -63,17 +62,8 @@ public class S3DeleteHandler extends S3BaseHandler<Void> {
 
     private void handle(RestRequest restRequest, RestResponseChannel restResponseChannel, Callback<Void> callback)
         throws RestServiceException {
-      deleteBlobHandler.handle(restRequest, restResponseChannel, ((result, exception) -> {
-        if (exception != null) {
-          callback.onCompletion(null, exception);
-        } else {
-          try {
-            restResponseChannel.setStatus(ResponseStatus.NoContent);
-            callback.onCompletion(null, null);
-          } catch (RestServiceException e) {
-            callback.onCompletion(null, e);
-          }
-        }
+      deleteBlobHandler.handle(restRequest, restResponseChannel, CallbackUtils.chainCallback(callback, (result) -> {
+        restResponseChannel.setStatus(ResponseStatus.NoContent);
       }));
     }
   }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3ListHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3ListHandler.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.github.ambry.commons.ByteBufferReadableStreamChannel;
 import com.github.ambry.commons.Callback;
-import com.github.ambry.commons.CallbackUtils;
+import com.github.ambry.frontend.FrontendMetrics;
 import com.github.ambry.frontend.NamedBlobListEntry;
 import com.github.ambry.frontend.NamedBlobListHandler;
 import com.github.ambry.frontend.Page;
@@ -43,6 +43,8 @@ import org.json.JSONTokener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.github.ambry.frontend.FrontendUtils.*;
+
 
 /**
  * Handles S3 requests for listing blobs that start with a provided prefix.
@@ -50,19 +52,21 @@ import org.slf4j.LoggerFactory;
  */
 public class S3ListHandler extends S3BaseHandler<ReadableStreamChannel> {
   private static final Logger LOGGER = LoggerFactory.getLogger(S3ListHandler.class);
-  private final NamedBlobListHandler namedBlobListHandler;
+  private static final ObjectMapper xmlMapper = new XmlMapper();
   public static final String PREFIX_PARAM_NAME = "prefix";
   public static final String MAXKEYS_PARAM_NAME = "max-keys";
   public static final String DELIMITER_PARAM_NAME = "delimiter";
   public static final String ENCODING_TYPE_PARAM_NAME = "encoding-type";
-  private static final ObjectMapper xmlMapper = new XmlMapper();
+  private final NamedBlobListHandler namedBlobListHandler;
+  private final FrontendMetrics metrics;
 
   /**
    * Constructs a handler for handling s3 requests for listing blobs.
    * @param namedBlobListHandler named blob list handler
    */
-  public S3ListHandler(NamedBlobListHandler namedBlobListHandler) {
+  public S3ListHandler(NamedBlobListHandler namedBlobListHandler, FrontendMetrics metrics) {
     this.namedBlobListHandler = namedBlobListHandler;
+    this.metrics = metrics;
   }
 
   /**
@@ -74,7 +78,7 @@ public class S3ListHandler extends S3BaseHandler<ReadableStreamChannel> {
   @Override
   protected void doHandle(RestRequest restRequest, RestResponseChannel restResponseChannel,
       Callback<ReadableStreamChannel> callback) {
-    namedBlobListHandler.handle(restRequest, restResponseChannel, CallbackUtils.chainCallback(callback, (result) -> {
+    namedBlobListHandler.handle(restRequest, restResponseChannel, buildCallback(metrics.s3ListHandleMetrics, (result) -> {
       // Convert from json response to S3 xml response as defined in
       // https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html#API_ListObjectsV2_ResponseSyntax.
       ByteBuffer byteBuffer = ((ByteBufferReadableStreamChannel) result).getContent();
@@ -84,8 +88,8 @@ public class S3ListHandler extends S3BaseHandler<ReadableStreamChannel> {
       restResponseChannel.setHeader(RestUtils.Headers.DATE, new GregorianCalendar().getTime());
       restResponseChannel.setHeader(RestUtils.Headers.CONTENT_TYPE, "application/xml");
       restResponseChannel.setHeader(RestUtils.Headers.CONTENT_LENGTH, readableStreamChannel.getSize());
-      return readableStreamChannel;
-    }));
+      callback.onCompletion(readableStreamChannel, null);
+    }, restRequest.getUri(), LOGGER, callback));
   }
 
   private ReadableStreamChannel serializeAsXml(RestRequest restRequest, Page<NamedBlobListEntry> namedBlobRecordPage)

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3MultipartUploadHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3MultipartUploadHandler.java
@@ -30,8 +30,6 @@ import com.github.ambry.rest.RestServiceErrorCode;
 import com.github.ambry.rest.RestServiceException;
 import com.github.ambry.router.ReadableStreamChannel;
 import com.github.ambry.router.Router;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static com.github.ambry.rest.RestUtils.*;
 
@@ -39,7 +37,7 @@ import static com.github.ambry.rest.RestUtils.*;
 /**
  * Handles requests for s3 multipart uploads.
  */
-public class S3MultipartUploadHandler {
+public class S3MultipartUploadHandler extends S3BaseHandler<ReadableStreamChannel> {
   private final S3CreateMultipartUploadHandler createMultipartUploadHandler;
   private final S3CompleteMultipartUploadHandler completeMultipartUploadHandler;
   private final S3MultipartUploadPartHandler uploadPartHandler;
@@ -72,8 +70,9 @@ public class S3MultipartUploadHandler {
    * @param restResponseChannel the {@link RestResponseChannel} where headers should be set.
    * @param callback the {@link Callback} to invoke when the response is ready (or if there is an exception).
    */
-  void handle(RestRequest restRequest, RestResponseChannel restResponseChannel,
-      Callback<ReadableStreamChannel> callback) {
+  @Override
+  protected void doHandle(RestRequest restRequest, RestResponseChannel restResponseChannel,
+      Callback<ReadableStreamChannel> callback) throws RestServiceException {
     if (isCreateRequest(restRequest)) {
       createMultipartUploadHandler.handle(restRequest, restResponseChannel, callback);
     } else if (isUploadPartRequest(restRequest)) {

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3MultipartUploadHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3MultipartUploadHandler.java
@@ -69,6 +69,7 @@ public class S3MultipartUploadHandler extends S3BaseHandler<ReadableStreamChanne
    * @param restRequest the {@link RestRequest} that contains the request parameters.
    * @param restResponseChannel the {@link RestResponseChannel} where headers should be set.
    * @param callback the {@link Callback} to invoke when the response is ready (or if there is an exception).
+   * @throws RestServiceException exception when the processing fails
    */
   @Override
   protected void doHandle(RestRequest restRequest, RestResponseChannel restResponseChannel,

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3MultipartUploadPartHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3MultipartUploadPartHandler.java
@@ -47,6 +47,7 @@ public class S3MultipartUploadPartHandler {
    * @param restRequest the {@link RestRequest} that contains the request parameters.
    * @param restResponseChannel the {@link RestResponseChannel} where headers should be set.
    * @param callback the {@link Callback} to invoke when the response is ready (or if there is an exception).
+   * @throws RestServiceException exception when the processing fails
    */
   void handle(RestRequest restRequest, RestResponseChannel restResponseChannel,
     Callback<ReadableStreamChannel> callback) throws RestServiceException {

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3MultipartUploadPartHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3MultipartUploadPartHandler.java
@@ -49,44 +49,39 @@ public class S3MultipartUploadPartHandler {
    * @param callback the {@link Callback} to invoke when the response is ready (or if there is an exception).
    */
   void handle(RestRequest restRequest, RestResponseChannel restResponseChannel,
-      Callback<ReadableStreamChannel> callback) {
-    try {
+    Callback<ReadableStreamChannel> callback) throws RestServiceException {
+    // 1. Set headers required by Ambry. These become the blob properties.
+    NamedBlobPath namedBlobPath = NamedBlobPath.parse(getRequestPath(restRequest), restRequest.getArgs());
+    String accountName = namedBlobPath.getAccountName();
+    restRequest.setArg(Headers.SERVICE_ID, accountName);
+    restRequest.setArg(Headers.AMBRY_CONTENT_TYPE, restRequest.getArgs().get(Headers.CONTENT_TYPE));
+    restRequest.setArg(Headers.AMBRY_CONTENT_ENCODING, restRequest.getArgs().get(Headers.CONTENT_ENCODING));
 
-      // 1. Set headers required by Ambry. These become the blob properties.
-      NamedBlobPath namedBlobPath = NamedBlobPath.parse(getRequestPath(restRequest), restRequest.getArgs());
-      String accountName = namedBlobPath.getAccountName();
-      restRequest.setArg(Headers.SERVICE_ID, accountName);
-      restRequest.setArg(Headers.AMBRY_CONTENT_TYPE, restRequest.getArgs().get(Headers.CONTENT_TYPE));
-      restRequest.setArg(Headers.AMBRY_CONTENT_ENCODING, restRequest.getArgs().get(Headers.CONTENT_ENCODING));
+    // 2. Set the internal headers session id and chunk-upload. They are used during for multipart part uploads
+    String uploadId = RestUtils.getHeader(restRequest.getArgs(), UPLOAD_ID_QUERY_PARAM, true);
+    restRequest.setArg(S3_CHUNK_UPLOAD, true);
+    restRequest.setArg(SESSION, uploadId);
 
-      // 2. Set the internal headers session id and chunk-upload. They are used during for multipart part uploads
-      String uploadId = RestUtils.getHeader(restRequest.getArgs(), UPLOAD_ID_QUERY_PARAM, true);
-      restRequest.setArg(S3_CHUNK_UPLOAD, true);
-      restRequest.setArg(SESSION, uploadId);
-
-      // 3. Intercept the response callback and make needed changes in response headers.
-      Callback<Void> wrappedCallback = (result, exception) -> {
-        if (exception != null) {
-          callback.onCompletion(null, exception);
-          return;
+    // 3. Intercept the response callback and make needed changes in response headers.
+    Callback<Void> wrappedCallback = (result, exception) -> {
+      if (exception != null) {
+        callback.onCompletion(null, exception);
+        return;
+      }
+      try {
+        // Set the response status to 200 since Ambry named blob PUT has response as 201.
+        if (restResponseChannel.getStatus() == ResponseStatus.Created) {
+          restResponseChannel.setStatus(ResponseStatus.Ok);
+          String blobId = RestUtils.getHeader(restRequest.getArgs(), LOCATION, true);
+          restResponseChannel.setHeader("ETag", blobId);
         }
-        try {
-          // Set the response status to 200 since Ambry named blob PUT has response as 201.
-          if (restResponseChannel.getStatus() == ResponseStatus.Created) {
-            restResponseChannel.setStatus(ResponseStatus.Ok);
-            String blobId = RestUtils.getHeader(restRequest.getArgs(), LOCATION, true);
-            restResponseChannel.setHeader("ETag", blobId);
-          }
-          //TODO [S3]: remove x-ambry- headers
-          callback.onCompletion(null, null);
-        } catch (RestServiceException e) {
-          callback.onCompletion(null, e);
-        }
-      };
+        //TODO [S3]: remove x-ambry- headers
+        callback.onCompletion(null, null);
+      } catch (RestServiceException e) {
+        callback.onCompletion(null, e);
+      }
+    };
 
-      namedBlobPutHandler.handle(restRequest, restResponseChannel, wrappedCallback);
-    } catch (RestServiceException e) {
-      callback.onCompletion(null, e);
-    }
+    namedBlobPutHandler.handle(restRequest, restResponseChannel, wrappedCallback);
   }
 }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3PostHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3PostHandler.java
@@ -27,7 +27,7 @@ import static com.github.ambry.rest.RestUtils.*;
 /**
  * Handles S3 POST requests.
  */
-public class S3PostHandler {
+public class S3PostHandler extends S3BaseHandler<ReadableStreamChannel> {
   private final S3MultipartUploadHandler multipartPostHandler;
 
   /**
@@ -43,14 +43,14 @@ public class S3PostHandler {
    * @param restResponseChannel the {@link RestResponseChannel} where headers should be set.
    * @param callback the {@link Callback} to invoke when the response is ready (or if there is an exception).
    */
-  public void handle(RestRequest restRequest, RestResponseChannel restResponseChannel,
-      Callback<ReadableStreamChannel> callback) {
+  @Override
+  protected void doHandle(RestRequest restRequest, RestResponseChannel restResponseChannel,
+      Callback<ReadableStreamChannel> callback) throws RestServiceException {
     if (isMultipartUploadRequest(restRequest)) {
       multipartPostHandler.handle(restRequest, restResponseChannel, callback);
     } else {
       // Placeholder for handling any non-multipart S3 POST requests in the future.
-      callback.onCompletion(null,
-          new RestServiceException("Unsupported S3 POST request", RestServiceErrorCode.BadRequest));
+      throw new RestServiceException("Unsupported S3 POST request", RestServiceErrorCode.BadRequest);
     }
   }
 

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3PostHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3PostHandler.java
@@ -42,6 +42,7 @@ public class S3PostHandler extends S3BaseHandler<ReadableStreamChannel> {
    * @param restRequest the {@link RestRequest} that contains the request parameters and body.
    * @param restResponseChannel the {@link RestResponseChannel} where headers should be set.
    * @param callback the {@link Callback} to invoke when the response is ready (or if there is an exception).
+   * @throws RestServiceException exception when the processing fails
    */
   @Override
   protected void doHandle(RestRequest restRequest, RestResponseChannel restResponseChannel,

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3PutHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3PutHandler.java
@@ -59,6 +59,7 @@ public class S3PutHandler extends S3BaseHandler<Void> {
    * @param restRequest the {@link RestRequest} that contains the request parameters and body.
    * @param restResponseChannel the {@link RestResponseChannel} where headers should be set.
    * @param callback the {@link Callback} to invoke when the response is ready (or if there is an exception).
+   * @throws RestServiceException exception when the processing fails
    */
   @Override
   protected void doHandle(RestRequest restRequest, RestResponseChannel restResponseChannel, Callback<Void> callback)

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/S3DeleteHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/S3DeleteHandlerTest.java
@@ -114,7 +114,7 @@ public class S3DeleteHandlerTest {
     DeleteBlobHandler deleteBlobHandler =
         new DeleteBlobHandler(router, securityService, ambryIdConverterFactory.getIdConverter(), injector, metrics,
             new MockClusterMap(), QuotaTestUtils.createDummyQuotaManager(), ACCOUNT_SERVICE);
-    s3DeleteHandler = new S3DeleteHandler(deleteBlobHandler);
+    s3DeleteHandler = new S3DeleteHandler(deleteBlobHandler, metrics);
   }
 
   private void putABlob() throws Exception {

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/S3ListHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/S3ListHandlerTest.java
@@ -155,6 +155,6 @@ public class S3ListHandlerTest {
         CLUSTER_NAME, QuotaTestUtils.createDummyQuotaManager(), ACCOUNT_SERVICE, null);
     NamedBlobListHandler namedBlobListHandler =
         new NamedBlobListHandler(securityServiceFactory.getSecurityService(), namedBlobDb, injector, metrics);
-    s3ListHandler = new S3ListHandler(namedBlobListHandler);
+    s3ListHandler = new S3ListHandler(namedBlobListHandler, metrics);
   }
 }

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/S3PutHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/S3PutHandlerTest.java
@@ -50,7 +50,6 @@ import java.util.Properties;
 import org.json.JSONObject;
 import org.junit.Test;
 
-import static com.github.ambry.frontend.s3.S3PutHandler.*;
 import static org.junit.Assert.*;
 
 
@@ -147,6 +146,6 @@ public class S3PutHandlerTest {
     getBlobHandler =
         new GetBlobHandler(frontendConfig, router, securityService, idConverter, injector, metrics, clusterMap,
             QuotaTestUtils.createDummyQuotaManager(), ACCOUNT_SERVICE);
-    s3PutHandler = new S3PutHandler(namedBlobPutHandler, null);
+    s3PutHandler = new S3PutHandler(namedBlobPutHandler, null, metrics);
   }
 }

--- a/ambry-utils/src/main/java/com/github/ambry/utils/ThrowingFunction.java
+++ b/ambry-utils/src/main/java/com/github/ambry/utils/ThrowingFunction.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.utils;
+
+import java.util.function.Function;
+
+/**
+ * Similar to {@link Function}, but able to throw checked exceptions.
+ * @param <T> the type of the input to the operation
+ * @param <R> the type of the return value of the operation
+ */
+public interface ThrowingFunction<T, R> {
+  /**
+   * Applies this function to the given argument.
+   * @param t the function argument
+   * @return the function result
+   * @throws Exception if the function fails
+   */
+  R apply(T t) throws Exception;
+}


### PR DESCRIPTION
This PR contains
* In method CallbackUtils.chainCallback(), this could lead to hang of request processing when when an Error occurs. Changed to catch Throwable, and wrap Error in  RestServiceException
* Added a pair of new new methods that invokes a preAction and finalCallback with complete error handling, in order to eliminate boilerplate code in S3 handlers
* Modified existing S3 handlers to use the new methods