### PR TITLE
[vcr-2.0] Backup local-leader only for faster progress

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/CloudConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/CloudConfig.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.config;
 
+import com.github.ambry.replication.ReplicationModelType;
 import com.github.ambry.utils.Utils;
 import java.util.HashSet;
 import java.util.Set;
@@ -448,8 +449,20 @@ public class CloudConfig {
   @Default("false")
   public final boolean vcrHelixUpdateDryRun;
 
+  /**
+   * To specify the type of replication to be used for backup.
+   * If set to "LEADER_BASED", VCR will back up local-leader only.
+   * If set to "ALL_TO_ALL", VCR will back up all local-replicas.
+   */
+  public final String BACKUP_POLICY = "backup.policy";
+  public final ReplicationModelType DEFAULT_BACKUP_POLICY = ReplicationModelType.ALL_TO_ALL;
+  @Config(BACKUP_POLICY)
+  public final ReplicationModelType backupPolicy;
+
+
   public CloudConfig(VerifiableProperties verifiableProperties) {
 
+    backupPolicy = ReplicationModelType.valueOf(verifiableProperties.getString(BACKUP_POLICY, DEFAULT_BACKUP_POLICY.name()));
     cloudCompactionGracePeriodDays = verifiableProperties.getInt(CLOUD_COMPACTION_GRACE_PERIOD_DAYS, 7);
     cloudCompactionDryRunEnabled = verifiableProperties.getBoolean(CLOUD_COMPACTION_DRY_RUN_ENABLED, true);
     ambryBackupVersion = verifiableProperties.getString(AMBRY_BACKUP_VERSION, DEFAULT_AMBRY_BACKUP_VERSION);

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicationManager.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicationManager.java
@@ -27,6 +27,7 @@ import com.github.ambry.clustermap.HelixClusterManager;
 import com.github.ambry.clustermap.HelixVcrUtil;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.clustermap.ReplicaId;
+import com.github.ambry.clustermap.ReplicaState;
 import com.github.ambry.clustermap.ReplicaSyncUpManager;
 import com.github.ambry.clustermap.ReplicaType;
 import com.github.ambry.clustermap.VcrClusterParticipant;
@@ -353,7 +354,8 @@ public class VcrReplicationManager extends ReplicationEngine {
       logger.error("Can't start cloudstore for replica {}", cloudReplica);
       throw new ReplicationException("Can't start cloudstore for replica " + cloudReplica);
     }
-    List<? extends ReplicaId> peerReplicas = cloudReplica.getPeerReplicaIds();
+    String localDc = vcrClusterParticipant.getCurrentDataNodeId().getDatacenterName();
+    List<? extends ReplicaId> peerReplicas = partitionId.getReplicaIdsByState(ReplicaState.LEADER, localDc);
     List<RemoteReplicaInfo> remoteReplicaInfos = new ArrayList<>();
     Store store = storeManager.getStore(partitionId);
     if (peerReplicas != null) {

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicationManager.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicationManager.java
@@ -367,8 +367,10 @@ public class VcrReplicationManager extends ReplicationEngine {
         logger.info("Backing up leader at {}:{} for partition {}", peerReplicas.get(0).getDataNodeId().getHostname(),
             peerReplicas.get(0).getMountPath(), partitionId.getId());
       }
-    } else {
+    } else if (cloudConfig.backupPolicy.equals(ReplicationModelType.ALL_TO_ALL)) {
       peerReplicas = cloudReplica.getPeerReplicaIds();
+    } else {
+      logger.error("Unrecognized backup policy {}", cloudConfig.backupPolicy);
     }
     List<RemoteReplicaInfo> remoteReplicaInfos = new ArrayList<>();
     Store store = storeManager.getStore(partitionId);


### PR DESCRIPTION
A flaw in replication causes some unnecessary traffic to Azure. Its not a bug or error, but a logical flaw.

1/ vcr-node fetches a list of blob-ids from all 3 replicas of a partition
2/ vcr-node filters missing blob-ids from all 3 lists by checking azure, these 3 missing-blob-lists are identical
3/ vcr-node fetches blob data from all 3 replicas for missing blobs
4/ vcr-node uploads missing blobs from all 3 replicas one replica at a time

The uploads from the first replica succeed, but the next two fail causing a blobUploadConflictCount error.
Its not due to multiple threads trying to replicate in parallel and writing to Azure. Confirmed this by assigning all 3 replicas to the same replication thread.

This happens in server-server replication also. But there it is cheap to keep checking the index or disk just before writing a blob to disk and there are locks to guard from concurrent PUT. Its not so cheap to keep doing that for Azure and there is no concurrency control or other mechanisms to prevent uploading the same blob twice. VCR-1.0 attempted to solve this using a recentBlobCache but that had a few issues and corner cases.
Short term solution is to do just leader-based replication between VCR and server for a 1-2 months until the backup finishes. Backups are a bit slow right now. Long term solution is to find a cheaper way to avoid multiple uploads of the same blob.

