### PR TITLE
changing storeKeyconverter logic to count based logic

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/store/AbstractStoreKeyConverter.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/AbstractStoreKeyConverter.java
@@ -1,0 +1,72 @@
+package com.github.ambry.store;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+public abstract class AbstractStoreKeyConverter implements StoreKeyConverter {
+  private final Map<StoreKey, StoreKey> conversionCache = new HashMap<>();
+  private final Map<StoreKey, Integer> cachedKeyCount = new HashMap<>();
+
+  @Override
+  public Map<StoreKey, StoreKey> convert(Collection<? extends StoreKey> input) throws Exception {
+    List<StoreKey> alreadyPresentStoreKeys = new ArrayList<>();
+    List<StoreKey> storeKeysTobeConverted = new ArrayList<>();
+
+    input.forEach((storeKey) -> {
+      if (conversionCache.containsKey(storeKey)) {
+        alreadyPresentStoreKeys.add(storeKey);
+      } else {
+        storeKeysTobeConverted.add(storeKey);
+      }
+    });
+
+    Map<StoreKey, StoreKey> map = convertKeys(storeKeysTobeConverted);
+
+    alreadyPresentStoreKeys.forEach((storeKey -> {
+      map.put(storeKey, conversionCache.get(storeKey));
+    }));
+
+    map.forEach((storeKey, convertedStoreKey) -> {
+      cachedKeyCount.put(storeKey, cachedKeyCount.getOrDefault(storeKey, 0) + 1);
+    });
+
+    conversionCache.putAll(map);
+    return Collections.unmodifiableMap(map);
+  }
+
+  @Override
+  public StoreKey getConverted(StoreKey storeKey) {
+    return getConvertedKey(storeKey, conversionCache.containsKey(storeKey), conversionCache.get(storeKey));
+  }
+
+
+  @Override
+  public void remove(Collection<? extends StoreKey> storeKeys) {
+    storeKeys.forEach(storeKey -> {
+      if (!cachedKeyCount.containsKey(storeKey)) {
+        return;
+      }
+      cachedKeyCount.put(storeKey, cachedKeyCount.get(storeKey) - 1);
+      if (cachedKeyCount.get(storeKey) != 0) {
+        return;
+      }
+      conversionCache.remove(storeKey);
+      cachedKeyCount.remove(storeKey);
+    });
+  }
+
+  @Override
+  public void dropCache() {
+    cachedKeyCount.clear();
+    conversionCache.clear();
+  }
+
+  abstract Map<StoreKey, StoreKey> convertKeys(Collection<? extends StoreKey> input) throws Exception;
+
+  abstract StoreKey getConvertedKey(StoreKey storeKey, Boolean isKeyPresent, StoreKey cachedMapping);
+}

--- a/ambry-api/src/main/java/com/github/ambry/store/AbstractStoreKeyConverter.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/AbstractStoreKeyConverter.java
@@ -21,10 +21,25 @@ import java.util.List;
 import java.util.Map;
 
 
+/**
+ * This is a counting cache based abstract implementation of {@link StoreKeyConverter}
+ * that can be used to convert store keys across different formats.
+ * </p>
+ * In this implementation keys will be cached when {@link #convert)} is called,
+ * and you need to call {@link #tryDropCache(Collection)} for the key same time as convert is called to remove it from the cache.
+ * You can also drop all cache in a single call to {@link #dropCache()}
+ */
 public abstract class AbstractStoreKeyConverter implements StoreKeyConverter {
   private final Map<StoreKey, StoreKey> conversionCache = new HashMap<>();
   private final Map<StoreKey, Integer> cachedKeyCount = new HashMap<>();
 
+  /**
+   * if any key is present in cache cached result will be returned.
+   * For the remaining keys conversion will be attempted.
+   * @param input the {@link StoreKey}s that need to be converted.
+   * @return {@link Map} map of storeKeys to converted keys
+   * @throws Exception
+   */
   @Override
   public Map<StoreKey, StoreKey> convert(Collection<? extends StoreKey> input) throws Exception {
     List<StoreKey> alreadyPresentStoreKeys = new ArrayList<>();
@@ -52,14 +67,24 @@ public abstract class AbstractStoreKeyConverter implements StoreKeyConverter {
     return Collections.unmodifiableMap(map);
   }
 
+  /**
+   * @param storeKey storeKey you want the converted version of.  If the key was not apart
+   *                 of a previous {@link #convert(Collection)} call, method may throw
+   *                 IllegalStateException
+   * @return
+   */
   @Override
   public StoreKey getConverted(StoreKey storeKey) {
     return getConvertedKey(storeKey, conversionCache.containsKey(storeKey), conversionCache.get(storeKey));
   }
 
-
+  /**
+   * This will remove the given keys from cache when it is called as
+   * same number of times as {@link #convert(Collection)} for a particular key
+   * @param storeKeys storeKeys you want to try to remove from cache
+   */
   @Override
-  public void remove(Collection<? extends StoreKey> storeKeys) {
+  public void tryDropCache(Collection<? extends StoreKey> storeKeys) {
     storeKeys.forEach(storeKey -> {
       if (!cachedKeyCount.containsKey(storeKey)) {
         return;
@@ -73,13 +98,27 @@ public abstract class AbstractStoreKeyConverter implements StoreKeyConverter {
     });
   }
 
+  /**
+   * Drops the Cache reference used by {@link AbstractStoreKeyConverter}
+   */
   @Override
   public void dropCache() {
     cachedKeyCount.clear();
     conversionCache.clear();
   }
 
+  /**
+   * This method will be called for the keys which are not present in cache
+   * @param input StoreKeys to be converted
+   */
   protected abstract Map<StoreKey, StoreKey> convertKeys(Collection<? extends StoreKey> input) throws Exception;
 
+  /**
+   * This methods response will be returned from {@link #getConverted(StoreKey)} method.
+   * @param storeKey  StoreKey that was queried
+   * @param isKeyPresent whether key is present in cache
+   * @param cachedMapping convertedMapping that is stored in cache. Will be null if if key is not present in cache.
+   * @return
+   */
   protected abstract StoreKey getConvertedKey(StoreKey storeKey, Boolean isKeyPresent, StoreKey cachedMapping);
 }

--- a/ambry-api/src/main/java/com/github/ambry/store/AbstractStoreKeyConverter.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/AbstractStoreKeyConverter.java
@@ -120,5 +120,5 @@ public abstract class AbstractStoreKeyConverter implements StoreKeyConverter {
    * @param cachedMapping convertedMapping that is stored in cache. Will be null if if key is not present in cache.
    * @return
    */
-  protected abstract StoreKey getConvertedKey(StoreKey storeKey, Boolean isKeyPresent, StoreKey cachedMapping);
+  protected abstract StoreKey getConvertedKey(StoreKey storeKey, boolean isKeyPresent, StoreKey cachedMapping);
 }

--- a/ambry-api/src/main/java/com/github/ambry/store/AbstractStoreKeyConverter.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/AbstractStoreKeyConverter.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2024 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
 package com.github.ambry.store;
 
 import java.util.ArrayList;
@@ -66,7 +79,7 @@ public abstract class AbstractStoreKeyConverter implements StoreKeyConverter {
     conversionCache.clear();
   }
 
-  abstract Map<StoreKey, StoreKey> convertKeys(Collection<? extends StoreKey> input) throws Exception;
+  protected abstract Map<StoreKey, StoreKey> convertKeys(Collection<? extends StoreKey> input) throws Exception;
 
   abstract StoreKey getConvertedKey(StoreKey storeKey, Boolean isKeyPresent, StoreKey cachedMapping);
 }

--- a/ambry-api/src/main/java/com/github/ambry/store/AbstractStoreKeyConverter.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/AbstractStoreKeyConverter.java
@@ -81,5 +81,5 @@ public abstract class AbstractStoreKeyConverter implements StoreKeyConverter {
 
   protected abstract Map<StoreKey, StoreKey> convertKeys(Collection<? extends StoreKey> input) throws Exception;
 
-  abstract StoreKey getConvertedKey(StoreKey storeKey, Boolean isKeyPresent, StoreKey cachedMapping);
+  protected abstract StoreKey getConvertedKey(StoreKey storeKey, Boolean isKeyPresent, StoreKey cachedMapping);
 }

--- a/ambry-api/src/main/java/com/github/ambry/store/StoreKeyConverter.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/StoreKeyConverter.java
@@ -44,14 +44,17 @@ public interface StoreKeyConverter {
    *                 IllegalStateException
    * @return the previously converted storeKey
    */
+
   StoreKey getConverted(StoreKey storeKey);
   /**
    * Removes the given storeKeys From cache
    * @param storeKeys storeKeys you want to remove from cache
    */
+
   default void tryDropCache(Collection<? extends  StoreKey> storeKeys) {};
   /**
    * Drops the cache reference used by {@link StoreKeyConverter}
    */
+
   void dropCache();
 }

--- a/ambry-api/src/main/java/com/github/ambry/store/StoreKeyConverter.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/StoreKeyConverter.java
@@ -45,12 +45,11 @@ public interface StoreKeyConverter {
    * @return the previously converted storeKey
    */
   StoreKey getConverted(StoreKey storeKey);
-
-
-  default void remove(Collection<? extends  StoreKey> storeKeys) {};
-
-
-
+  /**
+   * Removes the given storeKeys From cache
+   * @param storeKeys storeKeys you want to remove from cache
+   */
+  default void tryDropCache(Collection<? extends  StoreKey> storeKeys) {};
   /**
    * Drops the cache reference used by {@link StoreKeyConverter}
    */

--- a/ambry-api/src/main/java/com/github/ambry/store/StoreKeyConverter.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/StoreKeyConverter.java
@@ -44,17 +44,16 @@ public interface StoreKeyConverter {
    *                 IllegalStateException
    * @return the previously converted storeKey
    */
-
   StoreKey getConverted(StoreKey storeKey);
+
   /**
    * Removes the given storeKeys From cache
    * @param storeKeys storeKeys you want to remove from cache
    */
-
   default void tryDropCache(Collection<? extends  StoreKey> storeKeys) {};
+
   /**
    * Drops the cache reference used by {@link StoreKeyConverter}
    */
-
   void dropCache();
 }

--- a/ambry-api/src/main/java/com/github/ambry/store/StoreKeyConverter.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/StoreKeyConverter.java
@@ -46,6 +46,11 @@ public interface StoreKeyConverter {
    */
   StoreKey getConverted(StoreKey storeKey);
 
+
+  default void remove(Collection<? extends  StoreKey> storeKeys) {};
+
+
+
   /**
    * Drops the cache reference used by {@link StoreKeyConverter}
    */

--- a/ambry-commons/src/test/java/com/github/ambry/store/AbstractStoreKeyConverterTest.java
+++ b/ambry-commons/src/test/java/com/github/ambry/store/AbstractStoreKeyConverterTest.java
@@ -85,7 +85,7 @@ public class AbstractStoreKeyConverterTest {
     convertedMap = storeKeyConverter.convert(list);
     assertEquals("Size of keys in input and output is different", list.size(), convertedMap.size());
 
-    storeKeyConverter.remove(list);
+    storeKeyConverter.tryDropCache(list);
 
     try {
       StoreKey storeKey0Res = storeKeyConverter.getConverted(storeKey0);
@@ -94,7 +94,7 @@ public class AbstractStoreKeyConverterTest {
       fail("Exception thrown while storeKey0 is present");
     }
 
-    storeKeyConverter.remove(list);
+    storeKeyConverter.tryDropCache(list);
     try {
       storeKeyConverter.getConverted(storeKey0);
       fail("Get succeeded after cache is cleared");

--- a/ambry-commons/src/test/java/com/github/ambry/store/AbstractStoreKeyConverterTest.java
+++ b/ambry-commons/src/test/java/com/github/ambry/store/AbstractStoreKeyConverterTest.java
@@ -24,21 +24,38 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 
+/**
+ * Test for {@link AbstractStoreKeyConverter}
+ */
 public class AbstractStoreKeyConverterTest {
   private final StoreKeyConverter storeKeyConverter;
 
+  /**
+   * Using {@link com.github.ambry.store.MockStoreKeyConverterFactory.MockStoreKeyConverter}
+   * as it implements {@link AbstractStoreKeyConverter}
+   */
   public AbstractStoreKeyConverterTest() {
     storeKeyConverter = new MockStoreKeyConverterFactory(null, null).setConversionMap(new HashMap<>())
         .setReturnInputIfAbsent(true)
         .getStoreKeyConverter();
   }
 
+  /**
+   * Ensures that {@link #storeKeyConverter} implements {@link AbstractStoreKeyConverter}
+   * @throws Exception
+   */
   @Test
   public void testClassImplementation() throws Exception {
     assertTrue("storeKeyConverter is not inheriting AbstractStoreKeyConverter",
         storeKeyConverter instanceof AbstractStoreKeyConverter);
   }
 
+  /**
+   * Test conversion of keys by  first try getting keys without converting,
+   * then converting two keys try getting them ,
+   * and then clearing cache and again try getting keys
+   * @throws Exception
+   */
   @Test
   public void testBasicOperations() throws Exception {
     StoreKey storeKey0 = mock(StoreKey.class);
@@ -59,7 +76,7 @@ public class AbstractStoreKeyConverterTest {
     try {
       StoreKey storeKey0Res = storeKeyConverter.getConverted(storeKey0);
       assertNotNull("Conversion of storeKey0 should not be null", storeKey0Res);
-    }catch (Exception e){
+    } catch (Exception e) {
       fail("Exception thrown while storeKey0 is present");
     }
 
@@ -72,6 +89,12 @@ public class AbstractStoreKeyConverterTest {
     }
   }
 
+  /**
+   * Testing caching logic by calling convert two time on a list of keys,
+   * then try getting one of keys, then try removing these keys from cache,
+   * then try getting these keys and then removing these keys again and try getting again
+   * @throws Exception
+   */
   @Test
   public void testCachingOperations() throws Exception {
     StoreKey storeKey0 = mock(StoreKey.class);
@@ -90,7 +113,7 @@ public class AbstractStoreKeyConverterTest {
     try {
       StoreKey storeKey0Res = storeKeyConverter.getConverted(storeKey0);
       assertNotNull("Conversion of storeKey0 should not be null", storeKey0Res);
-    }catch (Exception e){
+    } catch (Exception e) {
       fail("Exception thrown while storeKey0 is present");
     }
 

--- a/ambry-commons/src/test/java/com/github/ambry/store/AbstractStoreKeyConverterTest.java
+++ b/ambry-commons/src/test/java/com/github/ambry/store/AbstractStoreKeyConverterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 LinkedIn Corp. All rights reserved.
+ * Copyright 2024 LinkedIn Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ambry-commons/src/test/java/com/github/ambry/store/AbstractStoreKeyConverterTest.java
+++ b/ambry-commons/src/test/java/com/github/ambry/store/AbstractStoreKeyConverterTest.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2018 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.store;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+
+public class AbstractStoreKeyConverterTest {
+  private final StoreKeyConverter storeKeyConverter;
+
+  public AbstractStoreKeyConverterTest() {
+    storeKeyConverter = new MockStoreKeyConverterFactory(null, null).setConversionMap(new HashMap<>())
+        .setReturnInputIfAbsent(true)
+        .getStoreKeyConverter();
+  }
+
+  @Test
+  public void testClassImplementation() throws Exception {
+    assertTrue("storeKeyConverter is not inheriting AbstractStoreKeyConverter",
+        storeKeyConverter instanceof AbstractStoreKeyConverter);
+  }
+
+  @Test
+  public void testBasicOperations() throws Exception {
+    StoreKey storeKey0 = mock(StoreKey.class);
+    StoreKey storeKey1 = mock(StoreKey.class);
+    assertNotSame("storeKeys should not be equal", storeKey0, storeKey1);
+    List<StoreKey> list = Arrays.asList(storeKey0, storeKey1);
+
+    try {
+      storeKeyConverter.getConverted(storeKey0);
+      fail("Get succeeded for not converted keys");
+    } catch (Exception e) {
+      //expected
+    }
+
+    Map<StoreKey, StoreKey> convertedMap = storeKeyConverter.convert(list);
+    assertEquals("Size of keys in input and output is different", list.size(), convertedMap.size());
+
+    try {
+      StoreKey storeKey0Res = storeKeyConverter.getConverted(storeKey0);
+      assertNotNull("Conversion of storeKey0 should not be null", storeKey0Res);
+    }catch (Exception e){
+      fail("Exception thrown while storeKey0 is present");
+    }
+
+    storeKeyConverter.dropCache();
+    try {
+      storeKeyConverter.getConverted(storeKey0);
+      fail("Get succeeded after cache is cleared");
+    } catch (Exception e) {
+      //expected
+    }
+  }
+
+  @Test
+  public void testCachingOperations() throws Exception {
+    StoreKey storeKey0 = mock(StoreKey.class);
+    StoreKey storeKey1 = mock(StoreKey.class);
+    assertNotSame("storeKeys should not be equal", storeKey0, storeKey1);
+    List<StoreKey> list = Arrays.asList(storeKey0, storeKey1);
+
+    Map<StoreKey, StoreKey> convertedMap = storeKeyConverter.convert(list);
+    assertEquals("Size of keys in input and output is different", list.size(), convertedMap.size());
+
+    convertedMap = storeKeyConverter.convert(list);
+    assertEquals("Size of keys in input and output is different", list.size(), convertedMap.size());
+
+    storeKeyConverter.remove(list);
+
+    try {
+      StoreKey storeKey0Res = storeKeyConverter.getConverted(storeKey0);
+      assertNotNull("Conversion of storeKey0 should not be null", storeKey0Res);
+    }catch (Exception e){
+      fail("Exception thrown while storeKey0 is present");
+    }
+
+    storeKeyConverter.remove(list);
+    try {
+      storeKeyConverter.getConverted(storeKey0);
+      fail("Get succeeded after cache is cleared");
+    } catch (Exception e) {
+      //expected
+    }
+  }
+}

--- a/ambry-messageformat/src/test/java/com/github/ambry/messageformat/MessageSievingInputStreamTest.java
+++ b/ambry-messageformat/src/test/java/com/github/ambry/messageformat/MessageSievingInputStreamTest.java
@@ -14,12 +14,14 @@
 package com.github.ambry.messageformat;
 
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.store.AbstractStoreKeyConverter;
 import com.github.ambry.store.Message;
 import com.github.ambry.store.MessageInfo;
 import com.github.ambry.store.MockId;
 import com.github.ambry.store.MockIdFactory;
 import com.github.ambry.store.StoreKey;
 import com.github.ambry.store.StoreKeyConverter;
+import com.github.ambry.store.StoreKeyConverterImplNoOp;
 import com.github.ambry.store.StoreKeyFactory;
 import com.github.ambry.store.TransformationOutput;
 import com.github.ambry.store.Transformer;
@@ -1028,11 +1030,9 @@ public class MessageSievingInputStreamTest {
  * be of length less than, equal to, or greater than the size of the input key. Additionally, a set of "invalid" keys
  * can be provided while instantiating, and for these keys a null mapping will be provided.
  */
-class RandomKeyConverter implements StoreKeyConverter {
+class RandomKeyConverter extends AbstractStoreKeyConverter {
 
   Collection<? extends StoreKey> invalids = Collections.emptyList();
-  Map<StoreKey, StoreKey> onceConverted = new HashMap<>();
-
   /**
    * Add invalid mappings.
    * @param invalids the keys for which no mapping will be generated during conversion.
@@ -1042,29 +1042,19 @@ class RandomKeyConverter implements StoreKeyConverter {
   }
 
   @Override
-  public Map<StoreKey, StoreKey> convert(Collection<? extends StoreKey> input) {
+  protected Map<StoreKey, StoreKey> convertKeys(Collection<? extends StoreKey> input) throws Exception {
     Map<StoreKey, StoreKey> output = new HashMap<>();
     input.forEach(inKey -> {
-      if (onceConverted.containsKey(inKey)) {
-        output.put(inKey, onceConverted.get(inKey));
-      } else {
         StoreKey replaceMent = invalids.contains(inKey) ? null : new MockId(
             inKey.getID().substring(0, inKey.getID().length() / 2) + Integer.toString(RANDOM.nextInt(1000)));
-        onceConverted.put(inKey, replaceMent);
         output.put(inKey, replaceMent);
-      }
     });
     return output;
   }
 
   @Override
-  public StoreKey getConverted(StoreKey storeKey) {
-    return onceConverted.get(storeKey);
-  }
-
-  @Override
-  public void dropCache() {
-    onceConverted = null;
+  protected StoreKey getConvertedKey(StoreKey storeKey, Boolean isKeyPresent, StoreKey cachedMapping) {
+    return cachedMapping;
   }
 }
 

--- a/ambry-messageformat/src/test/java/com/github/ambry/messageformat/MessageSievingInputStreamTest.java
+++ b/ambry-messageformat/src/test/java/com/github/ambry/messageformat/MessageSievingInputStreamTest.java
@@ -21,7 +21,6 @@ import com.github.ambry.store.MockId;
 import com.github.ambry.store.MockIdFactory;
 import com.github.ambry.store.StoreKey;
 import com.github.ambry.store.StoreKeyConverter;
-import com.github.ambry.store.StoreKeyConverterImplNoOp;
 import com.github.ambry.store.StoreKeyFactory;
 import com.github.ambry.store.TransformationOutput;
 import com.github.ambry.store.Transformer;

--- a/ambry-messageformat/src/test/java/com/github/ambry/messageformat/MessageSievingInputStreamTest.java
+++ b/ambry-messageformat/src/test/java/com/github/ambry/messageformat/MessageSievingInputStreamTest.java
@@ -1052,7 +1052,7 @@ class RandomKeyConverter extends AbstractStoreKeyConverter {
   }
 
   @Override
-  protected StoreKey getConvertedKey(StoreKey storeKey, Boolean isKeyPresent, StoreKey cachedMapping) {
+  protected StoreKey getConvertedKey(StoreKey storeKey, boolean isKeyPresent, StoreKey cachedMapping) {
     return cachedMapping;
   }
 }

--- a/ambry-test-utils/src/main/java/com/github/ambry/store/MockStoreKeyConverterFactory.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/store/MockStoreKeyConverterFactory.java
@@ -112,7 +112,7 @@ public class MockStoreKeyConverterFactory implements StoreKeyConverterFactory {
     }
 
     @Override
-    protected StoreKey getConvertedKey(StoreKey storeKey, Boolean isKeyPresent, StoreKey cachedMapping) {
+    protected StoreKey getConvertedKey(StoreKey storeKey, boolean isKeyPresent, StoreKey cachedMapping) {
       if (exception != null) {
         throw new IllegalStateException(exception);
       } else if (!isKeyPresent) {

--- a/ambry-test-utils/src/main/java/com/github/ambry/store/MockStoreKeyConverterFactory.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/store/MockStoreKeyConverterFactory.java
@@ -15,7 +15,6 @@ package com.github.ambry.store;
 
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.config.VerifiableProperties;
-import com.sun.org.apache.xpath.internal.operations.Bool;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;

--- a/ambry-test-utils/src/main/java/com/github/ambry/store/MockStoreKeyConverterFactory.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/store/MockStoreKeyConverterFactory.java
@@ -94,7 +94,7 @@ public class MockStoreKeyConverterFactory implements StoreKeyConverterFactory {
     }
 
     @Override
-    public Map<StoreKey, StoreKey> convertKeys(Collection<? extends StoreKey> input) throws Exception {
+    protected Map<StoreKey, StoreKey> convertKeys(Collection<? extends StoreKey> input) throws Exception {
       if (exception != null) {
         throw exception;
       }
@@ -112,7 +112,7 @@ public class MockStoreKeyConverterFactory implements StoreKeyConverterFactory {
     }
 
     @Override
-    StoreKey getConvertedKey(StoreKey storeKey, Boolean isKeyPresent, StoreKey cachedMapping) {
+    protected StoreKey getConvertedKey(StoreKey storeKey, Boolean isKeyPresent, StoreKey cachedMapping) {
       if (exception != null) {
         throw new IllegalStateException(exception);
       } else if (!isKeyPresent) {

--- a/ambry-test-utils/src/main/java/com/github/ambry/store/MockStoreKeyConverterFactory.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/store/MockStoreKeyConverterFactory.java
@@ -15,6 +15,7 @@ package com.github.ambry.store;
 
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.config.VerifiableProperties;
+import com.sun.org.apache.xpath.internal.operations.Bool;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -77,9 +78,8 @@ public class MockStoreKeyConverterFactory implements StoreKeyConverterFactory {
   /**
    * A mock implementation of {@link StoreKeyConverter}.
    */
-  public class MockStoreKeyConverter implements StoreKeyConverter {
+  public class MockStoreKeyConverter extends AbstractStoreKeyConverter {
 
-    private Map<StoreKey, StoreKey> lastConverted = new HashMap<>();
     private Map<StoreKey, StoreKey> conversionMap;
 
     private MockStoreKeyConverter(Map<StoreKey, StoreKey> conversionMap) {
@@ -95,7 +95,7 @@ public class MockStoreKeyConverterFactory implements StoreKeyConverterFactory {
     }
 
     @Override
-    public Map<StoreKey, StoreKey> convert(Collection<? extends StoreKey> input) throws Exception {
+    public Map<StoreKey, StoreKey> convertKeys(Collection<? extends StoreKey> input) throws Exception {
       if (exception != null) {
         throw exception;
       }
@@ -109,28 +109,17 @@ public class MockStoreKeyConverterFactory implements StoreKeyConverterFactory {
           }
         }
       }
-      //conversion gets added to cache
-      if (lastConverted == null) {
-        lastConverted = output;
-      } else {
-        lastConverted.putAll(output);
-      }
       return output;
     }
 
     @Override
-    public StoreKey getConverted(StoreKey storeKey) {
+    StoreKey getConvertedKey(StoreKey storeKey, Boolean isKeyPresent, StoreKey cachedMapping) {
       if (exception != null) {
         throw new IllegalStateException(exception);
-      } else if (!lastConverted.containsKey(storeKey)) {
+      } else if (!isKeyPresent) {
         throw new IllegalStateException(storeKey + " has not been converted");
       }
-      return lastConverted.get(storeKey);
-    }
-
-    @Override
-    public void dropCache() {
-      lastConverted = null;
+      return cachedMapping;
     }
   }
 }


### PR DESCRIPTION
Added tryDropCache for keys in StoreKeyConverter to try and drop some keys.
Adding an AbstractStoreKeyConverter and implementing in current test classes of StoreKeyConverter
to have same expected logic everywhere.
AbstractStoreKeyConverter is using a counting cache logic for keys.
Whenever a key is added its count will keep increasing, when tryDropCache is called for keys, count will decrease.
Keys will be dropped, when count becomes 0.
Rest of the behviour is same as expected