### PR TITLE
Create compaction buffer only based on buffer size

### DIFF
--- a/ambry-store/src/main/java/com/github/ambry/store/CompactionManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/CompactionManager.java
@@ -70,8 +70,7 @@ class CompactionManager {
       for (String trigger : storeConfig.storeCompactionTriggers) {
         triggers.add(Trigger.valueOf(trigger.toUpperCase()));
       }
-      compactionExecutor = new CompactionExecutor(triggers, storeConfig.storeCompactionMinBufferSize == 0 ? 0
-          : Math.max(storeConfig.storeCompactionOperationsBytesPerSec, storeConfig.storeCompactionMinBufferSize));
+      compactionExecutor = new CompactionExecutor(triggers, storeConfig.storeCompactionMinBufferSize);
       try {
         compactionPolicyFactory = Utils.getObj(storeConfig.storeCompactionPolicyFactory, storeConfig, time);
         compactionPolicy = compactionPolicyFactory.getCompactionPolicy();


### PR DESCRIPTION
## Summary

Only consider the buffer size configuration when creating a buffer in compaction. The buffer size should be orthogonal to the min or max bytes per second in compaction, Let's not use the bytes per second to determine buffer size.

