### PR TITLE
[DR] Get blob-content CRC of Azure blobs

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/store/Store.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/Store.java
@@ -15,6 +15,7 @@ package com.github.ambry.store;
 
 import com.github.ambry.clustermap.ReplicaState;
 import com.github.ambry.replication.FindToken;
+import java.io.IOException;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
@@ -217,4 +218,14 @@ public interface Store {
    * Shuts down the store
    */
   void shutdown() throws StoreException;
-}
+
+  /**
+   * Returns blob-content CRC
+   * @param msg Metadata of blob
+   * @return CRC of blob-content
+   * @throws StoreException
+   * @throws IOException
+   */
+  default Long getBlobContentCRC(MessageInfo msg) throws StoreException, IOException { return null; }
+
+  }

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/BackupIntegrityMonitor.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/BackupIntegrityMonitor.java
@@ -277,33 +277,20 @@ public class BackupIntegrityMonitor implements Runnable {
 
   /**
    * Returns CRC of blob-content
-   * @param msg
-   * @param store
-   * @return CRC
+   * @param msg Metadata of blob
+   * @param store Local blob store
+   * @return CRC of blob-content
    */
   Long getBlobContentCRC(MessageInfo msg, BlobStore store) {
-    EnumSet<StoreGetOptions> storeGetOptions = EnumSet.of(StoreGetOptions.Store_Include_Deleted,
-        StoreGetOptions.Store_Include_Expired);
-    MessageReadSet rdset = null;
-    Long crc = null;
     try {
-      StoreInfo stinfo = store.get(Collections.singletonList(msg.getStoreKey()), storeGetOptions);
-      rdset = stinfo.getMessageReadSet();
-      MessageInfo minfo = stinfo.getMessageReadSetInfo().get(0);
-      rdset.doPrefetch(0, minfo.getSize() - MessageFormatRecord.Crc_Size,
-          MessageFormatRecord.Crc_Size);
-      crc = rdset.getPrefetchedData(0).getLong(0);
+      return store.getBlobContentCRC(msg);
     } catch (Throwable e) {
       metrics.backupCheckerRuntimeError.inc();
       String err = String.format("[BackupIntegrityMonitor] Failed to get CRC for blob %s due to",
           msg.getStoreKey().getID());
       logger.error(err, e);
-    } finally {
-      if (rdset != null && rdset.count() > 0 && rdset.getPrefetchedData(0) != null) {
-        rdset.getPrefetchedData(0).release();
-      }
     }
-    return crc;
+    return null;
   }
 
 

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/BackupIntegrityMonitor.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/BackupIntegrityMonitor.java
@@ -294,6 +294,7 @@ public class BackupIntegrityMonitor implements Runnable {
           MessageFormatRecord.Crc_Size);
       crc = rdset.getPrefetchedData(0).getLong(0);
     } catch (Throwable e) {
+      metrics.backupCheckerRuntimeError.inc();
       String err = String.format("[BackupIntegrityMonitor] Failed to get CRC for blob %s due to",
           msg.getStoreKey().getID());
       logger.error(err, e);


### PR DESCRIPTION
We are going to compare CRC of blob from server and from Azure. This patch adds code to get blob-content CRC of Azure blobs recovered and stored in the local disk of backup-verification-app,. Refactored the code so that the same method runs in server and in verification-app to fetch CRC from local blob store.