### PR TITLE
[vcr-2.0] Deprecate V1 tests

### DIFF
--- a/ambry-cloud/src/test/java/com/github/ambry/cloud/CloudBlobMetadataTest.java
+++ b/ambry-cloud/src/test/java/com/github/ambry/cloud/CloudBlobMetadataTest.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.ArrayUtils;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static com.github.ambry.cloud.CloudBlobMetadata.*;
@@ -31,6 +32,7 @@ import static org.junit.Assert.*;
 
 
 /** Test for {@link CloudBlobMetadata} class. */
+@Ignore
 public class CloudBlobMetadataTest {
 
   private static final ObjectMapper mapperObj = new ObjectMapper();

--- a/ambry-cloud/src/test/java/com/github/ambry/cloud/StaticVcrClusterParticipantTest.java
+++ b/ambry-cloud/src/test/java/com/github/ambry/cloud/StaticVcrClusterParticipantTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Properties;
 import java.util.stream.Collectors;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -34,6 +35,7 @@ import static org.junit.Assert.*;
 /**
  * Test of StaticVcrCluster.
  */
+@Ignore
 public class StaticVcrClusterParticipantTest {
   private MockClusterAgentsFactory mockClusterAgentsFactory;
   private MockClusterMap mockClusterMap;

--- a/ambry-vcr/src/test/java/com/github/ambry/vcr/CloudBlobStoreTest.java
+++ b/ambry-vcr/src/test/java/com/github/ambry/vcr/CloudBlobStoreTest.java
@@ -132,7 +132,6 @@ import static org.mockito.Mockito.*;
 /**
  * Test class testing behavior of CloudBlobStore class.
  */
-@RunWith(Parameterized.class)
 public class CloudBlobStoreTest {
   public static final Logger logger = LoggerFactory.getLogger(CloudBlobStoreTest.class);
   private static final int SMALL_BLOB_SIZE = 100;
@@ -157,18 +156,8 @@ public class CloudBlobStoreTest {
   protected AccountService accountService = mock(AccountService.class);
   protected MetricRegistry metricRegistry;
 
-  /**
-   * Test parameters
-   * Version 1 = Legacy VCR code and tests
-   * Version 2 = VCR 2.0 with Sync cloud destination - AzureCloudDestinationSync
-   */
-  @Parameterized.Parameters
-  public static List<Object[]> data() {
-    return Arrays.asList(new Object[][]{{CloudConfig.AMBRY_BACKUP_VERSION_1}, {CloudConfig.AMBRY_BACKUP_VERSION_2}});
-  }
-
-  public CloudBlobStoreTest(String ambryBackupVersion) throws Exception {
-    this.ambryBackupVersion = ambryBackupVersion;
+  public CloudBlobStoreTest() throws Exception {
+    this.ambryBackupVersion = CloudConfig.AMBRY_BACKUP_VERSION_2; // v1 is deprecated
     this.isVcr = true; // Just hardcode true. false is for blueshift, which is deprecated.
     partitionId = new MockPartitionId();
     clusterMap = new MockClusterMap();

--- a/ambry-vcr/src/test/java/com/github/ambry/vcr/VcrBackupTest.java
+++ b/ambry-vcr/src/test/java/com/github/ambry/vcr/VcrBackupTest.java
@@ -75,6 +75,7 @@ import static org.junit.Assert.*;
 
 
 @RunWith(Parameterized.class)
+@Ignore
 public class VcrBackupTest {
   private static final Logger logger = LoggerFactory.getLogger(VcrBackupTest.class);
   private static TestUtils.ZkInfo zkInfo;

--- a/ambry-vcr/src/test/java/com/github/ambry/vcr/VcrServerTest.java
+++ b/ambry-vcr/src/test/java/com/github/ambry/vcr/VcrServerTest.java
@@ -59,6 +59,7 @@ import static org.mockito.Mockito.*;
 /**
  * Test of the VCR Server.
  */
+@Ignore
 public class VcrServerTest {
 
   private MockClusterAgentsFactory mockClusterAgentsFactory;


### PR DESCRIPTION
Deprecate V1 tests for VCR, since V1 is gone and the tests just take too much time