### PR TITLE
Set a 2 minutes timeout on codecov

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -56,7 +56,8 @@ jobs:
           gradle-version: wrapper
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v4
+        timeout-minutes: 2
 
   store-test:
 
@@ -82,7 +83,8 @@ jobs:
           gradle-version: wrapper
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v4
+        timeout-minutes: 2
 
   int-test:
 
@@ -127,7 +129,8 @@ jobs:
           gradle-version: wrapper
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v4
+        timeout-minutes: 2
 
   server-int-test:
 
@@ -172,7 +175,8 @@ jobs:
           gradle-version: wrapper
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v4
+        timeout-minutes: 2
 
   publish:
 


### PR DESCRIPTION
## Summary

Setting a 2 minutes timeout to report code coverage to codecov.io