### PR TITLE
Use ParanoidDurabilityOperationTracker when configured and turned on.

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
@@ -153,6 +153,9 @@ public class RouterConfig {
   public static final String ROUTER_GET_OPERATION_MIN_LOCAL_REPLICA_COUNT_TO_PRIORITIZE_LOCAL =
       "router.get.operation.min.local.replica.count.to.prioritize.local";
 
+  // Whether or not to use paranoid durability
+  public static final String ROUTER_PARANOID_DURABILITY_ENABLED = "router.paranoid.durability.enabled";
+
   /**
    * Number of independent scaling units for the router.
    */
@@ -733,6 +736,13 @@ public class RouterConfig {
   public final int routerGetOperationMinLocalReplicaCountToPrioritizeLocal;
 
   /**
+   * {@code true} if the router should use paranoid durability for PUTs when the corresponding container setting is turned on.
+   */
+  @Config(ROUTER_PARANOID_DURABILITY_ENABLED)
+  @Default("false")
+  public final boolean routerParanoidDurabilityEnabled;
+
+  /**
    * Create a RouterConfig instance.
    * @param verifiableProperties the properties map to refer to.
    */
@@ -895,6 +905,7 @@ public class RouterConfig {
     routerGetOperationMinLocalReplicaCountToPrioritizeLocal =
         verifiableProperties.getInt(ROUTER_GET_OPERATION_MIN_LOCAL_REPLICA_COUNT_TO_PRIORITIZE_LOCAL,
             DEFAULT_ROUTER_GET_OPERATION_MIN_LOCAL_REPLICA_COUNT_TO_PRIORITIZE_LOCAL);
+    routerParanoidDurabilityEnabled = verifiableProperties.getBoolean(ROUTER_PARANOID_DURABILITY_ENABLED, false);
   }
 
   /**

--- a/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
@@ -1406,7 +1406,14 @@ class PutOperation {
       OperationTracker operationTracker;
       String trackerType = routerConfig.routerPutOperationTrackerType;
       String originatingDcName = clusterMap.getDatacenterName(clusterMap.getLocalDatacenterId());
-      if (trackerType.equals(SimpleOperationTracker.class.getSimpleName())) {
+
+      Pair<Account, Container> accountContainer = RouterUtils.getAccountContainer(accountService,
+          passedInBlobProperties.getAccountId(),
+          passedInBlobProperties.getContainerId());
+
+      if(routerConfig.routerParanoidDurabilityEnabled && accountContainer.getSecond().isParanoidDurabilityEnabled()) {
+        operationTracker = new ParanoidDurabilityOperationTracker(routerConfig, partitionId, originatingDcName, routerMetrics);
+      } else if (trackerType.equals(SimpleOperationTracker.class.getSimpleName())) {
         operationTracker =
             new SimpleOperationTracker(routerConfig, RouterOperation.PutOperation, partitionId, originatingDcName, true,
                 routerMetrics);


### PR DESCRIPTION
This PR wires up ParanoidDurabilityOperationTracker for PUT requests when both of these conditions are true:

1. The container that we are trying to write to is configured to use paranoid durability (i.e. require a success from at least one remote colo).
2. The application is configured to use paranoid durability.

We require an extra configuration (item 2) as a kind of safety switch. If we discover a problem with paranoid durability, then we can turn it completely off globally by updating the configuration value and doing a config deployment. It also enables us to roll out the new feature in a fabric-by-fabric manner rather than turning it on everywhere at the same time for a given container.

Turning on paranoid durability for a given container (item 1 above) can be done for several containers at once by updating the account metadata, essentially by pushing an updated JSON file to ambry-frontend. Changing pre-existing containers like this is more of an operations task and is out of scope for this PR.

We will follow up later with changes to `ambry-client` in order for clients to turn on paranoid durability when they create new containers programmatically.