### PR TITLE
[vcr-2.0] Fix nullptr

### DIFF
--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationMetrics.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationMetrics.java
@@ -635,7 +635,9 @@ public class ReplicationMetrics {
     String localStoreErrorMetricName =
         remoteReplica.getDataNodeId().getHostname() + "-" + remoteReplica.getDataNodeId().getPort() + "-"
             + remoteReplica.getPartitionId().toString() + "-localStoreError";
-    localStoreErrorMap.get(localStoreErrorMetricName).inc();
+    if (localStoreErrorMap.containsKey(localStoreErrorMetricName)) {
+      localStoreErrorMap.get(localStoreErrorMetricName).inc();
+    }
   }
 
   public void incrementReplicationErrors(boolean sslEnabled) {


### PR DESCRIPTION
IDK why the metric is missing in vcr.
Its not important however, we have other metrics in vcr. The missing metric is causing null ptr exc.