### PR TITLE
Add new metrics to show distribution for delete tombstones

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/store/DeleteTombstoneStats.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/DeleteTombstoneStats.java
@@ -219,7 +219,6 @@ public class DeleteTombstoneStats {
         for (Pair<Long, AtomicLong> p : deltas) {
           if (p.getFirst() >= d) {
             p.getSecond().addAndGet(size);
-            break;
           }
         }
       }

--- a/ambry-api/src/main/java/com/github/ambry/store/DeleteTombstoneStats.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/DeleteTombstoneStats.java
@@ -1,0 +1,251 @@
+/**
+ * Copyright 2024 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.store;
+
+import com.github.ambry.utils.Pair;
+import com.github.ambry.utils.SystemTime;
+import com.github.ambry.utils.Time;
+import com.github.ambry.utils.Utils;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+
+/**
+ * A wrapper class to carry delete tombstone stats between different components
+ */
+public class DeleteTombstoneStats {
+  // The number of delete tombstones who have ttl (doesn't have to be expired)
+  public final long expiredCount;
+  // The size of delete tombstones who have ttl (doesn't have to be expired)
+  public final long expiredSize;
+  // The number of delete tombstones who don't have ttl
+  public final long permanentCount;
+  // The size of delete tombstones who don't have ttl
+  public final long permanentSize;
+  // The size of delete tombstones who don't have ttl and was deleted within one day
+  public final long permanentSizeOneDay;
+  // The size of delete tombstones who don't have ttl and was deleted within two days
+  public final long permanentSizeTwoDays;
+  // The size of delete tombstones who don't have ttl and was deleted within three days
+  public final long permanentSizeThreeDays;
+  // The size of delete tombstones who don't have ttl and was deleted within five days
+  public final long permanentSizeFiveDays;
+  // The size of delete tombstones who don't have ttl and was deleted within seven days
+  public final long permanentSizeSevenDays;
+  // The size of delete tombstones who don't have ttl and was deleted within ten days
+  public final long permanentSizeTenDays;
+  // The size of delete tombstones who don't have ttl and was deleted within fourteen days
+  public final long permanentSizeFourteenDays;
+
+  /**
+   * A static instance representing all zero stats.
+   */
+  public static final DeleteTombstoneStats BASE = new DeleteTombstoneStats(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+
+  /**
+   * Private constructor to create a {@link DeleteTombstoneStats}.
+   * @param expiredCount
+   * @param expiredSize
+   * @param permanentCount
+   * @param permanentSize
+   * @param permanentSizeOneDay
+   * @param permanentSizeTwoDays
+   * @param permanentSizeThreeDays
+   * @param permanentSizeFiveDays
+   * @param permanentSizeSevenDays
+   * @param permanentSizeTenDays
+   * @param permanentSizeFourteenDays
+   */
+  private DeleteTombstoneStats(long expiredCount, long expiredSize, long permanentCount, long permanentSize,
+      long permanentSizeOneDay, long permanentSizeTwoDays, long permanentSizeThreeDays, long permanentSizeFiveDays,
+      long permanentSizeSevenDays, long permanentSizeTenDays, long permanentSizeFourteenDays) {
+    this.expiredCount = expiredCount;
+    this.expiredSize = expiredSize;
+    this.permanentCount = permanentCount;
+    this.permanentSize = permanentSize;
+    this.permanentSizeOneDay = permanentSizeOneDay;
+    this.permanentSizeTwoDays = permanentSizeTwoDays;
+    this.permanentSizeThreeDays = permanentSizeThreeDays;
+    this.permanentSizeFiveDays = permanentSizeFiveDays;
+    this.permanentSizeSevenDays = permanentSizeSevenDays;
+    this.permanentSizeTenDays = permanentSizeTenDays;
+    this.permanentSizeFourteenDays = permanentSizeFourteenDays;
+  }
+
+  /**
+   * Merge the given {@link DeleteTombstoneStats} to create a new {@link DeleteTombstoneStats}.
+   * @param other The {@link DeleteTombstoneStats} to merge
+   * @return A new {@link DeleteTombstoneStats} whose stats are the sum of this stats and the given stats.
+   */
+  public DeleteTombstoneStats merge(DeleteTombstoneStats other) {
+    //@formatter:off
+    return new DeleteTombstoneStats(
+        this.expiredCount + other.expiredCount,
+        this.expiredSize + other.expiredSize,
+        this.permanentCount + other.permanentCount,
+        this.permanentSize + other.permanentSize,
+        this.permanentSizeOneDay + other.permanentSizeOneDay,
+        this.permanentSizeTwoDays + other.permanentSizeTwoDays,
+        this.permanentSizeThreeDays + other.permanentSizeThreeDays,
+        this.permanentSizeFiveDays + other.permanentSizeFiveDays,
+        this.permanentSizeSevenDays + other.permanentSizeSevenDays,
+        this.permanentSizeTenDays + other.permanentSizeTenDays,
+        this.permanentSizeFourteenDays + other.permanentSizeFourteenDays
+    );
+    //@formatter:on
+  }
+
+  /**
+   * A builder to build {@link DeleteTombstoneStats}.
+   */
+  public static class Builder {
+    private long expiredCount = 0;
+    private long expiredSize = 0;
+    private long permanentCount = 0;
+    private long permanentSize = 0;
+    //@formatter:off
+    private final List<Pair<Long, AtomicLong>> deltas = Arrays.asList(
+        Pair.of(TimeUnit.DAYS.toMillis(1), new AtomicLong(0)),
+        Pair.of(TimeUnit.DAYS.toMillis(2), new AtomicLong(0)),
+        Pair.of(TimeUnit.DAYS.toMillis(3), new AtomicLong(0)),
+        Pair.of(TimeUnit.DAYS.toMillis(5), new AtomicLong(0)),
+        Pair.of(TimeUnit.DAYS.toMillis(7), new AtomicLong(0)),
+        Pair.of(TimeUnit.DAYS.toMillis(10), new AtomicLong(0)),
+        Pair.of(TimeUnit.DAYS.toMillis(14), new AtomicLong(0))
+    );
+    //@formatter:on
+    private final Time time;
+
+    /**
+     * Constructor to create a builder.
+     */
+    public Builder() {
+      this(SystemTime.getInstance());
+    }
+
+    /**
+     * Constructor to create a builder.
+     * @param time The {@link Time} instance.
+     */
+    public Builder(Time time) {
+      this.time = time;
+    }
+
+    /**
+     * Generate some random value to initialize delete tombstone count and size. This is only used for testing.
+     * @param random The {@link Random} generator.
+     * @param countLimit The upper bound of delete tombstone count.
+     * @param sizeLimit The upper bound of delete tombstone size.
+     * @return This builder.
+     */
+    public Builder random(Random random, int countLimit, int sizeLimit) {
+      this.expiredCount = random.nextInt(countLimit);
+      this.permanentCount = random.nextInt(countLimit);
+      this.expiredSize = random.nextInt(sizeLimit);
+      this.permanentSize = random.nextInt(sizeLimit);
+      return this;
+    }
+
+    /**
+     * Increment {@link DeleteTombstoneStats#expiredCount} by one.
+     * @return This builder
+     */
+    public Builder expiredCountInc() {
+      this.expiredCount++;
+      return this;
+    }
+
+    /**
+     * Increment {@link DeleteTombstoneStats#expiredCount} by given count.
+     * @return This builder
+     */
+    public Builder expiredCountInc(long count) {
+      this.expiredCount += count;
+      return this;
+    }
+
+    /**
+     * Increment {@link DeleteTombstoneStats#permanentCount} by one.
+     * @return This builder.
+     */
+    public Builder permanentCountInc() {
+      this.permanentCount++;
+      return this;
+    }
+
+    /**
+     * Increment {@link DeleteTombstoneStats#permanentCount} by given count.
+     * @return This builder.
+     */
+    public Builder permanentCountInc(long count) {
+      this.permanentCount += count;
+      return this;
+    }
+
+    /**
+     * Increment {@link DeleteTombstoneStats#expiredSize} by the given size.
+     * @param size The size to increment
+     * @return
+     */
+    public Builder expiredSizeInc(long size) {
+      this.expiredSize += size;
+      return this;
+    }
+
+    /**
+     * Increment {@link DeleteTombstoneStats#permanentSize} by the given size, as well as the other permanent size based on time.
+     * @param size The size to increment
+     * @param operationTime The operation time of the delete tombstone
+     * @return
+     */
+    public Builder permanentSizeInc(long size, long operationTime) {
+      this.permanentSize += size;
+      if (operationTime != Utils.Infinite_Time) {
+        long d = time.milliseconds() - operationTime;
+        for (Pair<Long, AtomicLong> p : deltas) {
+          if (p.getFirst() >= d) {
+            p.getSecond().addAndGet(size);
+            break;
+          }
+        }
+      }
+      return this;
+    }
+
+    /**
+     * Build a {@link DeleteTombstoneStats}.
+     * @return
+     */
+    public DeleteTombstoneStats build() {
+      //@formatter:off
+      return new DeleteTombstoneStats(
+          this.expiredCount,
+          this.expiredSize,
+          this.permanentCount,
+          this.permanentSize,
+          this.deltas.get(0).getSecond().get(),
+          this.deltas.get(1).getSecond().get(),
+          this.deltas.get(2).getSecond().get(),
+          this.deltas.get(3).getSecond().get(),
+          this.deltas.get(4).getSecond().get(),
+          this.deltas.get(5).getSecond().get(),
+          this.deltas.get(6).getSecond().get()
+      );
+      //@formatter:on
+    }
+  }
+}

--- a/ambry-api/src/main/java/com/github/ambry/store/StoreStats.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/StoreStats.java
@@ -26,7 +26,6 @@ import java.util.Map;
 public interface StoreStats {
   String EXPIRED_DELETE_TOMBSTONE = "ExpiredDeleteTombstone";
   String PERMANENT_DELETE_TOMBSTONE = "PermanentDeleteTombstone";
-
   /**
    * Gets the size of valid data at a particular point in time. The caller specifies a reference time and acceptable
    * resolution for the stats in the form of a {@link TimeRange}. The store will return valid data size for a point
@@ -55,10 +54,8 @@ public interface StoreStats {
       List<Short> accountIdToExclude) throws StoreException;
 
   /**
-   * Fetches delete tombstone stats grouped by different types, i.e. {@link StoreStats#EXPIRED_DELETE_TOMBSTONE},
-   * {@link StoreStats#PERMANENT_DELETE_TOMBSTONE}.
-   * @return a map whose key specifies delete tombstone type and value is a {@link Pair} representing the delete
-   * tombstone count and total size
+   * Fetches delete tombstone stats.
+   * @return A {@link DeleteTombstoneStats} object.
    */
-  Map<String, Pair<Long, Long>> getDeleteTombstoneStats();
+  DeleteTombstoneStats getDeleteTombstoneStats();
 }

--- a/ambry-api/src/main/java/com/github/ambry/store/StoreStats.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/StoreStats.java
@@ -24,8 +24,6 @@ import java.util.Map;
  * Exposes important stats related to a {@link Store}.
  */
 public interface StoreStats {
-  String EXPIRED_DELETE_TOMBSTONE = "ExpiredDeleteTombstone";
-  String PERMANENT_DELETE_TOMBSTONE = "PermanentDeleteTombstone";
   /**
    * Gets the size of valid data at a particular point in time. The caller specifies a reference time and acceptable
    * resolution for the stats in the form of a {@link TimeRange}. The store will return valid data size for a point

--- a/ambry-api/src/test/java/com/github/ambry/store/DeleteTombstoneStatsTest.java
+++ b/ambry-api/src/test/java/com/github/ambry/store/DeleteTombstoneStatsTest.java
@@ -56,5 +56,19 @@ public class DeleteTombstoneStatsTest {
     Assert.assertEquals(133 * 7, stats.permanentSizeSevenDays);
     Assert.assertEquals(133 * 10, stats.permanentSizeTenDays);
     Assert.assertEquals(133 * 14, stats.permanentSizeFourteenDays);
+
+    DeleteTombstoneStats another = builder.build();
+    stats = stats.merge(another);
+    Assert.assertEquals(11 * 2, stats.expiredCount);
+    Assert.assertEquals(3000 * 2, stats.expiredSize);
+    Assert.assertEquals(21 * 2, stats.permanentCount);
+    Assert.assertEquals(expectedPermanentSize * 2, stats.permanentSize);
+    Assert.assertEquals(133 * 1 * 2, stats.permanentSizeOneDay);
+    Assert.assertEquals(133 * 2 * 2, stats.permanentSizeTwoDays);
+    Assert.assertEquals(133 * 3 * 2, stats.permanentSizeThreeDays);
+    Assert.assertEquals(133 * 5 * 2, stats.permanentSizeFiveDays);
+    Assert.assertEquals(133 * 7 * 2, stats.permanentSizeSevenDays);
+    Assert.assertEquals(133 * 10 * 2, stats.permanentSizeTenDays);
+    Assert.assertEquals(133 * 14 * 2, stats.permanentSizeFourteenDays);
   }
 }

--- a/ambry-api/src/test/java/com/github/ambry/store/DeleteTombstoneStatsTest.java
+++ b/ambry-api/src/test/java/com/github/ambry/store/DeleteTombstoneStatsTest.java
@@ -50,12 +50,12 @@ public class DeleteTombstoneStatsTest {
     Assert.assertEquals(21, stats.permanentCount);
     Assert.assertEquals(expectedPermanentSize, stats.permanentSize);
     Assert.assertEquals(133 * 1, stats.permanentSizeOneDay);
-    Assert.assertEquals(133 * 2, stats.permanentSizeTwoDays);
-    Assert.assertEquals(133 * 3, stats.permanentSizeThreeDays);
-    Assert.assertEquals(133 * 5, stats.permanentSizeFiveDays);
-    Assert.assertEquals(133 * 7, stats.permanentSizeSevenDays);
-    Assert.assertEquals(133 * 10, stats.permanentSizeTenDays);
-    Assert.assertEquals(133 * 14, stats.permanentSizeFourteenDays);
+    Assert.assertEquals(133 * 3, stats.permanentSizeTwoDays);
+    Assert.assertEquals(133 * 6, stats.permanentSizeThreeDays);
+    Assert.assertEquals(133 * 11, stats.permanentSizeFiveDays);
+    Assert.assertEquals(133 * 18, stats.permanentSizeSevenDays);
+    Assert.assertEquals(133 * 28, stats.permanentSizeTenDays);
+    Assert.assertEquals(133 * 42, stats.permanentSizeFourteenDays);
 
     DeleteTombstoneStats another = builder.build();
     stats = stats.merge(another);
@@ -64,11 +64,11 @@ public class DeleteTombstoneStatsTest {
     Assert.assertEquals(21 * 2, stats.permanentCount);
     Assert.assertEquals(expectedPermanentSize * 2, stats.permanentSize);
     Assert.assertEquals(133 * 1 * 2, stats.permanentSizeOneDay);
-    Assert.assertEquals(133 * 2 * 2, stats.permanentSizeTwoDays);
-    Assert.assertEquals(133 * 3 * 2, stats.permanentSizeThreeDays);
-    Assert.assertEquals(133 * 5 * 2, stats.permanentSizeFiveDays);
-    Assert.assertEquals(133 * 7 * 2, stats.permanentSizeSevenDays);
-    Assert.assertEquals(133 * 10 * 2, stats.permanentSizeTenDays);
-    Assert.assertEquals(133 * 14 * 2, stats.permanentSizeFourteenDays);
+    Assert.assertEquals(133 * 3 * 2, stats.permanentSizeTwoDays);
+    Assert.assertEquals(133 * 6 * 2, stats.permanentSizeThreeDays);
+    Assert.assertEquals(133 * 11 * 2, stats.permanentSizeFiveDays);
+    Assert.assertEquals(133 * 18 * 2, stats.permanentSizeSevenDays);
+    Assert.assertEquals(133 * 28 * 2, stats.permanentSizeTenDays);
+    Assert.assertEquals(133 * 42 * 2, stats.permanentSizeFourteenDays);
   }
 }

--- a/ambry-api/src/test/java/com/github/ambry/store/DeleteTombstoneStatsTest.java
+++ b/ambry-api/src/test/java/com/github/ambry/store/DeleteTombstoneStatsTest.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2024 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.store;
+
+import com.github.ambry.utils.MockTime;
+import java.util.concurrent.TimeUnit;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+/**
+ * Unit test for {@link DeleteTombstoneStats} and its builder.
+ */
+public class DeleteTombstoneStatsTest {
+  @Test
+  public void testBuilder() {
+    MockTime time = new MockTime(System.currentTimeMillis());
+    DeleteTombstoneStats.Builder builder = new DeleteTombstoneStats.Builder();
+    builder.expiredCountInc();
+    builder.expiredCountInc(10); // Expired count should be 11
+    builder.expiredSizeInc(1000); // Expired size should be 1000
+    builder.expiredSizeInc(2000); // Expired size should be 3000 now
+
+    builder.permanentCountInc();
+    builder.permanentCountInc(20); // permanent count should be 20
+    long expectedPermanentSize = 0;
+    for (int day : new int[]{20, 14, 10, 7, 5, 3, 2, 1}) {
+      builder.permanentSizeInc(day * 100, time.milliseconds() - TimeUnit.DAYS.toMillis(day) + 100);
+      expectedPermanentSize += day * 100;
+    }
+    // Do this one more time
+    for (int day : new int[]{20, 14, 10, 7, 5, 3, 2, 1}) {
+      builder.permanentSizeInc(day * 33, time.milliseconds() - TimeUnit.DAYS.toMillis(day) + 100);
+      expectedPermanentSize += day * 33;
+    }
+    DeleteTombstoneStats stats = builder.build();
+    Assert.assertEquals(11, stats.expiredCount);
+    Assert.assertEquals(3000, stats.expiredSize);
+    Assert.assertEquals(21, stats.permanentCount);
+    Assert.assertEquals(expectedPermanentSize, stats.permanentSize);
+    Assert.assertEquals(133 * 1, stats.permanentSizeOneDay);
+    Assert.assertEquals(133 * 2, stats.permanentSizeTwoDays);
+    Assert.assertEquals(133 * 3, stats.permanentSizeThreeDays);
+    Assert.assertEquals(133 * 5, stats.permanentSizeFiveDays);
+    Assert.assertEquals(133 * 7, stats.permanentSizeSevenDays);
+    Assert.assertEquals(133 * 10, stats.permanentSizeTenDays);
+    Assert.assertEquals(133 * 14, stats.permanentSizeFourteenDays);
+  }
+}

--- a/ambry-server/src/main/java/com/github/ambry/server/StatsManagerMetrics.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/StatsManagerMetrics.java
@@ -18,6 +18,7 @@ import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.store.DeleteTombstoneStats;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -30,11 +31,10 @@ class StatsManagerMetrics {
   final Histogram totalFetchAndAggregateTimeMs;
   final Histogram fetchAndAggregateTimePerStoreMs;
   private final AtomicBoolean deleteStatsGaugeInitialized = new AtomicBoolean(false);
-  private final AtomicReference<StatsManager.AggregatedDeleteTombstoneStats> aggregatedDeleteTombstoneStats;
+  private final AtomicReference<DeleteTombstoneStats> aggregatedDeleteTombstoneStats;
   private final MetricRegistry registry;
 
-  StatsManagerMetrics(MetricRegistry registry,
-      AtomicReference<StatsManager.AggregatedDeleteTombstoneStats> aggregatedDeleteTombstoneStats) {
+  StatsManagerMetrics(MetricRegistry registry, AtomicReference<DeleteTombstoneStats> aggregatedDeleteTombstoneStats) {
     this.registry = registry;
     this.aggregatedDeleteTombstoneStats = aggregatedDeleteTombstoneStats;
     statsAggregationFailureCount =
@@ -47,22 +47,43 @@ class StatsManagerMetrics {
 
   void initDeleteStatsGaugesIfNeeded() {
     if (deleteStatsGaugeInitialized.compareAndSet(false, true)) {
-      Gauge<Long> expiredDeleteTombstoneCount =
-          () -> aggregatedDeleteTombstoneStats.get().getExpiredDeleteTombstoneCount();
-      registry.register(MetricRegistry.name(StatsManager.class, "ExpiredDeleteTombstoneCount"),
-          expiredDeleteTombstoneCount);
-      Gauge<Long> expiredDeleteTombstoneSize =
-          () -> aggregatedDeleteTombstoneStats.get().getExpiredDeleteTombstoneSize();
-      registry.register(MetricRegistry.name(StatsManager.class, "ExpiredDeleteTombstoneSize"),
-          expiredDeleteTombstoneSize);
-      Gauge<Long> permanentDeleteTombstoneCount =
-          () -> aggregatedDeleteTombstoneStats.get().getPermanentDeleteTombstoneCount();
-      registry.register(MetricRegistry.name(StatsManager.class, "PermanentDeleteTombstoneCount"),
-          permanentDeleteTombstoneCount);
-      Gauge<Long> permanentDeleteTombstoneSize =
-          () -> aggregatedDeleteTombstoneStats.get().getPermanentDeleteTombstoneSize();
-      registry.register(MetricRegistry.name(StatsManager.class, "PermanentDeleteTombstoneSize"),
-          permanentDeleteTombstoneSize);
+      Gauge<Long> expiredDeleteTombstoneCount = () -> aggregatedDeleteTombstoneStats.get().expiredCount;
+      registry.gauge(MetricRegistry.name(StatsManager.class, "ExpiredDeleteTombstoneCount"),
+          () -> expiredDeleteTombstoneCount);
+      Gauge<Long> expiredDeleteTombstoneSize = () -> aggregatedDeleteTombstoneStats.get().expiredSize;
+      registry.gauge(MetricRegistry.name(StatsManager.class, "ExpiredDeleteTombstoneSize"),
+          () -> expiredDeleteTombstoneSize);
+      Gauge<Long> permanentDeleteTombstoneCount = () -> aggregatedDeleteTombstoneStats.get().permanentCount;
+      registry.gauge(MetricRegistry.name(StatsManager.class, "PermanentDeleteTombstoneCount"),
+          () -> permanentDeleteTombstoneCount);
+      Gauge<Long> permanentDeleteTombstoneSize = () -> aggregatedDeleteTombstoneStats.get().permanentSize;
+      registry.gauge(MetricRegistry.name(StatsManager.class, "PermanentDeleteTombstoneSize"),
+          () -> permanentDeleteTombstoneSize);
+      Gauge<Long> permanentDeleteTombstoneSizeOneDay = () -> aggregatedDeleteTombstoneStats.get().permanentSizeOneDay;
+      registry.gauge(MetricRegistry.name(StatsManager.class, "PermanentDeleteTombstoneSizeOneDay"),
+          () -> permanentDeleteTombstoneSizeOneDay);
+      Gauge<Long> permanentDeleteTombstoneSizeTwoDays = () -> aggregatedDeleteTombstoneStats.get().permanentSizeTwoDays;
+      registry.gauge(MetricRegistry.name(StatsManager.class, "PermanentDeleteTombstoneSizeTwoDays"),
+          () -> permanentDeleteTombstoneSizeTwoDays);
+      Gauge<Long> permanentDeleteTombstoneSizeThreeDays =
+          () -> aggregatedDeleteTombstoneStats.get().permanentSizeThreeDays;
+      registry.gauge(MetricRegistry.name(StatsManager.class, "PermanentDeleteTombstoneSizeThreeDays"),
+          () -> permanentDeleteTombstoneSizeThreeDays);
+      Gauge<Long> permanentDeleteTombstoneSizeFiveDays =
+          () -> aggregatedDeleteTombstoneStats.get().permanentSizeFiveDays;
+      registry.gauge(MetricRegistry.name(StatsManager.class, "PermanentDeleteTombstoneSizeFiveDays"),
+          () -> permanentDeleteTombstoneSizeFiveDays);
+      Gauge<Long> permanentDeleteTombstoneSizeSevenDays =
+          () -> aggregatedDeleteTombstoneStats.get().permanentSizeSevenDays;
+      registry.gauge(MetricRegistry.name(StatsManager.class, "PermanentDeleteTombstoneSizeSevenDays"),
+          () -> permanentDeleteTombstoneSizeSevenDays);
+      Gauge<Long> permanentDeleteTombstoneSizeTenDays = () -> aggregatedDeleteTombstoneStats.get().permanentSizeTenDays;
+      registry.gauge(MetricRegistry.name(StatsManager.class, "PermanentDeleteTombstoneSizeTenDays"),
+          () -> permanentDeleteTombstoneSizeTenDays);
+      Gauge<Long> permanentDeleteTombstoneSizeFourteenDays =
+          () -> aggregatedDeleteTombstoneStats.get().permanentSizeFourteenDays;
+      registry.gauge(MetricRegistry.name(StatsManager.class, "PermanentDeleteTombstoneSizeFourteenDays"),
+          () -> permanentDeleteTombstoneSizeFourteenDays);
     }
   }
 }

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
@@ -3384,13 +3384,12 @@ public class BlobStoreCompactorTest {
   private long getValidDataSize(List<LogSegmentName> logSegments, long deleteReferenceTimeMs,
       boolean invalidateExpiredDelete) {
     long size = 0;
-    Map<String, Pair<AtomicLong, AtomicLong>> deleteTombstoneStats = generateDeleteTombstoneStats();
     Pair<Set<MockId>, Set<MockId>> expiredDeletes = new Pair<>(new HashSet<>(), new HashSet<>());
     for (LogSegmentName segment : logSegments) {
       long logSegmentValidSize =
           state.getValidDataSizeForLogSegment(state.log.getSegment(segment), deleteReferenceTimeMs,
-              state.time.milliseconds(), getFileSpanForLogSegments(logSegments), deleteTombstoneStats, expiredDeletes,
-              invalidateExpiredDelete);
+              state.time.milliseconds(), getFileSpanForLogSegments(logSegments),
+              new DeleteTombstoneStats.Builder(state.time), expiredDeletes, invalidateExpiredDelete);
       size += logSegmentValidSize;
     }
     return size;
@@ -4049,12 +4048,11 @@ public class BlobStoreCompactorTest {
   private List<LogEntry> getValidLogEntriesInOrder(List<LogSegmentName> logSegmentsUnderConsideration,
       long deleteReferenceTimeMs, Pair<Set<MockId>, Set<MockId>> expiredDeletes, boolean invalidateExpiredDelete) {
     List<LogEntry> validLogEntriesInOrder = new ArrayList<>();
-    Map<String, Pair<AtomicLong, AtomicLong>> deleteTombstoneStats = generateDeleteTombstoneStats();
     for (LogSegmentName logSegment : logSegmentsUnderConsideration) {
       List<IndexEntry> validIndexEntries =
           state.getValidIndexEntriesForLogSegment(state.log.getSegment(logSegment), deleteReferenceTimeMs,
-              state.time.milliseconds(), getFileSpanForLogSegments(logSegmentsUnderConsideration), deleteTombstoneStats,
-              expiredDeletes, invalidateExpiredDelete);
+              state.time.milliseconds(), getFileSpanForLogSegments(logSegmentsUnderConsideration),
+              new DeleteTombstoneStats.Builder(state.time), expiredDeletes, invalidateExpiredDelete);
       addToLogEntriesInOrder(validIndexEntries, validLogEntriesInOrder);
     }
     return validLogEntriesInOrder;

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreStatsTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreStatsTest.java
@@ -44,7 +44,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import org.junit.After;
 import org.junit.Test;
@@ -52,7 +51,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import static com.github.ambry.store.CuratedLogIndexState.*;
-import static com.github.ambry.store.StoreStats.*;
 import static org.junit.Assert.*;
 import static org.junit.Assume.*;
 
@@ -1079,11 +1077,11 @@ public class BlobStoreStatsTest {
    */
   private long verifyContainerStorageStatsAndGetTotalValidSize(BlobStoreStats blobStoreStats, long referenceTimeInMs)
       throws StoreException {
-    Map<String, Pair<AtomicLong, AtomicLong>> deleteTombstoneStats = generateDeleteTombstoneStats();
+    DeleteTombstoneStats.Builder builder = new DeleteTombstoneStats.Builder(state.time);
     Map<Short, Map<Short, ContainerStorageStats>> actualContainerStorageStatsMap =
         blobStoreStats.getContainerStorageStats(referenceTimeInMs);
     Map<Short, Map<Short, ContainerStorageStats>> expectedContainerStorageStatsMap =
-        getContainerStorageStats(referenceTimeInMs, state.time.milliseconds(), deleteTombstoneStats);
+        getContainerStorageStats(referenceTimeInMs, state.time.milliseconds(), builder);
     long totalValidSize = 0L;
 
     for (Map.Entry<Short, Map<Short, ContainerStorageStats>> expectedContainerStorageStatsEntry : expectedContainerStorageStatsMap.entrySet()) {
@@ -1124,7 +1122,7 @@ public class BlobStoreStatsTest {
       }
     }
     // verify delete tombstone stats
-    verifyDeleteTombstoneStats(blobStoreStats, deleteTombstoneStats);
+    verifyDeleteTombstoneStats(blobStoreStats, builder.build());
     return totalValidSize;
   }
 
@@ -1149,7 +1147,7 @@ public class BlobStoreStatsTest {
     long expectedTotalLogSegmentValidSize = 0L;
     LogSegment logSegment = state.log.getFirstSegment();
     Pair<Set<MockId>, Set<MockId>> expiredDeletes = new Pair<>(new HashSet<>(), new HashSet<>());
-    Map<String, Pair<AtomicLong, AtomicLong>> deleteTombstoneStats = generateDeleteTombstoneStats();
+    DeleteTombstoneStats.Builder builder = new DeleteTombstoneStats.Builder(state.time);
     while (logSegment != null) {
       LogSegmentName logSegmentName = logSegment.getName();
       assertTrue("Log segment: " + logSegmentName + " not found in TimeRange " + timeRange,
@@ -1157,7 +1155,7 @@ public class BlobStoreStatsTest {
 
       long expectedLogSegmentValidSize =
           state.getValidDataSizeForLogSegment(logSegment, timeRange.getEndTimeInMs(), expiryReferenceTime, null,
-              deleteTombstoneStats, expiredDeletes, true);
+              builder, expiredDeletes, true);
       long actualLogSegmentValidSize = actualLogSegmentValidSizeMap.getSecond().get(logSegmentName);
       assertEquals("Valid data size mismatch for log segment: " + logSegmentName + " in TimeRange " + timeRange,
           expectedLogSegmentValidSize, actualLogSegmentValidSize);
@@ -1176,7 +1174,7 @@ public class BlobStoreStatsTest {
             && timeRange.getEndTimeInMs() >= actualLogSegmentValidSizeMap.getFirst());
     assertEquals("Total valid data size of all log segments mismatch", expectedTotalLogSegmentValidSize,
         actualTotalValidSize.getSecond().longValue());
-    verifyDeleteTombstoneStats(blobStoreStats, deleteTombstoneStats);
+    verifyDeleteTombstoneStats(blobStoreStats, builder.build());
     return actualTotalValidSize.getSecond();
   }
 
@@ -1185,11 +1183,11 @@ public class BlobStoreStatsTest {
    * verification purposes.
    * @param deleteReferenceTimeInMs the reference time in ms until which deletes are relevant
    * @param expiryReferenceTimeInMs the reference time in ms until which expirations are relevant
-   * @param deleteTombstoneStats a hashmap that tracks stats related delete tombstones in log segments.
+   * @param builder a builder that tracks stats related delete tombstones in log segments.
    * @return a nested {@link Map} of serviceId to containerId to valid data size
    */
   private Map<Short, Map<Short, ContainerStorageStats>> getContainerStorageStats(long deleteReferenceTimeInMs,
-      long expiryReferenceTimeInMs, Map<String, Pair<AtomicLong, AtomicLong>> deleteTombstoneStats) {
+      long expiryReferenceTimeInMs, DeleteTombstoneStats.Builder builder) {
     Map<Short, Map<Short, ContainerStorageStats>> containerStorageStats = new HashMap<>();
     Map<Short, Map<Short, Long>> validSizeMap = new HashMap<>();
     Map<Short, Map<Short, Long>> physicalSizeMap = new HashMap<>();
@@ -1197,7 +1195,7 @@ public class BlobStoreStatsTest {
     Pair<Set<MockId>, Set<MockId>> expiredDeletes = new Pair<>(new HashSet<>(), new HashSet<>());
     for (Offset indSegStartOffset : state.referenceIndex.keySet()) {
       state.getValidIndexEntriesForIndexSegment(indSegStartOffset, deleteReferenceTimeInMs, expiryReferenceTimeInMs,
-          null, deleteTombstoneStats, expiredDeletes, true, (entry, isValid) -> {
+          null, builder, expiredDeletes, true, (entry, isValid) -> {
             IndexValue indexValue = entry.getValue();
             if (indexValue.isPut() && isValid) {
               StatsUtils.updateNestedMapHelper(validSizeMap, indexValue.getAccountId(), indexValue.getContainerId(),
@@ -1220,19 +1218,16 @@ public class BlobStoreStatsTest {
     return containerStorageStats;
   }
 
-  private void verifyDeleteTombstoneStats(BlobStoreStats blobStoreStats,
-      Map<String, Pair<AtomicLong, AtomicLong>> deleteTombstoneStats) {
+  private void verifyDeleteTombstoneStats(BlobStoreStats blobStoreStats, DeleteTombstoneStats deleteTombstoneStats) {
     DeleteTombstoneStats storeDeleteTombstoneStats = blobStoreStats.getDeleteTombstoneStats();
-    assertEquals("Mismatch in permanent delete count",
-        deleteTombstoneStats.get(PERMANENT_DELETE_TOMBSTONE).getFirst().get(),
+    assertEquals("Mismatch in permanent delete count", deleteTombstoneStats.permanentCount,
         storeDeleteTombstoneStats.permanentCount);
-    assertEquals("Mismatch in permanent delete total size",
-        deleteTombstoneStats.get(PERMANENT_DELETE_TOMBSTONE).getSecond().get(),
+    assertEquals("Mismatch in permanent delete total size", deleteTombstoneStats.permanentSize,
         storeDeleteTombstoneStats.permanentSize);
-    assertEquals("Mismatch in expired delete count",
-        deleteTombstoneStats.get(EXPIRED_DELETE_TOMBSTONE).getFirst().get(), storeDeleteTombstoneStats.expiredCount);
-    assertEquals("Mismatch in expired delete total size",
-        deleteTombstoneStats.get(EXPIRED_DELETE_TOMBSTONE).getSecond().get(), storeDeleteTombstoneStats.expiredSize);
+    assertEquals("Mismatch in expired delete count", deleteTombstoneStats.expiredCount,
+        storeDeleteTombstoneStats.expiredCount);
+    assertEquals("Mismatch in expired delete total size", deleteTombstoneStats.expiredSize,
+        storeDeleteTombstoneStats.expiredSize);
   }
 
   /**

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreStatsTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreStatsTest.java
@@ -941,8 +941,7 @@ public class BlobStoreStatsTest {
       long deleteAndExpirationRefTimeInMs = state.time.milliseconds();
       Map<Short, Map<Short, ContainerStorageStats>> statsMap =
           blobStoreStats.getContainerStorageStats(deleteAndExpirationRefTimeInMs);
-      Optional.ofNullable(accountIdToExclude).orElse(Collections.EMPTY_LIST).
-          forEach(id -> statsMap.remove(id));
+      Optional.ofNullable(accountIdToExclude).orElse(Collections.EMPTY_LIST).forEach(id -> statsMap.remove(id));
 
       // Verify account stats snapshot
       Map<Short, Map<Short, ContainerStorageStats>> obtainedStatsMap =
@@ -1087,8 +1086,7 @@ public class BlobStoreStatsTest {
         getContainerStorageStats(referenceTimeInMs, state.time.milliseconds(), deleteTombstoneStats);
     long totalValidSize = 0L;
 
-    for (Map.Entry<Short, Map<Short, ContainerStorageStats>> expectedContainerStorageStatsEntry : expectedContainerStorageStatsMap
-        .entrySet()) {
+    for (Map.Entry<Short, Map<Short, ContainerStorageStats>> expectedContainerStorageStatsEntry : expectedContainerStorageStatsMap.entrySet()) {
       short accountId = expectedContainerStorageStatsEntry.getKey();
       assertTrue("Expected accountId: " + accountId + " not found",
           actualContainerStorageStatsMap.containsKey(accountId));
@@ -1117,8 +1115,7 @@ public class BlobStoreStatsTest {
       }
       actualContainerStorageStatsMap.remove(accountId);
     }
-    for (Map.Entry<Short, Map<Short, ContainerStorageStats>> actualContainerValidSizeEntry : actualContainerStorageStatsMap
-        .entrySet()) {
+    for (Map.Entry<Short, Map<Short, ContainerStorageStats>> actualContainerValidSizeEntry : actualContainerStorageStatsMap.entrySet()) {
       if (actualContainerValidSizeEntry.getValue().size() != 0) {
         for (Map.Entry<Short, ContainerStorageStats> mapEntry : actualContainerValidSizeEntry.getValue().entrySet()) {
           assertEquals("Additional values found in actual container valid size map for service "
@@ -1225,17 +1222,17 @@ public class BlobStoreStatsTest {
 
   private void verifyDeleteTombstoneStats(BlobStoreStats blobStoreStats,
       Map<String, Pair<AtomicLong, AtomicLong>> deleteTombstoneStats) {
-    Map<String, Pair<Long, Long>> storeDeleteStats = blobStoreStats.getDeleteTombstoneStats();
-    Pair<Long, Long> expiredDeletes = storeDeleteStats.get(EXPIRED_DELETE_TOMBSTONE);
-    Pair<Long, Long> permanentDeletes = storeDeleteStats.get(PERMANENT_DELETE_TOMBSTONE);
+    DeleteTombstoneStats storeDeleteTombstoneStats = blobStoreStats.getDeleteTombstoneStats();
     assertEquals("Mismatch in permanent delete count",
-        deleteTombstoneStats.get(PERMANENT_DELETE_TOMBSTONE).getFirst().get(), (long) permanentDeletes.getFirst());
+        deleteTombstoneStats.get(PERMANENT_DELETE_TOMBSTONE).getFirst().get(),
+        storeDeleteTombstoneStats.permanentCount);
     assertEquals("Mismatch in permanent delete total size",
-        deleteTombstoneStats.get(PERMANENT_DELETE_TOMBSTONE).getSecond().get(), (long) permanentDeletes.getSecond());
+        deleteTombstoneStats.get(PERMANENT_DELETE_TOMBSTONE).getSecond().get(),
+        storeDeleteTombstoneStats.permanentSize);
     assertEquals("Mismatch in expired delete count",
-        deleteTombstoneStats.get(EXPIRED_DELETE_TOMBSTONE).getFirst().get(), (long) expiredDeletes.getFirst());
+        deleteTombstoneStats.get(EXPIRED_DELETE_TOMBSTONE).getFirst().get(), storeDeleteTombstoneStats.expiredCount);
     assertEquals("Mismatch in expired delete total size",
-        deleteTombstoneStats.get(EXPIRED_DELETE_TOMBSTONE).getSecond().get(), (long) expiredDeletes.getSecond());
+        deleteTombstoneStats.get(EXPIRED_DELETE_TOMBSTONE).getSecond().get(), storeDeleteTombstoneStats.expiredSize);
   }
 
   /**

--- a/ambry-store/src/test/java/com/github/ambry/store/CuratedLogIndexState.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CuratedLogIndexState.java
@@ -1622,7 +1622,7 @@ class CuratedLogIndexState {
                   if (currentValue.getExpiresAtMs() == Utils.Infinite_Time || currentValue.isTtlUpdate()) {
                     // TODO check validity of permanent delete tombstone
                     builder.permanentCountInc()
-                        .permanentSizeInc(currentValue.getSize(), currentValue.getOperationTimeInMs());
+                        .permanentSizeInc(currentValue.getSize(), latestValue.getOperationTimeInMs());
                   } else {
                     builder.expiredCountInc().expiredSizeInc(currentValue.getSize());
                     if (invalidateExpiredDelete && currentValue.getExpiresAtMs() < expiryReferenceTimeMs) {

--- a/ambry-utils/src/main/java/com/github/ambry/utils/Pair.java
+++ b/ambry-utils/src/main/java/com/github/ambry/utils/Pair.java
@@ -26,6 +26,10 @@ public class Pair<A, B> {
   private final A first;
   private final B second;
 
+  public static <A, B> Pair<A, B> of(A first, B second) {
+    return new Pair<A, B>(first, second);
+  }
+
   /**
    * Construct a pair from two objects.
    * @param first the first object in the pair.


### PR DESCRIPTION
## Summary
Adding new metrics to show the delete tombstone's distribution based on time.

## What is new
Added several metrics for permanent delete tombstones.
1. `PermanentDeleteTombstoneSizeOneDay` shows the size of delete tombstones that are deleted within a day.
2. `PermanentDeleteTombstoneSizeTwoDays` shows the size of delete tombstones that are deleted within two days.

etc.. all the way to 14 days. Any delete tombstones that are deleted more than 14 days, will not be recorded here. But it's fine, since we have a metric `PermanentDeleteTombstoneSize` to record size of all delete tombstones.

## Code change
Added a `DeleteTombstoneStats` class and its builder. Use this class to carry stats between different components, like BlobStoreStats and StatsManager. 

## Test
Unit test