### PR TITLE
[vcr-2.0] Add error-metric when checking blob exists

### DIFF
--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestinationSync.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestinationSync.java
@@ -767,8 +767,8 @@ public class AzureCloudDestinationSync implements CloudDestination {
     try {
       return createOrGetBlobStore(blobLayout.containerName).getBlobClient(blobLayout.blobFilePath).exists();
     } catch (Throwable t) {
-      String error = String.format("Failed to check if blob %s exists in Azure blob storage due to %s", blobLayout, t.getMessage());
-      logger.error(error);
+      azureMetrics.blobCheckError.inc();
+      logger.error("Failed to check if blob {} exists in Azure blob storage due to {}", blobLayout, t.getMessage());
       return false;
     }
   }

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureMetrics.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureMetrics.java
@@ -200,10 +200,14 @@ public class AzureMetrics {
   public static final String COMPACTION_TASK_ERROR_COUNT = "CompactionTaskErrorCount";
   public final Counter compactionTaskErrorCount;
 
+  public static final String BLOB_CHECK_ERROR = "BlobCheckError";
+  public final Counter blobCheckError;
+
   public AzureMetrics(MetricRegistry registry) {
     this.metricRegistry = registry;
 
     // V2 metrics
+    blobCheckError = registry.counter(MetricRegistry.name(AzureMetrics.class, BLOB_CHECK_ERROR));
     blobCompactionErrorCount = registry.counter(MetricRegistry.name(AzureMetrics.class, BLOB_COMPACTION_ERROR_COUNT));
     blobCompactionLatency = registry.timer(MetricRegistry.name(AzureMetrics.class, BLOB_COMPACTION_LATENCY));
     blobCompactionSuccessRate = registry.meter(MetricRegistry.name(AzureMetrics.class, BLOB_COMPACTION_SUCCESS_RATE));


### PR DESCRIPTION
Emit an error metric when we encounter a failure to check if a blob exists in Azure Storage.