### PR TITLE
Add latency and success metrics for paranoid durability writes.

### DIFF
--- a/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterMetrics.java
@@ -106,6 +106,8 @@ public class NonBlockingRouterMetrics {
   public final Histogram updateBlobTtlOperationLatencyMs;
   public final Histogram replicateBlobOperationLatencyMs;
   public final Histogram routerRequestLatencyMs;
+  public final Histogram routerPutRequestLocalLatencyMs;
+  public final Histogram routerPutRequestRemoteLatencyMs;
   public final Histogram responseReceiveToHandleLatencyMs;
   public final Histogram getDataChunkLatencyMs;
   public final Histogram getMetadataChunkLatencyMs;
@@ -248,6 +250,9 @@ public class NonBlockingRouterMetrics {
 
   // Number of paranoid durability write failures
   public final Counter paranoidDurabilityFailureCount;
+  // Number of paranoid durability write successes
+  public final Counter paranoidDurabilitySuccessCount;
+
   // Number of times there are not enough replicas available to satisfy paranoid durability write requirements
   public final Counter paranoidDurabilityNotEnoughReplicasCount;
 
@@ -395,6 +400,10 @@ public class NonBlockingRouterMetrics {
         metricRegistry.histogram(MetricRegistry.name(ReplicateBlobOperation.class, "ReplicateBlobOperationLatencyMs"));
     routerRequestLatencyMs =
         metricRegistry.histogram(MetricRegistry.name(NonBlockingRouter.class, "RouterRequestLatencyMs"));
+    routerPutRequestLocalLatencyMs =
+        metricRegistry.histogram(MetricRegistry.name(NonBlockingRouter.class, "RouterPutRequestLocalLatencyMs"));
+    routerPutRequestRemoteLatencyMs =
+        metricRegistry.histogram(MetricRegistry.name(NonBlockingRouter.class, "RouterPutRequestRemoteLatencyMs"));
     responseReceiveToHandleLatencyMs =
         metricRegistry.histogram(MetricRegistry.name(NonBlockingRouter.class, "ResponseReceiveToHandleLatencyMs"));
     getDataChunkLatencyMs =
@@ -622,6 +631,8 @@ public class NonBlockingRouterMetrics {
     // ParanoidDurabilityOperationTracker metrics
     paranoidDurabilityFailureCount =
         metricRegistry.counter(MetricRegistry.name(ParanoidDurabilityOperationTracker.class, "ParanoidDurabilityFailureCount"));
+    paranoidDurabilitySuccessCount =
+        metricRegistry.counter(MetricRegistry.name(ParanoidDurabilityOperationTracker.class, "ParanoidDurabilitySuccessCount"));
     paranoidDurabilityNotEnoughReplicasCount =
         metricRegistry.counter(MetricRegistry.name(ParanoidDurabilityOperationTracker.class, "ParanoidDurabilityNotEnoughReplicasCount"));
 

--- a/ambry-router/src/main/java/com/github/ambry/router/ParanoidDurabilityOperationTracker.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/ParanoidDurabilityOperationTracker.java
@@ -226,6 +226,7 @@ public class ParanoidDurabilityOperationTracker extends SimpleOperationTracker {
   public boolean hasSucceeded() {
     if (hasSucceededLocally() && hasSucceededRemotely()) {
       logger.info("Paranoid durability PUT succeeded for partition " + partitionId);
+      routerMetrics.paranoidDurabilitySuccessCount.inc();
       return true;
     }
     return false;

--- a/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
@@ -1876,6 +1876,13 @@ class PutOperation {
           logger.trace("{}: Cross colo request successful for remote replica in {} ", loggingContext,
               requestInfo.getReplicaId().getDataNodeId().getDatacenterName());
           routerMetrics.crossColoSuccessCount.inc();
+
+          // We use a separate metric to the latency of remote vs local writes (such requests are routed through
+          // ParanoidDurabilityOperationTracker).
+          routerMetrics.routerPutRequestRemoteLatencyMs.update(requestLatencyMs);
+        }
+        else {
+          routerMetrics.routerPutRequestLocalLatencyMs.update(requestLatencyMs);
         }
       } else {
         onErrorResponse(requestInfo.getReplicaId(), putRequestFinalState);


### PR DESCRIPTION
In order to assist with debugging paranoid durability, this pull request adds latency metrics for local and remote writes, as well as a success count for paranoid durability writes (we previously only had a failure count).