### PR TITLE
Fix the bug to remove internal key when receiving the 100-continue header

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/rest/RestRequest.java
+++ b/ambry-api/src/main/java/com/github/ambry/rest/RestRequest.java
@@ -79,6 +79,12 @@ public interface RestRequest extends ReadableStreamChannel {
   Object setArg(String key, Object value);
 
   /**
+   * Remove one argument from the key-value map.
+   * @param key The key of the argument.
+   */
+  void removeArg(String key);
+
+  /**
    * If this request was over HTTPS, gets the {@link SSLSession} associated with the request.
    * @return The {@link SSLSession} for the request and response, or {@code null} if SSL was not used.
    */

--- a/ambry-api/src/test/java/com/github/ambry/rest/MockRestRequestService.java
+++ b/ambry-api/src/test/java/com/github/ambry/rest/MockRestRequestService.java
@@ -140,6 +140,8 @@ public class MockRestRequestService implements RestRequestService {
   public void handlePut(RestRequest restRequest, RestResponseChannel restResponseChannel) {
     if (shouldProceed(restRequest, restResponseChannel)) {
       try {
+        //set the internal key during preProcessRequest.
+        restRequest.setArg(InternalKeys.SEND_TRACKING_INFO, "true");
         if (CONTINUE.equals(restRequest.getArgs().get(EXPECT))) {
           restResponseChannel.setStatus(ResponseStatus.Continue);
           handleResponse(restRequest, restResponseChannel, null, null);

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbrySecurityService.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbrySecurityService.java
@@ -43,6 +43,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
@@ -63,6 +64,10 @@ class AmbrySecurityService implements SecurityService {
   static final Set<String> OPERATIONS = Collections.unmodifiableSet(
       Utils.getStaticFieldValuesAsStrings(Operations.class)
           .collect(Collectors.toCollection(() -> new TreeSet<>(String.CASE_INSENSITIVE_ORDER))));
+
+  static final List<String> INTERNAL_KEYS = Collections.unmodifiableList(
+      Utils.getStaticFieldValuesAsStrings(InternalKeys.class).collect(Collectors.toList()));
+
   private final FrontendConfig frontendConfig;
   private final FrontendMetrics frontendMetrics;
   private final UrlSigningService urlSigningService;
@@ -93,6 +98,10 @@ class AmbrySecurityService implements SecurityService {
       throw new IllegalArgumentException("RestRequest is null");
     } else if (restRequest.getArgs().containsKey(InternalKeys.KEEP_ALIVE_ON_ERROR_HINT)) {
       exception = new RestServiceException(InternalKeys.KEEP_ALIVE_ON_ERROR_HINT + " is not allowed in the request",
+          RestServiceErrorCode.BadRequest);
+      //we can't check all internal keys due to we have test in processRequestTest to test preProcessRequest without handler.
+    } else if (restRequest.getArgs().containsKey(InternalKeys.SEND_TRACKING_INFO)) {
+      exception = new RestServiceException(InternalKeys.SEND_TRACKING_INFO + " is not allowed in the request",
           RestServiceErrorCode.BadRequest);
     }
     restRequest.setArg(InternalKeys.SEND_TRACKING_INFO, frontendConfig.attachTrackingInfo);

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
@@ -4229,6 +4229,9 @@ class BadRestRequest extends BadRSC implements RestRequest {
   }
 
   @Override
+  public void removeArg(String key) { throw new IllegalStateException("Not implemented"); }
+
+  @Override
   public SSLSession getSSLSession() {
     return null;
   }

--- a/ambry-rest/src/main/java/com/github/ambry/rest/NettyRequest.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/NettyRequest.java
@@ -258,6 +258,9 @@ public class NettyRequest implements RestRequest {
   }
 
   @Override
+  public void removeArg(String key) { allArgs.remove(key); }
+
+  @Override
   public SSLSession getSSLSession() {
     return sslSession;
   }

--- a/ambry-rest/src/main/java/com/github/ambry/rest/WrappedRestRequest.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/WrappedRestRequest.java
@@ -65,6 +65,9 @@ public class WrappedRestRequest implements RestRequest {
   }
 
   @Override
+  public void removeArg(String key) { restRequest.removeArg(key); }
+
+  @Override
   public SSLSession getSSLSession() {
     return restRequest.getSSLSession();
   }

--- a/ambry-rest/src/test/java/com/github/ambry/rest/AsyncRequestResponseHandlerTest.java
+++ b/ambry-rest/src/test/java/com/github/ambry/rest/AsyncRequestResponseHandlerTest.java
@@ -893,6 +893,9 @@ class BadRestRequest implements RestRequest {
   }
 
   @Override
+  public void removeArg(String key) { throw new IllegalStateException("Not implemented"); }
+
+  @Override
   public SSLSession getSSLSession() {
     return null;
   }

--- a/ambry-test-utils/src/main/java/com/github/ambry/rest/MockRestRequest.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/rest/MockRestRequest.java
@@ -60,7 +60,7 @@ public class MockRestRequest implements RestRequest {
    * List of "events" (function calls) that can occur inside MockRestRequest.
    */
   public enum Event {
-    GetRestMethod, GetPath, GetUri, GetArgs, SetArgs, GetSize, ReadInto, IsOpen, Close, GetMetricsTracker
+    GetRestMethod, GetPath, GetUri, GetArgs, SetArgs, RemoveArgs, GetSize, ReadInto, IsOpen, Close, GetMetricsTracker
   }
 
   /**
@@ -181,6 +181,12 @@ public class MockRestRequest implements RestRequest {
   public Object setArg(String key, Object value) {
     onEventComplete(Event.SetArgs);
     return args.put(key, value);
+  }
+
+  @Override
+  public void removeArg(String key) {
+    onEventComplete(Event.RemoveArgs);
+    args.remove(key);
   }
 
   @Override

--- a/ambry-tools/src/main/java/com/github/ambry/tools/perf/rest/PerfNioServer.java
+++ b/ambry-tools/src/main/java/com/github/ambry/tools/perf/rest/PerfNioServer.java
@@ -268,6 +268,9 @@ class PerfNioServer implements NioServer {
     }
 
     @Override
+    public void removeArg(String key) { args.remove(key); }
+
+    @Override
     public SSLSession getSSLSession() {
       return null;
     }


### PR DESCRIPTION
This pr is to fix the bug that for 100-continue header support, the request will have some internal header after we handle request and send back 100-continue to customer. And in preProcessRequest we will return bad_request if any request has internal key during pre process stage.
This pr is to remove those internal args for 100-continue use case specifically.