### PR TITLE
Issue force delete for 503 delete operations

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
@@ -141,6 +141,7 @@ public class RouterConfig {
   public static final String ROUTER_TTLUPDATE_OFFLINE_REPAIR_ENABLED = "router.ttlupdate.offline.repair.enabled";
   // offline repair partially failed delete request
   public static final String ROUTER_DELETE_OFFLINE_REPAIR_ENABLED = "router.delete.offline.repair.enabled";
+  public static final String ROUTER_FORCE_DELETE_ENABLED = "router.force.delete.enabled";
   // offline repair db factory
   public static final String ROUTER_REPAIR_REQUESTS_DB_FACTORY = "router.repair.requests.db.factory";
   public static final String ROUTER_OPERATION_TRACKER_CHECK_ALL_ORIGINATING_REPLICAS_FOR_NOT_FOUND =
@@ -681,6 +682,15 @@ public class RouterConfig {
   public final boolean routerDeleteOfflineRepairEnabled;
 
   /**
+   * If this config is set to {@code true}, then when a delete operation failed, it will send a force delete request to
+   * its replicas to place a delete tombstone in blob store. Enable force delete would help frontend return success
+   * back to client instead of 503 when client is trying to delete a blob that doesn't exist but we have too many
+   * unavailable replicas to be sure of its nonexistence.
+   */
+  @Config(ROUTER_FORCE_DELETE_ENABLED)
+  public final boolean routerForceDeleteEnabled;
+
+  /**
    * Specify the RepairRequestsDBFactory we use for the background repair.
    */
   @Config(ROUTER_REPAIR_REQUESTS_DB_FACTORY)
@@ -888,6 +898,7 @@ public class RouterConfig {
         : verifiableProperties.getBoolean(ROUTER_TTLUPDATE_OFFLINE_REPAIR_ENABLED, false);
     routerDeleteOfflineRepairEnabled = routerRepairRequestsDbFactory == null ? false
         : verifiableProperties.getBoolean(ROUTER_DELETE_OFFLINE_REPAIR_ENABLED, false);
+    routerForceDeleteEnabled = verifiableProperties.getBoolean(ROUTER_FORCE_DELETE_ENABLED, false);
 
     routerGetBlobRetryLimitInSec = verifiableProperties.getIntInRange(ROUTER_GET_BLOB_RETRY_LIMIT_IN_SEC, 0, 0,
         ROUTER_GET_BLOB_RETRY_LIMIT_IN_SEC_MAX);

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/DeleteRequest.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/DeleteRequest.java
@@ -27,9 +27,9 @@ public class DeleteRequest extends RequestOrResponse {
   private final BlobId blobId;
   private final long deletionTimeInMs;
   private final boolean isForceDelete;
-  static final short DELETE_REQUEST_VERSION_1 = 1;
-  static final short DELETE_REQUEST_VERSION_2 = 2;
-  static final short DELETE_REQUEST_VERSION_3 = 3;
+  public static final short DELETE_REQUEST_VERSION_1 = 1;
+  public static final short DELETE_REQUEST_VERSION_2 = 2;
+  public static final short DELETE_REQUEST_VERSION_3 = 3;
   // TODO Update CURRENT_VERSION to 3 after the change is rolled out on all servers
   private final static short CURRENT_VERSION = DELETE_REQUEST_VERSION_2;
   protected static final int DELETION_TIME_FIELD_SIZE_IN_BYTES = Long.BYTES;

--- a/ambry-router/src/main/java/com/github/ambry/router/DeleteOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/DeleteOperation.java
@@ -81,6 +81,8 @@ class DeleteOperation {
   private final OperationQuotaCharger operationQuotaCharger;
   // Denotes whether the operation is complete.
   private boolean operationCompleted = false;
+  // When this variable is true, create DeleteRequest with force delete to be true.
+  private boolean enableForceDeleteInRequest = false;
 
   private final NonBlockingRouter nonBlockingRouter;
   private ReplicateBlobCallback replicateBlobCallback;
@@ -174,8 +176,13 @@ class DeleteOperation {
    * @return The DeleteRequest.
    */
   private DeleteRequest createDeleteRequest() {
-    return new DeleteRequest(NonBlockingRouter.correlationIdGenerator.incrementAndGet(), routerConfig.routerHostname,
-        blobId, deletionTimeMs);
+    if (!enableForceDeleteInRequest) {
+      return new DeleteRequest(NonBlockingRouter.correlationIdGenerator.incrementAndGet(), routerConfig.routerHostname,
+          blobId, deletionTimeMs);
+    } else {
+      return new DeleteRequest(NonBlockingRouter.correlationIdGenerator.incrementAndGet(), routerConfig.routerHostname,
+          blobId, deletionTimeMs, DeleteRequest.DELETE_REQUEST_VERSION_3, enableForceDeleteInRequest);
+    }
   }
 
   /**
@@ -387,7 +394,7 @@ class DeleteOperation {
     return (routerConfig.routerRepairWithReplicateBlobOnDeleteEnabled && operationTracker.hasNotFound()
         && operationTracker.getSuccessCount() > 0
         && getPrecedenceLevel(errorCode) >= getPrecedenceLevel(RouterErrorCode.AmbryUnavailable)
-        && (serviceId == null || !serviceId.startsWith(BackgroundDeleteRequest.SERVICE_ID_PREFIX)));
+        && !isServiceBackgroundDeleter());
     // @formatter:on
   }
 
@@ -407,7 +414,38 @@ class DeleteOperation {
         && routerConfig.routerDeleteOfflineRepairEnabled
         && operationTracker.getSuccessCount() > 0
         && getPrecedenceLevel(errorCode) >= getPrecedenceLevel(RouterErrorCode.AmbryUnavailable)
-        && (serviceId == null || !serviceId.startsWith(BackgroundDeleteRequest.SERVICE_ID_PREFIX)));
+        && !isServiceBackgroundDeleter());
+    // @formatter:on
+  }
+
+  private boolean shouldIssueForceDelete() {
+    // The conditions to issue force delete to replicas
+    // 1. the feature is enabled
+    // 2. there is no successful replica. If we have success replicas, we should try on demand replication and retry
+    // 3. error code precedence is over AmbryUnavailable. We don't do replication if the error is BlobExpired or TooManyRequests.
+    // 4. error code is not BlobDoesNotExist, when a blob doesn't exist, we shouldn't try to force delete
+    // 5. it's not a delete request from BackgroundDeleter.
+
+    // What does it mean? Here are the cases where we would need to force delete
+    // 1. 2 or 3 originating replicas return unavailable, including replica unavailable, disk unavailable, retry_after_backoff, io_error, network error...
+    // 2. we have 1 leader, 1 bootstrap, 1 offline replica in originating dc. They all return BlobNotFound
+    // 3. we have 1 leader, 1 standby, 1 bootstrap, 1 offline replica in originating dc. They all return BlobNotFound.
+    // These three cases won't return NOT_FOUND and won't trigger on demand replication and offline repair. But force delete
+    // might be able to help.
+    // Force delete shouldn't interfere with on demand replication and offline repair. But when force delete fails, it might
+    // trigger on demand replication.
+
+    // If the operationException is null, then this is a successful delete operation. don't try to issue force delete
+    if (operationException.get() == null) {
+      return false;
+    }
+    RouterErrorCode errorCode = ((RouterException) operationException.get()).getErrorCode();
+    // @formatter:off
+    return (routerConfig.routerForceDeleteEnabled
+        && operationTracker.getSuccessCount() == 0
+        && getPrecedenceLevel(errorCode) >= getPrecedenceLevel(RouterErrorCode.AmbryUnavailable)
+        && errorCode != RouterErrorCode.BlobDoesNotExist
+        && !isServiceBackgroundDeleter());
     // @formatter:on
   }
 
@@ -420,6 +458,11 @@ class DeleteOperation {
       if (operationTracker.hasSucceeded()) {
         operationException.set(null);
       } else {
+        if (enableForceDeleteInRequest) {
+          // We don't expect force delete to fail. Something is not right with servers
+          logger.error("ForceDelete : failed to force delete blob {}", blobId, operationException.get());
+          routerMetrics.forceDeleteBlobErrorCount.inc();
+        }
         // the operation is failed, try to recover with ReplicateBlob
         if (shouldReplicateBlobAndRetry()) {
           // if retryWithReplicateBlob returns true, it's under retry. operation is not completed yet. so return.
@@ -461,8 +504,7 @@ class DeleteOperation {
         }
 
         // Handle the exceptions of the background deleter
-        if (serviceId != null && serviceId.startsWith(BackgroundDeleteRequest.SERVICE_ID_PREFIX)
-            && operationException.get() != null) {
+        if (isServiceBackgroundDeleter() && operationException.get() != null) {
           RouterErrorCode code = ((RouterException) operationException.get()).getErrorCode();
           if (code == RouterErrorCode.BlobDoesNotExist) {
             // NOT_FOUND is not an error for the background deleter.
@@ -477,6 +519,26 @@ class DeleteOperation {
           }
           operationException.set(null);
         }
+
+        // Check if we should issue force delete for this operation.
+        // enableForceDeleteInRequest by default is false, it will be set to true only once here, which means, if it's
+        // already true, then we already enabled force delete but somehow it still failed.
+        if (!enableForceDeleteInRequest && shouldIssueForceDelete()) {
+          // Retry this delete operation with force delete
+          logger.info("Enabling force delete for blob: {}", blobId);
+          routerMetrics.forceDeleteBlobCount.inc();
+          enableForceDeleteInRequest = true;
+          // Reset the operation exception and the operation tracker
+          // Next time if we call operationTracker.isDone, it will return false. And it only returns true when force delete
+          // finishes.
+          operationException.set(null);
+          operationTracker =
+              new SimpleOperationTracker(routerConfig, RouterOperation.DeleteOperation, blobId.getPartition(),
+                  originatingDcName, false, routerMetrics, blobId);
+          deleteRequestInfos.clear();
+          // return here, so we don't have to change quota or set the operationCompleted to true.
+          return;
+        }
       }
       if (QuotaUtils.postProcessCharge(quotaChargeCallback)) {
         try {
@@ -488,6 +550,10 @@ class DeleteOperation {
       }
       operationCompleted = true;
     }
+  }
+
+  private boolean isServiceBackgroundDeleter() {
+    return serviceId != null && serviceId.startsWith(BackgroundDeleteRequest.SERVICE_ID_PREFIX);
   }
 
   /**

--- a/ambry-router/src/main/java/com/github/ambry/router/DeleteOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/DeleteOperation.java
@@ -181,7 +181,7 @@ class DeleteOperation {
           blobId, deletionTimeMs);
     } else {
       return new DeleteRequest(NonBlockingRouter.correlationIdGenerator.incrementAndGet(), routerConfig.routerHostname,
-          blobId, deletionTimeMs, DeleteRequest.DELETE_REQUEST_VERSION_3, enableForceDeleteInRequest);
+          blobId, deletionTimeMs, DeleteRequest.DELETE_REQUEST_VERSION_3, true);
     }
   }
 
@@ -422,7 +422,7 @@ class DeleteOperation {
     // The conditions to issue force delete to replicas
     // 1. the feature is enabled
     // 2. there is no successful replica. If we have success replicas, we should try on demand replication and retry
-    // 3. error code precedence is over AmbryUnavailable. We don't do replication if the error is BlobExpired or TooManyRequests.
+    // 3. error code precedence is over AmbryUnavailable. We don't do force delete if the error is BlobExpired or TooManyRequests.
     // 4. error code is not BlobDoesNotExist, when a blob doesn't exist, we shouldn't try to force delete
     // 5. it's not a delete request from BackgroundDeleter.
 

--- a/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouter.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouter.java
@@ -22,7 +22,6 @@ import com.github.ambry.commons.Callback;
 import com.github.ambry.commons.CallbackUtils;
 import com.github.ambry.commons.ResponseHandler;
 import com.github.ambry.config.RouterConfig;
-import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.messageformat.BlobInfo;
 import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.network.NetworkClient;
@@ -717,6 +716,13 @@ public class NonBlockingRouter implements Router {
         resource.close();
       } catch (IOException e) {
         logger.error("Exception thrown on closing {}", resource.getClass().getName());
+      }
+    }
+    if (repairRequestsDb != null) {
+      try {
+        repairRequestsDb.close();
+      } catch (Exception e) {
+        logger.error("Exception thrown on closing repair requests db", e);
       }
     }
     // close router metrics

--- a/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterMetrics.java
@@ -134,6 +134,8 @@ public class NonBlockingRouterMetrics {
   public final Counter offlineRepairOnDeleteErrorCount;
   public final Counter offlineRepairOnTtlUpdateCount;
   public final Counter offlineRepairOnTtlUpdateErrorCount;
+  public final Counter forceDeleteBlobCount;
+  public final Counter forceDeleteBlobErrorCount;
   public final Counter backgroundDeleterNotFoundCount;
   public final Counter backgroundDeleterExceptionCount;
   public final Counter operationAbortCount;
@@ -501,6 +503,9 @@ public class NonBlockingRouterMetrics {
         metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "OfflineRepairOnTtlUpdateCount"));
     offlineRepairOnTtlUpdateErrorCount =
         metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "OfflineRepairOnTtlUpdateErrorCount"));
+    forceDeleteBlobCount = metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "ForceDeleteBlobCount"));
+    forceDeleteBlobErrorCount =
+        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "ForceDeleteBlobErrorCount"));
     backgroundDeleterNotFoundCount =
         metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "BackgroundDeleterNotFoundCount"));
     backgroundDeleterExceptionCount =


### PR DESCRIPTION
## Summary

Issue a force delete request when the delete request is getting 503. 

## Details
When originating replicas returns more than 1 unavailable to frontend for delete operations, we have to return 503 back to client since we can't be sure about the status of the blob. If we have two unavailable hosts, (due to any reason, server busy, server unavailable, etc), it's impossible to know if this blob exists on these two hosts or not. In this case, we have to return 503 so client can retry later.

However, when executing delete, in most cases, we know it would be fine to place a delete tombstone to available replicas and just return 200 back to client, since the delete is the final state.

There are some catches here. If the cluster enables undelete, we might have some unavailable replicas that have blob at certain lifeVersion. A force delete would place a delete tombstone with life version 0, which will be overritten by the higher life version later. 

## Test
Unit tests.