### PR TITLE
MessageFormatException should be treated as Log format error

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/store/MessageStoreRecovery.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/MessageStoreRecovery.java
@@ -33,5 +33,6 @@ public interface MessageStoreRecovery {
    * @return A list of messages that were successfully recovered
    * @throws IOException
    */
-  List<MessageInfo> recover(Read read, long startOffset, long endOffset, StoreKeyFactory factory) throws IOException;
+  List<MessageInfo> recover(Read read, long startOffset, long endOffset, StoreKeyFactory factory)
+      throws IOException, StoreException;
 }

--- a/ambry-messageformat/src/test/java/com/github/ambry/messageformat/BlobStoreRecoveryTest.java
+++ b/ambry-messageformat/src/test/java/com/github/ambry/messageformat/BlobStoreRecoveryTest.java
@@ -18,6 +18,7 @@ import com.github.ambry.store.MessageStoreRecovery;
 import com.github.ambry.store.MockId;
 import com.github.ambry.store.MockIdFactory;
 import com.github.ambry.store.Read;
+import com.github.ambry.store.StoreException;
 import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.TestUtils;
@@ -172,7 +173,7 @@ public class BlobStoreRecoveryTest {
   }
 
   @Test
-  public void recoveryTest() throws MessageFormatException, IOException {
+  public void recoveryTest() throws MessageFormatException, IOException, StoreException {
     MessageStoreRecovery recovery = new BlobStoreRecovery();
     // create log and write to it
     ReadImp readrecovery = new ReadImp();


### PR DESCRIPTION
## Summary
When recovering records from log to index, we would just skip malformed records. But this should be treated as Log format error so we can remove this replica's directory and start over.

## Test
Unit test