### PR TITLE
Remove hardcoding of container name for S3 requests

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/account/Container.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/Container.java
@@ -126,12 +126,6 @@ public class Container {
   public static final String DEFAULT_PRIVATE_CONTAINER_NAME = "default-private-container";
 
   /**
-   * Default name for the containers associated with S3 APIs. Since, S3 requests on client side only take Account
-   * (i.e. Bucket) name, we use a default name for containers.
-   */
-  public static final String DEFAULT_S3_CONTAINER_NAME = "container-s3";
-
-  /**
    * The status of {@link #UNKNOWN_CONTAINER}.
    */
   public static final ContainerStatus UNKNOWN_CONTAINER_STATUS = ContainerStatus.ACTIVE;

--- a/ambry-api/src/test/java/com/github/ambry/rest/RequestPathTest.java
+++ b/ambry-api/src/test/java/com/github/ambry/rest/RequestPathTest.java
@@ -204,9 +204,9 @@ public class RequestPathTest {
    */
   @Test
   public void testS3Request() {
-    String path = "/s3/accountName/path/to/key";
-    RequestPath expectedRequestPath = new RequestPath("", "", "/named/accountName/container-s3/path/to/key",
-        "/named/accountName/container-s3/path/to/key", null, NO_BLOB_SEGMENT_IDX_SPECIFIED);
+    String path = "/s3/accountName/container-a/path/to/key";
+    RequestPath expectedRequestPath = new RequestPath("", "", "/named/accountName/container-a/path/to/key",
+        "/named/accountName/container-a/path/to/key", null, NO_BLOB_SEGMENT_IDX_SPECIFIED);
     parseRequestPathAndVerify(path, Collections.emptyList(), "", expectedRequestPath, new JSONObject());
   }
 

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3PutHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3PutHandler.java
@@ -82,7 +82,9 @@ public class S3PutHandler extends S3BaseHandler<Void> {
       if (restResponseChannel.getStatus() == ResponseStatus.Created) {
         // Set the response status to 200 since Ambry named blob PUT has response as 201.
         restResponseChannel.setStatus(ResponseStatus.Ok);
-        String blobId = RestUtils.getHeader(restRequest.getArgs(), LOCATION, true);
+        // Set S3 ETag header
+        String blobId = (String) restResponseChannel.getHeader(LOCATION);
+        blobId = blobId.startsWith("/") ? blobId.substring(1) : blobId;
         restResponseChannel.setHeader("ETag", blobId);
       }
       callback.onCompletion(null, null);

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/S3BaseHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/S3BaseHandlerTest.java
@@ -39,8 +39,9 @@ public class S3BaseHandlerTest {
   @Test
   public void removeAmbryHeadersTest() throws Exception {
     RestResponseChannel restResponseChannel = new MockRestResponseChannel();
-    RestRequest request = FrontendRestRequestServiceTest.createRestRequest(
-        RestMethod.HEAD, "/s3/account/key", new JSONObject(), null);
+    RestRequest request =
+        FrontendRestRequestServiceTest.createRestRequest(RestMethod.HEAD, "/s3/account/container/key", new JSONObject(),
+            null);
     request.setArg(RestUtils.InternalKeys.REQUEST_PATH,
         RequestPath.parse(request, frontendConfig.pathPrefixesToRemove, "ambry-test"));
     S3BaseHandler<Void> s3BaseHandler = new S3BaseHandler() {

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/S3DeleteHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/S3DeleteHandlerTest.java
@@ -61,7 +61,7 @@ public class S3DeleteHandlerTest {
 
   public S3DeleteHandlerTest() throws Exception {
     account = ACCOUNT_SERVICE.createAndAddRandomAccount();
-    container = new ContainerBuilder().setName(Container.DEFAULT_S3_CONTAINER_NAME)
+    container = new ContainerBuilder().setName("container-a")
         .setId((short) 10)
         .setParentAccountId(account.getId())
         .setStatus(Container.ContainerStatus.ACTIVE)
@@ -75,7 +75,7 @@ public class S3DeleteHandlerTest {
   @Test
   public void deleteObjectTest() throws Exception {
     // 1. Delete the object
-    String uri = String.format("/s3/%s/%s", account.getName(), KEY_NAME);
+    String uri = String.format("/s3/%s/%s/%s", account.getName(), container.getName(), KEY_NAME);
     RestRequest request =
         FrontendRestRequestServiceTest.createRestRequest(RestMethod.DELETE, uri, new JSONObject(), null);
     RestResponseChannel restResponseChannel = new MockRestResponseChannel();

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/S3HeadHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/S3HeadHandlerTest.java
@@ -64,7 +64,7 @@ public class S3HeadHandlerTest {
 
   public S3HeadHandlerTest() throws Exception {
     account = ACCOUNT_SERVICE.createAndAddRandomAccount();
-    container = new ContainerBuilder().setName(Container.DEFAULT_S3_CONTAINER_NAME)
+    container = new ContainerBuilder().setName("container-a")
         .setId((short) 10)
         .setParentAccountId(account.getId())
         .setStatus(Container.ContainerStatus.ACTIVE)
@@ -78,8 +78,9 @@ public class S3HeadHandlerTest {
   @Test
   public void headBucketTest() throws Exception {
     // 1. Head the bucket with range
-    String uri = String.format("/s3/%s/", account.getName());
-    RestRequest request = FrontendRestRequestServiceTest.createRestRequest(RestMethod.HEAD, uri, new JSONObject(), null);
+    String uri = String.format("/s3/%s/%s/", account.getName(), container.getName());
+    RestRequest request =
+        FrontendRestRequestServiceTest.createRestRequest(RestMethod.HEAD, uri, new JSONObject(), null);
     RestResponseChannel restResponseChannel = new MockRestResponseChannel();
     FutureResult<Void> futureResult = new FutureResult<>();
     request.setArg(RestUtils.InternalKeys.REQUEST_PATH,
@@ -94,8 +95,9 @@ public class S3HeadHandlerTest {
   @Test
   public void headObjectTest() throws Exception {
     // 1. Head the object with range
-    String uri = String.format("/s3/%s/%s", account.getName(), KEY_NAME);
-    RestRequest request = FrontendRestRequestServiceTest.createRestRequest(RestMethod.HEAD, uri, new JSONObject(), null);
+    String uri = String.format("/s3/%s/%s/%s", account.getName(), container.getName(), KEY_NAME);
+    RestRequest request =
+        FrontendRestRequestServiceTest.createRestRequest(RestMethod.HEAD, uri, new JSONObject(), null);
     RestResponseChannel restResponseChannel = new MockRestResponseChannel();
     FutureResult<Void> futureResult = new FutureResult<>();
     request.setArg(RestUtils.InternalKeys.REQUEST_PATH,
@@ -116,8 +118,9 @@ public class S3HeadHandlerTest {
   @Test
   public void headObjectWithRangeTest() throws Exception {
     // 1. Head the object with range
-    String uri = String.format("/s3/%s/%s", account.getName(), KEY_NAME);
-    RestRequest request = FrontendRestRequestServiceTest.createRestRequest(RestMethod.HEAD, uri, new JSONObject(), null);
+    String uri = String.format("/s3/%s/%s/%s", account.getName(), container.getName(), KEY_NAME);
+    RestRequest request =
+        FrontendRestRequestServiceTest.createRestRequest(RestMethod.HEAD, uri, new JSONObject(), null);
     RestResponseChannel restResponseChannel = new MockRestResponseChannel();
     FutureResult<Void> futureResult = new FutureResult<>();
     request.setArg(RestUtils.InternalKeys.REQUEST_PATH,

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/S3ListHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/S3ListHandlerTest.java
@@ -71,7 +71,7 @@ public class S3ListHandlerTest {
 
   public S3ListHandlerTest() throws Exception {
     account = ACCOUNT_SERVICE.createAndAddRandomAccount();
-    container = new ContainerBuilder().setName(Container.DEFAULT_S3_CONTAINER_NAME)
+    container = new ContainerBuilder().setName("container-a")
         .setId((short) 10)
         .setParentAccountId(account.getId())
         .setStatus(Container.ContainerStatus.ACTIVE)
@@ -105,8 +105,8 @@ public class S3ListHandlerTest {
 
     // 2. Get list of blobs by sending matching s3 request
     String s3_list_request_uri =
-        S3_PREFIX + SLASH + account.getName() + SLASH + "?prefix=" + PREFIX + "&delimiter=/" + "&max-keys=1"
-            + "&encoding-type=url";
+        S3_PREFIX + SLASH + account.getName() + SLASH + container.getName() + SLASH + "?prefix=" + PREFIX
+            + "&delimiter=/" + "&max-keys=1" + "&encoding-type=url";
     request =
         FrontendRestRequestServiceTest.createRestRequest(RestMethod.GET, s3_list_request_uri, new JSONObject(), null);
     request.setArg(RestUtils.InternalKeys.REQUEST_PATH,

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/S3PutHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/S3PutHandlerTest.java
@@ -66,7 +66,7 @@ public class S3PutHandlerTest {
 
   public S3PutHandlerTest() throws Exception {
     account = ACCOUNT_SERVICE.createAndAddRandomAccount();
-    Container container = new ContainerBuilder().setName(Container.DEFAULT_S3_CONTAINER_NAME)
+    Container container = new ContainerBuilder().setName("container-a")
         .setId((short) 10)
         .setParentAccountId(account.getId())
         .setStatus(Container.ContainerStatus.ACTIVE)
@@ -80,10 +80,10 @@ public class S3PutHandlerTest {
   public void putBlobsTest() throws Exception {
     // 1. Put a s3 blob
     String accountName = account.getName();
-    String containerName = Container.DEFAULT_S3_CONTAINER_NAME;
+    String containerName = "container-a";
     String blobName = "MyDirectory/MyKey";
     int size = 1024;
-    String uri = S3_PREFIX + SLASH + accountName + SLASH + blobName;
+    String uri = S3_PREFIX + SLASH + accountName + SLASH + containerName + SLASH + blobName;
     JSONObject headers = new JSONObject();
     headers.put(RestUtils.Headers.CONTENT_TYPE, "application/octet-stream");
     headers.put(RestUtils.Headers.CONTENT_LENGTH, size);


### PR DESCRIPTION
This PR removes hardcoding of container name for S3 Requests so that users don't have restriction of creating separate Ambry accounts for different use cases.

It also consists of a minor fix in `S3PutHandler` to send blob ID correctly in ETag header.