### PR TITLE
[vcr-2.0] Increase max cpu-scaling factor

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/CloudConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/CloudConfig.java
@@ -465,7 +465,7 @@ public class CloudConfig {
   public static final double DEFAULT_BACKUP_NODE_CPU_SCALE = -1; // 1 thread
   // num_cpu-1 threads, prevent a fork bomb
   public static final double MIN_BACKUP_NODE_CPU_SCALE = 1 - Double.valueOf(Runtime.getRuntime().availableProcessors());
-  public static final double MAX_BACKUP_NODE_CPU_SCALE = 4.0; // 4 * num_cpus, prevent a fork bomb
+  public static final double MAX_BACKUP_NODE_CPU_SCALE = 16.0; // 16 * num_cpus, this is max, not actual config value
   @Config(BACKUP_NODE_CPU_SCALE)
   public final double backupNodeCpuScale;
 


### PR DESCRIPTION
The current VCR cpu utilization continues to be low at 5% across all clusters. We are attempting to increase the number of worker threads. This patch increase the ceiling on the number of worker threads, not the actual number of worker threads itself. That will set in the internal fork.