### PR TITLE
Check crc for last index segment file before parsing its content

### DIFF
--- a/ambry-store/src/main/java/com/github/ambry/store/IndexSegment.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/IndexSegment.java
@@ -768,7 +768,7 @@ class IndexSegment implements Iterable<IndexEntry> {
     logger.info("IndexSegment : {} reading index from file", indexFile.getAbsolutePath());
 
     ByteBuffer byteBuffer = checkFileDataIntegrity(fileToRead);
-    byteBuffer.flip();
+    byteBuffer.position(0);
     byteBuffer.limit(byteBuffer.capacity() - CRC_FIELD_LENGTH);
     // We've checked the CRC and it matches, which means this index segment file is intact. All the errors from here
     // on are logical errors, not format errors.

--- a/ambry-store/src/main/java/com/github/ambry/store/IndexSegment.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/IndexSegment.java
@@ -208,9 +208,9 @@ class IndexSegment implements Iterable<IndexEntry> {
             logger.error(
                 "Index Segment {} encountered an error while loading to memory, ignore the error and rely on recovery to fix it.",
                 indexFile.getAbsolutePath(), e);
-            // Make sure we are using the current version
+            // Make sure we are using the current version, and don't set the last modified timestamp since it will be set
+            // later by recovery
             version = PersistentIndex.CURRENT_VERSION;
-            lastModifiedTimeSec.set(time.seconds());
           } else {
             throw e;
           }

--- a/ambry-store/src/main/java/com/github/ambry/store/IndexSegment.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/IndexSegment.java
@@ -208,6 +208,9 @@ class IndexSegment implements Iterable<IndexEntry> {
             logger.error(
                 "Index Segment {} encountered an error while loading to memory, ignore the error and rely on recovery to fix it.",
                 indexFile.getAbsolutePath(), e);
+            // Make sure we are using the current version
+            version = PersistentIndex.CURRENT_VERSION;
+            lastModifiedTimeSec.set(time.seconds());
           } else {
             throw e;
           }

--- a/ambry-store/src/test/java/com/github/ambry/store/IndexSegmentTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/IndexSegmentTest.java
@@ -802,11 +802,15 @@ public class IndexSegmentTest {
       stream.getChannel().force(true);
       temp.renameTo(indexFile);
     }
-    try {
-      createIndexSegmentFromFile(indexFile, true, journal);
-      fail("Should fail as index file is corrupted");
-    } catch (StoreException e) {
-      assertEquals("Mismatch in error code", StoreErrorCodes.Index_Creation_Failure, e.getErrorCode());
+    for (boolean sealed : new boolean[]{true, false}) {
+      try {
+        createIndexSegmentFromFile(indexFile, sealed, journal);
+        fail("Should fail as index file is corrupted");
+      } catch (StoreException e) {
+        assertEquals("Mismatch in error code", StoreErrorCodes.Index_Creation_Failure, e.getErrorCode());
+        StoreException rc = Utils.getRootCause(e, StoreException.class);
+        assertEquals("Mismatch in error code", StoreErrorCodes.Index_File_Format_Error, rc.getErrorCode());
+      }
     }
   }
 

--- a/ambry-store/src/test/java/com/github/ambry/store/IndexSegmentTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/IndexSegmentTest.java
@@ -1174,7 +1174,7 @@ public class IndexSegmentTest {
     assertEquals("Reset key mismatch ", resetKey, indexSegment.getResetKey());
     assertEquals("Reset key type mismatch ", resetKeyType, indexSegment.getResetKeyType());
     assertEquals("Reset key life version mismatch", resetKeyLifeVersion, indexSegment.getResetKeyLifeVersion());
-    if (formatVersion != PersistentIndex.VERSION_0) {
+    if (formatVersion != PersistentIndex.VERSION_0 && indexSegment.getLastModifiedTimeMs() != 0) {
       assertEquals("Last modified time is incorrect", lastModifiedTimeInMs, indexSegment.getLastModifiedTimeMs());
     }
     // in case of formatVersion 0, last modified time is calculated based on SystemTime and hence cannot verify for equivalency

--- a/ambry-utils/src/main/java/com/github/ambry/utils/Utils.java
+++ b/ambry-utils/src/main/java/com/github/ambry/utils/Utils.java
@@ -592,7 +592,7 @@ public class Utils {
    * @param offset starting offset of the fileChanel to be read from
    * @param buffer the destination of the read
    * @return actual io count of fileChannel.read()
-   * @throws IOException
+   * @throws IOException When ByteBuffer can't be filled up or any other IO error.
    */
   public static int readFileToByteBuffer(FileChannel fileChannel, long offset, ByteBuffer buffer) throws IOException {
     int ioCount = 0;


### PR DESCRIPTION
## Summary

Checking CRC of the unsealed index segment file before parsing its content to get all the index entries. Checking the CRC before parsing would expose file corruption error. If CRC matches with the content of the file, then all the errors in the parsing, will be treated as logical error.

## Test
Unit test
