### PR TITLE
Proactively examine blob store availability when there is disk io error

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -633,6 +633,14 @@ public class StoreConfig {
   public static final String storeProactivelyTestStorageAvailabilityName =
       "store.proactively.test.storage.availability";
 
+  /**
+   * Only when {@link #storeProactivelyTestStorageAvailability} is true does this configuration works. We will set some
+   * delay to run the test logic so the replication or frontend requests would be able to shut down blob stores.
+   */
+  @Config(storeProactiveTestDelayInSecondsName)
+  public final int storeProactiveTestDelayInSeconds;
+  public static final String storeProactiveTestDelayInSecondsName = "store.proactive.test.delay.in.seconds";
+
   public StoreConfig(VerifiableProperties verifiableProperties) {
     storeKeyFactory = verifiableProperties.getString("store.key.factory", "com.github.ambry.commons.BlobIdFactory");
     storeDataFlushIntervalSeconds = verifiableProperties.getLong("store.data.flush.interval.seconds", 60);
@@ -801,5 +809,7 @@ public class StoreConfig {
         verifiableProperties.getBoolean(storeRestoreUnavailableDiskInFullAutoName, false);
     storeProactivelyTestStorageAvailability =
         verifiableProperties.getBoolean(storeProactivelyTestStorageAvailabilityName, false);
+    storeProactiveTestDelayInSeconds =
+        verifiableProperties.getIntInRange(storeProactiveTestDelayInSecondsName, 60, 0, Integer.MAX_VALUE);
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -624,6 +624,15 @@ public class StoreConfig {
   public final boolean storeRestoreUnavailableDiskInFullAuto;
   public static final String storeRestoreUnavailableDiskInFullAutoName = "store.restore.unavailable.disk.in.full.auto";
 
+  /**
+   * True to proactively test storage availability of all blob stores on a disk when any blob store on this disk has
+   * io errors.
+   */
+  @Config(storeProactivelyTestStorageAvailabilityName)
+  public final boolean storeProactivelyTestStorageAvailability;
+  public static final String storeProactivelyTestStorageAvailabilityName =
+      "store.proactively.test.storage.availability";
+
   public StoreConfig(VerifiableProperties verifiableProperties) {
     storeKeyFactory = verifiableProperties.getString("store.key.factory", "com.github.ambry.commons.BlobIdFactory");
     storeDataFlushIntervalSeconds = verifiableProperties.getLong("store.data.flush.interval.seconds", 60);
@@ -790,5 +799,7 @@ public class StoreConfig {
         verifiableProperties.getBoolean(storeRemoveDirectoryAndRestartBlobStoreName, false);
     storeRestoreUnavailableDiskInFullAuto =
         verifiableProperties.getBoolean(storeRestoreUnavailableDiskInFullAutoName, false);
+    storeProactivelyTestStorageAvailability =
+        verifiableProperties.getBoolean(storeProactivelyTestStorageAvailabilityName, false);
   }
 }

--- a/ambry-cloud/src/test/java/com/github/ambry/cloud/RecoveryNetworkClientTest.java
+++ b/ambry-cloud/src/test/java/com/github/ambry/cloud/RecoveryNetworkClientTest.java
@@ -174,15 +174,11 @@ public class RecoveryNetworkClientTest {
     // Create local store
     localStore =
         new BlobStore(mockPartitionId.getReplicaIds().get(0), new StoreConfig(verifiableProperties),
-            Utils.newScheduler(1, false),
-            Utils.newScheduler(1, false),
-            new DiskIOScheduler(null),
-            StoreTestUtils.DEFAULT_DISK_SPACE_ALLOCATOR,
-            new StoreMetrics(mockClusterMap.getMetricRegistry()),
-            new StoreMetrics("UnderCompaction", mockClusterMap.getMetricRegistry()),
-            null, null, null, Collections.singletonList(mock(ReplicaStatusDelegate.class)),
-            new MockTime(), new InMemAccountService(false, false), null,
-            Utils.newScheduler(1, false));
+            Utils.newScheduler(1, false), Utils.newScheduler(1, false), null, new DiskIOScheduler(null),
+            StoreTestUtils.DEFAULT_DISK_SPACE_ALLOCATOR, new StoreMetrics(mockClusterMap.getMetricRegistry()),
+            new StoreMetrics("UnderCompaction", mockClusterMap.getMetricRegistry()), null, null, null,
+            Collections.singletonList(mock(ReplicaStatusDelegate.class)), new MockTime(),
+            new InMemAccountService(false, false), null, Utils.newScheduler(1, false));
     localStore.start();
     // Create remote-replica info
     remoteStore =

--- a/ambry-server/src/test/java/com/github/ambry/server/MockStorageManager.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/MockStorageManager.java
@@ -91,7 +91,7 @@ class MockStorageManager extends StorageManager {
     ReplicaState currentState = ReplicaState.STANDBY;
 
     TestStore(ReplicaId replicaId, ClusterParticipant clusterParticipant) {
-      super(replicaId, new StoreConfig(VPROPS), null, null, null, null, null, null, null, null, null,
+      super(replicaId, new StoreConfig(VPROPS), null, null, null, null, null, null, null, null, null, null,
           Collections.singletonList(new ReplicaStatusDelegate(clusterParticipant)), new MockTime(),
           new InMemAccountService(false, false), null, null);
       if (clusterParticipant instanceof HelixParticipant) {

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -61,6 +61,7 @@ import static com.github.ambry.clustermap.VcrClusterParticipant.*;
  * The blob store that controls the log and index
  */
 public class BlobStore implements Store {
+  private static final Logger logger = LoggerFactory.getLogger(BlobStore.class);
   static final String SEPARATOR = "_";
   static final String BOOTSTRAP_FILE_NAME = "bootstrap_in_progress";
   static final String DECOMMISSION_FILE_NAME = "decommission_in_progress";
@@ -71,9 +72,9 @@ public class BlobStore implements Store {
   private final DiskMetrics diskMetrics;
   private final ScheduledExecutorService taskScheduler;
   private final ScheduledExecutorService longLivedTaskScheduler;
+  private final DiskManager diskManager;
   private final DiskIOScheduler diskIOScheduler;
   private final DiskSpaceAllocator diskSpaceAllocator;
-  private static final Logger logger = LoggerFactory.getLogger(BlobStore.class);
   private final Object storeWriteLock = new Object();
   private final StoreConfig config;
   private final long capacityInBytes;
@@ -104,8 +105,7 @@ public class BlobStore implements Store {
   private volatile ReplicaState previousState;
   private volatile boolean recoverFromDecommission;
   // TODO remove this once ZK migration is complete
-  private AtomicReference<ReplicaSealStatus> replicaSealStatus =
-      new AtomicReference<>(ReplicaSealStatus.NOT_SEALED);
+  private AtomicReference<ReplicaSealStatus> replicaSealStatus = new AtomicReference<>(ReplicaSealStatus.NOT_SEALED);
   private AtomicBoolean isDisabled = new AtomicBoolean(false);
   protected PersistentIndex index;
 
@@ -133,6 +133,7 @@ public class BlobStore implements Store {
    *                                    tasks.
    * @param longLivedTaskScheduler      the {@link ScheduledExecutorService} for executing long period background
    *                                    tasks.
+   * @param diskManager                 the {@link DiskManager} object
    * @param diskIOScheduler             schedules disk IO operations
    * @param diskSpaceAllocator          allocates log segment files.
    * @param metrics                     the {@link StorageManagerMetrics} instance to use.
@@ -148,12 +149,12 @@ public class BlobStore implements Store {
    * @param indexPersistScheduler       a dedicated {@link ScheduledExecutorService} for persisting index segments.
    */
   public BlobStore(ReplicaId replicaId, StoreConfig config, ScheduledExecutorService taskScheduler,
-      ScheduledExecutorService longLivedTaskScheduler, DiskIOScheduler diskIOScheduler,
+      ScheduledExecutorService longLivedTaskScheduler, DiskManager diskManager, DiskIOScheduler diskIOScheduler,
       DiskSpaceAllocator diskSpaceAllocator, StoreMetrics metrics, StoreMetrics storeUnderCompactionMetrics,
       StoreKeyFactory factory, MessageStoreRecovery recovery, MessageStoreHardDelete hardDelete,
       List<ReplicaStatusDelegate> replicaStatusDelegates, Time time, AccountService accountService,
       DiskMetrics diskMetrics, ScheduledExecutorService indexPersistScheduler) {
-    this(replicaId, replicaId.getPartitionId().toString(), config, taskScheduler, longLivedTaskScheduler,
+    this(replicaId, replicaId.getPartitionId().toString(), config, taskScheduler, longLivedTaskScheduler, diskManager,
         diskIOScheduler, diskSpaceAllocator, metrics, storeUnderCompactionMetrics, replicaId.getReplicaPath(),
         replicaId.getCapacityInBytes(), factory, recovery, hardDelete, replicaStatusDelegates, time, accountService,
         null, diskMetrics, indexPersistScheduler);
@@ -167,6 +168,7 @@ public class BlobStore implements Store {
    * @param taskScheduler               the {@link ScheduledExecutorService} for executing background tasks.
    * @param longLivedTaskScheduler      the {@link ScheduledExecutorService} for executing long period background
    *                                    tasks.
+   * @param diskManager                 the {@link DiskManager} object
    * @param diskIOScheduler             schedules disk IO operations.
    * @param diskSpaceAllocator          allocates log segment files.
    * @param metrics                     the {@link StorageManagerMetrics} instance to use.
@@ -180,17 +182,17 @@ public class BlobStore implements Store {
    * @param indexPersistScheduler       a dedicated {@link ScheduledExecutorService} for persisting index segments.
    */
   BlobStore(String storeId, StoreConfig config, ScheduledExecutorService taskScheduler,
-      ScheduledExecutorService longLivedTaskScheduler, DiskIOScheduler diskIOScheduler,
+      ScheduledExecutorService longLivedTaskScheduler, DiskManager diskManager, DiskIOScheduler diskIOScheduler,
       DiskSpaceAllocator diskSpaceAllocator, StoreMetrics metrics, StoreMetrics storeUnderCompactionMetrics,
       String dataDir, long capacityInBytes, StoreKeyFactory factory, MessageStoreRecovery recovery,
       MessageStoreHardDelete hardDelete, Time time, ScheduledExecutorService indexPersistScheduler) {
-    this(null, storeId, config, taskScheduler, longLivedTaskScheduler, diskIOScheduler, diskSpaceAllocator, metrics,
-        storeUnderCompactionMetrics, dataDir, capacityInBytes, factory, recovery, hardDelete, null, time, null, null,
-        null, indexPersistScheduler);
+    this(null, storeId, config, taskScheduler, longLivedTaskScheduler, diskManager, diskIOScheduler, diskSpaceAllocator,
+        metrics, storeUnderCompactionMetrics, dataDir, capacityInBytes, factory, recovery, hardDelete, null, time, null,
+        null, null, indexPersistScheduler);
   }
 
   BlobStore(ReplicaId replicaId, String storeId, StoreConfig config, ScheduledExecutorService taskScheduler,
-      ScheduledExecutorService longLivedTaskScheduler, DiskIOScheduler diskIOScheduler,
+      ScheduledExecutorService longLivedTaskScheduler, DiskManager diskManager, DiskIOScheduler diskIOScheduler,
       DiskSpaceAllocator diskSpaceAllocator, StoreMetrics metrics, StoreMetrics storeUnderCompactionMetrics,
       String dataDir, long capacityInBytes, StoreKeyFactory factory, MessageStoreRecovery recovery,
       MessageStoreHardDelete hardDelete, List<ReplicaStatusDelegate> replicaStatusDelegates, Time time,
@@ -202,6 +204,7 @@ public class BlobStore implements Store {
     this.diskMetrics = diskMetrics;
     this.taskScheduler = taskScheduler;
     this.longLivedTaskScheduler = longLivedTaskScheduler;
+    this.diskManager = diskManager;
     this.diskIOScheduler = diskIOScheduler;
     this.diskSpaceAllocator = diskSpaceAllocator;
     this.metrics = metrics;
@@ -217,9 +220,8 @@ public class BlobStore implements Store {
     this.time = time;
     this.sealThresholdBytesHigh =
         (long) (capacityInBytes * (config.storeReadOnlyEnableSizeThresholdPercentage / 100.0));
-    this.sealThresholdBytesLow = (long) (capacityInBytes * (
-        (config.storeReadOnlyEnableSizeThresholdPercentage
-            - config.storeReadOnlyToPartialWriteEnableSizeThresholdPercentageDelta) / 100.0));
+    this.sealThresholdBytesLow = (long) (capacityInBytes * ((config.storeReadOnlyEnableSizeThresholdPercentage
+        - config.storeReadOnlyToPartialWriteEnableSizeThresholdPercentageDelta) / 100.0));
     this.partialSealThresholdBytesHigh =
         (long) (capacityInBytes * (config.storePartialWriteEnableSizeThresholdPercentage / 100.0));
     this.partialSealThresholdBytesLow = (long) (capacityInBytes * (
@@ -314,7 +316,7 @@ public class BlobStore implements Store {
           }
         }
         metrics.storeStartFailure.inc();
-        String err = String.format("Error while starting store for dir %s due to %s",  dataDir, e.getMessage());
+        String err = String.format("Error while starting store for dir %s due to %s", dataDir, e.getMessage());
         throw new StoreException(err, e, StoreErrorCodes.Initialization_Error);
       } finally {
         context.stop();
@@ -454,7 +456,7 @@ public class BlobStore implements Store {
       logger.debug("The current used capacity is {} bytes on store {}", index.getLogUsedCapacity(),
           replicaId.getPartitionId());
       updateSealedStatus();
-      if(!started && replicaStatusDelegates.size() > 1) {
+      if (!started && replicaStatusDelegates.size() > 1) {
         reconcileSealedStatus();
       }
       //else: maintain current replicaId status if percentFilled between threshold - delta and threshold
@@ -1086,6 +1088,48 @@ public class BlobStore implements Store {
   }
 
   /**
+   * Test if the storage for this blob is still available or not. This test would be triggered after a blob store
+   * on the same disk, encounters an io error. If this io error is indeed caused by disk error, we would want to
+   * shut down all the blob stores on this disk as soon as possible, so we can move all the replicas on this disk
+   * to a different place.
+   *
+   * In order to test underlying storage's availability, this method would try read one chunk of data from disk
+   * to memory for several times. If any of those read works, this method would return true.
+   * @return
+   */
+  boolean testStorageAvailability() {
+    if (!isStarted()) {
+      return false;
+    }
+    BlobReadOptions readOptions = index.getRandomPutEntryReadOptions();
+    if (readOptions == null) {
+      // There is no put entry in this blob store, then we don't determine if this storage is still available,
+      // just return true in this case.
+      logger.info("Failed to get a random put entry from store {}", dataDir);
+      return true;
+    }
+    // Read the same chunk for several times, The first time would load data from disk to page cache, and if it does,
+    // we can return true right away. If there is any error, the following reads would try again until the blob store
+    // is shut down.
+    for (int i = 0; i < config.storeIoErrorCountToTriggerShutdown; i++) {
+      if (!isStarted()) {
+        return false;
+      }
+      try {
+        readOptions.doPrefetch(0, readOptions.getMessageInfo().getSize());
+        readOptions.getPrefetchedData().release();
+        onSuccess("EXAMINE");
+        return true;
+      } catch (Exception e) {
+        if (e.getMessage().contains("Input/output error")) {
+          tryOnError();
+        }
+      }
+    }
+    return false;
+  }
+
+  /**
    * @return The number of byte been written to log
    */
   public long getLogEndOffsetInBytes() {
@@ -1124,7 +1168,7 @@ public class BlobStore implements Store {
 
   @Override
   public void setCurrentState(ReplicaState state) {
-    if(currentState != state){
+    if (currentState != state) {
       logger.info("storeId = {}, State change from {} to {}", storeId, currentState, state);
       previousState = currentState;
       currentState = state;
@@ -1251,10 +1295,9 @@ public class BlobStore implements Store {
               replicaId.getPartitionId(), index.getLogUsedCapacity(), sealThresholdBytesLow, sealThresholdBytesHigh);
         }
       }
-    } else if (resolvedReplicaSealStatus == ReplicaSealStatus.PARTIALLY_SEALED && (
-        (replicaStatusDelegates.size() > 1
-            && replicaSealStatus.getAndSet(ReplicaSealStatus.PARTIALLY_SEALED) != ReplicaSealStatus.PARTIALLY_SEALED)
-            || !replicaId.isPartiallySealed())) {
+    } else if (resolvedReplicaSealStatus == ReplicaSealStatus.PARTIALLY_SEALED && ((replicaStatusDelegates.size() > 1
+        && replicaSealStatus.getAndSet(ReplicaSealStatus.PARTIALLY_SEALED) != ReplicaSealStatus.PARTIALLY_SEALED)
+        || !replicaId.isPartiallySealed())) {
       for (ReplicaStatusDelegate replicaStatusDelegate : replicaStatusDelegates) {
         if (!replicaStatusDelegate.partialSeal(replicaId)) {
           metrics.partialSealSetError.inc();
@@ -1268,10 +1311,9 @@ public class BlobStore implements Store {
               partialSealThresholdBytesHigh);
         }
       }
-    } else if (resolvedReplicaSealStatus == ReplicaSealStatus.NOT_SEALED && (
-        (replicaStatusDelegates.size() > 1
-            && replicaSealStatus.getAndSet(ReplicaSealStatus.NOT_SEALED) != ReplicaSealStatus.NOT_SEALED)
-            || !replicaId.isUnsealed())) {
+    } else if (resolvedReplicaSealStatus == ReplicaSealStatus.NOT_SEALED && ((replicaStatusDelegates.size() > 1
+        && replicaSealStatus.getAndSet(ReplicaSealStatus.NOT_SEALED) != ReplicaSealStatus.NOT_SEALED)
+        || !replicaId.isUnsealed())) {
       for (ReplicaStatusDelegate replicaStatusDelegate : replicaStatusDelegates) {
         if (!replicaStatusDelegate.unseal(replicaId)) {
           metrics.unsealSetError.inc();
@@ -1325,7 +1367,6 @@ public class BlobStore implements Store {
     }
   }
 
-
   /**
    * Resolve the {@link ReplicaSealStatus} of this store's replica based on the current {@link ReplicaSealStatus} and
    * current log used capacity.
@@ -1335,15 +1376,15 @@ public class BlobStore implements Store {
     // If the size of log exceeds seal high threshold then the log should be marked as sealed.
     // If the log is already sealed, but the size exceeds low threshold, then we will wait for size to go below low
     // threshold before changing the replica state to partially_sealed.
-    if (index.getLogUsedCapacity() > sealThresholdBytesHigh ||
-        (replicaId.isSealed() && index.getLogUsedCapacity() >= sealThresholdBytesLow)) {
+    if (index.getLogUsedCapacity() > sealThresholdBytesHigh || (replicaId.isSealed()
+        && index.getLogUsedCapacity() >= sealThresholdBytesLow)) {
       return ReplicaSealStatus.SEALED;
     }
     // If the size of log exceeds partial seal high threshold then the log should be marked as partially sealed.
     // If the log is already partially sealed, but the size exceeds low threshold, then we will wait for size to go
     // below low threshold before changing the replica state to partially_sealed.
-    if (index.getLogUsedCapacity() > partialSealThresholdBytesHigh ||
-        (replicaId.isPartiallySealed() && index.getLogUsedCapacity() >= partialSealThresholdBytesLow)) {
+    if (index.getLogUsedCapacity() > partialSealThresholdBytesHigh || (replicaId.isPartiallySealed()
+        && index.getLogUsedCapacity() >= partialSealThresholdBytesLow)) {
       return ReplicaSealStatus.PARTIALLY_SEALED;
     }
     return ReplicaSealStatus.NOT_SEALED;
@@ -1400,6 +1441,16 @@ public class BlobStore implements Store {
         }
       }
       metrics.storeIoErrorTriggeredShutdownCount.inc();
+      if (diskManager != null) {
+        diskManager.onBlobStoreIOError();
+      }
+    }
+  }
+
+  private void tryOnError() {
+    try {
+      onError();
+    } catch (Exception e) {
     }
   }
 

--- a/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
@@ -748,7 +748,7 @@ public class DiskManager {
     if (storeConfig.storeProactivelyTestStorageAvailability && ioErrorCheckerScheduled.compareAndSet(false, true)) {
       // Schedule the ioError checker to go over all the blob stores on this disk
       logger.info("Submitting a task to test storage availability on disk {}", disk.getMountPath());
-      scheduler.submit(() -> {
+      scheduler.schedule(() -> {
         List<BlobStore> storesToCheck = new ArrayList<>(stores.values());
         for (BlobStore store : storesToCheck) {
           logger.info("Testing storage availability for blob store {} on disk {}", store.getDataDir(),
@@ -767,7 +767,7 @@ public class DiskManager {
           }
         }
         ioErrorCheckerScheduled.set(false);
-      });
+      }, storeConfig.storeProactiveTestDelayInSeconds, TimeUnit.SECONDS);
     }
   }
 

--- a/ambry-store/src/main/java/com/github/ambry/store/StoreMessageReadSet.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StoreMessageReadSet.java
@@ -92,6 +92,11 @@ class BlobReadOptions implements Comparable<BlobReadOptions>, Closeable {
   }
 
   @Override
+  public String toString() {
+    return "BlobReadOption: LogSegment[" + segment.getName() + "] Offset[" + offset + "]";
+  }
+
+  @Override
   public int compareTo(BlobReadOptions o) {
     return offset.compareTo(o.offset);
   }

--- a/ambry-store/src/main/java/com/github/ambry/store/StoreMetrics.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StoreMetrics.java
@@ -45,6 +45,7 @@ public class StoreMetrics {
   public final Timer findAllMessageInfosResponse;
   public final Timer isKeyDeletedResponse;
   public final Timer storeStartTime;
+  public final Histogram getRandomPutEntryReadOptionsInMs;
   public final Histogram storeShutdownTimeInMs;
   public final Histogram indexShutdownTimeInMs;
   public final Histogram hardDeleteShutdownTimeInMs;
@@ -158,6 +159,8 @@ public class StoreMetrics {
     isKeyDeletedResponse = registry.timer(MetricRegistry.name(BlobStore.class, name + "IsKeyDeletedResponse"));
     storeStartTime = registry.timer(MetricRegistry.name(BlobStore.class, name + "StoreStartTime"));
     storeShutdownTimeInMs = registry.histogram(MetricRegistry.name(BlobStore.class, name + "StoreShutdownTimeInMs"));
+    getRandomPutEntryReadOptionsInMs =
+        registry.histogram(MetricRegistry.name(PersistentIndex.class, name + "GetRandomPutEntryReadOptionsInMs"));
     indexShutdownTimeInMs =
         registry.histogram(MetricRegistry.name(PersistentIndex.class, name + "IndexShutdownTimeInMs"));
     hardDeleteShutdownTimeInMs =

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
@@ -42,6 +42,8 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -77,8 +79,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.mockito.Mockito;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 
 import static com.github.ambry.clustermap.ClusterMapUtils.*;
 import static com.github.ambry.clustermap.ReplicaState.*;
@@ -1889,9 +1889,9 @@ public class BlobStoreTest {
     StoreKeyFactory mockStoreKeyFactory = Mockito.spy(STORE_KEY_FACTORY);
     BlobStore testStore2 =
         new BlobStore(getMockReplicaId(tempDirStr), new StoreConfig(new VerifiableProperties(properties)), scheduler,
-            storeStatsScheduler, diskIOScheduler, diskSpaceAllocator, storeMetrics, storeMetrics, mockStoreKeyFactory, recovery,
-            hardDelete, Collections.singletonList(mockDelegate), time, new InMemAccountService(false, false), null,
-            scheduler);
+            storeStatsScheduler, null, diskIOScheduler, diskSpaceAllocator, storeMetrics, storeMetrics,
+            mockStoreKeyFactory, recovery, hardDelete, Collections.singletonList(mockDelegate), time,
+            new InMemAccountService(false, false), null, scheduler);
 
     testStore2.start();
     assertTrue("Store should start up", testStore2.isStarted());
@@ -2110,9 +2110,9 @@ public class BlobStoreTest {
     MetricRegistry registry = new MetricRegistry();
     storeMetrics = new StoreMetrics(registry);
     BlobStore testStore =
-        new BlobStore(getMockReplicaId(storeDir.getAbsolutePath()), config, scheduler, storeStatsScheduler,
-            diskIOScheduler, diskAllocator, storeMetrics, storeMetrics, STORE_KEY_FACTORY, recovery, hardDelete, null, time,
-            new InMemAccountService(false, false), null, scheduler);
+        new BlobStore(getMockReplicaId(storeDir.getAbsolutePath()), config, scheduler, storeStatsScheduler, null,
+            diskIOScheduler, diskAllocator, storeMetrics, storeMetrics, STORE_KEY_FACTORY, recovery, hardDelete, null,
+            time, new InMemAccountService(false, false), null, scheduler);
     testStore.start();
     DiskSpaceRequirements diskSpaceRequirements = testStore.getDiskSpaceRequirements();
     diskAllocator.initializePool(diskSpaceRequirements == null ? Collections.emptyList()
@@ -2227,7 +2227,7 @@ public class BlobStoreTest {
     when(dynamicParticipant.supportsStateChanges()).thenReturn(true);
     ReplicaStatusDelegate delegate = new ReplicaStatusDelegate(dynamicParticipant);
     BlobStore testStore =
-        new BlobStore(getMockReplicaId(storeDir.getAbsolutePath()), config, scheduler, storeStatsScheduler,
+        new BlobStore(getMockReplicaId(storeDir.getAbsolutePath()), config, scheduler, storeStatsScheduler, null,
             diskIOScheduler, diskAllocator, storeMetrics, storeMetrics, STORE_KEY_FACTORY, recovery, hardDelete,
             Collections.singletonList(delegate), time, new InMemAccountService(false, false), null, scheduler);
     testStore.start();
@@ -3918,17 +3918,17 @@ public class BlobStoreTest {
 
     MockBlobStore(ReplicaId replicaId, StoreConfig config, List<ReplicaStatusDelegate> replicaStatusDelegates,
         StoreMetrics metrics) {
-      super(replicaId, config, scheduler, storeStatsScheduler, diskIOScheduler, diskSpaceAllocator, metrics, metrics,
-          STORE_KEY_FACTORY, recovery, hardDelete, replicaStatusDelegates, time, new InMemAccountService(false, false),
-          null, scheduler);
+      super(replicaId, config, scheduler, storeStatsScheduler, null, diskIOScheduler, diskSpaceAllocator, metrics,
+          metrics, STORE_KEY_FACTORY, recovery, hardDelete, replicaStatusDelegates, time,
+          new InMemAccountService(false, false), null, scheduler);
     }
 
     MockBlobStore(ReplicaId replicaId, StoreConfig config, List<ReplicaStatusDelegate> replicaStatusDelegates,
         StoreMetrics metrics, BlobStoreStats blobStoreStats) {
-      super(replicaId, replicaId.getPartitionId().toString(), config, scheduler, storeStatsScheduler, diskIOScheduler,
-          diskSpaceAllocator, metrics, metrics, replicaId.getReplicaPath(), replicaId.getCapacityInBytes(),
-          STORE_KEY_FACTORY, recovery, hardDelete, replicaStatusDelegates, time, new InMemAccountService(false, false),
-          blobStoreStats, null, scheduler);
+      super(replicaId, replicaId.getPartitionId().toString(), config, scheduler, storeStatsScheduler, null,
+          diskIOScheduler, diskSpaceAllocator, metrics, metrics, replicaId.getReplicaPath(),
+          replicaId.getCapacityInBytes(), STORE_KEY_FACTORY, recovery, hardDelete, replicaStatusDelegates, time,
+          new InMemAccountService(false, false), blobStoreStats, null, scheduler);
     }
 
     /**

--- a/ambry-store/src/test/java/com/github/ambry/store/CompactionManagerTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CompactionManagerTest.java
@@ -520,8 +520,8 @@ public class CompactionManagerTest {
 
     MockBlobStore(StoreConfig config, StoreMetrics metrics, Time time, CountDownLatch compactCallsCountdown,
         CompactionDetails details) {
-      super(StoreTestUtils.createMockReplicaId("", 0, null), config, null, null, null, null, metrics, metrics, null,
-          null, null, null, time, new InMemAccountService(false, false), null, null);
+      super(StoreTestUtils.createMockReplicaId("", 0, null), config, null, null, null, null, null, metrics, metrics,
+          null, null, null, null, time, new InMemAccountService(false, false), null, null);
       this.compactCallsCountdown = compactCallsCountdown;
       this.details = details;
     }

--- a/ambry-store/src/test/java/com/github/ambry/store/CompactionPolicyTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CompactionPolicyTest.java
@@ -446,8 +446,8 @@ class MockBlobStore extends BlobStore {
   MockBlobStore(StoreConfig config, StoreMetrics metrics, Time time, long capacityInBytes, long segmentCapacity,
       long segmentHeaderSize, long usedCapacity, MockBlobStoreStats mockBlobStoreStats) {
     super(StoreTestUtils.createMockReplicaId(mockBlobStoreStats.getStoreId(), 0,
-            "/tmp/" + mockBlobStoreStats.getStoreId() + "/"), config, null, null, null, null, metrics, metrics, null, null,
-        null, null, time, new InMemAccountService(false, false), null, null);
+            "/tmp/" + mockBlobStoreStats.getStoreId() + "/"), config, null, null, null, null, null, metrics, metrics, null,
+        null, null, null, time, new InMemAccountService(false, false), null, null);
     this.capacityInBytes = capacityInBytes;
     this.segmentCapacity = segmentCapacity;
     this.segmentHeaderSize = segmentHeaderSize;

--- a/ambry-tools/src/main/java/com/github/ambry/store/DiskReformatter.java
+++ b/ambry-tools/src/main/java/com/github/ambry/store/DiskReformatter.java
@@ -308,9 +308,10 @@ public class DiskReformatter {
   private void ensureNotInUse(File srcDir, long storeCapacity) throws StoreException {
     MessageStoreRecovery recovery = new BlobStoreRecovery();
     StoreMetrics metrics = new StoreMetrics(new MetricRegistry());
-    Store store = new BlobStore("move_check_" + UUID.randomUUID().toString(), storeConfig, null, null, diskIOScheduler,
-        diskSpaceAllocator, metrics, metrics, srcDir.getAbsolutePath(), storeCapacity, storeKeyFactory, recovery, null,
-        time, null);
+    Store store =
+        new BlobStore("move_check_" + UUID.randomUUID().toString(), storeConfig, null, null, null, diskIOScheduler,
+            diskSpaceAllocator, metrics, metrics, srcDir.getAbsolutePath(), storeCapacity, storeKeyFactory, recovery,
+            null, time, null);
     store.start();
     store.shutdown();
   }

--- a/ambry-tools/src/main/java/com/github/ambry/store/StoreCopier.java
+++ b/ambry-tools/src/main/java/com/github/ambry/store/StoreCopier.java
@@ -166,10 +166,10 @@ public class StoreCopier implements Closeable {
     this.fetchSizeInBytes = fetchSizeInBytes;
     this.transformers = transformers;
     MessageStoreRecovery recovery = new BlobStoreRecovery();
-    src = new BlobStore(storeId, storeConfig, null, null, diskIOScheduler, diskSpaceAllocator, metrics, metrics,
+    src = new BlobStore(storeId, storeConfig, null, null, null, diskIOScheduler, diskSpaceAllocator, metrics, metrics,
         srcDir.getAbsolutePath(), storeCapacity, storeKeyFactory, recovery, null, time, null);
-    tgt = new BlobStore(storeId + "_tmp", storeConfig, scheduler, null, diskIOScheduler, diskSpaceAllocator, metrics,
-        metrics, tgtDir.getAbsolutePath(), storeCapacity, storeKeyFactory, recovery, null, time, scheduler);
+    tgt = new BlobStore(storeId + "_tmp", storeConfig, scheduler, null, null, diskIOScheduler, diskSpaceAllocator,
+        metrics, metrics, tgtDir.getAbsolutePath(), storeCapacity, storeKeyFactory, recovery, null, time, scheduler);
     src.start();
     tgt.start();
   }

--- a/ambry-tools/src/test/java/com/github/ambry/store/StoreCopierTest.java
+++ b/ambry-tools/src/test/java/com/github/ambry/store/StoreCopierTest.java
@@ -128,10 +128,9 @@ public class StoreCopierTest {
     StoreMetrics storeMetrics = new StoreMetrics(new MetricRegistry());
     Files.copy(new File(srcDir, StoreDescriptor.STORE_DESCRIPTOR_FILENAME).toPath(),
         new File(tgtDir, StoreDescriptor.STORE_DESCRIPTOR_FILENAME).toPath(), StandardCopyOption.REPLACE_EXISTING);
-    BlobStore tgt =
-        new BlobStore(STORE_ID, storeConfig, null, null, DISK_IO_SCHEDULER, StoreTestUtils.DEFAULT_DISK_SPACE_ALLOCATOR,
-            storeMetrics, storeMetrics, tgtDir.getAbsolutePath(), STORE_CAPACITY, STORE_KEY_FACTORY, null, null, time,
-            null);
+    BlobStore tgt = new BlobStore(STORE_ID, storeConfig, null, null, null, DISK_IO_SCHEDULER,
+        StoreTestUtils.DEFAULT_DISK_SPACE_ALLOCATOR, storeMetrics, storeMetrics, tgtDir.getAbsolutePath(),
+        STORE_CAPACITY, STORE_KEY_FACTORY, null, null, time, null);
     tgt.start();
     try {
       // should not be able to get expired or deleted ids
@@ -179,9 +178,9 @@ public class StoreCopierTest {
     long expiryTimeMs = time.milliseconds() + TimeUnit.SECONDS.toMillis(TestUtils.TTL_SECS);
     temporaryPutExpiryTimeMs =
         Utils.getTimeInMsToTheNearestSec(SystemTime.getInstance().milliseconds() + TimeUnit.DAYS.toMillis(1));
-    BlobStore src =
-        new BlobStore(STORE_ID, storeConfig, null, null, DISK_IO_SCHEDULER, StoreTestUtils.DEFAULT_DISK_SPACE_ALLOCATOR,
-            metrics, metrics, srcDir.getAbsolutePath(), STORE_CAPACITY, STORE_KEY_FACTORY, null, null, time, null);
+    BlobStore src = new BlobStore(STORE_ID, storeConfig, null, null, null, DISK_IO_SCHEDULER,
+        StoreTestUtils.DEFAULT_DISK_SPACE_ALLOCATOR, metrics, metrics, srcDir.getAbsolutePath(), STORE_CAPACITY,
+        STORE_KEY_FACTORY, null, null, time, null);
     src.start();
     try {
       short accountId = Utils.getRandomShort(TestUtils.RANDOM);

--- a/build.gradle
+++ b/build.gradle
@@ -214,7 +214,9 @@ project(':ambry-test-utils') {
         compile project(":ambry-server")
         compile project(":ambry-store")
         compile "org.bouncycastle:bcpkix-jdk15on:$bouncycastleVersion"
-        compile "org.apache.hadoop:hadoop-common:$hadoopCommonVersion"
+        compile("org.apache.hadoop:hadoop-common:$hadoopCommonVersion") {
+            exclude group: "org.bouncycastle"
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -214,6 +214,7 @@ project(':ambry-test-utils') {
         compile project(":ambry-server")
         compile project(":ambry-store")
         compile "org.bouncycastle:bcpkix-jdk15on:$bouncycastleVersion"
+        compile "org.apache.hadoop:hadoop-common:$hadoopCommonVersion"
     }
 }
 

--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -35,4 +35,5 @@ ext {
     mockitoVersion = "2.+"
     powermockVersion = "2.+"
     caffeineVersion = "2.9.3"
+    hadoopCommonVersion = "3.4.0"
 }


### PR DESCRIPTION
## Summary
Proactively test storage's availability for all the blob stores on a disk when any blob store on the same disk encountered an io error. 

When disk fails, all blob stores would become unavailable due to io error. But this process might take a long time since it relies on the frontend (or replication) to trigger several io operations, like put or get. Without any io operation, a blob store won't know that the underlying disk has already failed. 

This is particularly an issue when we have lots of old partitions that barely getting any frontend requests and barely getting any replication requests. When one blob store fails due to disk io error, this blob store would be shut down and the replica would enter ERROR state, but the rest of replicas on the same disk would still remain as STANDBY or LEADER. In this case, disk failure handler won't be able to handle this disk failure. 

In this PR, we proactively issue read requests to all blob stores on this disk to trigger read io operations and then force replicas to enter ERROR state. 

## Test
Unit test