### PR TITLE
Add filename to replication exception message

### DIFF
--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudTokenPersistor.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudTokenPersistor.java
@@ -80,7 +80,7 @@ public class CloudTokenPersistor extends ReplicaTokenPersistor {
       boolean tokenExists = cloudDestination.retrieveTokens(mountPath, replicaTokenFileName, tokenOutputStream);
       if (tokenExists) {
         InputStream inputStream = new ByteArrayInputStream(tokenOutputStream.toByteArray());
-        return replicaTokenSerde.deserializeTokens(inputStream);
+        return replicaTokenSerde.deserializeTokens(inputStream, replicaTokenFileName);
       } else {
         return Collections.emptyList();
       }

--- a/ambry-replication/src/main/java/com/github/ambry/replication/DiskTokenPersistor.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/DiskTokenPersistor.java
@@ -92,7 +92,7 @@ public class DiskTokenPersistor extends ReplicaTokenPersistor {
     File replicaTokenFile = new File(mountPath, replicaTokenFileName);
     if (replicaTokenFile.exists()) {
       try (FileInputStream fileInputStream = new FileInputStream(replicaTokenFile)) {
-        return replicaTokenSerde.deserializeTokens(fileInputStream);
+        return replicaTokenSerde.deserializeTokens(fileInputStream, replicaTokenFile.getAbsolutePath());
       } catch (IOException e) {
         throw new ReplicationException("IO error while reading from replica token file at mount path " + mountPath, e);
       }

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaTokenPersistor.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaTokenPersistor.java
@@ -189,14 +189,14 @@ public abstract class ReplicaTokenPersistor implements Runnable {
       }
     }
 
-    public List<ReplicaTokenInfo> deserializeTokens(InputStream inputStream) throws IOException, ReplicationException {
+    public List<ReplicaTokenInfo> deserializeTokens(InputStream inputStream, String replicaTokenFilename) throws IOException, ReplicationException {
       CrcInputStream crcStream = new CrcInputStream(inputStream);
       DataInputStream stream = new DataInputStream(crcStream);
       List<ReplicaTokenInfo> tokenInfoList = new ArrayList<>();
       try {
         short version = stream.readShort();
         if (version < VERSION_0 || version > VERSION_1) {
-          throw new ReplicationException("Invalid version found during replica token deserialization: " + version);
+          throw new ReplicationException("Invalid version " + version + " found during replica token deserialization from file " + replicaTokenFilename);
         }
         while (stream.available() > Crc_Size) {
           // read partition id
@@ -230,7 +230,7 @@ public abstract class ReplicaTokenPersistor implements Runnable {
         }
         return tokenInfoList;
       } catch (IOException e) {
-        throw new ReplicationException("IO error deserializing replica tokens", e);
+        throw new ReplicationException("IO error deserializing replica tokens from file " + replicaTokenFilename, e);
       } finally {
         stream.close();
       }

--- a/ambry-tools/src/main/java/com/github/ambry/store/DumpReplicaTokenTool.java
+++ b/ambry-tools/src/main/java/com/github/ambry/store/DumpReplicaTokenTool.java
@@ -106,7 +106,7 @@ public class DumpReplicaTokenTool {
     logger.info("Dumping replica token file {}", fileToRead);
     DataInputStream stream = new DataInputStream(new FileInputStream(fileToRead));
     try {
-      List<RemoteReplicaInfo.ReplicaTokenInfo> replicaTokenInfoList = replicaTokenSerde.deserializeTokens(stream);
+      List<RemoteReplicaInfo.ReplicaTokenInfo> replicaTokenInfoList = replicaTokenSerde.deserializeTokens(stream, fileToRead);
       for (RemoteReplicaInfo.ReplicaTokenInfo replicaTokenInfo : replicaTokenInfoList) {
         logger.info(replicaTokenInfo.toString() + " " + replicaTokenInfo.getReplicaToken().toString());
       }


### PR DESCRIPTION
We currently have at least one `ambry-server` host that fails to start up with the exception message below. Make it easier to debug by adding the name of the replication token file that is being read.

```
2024/03/25 15:04:01.391 ERROR [AmbryServer] [main] [ambry-server] [] Error during startup
com.github.ambry.replication.ReplicationException: IO error deserializing replica tokens
	at com.github.ambry.replication.ReplicaTokenPersistor$ReplicaTokenSerde.deserializeTokens(ReplicaTokenPersistor.java:233) ~[com.github.ambry.ambry-replication-0.4.327.jar:?]
	at com.github.ambry.replication.DiskTokenPersistor.retrieve(DiskTokenPersistor.java:95) ~[com.github.ambry.ambry-replication-0.4.327.jar:?]
	at com.github.ambry.replication.ReplicationEngine.retrieveReplicaTokensAndPersistIfNecessary(ReplicationEngine.java:433) ~[com.github.ambry.ambry-replication-0.4.327.jar:?]
	at com.github.ambry.replication.ReplicationManager.start(ReplicationManager.java:149) ~[com.github.ambry.ambry-replication-0.4.327.jar:?]
```