### PR TITLE
Remove exception keyword from log

### DIFF
--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/GetDatasetsHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/GetDatasetsHandler.java
@@ -153,7 +153,7 @@ public class GetDatasetsHandler {
       } catch (AccountServiceException ex) {
         LOGGER.error(
             "Dataset get failed for accountName " + accountName + " containerName " + containerName + " datasetName "
-                + datasetName, ex);
+                + datasetName);
         throw new RestServiceException(ex.getMessage(),
             RestServiceErrorCode.getRestServiceErrorCode(ex.getErrorCode()));
       }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/PostDatasetsHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/PostDatasetsHandler.java
@@ -192,7 +192,7 @@ public class PostDatasetsHandler {
       } catch (AccountServiceException ex) {
         logger.error(
             "Dataset update failed for accountName " + accountName + " containerName " + containerName + " datasetName "
-                + datasetName, ex);
+                + datasetName);
         throw new RestServiceException(ex.getMessage(),
             RestServiceErrorCode.getRestServiceErrorCode(ex.getErrorCode()));
       }


### PR DESCRIPTION
logger will print out the exception in log which will be handled by the response handler anyway. 
Remove this keyword from system log since it will trigger lots of exception ticket.