### PR TITLE
Filter out all valid log semgents in full range compaction

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -109,6 +109,15 @@ public class StoreConfig {
   public final int storeHybridCompactionFullCompactionStaggerLimitInHours;
 
   /**
+   * True to filter out all leading and trailing log segments whose data is 100% valid in compact all policy.
+   */
+  @Config(storeCompactAllPolicyFilterOutAllValidSegmentName)
+  @Default("false")
+  public final boolean storeCompactAllPolicyFilterOutAllValidSegment;
+  public static final String storeCompactAllPolicyFilterOutAllValidSegmentName =
+      "store.compact.all.policy.filter.out.all.valid.segment";
+
+  /**
    * How long (in days) a container must be in DELETE_IN_PROGRESS state before it's been deleted during compaction.
    */
   @Config("store.container.deletion.retention.days")
@@ -658,6 +667,8 @@ public class StoreConfig {
     storeHybridCompactionFullCompactionStaggerLimitInHours =
         verifiableProperties.getIntInRange("store.hybrid.compaction.full.compaction.stagger.limit.in.hours", 0, 0,
             Integer.MAX_VALUE);
+    storeCompactAllPolicyFilterOutAllValidSegment =
+        verifiableProperties.getBoolean(storeCompactAllPolicyFilterOutAllValidSegmentName, false);
     storeContainerDeletionRetentionDays = verifiableProperties.getInt("store.container.deletion.retention.days", 14);
     storeHardDeleteOperationsBytesPerSec =
         verifiableProperties.getIntInRange("store.hard.delete.operations.bytes.per.sec", 100 * 1024, 1,

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreStats.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreStats.java
@@ -243,10 +243,10 @@ class BlobStoreStats implements StoreStats, Closeable {
   }
 
   /**
-   * Return {@link PersistentIndex}.
+   * Return {@link LogSegmentSizeProvider}.
    * @return
    */
-  PersistentIndex getIndex() {
+  LogSegmentSizeProvider getLogSegmentSizeProvider() {
     return index;
   }
 

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreStats.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreStats.java
@@ -243,6 +243,14 @@ class BlobStoreStats implements StoreStats, Closeable {
   }
 
   /**
+   * Return {@link PersistentIndex}.
+   * @return
+   */
+  PersistentIndex getIndex() {
+    return index;
+  }
+
+  /**
    * Gets the size of valid data at a particular point in time for all log segments. The caller specifies a delete reference
    * time and acceptable resolution for the stats in the form of a {@link TimeRange}. The store will return data
    * for a point in time within the specified range.

--- a/ambry-store/src/main/java/com/github/ambry/store/CompactAllPolicyFactory.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/CompactAllPolicyFactory.java
@@ -128,7 +128,7 @@ class CompactAllPolicy implements CompactionPolicy {
       return null;
     }
 
-    for (int i = logSegmentsNotInJournal.size() - 1; i >= 0; i--) {
+    for (int i = logSegmentsNotInJournal.size() - 1; i >= allValidLogSegments.size(); i--) {
       if (!isLogSegmentDataAllValid.test(logSegmentsNotInJournal.get(i))) {
         break;
       }

--- a/ambry-store/src/main/java/com/github/ambry/store/CompactAllPolicyFactory.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/CompactAllPolicyFactory.java
@@ -77,7 +77,7 @@ class CompactAllPolicy implements CompactionPolicy {
         }
         //@formatter:off
         List<LogSegmentName> finalLogSegmentNames =
-            storeConfig.storeCompactAllPolicyFilterOutAllValidSegment
+            storeConfig.storeCompactAllPolicyFilterOutAllValidSegment && validDataSizeByLogSegment != null
             ?filterOutAllValidLogSegment(logSegmentsNotInJournal, blobStoreStats.getLogSegmentSizeProvider(), validDataSizeByLogSegment.getSecond())
             :logSegmentsNotInJournal;
         //@formatter:on
@@ -99,7 +99,7 @@ class CompactAllPolicy implements CompactionPolicy {
    * For instance, if segment_1, segment_2, segment_3 all have 100% valid data, this method would return a null.
    * I segment_1, segment_3 has 100% valid data, this method would return segment_2.
    * @param logSegmentsNotInJournal The list of {@link LogSegmentName}s that are not in journal.
-   * @param index The {@link PersistentIndex}.
+   * @param sizeProvider The {@link LogSegmentSizeProvider}.
    * @param validDataSizeByLogSegment The map from {@link LogSegmentName} to valid data size.
    * @return A list of {@link LogSegmentName}s.
    */

--- a/ambry-store/src/main/java/com/github/ambry/store/LogSegmentSizeProvider.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/LogSegmentSizeProvider.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2024 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.store;
+
+/**
+ * Provide data size for log segments.
+ */
+public interface LogSegmentSizeProvider {
+  /**
+   * Return the data size for the given {@link LogSegmentName}.
+   * @param name The {@link LogSegmentName}.
+   * @return The data size.
+   */
+  long getLogSegmentSize(LogSegmentName name);
+}

--- a/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
@@ -1807,6 +1807,11 @@ public class PersistentIndex {
     return getLogSegmentToIndexSegmentMapping(validIndexSegments).size();
   }
 
+  long getLogSegmentSize(LogSegmentName logSegmentName) {
+    LogSegment segment = log.getSegment(logSegmentName);
+    return segment.getEndOffset() - segment.getStartOffset();
+  }
+
   /**
    * @return the absolute position represented by {@code offset} in the {@link Log}.
    */

--- a/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
@@ -61,7 +61,7 @@ import org.slf4j.LoggerFactory;
  * recovering an index from the log and commit and recover index to disk . This class
  * is not thread safe and expects the caller to do appropriate synchronization.
  **/
-public class PersistentIndex {
+public class PersistentIndex implements LogSegmentSizeProvider {
 
   /**
    * Represents the different types of index entries.
@@ -1807,8 +1807,12 @@ public class PersistentIndex {
     return getLogSegmentToIndexSegmentMapping(validIndexSegments).size();
   }
 
-  long getLogSegmentSize(LogSegmentName logSegmentName) {
+  @Override
+  public long getLogSegmentSize(LogSegmentName logSegmentName) {
     LogSegment segment = log.getSegment(logSegmentName);
+    if (segment == null) {
+      throw new IllegalArgumentException("LogSegment " + logSegmentName + " doesn't exist");
+    }
     return segment.getEndOffset() - segment.getStartOffset();
   }
 

--- a/ambry-store/src/test/java/com/github/ambry/store/CompactAllPolicyTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CompactAllPolicyTest.java
@@ -43,7 +43,7 @@ public class CompactAllPolicyTest {
    * Instantiates {@link CompactionPolicyTest} with the required cast
    * @throws InterruptedException
    */
-  public CompactAllPolicyTest() throws InterruptedException {
+  public CompactAllPolicyTest() throws Exception {
     CompactionPolicyTest.StoreConfigWrapper wrapper = new CompactionPolicyTest.StoreConfigWrapper();
     wrapper.compactAllFilterAllValidSegment = true;
     Pair<MockBlobStore, StoreConfig> initState = CompactionPolicyTest.initializeBlobStore(properties, time, wrapper);

--- a/ambry-store/src/test/java/com/github/ambry/store/StatsBasedCompactionPolicyTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/StatsBasedCompactionPolicyTest.java
@@ -46,11 +46,11 @@ public class StatsBasedCompactionPolicyTest {
    * Instantiates {@link CompactionPolicyTest} with the required cast
    * @throws InterruptedException
    */
-  public StatsBasedCompactionPolicyTest() throws InterruptedException, StoreException {
+  public StatsBasedCompactionPolicyTest() throws Exception {
     setupBlobStore(properties);
   }
 
-  public void setupBlobStore(Properties prop) throws InterruptedException, StoreException {
+  public void setupBlobStore(Properties prop) throws Exception {
     Pair<MockBlobStore, StoreConfig> initState =
         CompactionPolicyTest.initializeBlobStore(prop, time, -1, -1, DEFAULT_MAX_BLOB_SIZE);
     config = initState.getSecond();
@@ -161,7 +161,7 @@ public class StatsBasedCompactionPolicyTest {
    * @throws StoreException, InterruptedException
    */
   @Test
-  public void testMiddleRangeCompactionGetCompactionDetails() throws StoreException, InterruptedException {
+  public void testMiddleRangeCompactionGetCompactionDetails() throws Exception {
     long logSegmentCount = blobStore.capacityInBytes / blobStore.segmentCapacity;
     // the test is designed to use for 10 log segments.
     assertEquals(logSegmentCount, 10);
@@ -209,8 +209,7 @@ public class StatsBasedCompactionPolicyTest {
    * @throws StoreException, InterruptedException
    */
   @Test
-  public void testWeightOnBenefitStatsBasedCompactionGetCompactionDetails()
-      throws StoreException, InterruptedException {
+  public void testWeightOnBenefitStatsBasedCompactionGetCompactionDetails() throws Exception {
     long logSegmentCount = blobStore.capacityInBytes / blobStore.segmentCapacity;
     // the test is designed to use for 10 log segments.
     assertEquals(logSegmentCount, 10);


### PR DESCRIPTION
## Summary

In full range compaction (CompactAllPolicy), we would return all log segments what are not in journal to compactor, even if some of the log segments are having 100% of valid data. This is totally unnecessary, especially for leading and trailing log segments.  Since we would have to copy all of their data out to a new log segment file. 

## What is new
### Add a configuration to `StoreConfig` to control this feature
Added a new configuration to `StoreConfig` to control this feature. This will be turn off by default and we need to change configuration to turn this on. This feature will be first turned on on only a few hosts and make sure it works, then propagate to other hosts
### Add a new interface `LogSegmentSizeProvider` to expose the data size of each log segment.
`BlobStoreStats` object has a reference to `PersistentIndex`, which knows the data size of each `LogSegment`. To best test the new logic, we are creating a new interface `LogSegmentSizeProvider` and let `PersistentIndex` implement this interface. 
In test, we have a map-based mock implementation.
### Add a filter function to filter out leading and trailing log segment whose data is 100% valid.


## Test
Unit tests 