### PR TITLE
Simplify exception generation when there are not enough replicas

### DIFF
--- a/ambry-router/src/main/java/com/github/ambry/router/SimpleOperationTracker.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/SimpleOperationTracker.java
@@ -399,18 +399,17 @@ class SimpleOperationTracker implements OperationTracker {
     maybeDeprioritizeLocalBootstrapReplicas(numLocalAndLiveReplicas);
     maybeShuffleWithRemoteReplicas(numLocalAndLiveReplicas, numRemoteOriginatingDcAndLiveReplicas);
     int replicaPoolSize = replicaPool.size();
-    // MockPartitionId.getReplicaIds() is returning a shared reference which may cause race condition.
-    // Please report the test failure if you run into this exception.
-    Supplier<IllegalArgumentException> notEnoughReplicasException = () -> new IllegalArgumentException(
-        generateErrorMessage(partitionId, examinedReplicas, replicaPool, backupReplicasToCheck, downReplicasToCheck,
-            routerOperation));
     possibleRunOfflineRepair = possibleRunOfflineRepair(replicaPoolSize);
     if (replicaPoolSize < getSuccessTarget()) {
       if (possibleRunOfflineRepair) {
         logger.info("RepairRequest: Not enough quorum for delete but give it a try since offline repair is enabled {}",
             blobId);
       } else {
-        throw notEnoughReplicasException.get();
+        // MockPartitionId.getReplicaIds() is returning a shared reference which may cause race condition.
+        // Please report the test failure if you run into this exception.
+        throw new IllegalArgumentException(
+            generateErrorMessage(partitionId, examinedReplicas, replicaPool, backupReplicasToCheck, downReplicasToCheck,
+                routerOperation));
       }
     }
   }


### PR DESCRIPTION
Make the code easier to understand by moving the generation of the exception to the place where it's used, and eliminate an extraneous variable.