### PR TITLE
[vcr-2.0] Fix DateFormat concurrency error

### DIFF
--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicaThread.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicaThread.java
@@ -37,6 +37,8 @@ import com.github.ambry.store.StoreKeyConverter;
 import com.github.ambry.store.Transformer;
 import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -127,6 +129,7 @@ public class VcrReplicaThread extends ReplicaThread {
     long lastOpTime = remoteReplicaInfo.getReplicatedUntilUTC();
     String partitionKey = String.valueOf(remoteReplicaInfo.getReplicaId().getPartitionId().getId());
     String rowKey = remoteReplicaInfo.getReplicaId().getDataNodeId().getHostname();
+    DateFormat formatter = new SimpleDateFormat(VcrReplicationManager.DATE_FORMAT);
     TableEntity entity = new TableEntity(partitionKey, rowKey)
         .addProperty(VcrReplicationManager.BACKUP_NODE, dataNodeId.getHostname())
         .addProperty(VcrReplicationManager.TOKEN_TYPE,
@@ -139,7 +142,7 @@ public class VcrReplicaThread extends ReplicaThread {
             token.getStoreKey() == null ? "none" : token.getStoreKey().getID())
         .addProperty(VcrReplicationManager.REPLICATED_UNITL_UTC,
             lastOpTime == Utils.Infinite_Time ? String.valueOf(Utils.Infinite_Time)
-                : VcrReplicationManager.DATE_FORMAT.format(lastOpTime))
+                : formatter.format(lastOpTime))
         .addProperty(VcrReplicationManager.BINARY_TOKEN,
             token.toBytes());
     // Now persist the token in cloud

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicationManager.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicationManager.java
@@ -119,7 +119,7 @@ public class VcrReplicationManager extends ReplicationEngine {
   public static final String STORE_KEY = "storeKey";
   public static final String REPLICATED_UNITL_UTC = "replicatedUntilUTC";
   public static final String BINARY_TOKEN = "binaryToken";
-  public static final DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy_MMM_dd_HH_mm_ss");
+  public static final String DATE_FORMAT ="yyyy_MMM_dd_HH_mm_ss";
 
   public VcrReplicationManager(VerifiableProperties properties, StoreManager storeManager,
       StoreKeyFactory storeKeyFactory, ClusterMap clusterMap, VcrClusterParticipant vcrClusterParticipant,
@@ -201,7 +201,8 @@ public class VcrReplicationManager extends ReplicationEngine {
             new ByteArrayInputStream((byte[]) row.getProperty(BINARY_TOKEN)));
         replicaInfo.setToken(findTokenFactory.getFindToken(inputStream));
         String replUntil = (String) row.getProperty(REPLICATED_UNITL_UTC);
-        long time = replUntil.equals(String.valueOf(Utils.Infinite_Time)) ? -1 : DATE_FORMAT.parse(replUntil).getTime();
+        DateFormat formatter = new SimpleDateFormat(DATE_FORMAT);
+        long time = replUntil.equals(String.valueOf(Utils.Infinite_Time)) ? -1 : formatter.parse(replUntil).getTime();
         replicaInfo.setReplicatedUntilUTC(time);
       } catch (Throwable t) {
         // log and metric

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicationManager.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicationManager.java
@@ -119,7 +119,7 @@ public class VcrReplicationManager extends ReplicationEngine {
   public static final String STORE_KEY = "storeKey";
   public static final String REPLICATED_UNITL_UTC = "replicatedUntilUTC";
   public static final String BINARY_TOKEN = "binaryToken";
-  public static final String DATE_FORMAT ="yyyy_MMM_dd_HH_mm_ss";
+  public static final String DATE_FORMAT = "yyyy_MMM_dd_HH_mm_ss";
 
   public VcrReplicationManager(VerifiableProperties properties, StoreManager storeManager,
       StoreKeyFactory storeKeyFactory, ClusterMap clusterMap, VcrClusterParticipant vcrClusterParticipant,

--- a/ambry-vcr/src/test/java/com/github/ambry/vcr/CloudTokenPersistorTest.java
+++ b/ambry-vcr/src/test/java/com/github/ambry/vcr/CloudTokenPersistorTest.java
@@ -66,6 +66,8 @@ import com.github.ambry.utils.Utils;
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -205,7 +207,8 @@ public class CloudTokenPersistorTest {
         Collections.emptyMap(), new SystemTime());
     vcrReplicaThread.advanceToken(replica, response);
     assertEquals(token, getTokenFromAzureTable().getSecond());
-    assertEquals(VcrReplicationManager.DATE_FORMAT.format(lastOpTime),
+    DateFormat formatter = new SimpleDateFormat(VcrReplicationManager.DATE_FORMAT);
+    assertEquals(formatter.format(lastOpTime),
         getTokenFromAzureTable().getFirst().getProperty(VcrReplicationManager.REPLICATED_UNITL_UTC));
   }
 
@@ -273,6 +276,7 @@ public class CloudTokenPersistorTest {
   protected void uploadTokenToAzureTable(RemoteReplicaInfo replica, StoreFindToken token, long lastOpTime) {
     String partitionKey = String.valueOf(replica.getReplicaId().getPartitionId().getId());
     String rowKey = replica.getReplicaId().getDataNodeId().getHostname();
+    DateFormat formatter = new SimpleDateFormat(VcrReplicationManager.DATE_FORMAT);
     TableEntity entity = new TableEntity(partitionKey, rowKey)
         .addProperty(VcrReplicationManager.TOKEN_TYPE,
             token.getType().toString())
@@ -284,7 +288,7 @@ public class CloudTokenPersistorTest {
             token.getStoreKey() == null ? "none" : token.getStoreKey().getID())
         .addProperty(VcrReplicationManager.REPLICATED_UNITL_UTC,
             lastOpTime == Utils.Infinite_Time ? String.valueOf(Utils.Infinite_Time)
-                : VcrReplicationManager.DATE_FORMAT.format(lastOpTime))
+                : formatter.format(lastOpTime))
         .addProperty(VcrReplicationManager.BINARY_TOKEN,
             token.toBytes());
     azuriteClient.upsertTableEntity(azureTableNameReplicaTokens, entity);


### PR DESCRIPTION
SimpleDateFormat object is not thread-safe. Multiple replication threads were using the same instance causing exceptions. These exceptions were caught by replication logic which then tried to update a non-existing metric causing null pointer exc. I am not sure why the metric is absent but that's not important right now.