### PR TITLE
[vcr-2.0] Tune thread-local-cache

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/CloudConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/CloudConfig.java
@@ -307,7 +307,7 @@ public class CloudConfig {
    * The max size of recently-accessed blob cache in each cloud blob store.
    */
   @Config(CLOUD_RECENT_BLOB_CACHE_LIMIT)
-  @Default("10000")
+  @Default("256")
   public final int recentBlobCacheLimit;
 
   /**

--- a/ambry-api/src/main/java/com/github/ambry/config/CloudConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/CloudConfig.java
@@ -307,7 +307,7 @@ public class CloudConfig {
    * The max size of recently-accessed blob cache in each cloud blob store.
    */
   @Config(CLOUD_RECENT_BLOB_CACHE_LIMIT)
-  @Default("128")
+  @Default("10000")
   public final int recentBlobCacheLimit;
 
   /**

--- a/ambry-api/src/main/java/com/github/ambry/config/CloudConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/CloudConfig.java
@@ -307,7 +307,7 @@ public class CloudConfig {
    * The max size of recently-accessed blob cache in each cloud blob store.
    */
   @Config(CLOUD_RECENT_BLOB_CACHE_LIMIT)
-  @Default("256")
+  @Default("128")
   public final int recentBlobCacheLimit;
 
   /**

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestinationSync.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestinationSync.java
@@ -197,7 +197,7 @@ public class AzureCloudDestinationSync implements CloudDestination {
       // The thread that creates this client object is not the thread that uploads blobs to Azure,
       // So we need this fn to create thread-specific caches
       String cacheName = "thread-local-mdcache-" + Thread.currentThread().getName();
-      threadLocalMdCache.set(new AmbryCache(cacheName, true, 2<<10, metrics));
+      threadLocalMdCache.set(new AmbryCache(cacheName, true, cloudConfig.recentBlobCacheLimit, metrics));
       logger.info("Created AmbryCache {}", threadLocalMdCache.get().toString());
     }
     return threadLocalMdCache.get();


### PR DESCRIPTION
The memory load is quite high on backup-nodes and the vcr-server is crashing due to out-of-memory error. I do not suspect a memleak. The crash is happening after enabling the thread-local-cache, which is just a wrapper over open-src Caffeine cache. The cache is capped by the number of objects, but I suspect that even though the cache itself is not full, there isn't any memory to insert another item in the cache.