### PR TITLE
Fix a bug when adding new partitions in FULL AUTO

### DIFF
--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
@@ -882,7 +882,7 @@ public class HelixClusterManager implements ClusterMap {
             partitionIdStr);
         return null;
       }
-      partitionNameToAmbryPartition.putIfAbsent(ambryPartition.toPathString(), ambryPartition);
+      addPartitionIfAbsent(ambryPartition, replicaCapacity);
       AmbryServerReplica replica = new AmbryServerReplica(clusterMapConfig, ambryPartition, disk, true, replicaCapacity,
           ReplicaSealStatus.NOT_SEALED);
       logger.info("Created bootstrap replica {} for Partition {}", replica, partitionIdStr);


### PR DESCRIPTION
## Summary

When adding a new partition to a new host in FULL AUTO, we would wait go through helix state transition to create a bootstrap replica before we update the property store to add replicas to data node config.  When creating bootstrap replica, we would put the partition name to `partitionNameToAmbryParitition` map, so later when the property store is updated, we would ignore adding partition to partitionMap. That's why we encountered a `Partition Id from stream is unknown` error.

This pr fixes that.