### PR TITLE
[DR] Debug branch

### DIFF
--- a/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
@@ -431,19 +431,6 @@ public class DiskManager {
       if (!running) {
         logger.error("Failed to add {} because disk manager is not running", replica.getPartitionId());
       } else {
-        // Clean up existing dir associated with this replica to add. Here we re-create a new store because we don't
-        // know the state of files in old directory. (The old directory was created last time when adding this replica
-        // but failed at some point before updating InstanceConfig)
-        File storeDir = new File(replica.getReplicaPath());
-        if (storeDir.exists()) {
-          logger.info("Deleting previous store directory associated with {}", replica);
-          try {
-            Utils.deleteFileOrDirectory(storeDir);
-          } catch (Exception e) {
-            throw new IOException("Couldn't delete store directory " + replica.getReplicaPath(), e);
-          }
-          logger.info("Old store directory is deleted for {}", replica);
-        }
         BlobStore store = new BlobStore(replica, storeConfig, scheduler, longLivedTaskScheduler, this, diskIOScheduler,
             diskSpaceAllocator, storeMainMetrics, storeUnderCompactionMetrics, keyFactory, recovery, hardDelete,
             replicaStatusDelegates, time, accountService, null, indexPersistScheduler);


### PR DESCRIPTION
THIS WILL NOT COMPILE UNLESS YOU EDIT IT AS REQUIRED.

This patch helps debug the backup-checker-app to rule out any bugs in the code or debug any issues in the backup.

To use this patch, pull it, rebase on master.
Apply your changes, if any.
Compile and copy the necessary jar files on to the backup-checker hosts.

Usecases:
1. Restoring a selected partition

If you wish to recover a particular partition from cloud and run checker on it, you can do so with this patch.

2. Re-using restored partition from local-disk Once the backup has been restored, you'd want to use the copy in the local-disk of the backup-checker host and re-run checker for further troubleshooting. But each time the backup-checker-app starts, it wipes the disk. This patch prevents that allowing you to debug.