### PR TITLE
Add buffered directio to compaction

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -159,6 +159,15 @@ public class StoreConfig {
   public final boolean storeCompactionEnableDirectIO;
 
   /**
+   * The buffer size when using direct io in compaction to write to the target log segments.
+   * 0 means no buffer for direct io. And buffer size has to be a multiple of file system blob size.
+   */
+  @Config(storeCompactionDirectIOBufferSizeName)
+  @Default("0")
+  public final int storeCompactionDirectIOBufferSize;
+  public static final String storeCompactionDirectIOBufferSizeName = "store.compaction.direct.io.buffer.size";
+
+  /**
    * Whether to purge expired delete tombstone in compaction.
    */
   @Config("store.compaction.purge.delete.tombstone")
@@ -647,6 +656,8 @@ public class StoreConfig {
     storeCompactionThrottlerCheckIntervalMs =
         verifiableProperties.getIntInRange("store.compaction.throttler.check.interval.ms", -1, -1, Integer.MAX_VALUE);
     storeCompactionEnableDirectIO = verifiableProperties.getBoolean("store.compaction.enable.direct.io", false);
+    storeCompactionDirectIOBufferSize =
+        verifiableProperties.getIntInRange(storeCompactionDirectIOBufferSizeName, 0, 0, 100 * 1024 * 1024);
     storeCompactionPurgeDeleteTombstone =
         verifiableProperties.getBoolean("store.compaction.purge.delete.tombstone", false);
     storeCompactionMinBufferSize =

--- a/ambry-store/src/main/java/com/github/ambry/store/LogSegment.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/LogSegment.java
@@ -543,6 +543,7 @@ class LogSegment implements Read, Write {
    */
   void flush() throws IOException {
     fileChannel.force(true);
+    directIOExecutor.flush();
   }
 
   /**
@@ -554,10 +555,12 @@ class LogSegment implements Read, Write {
     if (open.compareAndSet(true, false)) {
       if (!skipDiskFlush) {
         flush();
+        directIOExecutor.flush();
       }
       try {
         // attempt to close file descriptors even when there is a disk I/O error.
         fileChannel.close();
+        directIOExecutor.close();
       } catch (IOException e) {
         if (!skipDiskFlush) {
           throw e;

--- a/ambry-store/src/main/java/com/github/ambry/store/LogSegment.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/LogSegment.java
@@ -91,6 +91,7 @@ class LogSegment implements Read, Write {
     this.name = name;
     this.capacityInBytes = capacityInBytes;
     this.metrics = metrics;
+    this.directIOExecutor = createDirectIOExecutor(config.storeCompactionDirectIOBufferSize);
     try {
       fileChannel = Utils.openChannel(file, true);
       segmentView = new Pair<>(file, fileChannel);
@@ -104,7 +105,6 @@ class LogSegment implements Read, Write {
       if (config.storeSetFilePermissionEnabled) {
         Files.setPosixFilePermissions(this.file.toPath(), config.storeDataFilePermission);
       }
-      directIOExecutor = createDirectIOExecutor(config.storeCompactionDirectIOBufferSize);
     } catch (IOException e) {
       throw new StoreException("File not found while creating the log segment", e, StoreErrorCodes.File_Not_Found);
     }

--- a/ambry-store/src/main/java/com/github/ambry/store/LogSegment.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/LogSegment.java
@@ -151,13 +151,13 @@ class LogSegment implements Read, Write {
       this.name = name;
       this.metrics = metrics;
       fileChannel = Utils.openChannel(file, true);
+      directIOExecutor = createDirectIOExecutor(config.storeCompactionDirectIOBufferSize);
       segmentView = new Pair<>(file, fileChannel);
       // externals will set the correct value of end offset.
       endOffset = new AtomicLong(startOffset);
       if (config.storeSetFilePermissionEnabled) {
         Files.setPosixFilePermissions(this.file.toPath(), config.storeDataFilePermission);
       }
-      directIOExecutor = createDirectIOExecutor(config.storeCompactionDirectIOBufferSize);
     } catch (FileNotFoundException e) {
       throw new StoreException("File not found while creating log segment [" + file.getAbsolutePath() + "]", e,
           StoreErrorCodes.File_Not_Found);
@@ -190,6 +190,7 @@ class LogSegment implements Read, Write {
     this.capacityInBytes = capacityInBytes;
     this.metrics = metrics;
     this.fileChannel = fileChannel;
+    this.directIOExecutor = createDirectIOExecutor(config.storeCompactionDirectIOBufferSize);
     try {
       segmentView = new Pair<>(file, fileChannel);
       // externals will set the correct value of end offset.
@@ -200,7 +201,6 @@ class LogSegment implements Read, Write {
       if (config.storeSetFilePermissionEnabled) {
         Files.setPosixFilePermissions(file.toPath(), config.storeDataFilePermission);
       }
-      directIOExecutor = createDirectIOExecutor(config.storeCompactionDirectIOBufferSize);
     } catch (IOException e) {
       // the IOException comes from Files.setPosixFilePermissions which happens when file not found
       throw new StoreException("File not found while creating log segment", e, StoreErrorCodes.File_Not_Found);

--- a/ambry-store/src/main/java/com/github/ambry/store/LogSegment.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/LogSegment.java
@@ -555,7 +555,6 @@ class LogSegment implements Read, Write {
     if (open.compareAndSet(true, false)) {
       if (!skipDiskFlush) {
         flush();
-        directIOExecutor.flush();
       }
       try {
         // attempt to close file descriptors even when there is a disk I/O error.
@@ -655,8 +654,8 @@ class LogSegment implements Read, Write {
 
     @Override
     public <T> T execute(DirectIOOp<T> op) throws IOException {
-      // the direct io executes all the operation in the same thread so we don't need
-      // to care able the thread safety.
+      // The direct io executes all the operation in the same thread, we don't need
+      // to care about the thread safety.
       if (directIo == null) {
         directIo = DirectIoByteChannelAligner.open(file, bufferSize, false);
       }

--- a/ambry-store/src/main/java/com/github/ambry/store/LogSegment.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/LogSegment.java
@@ -17,6 +17,7 @@ import com.github.ambry.config.StoreConfig;
 import com.github.ambry.utils.CrcInputStream;
 import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.Utils;
+import java.io.Closeable;
 import java.io.DataInputStream;
 import java.io.EOFException;
 import java.io.File;
@@ -33,6 +34,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.zip.CRC32;
 import net.smacke.jaydio.DirectRandomAccessFile;
+import net.smacke.jaydio.align.DirectIoByteChannelAligner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,6 +67,8 @@ class LogSegment implements Read, Write {
   private ByteBuffer byteBufferForAppend = null;
   static final AtomicInteger byteBufferForAppendTotalCount = new AtomicInteger(0);
   private static final Logger logger = LoggerFactory.getLogger(LogSegment.class);
+
+  private final DirectIOExecutor directIOExecutor;
 
   /**
    * Creates a LogSegment abstraction with the given capacity.
@@ -100,6 +104,7 @@ class LogSegment implements Read, Write {
       if (config.storeSetFilePermissionEnabled) {
         Files.setPosixFilePermissions(this.file.toPath(), config.storeDataFilePermission);
       }
+      directIOExecutor = createDirectIOExecutor(config.storeCompactionDirectIOBufferSize);
     } catch (IOException e) {
       throw new StoreException("File not found while creating the log segment", e, StoreErrorCodes.File_Not_Found);
     }
@@ -152,6 +157,7 @@ class LogSegment implements Read, Write {
       if (config.storeSetFilePermissionEnabled) {
         Files.setPosixFilePermissions(this.file.toPath(), config.storeDataFilePermission);
       }
+      directIOExecutor = createDirectIOExecutor(config.storeCompactionDirectIOBufferSize);
     } catch (FileNotFoundException e) {
       throw new StoreException("File not found while creating log segment [" + file.getAbsolutePath() + "]", e,
           StoreErrorCodes.File_Not_Found);
@@ -194,10 +200,18 @@ class LogSegment implements Read, Write {
       if (config.storeSetFilePermissionEnabled) {
         Files.setPosixFilePermissions(file.toPath(), config.storeDataFilePermission);
       }
+      directIOExecutor = createDirectIOExecutor(config.storeCompactionDirectIOBufferSize);
     } catch (IOException e) {
       // the IOException comes from Files.setPosixFilePermissions which happens when file not found
       throw new StoreException("File not found while creating log segment", e, StoreErrorCodes.File_Not_Found);
     }
+  }
+
+  private DirectIOExecutor createDirectIOExecutor(int bufferSize) {
+    if (bufferSize == 0) {
+      return new DirectIOOneTimeExecutor();
+    }
+    return new DirectIOBufferedExecutor(bufferSize);
   }
 
   /**
@@ -291,9 +305,13 @@ class LogSegment implements Read, Write {
           StoreErrorCodes.Channel_Closed);
     }
     validateAppendSize(length);
-    try (DirectRandomAccessFile directFile = new DirectRandomAccessFile(file, "rw", 2 * 1024 * 1024)) {
-      directFile.seek(endOffset.get());
-      directFile.write(byteArray, offset, length);
+
+    try {
+      directIOExecutor.execute(directIo -> {
+        directIo.position(endOffset.get());
+        directIo.writeBytes(byteArray, offset, length);
+        return null;
+      });
       endOffset.addAndGet(length);
     } catch (IOException e) {
       StoreErrorCodes errorCode = StoreException.resolveErrorCode(e);
@@ -582,5 +600,101 @@ class LogSegment implements Read, Write {
 
   public StoreMetrics getMetrics() {
     return metrics;
+  }
+
+  /**
+   * Interface to run some direct io operations.
+   * @param <T> The return type of the operation.
+   */
+  private interface DirectIOOp<T> {
+    /**
+     * Run the direct io operations, like read, write etc with the provided {@link DirectIoByteChannelAligner}.
+     * @param directIo The direct io file to run the operations.
+     * @return
+     * @throws IOException
+     */
+    T run(DirectIoByteChannelAligner directIo) throws IOException;
+  }
+
+  /**
+   * Direct IO executor interface.
+   */
+  private interface DirectIOExecutor extends Closeable {
+    /**
+     * Execute the {@link DirectIOOp}.
+     * @param op The direct io op to execute.
+     * @param <T> The return type of this operation.
+     * @return
+     * @throws IOException
+     */
+    <T> T execute(DirectIOOp<T> op) throws IOException;
+
+    /**
+     * Flush if there is any buffer.
+     * @throws IOException
+     */
+    void flush() throws IOException;
+
+    @Override
+    void close() throws IOException;
+  }
+
+  /**
+   * A buffered implementation of {@link DirectIOExecutor}.
+   */
+  private class DirectIOBufferedExecutor implements DirectIOExecutor {
+    private DirectIoByteChannelAligner directIo = null;
+    private final int bufferSize;
+
+    public DirectIOBufferedExecutor(int bufferSize) {
+      this.bufferSize = bufferSize;
+    }
+
+    @Override
+    public <T> T execute(DirectIOOp<T> op) throws IOException {
+      // the direct io executes all the operation in the same thread so we don't need
+      // to care able the thread safety.
+      if (directIo == null) {
+        directIo = DirectIoByteChannelAligner.open(file, bufferSize, false);
+      }
+      return op.run(directIo);
+    }
+
+    @Override
+    public void flush() throws IOException {
+      if (directIo != null) {
+        directIo.flush();
+      }
+    }
+
+    @Override
+    public void close() throws IOException {
+      if (directIo != null) {
+        directIo.close();
+      }
+    }
+  }
+
+  /**
+   * A non-buffered implementation of {@link DirectIOExecutor}. It will open a direct io file every time an operation
+   * is executed.
+   */
+  private class DirectIOOneTimeExecutor implements DirectIOExecutor {
+    @Override
+    public <T> T execute(DirectIOOp<T> op) throws IOException {
+      try (DirectIoByteChannelAligner directIo = DirectIoByteChannelAligner.open(file, 2 * 1024 * 1024, false)) {
+        return op.run(directIo);
+      }
+    }
+
+    @Override
+    public void flush() throws IOException {
+      // no op
+    }
+
+    @Override
+    public void close() throws IOException {
+      // no op
+    }
   }
 }


### PR DESCRIPTION
## Summary

Add a buffered implemetation of direct io for writing to log segment in compaction.

## Details
We are add a configuration to switch between a buffered implementation and a non-buffered implementation. The code looks a bit weird right now as we have to compatible with the existing logic and use configuration to switch between the new logic and the existing one. After we verify the new logic (buffered direct io) would improve the disk performance, we have to refactor the code for io operation.

## Test
Unit test