### PR TITLE
Add partial support for listing parts of Multipart Upload

### DIFF
--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestService.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestService.java
@@ -229,13 +229,13 @@ class FrontendRestRequestService implements RestRequestService {
         accountAndContainerInjector);
     s3DeleteHandler = new S3DeleteHandler(deleteBlobHandler, frontendMetrics);
     s3HeadHandler = new S3HeadHandler(headBlobHandler, securityService, frontendMetrics, accountService);
-    s3ListHandler = new S3ListHandler(namedBlobListHandler, frontendMetrics);
     s3HeadHandler = new S3HeadHandler(headBlobHandler, securityService, frontendMetrics, accountService);
     s3MultipartUploadHandler =
         new S3MultipartUploadHandler(securityService, frontendMetrics, accountAndContainerInjector, frontendConfig,
             namedBlobDb, idConverter, router, quotaManager);
     s3PostHandler = new S3PostHandler(s3MultipartUploadHandler);
     s3PutHandler = new S3PutHandler(namedBlobPutHandler, s3MultipartUploadHandler, frontendMetrics);
+    s3ListHandler = new S3ListHandler(namedBlobListHandler, frontendMetrics, s3MultipartUploadHandler);
     namedBlobsCleanupRunner = new NamedBlobsCleanupRunner(router, namedBlobDb);
     if (frontendConfig.enableNamedBlobCleanupTask) {
       namedBlobsCleanupScheduler = Utils.newScheduler(1, "named-blobs-cleanup-", false);
@@ -315,15 +315,14 @@ class FrontendRestRequestService implements RestRequestService {
       } else if (requestPath.matchesOperation(Operations.STATS_REPORT)) {
         getStatsReportHandler.handle(restRequest, restResponseChannel,
             (result, exception) -> submitResponse(restRequest, restResponseChannel, result, exception));
+      } else if (S3ListHandler.isListBucketRequest(restRequest) || S3MultipartUploadHandler.isListPartRequest(
+          restRequest)) {
+        s3ListHandler.handle(restRequest, restResponseChannel,
+            (result, exception) -> submitResponse(restRequest, restResponseChannel, result, exception));
       } else if (requestPath.matchesOperation(Operations.NAMED_BLOB)
           && NamedBlobPath.parse(requestPath, restRequest.getArgs()).getBlobName() == null) {
-        if (isS3Request(restRequest)) {
-          s3ListHandler.handle(restRequest, restResponseChannel,
-              (result, exception) -> submitResponse(restRequest, restResponseChannel, result, exception));
-        } else {
-          namedBlobListHandler.handle(restRequest, restResponseChannel,
-              (result, exception) -> submitResponse(restRequest, restResponseChannel, result, exception));
-        }
+        namedBlobListHandler.handle(restRequest, restResponseChannel,
+            (result, exception) -> submitResponse(restRequest, restResponseChannel, result, exception));
       } else if (RestUtils.getBooleanHeader(restRequest.getArgs(), ENABLE_DATASET_VERSION_LISTING, false)
           && DatasetVersionPath.parse(requestPath, restRequest.getArgs()).getVersion() == null) {
         listDatasetVersionHandler.handle(restRequest, restResponseChannel,

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3ListHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3ListHandler.java
@@ -21,7 +21,11 @@ import com.github.ambry.commons.Callback;
 import com.github.ambry.frontend.FrontendMetrics;
 import com.github.ambry.frontend.NamedBlobListEntry;
 import com.github.ambry.frontend.NamedBlobListHandler;
+import com.github.ambry.frontend.NamedBlobPath;
+import com.github.ambry.frontend.Operations;
 import com.github.ambry.frontend.Page;
+import com.github.ambry.rest.RequestPath;
+import com.github.ambry.rest.RestMethod;
 import com.github.ambry.rest.RestRequest;
 import com.github.ambry.rest.RestResponseChannel;
 import com.github.ambry.rest.RestServiceException;
@@ -43,6 +47,7 @@ import org.slf4j.LoggerFactory;
 
 import static com.github.ambry.frontend.FrontendUtils.*;
 import static com.github.ambry.frontend.s3.S3MessagePayload.*;
+import static com.github.ambry.rest.RestUtils.InternalKeys.*;
 
 
 /**
@@ -58,14 +63,18 @@ public class S3ListHandler extends S3BaseHandler<ReadableStreamChannel> {
   public static final String ENCODING_TYPE_PARAM_NAME = "encoding-type";
   private final NamedBlobListHandler namedBlobListHandler;
   private final FrontendMetrics metrics;
+  private final S3MultipartUploadHandler multipartUploadHandler;
 
   /**
    * Constructs a handler for handling s3 requests for listing blobs.
-   * @param namedBlobListHandler named blob list handler
+   * @param namedBlobListHandler  the {@link NamedBlobListHandler} to use.
+   * @param multipartUploadHandler the {@link S3MultipartUploadHandler} to use.
    */
-  public S3ListHandler(NamedBlobListHandler namedBlobListHandler, FrontendMetrics metrics) {
+  public S3ListHandler(NamedBlobListHandler namedBlobListHandler, FrontendMetrics metrics,
+      S3MultipartUploadHandler multipartUploadHandler) {
     this.namedBlobListHandler = namedBlobListHandler;
     this.metrics = metrics;
+    this.multipartUploadHandler = multipartUploadHandler;
   }
 
   /**
@@ -77,18 +86,25 @@ public class S3ListHandler extends S3BaseHandler<ReadableStreamChannel> {
   @Override
   protected void doHandle(RestRequest restRequest, RestResponseChannel restResponseChannel,
       Callback<ReadableStreamChannel> callback) {
-    namedBlobListHandler.handle(restRequest, restResponseChannel, buildCallback(metrics.s3ListHandleMetrics, (result) -> {
-      // Convert from json response to S3 xml response as defined in
-      // https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html#API_ListObjectsV2_ResponseSyntax.
-      ByteBuffer byteBuffer = ((ByteBufferReadableStreamChannel) result).getContent();
-      JSONObject jsonObject = new JSONObject(new JSONTokener(new ByteBufferDataInputStream(byteBuffer)));
-      Page<NamedBlobListEntry> page = Page.fromJson(jsonObject, NamedBlobListEntry::new);
-      ReadableStreamChannel readableStreamChannel = serializeAsXml(restRequest, page);
-      restResponseChannel.setHeader(RestUtils.Headers.DATE, new GregorianCalendar().getTime());
-      restResponseChannel.setHeader(RestUtils.Headers.CONTENT_TYPE, "application/xml");
-      restResponseChannel.setHeader(RestUtils.Headers.CONTENT_LENGTH, readableStreamChannel.getSize());
-      callback.onCompletion(readableStreamChannel, null);
-    }, restRequest.getUri(), LOGGER, callback));
+
+    if (S3MultipartUploadHandler.isListPartRequest(restRequest)) {
+      multipartUploadHandler.handle(restRequest, restResponseChannel, callback);
+      return;
+    }
+
+    namedBlobListHandler.handle(restRequest, restResponseChannel,
+        buildCallback(metrics.s3ListHandleMetrics, (result) -> {
+          // Convert from json response to S3 xml response as defined in
+          // https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html#API_ListObjectsV2_ResponseSyntax.
+          ByteBuffer byteBuffer = ((ByteBufferReadableStreamChannel) result).getContent();
+          JSONObject jsonObject = new JSONObject(new JSONTokener(new ByteBufferDataInputStream(byteBuffer)));
+          Page<NamedBlobListEntry> page = Page.fromJson(jsonObject, NamedBlobListEntry::new);
+          ReadableStreamChannel readableStreamChannel = serializeAsXml(restRequest, page);
+          restResponseChannel.setHeader(RestUtils.Headers.DATE, new GregorianCalendar().getTime());
+          restResponseChannel.setHeader(RestUtils.Headers.CONTENT_TYPE, "application/xml");
+          restResponseChannel.setHeader(RestUtils.Headers.CONTENT_LENGTH, readableStreamChannel.getSize());
+          callback.onCompletion(readableStreamChannel, null);
+        }, restRequest.getUri(), LOGGER, callback));
   }
 
   private ReadableStreamChannel serializeAsXml(RestRequest restRequest, Page<NamedBlobListEntry> namedBlobRecordPage)
@@ -117,5 +133,16 @@ public class S3ListHandler extends S3BaseHandler<ReadableStreamChannel> {
     // Serialize xml
     xmlMapper.writeValue(outputStream, result);
     return new ByteBufferReadableStreamChannel(ByteBuffer.wrap(outputStream.toByteArray()));
+  }
+
+  /**
+   * @param restRequest the {@link RestRequest} that contains the request parameters.
+   * @return {@code True} if it is a request to list parts of a completed multipart upload request.
+   */
+  public static boolean isListBucketRequest(RestRequest restRequest) throws RestServiceException {
+    RequestPath requestPath = (RequestPath) restRequest.getArgs().get(REQUEST_PATH);
+    return restRequest.getRestMethod() == RestMethod.GET && restRequest.getArgs().containsKey(S3_REQUEST)
+        && requestPath.matchesOperation(Operations.NAMED_BLOB)
+        && NamedBlobPath.parse(requestPath, restRequest.getArgs()).getBlobName() == null;
   }
 }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3MessagePayload.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3MessagePayload.java
@@ -240,4 +240,29 @@ public class S3MessagePayload {
       return "Key=" + key + ", " + "LastModified=" + lastModified;
     }
   }
+
+  public static class ListPartsResult {
+
+    @JacksonXmlProperty(localName = "Bucket")
+    private String bucket;
+    @JacksonXmlProperty(localName = "Key")
+    private String key;
+    @JacksonXmlProperty(localName = "UploadId")
+    private String uploadId;
+
+    public ListPartsResult() {
+
+    }
+
+    public ListPartsResult(String bucket, String key, String uploadId) {
+      this.bucket = bucket;
+      this.key = key;
+      this.uploadId = uploadId;
+    }
+
+    @Override
+    public String toString() {
+      return "Bucket=" + bucket + ", Key=" + key + ", UploadId=" + uploadId;
+    }
+  }
 }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3MultipartCompleteUploadHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3MultipartCompleteUploadHandler.java
@@ -251,15 +251,10 @@ public class S3MultipartCompleteUploadHandler {
     private Callback<Void> routerTtlUpdateCallback(BlobInfo blobInfo, String blobId) {
       return buildCallback(frontendMetrics.updateBlobTtlRouterMetrics, convertedBlobId -> {
         // Set the named blob state to be 'READY' after the Ttl update succeed
-        if (!restRequest.getArgs().containsKey(RestUtils.InternalKeys.NAMED_BLOB_VERSION)) {
-          throw new RestServiceException("Internal key " + RestUtils.InternalKeys.NAMED_BLOB_VERSION
-              + " is required in Named Blob TTL update callback!", RestServiceErrorCode.InternalServerError);
-        }
-        long namedBlobVersion = (long) restRequest.getArgs().get(NAMED_BLOB_VERSION);
         String blobIdClean = RestUtils.stripSlashAndExtensionFromId(blobId);
         NamedBlobPath namedBlobPath = NamedBlobPath.parse(RestUtils.getRequestPath(restRequest), restRequest.getArgs());
         NamedBlobRecord record = new NamedBlobRecord(namedBlobPath.getAccountName(), namedBlobPath.getContainerName(),
-            namedBlobPath.getBlobName(), blobIdClean, Utils.Infinite_Time, namedBlobVersion);
+            namedBlobPath.getBlobName(), blobIdClean, Utils.Infinite_Time);
         namedBlobDb.updateBlobTtlAndStateToReady(record).get();
         securityService.processResponse(restRequest, restResponseChannel, blobInfo, securityProcessResponseCallback());
       }, uri, LOGGER, finalCallback);

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3MultipartCreateUploadHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3MultipartCreateUploadHandler.java
@@ -42,8 +42,8 @@ import static com.github.ambry.frontend.s3.S3MessagePayload.*;
  * Handles a request for s3 CreateMultipartUploads according to the
  * <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">...</a>
  */
-public class S3CreateMultipartUploadHandler {
-  private static final Logger LOGGER = LoggerFactory.getLogger(S3CreateMultipartUploadHandler.class);
+public class S3MultipartCreateUploadHandler {
+  private static final Logger LOGGER = LoggerFactory.getLogger(S3MultipartCreateUploadHandler.class);
   private static final ObjectMapper objectMapper = new XmlMapper();
   private final SecurityService securityService;
   private final FrontendMetrics frontendMetrics;
@@ -53,7 +53,7 @@ public class S3CreateMultipartUploadHandler {
    * @param securityService   the {@link SecurityService} to use.
    * @param frontendMetrics   {@link FrontendMetrics} instance where metrics should be recorded.
    */
-  public S3CreateMultipartUploadHandler(SecurityService securityService, FrontendMetrics frontendMetrics) {
+  public S3MultipartCreateUploadHandler(SecurityService securityService, FrontendMetrics frontendMetrics) {
     this.securityService = securityService;
     this.frontendMetrics = frontendMetrics;
   }
@@ -65,7 +65,7 @@ public class S3CreateMultipartUploadHandler {
    */
   void handle(RestRequest restRequest, RestResponseChannel restResponseChannel,
       Callback<ReadableStreamChannel> callback) {
-    new S3CreateMultipartUploadHandler.CallbackChain(restRequest, restResponseChannel, callback).start();
+    new S3MultipartCreateUploadHandler.CallbackChain(restRequest, restResponseChannel, callback).start();
   }
 
   /**

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3MultipartListPartsHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3MultipartListPartsHandler.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2024 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ */
+package com.github.ambry.frontend.s3;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.github.ambry.commons.ByteBufferReadableStreamChannel;
+import com.github.ambry.commons.Callback;
+import com.github.ambry.frontend.AccountAndContainerInjector;
+import com.github.ambry.frontend.FrontendMetrics;
+import com.github.ambry.frontend.NamedBlobPath;
+import com.github.ambry.frontend.SecurityService;
+import com.github.ambry.rest.RequestPath;
+import com.github.ambry.rest.RestRequest;
+import com.github.ambry.rest.RestResponseChannel;
+import com.github.ambry.rest.RestServiceException;
+import com.github.ambry.rest.RestUtils;
+import com.github.ambry.router.ReadableStreamChannel;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.GregorianCalendar;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.github.ambry.frontend.FrontendUtils.*;
+import static com.github.ambry.frontend.s3.S3MessagePayload.*;
+import static com.github.ambry.rest.RestUtils.InternalKeys.*;
+import static com.github.ambry.rest.RestUtils.*;
+
+
+/**
+ * Handles a request for listing parts that have been uploaded for a specific multipart upload ID.
+ * <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html">...</a>
+ * TODO [S3] For now, this API returns empty list. Flink only uses it before starting a new multipart upload. So,
+ *  sending an empty list unblocks them. In future, we may need to fetch the actual part IDs.
+ */
+public class S3MultipartListPartsHandler {
+  private static final Logger LOGGER = LoggerFactory.getLogger(S3MultipartListPartsHandler.class);
+  private static final ObjectMapper objectMapper = new XmlMapper();
+  private final SecurityService securityService;
+  private final FrontendMetrics frontendMetrics;
+  private final AccountAndContainerInjector accountAndContainerInjector;
+
+  /**
+   * Construct a handler for handling S3 ListParts requests during multipart uploads.
+   *
+   * @param securityService             the {@link SecurityService} to use.
+   * @param frontendMetrics             {@link FrontendMetrics} instance where metrics should be recorded.
+   * @param accountAndContainerInjector helper to resolve account and container for a given request.
+   */
+  public S3MultipartListPartsHandler(SecurityService securityService, FrontendMetrics frontendMetrics,
+      AccountAndContainerInjector accountAndContainerInjector) {
+    this.securityService = securityService;
+    this.frontendMetrics = frontendMetrics;
+    this.accountAndContainerInjector = accountAndContainerInjector;
+  }
+
+  /**
+   * @param restRequest the {@link RestRequest} that contains the request parameters.
+   * @param restResponseChannel the {@link RestResponseChannel} where headers should be set.
+   * @param callback the {@link Callback} to invoke when the response is ready (or if there is an exception).
+   */
+  void handle(RestRequest restRequest, RestResponseChannel restResponseChannel,
+      Callback<ReadableStreamChannel> callback) {
+    new S3MultipartListPartsHandler.CallbackChain(restRequest, restResponseChannel, callback).start();
+  }
+
+  /**
+   * Represents the chain of actions to take. Keeps request context that is relevant to all callback stages.
+   */
+  private class CallbackChain {
+    private final RestRequest restRequest;
+    private final RestResponseChannel restResponseChannel;
+    private final Callback<ReadableStreamChannel> finalCallback;
+    private final String uri;
+
+    /**
+     * @param restRequest the {@link RestRequest}.
+     * @param restResponseChannel the {@link RestResponseChannel}.
+     * @param finalCallback the {@link Callback} to call on completion.
+     */
+    private CallbackChain(RestRequest restRequest, RestResponseChannel restResponseChannel,
+        Callback<ReadableStreamChannel> finalCallback) {
+      this.restRequest = restRequest;
+      this.restResponseChannel = restResponseChannel;
+      this.finalCallback = finalCallback;
+      this.uri = restRequest.getUri();
+    }
+
+    /**
+     * Start the chain by calling {@link SecurityService#processRequest}.
+     */
+    private void start() {
+      try {
+        accountAndContainerInjector.injectAccountContainerForNamedBlob(restRequest,
+            frontendMetrics.getBlobMetricsGroup);
+        securityService.processRequest(restRequest, securityProcessRequestCallback());
+      } catch (Exception e) {
+        finalCallback.onCompletion(null, e);
+      }
+    }
+
+    /**
+     * After {@link SecurityService#processRequest} finishes, call {@link SecurityService#postProcessRequest} to perform
+     * request time security checks that rely on the request being fully parsed and any additional arguments set.
+     * @return a {@link Callback} to be used with {@link SecurityService#processRequest}.
+     */
+    private Callback<Void> securityProcessRequestCallback() {
+      return buildCallback(frontendMetrics.putSecurityProcessRequestMetrics, securityCheckResult -> {
+        securityService.postProcessRequest(restRequest, securityPostProcessRequestCallback());
+      }, uri, LOGGER, finalCallback);
+    }
+
+    /**
+     * After {@link SecurityService#postProcessRequest} finishes, return response for the request.
+     * @return a {@link Callback} to be used with {@link SecurityService#postProcessRequest}.
+     */
+    private Callback<Void> securityPostProcessRequestCallback() {
+      return buildCallback(frontendMetrics.putSecurityPostProcessRequestMetrics, securityCheckResult -> {
+        try {
+          RequestPath requestPath = (RequestPath) restRequest.getArgs().get(REQUEST_PATH);
+          NamedBlobPath namedBlobPath = NamedBlobPath.parse(requestPath, restRequest.getArgs());
+          String bucket = namedBlobPath.getAccountName();
+          String key = namedBlobPath.getBlobName();
+          String uploadId = (String) restRequest.getArgs().get(UPLOAD_ID_QUERY_PARAM);
+          LOGGER.debug(
+              "Sending response for listing parts of a multipart upload. Bucket = {}, Key = {}, Upload Id = {}", bucket,
+              key, uploadId);
+          ListPartsResult listPartsResult = new ListPartsResult(bucket, key, uploadId);
+          ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+          objectMapper.writeValue(outputStream, listPartsResult);
+          ReadableStreamChannel channel =
+              new ByteBufferReadableStreamChannel(ByteBuffer.wrap(outputStream.toByteArray()));
+          restResponseChannel.setHeader(RestUtils.Headers.DATE, new GregorianCalendar().getTime());
+          restResponseChannel.setHeader(RestUtils.Headers.CONTENT_TYPE, "application/xml");
+          restResponseChannel.setHeader(RestUtils.Headers.CONTENT_LENGTH, channel.getSize());
+          finalCallback.onCompletion(channel, null);
+        } catch (RestServiceException | IOException e) {
+          finalCallback.onCompletion(null, e);
+        }
+      }, uri, LOGGER, finalCallback);
+    }
+  }
+}

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3MultipartUploadHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3MultipartUploadHandler.java
@@ -22,16 +22,12 @@ import com.github.ambry.frontend.IdConverter;
 import com.github.ambry.frontend.SecurityService;
 import com.github.ambry.named.NamedBlobDb;
 import com.github.ambry.quota.QuotaManager;
-import com.github.ambry.rest.RestMethod;
 import com.github.ambry.rest.RestRequest;
 import com.github.ambry.rest.RestResponseChannel;
 import com.github.ambry.rest.RestServiceErrorCode;
 import com.github.ambry.rest.RestServiceException;
 import com.github.ambry.router.ReadableStreamChannel;
 import com.github.ambry.router.Router;
-
-import static com.github.ambry.rest.RestUtils.*;
-import static com.github.ambry.rest.RestUtils.InternalKeys.*;
 
 
 /**
@@ -76,53 +72,17 @@ public class S3MultipartUploadHandler extends S3BaseHandler<ReadableStreamChanne
   @Override
   protected void doHandle(RestRequest restRequest, RestResponseChannel restResponseChannel,
       Callback<ReadableStreamChannel> callback) throws RestServiceException {
-    if (isCreateRequest(restRequest)) {
+    if (isMultipartCreateUploadRequest(restRequest)) {
       createMultipartUploadHandler.handle(restRequest, restResponseChannel, callback);
-    } else if (isUploadPartRequest(restRequest)) {
+    } else if (isMultipartUploadPartRequest(restRequest)) {
       uploadPartHandler.handle(restRequest, restResponseChannel, callback);
-    } else if (isCompleteRequest(restRequest)) {
+    } else if (isMultipartCompleteUploadRequest(restRequest)) {
       completeMultipartUploadHandler.handle(restRequest, restResponseChannel, callback);
-    } else if (isListPartRequest(restRequest)) {
+    } else if (isMultipartListPartRequest(restRequest)) {
       listPartsHandler.handle(restRequest, restResponseChannel, callback);
     } else {
       callback.onCompletion(null,
           new RestServiceException("Invalid S3 Multipart request", RestServiceErrorCode.BadRequest));
     }
-  }
-
-  /**
-   * @param restRequest the {@link RestRequest} that contains the request parameters.
-   * @return {@code True} if it is a creation/initiation of multipart uploads.
-   */
-  public static boolean isCreateRequest(RestRequest restRequest) {
-    return restRequest.getRestMethod() == RestMethod.POST && restRequest.getArgs().containsKey(S3_REQUEST)
-        && restRequest.getArgs().containsKey(UPLOADS_QUERY_PARAM);
-  }
-
-  /**
-   * @param restRequest the {@link RestRequest} that contains the request parameters.
-   * @return {@code True} if it is a completion/abortion of multipart uploads.
-   */
-  public static boolean isCompleteRequest(RestRequest restRequest) {
-    return restRequest.getRestMethod() == RestMethod.POST && restRequest.getArgs().containsKey(S3_REQUEST)
-        && restRequest.getArgs().containsKey(UPLOAD_ID_QUERY_PARAM);
-  }
-
-  /**
-   * @param restRequest the {@link RestRequest} that contains the request parameters.
-   * @return {@code True} if it is an upload part request for multipart uploads.
-   */
-  public static boolean isUploadPartRequest(RestRequest restRequest) {
-    return restRequest.getRestMethod() == RestMethod.PUT && restRequest.getArgs().containsKey(S3_REQUEST)
-        && restRequest.getArgs().containsKey(UPLOAD_ID_QUERY_PARAM);
-  }
-
-  /**
-   * @param restRequest the {@link RestRequest} that contains the request parameters.
-   * @return {@code True} if it is a request to list parts of a completed multipart upload request.
-   */
-  public static boolean isListPartRequest(RestRequest restRequest) {
-    return restRequest.getRestMethod() == RestMethod.GET && restRequest.getArgs().containsKey(S3_REQUEST)
-        && restRequest.getArgs().containsKey(UPLOAD_ID_QUERY_PARAM);
   }
 }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3PostHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3PostHandler.java
@@ -45,8 +45,8 @@ public class S3PostHandler extends S3BaseHandler<ReadableStreamChannel> {
   @Override
   protected void doHandle(RestRequest restRequest, RestResponseChannel restResponseChannel,
       Callback<ReadableStreamChannel> callback) throws RestServiceException {
-    if (S3MultipartUploadHandler.isCreateRequest(restRequest) || S3MultipartUploadHandler.isCompleteRequest(
-        restRequest)) {
+    if (S3MultipartUploadHandler.isMultipartCreateUploadRequest(restRequest)
+        || S3MultipartUploadHandler.isMultipartCompleteUploadRequest(restRequest)) {
       multipartPostHandler.handle(restRequest, restResponseChannel, callback);
     } else {
       // Placeholder for handling any non-multipart S3 POST requests in the future.

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3PostHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3PostHandler.java
@@ -21,8 +21,6 @@ import com.github.ambry.rest.RestServiceErrorCode;
 import com.github.ambry.rest.RestServiceException;
 import com.github.ambry.router.ReadableStreamChannel;
 
-import static com.github.ambry.rest.RestUtils.*;
-
 
 /**
  * Handles S3 POST requests.
@@ -47,16 +45,12 @@ public class S3PostHandler extends S3BaseHandler<ReadableStreamChannel> {
   @Override
   protected void doHandle(RestRequest restRequest, RestResponseChannel restResponseChannel,
       Callback<ReadableStreamChannel> callback) throws RestServiceException {
-    if (isMultipartUploadRequest(restRequest)) {
+    if (S3MultipartUploadHandler.isCreateRequest(restRequest) || S3MultipartUploadHandler.isCompleteRequest(
+        restRequest)) {
       multipartPostHandler.handle(restRequest, restResponseChannel, callback);
     } else {
       // Placeholder for handling any non-multipart S3 POST requests in the future.
       throw new RestServiceException("Unsupported S3 POST request", RestServiceErrorCode.BadRequest);
     }
-  }
-
-  private boolean isMultipartUploadRequest(RestRequest restRequest) {
-    return restRequest.getArgs().containsKey(UPLOADS_QUERY_PARAM) || restRequest.getArgs()
-        .containsKey(UPLOAD_ID_QUERY_PARAM);
   }
 }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3PutHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3PutHandler.java
@@ -63,7 +63,7 @@ public class S3PutHandler extends S3BaseHandler<Void> {
   @Override
   protected void doHandle(RestRequest restRequest, RestResponseChannel restResponseChannel, Callback<Void> callback)
       throws RestServiceException {
-    if (isMultipartUploadRequest(restRequest)) {
+    if (S3MultipartUploadHandler.isUploadPartRequest(restRequest)) {
       multipartUploadHandler.handle(restRequest, restResponseChannel,
           (result, exception) -> callback.onCompletion(null, exception));
       return;
@@ -88,10 +88,5 @@ public class S3PutHandler extends S3BaseHandler<Void> {
       }
       callback.onCompletion(null, null);
     }, restRequest.getUri(), LOGGER, callback));
-  }
-
-  private boolean isMultipartUploadRequest(RestRequest restRequest) {
-    return restRequest.getArgs().containsKey(UPLOADS_QUERY_PARAM) || restRequest.getArgs()
-        .containsKey(UPLOAD_ID_QUERY_PARAM);
   }
 }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3PutHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3PutHandler.java
@@ -63,7 +63,7 @@ public class S3PutHandler extends S3BaseHandler<Void> {
   @Override
   protected void doHandle(RestRequest restRequest, RestResponseChannel restResponseChannel, Callback<Void> callback)
       throws RestServiceException {
-    if (S3MultipartUploadHandler.isUploadPartRequest(restRequest)) {
+    if (S3MultipartUploadHandler.isMultipartUploadPartRequest(restRequest)) {
       multipartUploadHandler.handle(restRequest, restResponseChannel,
           (result, exception) -> callback.onCompletion(null, exception));
       return;

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
@@ -41,6 +41,7 @@ import com.github.ambry.config.FrontendConfig;
 import com.github.ambry.config.QuotaConfig;
 import com.github.ambry.config.RouterConfig;
 import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.frontend.s3.S3MultipartUploadHandler;
 import com.github.ambry.messageformat.BlobInfo;
 import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.named.DeleteResult;
@@ -4152,8 +4153,8 @@ class FrontendTestIdConverterFactory implements IdConverterFactory {
       if (!isOpen) {
         throw new IllegalStateException("IdConverter closed");
       }
-      if (restRequest.getRestMethod() == RestMethod.PUT && RestUtils.getRequestPath(restRequest)
-          .matchesOperation(Operations.NAMED_BLOB)) {
+      if ((restRequest.getRestMethod() == RestMethod.PUT || restRequest.getRestMethod() == RestMethod.POST)
+          && RestUtils.getRequestPath(restRequest).matchesOperation(Operations.NAMED_BLOB)) {
         restRequest.setArg(RestUtils.InternalKeys.NAMED_BLOB_VERSION, -1L);
       }
       return completeOperation(input, blobInfo, callback);

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/S3ListHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/S3ListHandlerTest.java
@@ -156,6 +156,6 @@ public class S3ListHandlerTest {
         CLUSTER_NAME, QuotaTestUtils.createDummyQuotaManager(), ACCOUNT_SERVICE, null);
     NamedBlobListHandler namedBlobListHandler =
         new NamedBlobListHandler(securityServiceFactory.getSecurityService(), namedBlobDb, injector, metrics);
-    s3ListHandler = new S3ListHandler(namedBlobListHandler, metrics);
+    s3ListHandler = new S3ListHandler(namedBlobListHandler, metrics, null);
   }
 }

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/S3ListHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/S3ListHandlerTest.java
@@ -156,6 +156,6 @@ public class S3ListHandlerTest {
         CLUSTER_NAME, QuotaTestUtils.createDummyQuotaManager(), ACCOUNT_SERVICE, null);
     NamedBlobListHandler namedBlobListHandler =
         new NamedBlobListHandler(securityServiceFactory.getSecurityService(), namedBlobDb, injector, metrics);
-    s3ListHandler = new S3ListHandler(namedBlobListHandler, metrics, null);
+    s3ListHandler = new S3ListHandler(namedBlobListHandler, metrics);
   }
 }


### PR DESCRIPTION
This PR adds support for listing parts for a completed multipart upload. For now, the API returns empty list. Flink customer only uses it before starting a new multipart upload. So, sending an empty list unblocks them. In future, we may need to fetch the actual part IDs.

Reference API: https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html

Also renamed `S3CreateMultipartUploadHandler` to `S3MultipartCreateUploadHandler` and `S3CompleteMultipartUploadHandler` to `S3MultipartCompleteUploadHandler`