### PR TITLE
Record more exceptions for replication

### DIFF
--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -2198,6 +2198,9 @@ public class ReplicaThread implements Runnable {
      * @param message The message to log out
      */
     private void setException(Exception e, String message) {
+      if (!(e instanceof ReplicationException)) {
+        replicationMetrics.incrementReplicationErrorCount(replicatingFromRemoteColo, datacenterName);
+      }
       if (e instanceof ReplicationException
           && ((ReplicationException) e).getServerErrorCode() == ServerErrorCode.Retry_After_Backoff) {
         replicationMetrics.incrementRetryAfterBackoffErrorCount(replicatingFromRemoteColo, datacenterName);

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationMetrics.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationMetrics.java
@@ -651,12 +651,24 @@ public class ReplicationMetrics {
     }
   }
 
+  /**
+   * This is not used anywhere.
+   * @param sslEnabled
+   */
   public void incrementReplicationErrors(boolean sslEnabled) {
     replicationErrors.inc();
     if (sslEnabled) {
       sslReplicationErrors.inc();
     } else {
       plainTextReplicationErrors.inc();
+    }
+  }
+
+  public void incrementReplicationErrorCount(boolean remoteColo, String datacenter) {
+    if (remoteColo) {
+      dcToReplicationError.get(datacenter).inc();
+    } else {
+      intraColoReplicationErrorCount.inc();
     }
   }
 


### PR DESCRIPTION
## Summary
In ReplicaThread, we try to record exceptions in the metric for error cases. However, we don't have an umbrella exception counter for overall error cases. This PR adds that.

## Test
Unit test