### PR TITLE
Terminate JVM in disk failure handler when too many disks failed

### DIFF
--- a/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
@@ -244,16 +244,29 @@ public class StorageManager implements StoreManager {
         failedDiskIds.add(entry.getKey());
       }
     }
-    int totalDisks = currentNode.getDiskIds().size();
     int failedDisks = failedDiskIds.size();
-    // The failed disks has to larger than the threshold. If the threshold is 1, then even if all disks failed, it won't
-    // throw an exception.
-    if (totalDisks != 0 && failedDisks / (1.0f * totalDisks) > storeConfig.storeThresholdOfDiskFailuresToTerminate) {
-      logger.error("There are {} failed disks, and total disk is {}, surpassed the threshold {}", failedDisks,
-          totalDisks, storeConfig.storeThresholdOfDiskFailuresToTerminate);
+    if (tooManyFailedDisks(failedDisks)) {
       logger.error("Failed disks are {}", failedDisks);
       throw new StoreException("More than enough disks failed", StoreErrorCodes.Initialization_Error);
     }
+  }
+
+  /**
+   * Return true is too many disks failed.
+   * @param failedDiskCount The number of failed disks.
+   * @return
+   */
+  boolean tooManyFailedDisks(int failedDiskCount) {
+    int totalDisks = currentNode.getDiskIds().size();
+    // The failed disks has to larger than the threshold. If the threshold is 1, then even if all disks failed, it won't
+    // throw an exception.
+    if (totalDisks != 0
+        && failedDiskCount / (1.0f * totalDisks) > storeConfig.storeThresholdOfDiskFailuresToTerminate) {
+      logger.error("There are {} failed disks, and total disk is {}, surpassed the threshold {}", failedDiskCount,
+          totalDisks, storeConfig.storeThresholdOfDiskFailuresToTerminate);
+      return true;
+    }
+    return false;
   }
 
   /**
@@ -1012,7 +1025,6 @@ public class StorageManager implements StoreManager {
         .filter(diskId -> diskId.getState() == HardwareState.UNAVAILABLE)
         .collect(Collectors.toList());
     private final long acquireLockBackoffTime = storeConfig.storeDiskFailureHandlerRetryLockBackoffTimeInSeconds * 1000;
-    private final int capacityReportingPercentage = storeConfig.storeDiskCapacityReportingPercentage;
 
     /**
      * Expose for testing
@@ -1036,6 +1048,16 @@ public class StorageManager implements StoreManager {
         return;
       }
       logger.info("Current Node is in FULL_AUTO, try to detect disk failure.");
+      // First check how many disks are already unavailable
+      int unavailableDiskCount = currentNode.getDiskIds()
+          .stream()
+          .filter(diskId -> diskId.getState() == HardwareState.UNAVAILABLE)
+          .collect(Collectors.toList())
+          .size();
+      if (tooManyFailedDisks(unavailableDiskCount)) {
+        System.exit(1);
+      }
+
       // First, we have to detect if there is a new disk failure
       List<DiskId> newFailedDisks = diskToDiskManager.keySet()
           .stream()

--- a/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
@@ -1048,7 +1048,10 @@ public class StorageManager implements StoreManager {
         return;
       }
       logger.info("Current Node is in FULL_AUTO, try to detect disk failure.");
-      // First check how many disks are already unavailable
+      // First check if there are too many disks are already unavailable. Terminate JVM if so.
+      // The purpose of doing this check here instead of the end of this method is to make sure
+      // that this JVM would be albe to emit unavailable disk metric for at least a couple of minutes
+      // before next round of disk failure handler execution.
       int unavailableDiskCount = currentNode.getDiskIds()
           .stream()
           .filter(diskId -> diskId.getState() == HardwareState.UNAVAILABLE)

--- a/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
@@ -1048,9 +1048,9 @@ public class StorageManager implements StoreManager {
         return;
       }
       logger.info("Current Node is in FULL_AUTO, try to detect disk failure.");
-      // First check if there are too many disks are already unavailable. Terminate JVM if so.
+      // First check if there are too many disks that are already unavailable. Terminate JVM if so.
       // The purpose of doing this check here instead of the end of this method is to make sure
-      // that this JVM would be albe to emit unavailable disk metric for at least a couple of minutes
+      // that this JVM would be able to emit unavailable disk metric for at least a couple of minutes
       // before next round of disk failure handler execution.
       int unavailableDiskCount = currentNode.getDiskIds()
           .stream()


### PR DESCRIPTION
## Summary
When storage manager starts, we would check if there are too many unavailable disks. If so, StorageManager would throw an exception to fail the initialization. In this PR, we are bringing the same logic to DiskFailureHandler.

## Reasons for change
Disks could fail at any given time. If all disks fail at runtime, StorageManager would be able to successfully start up without any exception. However, when disk failure handler is running, it would move all the replicas out. Why do we want to terminate JVM when this happens? The reason is that we want to kill the JVM this host would become unavailable from our tools. It would be much easier to use our tools for find unavailable hosts.

## Changes
Using `System.exit(1)` to terminate JVM in disk failure handler when the number of failed disks reaches the threshold for termination.

## Test
No tests.