### PR TITLE
DiskFailureHandler: check MM reason before exist MM

### DIFF
--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
@@ -14,6 +14,8 @@
 package com.github.ambry.clustermap;
 
 import com.codahale.metrics.MetricRegistry;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.ambry.accountstats.AccountStatsStore;
 import com.github.ambry.commons.Callback;
 import com.github.ambry.commons.CommonUtils;
@@ -39,9 +41,11 @@ import org.apache.helix.AccessOption;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixManager;
 import org.apache.helix.InstanceType;
+import org.apache.helix.PropertyKey;
 import org.apache.helix.lock.LockScope;
 import org.apache.helix.lock.helix.HelixLockScope;
 import org.apache.helix.lock.helix.ZKDistributedNonblockingLock;
+import org.apache.helix.model.ControllerHistory;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.participant.StateMachineEngine;
 import org.apache.helix.store.HelixPropertyStore;
@@ -78,6 +82,7 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
   private volatile boolean inMaintenanceMode = false;
   private volatile String maintenanceModeReason = null;
   final Map<StateModelListenerType, PartitionStateChangeListener> partitionStateChangeListeners;
+  private static final ObjectMapper objectMapper = new ObjectMapper();
 
   private static final Logger logger = LoggerFactory.getLogger(HelixParticipant.class);
 
@@ -481,9 +486,16 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
         throw new IllegalStateException("Cluster is not in maintenance mode");
       }
       try {
-        helixAdmin.manuallyEnableMaintenanceMode(clusterName, false, maintenanceModeReason, null);
+        MaintenanceRecord record = getLastMaintenanceRecord();
+        if (record.operationType.equals(MaintenanceRecord.OPERATION_TYPE_ENTER) && record.reason.equals(
+            maintenanceModeReason)) {
+          helixAdmin.manuallyEnableMaintenanceMode(clusterName, false, maintenanceModeReason, null);
+          logger.info("Cluster {} exits maintenance mode: {}", clusterName, maintenanceModeReason);
+        } else {
+          logger.error("Maintenance record is not expected, operation type: {}, reason: {}", record.operationType,
+              record.reason);
+        }
         inMaintenanceMode = false;
-        logger.info("Cluster {} exits maintenance mode: {}", clusterName, maintenanceModeReason);
         maintenanceModeReason = null;
         exitMaintenanceMode = true;
       } catch (Exception e) {
@@ -491,6 +503,46 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
       }
     }
     return exitMaintenanceMode;
+  }
+
+  /**
+   * Maintenance record. This is an internal structure in helix. It might be changed with new version of helix controller.
+   */
+  static class MaintenanceRecord {
+    @JsonProperty("DATE")
+    public String date;
+    @JsonProperty("TIMESTAMP")
+    public String timestamp;
+    @JsonProperty("OPERATION_TYPE")
+    public String operationType;
+    @JsonProperty("REASON")
+    public String reason;
+    @JsonProperty("TRIGGERED_BY")
+    public String triggeredBy;
+    @JsonProperty("USER")
+    public String user;
+
+    public static final String OPERATION_TYPE_EXIT = "EXIT";
+    public static final String OPERATION_TYPE_ENTER = "ENTER";
+  }
+
+  /**
+   * Get the latest maintenance record. We are assuming this will only be called after cluster enters maintenance mode
+   * so the maintanance record should not be empty. It will throw an exception if there is no maintenance record present
+   * in helix.
+   * @return The latest {@link MaintenanceRecord}.
+   * @throws Exception
+   */
+  MaintenanceRecord getLastMaintenanceRecord() throws Exception {
+    PropertyKey.Builder keyBuilder = new PropertyKey.Builder(clusterName);
+    PropertyKey key = keyBuilder.controllerLeaderHistory();
+    ControllerHistory controllerHistory = manager.getHelixDataAccessor().getProperty(key);
+    List<String> maintenanceHistory = controllerHistory.getMaintenanceHistoryList();
+    if (maintenanceHistory == null || maintenanceHistory.isEmpty()) {
+      throw new IllegalStateException("Missing maintenance history");
+    }
+    String serializedRecord = maintenanceHistory.get(maintenanceHistory.size() - 1);
+    return objectMapper.readValue(serializedRecord, MaintenanceRecord.class);
   }
 
   @Override

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
@@ -487,8 +487,7 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
       }
       try {
         MaintenanceRecord record = getLastMaintenanceRecord();
-        if (record.operationType.equals(MaintenanceRecord.OPERATION_TYPE_ENTER) && record.reason.equals(
-            maintenanceModeReason)) {
+        if (record.reason.equals(maintenanceModeReason)) {
           helixAdmin.manuallyEnableMaintenanceMode(clusterName, false, maintenanceModeReason, null);
           logger.info("Cluster {} exits maintenance mode: {}", clusterName, maintenanceModeReason);
         } else {
@@ -521,9 +520,6 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
     public String triggeredBy;
     @JsonProperty("USER")
     public String user;
-
-    public static final String OPERATION_TYPE_EXIT = "EXIT";
-    public static final String OPERATION_TYPE_ENTER = "ENTER";
   }
 
   /**

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixParticipantTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixParticipantTest.java
@@ -923,9 +923,28 @@ public class HelixParticipantTest {
     HelixParticipant helixParticipant =
         new HelixParticipant(mock(HelixClusterManager.class), clusterMapConfig, new HelixFactory(), metricRegistry,
             getDefaultZkConnectStr(clusterMapConfig), true);
+    String newPort = null;
+    while (newPort == null || props.getProperty("clustermap.port").equals(newPort)) {
+      newPort = String.valueOf(testHardwareLayout.getRandomDataNodeFromDc(dcName).getPort());
+    }
+    Properties props2 = new Properties();
+    props2.setProperty("clustermap.host.name", props.getProperty("clustermap.host.name"));
+    props2.setProperty("clustermap.port", newPort);
+    props2.setProperty("clustermap.cluster.name", clusterName);
+    props2.setProperty("clustermap.datacenter.name", dcName);
+    props2.setProperty("clustermap.dcs.zk.connect.strings", zkJson.toString(2));
+    props2.setProperty("clustermap.state.model.definition", stateModelDef);
+    props2.setProperty("clustermap.data.node.config.source.type", dataNodeConfigSourceType.name());
+    props2.setProperty("clustermap.enable.state.model.listener", "true");
+    props2.setProperty(ClusterMapConfig.DISTRIBUTED_LOCK_LEASE_TIMEOUT_IN_MS,
+        String.valueOf(distributedLockLeaseTimeout));
+    ClusterMapConfig clusterMapConfig2 = new ClusterMapConfig(new VerifiableProperties(props2));
     HelixParticipant helixParticipant2 =
-        new HelixParticipant(mock(HelixClusterManager.class), clusterMapConfig, new HelixFactory(), metricRegistry,
-            getDefaultZkConnectStr(clusterMapConfig), true);
+        new HelixParticipant(mock(HelixClusterManager.class), clusterMapConfig2, new HelixFactory(), metricRegistry,
+            getDefaultZkConnectStr(clusterMapConfig2), true);
+    // Calling participate so manager can connect to zookeeper
+    helixParticipant.participate(Collections.emptyList(), null, null);
+    helixParticipant2.participate(Collections.emptyList(), null, null);
 
     try {
       helixParticipant.exitMaintenanceMode();
@@ -934,12 +953,50 @@ public class HelixParticipantTest {
     }
     assertTrue("First participant should enter maintenance mode", helixParticipant.enterMaintenanceMode("ForTesting"));
     assertFalse("Second participant should fail at entering maintenance mode",
-        helixParticipant2.enterMaintenanceMode("ForTesting"));
+        helixParticipant2.enterMaintenanceMode("ForTesting2"));
+
+    HelixParticipant.MaintenanceRecord record = helixParticipant.getLastMaintenanceRecord();
+    assertEquals(HelixParticipant.MaintenanceRecord.OPERATION_TYPE_ENTER, record.operationType);
+    assertEquals("ForTesting", record.reason);
 
     assertTrue("First participant should exit maintenance mode", helixParticipant.exitMaintenanceMode());
+    record = helixParticipant.getLastMaintenanceRecord();
+    assertEquals(HelixParticipant.MaintenanceRecord.OPERATION_TYPE_EXIT, record.operationType);
+    assertEquals("ForTesting", record.reason);
+
     assertTrue("Second participant should enter maintenance mode",
-        helixParticipant2.enterMaintenanceMode("ForTesting"));
+        helixParticipant2.enterMaintenanceMode("ForTesting2"));
+    record = helixParticipant.getLastMaintenanceRecord();
+    assertEquals(HelixParticipant.MaintenanceRecord.OPERATION_TYPE_ENTER, record.operationType);
+    assertEquals("ForTesting2", record.reason);
+
     assertTrue("Second participant should exit maintenance mode", helixParticipant2.exitMaintenanceMode());
+    record = helixParticipant.getLastMaintenanceRecord();
+    assertEquals(HelixParticipant.MaintenanceRecord.OPERATION_TYPE_EXIT, record.operationType);
+    assertEquals("ForTesting2", record.reason);
+
+    // Enter MM again, but this time, other application might enter MM as well
+    assertTrue("First participant should enter maintenance mode", helixParticipant.enterMaintenanceMode("ForTesting"));
+    helixParticipant2.getHelixAdmin().manuallyEnableMaintenanceMode(clusterName, true, "OVERRIDE", null);
+    record = helixParticipant.getLastMaintenanceRecord();
+    assertEquals(HelixParticipant.MaintenanceRecord.OPERATION_TYPE_ENTER, record.operationType);
+    assertEquals("OVERRIDE", record.reason);
+    assertTrue("First participant should exit maintenance mode without calling helix participant",
+        helixParticipant.exitMaintenanceMode());
+    record = helixParticipant.getLastMaintenanceRecord();
+    assertEquals(HelixParticipant.MaintenanceRecord.OPERATION_TYPE_ENTER, record.operationType);
+    assertEquals("OVERRIDE", record.reason);
+    helixParticipant2.getHelixAdmin().manuallyEnableMaintenanceMode(clusterName, false, "OVERRIDE", null);
+
+    // Enter MM again, but this time, other application would exit
+    assertTrue("First participant should enter maintenance mode", helixParticipant.enterMaintenanceMode("ForTesting"));
+    helixParticipant2.getHelixAdmin().manuallyEnableMaintenanceMode(clusterName, true, "OVERRIDE", null);
+    helixParticipant2.getHelixAdmin().manuallyEnableMaintenanceMode(clusterName, false, "OVERRIDE", null);
+    record = helixParticipant.getLastMaintenanceRecord();
+    assertEquals(HelixParticipant.MaintenanceRecord.OPERATION_TYPE_EXIT, record.operationType);
+    assertEquals("OVERRIDE", record.reason);
+    assertTrue("First participant should exit maintenance mode without calling helix participant",
+        helixParticipant.exitMaintenanceMode());
 
     helixParticipant.close();
     helixParticipant2.close();

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixParticipantTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixParticipantTest.java
@@ -956,35 +956,35 @@ public class HelixParticipantTest {
         helixParticipant2.enterMaintenanceMode("ForTesting2"));
 
     HelixParticipant.MaintenanceRecord record = helixParticipant.getLastMaintenanceRecord();
-    assertEquals(HelixParticipant.MaintenanceRecord.OPERATION_TYPE_ENTER, record.operationType);
+    assertEquals("ENTER", record.operationType);
     assertEquals("ForTesting", record.reason);
 
     assertTrue("First participant should exit maintenance mode", helixParticipant.exitMaintenanceMode());
     record = helixParticipant.getLastMaintenanceRecord();
-    assertEquals(HelixParticipant.MaintenanceRecord.OPERATION_TYPE_EXIT, record.operationType);
+    assertEquals("EXIT", record.operationType);
     assertEquals("ForTesting", record.reason);
 
     assertTrue("Second participant should enter maintenance mode",
         helixParticipant2.enterMaintenanceMode("ForTesting2"));
     record = helixParticipant.getLastMaintenanceRecord();
-    assertEquals(HelixParticipant.MaintenanceRecord.OPERATION_TYPE_ENTER, record.operationType);
+    assertEquals("ENTER", record.operationType);
     assertEquals("ForTesting2", record.reason);
 
     assertTrue("Second participant should exit maintenance mode", helixParticipant2.exitMaintenanceMode());
     record = helixParticipant.getLastMaintenanceRecord();
-    assertEquals(HelixParticipant.MaintenanceRecord.OPERATION_TYPE_EXIT, record.operationType);
+    assertEquals("EXIT", record.operationType);
     assertEquals("ForTesting2", record.reason);
 
     // Enter MM again, but this time, other application might enter MM as well
     assertTrue("First participant should enter maintenance mode", helixParticipant.enterMaintenanceMode("ForTesting"));
     helixParticipant2.getHelixAdmin().manuallyEnableMaintenanceMode(clusterName, true, "OVERRIDE", null);
     record = helixParticipant.getLastMaintenanceRecord();
-    assertEquals(HelixParticipant.MaintenanceRecord.OPERATION_TYPE_ENTER, record.operationType);
+    assertEquals("ENTER", record.operationType);
     assertEquals("OVERRIDE", record.reason);
     assertTrue("First participant should exit maintenance mode without calling helix participant",
         helixParticipant.exitMaintenanceMode());
     record = helixParticipant.getLastMaintenanceRecord();
-    assertEquals(HelixParticipant.MaintenanceRecord.OPERATION_TYPE_ENTER, record.operationType);
+    assertEquals("ENTER", record.operationType);
     assertEquals("OVERRIDE", record.reason);
     helixParticipant2.getHelixAdmin().manuallyEnableMaintenanceMode(clusterName, false, "OVERRIDE", null);
 
@@ -993,7 +993,7 @@ public class HelixParticipantTest {
     helixParticipant2.getHelixAdmin().manuallyEnableMaintenanceMode(clusterName, true, "OVERRIDE", null);
     helixParticipant2.getHelixAdmin().manuallyEnableMaintenanceMode(clusterName, false, "OVERRIDE", null);
     record = helixParticipant.getLastMaintenanceRecord();
-    assertEquals(HelixParticipant.MaintenanceRecord.OPERATION_TYPE_EXIT, record.operationType);
+    assertEquals("EXIT", record.operationType);
     assertEquals("OVERRIDE", record.reason);
     assertTrue("First participant should exit maintenance mode without calling helix participant",
         helixParticipant.exitMaintenanceMode());

--- a/build.gradle
+++ b/build.gradle
@@ -293,6 +293,9 @@ project(':ambry-clustermap') {
                 project(':ambry-utils')
         compile "org.apache.helix:helix-core:$helixVersion"
         compile "org.apache.helix:helix-lock:$helixVersion"
+        compile "com.fasterxml.jackson.core:jackson-core:$jacksonVersion"
+        compile "com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion"
+        compile "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
         compile "io.dropwizard.metrics:metrics-core:$metricsVersion"
         compile "org.json:json:$jsonVersion"
         testCompile project(':ambry-commons')


### PR DESCRIPTION
## Summary
In disk failure handler, before exiting MaintenanceMode, we should check if the MM reason has been updated or not. If it has already been updated (overridden) by other application, we should not exit MM in disk failure handler.

## Reason for this change
When doing deployment, we don't want to back off if the cluster is in MM due to any other reason, so we would override the MM reason before the deployment. If we run into a race condition where
1. DiskFailureHandler Enter MM
2. Deployment Enter MM by overriding the reason
3. DiskFailureHandler Exit MM

In this case, DiskFailureHandler would exit MM and leave deployment without any protection from MM.

## Test
Unit test