### PR TITLE
Metrics for the count of partitions where there are 1, 2, or 3 local replicas down

### DIFF
--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
@@ -1478,6 +1478,13 @@ public class HelixClusterManager implements ClusterMap {
     long getAllocatedUsableCapacity() {
       return clusterWideAllocatedUsableCapacityBytes.get();
     }
+
+    /**
+     * @return the current data center name
+     */
+    String getDatacenterName() {
+      return clusterMapConfig.clusterMapDatacenterName;
+    }
   }
 
   /**


### PR DESCRIPTION
We are adding two types of metrics. One includes 'bootstrap/inactive' replicas as 'down' replicas while other doesn't.