### PR TITLE
Multipart part upload uses its own CallbackChain, don't use namedBlobPutUploader.

### DIFF
--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestService.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestService.java
@@ -232,8 +232,8 @@ class FrontendRestRequestService implements RestRequestService {
     s3ListHandler = new S3ListHandler(namedBlobListHandler, frontendMetrics);
     s3HeadHandler = new S3HeadHandler(headBlobHandler, securityService, frontendMetrics, accountService);
     s3MultipartUploadHandler =
-        new S3MultipartUploadHandler(securityService, frontendMetrics, namedBlobPutHandler, accountAndContainerInjector,
-            frontendConfig, namedBlobDb, idConverter, router, quotaManager);
+        new S3MultipartUploadHandler(securityService, frontendMetrics, accountAndContainerInjector, frontendConfig,
+            namedBlobDb, idConverter, router, quotaManager);
     s3PostHandler = new S3PostHandler(s3MultipartUploadHandler);
     s3PutHandler = new S3PutHandler(namedBlobPutHandler, s3MultipartUploadHandler, frontendMetrics);
     namedBlobsCleanupRunner = new NamedBlobsCleanupRunner(router, namedBlobDb);

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
@@ -25,7 +25,6 @@ import com.github.ambry.commons.RetryExecutor;
 import com.github.ambry.commons.RetryPolicies;
 import com.github.ambry.commons.RetryPolicy;
 import com.github.ambry.config.FrontendConfig;
-import com.github.ambry.frontend.s3.S3MultipartUploadHandler;
 import com.github.ambry.messageformat.BlobInfo;
 import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.named.NamedBlobDb;
@@ -281,12 +280,7 @@ public class NamedBlobPutHandler {
     private Callback<String> idConverterCallback(BlobInfo blobInfo, String blobId) {
       return buildCallback(frontendMetrics.putIdConversionMetrics, convertedBlobId -> {
         restResponseChannel.setHeader(RestUtils.Headers.LOCATION, convertedBlobId);
-        // TODO [S3] Probably we don't reuse NamedBlobPutHandler but write a new S3PutHandler.
-        if (S3MultipartUploadHandler.isUploadPartRequest(restRequest)) {
-          // For s3 part upload, we don't need to do TtlUpdate, named blob db update etc. It only needs the PutBlob
-          securityService.processResponse(restRequest, restResponseChannel, blobInfo,
-              securityProcessResponseCallback());
-        } else if (blobInfo.getBlobProperties().getTimeToLiveInSeconds() == Utils.Infinite_Time) {
+        if (blobInfo.getBlobProperties().getTimeToLiveInSeconds() == Utils.Infinite_Time) {
           // Do ttl update with retryExecutor. Use the blob ID returned from the router instead of the converted ID
           // since the converted ID may be changed by the ID converter.
           String serviceId = blobInfo.getBlobProperties().getServiceId();
@@ -448,10 +442,6 @@ public class NamedBlobPutHandler {
       Long maxUploadSize = RestUtils.getLongHeader(restRequest.getArgs(), RestUtils.Headers.MAX_UPLOAD_SIZE, false);
       if (maxUploadSize != null) {
         builder.maxUploadSize(maxUploadSize);
-      }
-      // if it's the s3 part upload for the multi-part request, skip creating the composite chunk.
-      if (S3MultipartUploadHandler.isUploadPartRequest(restRequest)) {
-        builder.skipCompositeChunk(true);
       }
       return builder.build();
     }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3MultipartUploadHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3MultipartUploadHandler.java
@@ -19,7 +19,6 @@ import com.github.ambry.config.FrontendConfig;
 import com.github.ambry.frontend.AccountAndContainerInjector;
 import com.github.ambry.frontend.FrontendMetrics;
 import com.github.ambry.frontend.IdConverter;
-import com.github.ambry.frontend.NamedBlobPutHandler;
 import com.github.ambry.frontend.SecurityService;
 import com.github.ambry.named.NamedBlobDb;
 import com.github.ambry.quota.QuotaManager;

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3MultipartUploadHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3MultipartUploadHandler.java
@@ -47,7 +47,6 @@ public class S3MultipartUploadHandler extends S3BaseHandler<ReadableStreamChanne
    * Construct a handler for handling S3 POST requests during multipart uploads.
    * @param securityService the {@link SecurityService} to use.
    * @param frontendMetrics {@link FrontendMetrics} instance where metrics should be recorded.
-   * @param namedBlobPutHandler the {@link NamedBlobPutHandler} to use.
    * @param accountAndContainerInjector helper to resolve account and container for a given request.
    * @param frontendConfig the {@link FrontendConfig} to use.
    * @param namedBlobDb the {@link NamedBlobDb} to use.
@@ -56,14 +55,15 @@ public class S3MultipartUploadHandler extends S3BaseHandler<ReadableStreamChanne
    * @param quotaManager The {@link QuotaManager} class to account for quota usage in serving requests.
    */
   public S3MultipartUploadHandler(SecurityService securityService, FrontendMetrics frontendMetrics,
-      NamedBlobPutHandler namedBlobPutHandler, AccountAndContainerInjector accountAndContainerInjector,
-      FrontendConfig frontendConfig, NamedBlobDb namedBlobDb, IdConverter idConverter, Router router,
-      QuotaManager quotaManager) {
+      AccountAndContainerInjector accountAndContainerInjector, FrontendConfig frontendConfig, NamedBlobDb namedBlobDb,
+      IdConverter idConverter, Router router, QuotaManager quotaManager) {
     this.createMultipartUploadHandler = new S3CreateMultipartUploadHandler(securityService, frontendMetrics);
     this.completeMultipartUploadHandler =
         new S3CompleteMultipartUploadHandler(securityService, namedBlobDb, idConverter, router,
             accountAndContainerInjector, frontendMetrics, frontendConfig, quotaManager);
-    this.uploadPartHandler = new S3MultipartUploadPartHandler(namedBlobPutHandler);
+    this.uploadPartHandler =
+        new S3MultipartUploadPartHandler(securityService, idConverter, router, accountAndContainerInjector,
+            frontendConfig, frontendMetrics, quotaManager);
   }
 
   /**

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3MultipartUploadPartHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3MultipartUploadPartHandler.java
@@ -14,18 +14,39 @@
  */
 package com.github.ambry.frontend.s3;
 
+import com.github.ambry.account.Container;
 import com.github.ambry.commons.Callback;
+import com.github.ambry.config.FrontendConfig;
+import com.github.ambry.frontend.AccountAndContainerInjector;
+import com.github.ambry.frontend.FrontendMetrics;
+import com.github.ambry.frontend.IdConverter;
 import com.github.ambry.frontend.NamedBlobPath;
-import com.github.ambry.frontend.NamedBlobPutHandler;
+import com.github.ambry.frontend.SecurityService;
+import com.github.ambry.messageformat.BlobInfo;
+import com.github.ambry.messageformat.BlobProperties;
+import com.github.ambry.quota.QuotaManager;
+import com.github.ambry.quota.QuotaUtils;
 import com.github.ambry.rest.ResponseStatus;
 import com.github.ambry.rest.RestRequest;
 import com.github.ambry.rest.RestResponseChannel;
+import com.github.ambry.rest.RestServiceErrorCode;
 import com.github.ambry.rest.RestServiceException;
 import com.github.ambry.rest.RestUtils;
+import com.github.ambry.router.PutBlobOptions;
+import com.github.ambry.router.PutBlobOptionsBuilder;
 import com.github.ambry.router.ReadableStreamChannel;
+import com.github.ambry.router.Router;
+import com.github.ambry.utils.Utils;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import static com.github.ambry.frontend.FrontendUtils.*;
 import static com.github.ambry.rest.RestUtils.*;
 import static com.github.ambry.rest.RestUtils.Headers.*;
+import static com.github.ambry.rest.RestUtils.InternalKeys.*;
 
 
 /**
@@ -33,14 +54,35 @@ import static com.github.ambry.rest.RestUtils.Headers.*;
  * <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">...</a>
  */
 public class S3MultipartUploadPartHandler {
-  private final NamedBlobPutHandler namedBlobPutHandler;
+  private static final Logger logger = LoggerFactory.getLogger(S3MultipartUploadPartHandler.class);
+  private final SecurityService securityService;
+  private final IdConverter idConverter;
+  private final Router router;
+  private final AccountAndContainerInjector accountAndContainerInjector;
+  private final FrontendConfig frontendConfig;
+  private final FrontendMetrics frontendMetrics;
+  private final QuotaManager quotaManager;
 
   /**
    * Construct a handler for handling S3 POST requests during multipart uploads.
-   * @param namedBlobPutHandler the {@link NamedBlobPutHandler} to use.
+   * @param securityService             the {@link SecurityService} to use.
+   * @param idConverter                 the {@link IdConverter} to use.
+   * @param router                      the {@link Router} to use.
+   * @param accountAndContainerInjector helper to resolve account and container for a given request.
+   * @param frontendConfig              the {@link FrontendConfig} to use.
+   * @param frontendMetrics             {@link FrontendMetrics} instance where metrics should be recorded.
+   * @param quotaManager                The {@link QuotaManager} class to account for quota usage in serving requests.
    */
-  public S3MultipartUploadPartHandler(NamedBlobPutHandler namedBlobPutHandler) {
-    this.namedBlobPutHandler = namedBlobPutHandler;
+  public S3MultipartUploadPartHandler(SecurityService securityService, IdConverter idConverter, Router router,
+      AccountAndContainerInjector accountAndContainerInjector, FrontendConfig frontendConfig,
+      FrontendMetrics frontendMetrics, QuotaManager quotaManager) {
+    this.securityService = securityService;
+    this.idConverter = idConverter;
+    this.router = router;
+    this.accountAndContainerInjector = accountAndContainerInjector;
+    this.frontendConfig = frontendConfig;
+    this.frontendMetrics = frontendMetrics;
+    this.quotaManager = quotaManager;
   }
 
   /**
@@ -65,28 +107,202 @@ public class S3MultipartUploadPartHandler {
     // TODO [S3] : set part ttl value
     // restRequest.setArg(TTL, xxx);
 
-    // 3. Intercept the response callback and make needed changes in response headers.
-    Callback<Void> wrappedCallback = (result, exception) -> {
-      if (exception != null) {
-        callback.onCompletion(null, exception);
-        return;
-      }
+    restRequest.setArg(SEND_FAILURE_REASON, Boolean.TRUE);
+
+    // TODO [S3] verifyChunkAccountAndContainer? getAndVerifyReservedMetadataBlobId?
+    new S3MultipartUploadPartHandler.CallbackChain(restRequest, restResponseChannel, callback).start();
+  }
+
+  /**
+   * Represents the chain of actions to take. Keeps request context that is relevant to all callback stages.
+   */
+  private class CallbackChain {
+    private final RestRequest restRequest;
+    private final RestResponseChannel restResponseChannel;
+    private final Callback<ReadableStreamChannel> finalCallback;
+    private final String uri;
+
+    /**
+     * @param restRequest the {@link RestRequest}.
+     * @param restResponseChannel the {@link RestResponseChannel}.
+     * @param finalCallback the {@link Callback} to call on completion.
+     */
+    private CallbackChain(RestRequest restRequest, RestResponseChannel restResponseChannel,
+        Callback<ReadableStreamChannel> finalCallback) {
+      this.restRequest = restRequest;
+      this.restResponseChannel = restResponseChannel;
+      this.finalCallback = finalCallback;
+      this.uri = restRequest.getUri();
+    }
+
+    /**
+     * Start the chain by calling {@link SecurityService#processRequest}.
+     */
+    private void start() {
+      restRequest.getMetricsTracker()
+          .injectMetrics(frontendMetrics.putBlobMetricsGroup.getRestRequestMetrics(restRequest.isSslUsed(), false));
       try {
-        // Set the response status to 200 since Ambry named blob PUT has response as 201.
-        if (restResponseChannel.getStatus() == ResponseStatus.Created) {
-          restResponseChannel.setStatus(ResponseStatus.Ok);
-        }
-
-        // Set S3 ETag header
-        String blobId = (String) restResponseChannel.getHeader(LOCATION);
-        restResponseChannel.setHeader("ETag", blobId);
-        //TODO [S3]: remove x-ambry- headers
-        callback.onCompletion(null, null);
-      } catch (RestServiceException e) {
-        callback.onCompletion(null, e);
+        // Start the callback chain by parsing blob info headers and performing request security processing.
+        securityService.processRequest(restRequest, securityProcessRequestCallback());
+      } catch (Exception e) {
+        finalCallback.onCompletion(null, e);
       }
-    };
+    }
 
-    namedBlobPutHandler.handle(restRequest, restResponseChannel, wrappedCallback);
+    /**
+     * After {@link SecurityService#processRequest} finishes, call {@link SecurityService#postProcessRequest} to perform
+     * request time security checks that rely on the request being fully parsed and any additional arguments set.
+     * @return a {@link Callback} to be used with {@link SecurityService#processRequest}.
+     */
+    private Callback<Void> securityProcessRequestCallback() {
+      return buildCallback(frontendMetrics.putSecurityProcessRequestMetrics, securityCheckResult -> {
+        //make sure this has been called after processRequest(permission check) since it needs to query dataset db.
+        BlobInfo blobInfo = getBlobInfoFromRequest();
+        securityService.postProcessRequest(restRequest, securityPostProcessRequestCallback(blobInfo));
+      }, uri, logger, finalCallback);
+    }
+
+    /**
+     * After {@link SecurityService#postProcessRequest} finishes, call {@link Router#putBlob} to persist the blob in the
+     * storage layer.
+     * @param blobInfo the {@link BlobInfo} to make the router call with.
+     * @return a {@link Callback} to be used with {@link SecurityService#postProcessRequest}.
+     */
+    private Callback<Void> securityPostProcessRequestCallback(BlobInfo blobInfo) {
+      return buildCallback(frontendMetrics.putSecurityPostProcessRequestMetrics, securityCheckResult -> {
+        PutBlobOptions options = getPutBlobOptionsFromRequest();
+        router.putBlob(getPropertiesForRouterUpload(blobInfo), blobInfo.getUserMetadata(), restRequest, options,
+            routerPutBlobCallback(blobInfo), QuotaUtils.buildQuotaChargeCallback(restRequest, quotaManager, true));
+      }, uri, logger, finalCallback);
+    }
+
+    /**
+     * After {@link Router#putBlob} finishes, call {@link IdConverter#convert} to store the mapping between blobName and
+     * blobId.
+     * @param blobInfo the {@link BlobInfo} to use for security checks.
+     * @return a {@link Callback} to be used with {@link Router#putBlob}.
+     */
+    private Callback<String> routerPutBlobCallback(BlobInfo blobInfo) {
+      return buildCallback(frontendMetrics.putRouterPutBlobMetrics, blobId -> {
+        restResponseChannel.setHeader(RestUtils.Headers.BLOB_SIZE, restRequest.getBlobBytesReceived());
+        idConverter.convert(restRequest, blobId, blobInfo, idConverterCallback(blobInfo, blobId));
+      }, uri, logger, finalCallback);
+    }
+
+    /**
+     * After {@link IdConverter#convert} finishes, call {@link SecurityService#postProcessRequest} to perform
+     * request time security checks that rely on the request being fully parsed and any additional arguments set.
+     * @param blobInfo the {@link BlobInfo} to use for security checks.
+     * @param blobId the blob ID returned by the router (without decoration or obfuscation by id converter).
+     * @return a {@link Callback} to be used with {@link IdConverter#convert}.
+     */
+    private Callback<String> idConverterCallback(BlobInfo blobInfo, String blobId) {
+      return buildCallback(frontendMetrics.putIdConversionMetrics, convertedBlobId -> {
+        restResponseChannel.setHeader(RestUtils.Headers.LOCATION, convertedBlobId);
+        securityService.processResponse(restRequest, restResponseChannel, blobInfo, securityProcessResponseCallback());
+      }, uri, logger, finalCallback);
+    }
+
+    /**
+     * After {@link SecurityService#processResponse}, call {@code finalCallback}.
+     * @return a {@link Callback} to be used with {@link SecurityService#processResponse}.
+     */
+    private Callback<Void> securityProcessResponseCallback() {
+      return buildCallback(frontendMetrics.putBlobSecurityProcessResponseMetrics, securityCheckResult -> {
+        try {
+          // Set the response status to 200 since Ambry named blob PUT has response as 201.
+          if (restResponseChannel.getStatus() == ResponseStatus.Created) {
+            restResponseChannel.setStatus(ResponseStatus.Ok);
+          }
+
+          // Set S3 ETag header
+          String blobId = (String) restResponseChannel.getHeader(LOCATION);
+          restResponseChannel.setHeader("ETag", blobId);
+          //TODO [S3]: remove x-ambry- headers
+          finalCallback.onCompletion(null, null);
+        } catch (RestServiceException e) {
+          finalCallback.onCompletion(null, e);
+        }
+      }, restRequest.getUri(), logger, finalCallback);
+    }
+
+    /**
+     * Parse {@link BlobInfo} from the request arguments. This method will also ensure that the correct account and
+     * container objects are attached to the request.
+     * @return the {@link BlobInfo} parsed from the request arguments.
+     * @throws RestServiceException if there is an error while parsing the {@link BlobInfo} arguments.
+     */
+    private BlobInfo getBlobInfoFromRequest() throws RestServiceException {
+      long propsBuildStartTime = System.currentTimeMillis();
+      accountAndContainerInjector.injectAccountContainerForNamedBlob(restRequest, frontendMetrics.putBlobMetricsGroup);
+      if (RestUtils.isDatasetVersionQueryEnabled(restRequest.getArgs())) {
+        accountAndContainerInjector.injectDatasetForNamedBlob(restRequest);
+      }
+      BlobProperties blobProperties = RestUtils.buildBlobProperties(restRequest.getArgs());
+      Container container = RestUtils.getContainerFromArgs(restRequest.getArgs());
+      if (blobProperties.getTimeToLiveInSeconds() + TimeUnit.MILLISECONDS.toSeconds(
+          blobProperties.getCreationTimeInMs()) > Integer.MAX_VALUE) {
+        logger.debug("TTL set to very large value in PUT request with BlobProperties {}", blobProperties);
+        frontendMetrics.ttlTooLargeError.inc();
+      } else if (container.isTtlRequired() && (blobProperties.getTimeToLiveInSeconds() == Utils.Infinite_Time
+          || blobProperties.getTimeToLiveInSeconds() > frontendConfig.maxAcceptableTtlSecsIfTtlRequired)) {
+        String descriptor = RestUtils.getAccountFromArgs(restRequest.getArgs()).getName() + ":" + container.getName();
+        if (frontendConfig.failIfTtlRequiredButNotProvided) {
+          throw new RestServiceException(
+              "TTL < " + frontendConfig.maxAcceptableTtlSecsIfTtlRequired + " is required for upload to " + descriptor,
+              RestServiceErrorCode.InvalidArgs);
+        } else {
+          logger.debug("{} attempted an upload with ttl {} to {}", blobProperties.getServiceId(),
+              blobProperties.getTimeToLiveInSeconds(), descriptor);
+          frontendMetrics.ttlNotCompliantError.inc();
+          restResponseChannel.setHeader(RestUtils.Headers.NON_COMPLIANCE_WARNING,
+              "TTL < " + frontendConfig.maxAcceptableTtlSecsIfTtlRequired + " will be required for future uploads");
+        }
+      }
+      // inject encryption frontendMetrics if applicable
+      if (blobProperties.isEncrypted()) {
+        restRequest.getMetricsTracker()
+            .injectMetrics(frontendMetrics.putBlobMetricsGroup.getRestRequestMetrics(restRequest.isSslUsed(), true));
+      }
+      Map<String, Object> userMetadataFromRequest = new HashMap<>(restRequest.getArgs());
+      byte[] userMetadata = RestUtils.buildUserMetadata(userMetadataFromRequest);
+      frontendMetrics.blobPropsBuildForNameBlobPutTimeInMs.update(System.currentTimeMillis() - propsBuildStartTime);
+      logger.trace("Blob properties of blob being PUT - {}", blobProperties);
+      return new BlobInfo(blobProperties, userMetadata);
+    }
+
+    /**
+     * @return the {@link PutBlobOptions} to use, parsed from the request.
+     */
+    private PutBlobOptions getPutBlobOptionsFromRequest() throws RestServiceException {
+      PutBlobOptionsBuilder builder = new PutBlobOptionsBuilder().chunkUpload(false).restRequest(restRequest);
+      Long maxUploadSize = RestUtils.getLongHeader(restRequest.getArgs(), RestUtils.Headers.MAX_UPLOAD_SIZE, false);
+      if (maxUploadSize != null) {
+        builder.maxUploadSize(maxUploadSize);
+      }
+
+      // it's the s3 part upload for the multi-part request, skip creating the composite chunk.
+      builder.skipCompositeChunk(true);
+      return builder.build();
+    }
+
+    /**
+     * Create a {@link BlobProperties} for the router upload (putBlob or stitchBlob) with a finite TTL such that
+     * orphaned blobs will not be created if the write to the named blob metadata DB fails.
+     * @param blobInfoFromRequest the {@link BlobInfo} parsed from the request.
+     * @return a {@link BlobProperties} for a TTL-ed initial router call.
+     */
+    BlobProperties getPropertiesForRouterUpload(BlobInfo blobInfoFromRequest) {
+      BlobProperties properties;
+      if (blobInfoFromRequest.getBlobProperties().getTimeToLiveInSeconds() == Utils.Infinite_Time) {
+        properties = new BlobProperties(blobInfoFromRequest.getBlobProperties());
+        // For blob with infinite time, the procedure is putBlob with a TTL, record insert to database with
+        // infinite TTL, and ttlUpdate.
+        properties.setTimeToLiveInSeconds(frontendConfig.permanentNamedBlobInitialPutTtl);
+      } else {
+        properties = blobInfoFromRequest.getBlobProperties();
+      }
+      return properties;
+    }
   }
 }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3PutHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3PutHandler.java
@@ -22,7 +22,6 @@ import com.github.ambry.rest.ResponseStatus;
 import com.github.ambry.rest.RestRequest;
 import com.github.ambry.rest.RestResponseChannel;
 import com.github.ambry.rest.RestServiceException;
-import com.github.ambry.rest.RestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/S3MultipartUploadTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/S3MultipartUploadTest.java
@@ -267,8 +267,7 @@ public class S3MultipartUploadTest {
     getBlobHandler =
         new GetBlobHandler(frontendConfig, router, securityService, idConverter, injector, metrics, clusterMap,
             quotaManager, ACCOUNT_SERVICE);
-    s3MultipartUploadHandler =
-        new S3MultipartUploadHandler(securityService, metrics, namedBlobPutHandler, injector, frontendConfig,
+    s3MultipartUploadHandler = new S3MultipartUploadHandler(securityService, metrics, injector, frontendConfig,
             namedBlobDb, idConverter, router, quotaManager);
     s3PostHandler = new S3PostHandler(s3MultipartUploadHandler);
     s3PutHandler = new S3PutHandler(namedBlobPutHandler, s3MultipartUploadHandler, metrics);


### PR DESCRIPTION
S3 Multipart part upload don't use namedBlobPutHandler.
1. Part upload only have the security check and PutBlob. It doesn't need TtlUpdate, Stitch function, db operation or dataset logic. So create its own simple CallbackChain.
2. Removed the S3 part upload code from the namedBlobPutHandler.

After this, all the Multipart handlers have their own CallbackChain

- S3CreateMultipartUploadHandler
- S3CompleteMultipartUploadHandler
- S3MultipartUploadPartHandler