### PR TITLE
[Paranoid Durability] Add metric for how often a partition is not available for PUTs in a remote colo.

### DIFF
--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
@@ -239,7 +239,7 @@ public class HelixClusterManager implements ClusterMap {
     partitionSelectionHelper =
         new PartitionSelectionHelper(helixClusterManagerQueryHelper, clusterMapConfig.clusterMapDatacenterName,
             clusterMapConfig.clustermapWritablePartitionMinReplicaCount,
-            clusterMapConfig.clusterMapDefaultPartitionClass);
+            clusterMapConfig.clusterMapDefaultPartitionClass, helixClusterManagerMetrics);
     // register partition selection helper as a listener of cluster map changes.
     registerClusterMapListener(partitionSelectionHelper);
   }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManagerMetrics.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManagerMetrics.java
@@ -58,6 +58,7 @@ class HelixClusterManagerMetrics {
   public Gauge<Long> helixClusterManagerCurrentXid;
   public final Timer routingTableQueryTime;
   public final Counter resourceNameMismatchCount;
+  public final Counter paranoidDurabilityIneligibleReplicaCount;
 
   /**
    * Metrics for the {@link HelixClusterManager}
@@ -102,6 +103,8 @@ class HelixClusterManagerMetrics {
         registry.counter(MetricRegistry.name(HelixClusterManager.class, "instanceDeleteTriggerCount"));
     resourceNameMismatchCount =
         registry.counter(MetricRegistry.name(HelixClusterManager.class, "resourceNameMismatchCount"));
+    paranoidDurabilityIneligibleReplicaCount =
+        registry.counter(MetricRegistry.name(HelixClusterManager.class, "ineligibleReplicaCount"));
   }
 
   void initializeInstantiationMetric(final boolean instantiated, final long instantiationExceptionCount) {

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PartitionLayout.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PartitionLayout.java
@@ -75,7 +75,7 @@ public class PartitionLayout {
     partitionSelectionHelper =
         new ClusterMapUtils.PartitionSelectionHelper(new StaticClusterManagerQueryHelper(), localDatacenterName,
             clusterMapConfig.clustermapWritablePartitionMinReplicaCount,
-            clusterMapConfig.clusterMapDefaultPartitionClass);
+            clusterMapConfig.clusterMapDefaultPartitionClass, null);
   }
 
   /**
@@ -97,7 +97,7 @@ public class PartitionLayout {
     partitionSelectionHelper =
         new ClusterMapUtils.PartitionSelectionHelper(new StaticClusterManagerQueryHelper(), localDatacenterName,
             clusterMapConfig.clustermapWritablePartitionMinReplicaCount,
-            clusterMapConfig.clusterMapDefaultPartitionClass);
+            clusterMapConfig.clusterMapDefaultPartitionClass, null);
   }
 
   public HardwareLayout getHardwareLayout() {

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/ClusterMapUtilsTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/ClusterMapUtilsTest.java
@@ -102,7 +102,7 @@ public class ClusterMapUtilsTest {
     doReturn(allPartitionIdsMain).when(mockClusterManagerQueryHelper).getPartitions();
     ClusterMapUtils.PartitionSelectionHelper psh =
         new ClusterMapUtils.PartitionSelectionHelper(mockClusterManagerQueryHelper, null, minimumLocalReplicaCount,
-            maxReplicasAllSites);
+            maxReplicasAllSites, null);
 
     String[] dcsToTry = {null, "", dc1, dc2};
     for (String dc : dcsToTry) {
@@ -157,7 +157,7 @@ public class ClusterMapUtilsTest {
     }
     // additional test: ensure getRandomWritablePartition now honors replica state for PUT request
     psh = new ClusterMapUtils.PartitionSelectionHelper(mockClusterManagerQueryHelper, dc1, minimumLocalReplicaCount,
-        maxReplicasAllSites);
+        maxReplicasAllSites, null);
     ReplicaId replicaId = everywhere1.getReplicaIds()
         .stream()
         .filter(r -> r.getDataNodeId().getDatacenterName().equals(dc1))
@@ -192,7 +192,7 @@ public class ClusterMapUtilsTest {
     int minimumLocalReplicaCount = 3;
     ClusterMapUtils.PartitionSelectionHelper psh =
         new ClusterMapUtils.PartitionSelectionHelper(mockClusterManagerQueryHelper, dc1, minimumLocalReplicaCount,
-            partitionClass);
+            partitionClass, null);
     // verify get all partitions return correct result
     assertEquals("Returned partitions are not expected", allPartitions, psh.getPartitions(null));
     // verify get writable partitions return partition2 and partition3 only
@@ -204,7 +204,7 @@ public class ClusterMapUtilsTest {
     // create another partition selection helper with minimumLocalReplicaCount = 4
     minimumLocalReplicaCount = 4;
     psh = new ClusterMapUtils.PartitionSelectionHelper(mockClusterManagerQueryHelper, dc1, minimumLocalReplicaCount,
-        partitionClass);
+        partitionClass, null);
     assertEquals("Returned writable partitions are not expected", Arrays.asList(partition3),
         psh.getWritablePartitions(partitionClass));
     assertEquals("Get random writable partition should return partition3 only", partition3,

--- a/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockClusterMap.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockClusterMap.java
@@ -206,7 +206,7 @@ public class MockClusterMap implements ClusterMap {
     doReturn(partitions.values()).when(mockClusterManagerQueryHelper).getPartitions();
     partitionSelectionHelper =
         new ClusterMapUtils.PartitionSelectionHelper(mockClusterManagerQueryHelper, localDatacenterName,
-            Math.min(defaultPartition.getReplicaIds().size(), 3), DEFAULT_PARTITION_CLASS);
+            Math.min(defaultPartition.getReplicaIds().size(), 3), DEFAULT_PARTITION_CLASS, null);
   }
 
   /**
@@ -228,7 +228,7 @@ public class MockClusterMap implements ClusterMap {
     doReturn(partitions.values()).when(mockClusterManagerQueryHelper).getPartitions();
     partitionSelectionHelper =
         new ClusterMapUtils.PartitionSelectionHelper(mockClusterManagerQueryHelper, localDatacenterName,
-            Math.min(partitionIdList.get(0).getReplicaIds().size(), 3), DEFAULT_PARTITION_CLASS);
+            Math.min(partitionIdList.get(0).getReplicaIds().size(), 3), DEFAULT_PARTITION_CLASS, null);
     Set<String> dcNames = new HashSet<>();
     datanodes.forEach(node -> dcNames.add(node.getDatacenterName()));
     dataCentersInClusterMap.addAll(dcNames);
@@ -270,7 +270,7 @@ public class MockClusterMap implements ClusterMap {
     doReturn(partitions.values()).when(mockClusterManagerQueryHelper).getPartitions();
     partitionSelectionHelper =
         new ClusterMapUtils.PartitionSelectionHelper(mockClusterManagerQueryHelper, localDatacenterName,
-            Math.min(mockPartitionId.getReplicaIds().size(), 3), DEFAULT_PARTITION_CLASS);
+            Math.min(mockPartitionId.getReplicaIds().size(), 3), DEFAULT_PARTITION_CLASS, null);
     specialPartition = null;
   }
 


### PR DESCRIPTION
With Paranoid Durability we will write directly to at least one replica in each remote colo, circumventing regular replication, which is considered too slow for Samza. See [Ambry Paranoid Durability Design](https://docs.google.com/document/d/1Vs35udWM3JPoCuNjSb4iZGZeoWfzZ23rJljonZmvumg/edit#heading=h.hmogsghmufas)

This PR creates a new metric to show how often we currently choose a replica for writing that is available in the local colo, but is not fully available in remote colos. This will help us gain insight into current partition/replica health and how well we can expect our current partition selection algorithm to work with Paranoid Durability in the future.