### PR TITLE
[Paranoid Durability] Add new container field for paranoid durability.

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/account/Container.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/Container.java
@@ -67,6 +67,7 @@ public class Container {
   static final long CONTAINER_DELETE_TRIGGER_TIME_DEFAULT_VALUE = 0;
   static final boolean SECURE_PATH_REQUIRED_DEFAULT_VALUE = false;
   static final boolean OVERRIDE_ACCOUNT_ACL_DEFAULT_VALUE = false;
+  static final boolean PARANOID_DURABILITY_ENABLED_DEFAULT_VALUE = false;
   static final NamedBlobMode NAMED_BLOB_MODE_DEFAULT_VALUE = NamedBlobMode.DISABLED;
   static final boolean CACHEABLE_DEFAULT_VALUE = true;
   static final Set<String> CONTENT_TYPE_WHITELIST_FOR_FILENAMES_ON_DOWNLOAD_DEFAULT_VALUE = Collections.emptySet();
@@ -240,6 +241,23 @@ public class Container {
   public static final boolean DEFAULT_PRIVATE_CONTAINER_MEDIA_SCAN_DISABLED_SETTING = MEDIA_SCAN_DISABLED_DEFAULT_VALUE;
 
   /**
+   * The paranoid durability setting for {@link #UNKNOWN_CONTAINER}.
+   */
+  public static final boolean UNKNOWN_CONTAINER_PARANOID_DURABILITY_SETTING = PARANOID_DURABILITY_ENABLED_DEFAULT_VALUE;
+
+  /**
+   * The paranoid durability setting for {@link #DEFAULT_PUBLIC_CONTAINER}.
+   */
+  public static final boolean DEFAULT_PUBLIC_CONTAINER_PARANOID_DURABILITY_SETTING =
+      PARANOID_DURABILITY_ENABLED_DEFAULT_VALUE;
+
+  /**
+   * The paranoid durability setting for {@link #DEFAULT_PRIVATE_CONTAINER}.
+   */
+  public static final boolean DEFAULT_PRIVATE_CONTAINER_PARANOID_DURABILITY_SETTING =
+      PARANOID_DURABILITY_ENABLED_DEFAULT_VALUE;
+
+  /**
    * The ttl required setting for {@link #UNKNOWN_CONTAINER}.
    */
   public static final boolean UNKNOWN_CONTAINER_TTL_REQUIRED_SETTING = TTL_REQUIRED_DEFAULT_VALUE;
@@ -281,11 +299,12 @@ public class Container {
       new Container(UNKNOWN_CONTAINER_ID, UNKNOWN_CONTAINER_NAME, UNKNOWN_CONTAINER_STATUS,
           UNKNOWN_CONTAINER_DESCRIPTION, UNKNOWN_CONTAINER_ENCRYPTED_SETTING,
           UNKNOWN_CONTAINER_PREVIOUSLY_ENCRYPTED_SETTING, UNKNOWN_CONTAINER_CACHEABLE_SETTING,
-          UNKNOWN_CONTAINER_MEDIA_SCAN_DISABLED_SETTING, null, UNKNOWN_CONTAINER_TTL_REQUIRED_SETTING,
-          SECURE_PATH_REQUIRED_DEFAULT_VALUE, CONTENT_TYPE_WHITELIST_FOR_FILENAMES_ON_DOWNLOAD_DEFAULT_VALUE,
-          BACKUP_ENABLED_DEFAULT_VALUE, OVERRIDE_ACCOUNT_ACL_DEFAULT_VALUE, NAMED_BLOB_MODE_DEFAULT_VALUE,
-          UNKNOWN_CONTAINER_PARENT_ACCOUNT_ID, UNKNOWN_CONTAINER_DELETE_TRIGGER_TIME, LAST_MODIFIED_TIME_DEFAULT_VALUE,
-          SNAPSHOT_VERSION_DEFAULT_VALUE, ACCESS_CONTROL_ALLOW_ORIGIN_DEFAULT_VALUE, CACHE_TTL_IN_SECOND_DEFAULT_VALUE,
+          UNKNOWN_CONTAINER_MEDIA_SCAN_DISABLED_SETTING, UNKNOWN_CONTAINER_PARANOID_DURABILITY_SETTING, null,
+          UNKNOWN_CONTAINER_TTL_REQUIRED_SETTING, SECURE_PATH_REQUIRED_DEFAULT_VALUE,
+          CONTENT_TYPE_WHITELIST_FOR_FILENAMES_ON_DOWNLOAD_DEFAULT_VALUE, BACKUP_ENABLED_DEFAULT_VALUE,
+          OVERRIDE_ACCOUNT_ACL_DEFAULT_VALUE, NAMED_BLOB_MODE_DEFAULT_VALUE, UNKNOWN_CONTAINER_PARENT_ACCOUNT_ID,
+          UNKNOWN_CONTAINER_DELETE_TRIGGER_TIME, LAST_MODIFIED_TIME_DEFAULT_VALUE, SNAPSHOT_VERSION_DEFAULT_VALUE,
+          ACCESS_CONTROL_ALLOW_ORIGIN_DEFAULT_VALUE, CACHE_TTL_IN_SECOND_DEFAULT_VALUE,
           USER_METADATA_KEYS_TO_NOT_PREFIX_IN_RESPONSE_DEFAULT_VALUE);
 
   /**
@@ -299,12 +318,13 @@ public class Container {
       new Container(DEFAULT_PUBLIC_CONTAINER_ID, DEFAULT_PUBLIC_CONTAINER_NAME, DEFAULT_PUBLIC_CONTAINER_STATUS,
           DEFAULT_PUBLIC_CONTAINER_DESCRIPTION, DEFAULT_PUBLIC_CONTAINER_ENCRYPTED_SETTING,
           DEFAULT_PUBLIC_CONTAINER_PREVIOUSLY_ENCRYPTED_SETTING, DEFAULT_PUBLIC_CONTAINER_CACHEABLE_SETTING,
-          DEFAULT_PUBLIC_CONTAINER_MEDIA_SCAN_DISABLED_SETTING, null, DEFAULT_PUBLIC_CONTAINER_TTL_REQUIRED_SETTING,
-          SECURE_PATH_REQUIRED_DEFAULT_VALUE, CONTENT_TYPE_WHITELIST_FOR_FILENAMES_ON_DOWNLOAD_DEFAULT_VALUE,
-          BACKUP_ENABLED_DEFAULT_VALUE, OVERRIDE_ACCOUNT_ACL_DEFAULT_VALUE, NAMED_BLOB_MODE_DEFAULT_VALUE,
-          DEFAULT_PUBLIC_CONTAINER_PARENT_ACCOUNT_ID, DEFAULT_PRIVATE_CONTAINER_DELETE_TRIGGER_TIME,
-          LAST_MODIFIED_TIME_DEFAULT_VALUE, SNAPSHOT_VERSION_DEFAULT_VALUE, ACCESS_CONTROL_ALLOW_ORIGIN_DEFAULT_VALUE,
-          CACHE_TTL_IN_SECOND_DEFAULT_VALUE, USER_METADATA_KEYS_TO_NOT_PREFIX_IN_RESPONSE_DEFAULT_VALUE);
+          DEFAULT_PUBLIC_CONTAINER_MEDIA_SCAN_DISABLED_SETTING, DEFAULT_PUBLIC_CONTAINER_PARANOID_DURABILITY_SETTING,
+          null, DEFAULT_PUBLIC_CONTAINER_TTL_REQUIRED_SETTING, SECURE_PATH_REQUIRED_DEFAULT_VALUE,
+          CONTENT_TYPE_WHITELIST_FOR_FILENAMES_ON_DOWNLOAD_DEFAULT_VALUE, BACKUP_ENABLED_DEFAULT_VALUE,
+          OVERRIDE_ACCOUNT_ACL_DEFAULT_VALUE, NAMED_BLOB_MODE_DEFAULT_VALUE, DEFAULT_PUBLIC_CONTAINER_PARENT_ACCOUNT_ID,
+          DEFAULT_PRIVATE_CONTAINER_DELETE_TRIGGER_TIME, LAST_MODIFIED_TIME_DEFAULT_VALUE,
+          SNAPSHOT_VERSION_DEFAULT_VALUE, ACCESS_CONTROL_ALLOW_ORIGIN_DEFAULT_VALUE, CACHE_TTL_IN_SECOND_DEFAULT_VALUE,
+          USER_METADATA_KEYS_TO_NOT_PREFIX_IN_RESPONSE_DEFAULT_VALUE);
 
   /**
    * A container defined specifically for the blobs put without specifying target container but isPrivate flag is
@@ -317,9 +337,10 @@ public class Container {
       new Container(DEFAULT_PRIVATE_CONTAINER_ID, DEFAULT_PRIVATE_CONTAINER_NAME, DEFAULT_PRIVATE_CONTAINER_STATUS,
           DEFAULT_PRIVATE_CONTAINER_DESCRIPTION, DEFAULT_PRIVATE_CONTAINER_ENCRYPTED_SETTING,
           DEFAULT_PRIVATE_CONTAINER_PREVIOUSLY_ENCRYPTED_SETTING, DEFAULT_PRIVATE_CONTAINER_CACHEABLE_SETTING,
-          DEFAULT_PRIVATE_CONTAINER_MEDIA_SCAN_DISABLED_SETTING, null, DEFAULT_PRIVATE_CONTAINER_TTL_REQUIRED_SETTING,
-          SECURE_PATH_REQUIRED_DEFAULT_VALUE, CONTENT_TYPE_WHITELIST_FOR_FILENAMES_ON_DOWNLOAD_DEFAULT_VALUE,
-          BACKUP_ENABLED_DEFAULT_VALUE, OVERRIDE_ACCOUNT_ACL_DEFAULT_VALUE, NAMED_BLOB_MODE_DEFAULT_VALUE,
+          DEFAULT_PRIVATE_CONTAINER_MEDIA_SCAN_DISABLED_SETTING, DEFAULT_PRIVATE_CONTAINER_PARANOID_DURABILITY_SETTING,
+          null, DEFAULT_PRIVATE_CONTAINER_TTL_REQUIRED_SETTING, SECURE_PATH_REQUIRED_DEFAULT_VALUE,
+          CONTENT_TYPE_WHITELIST_FOR_FILENAMES_ON_DOWNLOAD_DEFAULT_VALUE, BACKUP_ENABLED_DEFAULT_VALUE,
+          OVERRIDE_ACCOUNT_ACL_DEFAULT_VALUE, NAMED_BLOB_MODE_DEFAULT_VALUE,
           DEFAULT_PRIVATE_CONTAINER_PARENT_ACCOUNT_ID, DEFAULT_PUBLIC_CONTAINER_DELETE_TRIGGER_TIME,
           LAST_MODIFIED_TIME_DEFAULT_VALUE, SNAPSHOT_VERSION_DEFAULT_VALUE, ACCESS_CONTROL_ALLOW_ORIGIN_DEFAULT_VALUE,
           CACHE_TTL_IN_SECOND_DEFAULT_VALUE, USER_METADATA_KEYS_TO_NOT_PREFIX_IN_RESPONSE_DEFAULT_VALUE);
@@ -338,6 +359,7 @@ public class Container {
   private final boolean cacheable;
   private final boolean backupEnabled;
   private final boolean mediaScanDisabled;
+  private final boolean paranoidDurabilityEnabled;
   private final String replicationPolicy;
   private final boolean ttlRequired;
   private final boolean securePathRequired;
@@ -366,6 +388,7 @@ public class Container {
    * @param cacheable {@code true} if cache control headers should be set to allow CDNs and browsers to cache blobs in
    *                  this container.
    * @param mediaScanDisabled {@code true} if media scanning for content in this container should be disabled.
+   * @param paranoidDurabilityEnabled {@code true} if paranoid durability should be enabled for this container.
    * @param replicationPolicy the replication policy to use. If {@code null}, the cluster's default will be used.
    * @param ttlRequired {@code true} if ttl is required on content created in this container.
    * @param securePathRequired {@code true} if secure path validation is required in this container.
@@ -379,11 +402,12 @@ public class Container {
    * @param accessControlAllowOrigin The Access-Control-Allow-Origin header field name of this container.
    */
   public Container(short id, String name, ContainerStatus status, String description, boolean encrypted,
-      boolean previouslyEncrypted, boolean cacheable, boolean mediaScanDisabled, String replicationPolicy,
-      boolean ttlRequired, boolean securePathRequired, Set<String> contentTypeWhitelistForFilenamesOnDownload,
-      boolean backupEnabled, boolean overrideAccountAcl, NamedBlobMode namedBlobMode, short parentAccountId,
-      long deleteTriggerTime, long lastModifiedTime, int snapshotVersion, String accessControlAllowOrigin,
-      Long cacheTtlInSecond, Set<String> userMetadataKeysToNotPrefixInResponse) {
+      boolean previouslyEncrypted, boolean cacheable, boolean mediaScanDisabled, boolean paranoidDurabilityEnabled,
+      String replicationPolicy, boolean ttlRequired, boolean securePathRequired,
+      Set<String> contentTypeWhitelistForFilenamesOnDownload, boolean backupEnabled, boolean overrideAccountAcl,
+      NamedBlobMode namedBlobMode, short parentAccountId, long deleteTriggerTime, long lastModifiedTime,
+      int snapshotVersion, String accessControlAllowOrigin, Long cacheTtlInSecond,
+      Set<String> userMetadataKeysToNotPrefixInResponse) {
     checkPreconditions(name, status, encrypted, previouslyEncrypted);
     this.id = id;
     this.name = name;
@@ -399,6 +423,7 @@ public class Container {
         this.encrypted = ENCRYPTED_DEFAULT_VALUE;
         this.previouslyEncrypted = PREVIOUSLY_ENCRYPTED_DEFAULT_VALUE;
         this.mediaScanDisabled = MEDIA_SCAN_DISABLED_DEFAULT_VALUE;
+        this.paranoidDurabilityEnabled = PARANOID_DURABILITY_ENABLED_DEFAULT_VALUE;
         this.replicationPolicy = null;
         this.deleteTriggerTime = CONTAINER_DELETE_TRIGGER_TIME_DEFAULT_VALUE;
         this.ttlRequired = TTL_REQUIRED_DEFAULT_VALUE;
@@ -416,6 +441,7 @@ public class Container {
         this.encrypted = encrypted;
         this.previouslyEncrypted = previouslyEncrypted;
         this.mediaScanDisabled = mediaScanDisabled;
+        this.paranoidDurabilityEnabled = paranoidDurabilityEnabled;
         this.replicationPolicy = replicationPolicy;
         this.deleteTriggerTime = deleteTriggerTime;
         this.ttlRequired = ttlRequired;
@@ -550,6 +576,13 @@ public class Container {
   }
 
   /**
+   * @return {@code true} if paranoid durability should be enabled for PUTs in this container.
+   */
+  public boolean isParanoidDurabilityEnabled() {
+    return paranoidDurabilityEnabled;
+  }
+
+  /**
    * @return the replication policy desired by the container. Can be {@code null} if the container has no preference.
    */
   public String getReplicationPolicy() {
@@ -667,6 +700,7 @@ public class Container {
         && previouslyEncrypted == container.previouslyEncrypted
         && cacheable == container.cacheable
         && mediaScanDisabled == container.mediaScanDisabled
+        && paranoidDurabilityEnabled == container.paranoidDurabilityEnabled
         && parentAccountId == container.parentAccountId
         && Objects.equals(name, container.name)
         && status == container.status

--- a/ambry-api/src/main/java/com/github/ambry/account/ContainerBuilder.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/ContainerBuilder.java
@@ -43,6 +43,7 @@ public class ContainerBuilder {
   private boolean previouslyEncrypted = PREVIOUSLY_ENCRYPTED_DEFAULT_VALUE;
   private boolean cacheable = CACHEABLE_DEFAULT_VALUE;
   private boolean mediaScanDisabled = MEDIA_SCAN_DISABLED_DEFAULT_VALUE;
+  private boolean paranoidDurabilityEnabled = PARANOID_DURABILITY_ENABLED_DEFAULT_VALUE;
   private String replicationPolicy = null;
   private boolean ttlRequired = TTL_REQUIRED_DEFAULT_VALUE;
   private boolean securePathRequired = SECURE_PATH_REQUIRED_DEFAULT_VALUE;
@@ -77,6 +78,7 @@ public class ContainerBuilder {
     previouslyEncrypted = origin.wasPreviouslyEncrypted();
     cacheable = origin.isCacheable();
     mediaScanDisabled = origin.isMediaScanDisabled();
+    paranoidDurabilityEnabled = origin.isParanoidDurabilityEnabled();
     replicationPolicy = origin.getReplicationPolicy();
     ttlRequired = origin.isTtlRequired();
     parentAccountId = origin.getParentAccountId();
@@ -225,6 +227,16 @@ public class ContainerBuilder {
   }
 
   /**
+   * Sets the paranoid durability enabled setting of the {@link Container} to build
+   * @param paranoidDurabilityEnabled The paranoid durability enabled setting to set.
+   * @return This builder.
+   */
+  public ContainerBuilder setParanoidDurabilityEnabled(boolean paranoidDurabilityEnabled) {
+    this.paranoidDurabilityEnabled = paranoidDurabilityEnabled;
+    return this;
+  }
+
+  /**
    * Sets the ttl required setting of the {@link Container}.
    * @param ttlRequired The ttlRequired setting to set.
    * @return This builder.
@@ -347,7 +359,7 @@ public class ContainerBuilder {
       throw new IllegalStateException("Container id or container name is not present");
     }
     return new Container(id, name, status, description, encrypted, previouslyEncrypted || encrypted, cacheable,
-        mediaScanDisabled, replicationPolicy, ttlRequired, securePathRequired,
+        mediaScanDisabled, paranoidDurabilityEnabled, replicationPolicy, ttlRequired, securePathRequired,
         contentTypeWhitelistForFilenamesOnDownload, backupEnabled, overrideAccountAcl, namedBlobMode,
         parentAccountId == null ? UNKNOWN_CONTAINER_PARENT_ACCOUNT_ID : parentAccountId.shortValue(), deleteTriggerTime,
         lastModifiedTime, snapshotVersion, accessControlAllowOrigin, cacheTtlInSecond,

--- a/ambry-api/src/test/java/com/github/ambry/account/AccountContainerTest.java
+++ b/ambry-api/src/test/java/com/github/ambry/account/AccountContainerTest.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.ambry.quota.QuotaResourceType;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
+import com.sun.org.apache.xpath.internal.operations.Bool;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -77,6 +78,7 @@ public class AccountContainerTest {
   private List<Boolean> refContainerCachingValues;
   private List<Boolean> refContainerBackupEnabledValues;
   private List<Boolean> refContainerMediaScanDisabledValues;
+  private List<Boolean> refContainerParanoidDurabilityEnabledValues;
   private List<String> refContainerReplicationPolicyValues;
   private List<Boolean> refContainerTtlRequiredValues;
   private List<Long> refContainerDeleteTriggerTime;
@@ -441,6 +443,7 @@ public class AccountContainerTest {
       boolean updatedPreviouslyEncrypted = updatedEncrypted || container.wasPreviouslyEncrypted();
       boolean updatedCacheable = !container.isCacheable();
       boolean updatedMediaScanDisabled = !container.isMediaScanDisabled();
+      boolean updatedParanoidDurabilityEnabled = !container.isParanoidDurabilityEnabled();
       String updatedReplicationPolicy = container.getReplicationPolicy() + "---updated";
       boolean updatedTtlRequired = !container.isTtlRequired();
       boolean updatedSignedPathRequired = !container.isSecurePathRequired();
@@ -463,6 +466,7 @@ public class AccountContainerTest {
           .setEncrypted(updatedEncrypted)
           .setCacheable(updatedCacheable)
           .setMediaScanDisabled(updatedMediaScanDisabled)
+          .setParanoidDurabilityEnabled(updatedParanoidDurabilityEnabled)
           .setReplicationPolicy(updatedReplicationPolicy)
           .setTtlRequired(updatedTtlRequired)
           .setSecurePathRequired(updatedSignedPathRequired)
@@ -488,6 +492,8 @@ public class AccountContainerTest {
               updatedContainer.wasPreviouslyEncrypted());
           assertEquals("Wrong media scan disabled setting", MEDIA_SCAN_DISABLED_DEFAULT_VALUE,
               updatedContainer.isMediaScanDisabled());
+          assertEquals("Wrong paranoid durability enabled setting", PARANOID_DURABILITY_ENABLED_DEFAULT_VALUE,
+              updatedContainer.isParanoidDurabilityEnabled());
           assertNull("Wrong replication policy", updatedContainer.getReplicationPolicy());
           assertEquals("Wrong ttl required setting", TTL_REQUIRED_DEFAULT_VALUE, updatedContainer.isTtlRequired());
           assertEquals("Wrong secure required setting", SECURE_PATH_REQUIRED_DEFAULT_VALUE,
@@ -503,6 +509,8 @@ public class AccountContainerTest {
               updatedContainer.wasPreviouslyEncrypted());
           assertEquals("Wrong media scan disabled setting", updatedMediaScanDisabled,
               updatedContainer.isMediaScanDisabled());
+          assertEquals("Wrong paranoid durability enabled setting", updatedParanoidDurabilityEnabled,
+              updatedContainer.isParanoidDurabilityEnabled());
           assertEquals("Wrong replication policy", updatedReplicationPolicy, updatedContainer.getReplicationPolicy());
           assertEquals("Wrong ttl required setting", updatedTtlRequired, updatedContainer.isTtlRequired());
           assertEquals("Wrong secure path required setting", updatedSignedPathRequired,
@@ -578,6 +586,8 @@ public class AccountContainerTest {
         Container.UNKNOWN_CONTAINER_PREVIOUSLY_ENCRYPTED_SETTING, unknownContainer.wasPreviouslyEncrypted());
     assertEquals("Wrong mediaScanDisabled setting for UNKNOWN_CONTAINER",
         Container.UNKNOWN_CONTAINER_MEDIA_SCAN_DISABLED_SETTING, unknownContainer.isMediaScanDisabled());
+    assertEquals("Wrong paranoidDurabilityEnabled setting for UNKNOWN_CONTAINER",
+        Container.UNKNOWN_CONTAINER_PARANOID_DURABILITY_SETTING, unknownContainer.isParanoidDurabilityEnabled());
     // DEFAULT_PUBLIC_CONTAINER
     assertEquals("Wrong id for DEFAULT_PUBLIC_CONTAINER", Container.DEFAULT_PUBLIC_CONTAINER_ID,
         unknownPublicContainer.getId());
@@ -598,6 +608,8 @@ public class AccountContainerTest {
         unknownPublicContainer.wasPreviouslyEncrypted());
     assertEquals("Wrong mediaScanDisabled setting for DEFAULT_PUBLIC_CONTAINER",
         Container.DEFAULT_PUBLIC_CONTAINER_MEDIA_SCAN_DISABLED_SETTING, unknownPublicContainer.isMediaScanDisabled());
+    assertEquals("Wrong paranoidDurabilityEnabled setting for DEFAULT_PUBLIC_CONTAINER",
+        Container.DEFAULT_PUBLIC_CONTAINER_PARANOID_DURABILITY_SETTING, unknownPublicContainer.isParanoidDurabilityEnabled());
     // DEFAULT_PRIVATE_CONTAINER
     assertEquals("Wrong id for DEFAULT_PRIVATE_CONTAINER", Container.DEFAULT_PRIVATE_CONTAINER_ID,
         unknownPrivateContainer.getId());
@@ -618,6 +630,8 @@ public class AccountContainerTest {
         unknownPrivateContainer.wasPreviouslyEncrypted());
     assertEquals("Wrong mediaScanDisabled setting for DEFAULT_PRIVATE_CONTAINER",
         Container.DEFAULT_PRIVATE_CONTAINER_MEDIA_SCAN_DISABLED_SETTING, unknownPrivateContainer.isMediaScanDisabled());
+    assertEquals("Wrong paranoidDurabilityEnabled setting for DEFAULT_PRIVATE_CONTAINER",
+        Container.DEFAULT_PRIVATE_CONTAINER_PARANOID_DURABILITY_SETTING, unknownPrivateContainer.isParanoidDurabilityEnabled());
     // UNKNOWN_ACCOUNT
     assertEquals("Wrong id for UNKNOWN_ACCOUNT", Account.UNKNOWN_ACCOUNT_ID, unknownAccount.getId());
     assertEquals("Wrong name for UNKNOWN_ACCOUNT", Account.UNKNOWN_ACCOUNT_NAME, unknownAccount.getName());
@@ -806,6 +820,7 @@ public class AccountContainerTest {
         .setCacheable(container.isCacheable())
         .setBackupEnabled(container.isBackupEnabled())
         .setMediaScanDisabled(container.isMediaScanDisabled())
+        .setParanoidDurabilityEnabled(container.isParanoidDurabilityEnabled())
         .setReplicationPolicy(container.getReplicationPolicy())
         .setTtlRequired(container.isTtlRequired())
         .setContentTypeWhitelistForFilenamesOnDownload(container.getContentTypeWhitelistForFilenamesOnDownload())
@@ -869,6 +884,8 @@ public class AccountContainerTest {
             container.wasPreviouslyEncrypted());
         assertEquals("Wrong media scan disabled setting", MEDIA_SCAN_DISABLED_DEFAULT_VALUE,
             container.isMediaScanDisabled());
+        assertEquals("Wrong paranoid durability enabled setting", PARANOID_DURABILITY_ENABLED_DEFAULT_VALUE,
+            container.isParanoidDurabilityEnabled());
         assertNull("Wrong replication policy", container.getReplicationPolicy());
         assertEquals("Wrong ttl required setting", TTL_REQUIRED_DEFAULT_VALUE, container.isTtlRequired());
         assertEquals("Wrong secure path required setting", SECURE_PATH_REQUIRED_DEFAULT_VALUE,
@@ -883,6 +900,8 @@ public class AccountContainerTest {
             container.wasPreviouslyEncrypted());
         assertEquals("Wrong media scan disabled setting", refContainerMediaScanDisabledValues.get(index),
             container.isMediaScanDisabled());
+        assertEquals("Wrong paranoid durability enabled setting", refContainerParanoidDurabilityEnabledValues.get(index),
+            container.isParanoidDurabilityEnabled());
         assertEquals("Wrong replication policy", refContainerReplicationPolicyValues.get(index),
             container.getReplicationPolicy());
         assertEquals("Wrong ttl required setting", refContainerTtlRequiredValues.get(index), container.isTtlRequired());
@@ -973,7 +992,7 @@ public class AccountContainerTest {
   private void buildContainerWithBadFieldsAndFail(String name, ContainerStatus status, boolean encrypted,
       boolean previouslyEncrypted, Class<? extends Exception> exceptionClass) throws Exception {
     TestUtils.assertException(exceptionClass, () -> {
-      new Container((short) 0, name, status, "description", encrypted, previouslyEncrypted, false, false, null, false,
+      new Container((short) 0, name, status, "description", encrypted, previouslyEncrypted, false, false, false, null, false,
           false, Collections.emptySet(), false, false, getRandomNamedBlobMode(), (short) 0, System.currentTimeMillis(),
           System.currentTimeMillis(), 0, null, null, null);
     }, null);
@@ -1007,6 +1026,7 @@ public class AccountContainerTest {
     refContainerCachingValues = new ArrayList<>();
     refContainerBackupEnabledValues = new ArrayList<>();
     refContainerMediaScanDisabledValues = new ArrayList<>();
+    refContainerParanoidDurabilityEnabledValues = new ArrayList<>();
     refContainerReplicationPolicyValues = new ArrayList<>();
     refContainerTtlRequiredValues = new ArrayList<>();
     refContainerDeleteTriggerTime = new ArrayList<>();
@@ -1040,6 +1060,7 @@ public class AccountContainerTest {
       refContainerCachingValues.add(random.nextBoolean());
       refContainerBackupEnabledValues.add(random.nextBoolean());
       refContainerMediaScanDisabledValues.add(random.nextBoolean());
+      refContainerParanoidDurabilityEnabledValues.add(random.nextBoolean());
       if (refContainerReplicationPolicyValues.contains(null)) {
         refContainerReplicationPolicyValues.add(TestUtils.getRandomString(10));
       } else {
@@ -1075,7 +1096,7 @@ public class AccountContainerTest {
       refContainers.add(new Container(refContainerIds.get(i), refContainerNames.get(i), refContainerStatuses.get(i),
           refContainerDescriptions.get(i), refContainerEncryptionValues.get(i),
           refContainerPreviousEncryptionValues.get(i), refContainerCachingValues.get(i),
-          refContainerMediaScanDisabledValues.get(i), refContainerReplicationPolicyValues.get(i),
+          refContainerMediaScanDisabledValues.get(i), refContainerParanoidDurabilityEnabledValues.get(i), refContainerReplicationPolicyValues.get(i),
           refContainerTtlRequiredValues.get(i), refContainerSignedPathRequiredValues.get(i),
           refContainerContentTypeAllowListForFilenamesOnDownloadValues.get(i), refContainerBackupEnabledValues.get(i),
           refContainerOverrideAccountAcls.get(i), refContainerNamedBlobModes.get(i), refAccountId,

--- a/ambry-cloud/src/test/java/com/github/ambry/cloud/RecoveryNetworkClientTest.java
+++ b/ambry-cloud/src/test/java/com/github/ambry/cloud/RecoveryNetworkClientTest.java
@@ -157,7 +157,7 @@ public class RecoveryNetworkClientTest {
         new Container(CONTAINER_ID, "testContainer", Container.ContainerStatus.ACTIVE,
             "Test Container", false,
             false, false,
-            false, null, false,
+            false, false, null, false,
             false, Collections.emptySet(),
             false, false, Container.NamedBlobMode.DISABLED, ACCOUNT_ID, 0,
             0, 0, "",


### PR DESCRIPTION
This PR adds a new field for paranoid durability to Ambry's `Container` class. The paranoid durability feature applies to PUTs/writes, and requires a minimum of one replica in a remote colo to acknowledge a write before returning success. We want this feature to be used sparingly, since it will add additional latency and cross-colo I/O to all writes. Therefore, the default setting for all containers is false (i.e. paranoid durability is OFF by default). So this new setting will need to be explicitly turned on for each container that wants to use it.