### PR TITLE
Log when a paranoid durability write succeeds.

### DIFF
--- a/ambry-router/src/main/java/com/github/ambry/router/ParanoidDurabilityOperationTracker.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/ParanoidDurabilityOperationTracker.java
@@ -224,7 +224,11 @@ public class ParanoidDurabilityOperationTracker extends SimpleOperationTracker {
    * @return true if we have received enough successful responses from both local and remote replicas, false otherwise.
    */
   public boolean hasSucceeded() {
-    return hasSucceededLocally() && hasSucceededRemotely();
+    if (hasSucceededLocally() && hasSucceededRemotely()) {
+      logger.info("Paranoid durability PUT succeeded for partition " + partitionId);
+      return true;
+    }
+    return false;
   }
 
   /**
@@ -307,7 +311,7 @@ public class ParanoidDurabilityOperationTracker extends SimpleOperationTracker {
    * @return true if we have received enough failed responses from both local and remote replicas, false otherwise.
    */
   public boolean hasFailed() {
-      return hasFailedLocally() || hasFailedRemotely();
+    return hasFailedLocally() || hasFailedRemotely();
   }
 
   /**


### PR DESCRIPTION
To verify that the paranoid durability feature is working as intended this PR adds a log statement for when a request succeeds in `ParanoidDurabilityOperationTracker`. We are planning to use this log for initial testing and will either change it to debug/trace or remove it in order to prevent flooding logs in later stages of the rollout.