### PR TITLE
[DR][Backup-checker] Disregard message_info timestamps

### DIFF
--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/BackupIntegrityMonitor.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/BackupIntegrityMonitor.java
@@ -219,13 +219,15 @@ public class BackupIntegrityMonitor implements Runnable {
       logger.info("[BackupIntegrityMonitor] Starting scanning peer server replica [{}]", serverReplica);
       StoreFindToken newDiskToken = new StoreFindToken(), oldDiskToken = null;
       /**
-       * This loop scans the remote peer server replica for metadata of all blobs since the beginning till present time.
-       * The termination condition is that the token from peer, which records the progress of the scan,
-       * remains unchanged between successive calls to replicate(). The fundamental requirement for this
-       * is that we scan __faster__ than the replica grows. Metadata scans are always faster than full data scans.
-       * To further ensure termination, we use a large value for replicationFetchSizeInBytes like 128MB or 256MB,
-       * instead of the default 4MB so that we step faster in larger step sizes through the log.
-       * TODO: There could be a metric to track time to scan a peer replica to ensure we don't loop infinitely.
+       * This loop iterates through the remote peer server replica to retrieve metadata for all blobs from the
+       * beginning to the current time. The termination condition relies on the token from the peer, which indicates
+       * the progress of the scan. The loop stops if this token remains unchanged between successive calls to the
+       * replicate() function. The essential requirement is that our scanning process must outpace the growth rate of
+       * the replica. Metadata scans, being lighter than full data scans, ensure faster iteration. To ensure timely
+       * termination, we've increased `replicationFetchSizeInBytes` significantly, such as to 128MB or 256MB, from its
+       * default of 4MB. This adjustment allows us to advance through the log in larger steps.
+       * TODO: Consider implementing a metric to monitor the time taken to scan a peer replica to prevent potential
+       * TODO: infinite looping.
        */
       while (!newDiskToken.equals(oldDiskToken)) {
         serverScanner.replicate();

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/BackupIntegrityMonitor.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/BackupIntegrityMonitor.java
@@ -224,8 +224,8 @@ public class BackupIntegrityMonitor implements Runnable {
        * the progress of the scan. The loop stops if this token remains unchanged between successive calls to the
        * replicate() function. The essential requirement is that our scanning process must outpace the growth rate of
        * the replica. Metadata scans, being lighter than full data scans, ensure faster iteration. To ensure timely
-       * termination, we've increased replicationFetchSizeInBytes significantly, such as to 128MB or 256MB, from its
-       * default of 4MB. This adjustment allows us to advance through the log in larger steps.
+       * termination, we must increase replicationFetchSizeInBytes significantly to 128MB or 256MB, from its
+       * default of 4MB. This adjustment allows us to advance through the log faster.
        * TODO: Consider implementing a metric to monitor the time taken to scan a peer replica to prevent potential
        * TODO: infinite looping.
        */

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/BackupIntegrityMonitor.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/BackupIntegrityMonitor.java
@@ -226,8 +226,7 @@ public class BackupIntegrityMonitor implements Runnable {
        * the replica. Metadata scans, being lighter than full data scans, ensure faster iteration. To ensure timely
        * termination, we must increase replicationFetchSizeInBytes significantly to 128MB or 256MB, from its
        * default of 4MB. This adjustment allows us to advance through the log faster.
-       * TODO: Consider implementing a metric to monitor the time taken to scan a peer replica to prevent potential
-       * TODO: infinite looping.
+       * TODO: Consider implementing a metric to monitor and prevent infinite loop.
        */
       while (!newDiskToken.equals(oldDiskToken)) {
         serverScanner.replicate();

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/BackupIntegrityMonitor.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/BackupIntegrityMonitor.java
@@ -233,8 +233,8 @@ public class BackupIntegrityMonitor implements Runnable {
         serverScanner.replicate();
         oldDiskToken = newDiskToken;
         newDiskToken = (StoreFindToken) serverReplica.getToken();
-        logger.info("[BackupIntegrityMonitor] Scanned {} num_server_blobs from peer server replica {}, lag = {}",
-            serverScanner.getNumBlobScanned(), serverReplica, serverReplica.getLocalLagFromRemoteInBytes());
+        logger.info("[BackupIntegrityMonitor] Scanned {} num_server_blobs from peer server replica {}",
+            serverScanner.getNumBlobScanned(), serverReplica);
       }
       logger.info("[BackupIntegrityMonitor] Completed scanning {} num_server_blobs from peer server replica {}",
           serverScanner.getNumBlobScanned(), serverReplica);

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/BackupIntegrityMonitor.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/BackupIntegrityMonitor.java
@@ -99,15 +99,6 @@ public class BackupIntegrityMonitor implements Runnable {
   private final RecoveryMetrics metrics;
   private final HashSet<Long> seen;
 
-  class AzureBlobInfo {
-    public HashMap<String, MessageInfo> azureBlobs;
-    public long partitionBackedUpUntil;
-    public AzureBlobInfo(HashMap<String, MessageInfo> map, long t) {
-      azureBlobs = map;
-      partitionBackedUpUntil = t;
-    }
-  }
-
   public BackupIntegrityMonitor(RecoveryManager azure, ReplicationManager server,
       CompositeClusterManager cluster, StorageManager storage, DataNodeId node,
       VerifiableProperties properties) throws ReflectiveOperationException {
@@ -220,28 +211,30 @@ public class BackupIntegrityMonitor implements Runnable {
    * Compares metadata received from servers with metadata received from Azure cloud
    * @param serverReplica
    * @param cloudReplica
-   * @param partitionBackedUpUntil
    */
-  void compareMetadata(RemoteReplicaInfo serverReplica, RemoteReplicaInfo cloudReplica, long partitionBackedUpUntil) {
+  void compareMetadata(RemoteReplicaInfo serverReplica, RemoteReplicaInfo cloudReplica) {
     long partitionId = serverReplica.getReplicaId().getPartitionId().getId();
-    long scanStartTime, scanEndTime = serverReplica.getReplicatedUntilTime();
-    DateFormat formatter = new SimpleDateFormat(VcrReplicationManager.DATE_FORMAT);
     try {
       serverScanner.addRemoteReplicaInfo(serverReplica);
-      logger.info("[BackupIntegrityMonitor] Queued peer server replica for scan [{}]", serverReplica);
-
-      while (scanEndTime < partitionBackedUpUntil) {
-        scanStartTime = serverReplica.getReplicatedUntilTime();
+      logger.info("[BackupIntegrityMonitor] Starting scanning peer server replica [{}]", serverReplica);
+      StoreFindToken newDiskToken = new StoreFindToken(), oldDiskToken = null;
+      /**
+       * This loop scans the remote peer server replica for metadata of all blobs since the beginning till present time.
+       * The termination condition is that the token from peer, which records the progress of the scan,
+       * remains unchanged between successive calls to replicate(). The fundamental requirement for this
+       * is that we scan __faster__ than the replica grows. Metadata scans are always faster than full data scans.
+       * To further ensure termination, we use a large value for replicationFetchSizeInBytes like 128MB or 256MB,
+       * instead of the default 4MB so that we step faster in larger step sizes through the log.
+       * TODO: There could be a metric to track time to scan a peer replica to ensure we don't loop infinitely.
+       */
+      while (!newDiskToken.equals(oldDiskToken)) {
         serverScanner.replicate();
-        scanEndTime = serverReplica.getReplicatedUntilTime();
-        if (scanEndTime - scanStartTime > SCAN_MILESTONE) {
-          // Print progress, if a SCAN_MILESTONE's worth of data has been received from server
-          logger.info("[BackupIntegrityMonitor] Scanned {} num_server_blobs from peer server replica {} until {}, stop at {}",
-              serverScanner.getNumBlobScanned(), serverReplica, formatter.format(scanEndTime),
-              formatter.format(partitionBackedUpUntil));
-        }
+        oldDiskToken = newDiskToken;
+        newDiskToken = (StoreFindToken) serverReplica.getToken();
+        logger.info("[BackupIntegrityMonitor] Scanned {} num_server_blobs from peer server replica {}, lag = {}",
+            serverScanner.getNumBlobScanned(), serverReplica, serverReplica.getLocalLagFromRemoteInBytes());
       }
-      logger.info("[BackupIntegrityMonitor] Scanned {} num_server_blobs from peer server replica {}",
+      logger.info("[BackupIntegrityMonitor] Completed scanning {} num_server_blobs from peer server replica {}",
           serverScanner.getNumBlobScanned(), serverReplica);
 
       serverScanner.printKeysAbsentInServer(serverReplica);
@@ -295,22 +288,20 @@ public class BackupIntegrityMonitor implements Runnable {
    * @return
    * @throws StoreException
    */
-  AzureBlobInfo getAzureBlobInfoFromLocalStore(BlobStore store) throws StoreException {
+  HashMap<String, MessageInfo> getAzureBlobInfoFromLocalStore(BlobStore store) throws StoreException {
     HashMap<String, MessageInfo> azureBlobs = new HashMap<>();
     StoreFindToken newDiskToken = new StoreFindToken(), oldDiskToken = null;
-    long partitionBackedUpUntil = Utils.Infinite_Time;
     while (!newDiskToken.equals(oldDiskToken)) {
       FindInfo finfo = store.findEntriesSince(newDiskToken, 1000 * (2 << 20),
           null, null);
       for (MessageInfo msg: finfo.getMessageEntries()) {
         azureBlobs.put(msg.getStoreKey().getID(), new MessageInfo(msg, getBlobContentCRC(msg, store)));
-        partitionBackedUpUntil = Math.max(partitionBackedUpUntil, msg.getOperationTimeMs());
       }
       oldDiskToken = newDiskToken;
       newDiskToken = (StoreFindToken) finfo.getFindToken();
       logger.info("[BackupIntegrityMonitor] Disk-token = {}", newDiskToken.toString());
     }
-    return new AzureBlobInfo(azureBlobs, partitionBackedUpUntil);
+    return azureBlobs;
   }
 
 
@@ -333,7 +324,6 @@ public class BackupIntegrityMonitor implements Runnable {
       }
       partitions = partitions.stream()
           .filter(p -> !seen.contains(p.getId()))
-          .filter(p -> p.getId() <= 2000) // pick an older partition, likely backed up completely and is sealed
           .collect(Collectors.toList());
       partition = (AmbryPartition) partitions.get(random.nextInt(partitions.size()));
       seen.add(partition.getId());
@@ -375,24 +365,20 @@ public class BackupIntegrityMonitor implements Runnable {
       /** Compare metadata from server replicas with metadata from Azure */
       List<RemoteReplicaInfo> serverReplicas =
           serverReplicationManager.createRemoteReplicaInfos(replicas, store.getReplicaId());
-      DateFormat formatter = new SimpleDateFormat(VcrReplicationManager.DATE_FORMAT);
       for (RemoteReplicaInfo serverReplica : serverReplicas) {
         /**
          * Find out how far each replica of the partition has been backed-up in Azure.
          * We will use this information to scan the replica until when it has been backed-up.
          * And then compare data in the replica until that point with the backup in Azure.
          */
-        AzureBlobInfo azureBlobInfo = getAzureBlobInfoFromLocalStore(store);
-        if (azureToken.getNumBlobs() != azureBlobInfo.azureBlobs.size()) {
+        HashMap<String, MessageInfo> azureBlobs = getAzureBlobInfoFromLocalStore(store);
+        if (azureToken.getNumBlobs() != azureBlobs.size()) {
           metrics.backupCheckerRuntimeError.inc();
-          logger.error("[BackupIntegrityMonitor] Mismatch, num_azure_blobs = {}, num_azure_blobs on-disk = {}",
-              azureToken.getNumBlobs(), azureBlobInfo.azureBlobs.size());
+          logger.warn("[BackupIntegrityMonitor] Mismatch, num_azure_blobs = {}, num_azure_blobs on-disk = {}",
+              azureToken.getNumBlobs(), azureBlobs.size());
         }
-        logger.info("[BackupIntegrityMonitor] Scanning partition-{} from peer server replica [{}] until {} ({} ms)",
-            partition.getId(), serverReplica, formatter.format(azureBlobInfo.partitionBackedUpUntil),
-            azureBlobInfo.partitionBackedUpUntil);
-        serverScanner.setAzureBlobInfo(azureBlobInfo.azureBlobs, azureBlobInfo.partitionBackedUpUntil);
-        compareMetadata(serverReplica, cloudReplica, azureBlobInfo.partitionBackedUpUntil);
+        serverScanner.setAzureBlobInfo(azureBlobs);
+        compareMetadata(serverReplica, cloudReplica);
       }
     } catch (Throwable e) {
       metrics.backupCheckerRuntimeError.inc();

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/BackupIntegrityMonitor.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/BackupIntegrityMonitor.java
@@ -224,7 +224,7 @@ public class BackupIntegrityMonitor implements Runnable {
        * the progress of the scan. The loop stops if this token remains unchanged between successive calls to the
        * replicate() function. The essential requirement is that our scanning process must outpace the growth rate of
        * the replica. Metadata scans, being lighter than full data scans, ensure faster iteration. To ensure timely
-       * termination, we've increased `replicationFetchSizeInBytes` significantly, such as to 128MB or 256MB, from its
+       * termination, we've increased replicationFetchSizeInBytes significantly, such as to 128MB or 256MB, from its
        * default of 4MB. This adjustment allows us to advance through the log in larger steps.
        * TODO: Consider implementing a metric to monitor the time taken to scan a peer replica to prevent potential
        * TODO: infinite looping.

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestinationSync.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestinationSync.java
@@ -197,6 +197,7 @@ public class AzureCloudDestinationSync implements CloudDestination {
       // The thread that creates this client object is not the thread that uploads blobs to Azure,
       // So we need this fn to create thread-specific caches
       String cacheName = "thread-local-mdcache-" + Thread.currentThread().getName();
+      // Enable cache ifd size > 0, else disable
       threadLocalMdCache.set(new AmbryCache(cacheName, cloudConfig.recentBlobCacheLimit > 0,
           cloudConfig.recentBlobCacheLimit, metrics));
       logger.info("Created AmbryCache {}", threadLocalMdCache.get().toString());

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestinationSync.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestinationSync.java
@@ -197,7 +197,8 @@ public class AzureCloudDestinationSync implements CloudDestination {
       // The thread that creates this client object is not the thread that uploads blobs to Azure,
       // So we need this fn to create thread-specific caches
       String cacheName = "thread-local-mdcache-" + Thread.currentThread().getName();
-      threadLocalMdCache.set(new AmbryCache(cacheName, true, cloudConfig.recentBlobCacheLimit, metrics));
+      threadLocalMdCache.set(new AmbryCache(cacheName, cloudConfig.recentBlobCacheLimit > 0,
+          cloudConfig.recentBlobCacheLimit, metrics));
       logger.info("Created AmbryCache {}", threadLocalMdCache.get().toString());
     }
     return threadLocalMdCache.get();

--- a/ambry-replication/src/main/java/com/github/ambry/replication/BackupCheckerThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/BackupCheckerThread.java
@@ -230,8 +230,7 @@ public class BackupCheckerThread extends ReplicaThread {
           metadata.getMessageInfoList().stream()
               .map(serverBlob -> {
                 numBlobScanned.incrementAndGet();
-                replica.setReplicatedUntilTime(Math.max(replica.getReplicatedUntilTime(),
-                    serverBlob.getOperationTimeMs()));
+                replica.setReplicatedUntilTime(serverBlob.getOperationTimeMs());
                 return mapBlob(serverBlob);
               })
               .filter(serverBlob -> serverBlob.getStoreKey() != null)

--- a/ambry-replication/src/main/java/com/github/ambry/replication/BackupCheckerThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/BackupCheckerThread.java
@@ -82,7 +82,6 @@ public class BackupCheckerThread extends ReplicaThread {
   public static final String BLOB_STATE_MISMATCHES_FILE = "blob_state_mismatches";
   public static final String REPLICA_STATUS_FILE = "server_replica_token";
   protected AtomicInteger numBlobScanned;
-  protected long partitionBackedUpUntil = -1;
 
   public BackupCheckerThread(String threadName, FindTokenHelper findTokenHelper, ClusterMap clusterMap,
       AtomicInteger correlationIdGenerator, DataNodeId dataNodeId, NetworkClient networkClient,
@@ -112,13 +111,12 @@ public class BackupCheckerThread extends ReplicaThread {
     return this.fileManager;
   }
 
-  public void setAzureBlobInfo(HashMap<String, MessageInfo> azureBlobMap, long partitionBackedUpUntil) {
+  public void setAzureBlobInfo(HashMap<String, MessageInfo> azureBlobMap) {
     if (azureBlobMap == null) {
       logger.error("Azure blob map cannot be null");
       return;
     }
     this.azureBlobMap = azureBlobMap;
-    this.partitionBackedUpUntil = partitionBackedUpUntil;
   }
 
   /**
@@ -267,12 +265,6 @@ public class BackupCheckerThread extends ReplicaThread {
                 // 2. cloud compaction executed before server compaction
                 // 3. replication ignored such blobs and did not upload them to azure
                 return !((serverBlob.isDeleted() || serverBlob.isExpired()) && status.contains(BLOB_ABSENT_IN_AZURE));
-              })
-              .filter(tuple -> {
-                MessageInfo serverBlob = (MessageInfo) tuple.getLeft();
-                Set<BlobMatchStatus> status = (Set<BlobMatchStatus>) tuple.getRight();
-                // ignore blobs that are yet to be backed up
-                return !(serverBlob.getOperationTimeMs() > partitionBackedUpUntil && status.contains(BLOB_ABSENT_IN_AZURE));
               })
               .forEach(tuple -> {
                 MessageInfo serverBlob = (MessageInfo) tuple.getLeft();

--- a/ambry-replication/src/main/java/com/github/ambry/replication/RemoteReplicaInfo.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/RemoteReplicaInfo.java
@@ -186,7 +186,7 @@ public class RemoteReplicaInfo {
     }
   }
 
-  long getLocalLagFromRemoteInBytes() {
+  public long getLocalLagFromRemoteInBytes() {
     return localLagFromRemoteStore;
   }
 

--- a/ambry-replication/src/main/java/com/github/ambry/replication/RemoteReplicaInfo.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/RemoteReplicaInfo.java
@@ -186,7 +186,7 @@ public class RemoteReplicaInfo {
     }
   }
 
-  public long getLocalLagFromRemoteInBytes() {
+  long getLocalLagFromRemoteInBytes() {
     return localLagFromRemoteStore;
   }
 

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -932,7 +932,12 @@ public class ReplicaThread implements Runnable {
           || !skipPredicate.test(messageInfo))) {
         remoteMessageToConvertedKeyNonNull.put(messageInfo, convertedKey);
       }
-      lastOpTime = Math.max(lastOpTime, messageInfo.getOperationTimeMs());
+      /**
+       * These message_info timestamps from peer replica do not increase monotonically, rendering them useless
+       * for any practical purpose. However, we still record it here to get an idea of how far along the backup
+       * is done for a partition. Take it with a pinch of salt.
+       */
+      lastOpTime = messageInfo.getOperationTimeMs();
     }
     remoteReplicaInfo.setReplicatedUntilTime(lastOpTime);
     Set<StoreKey> convertedMissingStoreKeys =


### PR DESCRIPTION
The backup checker compares a cloud replica with a peer server's replica to detect inconsistencies. The server replica's size grows indefinitely, necessitating a strategy to limit the replication process. Relying on timestamps from the server replica has proven unreliable because they do not consistently increase. This is due to the server sending combined messages that encompass all state transitions of a blob, including the timestamp of the latest state transition. Depending on this timestamp to decide when to stop replication often results in missing blobs.

For instance, consider a sequence of operations: t1 (put-b1), t2 (put-b2), t3 (update-ttl-b1). The server sends replication messages m1 (b1, t3) and m2 (b2) because b2 appears after b1 in the log. If replication is halted at t3, blob b2 would be missed.

To address this issue, we have opted not to rely on timestamps any longer. Instead, we now monitor the progression of a token. If the token does not advance between successive calls to the `replicate()` function, we decide to terminate the replication process.

The core principle guiding this approach is that our metadata scans of the remote peer server are consistently faster than full data scans. This allows us to advance more rapidly through the log, reducing the risk of indefinite replication.
