### PR TITLE
Only print error message, do not log exception in error message.

### DIFF
--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/AccountAndContainerInjector.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/AccountAndContainerInjector.java
@@ -448,7 +448,7 @@ public class AccountAndContainerInjector {
         frontendMetrics.unrecognizedDatasetNameCount.inc();
         logger.error(
             "Dataset get failed for accountName " + accountName + " containerName " + containerName + " datasetName "
-                + datasetName, e);
+                + datasetName);
         throw new RestServiceException(e.getMessage(), RestServiceErrorCode.getRestServiceErrorCode(e.getErrorCode()));
       }
     }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/GetBlobHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/GetBlobHandler.java
@@ -353,7 +353,7 @@ public class GetBlobHandler {
       } catch (AccountServiceException ex) {
         LOGGER.error(
             "Failed to get dataset version for accountName: " + accountName + " containerName: " + containerName
-                + " datasetName: " + datasetName + " version: " + version, ex);
+                + " datasetName: " + datasetName + " version: " + version);
         throw new RestServiceException(ex.getMessage(),
             RestServiceErrorCode.getRestServiceErrorCode(ex.getErrorCode()));
       }


### PR DESCRIPTION
Currently exception ticket will find the Exception key word and treat this error message as exception. With this change, the exception message it self won't be logged, so we leverage the error message only and don't treat it as an exception.