### PR TITLE
Restore disk's availability when starting up storage manager

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -608,6 +608,9 @@ public class StoreConfig {
   public static final String storeRemoveDirectoryAndRestartBlobStoreName =
       "store.remove.directory.and.restart.blob.store";
 
+  /**
+   * True to restore disk's availability on data node config when an unavailable disk is fixed in FULL AUTO mode.
+   */
   @Config(storeRestoreUnavailableDiskInFullAutoName)
   public final boolean storeRestoreUnavailableDiskInFullAuto;
   public static final String storeRestoreUnavailableDiskInFullAutoName = "store.restore.unavailable.disk.in.full.auto";

--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -608,6 +608,10 @@ public class StoreConfig {
   public static final String storeRemoveDirectoryAndRestartBlobStoreName =
       "store.remove.directory.and.restart.blob.store";
 
+  @Config(storeRestoreUnavailableDiskInFullAutoName)
+  public final boolean storeRestoreUnavailableDiskInFullAuto;
+  public static final String storeRestoreUnavailableDiskInFullAutoName = "store.restore.unavailable.disk.in.full.auto";
+
   public StoreConfig(VerifiableProperties verifiableProperties) {
     storeKeyFactory = verifiableProperties.getString("store.key.factory", "com.github.ambry.commons.BlobIdFactory");
     storeDataFlushIntervalSeconds = verifiableProperties.getLong("store.data.flush.interval.seconds", 60);
@@ -770,5 +774,7 @@ public class StoreConfig {
         verifiableProperties.getBoolean(storeRemoveUnexpectedDirsInFullAutoName, false);
     storeRemoveDirectoryAndRestartBlobStore =
         verifiableProperties.getBoolean(storeRemoveDirectoryAndRestartBlobStoreName, false);
+    storeRestoreUnavailableDiskInFullAuto =
+        verifiableProperties.getBoolean(storeRestoreUnavailableDiskInFullAutoName, false);
   }
 }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
@@ -503,9 +503,12 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
       try {
         InstanceConfig instanceConfig = helixAdmin.getInstanceConfig(clusterName, instanceName);
         Map<String, Integer> capacityMap = new HashMap<>(instanceConfig.getInstanceCapacityMap());
-        capacityMap.put(DISK_KEY, diskCapacity);
-        instanceConfig.setInstanceCapacityMap(capacityMap);
-        helixAdmin.setInstanceConfig(clusterName, instanceName, instanceConfig);
+        // If the capacity is already the target value, then just return success
+        if (capacityMap.getOrDefault(DISK_KEY, -1) != diskCapacity) {
+          capacityMap.put(DISK_KEY, diskCapacity);
+          instanceConfig.setInstanceCapacityMap(capacityMap);
+          helixAdmin.setInstanceConfig(clusterName, instanceName, instanceConfig);
+        }
         success = true;
       } catch (Exception e) {
         logger.error("Failed to update disk capacity: {}", diskCapacity, e);

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
@@ -61,7 +61,7 @@ import static com.github.ambry.clustermap.StateTransitionException.TransitionErr
  */
 public class HelixParticipant implements ClusterParticipant, PartitionStateChangeListener {
   public static final String DISK_KEY = "DISK";
-  protected final HelixParticipantMetrics participantMetrics;
+  final HelixParticipantMetrics participantMetrics;
   private final HelixClusterManager clusterManager;
   private final String clusterName;
   private final String zkConnectStr;
@@ -508,6 +508,7 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
           capacityMap.put(DISK_KEY, diskCapacity);
           instanceConfig.setInstanceCapacityMap(capacityMap);
           helixAdmin.setInstanceConfig(clusterName, instanceName, instanceConfig);
+          participantMetrics.updateDiskCapacityCounter.inc();
         }
         success = true;
       } catch (Exception e) {

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipantMetrics.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipantMetrics.java
@@ -31,6 +31,8 @@ class HelixParticipantMetrics {
   final Counter partitionDroppedCount;
   final Counter setReplicaDisabledStateErrorCount;
 
+  public final Counter updateDiskCapacityCounter;
+
   HelixParticipantMetrics(MetricRegistry metricRegistry, String zkConnectStr,
       Map<String, ReplicaState> localPartitionAndState) {
     String zkSuffix = zkConnectStr == null ? "" : "-" + zkConnectStr;
@@ -58,6 +60,8 @@ class HelixParticipantMetrics {
         metricRegistry.counter(MetricRegistry.name(HelixParticipant.class, "partitionDroppedCount" + zkSuffix));
     setReplicaDisabledStateErrorCount = metricRegistry.counter(
         MetricRegistry.name(HelixParticipant.class, "setReplicaDisabledStateErrorCount" + zkSuffix));
+    updateDiskCapacityCounter =
+        metricRegistry.counter(MetricRegistry.name(HelixParticipant.class, "updateDiskCapacityCount"));
   }
 
   /**

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixParticipantTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixParticipantTest.java
@@ -673,10 +673,17 @@ public class HelixParticipantTest {
       fail("Should fail on negative number");
     } catch (IllegalArgumentException e) {
     }
+    long updateCount = helixParticipant.participantMetrics.updateDiskCapacityCounter.getCount();
     assertTrue(helixParticipant.updateDiskCapacity(1000));
+    assertEquals(updateCount + 1, helixParticipant.participantMetrics.updateDiskCapacityCounter.getCount());
     instanceConfig = helixAdmin.getInstanceConfig(clusterName, instanceName);
     assertTrue(instanceConfig.getInstanceCapacityMap().containsKey(HelixParticipant.DISK_KEY));
     assertEquals(1000, instanceConfig.getInstanceCapacityMap().get(HelixParticipant.DISK_KEY).intValue());
+
+    // update with the same capacity again, this time we shouldn't update it.
+    updateCount++;
+    assertTrue(helixParticipant.updateDiskCapacity(1000));
+    assertEquals(updateCount, helixParticipant.participantMetrics.updateDiskCapacityCounter.getCount());
     helixParticipant.close();
   }
 

--- a/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
@@ -268,7 +268,7 @@ public class StorageManager implements StoreManager {
     if (!storeConfig.storeRestoreUnavailableDiskInFullAuto || !clusterMap.isDataNodeInFullAutoMode(currentNode)) {
       return failedDiskIds;
     }
-    // We should try to retore the availability of failed disks
+    // We should try to restore the availability of failed disks
     if (!failedDiskIds.isEmpty()) {
       List<DiskId> disksToRecover = new ArrayList<>();
       for (DiskId diskId : failedDiskIds) {

--- a/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
@@ -238,16 +238,13 @@ public class StorageManager implements StoreManager {
    * @throws StoreException
    */
   void verifyDiskHealth() throws StoreException {
-    List<DiskId> allDiskIds = currentNode.getDiskIds();
-    Set<DiskId> failedDiskIds = allDiskIds.stream()
-        .filter(diskId -> diskId.getState() == HardwareState.UNAVAILABLE)
-        .collect(Collectors.toSet());
+    Set<DiskId> failedDiskIds = maybeRestoreDiskAvailability();
     for (Map.Entry<DiskId, DiskManager> entry : diskToDiskManager.entrySet()) {
       if (!entry.getValue().isRunning()) {
         failedDiskIds.add(entry.getKey());
       }
     }
-    int totalDisks = allDiskIds.size();
+    int totalDisks = currentNode.getDiskIds().size();
     int failedDisks = failedDiskIds.size();
     // The failed disks has to larger than the threshold. If the threshold is 1, then even if all disks failed, it won't
     // throw an exception.
@@ -257,6 +254,47 @@ public class StorageManager implements StoreManager {
       logger.error("Failed disks are {}", failedDisks);
       throw new StoreException("More than enough disks failed", StoreErrorCodes.Initialization_Error);
     }
+  }
+
+  /**
+   * Maybe restore disk's availability and update instance capacity.
+   * @return A set of {@link DiskId}s that are still unavailable.
+   */
+  Set<DiskId> maybeRestoreDiskAvailability() {
+    List<DiskId> allDiskIds = currentNode.getDiskIds();
+    Set<DiskId> failedDiskIds = allDiskIds.stream()
+        .filter(diskId -> diskId.getState() == HardwareState.UNAVAILABLE)
+        .collect(Collectors.toSet());
+    if (!storeConfig.storeRestoreUnavailableDiskInFullAuto || !clusterMap.isDataNodeInFullAutoMode(currentNode)) {
+      return failedDiskIds;
+    }
+    // We should try to retore the availability of failed disks
+    if (!failedDiskIds.isEmpty()) {
+      List<DiskId> disksToRecover = new ArrayList<>();
+      for (DiskId diskId : failedDiskIds) {
+        // If the mount path exist and is a directory, it's likely disk is already recovered
+        File mount = new File(diskId.getMountPath());
+        if (mount.exists() && mount.isDirectory()) {
+          disksToRecover.add(diskId);
+        }
+      }
+      // We can set the disk available again
+      if (!primaryClusterParticipant.setDisksState(disksToRecover, HardwareState.AVAILABLE)) {
+        logger.error("Fail to restore availability for disk " + disksToRecover + ", ignore the error and move on");
+        return failedDiskIds;
+      } else {
+        logger.info("Successfully restore availability for disk " + disksToRecover);
+      }
+      disksToRecover.forEach(diskId -> diskId.setState(HardwareState.AVAILABLE));
+      failedDiskIds.removeAll(disksToRecover);
+    }
+
+    int actualCapacityInGB = getCapacityOfHealthyDisks(allDiskIds, failedDiskIds);
+    if (!primaryClusterParticipant.updateDiskCapacity(actualCapacityInGB)) {
+      throw new IllegalStateException("Failed to update disk capacity to " + actualCapacityInGB);
+    }
+    logger.info("Successfully update disk capacity to {} when restoring disk availability", actualCapacityInGB);
+    return failedDiskIds;
   }
 
   @Override
@@ -358,6 +396,18 @@ public class StorageManager implements StoreManager {
   public boolean controlCompactionForBlobStore(PartitionId id, boolean enabled) {
     DiskManager diskManager = partitionToDiskManager.get(id);
     return diskManager != null && diskManager.controlCompactionForBlobStore(id, enabled);
+  }
+
+  int getCapacityOfHealthyDisks(List<DiskId> allDiskIds, Collection<DiskId> failedDiskIds) {
+    int capacityReportingPercentage = storeConfig.storeDiskCapacityReportingPercentage;
+    // Update disk capacity
+    long healthyDiskCapacity = allDiskIds.stream()
+        .filter(((Predicate<DiskId>) failedDiskIds::contains).negate())
+        .mapToLong(DiskId::getRawCapacityInBytes)
+        .sum();
+    final long GB = 1024 * 1024 * 1024;
+    long capacityInGB = healthyDiskCapacity / GB;
+    return (int) ((double) capacityInGB * capacityReportingPercentage / 100);
   }
 
   /**
@@ -1009,7 +1059,7 @@ public class StorageManager implements StoreManager {
       // messages, then when we reset the partitions, replica list in the StorageManager would be obsolete. Fortunately
       // all the replicas in the failed disks are already stopped, we just have to remove the disk from disk maps.
       failedDisks.addAll(newFailedDisks);
-      long healthyDiskCapacity = diskToDiskManager.keySet()
+      long healthyDiskCapacity = currentNode.getDiskIds()
           .stream()
           .filter(((Predicate<DiskId>) failedDisks::contains).negate())
           .mapToLong(DiskId::getRawCapacityInBytes)

--- a/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
@@ -398,9 +398,15 @@ public class StorageManager implements StoreManager {
     return diskManager != null && diskManager.controlCompactionForBlobStore(id, enabled);
   }
 
+  /**
+   * Return the disk capacity for healthy disks. This capacity is the sum of all healthy disks. The unit
+   * is GiB. This disk capacity is the value to report in instance config.
+   * @param allDiskIds All the disks on data node config
+   * @param failedDiskIds The failed disks
+   * @return The disk capacity.
+   */
   int getCapacityOfHealthyDisks(List<DiskId> allDiskIds, Collection<DiskId> failedDiskIds) {
     int capacityReportingPercentage = storeConfig.storeDiskCapacityReportingPercentage;
-    // Update disk capacity
     long healthyDiskCapacity = allDiskIds.stream()
         .filter(((Predicate<DiskId>) failedDiskIds::contains).negate())
         .mapToLong(DiskId::getRawCapacityInBytes)


### PR DESCRIPTION
## Summary
When disk fails, we have a disk failure handler to set the availability of this disk to false and decrease instance capacity. After  disk is fixed, we need to manually restore the disk's availability and update instance capacity in helix. This can be done in code automatically. This PR is trying to do that.

There is a simple method to check if the disk is recovered, we just have to check the mount path of the disk and make sure it exists and is a directory. This is by no mean a prefect condition, but most of the time, it works.

After that, we would update the property store to mark those unavailable disks back to available and increase the instance capacity. This is a two-step operation and they are not atomic, so it's possible we only successfully finish first step and fail on second step. In order to recover it, we will alway try to update the instance capacity when starting up.

## Test
Unit test