### PR TITLE
Server returns Blob_Deleted for deleted blob out of retention

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/store/StoreGetOptions.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/StoreGetOptions.java
@@ -25,8 +25,12 @@ public enum StoreGetOptions {
   Store_Include_Expired,
   /**
    * This option indicates that the store needs to return the message even if it has been
-   * marked for deletion as long as the message has not been physically deleted from the
-   * store.
+   * marked for deletion as long as the message is still in delete retention window
    */
-  Store_Include_Deleted
+  Store_Include_Deleted,
+  /**
+   * This option indicates that the store needs to return the message as long as the message
+   * has not been physically deleted from the store.
+   */
+  Store_Include_Compaction_Ready
 }

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryRequests.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryRequests.java
@@ -33,7 +33,6 @@ import com.github.ambry.messageformat.MessageFormatException;
 import com.github.ambry.messageformat.MessageFormatFlags;
 import com.github.ambry.messageformat.MessageFormatInputStream;
 import com.github.ambry.messageformat.MessageFormatMetrics;
-import com.github.ambry.messageformat.MessageFormatRecord;
 import com.github.ambry.messageformat.MessageFormatSend;
 import com.github.ambry.messageformat.MessageFormatWriteSet;
 import com.github.ambry.messageformat.MessageSievingInputStream;
@@ -87,7 +86,6 @@ import com.github.ambry.store.FindInfo;
 import com.github.ambry.store.IdUndeletedStoreException;
 import com.github.ambry.store.Message;
 import com.github.ambry.store.MessageInfo;
-import com.github.ambry.store.MessageReadSet;
 import com.github.ambry.store.Store;
 import com.github.ambry.store.StoreErrorCodes;
 import com.github.ambry.store.StoreException;
@@ -1499,7 +1497,7 @@ public class AmbryRequests implements RequestAPI {
       storeGetOptions = EnumSet.of(StoreGetOptions.Store_Include_Deleted);
     }
     if (getRequest.getGetOption() == GetOption.Include_All) {
-      storeGetOptions = EnumSet.of(StoreGetOptions.Store_Include_Deleted, StoreGetOptions.Store_Include_Expired);
+      storeGetOptions = EnumSet.allOf(StoreGetOptions.class);
     }
     return storeGetOptions;
   }

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -343,7 +343,7 @@ public class BlobStore implements Store {
         StoreGetOptions.Store_Include_Expired);
     MessageReadSet rdset = null;
     try {
-      StoreInfo stinfo = this.get(Collections.singletonList(msg.getStoreKey()), storeGetOptions);
+      StoreInfo stinfo = get(Collections.singletonList(msg.getStoreKey()), storeGetOptions);
       rdset = stinfo.getMessageReadSet();
       MessageInfo minfo = stinfo.getMessageReadSetInfo().get(0);
       rdset.doPrefetch(0, minfo.getSize() - MessageFormatRecord.Crc_Size,

--- a/ambry-store/src/main/java/com/github/ambry/store/HardDeleter.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/HardDeleter.java
@@ -632,7 +632,8 @@ public class HardDeleter implements Runnable {
    */
   private void performHardDeletes(List<MessageInfo> messageInfoList) throws StoreException {
     try {
-      EnumSet<StoreGetOptions> getOptions = EnumSet.of(StoreGetOptions.Store_Include_Deleted);
+      EnumSet<StoreGetOptions> getOptions =
+          EnumSet.of(StoreGetOptions.Store_Include_Deleted, StoreGetOptions.Store_Include_Compaction_Ready);
       List<BlobReadOptions> readOptionsList = new ArrayList<BlobReadOptions>(messageInfoList.size());
 
       /* First create the readOptionsList */

--- a/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
@@ -1377,7 +1377,7 @@ public class PersistentIndex implements LogSegmentSizeProvider {
         long deleteOperationTime = value.getOperationTimeInMs();
         if (getOptions.contains(StoreGetOptions.Store_Include_Compaction_Ready) || (
             getOptions.contains(StoreGetOptions.Store_Include_Deleted)
-                && deleteOperationTime + TimeUnit.MILLISECONDS.toMillis(config.storeDeletedMessageRetentionMinutes)
+                && deleteOperationTime + TimeUnit.MINUTES.toMillis(config.storeDeletedMessageRetentionMinutes)
                 >= time.milliseconds())) {
           readOptions = getDeletedBlobReadOptions(value, id, indexSegments);
         } else {

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
@@ -276,7 +276,7 @@ public class BlobStoreTest {
   // A list of keys grouped by the log segment that they belong to
   private final List<Set<MockId>> idsByLogSegment = new ArrayList<>();
   // Set of all deleted keys
-  private final Set<MockId> deletedKeys = Collections.newSetFromMap(new ConcurrentHashMap<MockId, Boolean>());
+  private final Map<MockId, Long> deletedKeys = new ConcurrentHashMap<MockId, Long>();
   // Set of all expired keys
   private final Set<MockId> expiredKeys = Collections.newSetFromMap(new ConcurrentHashMap<MockId, Boolean>());
   // Set of all keys that are not deleted/expired
@@ -657,13 +657,27 @@ public class BlobStoreTest {
     checkStoreInfo(storeInfo, liveKeys);
 
     MockMessageStoreHardDelete hd = (MockMessageStoreHardDelete) hardDelete;
-    for (MockId id : deletedKeys) {
+    for (MockId id : deletedKeys.keySet()) {
       // cannot get without StoreGetOptions
       verifyGetFailure(id, StoreErrorCodes.ID_Deleted);
 
       // with StoreGetOptions.Store_Include_Deleted
-      storeInfo = store.get(Collections.singletonList(id), EnumSet.of(StoreGetOptions.Store_Include_Deleted));
+      storeInfo = store.get(Collections.singletonList(id), EnumSet.of(StoreGetOptions.Store_Include_Compaction_Ready));
       checkStoreInfo(storeInfo, Collections.singleton(id));
+
+      long operationTimeMs = deletedKeys.get(id);
+      if (operationTimeMs + TimeUnit.MINUTES.toMillis(CuratedLogIndexState.deleteRetentionHour * 60)
+          >= time.milliseconds()) {
+        storeInfo = store.get(Collections.singletonList(id), EnumSet.of(StoreGetOptions.Store_Include_Deleted));
+        checkStoreInfo(storeInfo, Collections.singleton(id));
+      } else {
+        try {
+          store.get(Collections.singletonList(id), EnumSet.of(StoreGetOptions.Store_Include_Deleted));
+          fail("Should not be able to GET " + id);
+        } catch (StoreException e) {
+          assertEquals("Unexpected StoreErrorCode", StoreErrorCodes.ID_Deleted, e.getErrorCode());
+        }
+      }
 
       // with all StoreGetOptions
       storeInfo = store.get(Collections.singletonList(id), EnumSet.allOf(StoreGetOptions.class));
@@ -1228,7 +1242,7 @@ public class BlobStoreTest {
     info = new MessageInfo(addedId, DELETE_RECORD_SIZE, true, false, false, Utils.Infinite_Time, null,
         addedId.getAccountId(), addedId.getContainerId(), time.milliseconds(), lifeVersion);
     store.delete(Collections.singletonList(info));
-    deletedKeys.add(addedId);
+    deletedKeys.put(addedId, time.milliseconds());
     undeletedKeys.remove(addedId);
     liveKeys.remove(addedId);
     StoreInfo storeInfo = store.get(Arrays.asList(addedId), EnumSet.of(StoreGetOptions.Store_Include_Deleted));
@@ -1273,7 +1287,7 @@ public class BlobStoreTest {
     info = new MessageInfo(addedId, DELETE_RECORD_SIZE, true, false, false, Utils.Infinite_Time, null,
         addedId.getAccountId(), addedId.getContainerId(), time.milliseconds(), MessageInfo.LIFE_VERSION_FROM_FRONTEND);
     store.delete(Collections.singletonList(info));
-    deletedKeys.add(addedId);
+    deletedKeys.put(addedId, time.milliseconds());
     undeletedKeys.remove(addedId);
     liveKeys.remove(addedId);
     storeInfo = store.get(Arrays.asList(addedId), EnumSet.of(StoreGetOptions.Store_Include_Deleted));
@@ -1423,7 +1437,7 @@ public class BlobStoreTest {
   @Test
   public void deleteErrorCasesTest() throws StoreException {
     // ID that is already deleted
-    verifyDeleteFailure(deletedKeys.iterator().next(), StoreErrorCodes.ID_Deleted);
+    verifyDeleteFailure(deletedKeys.keySet().iterator().next(), StoreErrorCodes.ID_Deleted);
     // ID that does not exist
     verifyDeleteFailure(getUniqueId(), StoreErrorCodes.ID_Not_Found);
     MockId id = getUniqueId();
@@ -1555,12 +1569,12 @@ public class BlobStoreTest {
     inNoTtlUpdatePeriodTest();
     // ID that is already updated
     for (MockId ttlUpdated : ttlUpdatedKeys) {
-      if (!deletedKeys.contains(ttlUpdated)) {
+      if (!deletedKeys.containsKey(ttlUpdated)) {
         verifyTtlUpdateFailure(ttlUpdated, Utils.Infinite_Time, StoreErrorCodes.Already_Updated);
       }
     }
     // ID that is already deleted
-    for (MockId deleted : deletedKeys) {
+    for (MockId deleted : deletedKeys.keySet()) {
       verifyTtlUpdateFailure(deleted, Utils.Infinite_Time, StoreErrorCodes.ID_Deleted);
     }
     // Attempt to set expiry time to anything other than infinity
@@ -1788,7 +1802,7 @@ public class BlobStoreTest {
   @Test
   public void isKeyDeletedTest() throws StoreException {
     for (MockId id : allKeys.keySet()) {
-      assertEquals("Returned state is not as expected", deletedKeys.contains(id), store.isKeyDeleted(id));
+      assertEquals("Returned state is not as expected", deletedKeys.containsKey(id), store.isKeyDeleted(id));
     }
     for (MockId id : deletedAndShouldBeCompactedKeys) {
       assertTrue("Returned state is not as expected", store.isKeyDeleted(id));
@@ -3007,7 +3021,7 @@ public class BlobStoreTest {
       store.forceDelete(Collections.singletonList(info));
     }
 
-    deletedKeys.add(idToDelete);
+    deletedKeys.put(idToDelete, operationTimeMs);
     undeletedKeys.remove(idToDelete);
     liveKeys.remove(idToDelete);
     return info;
@@ -3081,7 +3095,7 @@ public class BlobStoreTest {
       assertEquals("ContainerId mismatch", expectedInfo.getContainerId(), messageInfo.getContainerId());
       assertEquals("OperationTime mismatch", expectedInfo.getOperationTimeMs(), messageInfo.getOperationTimeMs());
       assertEquals("isTTLUpdated not as expected", ttlUpdatedKeys.contains(id), messageInfo.isTtlUpdated());
-      assertEquals("isDeleted not as expected", deletedKeys.contains(id), messageInfo.isDeleted());
+      assertEquals("isDeleted not as expected", deletedKeys.containsKey(id), messageInfo.isDeleted());
       assertEquals("isUndeleted not as expected", undeletedKeys.contains(id), messageInfo.isUndeleted());
       if (IndexValue.hasLifeVersion(lifeVersion)) {
         assertEquals("lifeVersion not as expected", lifeVersion, messageInfo.getLifeVersion());
@@ -3181,8 +3195,6 @@ public class BlobStoreTest {
       deletes++;
       idsByLogSegment.get(2).add(idToDelete);
       // 1 DELETE for the PUT in the same segment
-      deletedKeys.add(addedId);
-      liveKeys.remove(addedId);
       delete(addedId);
       deletes++;
 
@@ -3365,7 +3377,6 @@ public class BlobStoreTest {
       // 1 DELETE for the expired PUT
       delete(id);
       deletedKeyCount++;
-      deletedKeys.add(id);
       expiredKeys.remove(id);
       idsGroupedByIndexSegment.add(idsInIndexSegment);
       idsInLogSegment.addAll(idsInIndexSegment);
@@ -3501,8 +3512,6 @@ public class BlobStoreTest {
     if (deleteCandidate == null) {
       throw new IllegalStateException("Could not find a key to delete in set: " + ids);
     }
-    deletedKeys.add(deleteCandidate);
-    liveKeys.remove(deleteCandidate);
     return deleteCandidate;
   }
 
@@ -3626,7 +3635,7 @@ public class BlobStoreTest {
         } catch (ExecutionException e) {
           StoreException storeException = (StoreException) e.getCause();
           StoreErrorCodes expectedCode = StoreErrorCodes.ID_Not_Found;
-          if (deletedKeys.contains(id)) {
+          if (deletedKeys.containsKey(id)) {
             expectedCode = StoreErrorCodes.ID_Deleted;
           } else if (expiredKeys.contains(id)) {
             expectedCode = StoreErrorCodes.TTL_Expired;


### PR DESCRIPTION
## Summary
When issuing a get request with include_deleted get option, frontend would send a get request to server to fetch the content of the blob. However, if any chunk blob is deleted and out of retention window, even if we have metadata chunk still in the server, we can't finish downloading the entire blob. 

This PR fixes this issue by not returning content for metadata. Now if client issues a get request with include_deleted get option and trying to download a blob that was already deleted and out of retention window, server would just return ID_Deleted error back to frontend so frontend would just return 410 back to client right away.

To download deleted and out of retention blobs, we can issue a get request with include_all.

## Details
### Add a new StoreGetOptions `Store_Include_Compaction_Ready` 
### Change the meaning of `Store_Include_Deleted`

## Test
Unit test 