### PR TITLE
Exclude xnio from dependency due to vulnerability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -216,6 +216,7 @@ project(':ambry-test-utils') {
         compile "org.bouncycastle:bcpkix-jdk15on:$bouncycastleVersion"
         compile("org.apache.hadoop:hadoop-common:$hadoopCommonVersion") {
             exclude group: "org.bouncycastle"
+            exclude group: "org.jboss", module: "xnio"
         }
     }
 }


### PR DESCRIPTION
## Summary 
Exclude xnio package from dependency due to vulnerability https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-5685

## Test
unit test