### PR TITLE
[DR] Compare metadata from all replicas of a partition with its backup

### DIFF
--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/BackupIntegrityMonitor.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/BackupIntegrityMonitor.java
@@ -288,7 +288,7 @@ public class BackupIntegrityMonitor implements Runnable {
    * @throws IOException
    */
   HashMap<String, MessageInfo> getAzureBlobsFromLocalStore(BlobStore store) throws StoreException, IOException {
-    MessageReadSet rdset = null;
+    MessageReadSet rdset;
     HashMap<String, MessageInfo> azureBlobs = new HashMap<>();
     StoreFindToken newDiskToken = new StoreFindToken(), oldDiskToken = null;
     EnumSet<StoreGetOptions> storeGetOptions = EnumSet.of(StoreGetOptions.Store_Include_Deleted,
@@ -314,7 +314,7 @@ public class BackupIntegrityMonitor implements Runnable {
             }
           }
         }
-        azureBlobs.put(msg.getStoreKey().getID(), msg);
+        azureBlobs.put(msg.getStoreKey().getID(), new MessageInfo(msg, crc));
       }
       oldDiskToken = newDiskToken;
       newDiskToken = (StoreFindToken) finfo.getFindToken();
@@ -369,7 +369,7 @@ public class BackupIntegrityMonitor implements Runnable {
       if (partitionBackedUpUntil == Utils.Infinite_Time) {
         partitionBackedUpUntil = System.currentTimeMillis() - SCAN_STOP_RELTIME;
       }
-      
+
       /** Create local Store S */
       BlobStore store = startLocalStore(partition);
 
@@ -402,7 +402,7 @@ public class BackupIntegrityMonitor implements Runnable {
         throw new RuntimeException(String.format("[BackupIntegrityMonitor] No server replicas available for partition-%s",
             partition.getId()));
       }
-      
+
 
       /** Compare metadata from server replicas with metadata from Azure */
       List<RemoteReplicaInfo> serverReplicas =

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/BackupIntegrityMonitor.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/BackupIntegrityMonitor.java
@@ -13,7 +13,6 @@
  */
 package com.github.ambry.cloud;
 
-import com.azure.data.tables.models.TableEntity;
 import com.github.ambry.cloud.azure.AzureCloudConfig;
 import com.github.ambry.cloud.azure.AzureCloudDestinationSync;
 import com.github.ambry.clustermap.AmbryDisk;

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/BackupIntegrityMonitor.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/BackupIntegrityMonitor.java
@@ -137,15 +137,14 @@ public class BackupIntegrityMonitor implements Runnable {
         .forEach(d -> logger.info("[BackupIntegrityMonitor] Disk = {} {} {} bytes",
             d.getMountPath(), d.getState(), d.getRawCapacityInBytes()));
     logger.info("[BackupIntegrityMonitor] Created BackupIntegrityMonitor");
-    this.run();
   }
 
   /**
    * Starts and schedules monitor
    */
   public void start() {
-    // executor.scheduleWithFixedDelay(this::run, 0, 1, TimeUnit.HOURS);
-    // logger.info("[BackupIntegrityMonitor] Started BackupIntegrityMonitor");
+    executor.scheduleWithFixedDelay(this::run, 0, 1, TimeUnit.HOURS);
+    logger.info("[BackupIntegrityMonitor] Started BackupIntegrityMonitor");
   }
 
   /**

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/BackupIntegrityMonitor.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/BackupIntegrityMonitor.java
@@ -218,6 +218,12 @@ public class BackupIntegrityMonitor implements Runnable {
     }
   }
 
+  /**
+   * Compares metadata received from servers with metadata received from Azure cloud
+   * @param serverReplica
+   * @param serverToAzureReplToken
+   * @param azureToServerReplToken
+   */
   void compareMetadata(RemoteReplicaInfo serverReplica, TableEntity serverToAzureReplToken, RecoveryToken azureToServerReplToken) {
     long partitionId = serverReplica.getReplicaId().getPartitionId().getId();
     try {
@@ -344,6 +350,7 @@ public class BackupIntegrityMonitor implements Runnable {
       while (!newDiskToken.equals(oldDiskToken)) {
         FindInfo finfo = store.findEntriesSince(newDiskToken, 1000 * (2 << 20),
             null, null);
+        // Get CRC of blob recovered from Azure and stored on local-disk
         for (MessageInfo msg: finfo.getMessageEntries()) {
           StoreInfo stinfo = store.get(Collections.singletonList(msg.getStoreKey()), storeGetOptions);
           rdset = stinfo.getMessageReadSet();
@@ -377,6 +384,7 @@ public class BackupIntegrityMonitor implements Runnable {
             partition.getId()));
       }
 
+      /** Compare metadata from server replicas with metadata from Azure */
       List<RemoteReplicaInfo> serverReplicas =
           serverReplicationManager.createRemoteReplicaInfos(replicas, store.getReplicaId());
       for (RemoteReplicaInfo s : serverReplicas) {

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/BackupIntegrityMonitor.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/BackupIntegrityMonitor.java
@@ -28,9 +28,7 @@ import com.github.ambry.clustermap.HardwareState;
 import com.github.ambry.clustermap.HelixClusterManager;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.clustermap.ReplicaSealStatus;
-import com.github.ambry.clustermap.ReplicaState;
 import com.github.ambry.clustermap.StaticClusterManager;
-import com.github.ambry.commons.BlobId;
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.ReplicationConfig;
 import com.github.ambry.config.VerifiableProperties;
@@ -52,9 +50,7 @@ import com.github.ambry.store.StoreInfo;
 import com.github.ambry.utils.Utils;
 import java.io.File;
 import java.io.IOException;
-import java.sql.Blob;
 import java.text.DateFormat;
-import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Collections;
@@ -63,7 +59,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
-import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -233,7 +228,7 @@ public class BackupIntegrityMonitor implements Runnable {
     long scanStartTime, scanEndTime = serverReplica.getReplicatedUntilTime();
     DateFormat formatter = new SimpleDateFormat(VcrReplicationManager.DATE_FORMAT);
     try {
-      serverScanner.setAzureBlobMap(azureBlobs);
+      serverScanner.setAzureBlobInfo(azureBlobs, partitionBackedUpUntil);
       serverScanner.addRemoteReplicaInfo(serverReplica);
       logger.info("[BackupIntegrityMonitor] Queued peer server replica for scan [{}]", serverReplica);
 

--- a/ambry-replication/src/main/java/com/github/ambry/replication/BackupCheckerThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/BackupCheckerThread.java
@@ -72,6 +72,7 @@ public class BackupCheckerThread extends ReplicaThread {
   public static final String BLOB_STATE_MISMATCHES_FILE = "blob_state_mismatches";
   public static final String REPLICA_STATUS_FILE = "server_replica_token";
   protected AtomicInteger numBlobScanned;
+  protected long partitionBackedUpUntil = -1;
 
   public BackupCheckerThread(String threadName, FindTokenHelper findTokenHelper, ClusterMap clusterMap,
       AtomicInteger correlationIdGenerator, DataNodeId dataNodeId, NetworkClient networkClient,
@@ -100,12 +101,13 @@ public class BackupCheckerThread extends ReplicaThread {
     return this.fileManager;
   }
 
-  public void setAzureBlobMap(HashMap<String, MessageInfo> azureBlobMap) {
+  public void setAzureBlobInfo(HashMap<String, MessageInfo> azureBlobMap, long partitionBackedUpUntil) {
     if (azureBlobMap == null) {
       logger.error("Azure blob map cannot be null");
       return;
     }
     this.azureBlobMap = azureBlobMap;
+    this.partitionBackedUpUntil = partitionBackedUpUntil;
   }
 
   /**
@@ -209,6 +211,12 @@ public class BackupCheckerThread extends ReplicaThread {
                 Set<BlobMatchStatus> status = (Set<BlobMatchStatus>) tuple.getRight();
                 // ignore blobs that are deleted or expired on server and absent in azure
                 return !((serverBlob.isDeleted() || serverBlob.isExpired()) && status.contains(BLOB_ABSENT_IN_AZURE));
+              })
+              .filter(tuple -> {
+                MessageInfo serverBlob = (MessageInfo) tuple.getLeft();
+                Set<BlobMatchStatus> status = (Set<BlobMatchStatus>) tuple.getRight();
+                // ignore blobs that are yet to be backed up
+                return !(serverBlob.getOperationTimeMs() > partitionBackedUpUntil && status.contains(BLOB_ABSENT_IN_AZURE));
               })
               .forEach(tuple -> {
                 MessageInfo serverBlob = (MessageInfo) tuple.getLeft();


### PR DESCRIPTION
This patch adds support in the verification-app to compare blob metadata between all 3 server replicas of a partition and its cloud backup. It also adds some filters to reduce false alarms and unhelpful comparisons.
Lastly, we leave the partition on the local disk of the verification app to allow for debugging, instead of wiping it out. It will be wiped out later anyways.