### PR TITLE
Paranoid durability - basic functionality

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
@@ -273,7 +273,7 @@ public class RouterConfig {
    * Paranoid durability: The min number of successful responses in remote data centers required for a put operation.
    */
   @Config(ROUTER_PUT_REMOTE_SUCCESS_TARGET)
-  @Default("0")
+  @Default("1")
   public final int routerPutRemoteSuccessTarget;
 
   /**

--- a/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
@@ -259,7 +259,7 @@ public class RouterConfig {
    * Paranoid durability: Max parallel requests issued at a time in remote data centers for a chunk.
    */
   @Config(ROUTER_PUT_REMOTE_REQUEST_PARALLELISM)
-  @Default("0")
+  @Default("1")
   public final int routerPutRemoteRequestParallelism;
 
   /**

--- a/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
@@ -60,10 +60,8 @@ public class RouterConfig {
   public static final String ROUTER_DROP_REQUEST_ON_TIMEOUT = "router.drop.request.on.timeout";
   public static final String ROUTER_MAX_PUT_CHUNK_SIZE_BYTES = "router.max.put.chunk.size.bytes";
   public static final String ROUTER_PUT_REQUEST_PARALLELISM = "router.put.request.parallelism";
-  public static final String ROUTER_PUT_LOCAL_REQUEST_PARALLELISM = "router.put.local.request.parallelism";
   public static final String ROUTER_PUT_REMOTE_REQUEST_PARALLELISM = "router.put.remote.request.parallelism";
   public static final String ROUTER_PUT_SUCCESS_TARGET = "router.put.success.target";
-  public static final String ROUTER_PUT_LOCAL_SUCCESS_TARGET = "router.put.local.success.target";
   public static final String ROUTER_PUT_REMOTE_SUCCESS_TARGET = "router.put.remote.success.target";
   public static final String ROUTER_REPLICATE_BLOB_REQUEST_PARALLELISM = "router.replicate.blob.request.parallelism";
   public static final String ROUTER_REPLICATE_BLOB_SUCCESS_TARGET = "router.replicate.blob.success.target";
@@ -258,13 +256,6 @@ public class RouterConfig {
   public final int routerPutRequestParallelism;
 
   /**
-   * Paranoid durability: Max parallel requests issued at a time in the local data center for a chunk.
-   */
-  @Config(ROUTER_PUT_LOCAL_REQUEST_PARALLELISM)
-  @Default("3")
-  public final int routerPutLocalRequestParallelism;
-
-  /**
    * Paranoid durability: Max parallel requests issued at a time in remote data centers for a chunk.
    */
   @Config(ROUTER_PUT_REMOTE_REQUEST_PARALLELISM)
@@ -277,13 +268,6 @@ public class RouterConfig {
   @Config(ROUTER_PUT_SUCCESS_TARGET)
   @Default("2")
   public final int routerPutSuccessTarget;
-
-  /**
-   * Paranoid durability: The min number of successful responses in the local data center required for a put operation.
-   */
-  @Config(ROUTER_PUT_LOCAL_SUCCESS_TARGET)
-  @Default("2")
-  public final int routerPutLocalSuccessTarget;
 
   /**
    * Paranoid durability: The min number of successful responses in remote data centers required for a put operation.
@@ -784,13 +768,10 @@ public class RouterConfig {
         verifiableProperties.getIntInRange(ROUTER_MAX_PUT_CHUNK_SIZE_BYTES, 4 * 1024 * 1024, 1, Integer.MAX_VALUE);
     routerPutRequestParallelism =
         verifiableProperties.getIntInRange(ROUTER_PUT_REQUEST_PARALLELISM, 3, 1, Integer.MAX_VALUE);
-    routerPutLocalRequestParallelism =
-        verifiableProperties.getIntInRange(ROUTER_PUT_LOCAL_REQUEST_PARALLELISM, 3, 1, Integer.MAX_VALUE);
     routerPutRemoteRequestParallelism =
-        verifiableProperties.getIntInRange(ROUTER_PUT_REMOTE_REQUEST_PARALLELISM, 0, 0, Integer.MAX_VALUE);
+        verifiableProperties.getIntInRange(ROUTER_PUT_REMOTE_REQUEST_PARALLELISM, 1, 1, Integer.MAX_VALUE);
     routerPutSuccessTarget = verifiableProperties.getIntInRange(ROUTER_PUT_SUCCESS_TARGET, 2, 1, Integer.MAX_VALUE);
-    routerPutLocalSuccessTarget = verifiableProperties.getIntInRange(ROUTER_PUT_LOCAL_SUCCESS_TARGET, 2, 1, Integer.MAX_VALUE);
-    routerPutRemoteSuccessTarget = verifiableProperties.getIntInRange(ROUTER_PUT_REMOTE_SUCCESS_TARGET, 0, 0, Integer.MAX_VALUE);
+    routerPutRemoteSuccessTarget = verifiableProperties.getIntInRange(ROUTER_PUT_REMOTE_SUCCESS_TARGET, 1, 1, Integer.MAX_VALUE);
     routerReplicateBlobRequestParallelism =
         verifiableProperties.getIntInRange(ROUTER_REPLICATE_BLOB_REQUEST_PARALLELISM, 3, 1, Integer.MAX_VALUE);
     routerReplicateBlobSuccessTarget =

--- a/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
@@ -60,7 +60,11 @@ public class RouterConfig {
   public static final String ROUTER_DROP_REQUEST_ON_TIMEOUT = "router.drop.request.on.timeout";
   public static final String ROUTER_MAX_PUT_CHUNK_SIZE_BYTES = "router.max.put.chunk.size.bytes";
   public static final String ROUTER_PUT_REQUEST_PARALLELISM = "router.put.request.parallelism";
+  public static final String ROUTER_PUT_LOCAL_REQUEST_PARALLELISM = "router.put.local.request.parallelism";
+  public static final String ROUTER_PUT_REMOTE_REQUEST_PARALLELISM = "router.put.remote.request.parallelism";
   public static final String ROUTER_PUT_SUCCESS_TARGET = "router.put.success.target";
+  public static final String ROUTER_PUT_LOCAL_SUCCESS_TARGET = "router.put.local.success.target";
+  public static final String ROUTER_PUT_REMOTE_SUCCESS_TARGET = "router.put.remote.success.target";
   public static final String ROUTER_REPLICATE_BLOB_REQUEST_PARALLELISM = "router.replicate.blob.request.parallelism";
   public static final String ROUTER_REPLICATE_BLOB_SUCCESS_TARGET = "router.replicate.blob.success.target";
   public static final String ROUTER_MAX_SLIPPED_PUT_ATTEMPTS = "router.max.slipped.put.attempts";
@@ -254,11 +258,39 @@ public class RouterConfig {
   public final int routerPutRequestParallelism;
 
   /**
+   * Paranoid durability: Max parallel requests issued at a time in the local data center for a chunk.
+   */
+  @Config(ROUTER_PUT_LOCAL_REQUEST_PARALLELISM)
+  @Default("3")
+  public final int routerPutLocalRequestParallelism;
+
+  /**
+   * Paranoid durability: Max parallel requests issued at a time in remote data centers for a chunk.
+   */
+  @Config(ROUTER_PUT_REMOTE_REQUEST_PARALLELISM)
+  @Default("0")
+  public final int routerPutRemoteRequestParallelism;
+
+  /**
    * The minimum number of successful responses required for a put operation.
    */
   @Config(ROUTER_PUT_SUCCESS_TARGET)
   @Default("2")
   public final int routerPutSuccessTarget;
+
+  /**
+   * Paranoid durability: The min number of successful responses in the local data center required for a put operation.
+   */
+  @Config(ROUTER_PUT_LOCAL_SUCCESS_TARGET)
+  @Default("2")
+  public final int routerPutLocalSuccessTarget;
+
+  /**
+   * Paranoid durability: The min number of successful responses in remote data centers required for a put operation.
+   */
+  @Config(ROUTER_PUT_REMOTE_SUCCESS_TARGET)
+  @Default("0")
+  public final int routerPutRemoteSuccessTarget;
 
   /**
    * The maximum number of parallel requests issued at a time by the ReplicateBlob manager.
@@ -752,7 +784,13 @@ public class RouterConfig {
         verifiableProperties.getIntInRange(ROUTER_MAX_PUT_CHUNK_SIZE_BYTES, 4 * 1024 * 1024, 1, Integer.MAX_VALUE);
     routerPutRequestParallelism =
         verifiableProperties.getIntInRange(ROUTER_PUT_REQUEST_PARALLELISM, 3, 1, Integer.MAX_VALUE);
+    routerPutLocalRequestParallelism =
+        verifiableProperties.getIntInRange(ROUTER_PUT_LOCAL_REQUEST_PARALLELISM, 3, 1, Integer.MAX_VALUE);
+    routerPutRemoteRequestParallelism =
+        verifiableProperties.getIntInRange(ROUTER_PUT_REMOTE_REQUEST_PARALLELISM, 0, 0, Integer.MAX_VALUE);
     routerPutSuccessTarget = verifiableProperties.getIntInRange(ROUTER_PUT_SUCCESS_TARGET, 2, 1, Integer.MAX_VALUE);
+    routerPutLocalSuccessTarget = verifiableProperties.getIntInRange(ROUTER_PUT_LOCAL_SUCCESS_TARGET, 2, 1, Integer.MAX_VALUE);
+    routerPutRemoteSuccessTarget = verifiableProperties.getIntInRange(ROUTER_PUT_REMOTE_SUCCESS_TARGET, 0, 0, Integer.MAX_VALUE);
     routerReplicateBlobRequestParallelism =
         verifiableProperties.getIntInRange(ROUTER_REPLICATE_BLOB_REQUEST_PARALLELISM, 3, 1, Integer.MAX_VALUE);
     routerReplicateBlobSuccessTarget =

--- a/ambry-router/src/main/java/com/github/ambry/router/ParanoidDurabilityOperationTracker.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/ParanoidDurabilityOperationTracker.java
@@ -1,0 +1,314 @@
+package com.github.ambry.router;
+
+import com.github.ambry.clustermap.PartitionId;
+import com.github.ambry.clustermap.ReplicaId;
+import com.github.ambry.clustermap.ReplicaState;
+import com.github.ambry.config.RouterConfig;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An implementation of {@link OperationTracker} for PUTs only (it does not support any other request types). It differs
+ * from {@link SimpleOperationTracker} in that it is "paranoid" about durability. In addition to writing the new blob to
+ * the required number of local replicas, it also requires writes to succeed for at least one replica in one remote
+ * data center, effectively circumventing cross-datacenter replication (configurable). This is useful for clients such
+ * as Samza, that require strong durability guarantees.
+ *
+ */
+public class ParanoidDurabilityOperationTracker extends SimpleOperationTracker {
+  private static final Logger logger = LoggerFactory.getLogger(ParanoidDurabilityOperationTracker.class);
+  protected final int localReplicaSuccessTarget;
+  protected int remoteReplicaSuccessTarget = 0;
+  protected final int localReplicaParallelism;
+  protected final int remoteReplicaParallelism;
+  protected int localInflightCount = 0;
+  protected int remoteInflightCount = 0;
+  protected int localReplicaSuccessCount = 0;
+  protected int remoteReplicaSuccessCount = 0;
+  private final Map<String, LinkedList<ReplicaId>> replicaPoolByDc = new HashMap<>();
+  private final ParanoidDurabilityTrackerIterator otIterator;
+  private Iterator<ReplicaId> replicaByDcIterator;
+  private Map<String, Integer> failedCountByDc;
+  private Map<String, Integer> replicaSuccessCountByDc;
+  private Map<String, Integer> disabledCountByDc;
+  private Map<String, Integer> replicaInPoolOrFlightCountByDc;
+  private Map<String, Integer> totalReplicaCountByDc;
+  private Set<String> allDatacenters;
+  private List<String> remoteDatacenters;
+
+  ParanoidDurabilityOperationTracker(RouterConfig routerConfig, PartitionId partitionId, String originatingDcName,
+      NonBlockingRouterMetrics routerMetrics) {
+    super(routerConfig, RouterOperation.PutOperation, partitionId, originatingDcName, true, routerMetrics);
+
+    localReplicaParallelism = routerConfig.routerPutLocalRequestParallelism;
+    remoteReplicaParallelism = routerConfig.routerPutRemoteRequestParallelism;
+    localReplicaSuccessTarget = routerConfig.routerPutLocalSuccessTarget;
+    remoteReplicaSuccessTarget = routerConfig.routerPutRemoteSuccessTarget;
+
+    List<ReplicaId> allEligibleReplicas = getEligibleReplicas(datacenterName, EnumSet.of(ReplicaState.STANDBY, ReplicaState.LEADER));
+    addReplicasToPool(allEligibleReplicas);
+    this.otIterator = new ParanoidDurabilityTrackerIterator();
+  }
+
+  private void addReplicasToPool(List<? extends ReplicaId> replicas) {
+    Collections.shuffle(replicas);
+
+    for (ReplicaId replicaId : replicas) {
+      if (!replicaId.isDown()) {
+          addToBeginningOfPool(replicaId);
+      } else {
+        addToEndOfPool(replicaId); // As a last ditch attempt, we may still try to write to a down replica.
+      }
+    }
+
+    if(!enoughReplicas()) {
+      throw new IllegalArgumentException(generateErrorMessage(partitionId));
+    }
+    initializeTracking();
+  }
+
+  private void initializeTracking() {
+    replicaSuccessCountByDc = new HashMap<String, Integer>();
+    replicaInPoolOrFlightCountByDc = new HashMap<String, Integer>();
+    remoteDatacenters = new ArrayList<String>();
+
+    replicaPoolByDc.forEach((dcName, v) -> {
+      failedCountByDc.put(dcName, 0);
+      replicaSuccessCountByDc.put(dcName, 0);
+      replicaInPoolOrFlightCountByDc.put(dcName, 0);
+      disabledCountByDc.put(dcName, 0);
+      totalReplicaCountByDc.put(dcName, v.size());
+      allDatacenters.add(dcName);
+      if(!dcName.equals(datacenterName)) {
+        remoteDatacenters.add(dcName);
+      }
+    });
+  }
+
+  private String generateErrorMessage(PartitionId partitionId) {
+    StringBuilder errMsg = new StringBuilder("Partition " + partitionId + " has too few replicas to satisfy paranoid durability requirements. ");
+    replicaPoolByDc.forEach((dcName, v) -> {
+      errMsg.append("Datacenter: ").append(dcName).append(" has ").append(v.size()).append(" replicas in LEADER or STANDBY. ");
+    });
+    return errMsg.toString();
+  }
+
+  private boolean enoughReplicas() {
+    for (String currentDc : replicaPoolByDc.keySet()) {
+      if(currentDc.equals(datacenterName)) {
+        if (replicaPoolByDc.get(currentDc).size() < localReplicaSuccessTarget) {
+          logger.error("Not enough replicas in local data center for partition " + partitionId +
+              " to satisfy paranoid durability requirements " +
+              "(wanted " + localReplicaSuccessTarget + ", but found " + replicaPoolByDc.get(currentDc).size() + ")");
+          return false;
+        }
+      } else {
+        if (replicaPoolByDc.get(currentDc).size() < remoteReplicaSuccessTarget) {
+          logger.error("Not enough replicas in remote data center " + currentDc + " for partition " + partitionId
+              + " to satisfy paranoid durability requirements " +
+              "(wanted " + remoteReplicaSuccessTarget + ", but found " + replicaPoolByDc.get(currentDc).size() + ")");
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  public boolean hasSucceeded() {
+    return hasSucceededLocally() && hasSucceededRemotely();
+  }
+
+  private boolean hasSucceededLocally() {
+    return localReplicaSuccessCount >= localReplicaSuccessTarget;
+  }
+
+  private boolean hasSucceededRemotely() {
+    return remoteReplicaSuccessCount >= remoteReplicaSuccessTarget;
+  }
+
+  /**
+   * Add a replica to the beginning of the replica pool linked list for the given data center.
+   * @param replicaId the replica to add.
+   */
+  private void addToBeginningOfPool(ReplicaId replicaId) {
+    modifyReplicasInPoolOrInFlightCount(replicaId, 1);
+    replicaPoolByDc.computeIfAbsent(replicaId.getDataNodeId().getDatacenterName(), k -> new LinkedList<>())
+        .addFirst(replicaId);
+  }
+
+
+  /**
+   * Add a replica to the end of the replica pool linked list for the given data center.
+   * @param replicaId the replica to add.
+   */
+  private void addToEndOfPool(ReplicaId replicaId) {
+    modifyReplicasInPoolOrInFlightCount(replicaId, 1);
+    replicaPoolByDc.computeIfAbsent(replicaId.getDataNodeId().getDatacenterName(), k -> new LinkedList<>())
+        .addLast(replicaId);
+  }
+
+  public void onResponse(ReplicaId replicaId, TrackedRequestFinalState trackedRequestFinalState) {
+    super.onResponse(replicaId, trackedRequestFinalState);
+    modifyReplicasInPoolOrInFlightCount(replicaId, -1);
+
+    String dcName = replicaId.getDataNodeId().getDatacenterName();
+
+    switch (trackedRequestFinalState) {
+      case SUCCESS:
+        replicaSuccessCountByDc.put(dcName, replicaSuccessCountByDc.get(dcName) + 1);
+        if (dcName.equals(datacenterName)) {
+          localReplicaSuccessCount++;
+        } else {
+          remoteReplicaSuccessCount++;
+        }
+        break;
+      case REQUEST_DISABLED:
+        disabledCountByDc.put(dcName, disabledCountByDc.get(dcName) + 1);
+        break;
+      default:
+        failedCountByDc.put(dcName, failedCountByDc.get(dcName) + 1);
+    }
+  }
+
+  public boolean hasFailed() {
+    if (routerConfig.routerPutUseDynamicSuccessTarget) {
+      for(String dcName : allDatacenters) {
+        if (dcName.equals(datacenterName)) {  // Local colo
+          if (hasFailedDynamically(dcName, routerConfig.routerPutSuccessTarget)) return true;
+        } else {
+          if (hasFailedDynamically(dcName, routerConfig.routerPutRemoteSuccessTarget)) return true;
+        }
+      }
+      return false;
+    } else {
+      return hasFailedLocally() || hasFailedRemotely();
+    }
+  }
+
+  private boolean hasFailedDynamically(String dc, int successTarget)  {
+    return (totalReplicaCountByDc.get(dc) - failedCountByDc.get(dc)) < Math.max(totalReplicaCountByDc.get(dc) - 1, successTarget + disabledCountByDc.get(dc));
+  }
+
+  private boolean hasFailedRemotely() {
+    for(String dcName : allDatacenters) {
+      if(!dcName.equals(datacenterName)) {
+        if (replicaSuccessCountByDc.get(dcName) < Math.max(totalReplicaCountByDc.get(dcName) - 1,
+            routerConfig.routerPutRemoteSuccessTarget + disabledCountByDc.get(dcName))) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  private boolean hasFailedLocally() {
+    return replicaInPoolOrFlightCountByDc.get(datacenterName) + replicaSuccessCountByDc.get(datacenterName) < replicaSuccessTarget;
+  }
+
+  /**
+   * Add {@code delta} to a replicas in pool or in flight counter.
+   * @param delta the value to add to the counter.
+   */
+  private void modifyReplicasInPoolOrInFlightCount(ReplicaId replica, int delta) {
+    String dcName = replica.getDataNodeId().getDatacenterName();
+    replicaInPoolOrFlightCountByDc.put(dcName, replicaInPoolOrFlightCountByDc.get(dcName) + delta);
+  }
+
+
+  int getCurrentLocalParallelism() {
+    return replicaParallelism;
+  }
+
+  int getCurrentRemoteParallelism() {
+    return remoteReplicaParallelism;
+  }
+
+  @Override
+  public Iterator<ReplicaId> getReplicaIterator() {
+    return otIterator;
+  }
+
+  private class ParanoidDurabilityTrackerIterator implements Iterator<ReplicaId> {
+    private int currentDatacenterIndex = 0;
+
+    @Override
+    public boolean hasNext() {
+      return hasNextLocal() || hasNextRemote();
+    }
+
+    @Override
+    public void remove() {
+      if(isLocalReplica(lastReturnedByIterator)){
+        localInflightCount++;
+      } else {
+        remoteInflightCount++;
+      }
+      replicaPoolByDc.get(lastReturnedByIterator.getDataNodeId().getDatacenterName()).remove(lastReturnedByIterator);
+    }
+
+    @Override
+    public ReplicaId next() {
+      if (!hasNext()) {
+        throw new NoSuchElementException();
+      }
+
+      if (hasNextLocal()) {
+        lastReturnedByIterator = replicaPoolByDc.get(datacenterName).removeFirst();
+      } else {
+        // hasNextRemote() must be true
+        String nextColo = getNextRemoteDatacenter();
+        lastReturnedByIterator = replicaPoolByDc.get(nextColo).removeFirst();
+      }
+      return lastReturnedByIterator;
+    }
+
+    private boolean hasNextLocal() {
+      return localInflightCount < getCurrentLocalParallelism() && !replicaPoolByDc.get(datacenterName).isEmpty();
+    }
+
+    private boolean hasNextRemote() {
+      return remoteInflightCount < getCurrentRemoteParallelism() && remoteReplicasLeft();
+    }
+
+    private boolean remoteReplicasLeft() {
+      for(String dcName : remoteDatacenters) {
+        if(!replicaPoolByDc.get(dcName).isEmpty()) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    private boolean isLocalReplica(ReplicaId replica) {
+      return replica.getDataNodeId().getDatacenterName().equals(datacenterName);
+    }
+
+    /**
+     * Get the next remote DC to send a request to. This method should only get called if there are remote
+     * replicas left to send requests to, so there must be at least one remote DC that has at least one replica left.
+     * @return the name of the next remote data center to send a request to.
+     */
+    private String getNextRemoteDatacenter()  {
+      int i = 0;
+      int remoteDatacenterCount = remoteDatacenters.size();
+      String nextDatacenter;
+      do {
+        nextDatacenter = remoteDatacenters.get(currentDatacenterIndex);
+        currentDatacenterIndex = (currentDatacenterIndex + 1) % remoteDatacenterCount;
+        i++;
+      } while (replicaPoolByDc.get(nextDatacenter).isEmpty() &&
+          i <= remoteDatacenterCount);                           // Guard against infinite loop
+      return nextDatacenter;
+    }
+  }
+}

--- a/ambry-router/src/main/java/com/github/ambry/router/ParanoidDurabilityOperationTracker.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/ParanoidDurabilityOperationTracker.java
@@ -50,12 +50,12 @@ public class ParanoidDurabilityOperationTracker extends SimpleOperationTracker {
       NonBlockingRouterMetrics routerMetrics) {
     super(routerConfig, RouterOperation.PutOperation, partitionId, originatingDcName, true, routerMetrics);
 
-    localReplicaParallelism = routerConfig.routerPutLocalRequestParallelism;
+    localReplicaParallelism = routerConfig.routerPutRequestParallelism;
     remoteReplicaParallelism = routerConfig.routerPutRemoteRequestParallelism;
-    localReplicaSuccessTarget = routerConfig.routerPutLocalSuccessTarget;
+    localReplicaSuccessTarget = routerConfig.routerPutSuccessTarget;
     remoteReplicaSuccessTarget = routerConfig.routerPutRemoteSuccessTarget;
 
-    List<ReplicaId> allEligibleReplicas = getEligibleReplicas(datacenterName, EnumSet.of(ReplicaState.STANDBY, ReplicaState.LEADER));
+    List<ReplicaId> allEligibleReplicas = getEligibleReplicas(null, EnumSet.of(ReplicaState.STANDBY, ReplicaState.LEADER));
     addReplicasToPool(allEligibleReplicas);
     this.otIterator = new ParanoidDurabilityTrackerIterator();
   }
@@ -65,7 +65,7 @@ public class ParanoidDurabilityOperationTracker extends SimpleOperationTracker {
 
     for (ReplicaId replicaId : replicas) {
       if (!replicaId.isDown()) {
-          addToBeginningOfPool(replicaId);
+        addToBeginningOfPool(replicaId);
       } else {
         addToEndOfPool(replicaId); // As a last ditch attempt, we may still try to write to a down replica.
       }

--- a/ambry-router/src/main/java/com/github/ambry/router/SimpleOperationTracker.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/SimpleOperationTracker.java
@@ -820,7 +820,7 @@ class SimpleOperationTracker implements OperationTracker {
    * @param replicaId The replica id
    * @return Replica state for replica id.
    */
-  private ReplicaState getReplicaState(ReplicaId replicaId) {
+  protected ReplicaState getReplicaState(ReplicaId replicaId) {
     for (Map.Entry<ReplicaState, List<ReplicaId>> entry : allDcReplicasByState.entrySet()) {
       if (entry.getValue().contains(replicaId)) {
         return entry.getKey();

--- a/ambry-router/src/main/java/com/github/ambry/router/SimpleOperationTracker.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/SimpleOperationTracker.java
@@ -81,9 +81,9 @@ class SimpleOperationTracker implements OperationTracker {
   protected final LinkedList<ReplicaId> replicaPool = new LinkedList<>();
   protected final NonBlockingRouterMetrics routerMetrics;
   private final OpTrackerIterator otIterator;
-  private final RouterOperation routerOperation;
-  private final PartitionId partitionId;
-  private final RouterConfig routerConfig;
+  protected final RouterOperation routerOperation;
+  protected final PartitionId partitionId;
+  protected final RouterConfig routerConfig;
   protected int inflightCount = 0;
   protected int replicaSuccessCount = 0;
   protected List<ReplicaId> successReplica = new ArrayList<>();
@@ -93,8 +93,8 @@ class SimpleOperationTracker implements OperationTracker {
   protected int originatingDcNotFoundCount = 0;
   protected int totalNotFoundCount = 0;
   protected ReplicaId lastReturnedByIterator = null;
-  private Iterator<ReplicaId> replicaIterator;
-  private final Set<ReplicaId> originatingDcLeaderOrStandbyReplicas;
+  protected Iterator<ReplicaId> replicaIterator;
+  protected final Set<ReplicaId> originatingDcLeaderOrStandbyReplicas;
   private final int originatingDcTotalReplicaCount;
   private final Map<ReplicaState, List<ReplicaId>> allDcReplicasByState;
   private final BlobId blobId;
@@ -775,7 +775,7 @@ class SimpleOperationTracker implements OperationTracker {
    * @param downReplicas Replicas added to downReplicas.
    * @param routerOperation The operation type associated with current operation tracker.
    */
-  private static String generateErrorMessage(PartitionId partitionId, List<ReplicaId> examinedReplicas,
+  protected static String generateErrorMessage(PartitionId partitionId, List<ReplicaId> examinedReplicas,
       List<ReplicaId> replicaPool, List<ReplicaId> backupReplicas, List<ReplicaId> downReplicas,
       RouterOperation routerOperation) {
     StringBuilder errMsg = new StringBuilder("Total Replica count ").append(replicaPool.size())

--- a/ambry-router/src/main/java/com/github/ambry/router/SimpleOperationTracker.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/SimpleOperationTracker.java
@@ -96,7 +96,7 @@ class SimpleOperationTracker implements OperationTracker {
   protected Iterator<ReplicaId> replicaIterator;
   protected final Set<ReplicaId> originatingDcLeaderOrStandbyReplicas;
   private final int originatingDcTotalReplicaCount;
-  private final Map<ReplicaState, List<ReplicaId>> allDcReplicasByState;
+  protected final Map<ReplicaState, List<ReplicaId>> allDcReplicasByState;
   private final BlobId blobId;
   // is that possible to run the offline repair?
   private boolean possibleRunOfflineRepair;
@@ -575,7 +575,7 @@ class SimpleOperationTracker implements OperationTracker {
    * @param states a set of {@link ReplicaState}(s) that replicas should match.
    * @return a list of eligible replicas that are in specified states.
    */
-  private List<ReplicaId> getEligibleReplicas(String dcName, EnumSet<ReplicaState> states) {
+  protected List<ReplicaId> getEligibleReplicas(String dcName, EnumSet<ReplicaState> states) {
     Map<ReplicaState, List<ReplicaId>> replicasByState = getReplicasByState(dcName, states);
     List<ReplicaId> eligibleReplicas = new ArrayList<>();
     for (List<ReplicaId> replicas : replicasByState.values()) {


### PR DESCRIPTION
This PR adds the basic required functionality for paranoid durability, where we require PUTs to succeed in at least one remote colo, reducing the risk of data loss in exceptional situations.

The writes in the local colo follow the same logic as before, but the remote (i.e. cross colo) writes are executed as follows:

- We allow simultaneous local and remote writes (respecting the parallelism configurations).
- We prefer to write to remote replicas that are in Helix LEADER state.
- We alternate writing to each remote data center. So, for example, if the current (local) colo is prod-ltx1, then we might attempt to write first to the LEADER in prod-lor1. If that write fails, we'll try to write to the LEADER in prod-lva1 instead of attempting further replicas in prod-lor1. The assumption behind this is that if a remote colo write fails, it is likely that we have hit a networking or colo-related issue, and so we should try the other colo now.

I've tested this locally, and as agreed with the rest of the team I'll follow up with pull requests with tests and metrics and the required wiring.