### PR TITLE
[Frontend] Fix memory leak in 100-continue feature

### DIFF
--- a/ambry-rest/src/main/java/com/github/ambry/rest/NettyMessageProcessor.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/NettyMessageProcessor.java
@@ -373,13 +373,14 @@ public class NettyMessageProcessor extends SimpleChannelInboundHandler<HttpObjec
         nettyMetrics.requestChunkProcessingTimeInMs.update(chunkProcessingTime);
         request.getMetricsTracker().nioMetricsTracker.addToRequestProcessingTime(chunkProcessingTime);
       }
-      if ( success &&
-          ( (!request.getRestMethod().equals(RestMethod.POST) && !request.getRestMethod().equals(RestMethod.PUT)) ||
-              (request.isMultipart() && requestContentFullyReceived) ||
-              CONTINUE.equals(request.getArgs().get(EXPECT))) ) {
-        if (CONTINUE.equals(request.getArgs().get(EXPECT))) {
+      boolean isPutOrPost = request.getRestMethod().equals(RestMethod.POST) || request.getRestMethod().equals(RestMethod.PUT);
+      boolean isMultipart = request.isMultipart() && requestContentFullyReceived;
+      boolean hasContinue = CONTINUE.equals(request.getArgs().get(EXPECT));
+      if (success && (!isPutOrPost || isMultipart || hasContinue)) {
+        if (hasContinue) {
           request.setArg(EXPECT, "");
           responseChannel = new NettyResponseChannel(ctx, nettyMetrics, performanceConfig, nettyConfig);
+          // FIXME: The request could be accepted as ctor arg to NettyResponseChannel to avoid null pointers
           responseChannel.setRequest(request);
         }
         requestHandler.handleRequest(request, responseChannel);

--- a/ambry-rest/src/main/java/com/github/ambry/rest/NettyMessageProcessor.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/NettyMessageProcessor.java
@@ -373,13 +373,14 @@ public class NettyMessageProcessor extends SimpleChannelInboundHandler<HttpObjec
         nettyMetrics.requestChunkProcessingTimeInMs.update(chunkProcessingTime);
         request.getMetricsTracker().nioMetricsTracker.addToRequestProcessingTime(chunkProcessingTime);
       }
-      if (success && (
-          (!request.getRestMethod().equals(RestMethod.POST) && !request.getRestMethod().equals(RestMethod.PUT)) || (
-              request.isMultipart() && requestContentFullyReceived)) || CONTINUE.equals(
-          request.getArgs().get(EXPECT))) {
+      if ( success &&
+          ( (!request.getRestMethod().equals(RestMethod.POST) && !request.getRestMethod().equals(RestMethod.PUT)) ||
+              (request.isMultipart() && requestContentFullyReceived) ||
+              CONTINUE.equals(request.getArgs().get(EXPECT))) ) {
         if (CONTINUE.equals(request.getArgs().get(EXPECT))) {
           request.setArg(EXPECT, "");
           responseChannel = new NettyResponseChannel(ctx, nettyMetrics, performanceConfig, nettyConfig);
+          responseChannel.setRequest(request);
         }
         requestHandler.handleRequest(request, responseChannel);
       }


### PR DESCRIPTION
This patch fixes a memory bloat issue in 100-continue feature.

First, the if-clause to handle 100-continue should be `success && (a || b || c)` but was this `success && (a || b) || c`.

Second, the Response wasn't linked to Request. As a result, the Request is dangling and not released into the heap causing memory leak. In the future, the Request could be accepted as constructor arg to Response to avoid null pointers.