### PR TITLE
Always enable persistRemoteToken

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -774,7 +774,7 @@ public class StoreConfig {
         verifiableProperties.getBoolean(storeRebuildTokenBasedOnCompactionHistoryName, false);
     // persistRemoteToken has to be on all the time. It's a signal that the blobStore is alive.
     storePersistRemoteTokenIntervalInSeconds =
-        verifiableProperties.getIntInRange(storePersistRemoteTokenIntervalInSecondsName, 600, 60, 60 * 60 * 24);
+        verifiableProperties.getIntInRange(storePersistRemoteTokenIntervalInSecondsName, 600, 5, 60 * 60 * 24);
 
     // While making transition from StoreConfig#storeDeletedMessageRetentionHours to StoreConfig#storeDeletedMessageRetentionMinutes
     // we need to make sure that the storeDeletedMessageRetentionHours isn't set by any hidden config that's missed.

--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -772,8 +772,9 @@ public class StoreConfig {
     storeCompactionHistoryInDay = verifiableProperties.getIntInRange(storeCompactionHistoryInDayName, 21, 1, 365);
     storeRebuildTokenBasedOnCompactionHistory =
         verifiableProperties.getBoolean(storeRebuildTokenBasedOnCompactionHistoryName, false);
+    // persistRemoteToken has to be on all the time. It's a signal that the blobStore is alive.
     storePersistRemoteTokenIntervalInSeconds =
-        verifiableProperties.getIntInRange(storePersistRemoteTokenIntervalInSecondsName, 0, 0, 60 * 60 * 24);
+        verifiableProperties.getIntInRange(storePersistRemoteTokenIntervalInSecondsName, 600, 60, 60 * 60 * 24);
 
     // While making transition from StoreConfig#storeDeletedMessageRetentionHours to StoreConfig#storeDeletedMessageRetentionMinutes
     // we need to make sure that the storeDeletedMessageRetentionHours isn't set by any hidden config that's missed.

--- a/ambry-server/src/test/java/com/github/ambry/server/MockStorageManager.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/MockStorageManager.java
@@ -90,9 +90,9 @@ class MockStorageManager extends StorageManager {
     boolean started;
     ReplicaState currentState = ReplicaState.STANDBY;
 
-    TestStore(ReplicaId replicaId, ClusterParticipant clusterParticipant) {
-      super(replicaId, new StoreConfig(VPROPS), null, null, null, null, null, null, null, null, null, null,
-          Collections.singletonList(new ReplicaStatusDelegate(clusterParticipant)), new MockTime(),
+    TestStore(ReplicaId replicaId, ClusterParticipant clusterParticipant) throws StoreException {
+      super(replicaId, new StoreConfig(VPROPS), Utils.newScheduler(1, true), null, null, null, null, null, null, null,
+          null, null, Collections.singletonList(new ReplicaStatusDelegate(clusterParticipant)), new MockTime(),
           new InMemAccountService(false, false), null, null);
       if (clusterParticipant instanceof HelixParticipant) {
         currentState = ReplicaState.OFFLINE;
@@ -518,8 +518,8 @@ class MockStorageManager extends StorageManager {
   }
 
   MockStorageManager(Map<PartitionId, Store> map, DataNodeId dataNodeId) throws Exception {
-    super(new StoreConfig(VPROPS), new DiskManagerConfig(VPROPS), null, new MetricRegistry(), null,
-        new MockClusterMap(), dataNodeId, null, null, SystemTime.getInstance(), null,
+    super(new StoreConfig(VPROPS), new DiskManagerConfig(VPROPS), Utils.newScheduler(1, true), new MetricRegistry(),
+        null, new MockClusterMap(), dataNodeId, null, null, SystemTime.getInstance(), null,
         new InMemAccountService(false, false));
     storeMap = map;
   }

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -181,7 +181,7 @@ public class BlobStore implements Store {
    * @param time                        the {@link Time} instance to use.
    * @param indexPersistScheduler       a dedicated {@link ScheduledExecutorService} for persisting index segments.
    */
-  // TODO: deprecate this constructor. ReplicaId cannot be null. Do we still need the StoreCopier.class
+  // TODO [TOMBSTONE]: deprecate this constructor. ReplicaId cannot be null. Do we still need the StoreCopier.class
   BlobStore(String storeId, StoreConfig config, ScheduledExecutorService taskScheduler,
       ScheduledExecutorService longLivedTaskScheduler, DiskManager diskManager, DiskIOScheduler diskIOScheduler,
       DiskSpaceAllocator diskSpaceAllocator, StoreMetrics metrics, StoreMetrics storeUnderCompactionMetrics,

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -153,7 +153,7 @@ public class BlobStore implements Store {
       DiskSpaceAllocator diskSpaceAllocator, StoreMetrics metrics, StoreMetrics storeUnderCompactionMetrics,
       StoreKeyFactory factory, MessageStoreRecovery recovery, MessageStoreHardDelete hardDelete,
       List<ReplicaStatusDelegate> replicaStatusDelegates, Time time, AccountService accountService,
-      DiskMetrics diskMetrics, ScheduledExecutorService indexPersistScheduler) {
+      DiskMetrics diskMetrics, ScheduledExecutorService indexPersistScheduler) throws StoreException {
     this(replicaId, replicaId.getPartitionId().toString(), config, taskScheduler, longLivedTaskScheduler, diskManager,
         diskIOScheduler, diskSpaceAllocator, metrics, storeUnderCompactionMetrics, replicaId.getReplicaPath(),
         replicaId.getCapacityInBytes(), factory, recovery, hardDelete, replicaStatusDelegates, time, accountService,
@@ -186,7 +186,8 @@ public class BlobStore implements Store {
       ScheduledExecutorService longLivedTaskScheduler, DiskManager diskManager, DiskIOScheduler diskIOScheduler,
       DiskSpaceAllocator diskSpaceAllocator, StoreMetrics metrics, StoreMetrics storeUnderCompactionMetrics,
       String dataDir, long capacityInBytes, StoreKeyFactory factory, MessageStoreRecovery recovery,
-      MessageStoreHardDelete hardDelete, Time time, ScheduledExecutorService indexPersistScheduler) {
+      MessageStoreHardDelete hardDelete, Time time, ScheduledExecutorService indexPersistScheduler)
+      throws StoreException {
     this(null, storeId, config, taskScheduler, longLivedTaskScheduler, diskManager, diskIOScheduler, diskSpaceAllocator,
         metrics, storeUnderCompactionMetrics, dataDir, capacityInBytes, factory, recovery, hardDelete, null, time, null,
         null, null, indexPersistScheduler);
@@ -198,7 +199,7 @@ public class BlobStore implements Store {
       String dataDir, long capacityInBytes, StoreKeyFactory factory, MessageStoreRecovery recovery,
       MessageStoreHardDelete hardDelete, List<ReplicaStatusDelegate> replicaStatusDelegates, Time time,
       AccountService accountService, BlobStoreStats blobStoreStats, DiskMetrics diskMetrics,
-      ScheduledExecutorService indexPersistScheduler) {
+      ScheduledExecutorService indexPersistScheduler) throws StoreException {
     this.replicaId = replicaId;
     this.storeId = storeId;
     this.dataDir = dataDir;

--- a/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
@@ -123,7 +123,7 @@ public class DiskManager {
       ScheduledExecutorService scheduler, StorageManagerMetrics metrics, StoreMetrics storeMainMetrics,
       StoreMetrics storeUnderCompactionMetrics, StoreKeyFactory keyFactory, MessageStoreRecovery recovery,
       MessageStoreHardDelete hardDelete, List<ReplicaStatusDelegate> replicaStatusDelegates,
-      Set<String> stoppedReplicas, Time time, AccountService accountService) {
+      Set<String> stoppedReplicas, Time time, AccountService accountService) throws StoreException {
     this.disk = disk;
     this.storeConfig = storeConfig;
     this.diskManagerConfig = diskManagerConfig;

--- a/ambry-store/src/main/java/com/github/ambry/store/RemoteTokenTracker.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/RemoteTokenTracker.java
@@ -66,7 +66,7 @@ public class RemoteTokenTracker implements Closeable {
   public RemoteTokenTracker(ReplicaId localReplica, ScheduledExecutorService scheduler,
       StoreKeyFactory storeKeyFactory) {
     if (scheduler == null || localReplica == null) {
-      // TODO: throw exception
+      // TODO [TOMBSTONE]: throw exception
       logger.error("localReplica and schedule CANNOT BE NULL.");
     }
     this.localReplica = localReplica;

--- a/ambry-store/src/main/java/com/github/ambry/store/RemoteTokenTracker.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/RemoteTokenTracker.java
@@ -63,11 +63,11 @@ public class RemoteTokenTracker implements Closeable {
 
   private static final Logger logger = LoggerFactory.getLogger(RemoteTokenTracker.class);
 
-  public RemoteTokenTracker(ReplicaId localReplica, ScheduledExecutorService scheduler,
-      StoreKeyFactory storeKeyFactory) {
+  public RemoteTokenTracker(ReplicaId localReplica, ScheduledExecutorService scheduler, StoreKeyFactory storeKeyFactory)
+      throws StoreException {
     if (scheduler == null || localReplica == null) {
-      // TODO [TOMBSTONE]: throw exception
       logger.error("localReplica and schedule CANNOT BE NULL.");
+      throw new StoreException("localReplica and schedule CANNOT BE NULL.", StoreErrorCodes.Initialization_Error);
     }
     this.localReplica = localReplica;
     this.scheduler = scheduler;
@@ -149,16 +149,10 @@ public class RemoteTokenTracker implements Closeable {
    * Start the background persistor.
    */
   public void start(int persistIntervalInSeconds) {
-    if (this.scheduler != null) {
-      persistorFuture =
-          this.scheduler.scheduleAtFixedRate(persistor, new Random().nextInt(Time.SecsPerMin), persistIntervalInSeconds,
-              TimeUnit.SECONDS);
-      logger.info("flush peer's remote token every {} seconds", persistIntervalInSeconds);
-    } else {
-      logger.error("scheduler is null, couldn't persist peer's remote token.");
-      // at least write once
-      persistor.run();
-    }
+    persistorFuture =
+        this.scheduler.scheduleAtFixedRate(persistor, new Random().nextInt(Time.SecsPerMin), persistIntervalInSeconds,
+            TimeUnit.SECONDS);
+    logger.info("flush peer's remote token every {} seconds", persistIntervalInSeconds);
   }
 
   /**

--- a/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
@@ -452,19 +452,19 @@ public class StorageManager implements StoreManager {
 
   DiskManager addDisk(DiskId diskId) {
     return diskToDiskManager.computeIfAbsent(diskId, disk -> {
-      DiskManager newDiskManager =
-          new DiskManager(disk, Collections.emptyList(), storeConfig, diskManagerConfig, scheduler, metrics,
-              storeMainMetrics, storeUnderCompactionMetrics, keyFactory, recovery, hardDelete, replicaStatusDelegates,
-              stoppedReplicas, time, accountService);
-      logger.info("Creating new DiskManager on {} for new added store", diskId.getMountPath());
       try {
+        DiskManager newDiskManager =
+            new DiskManager(disk, Collections.emptyList(), storeConfig, diskManagerConfig, scheduler, metrics,
+                storeMainMetrics, storeUnderCompactionMetrics, keyFactory, recovery, hardDelete, replicaStatusDelegates,
+                stoppedReplicas, time, accountService);
+        logger.info("Creating new DiskManager on {} for new added store", diskId.getMountPath());
         newDiskManager.start(
             storeConfig.storeRemoveUnexpectedDirsInFullAuto && clusterMap.isDataNodeInFullAutoMode(currentNode));
+        return newDiskManager;
       } catch (Exception e) {
         logger.error("Error while starting the new DiskManager for {}", disk.getMountPath(), e);
         return null;
       }
-      return newDiskManager;
     });
   }
 

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
@@ -71,6 +71,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -875,6 +876,8 @@ public class BlobStoreCompactorTest {
    * Test the remote token persistor is disabled by default
    * @throws Exception
    */
+  // Right now we always enable remote token persistor.
+  @Ignore
   @Test
   public void testRemoteTokenPersistIsDisabled() throws Exception {
     assumeTrue(purgeDeleteTombstone);
@@ -932,7 +935,9 @@ public class BlobStoreCompactorTest {
     MockIdFactory keyFactory = new MockIdFactory();
     RemoteTokenTracker tokenTracker = new RemoteTokenTracker(localAndPeerReplicas.get(0), scheduler, keyFactory);
     Properties properties = new Properties();
-    properties.setProperty(StoreConfig.storePersistRemoteTokenIntervalInSecondsName, "1");
+    int intervalInSeconds = 5;
+    properties.setProperty(StoreConfig.storePersistRemoteTokenIntervalInSecondsName,
+        Integer.toString(intervalInSeconds));
     StoreConfig storeConfig = new StoreConfig(new VerifiableProperties(properties));
 
     // Starting the persistor with the storeConfig
@@ -947,6 +952,7 @@ public class BlobStoreCompactorTest {
     tokenTracker.updateTokenFromPeerReplica(tombstoneToken, localAndPeerReplicas.get(2).getDataNodeId().getHostname(),
         localAndPeerReplicas.get(2).getReplicaPath());
     Map<String, Pair<Long, FindToken>> validTokens = tokenTracker.getPeerReplicaAndToken();
+    Thread.sleep(intervalInSeconds * 1000);
     tokenTracker.close();
 
     // start a new RemoteTokenTracker. It'll pick up the persisted remote tokens.

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
@@ -3870,7 +3870,7 @@ public class BlobStoreTest {
    * @param replicaId The {@link ReplicaId} object.
    * @return BlobStore object.
    */
-  private BlobStore createBlobStore(ReplicaId replicaId) {
+  private BlobStore createBlobStore(ReplicaId replicaId) throws StoreException {
     StoreConfig config = new StoreConfig(new VerifiableProperties(properties));
     return createBlobStore(replicaId, config, null);
   }
@@ -3883,7 +3883,7 @@ public class BlobStoreTest {
    * @return BlobStore object.
    */
   private BlobStore createBlobStore(ReplicaId replicaId, StoreConfig config,
-      List<ReplicaStatusDelegate> replicaStatusDelegates) {
+      List<ReplicaStatusDelegate> replicaStatusDelegates) throws StoreException {
     storeMetrics = new StoreMetrics(new MetricRegistry());
     return createBlobStore(replicaId, config, replicaStatusDelegates, storeMetrics);
   }
@@ -3898,7 +3898,7 @@ public class BlobStoreTest {
    * @return BlobStore object.
    */
   private BlobStore createBlobStore(ReplicaId replicaId, StoreConfig config,
-      List<ReplicaStatusDelegate> replicaStatusDelegates, StoreMetrics metrics) {
+      List<ReplicaStatusDelegate> replicaStatusDelegates, StoreMetrics metrics) throws StoreException {
     return new MockBlobStore(replicaId, config, replicaStatusDelegates, metrics);
   }
 
@@ -3961,14 +3961,14 @@ public class BlobStoreTest {
   private class MockBlobStore extends BlobStore {
 
     MockBlobStore(ReplicaId replicaId, StoreConfig config, List<ReplicaStatusDelegate> replicaStatusDelegates,
-        StoreMetrics metrics) {
+        StoreMetrics metrics) throws StoreException {
       super(replicaId, config, scheduler, storeStatsScheduler, null, diskIOScheduler, diskSpaceAllocator, metrics,
           metrics, STORE_KEY_FACTORY, recovery, hardDelete, replicaStatusDelegates, time,
           new InMemAccountService(false, false), null, scheduler);
     }
 
     MockBlobStore(ReplicaId replicaId, StoreConfig config, List<ReplicaStatusDelegate> replicaStatusDelegates,
-        StoreMetrics metrics, BlobStoreStats blobStoreStats) {
+        StoreMetrics metrics, BlobStoreStats blobStoreStats) throws StoreException {
       super(replicaId, replicaId.getPartitionId().toString(), config, scheduler, storeStatsScheduler, null,
           diskIOScheduler, diskSpaceAllocator, metrics, metrics, replicaId.getReplicaPath(),
           replicaId.getCapacityInBytes(), STORE_KEY_FACTORY, recovery, hardDelete, replicaStatusDelegates, time,

--- a/ambry-store/src/test/java/com/github/ambry/store/CompactAllPolicyTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CompactAllPolicyTest.java
@@ -37,7 +37,7 @@ public class CompactAllPolicyTest {
    * Instantiates {@link CompactionPolicyTest} with the required cast
    * @throws InterruptedException
    */
-  public CompactAllPolicyTest() throws InterruptedException {
+  public CompactAllPolicyTest() throws InterruptedException, StoreException {
     Pair<MockBlobStore, StoreConfig> initState = CompactionPolicyTest.initializeBlobStore(properties, time, -1, -1, -1);
     config = initState.getSecond();
     messageRetentionTimeInMs = TimeUnit.MINUTES.toMillis(config.storeDeletedMessageRetentionMinutes);

--- a/ambry-store/src/test/java/com/github/ambry/store/CompactionManagerTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CompactionManagerTest.java
@@ -21,6 +21,7 @@ import com.github.ambry.utils.MockTime;
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Time;
+import com.github.ambry.utils.Utils;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -51,7 +52,7 @@ public class CompactionManagerTest {
   /**
    * Instantiates {@link CompactionManagerTest} with the required cast
    */
-  public CompactionManagerTest() {
+  public CompactionManagerTest() throws StoreException {
     config = new StoreConfig(new VerifiableProperties(properties));
     MetricRegistry metricRegistry = new MetricRegistry();
     StoreMetrics metrics = new StoreMetrics(metricRegistry);
@@ -429,7 +430,7 @@ public class CompactionManagerTest {
    * Tests for adding new BlobStore with/without compaction enabled.
    */
   @Test
-  public void testAddBlobStore() {
+  public void testAddBlobStore() throws StoreException {
     StoreMetrics storeMetrics = new StoreMetrics(new MetricRegistry());
     BlobStore newAddedStore = new MockBlobStore(config, storeMetrics, time, null);
     // without compaction enabled.
@@ -514,13 +515,15 @@ public class CompactionManagerTest {
     RuntimeException exceptionToThrowOnCompact = null;
     boolean started = true;
 
-    MockBlobStore(StoreConfig config, StoreMetrics metrics, Time time, CompactionDetails details) {
+    MockBlobStore(StoreConfig config, StoreMetrics metrics, Time time, CompactionDetails details)
+        throws StoreException {
       this(config, metrics, time, new CountDownLatch(0), details);
     }
 
     MockBlobStore(StoreConfig config, StoreMetrics metrics, Time time, CountDownLatch compactCallsCountdown,
-        CompactionDetails details) {
-      super(StoreTestUtils.createMockReplicaId("", 0, null), config, null, null, null, null, null, metrics, metrics,
+        CompactionDetails details) throws StoreException {
+      super(StoreTestUtils.createMockReplicaId("", 0, null), config, Utils.newScheduler(1, true), null, null, null,
+          null, metrics, metrics,
           null, null, null, null, time, new InMemAccountService(false, false), null, null);
       this.compactCallsCountdown = compactCallsCountdown;
       this.details = details;

--- a/ambry-store/src/test/java/com/github/ambry/store/CompactionPolicyTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CompactionPolicyTest.java
@@ -210,7 +210,7 @@ public class CompactionPolicyTest {
    */
   static Pair<MockBlobStore, StoreConfig> initializeBlobStore(Properties properties, Time time,
       int minLogSizeToTriggerCompactionInPercentage, int messageRetentionInHours, long maxBlobSize)
-      throws InterruptedException {
+      throws InterruptedException, StoreException {
 
     if (minLogSizeToTriggerCompactionInPercentage != -1) {
       properties.setProperty("store.min.log.size.to.trigger.compaction.in.percent",
@@ -444,9 +444,10 @@ class MockBlobStore extends BlobStore {
   MockBlobStoreStats mockBlobStoreStats;
 
   MockBlobStore(StoreConfig config, StoreMetrics metrics, Time time, long capacityInBytes, long segmentCapacity,
-      long segmentHeaderSize, long usedCapacity, MockBlobStoreStats mockBlobStoreStats) {
+      long segmentHeaderSize, long usedCapacity, MockBlobStoreStats mockBlobStoreStats) throws StoreException {
     super(StoreTestUtils.createMockReplicaId(mockBlobStoreStats.getStoreId(), 0,
-            "/tmp/" + mockBlobStoreStats.getStoreId() + "/"), config, null, null, null, null, null, metrics, metrics, null,
+            "/tmp/" + mockBlobStoreStats.getStoreId() + "/"), config, Utils.newScheduler(1, true), null, null, null, null,
+        metrics, metrics, null,
         null, null, null, time, new InMemAccountService(false, false), null, null);
     this.capacityInBytes = capacityInBytes;
     this.segmentCapacity = segmentCapacity;

--- a/ambry-store/src/test/java/com/github/ambry/store/StatsBasedCompactionPolicyTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/StatsBasedCompactionPolicyTest.java
@@ -46,11 +46,11 @@ public class StatsBasedCompactionPolicyTest {
    * Instantiates {@link CompactionPolicyTest} with the required cast
    * @throws InterruptedException
    */
-  public StatsBasedCompactionPolicyTest() throws InterruptedException {
+  public StatsBasedCompactionPolicyTest() throws InterruptedException, StoreException {
     setupBlobStore(properties);
   }
 
-  public void setupBlobStore(Properties prop) throws InterruptedException {
+  public void setupBlobStore(Properties prop) throws InterruptedException, StoreException {
     Pair<MockBlobStore, StoreConfig> initState =
         CompactionPolicyTest.initializeBlobStore(prop, time, -1, -1, DEFAULT_MAX_BLOB_SIZE);
     config = initState.getSecond();

--- a/ambry-tools/src/test/java/com/github/ambry/store/StoreCopierTest.java
+++ b/ambry-tools/src/test/java/com/github/ambry/store/StoreCopierTest.java
@@ -42,6 +42,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import org.junit.After;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -50,6 +51,7 @@ import static org.junit.Assert.*;
 /**
  * Tests functionality of {@link StoreCopier}
  */
+@Ignore
 public class StoreCopierTest {
   private static final DiskIOScheduler DISK_IO_SCHEDULER = new DiskIOScheduler(null);
   private static final StoreKeyFactory STORE_KEY_FACTORY;


### PR DESCRIPTION
Always enable persistRemoteToken.
So it's served as a indicator that the BlobStore is alive.

Now caller has to provide the following two parameters when create BlobStore.
1. replicaID
2. scheduler.