### PR TITLE
Increase blob_name field length from 191 chars to 350 chars

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/frontend/NamedBlobPath.java
+++ b/ambry-api/src/main/java/com/github/ambry/frontend/NamedBlobPath.java
@@ -34,7 +34,7 @@ public class NamedBlobPath {
 
   static final String PREFIX_PARAM = "prefix";
   static final String PAGE_PARAM = "page";
-  static final int MAX_BLOB_NAME_LENGTH = 191;
+  static final int MAX_BLOB_NAME_LENGTH = 350;
 
   /**
    * Parse the input path if it's a named blob request.

--- a/ambry-named-mysql/src/main/resources/NamedBlobsSchema.ddl
+++ b/ambry-named-mysql/src/main/resources/NamedBlobsSchema.ddl
@@ -2,7 +2,7 @@
 CREATE TABLE IF NOT EXISTS named_blobs_v2 (
     account_id int NOT NULL,
     container_id int NOT NULL,
-    blob_name varchar(191) NOT NULL,
+    blob_name varchar(350) NOT NULL,
     version bigint NOT NULL,
     blob_id varbinary(50) NOT NULL,
     blob_state smallint NOT NULL,


### PR DESCRIPTION
Blob_name field length has been updated to 350 chars on MySql DB. Updating the limit in our frontend code too.