### PR TITLE
[vcr-2.0] Trying to speed up backups

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/CloudConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/CloudConfig.java
@@ -469,9 +469,17 @@ public class CloudConfig {
   @Config(BACKUP_NODE_CPU_SCALE)
   public final double backupNodeCpuScale;
 
+  /**
+   * Fraction of token expiry time after which storage client token refresh will be attempted.
+   */
+  public static final String REPLICA_SELECTION_POLICY = "replica.selection.policy";
+  public static final ReplicaSelectionPolicy DEFAULT_REPLICA_SELECTION_POLICY = ReplicaSelectionPolicy.ROUND_ROBIN;
+  @Config(REPLICA_SELECTION_POLICY)
+  public ReplicaSelectionPolicy replicaSelectionPolicy;
 
   public CloudConfig(VerifiableProperties verifiableProperties) {
-
+    replicaSelectionPolicy = verifiableProperties.getEnum(REPLICA_SELECTION_POLICY, ReplicaSelectionPolicy.class,
+        DEFAULT_REPLICA_SELECTION_POLICY);
     backupNodeCpuScale = verifiableProperties.getDoubleInRange(BACKUP_NODE_CPU_SCALE,
         DEFAULT_BACKUP_NODE_CPU_SCALE, MIN_BACKUP_NODE_CPU_SCALE, MAX_BACKUP_NODE_CPU_SCALE);
     cloudCompactionGracePeriodDays = verifiableProperties.getInt(CLOUD_COMPACTION_GRACE_PERIOD_DAYS, 7);

--- a/ambry-api/src/main/java/com/github/ambry/config/CloudConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/CloudConfig.java
@@ -470,7 +470,7 @@ public class CloudConfig {
   public final double backupNodeCpuScale;
 
   /**
-   * Fraction of token expiry time after which storage client token refresh will be attempted.
+   * Specifies how the backup-node must select server replicas to replicate from
    */
   public static final String REPLICA_SELECTION_POLICY = "replica.selection.policy";
   public static final ReplicaSelectionPolicy DEFAULT_REPLICA_SELECTION_POLICY = ReplicaSelectionPolicy.ROUND_ROBIN;

--- a/ambry-api/src/main/java/com/github/ambry/config/ReplicaSelectionPolicy.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/ReplicaSelectionPolicy.java
@@ -1,5 +1,23 @@
+/**
+ * Copyright 2024 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
 package com.github.ambry.config;
 
+/**
+ * Specifies how the backup-node must select server replicas to back up.
+ * FIXED: The backup-node will select the same server replica each time for a partition
+ * ROUND_ROBIN: The backup-node will cycle through all replicas of a partition
+ */
 public enum ReplicaSelectionPolicy {
   FIXED,
   ROUND_ROBIN

--- a/ambry-api/src/main/java/com/github/ambry/config/ReplicaSelectionPolicy.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/ReplicaSelectionPolicy.java
@@ -1,0 +1,6 @@
+package com.github.ambry.config;
+
+public enum ReplicaSelectionPolicy {
+  FIXED,
+  ROUND_ROBIN
+}

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobStore.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobStore.java
@@ -1286,17 +1286,38 @@ public class CloudBlobStore implements Store {
 
   @Override
   public Set<StoreKey> findMissingKeys(List<StoreKey> keys) throws StoreException {
-    Set<StoreKey> missingKeys = new HashSet<>();
-    keys.stream().forEach(k -> {
-      try {
-        if (!cloudDestination.getBlobMetadata(Collections.singletonList((BlobId) k)).containsKey(k.getID())) {
-          missingKeys.add(k);
-        }
-      } catch (Throwable e) {
-        // pass; error is handled or printed in getBlobMetadata
-      }
-    });
-    return missingKeys;
+    checkStarted();
+
+    if (recentBlobCache == null) {
+      return keys.stream()
+          .filter(key -> !cloudDestination.doesBlobExist((BlobId) key))
+          .collect(Collectors.toSet());
+    }
+
+    // Check existence of keys in cloud metadata
+    // Note that it is ok to refer cache here, because all we are doing is eliminating blobs that were seen before and
+    // we don't care about the state of the blob.
+    // TODO Fix corner case where a blob is deleted in cache, and has been compacted. Ideally it should show as missing.
+    List<BlobId> blobIdQueryList = keys.stream()
+        .filter(key -> !checkCacheState(key.getID()))
+        .map(key -> (BlobId) key)
+        .collect(Collectors.toList());
+    if (blobIdQueryList.isEmpty()) {
+      // Cool, the cache did its job and eliminated a possibly expensive query to cloud!
+      return Collections.emptySet();
+    }
+    try {
+      Set<String> foundSet =
+          requestAgent.doWithRetries(() -> cloudDestination.getBlobMetadata(blobIdQueryList), "FindMissingKeys",
+              partitionId.toPathString()).keySet();
+      // return input keys - cached keys - keys returned by query
+      return keys.stream()
+          .filter(key -> !foundSet.contains(key.getID()))
+          .filter(key -> !recentBlobCache.containsKey(key.getID()))
+          .collect(Collectors.toSet());
+    } catch (CloudStorageException ex) {
+      throw new StoreException(ex, StoreErrorCodes.IOError);
+    }
   }
 
   @Override

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicaThread.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicaThread.java
@@ -116,7 +116,6 @@ public class VcrReplicaThread extends ReplicaThread {
     replicas.values().forEach(rlist -> rlist.forEach(replica -> partitions.computeIfAbsent(
         replica.getReplicaId().getPartitionId().getId(), k -> new ArrayList<>()).add(replica)));
     // Pick one replica per partition for this iteration
-    // Group by data node
     Map<DataNodeId, List<RemoteReplicaInfo>> nodes = new HashMap<>();
     partitions.values().forEach(rlist -> {
       rlist.sort(comparator);
@@ -134,6 +133,7 @@ public class VcrReplicaThread extends ReplicaThread {
               vcrNodeConfig.DEFAULT_REPLICA_SELECTION_POLICY, replica.getReplicaId().getDataNodeId().getHostname(),
               replica.getReplicaId().getPartitionId().getId());
       }
+      // Group by data node
       nodes.computeIfAbsent(replica.getReplicaId().getDataNodeId(), k -> new ArrayList<>()).add(replica);
     });
     numReplIter = (numReplIter % 100) + 1; // Prevent integer overflow

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestinationSync.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestinationSync.java
@@ -568,10 +568,30 @@ public class AzureCloudDestinationSync implements CloudDestination {
    * @return HTTP response and blob metadata
    */
   protected Response<Void> updateBlobMetadata(AzureBlobLayoutStrategy.BlobLayout blobLayout, BlobProperties blobProperties, Map<String, String> metadata) {
+    threadLocalMdCache.get().deleteObject(blobLayout.blobFilePath);
     BlobClient blobClient = createOrGetBlobStore(blobLayout.containerName).getBlobClient(blobLayout.blobFilePath);
     BlobRequestConditions blobRequestConditions = new BlobRequestConditions().setIfMatch(blobProperties.getETag());
     return blobClient.setMetadataWithResponse(metadata, blobRequestConditions,
         Duration.ofMillis(cloudConfig.cloudRequestTimeout), Context.NONE);
+  }
+
+  /**
+   * Returns cached blob properties from Azure
+   * @param blobLayout BlobLayout
+   * @return Blob properties
+   * @throws CloudStorageException
+   */
+  protected BlobProperties getBlobPropertiesCached(AzureBlobLayoutStrategy.BlobLayout blobLayout)
+      throws CloudStorageException {
+    BlobMetadata entry = (BlobMetadata) threadLocalMdCache.get().getObject(blobLayout.blobFilePath);
+    BlobProperties blobProperties;
+    if (entry == null) {
+      blobProperties = getBlobProperties(blobLayout);
+      threadLocalMdCache.get().putObject(blobLayout.blobFilePath, new BlobMetadata(blobProperties));
+    } else {
+      blobProperties = entry.getProperties();
+    }
+    return blobProperties;
   }
 
   /**
@@ -623,7 +643,7 @@ public class AzureCloudDestinationSync implements CloudDestination {
     Map<String, Object> newMetadata = new HashMap<>();
     newMetadata.put(CloudBlobMetadata.FIELD_DELETION_TIME, String.valueOf(deletionTime));
     newMetadata.put(CloudBlobMetadata.FIELD_LIFE_VERSION, lifeVersion);
-    BlobProperties blobProperties = getBlobProperties(blobLayout);
+    BlobProperties blobProperties = getBlobPropertiesCached(blobLayout);
     Map<String, String> cloudMetadata = blobProperties.getMetadata();
 
     try {
@@ -690,7 +710,7 @@ public class AzureCloudDestinationSync implements CloudDestination {
     Timer.Context storageTimer = azureMetrics.blobUndeleteLatency.time();
     AzureBlobLayoutStrategy.BlobLayout blobLayout = azureBlobLayoutStrategy.getDataBlobLayout(blobId);
     String blobIdStr = blobLayout.blobFilePath;
-    BlobProperties blobProperties = getBlobProperties(blobLayout);
+    BlobProperties blobProperties = getBlobPropertiesCached(blobLayout);
     Map<String, String> cloudMetadata = blobProperties.getMetadata();
     Map<String, Object> newMetadata = new HashMap<>();
     newMetadata.put(CloudBlobMetadata.FIELD_LIFE_VERSION, lifeVersion);
@@ -797,7 +817,7 @@ public class AzureCloudDestinationSync implements CloudDestination {
     Timer.Context storageTimer = azureMetrics.blobUpdateTTLLatency.time();
     AzureBlobLayoutStrategy.BlobLayout blobLayout = azureBlobLayoutStrategy.getDataBlobLayout(blobId);
     String blobIdStr = blobLayout.blobFilePath;
-    BlobProperties blobProperties = getBlobProperties(blobLayout);
+    BlobProperties blobProperties = getBlobPropertiesCached(blobLayout);
     Map<String, String> cloudMetadata = blobProperties.getMetadata();
 
     // Below is the correct behavior. For ref, look at BlobStore::updateTTL and ReplicaThread::applyTtlUpdate.
@@ -901,14 +921,7 @@ public class AzureCloudDestinationSync implements CloudDestination {
     for (BlobId blobId: blobIds) {
       AzureBlobLayoutStrategy.BlobLayout blobLayout = this.azureBlobLayoutStrategy.getDataBlobLayout(blobId);
       try {
-        BlobMetadata entry = (BlobMetadata) threadLocalMdCache.get().getObject(blobLayout.blobFilePath);
-        BlobProperties blobProperties;
-        if (entry == null) {
-          blobProperties = getBlobProperties(blobLayout);
-          threadLocalMdCache.get().putObject(blobLayout.blobFilePath, new BlobMetadata(blobProperties));
-        } else {
-          blobProperties = entry.getProperties();
-        }
+        BlobProperties blobProperties = getBlobPropertiesCached(blobLayout);
         cloudBlobMetadataMap.put(blobId.getID(), CloudBlobMetadata.fromMap(blobProperties.getMetadata()));
       } catch (CloudStorageException cse) {
         if (cse.getCause() instanceof BlobStorageException &&

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestinationSync.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestinationSync.java
@@ -52,8 +52,6 @@ import com.github.ambry.cloud.CloudStorageException;
 import com.github.ambry.cloud.CloudUpdateValidator;
 import com.github.ambry.cloud.FindResult;
 import com.github.ambry.clustermap.ClusterMap;
-import com.github.ambry.commons.AmbryCache;
-import com.github.ambry.commons.AmbryCacheEntry;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.config.CloudConfig;
 import com.github.ambry.config.ClusterMapConfig;
@@ -72,7 +70,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.time.Duration;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -106,18 +103,7 @@ public class AzureCloudDestinationSync implements CloudDestination {
   protected AccountService accountService;
   protected StoreConfig storeConfig;
   public static final Logger logger = LoggerFactory.getLogger(AzureCloudDestinationSync.class);
-  ThreadLocal<AmbryCache> threadLocalMdCache;
-  protected class BlobMetadata implements AmbryCacheEntry {
 
-    private final BlobProperties properties;
-    public BlobMetadata(BlobProperties properties) {
-      this.properties = properties;
-    }
-
-    public BlobProperties getProperties() {
-      return properties;
-    }
-  }
   /**
    * Constructor for AzureCloudDestinationSync
    * @param verifiableProperties Configuration properties
@@ -184,9 +170,6 @@ public class AzureCloudDestinationSync implements CloudDestination {
     logger.info("azureCloudConfig.azureStorageClientClass = {}", azureCloudConfig.azureStorageClientClass);
     StorageClient storageClient =
         Utils.getObj(azureCloudConfig.azureStorageClientClass, cloudConfig, azureCloudConfig, azureMetrics);
-    threadLocalMdCache = new ThreadLocal<>();
-    threadLocalMdCache.set(
-        new AmbryCache("thread-local-mdcache", true, 1000, metricRegistry));
     this.azureStorageClient = storageClient.getStorageSyncClient();
     this.azureTableServiceClient = storageClient.getTableServiceClient();
     testAzureStorageConnectivity();
@@ -901,14 +884,7 @@ public class AzureCloudDestinationSync implements CloudDestination {
     for (BlobId blobId: blobIds) {
       AzureBlobLayoutStrategy.BlobLayout blobLayout = this.azureBlobLayoutStrategy.getDataBlobLayout(blobId);
       try {
-        BlobMetadata entry = (BlobMetadata) threadLocalMdCache.get().getObject(blobLayout.blobFilePath);
-        BlobProperties blobProperties;
-        if (entry == null) {
-          blobProperties = getBlobProperties(blobLayout);
-          threadLocalMdCache.get().putObject(blobLayout.blobFilePath, new BlobMetadata(blobProperties));
-        } else {
-          blobProperties = entry.getProperties();
-        }
+        BlobProperties blobProperties = getBlobProperties(blobLayout);
         cloudBlobMetadataMap.put(blobId.getID(), CloudBlobMetadata.fromMap(blobProperties.getMetadata()));
       } catch (CloudStorageException cse) {
         if (cse.getCause() instanceof BlobStorageException &&

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestinationSync.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestinationSync.java
@@ -409,6 +409,7 @@ public class AzureCloudDestinationSync implements CloudDestination {
    */
   public boolean uploadBlobs(MessageFormatWriteSet messageSetToWrite) throws CloudStorageException {
     // Each input stream is a blob
+    Timer.Context storageTimer = azureMetrics.blobBatchUploadLatency.time();
     MessageSievingInputStream stream = (MessageSievingInputStream) messageSetToWrite.getStreamToWrite();
     ListIterator<InputStream> messageStreamListIter = stream.getValidMessageStreamList().listIterator();
     boolean unused_ret = true;
@@ -420,6 +421,7 @@ public class AzureCloudDestinationSync implements CloudDestination {
       cloudBlobMetadata.setReplicaLocation(stream.getReplicaLocation());
       unused_ret &= uploadBlob(blobId, messageInfo.getSize(), cloudBlobMetadata, messageStreamListIter.next());
     }
+    storageTimer.stop();
     // Unused return value
     return unused_ret;
   }

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureMetrics.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureMetrics.java
@@ -203,10 +203,13 @@ public class AzureMetrics {
   public static final String BLOB_CHECK_ERROR = "BlobCheckError";
   public final Counter blobCheckError;
 
+  public static final String BLOB_BATCH_UPLOAD_LATENCY = "BlobBatchUploadLatency";
+  public final Timer blobBatchUploadLatency;
   public AzureMetrics(MetricRegistry registry) {
     this.metricRegistry = registry;
 
     // V2 metrics
+    blobBatchUploadLatency = registry.timer(MetricRegistry.name(AzureMetrics.class, BLOB_BATCH_UPLOAD_LATENCY));
     blobCheckError = registry.counter(MetricRegistry.name(AzureMetrics.class, BLOB_CHECK_ERROR));
     blobCompactionErrorCount = registry.counter(MetricRegistry.name(AzureMetrics.class, BLOB_COMPACTION_ERROR_COUNT));
     blobCompactionLatency = registry.timer(MetricRegistry.name(AzureMetrics.class, BLOB_COMPACTION_LATENCY));

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
@@ -388,8 +388,11 @@ public abstract class ReplicationEngine implements ReplicationAPI {
       String threadIdentity = getReplicaThreadName(datacenter, i);
       try {
         StoreKeyConverter threadSpecificKeyConverter = storeKeyConverterFactory.getStoreKeyConverter();
-        Transformer threadSpecificTransformer =
-            Utils.getObj(transformerClassName, storeKeyFactory, threadSpecificKeyConverter);
+        Transformer threadSpecificTransformer = null;
+        if (transformerClassName != null && !transformerClassName.isEmpty()) {
+          threadSpecificTransformer =
+              Utils.getObj(transformerClassName, storeKeyFactory, threadSpecificKeyConverter);
+        }
         ReplicaThread replicaThread =
             getReplicaThread(threadIdentity, tokenHelper, clusterMap, correlationIdGenerator, dataNodeId,
                 networkClientFactory.getNetworkClient(), replicationConfig, replicationMetrics, notification,

--- a/ambry-vcr/src/main/java/com/github/ambry/vcr/VcrServer.java
+++ b/ambry-vcr/src/main/java/com/github/ambry/vcr/VcrServer.java
@@ -27,6 +27,7 @@ import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.VcrClusterAgentsFactory;
 import com.github.ambry.clustermap.VcrClusterParticipant;
+import com.github.ambry.commons.NettyInternalMetrics;
 import com.github.ambry.commons.NettySslHttp2Factory;
 import com.github.ambry.commons.SSLFactory;
 import com.github.ambry.commons.ServerMetrics;
@@ -106,6 +107,7 @@ public class VcrServer {
   private CloudDestination cloudDestination;
   private ServerSecurityService serverSecurityService;
   private ServerMetrics serverMetrics;
+  private NettyInternalMetrics nettyInternalMetrics;
 
   /**
    * VcrServer constructor.
@@ -155,6 +157,8 @@ public class VcrServer {
       logger.info("Initialized clusterMap");
       registry = clusterMap.getMetricRegistry();
       serverMetrics = new ServerMetrics(registry, VcrServer.class, VcrServer.class);
+      nettyInternalMetrics = new NettyInternalMetrics(registry, new NettyConfig(properties));
+      nettyInternalMetrics.start();
 
       logger.info("Setting up JMX.");
       long startTime = SystemTime.getInstance().milliseconds();
@@ -316,6 +320,9 @@ public class VcrServer {
       }
       if (cloudDestination != null) {
         cloudDestination.close();
+      }
+      if (nettyInternalMetrics != null) {
+        nettyInternalMetrics.stop();
       }
       logger.info("VCR shutdown completed");
     } catch (Exception e) {


### PR DESCRIPTION
main cluster's backup is progressing too slow. This patch tries to speed it up by providing the option to reduce the number of replicas the backup-host has to talk to and eliminating deserializing the blob on the path to the cloud.