### PR TITLE
[vcr-2.0] Add configurable azure-retry policy

### DIFF
--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudConfig.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudConfig.java
@@ -450,12 +450,12 @@ public class AzureCloudConfig {
   public final RetryPolicyType azureRetryPolicy;
 
   public static final String AZURE_RETRY_DELAY_MS = "azure.retry.delay.ms";
-  public static final Long DEFAULT_AZURE_RETRY_DELAY_MS = null;
+  public static final Long DEFAULT_AZURE_RETRY_DELAY_MS = null; // Defaults to 4ms for EXP and 30ms for FIXED
   @Config(AZURE_RETRY_POLICY)
   public final Long azureRetryDelayInMs;
 
   public static final String AZURE_RETRY_DELAY_MAX_MS = "azure.retry.delay.max.ms";
-  public static final Long DEFAULT_AZURE_RETRY_DELAY_MAX_MS = null;
+  public static final Long DEFAULT_AZURE_RETRY_DELAY_MAX_MS = null; // Defaults to 120ms
   @Config(AZURE_RETRY_POLICY)
   public final Long azureMaxRetryDelayInMs;
 

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudConfig.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudConfig.java
@@ -450,12 +450,12 @@ public class AzureCloudConfig {
   public final RetryPolicyType azureRetryPolicy;
 
   public static final String AZURE_RETRY_DELAY_MS = "azure.retry.delay.ms";
-  public static final Long DEFAULT_AZURE_RETRY_DELAY_MS = Long.valueOf(4);
+  public static final Long DEFAULT_AZURE_RETRY_DELAY_MS = Long.valueOf(4); // Defaults from RequestRetryOptions
   @Config(AZURE_RETRY_POLICY)
   public final Long azureRetryDelayInMs;
 
   public static final String AZURE_RETRY_DELAY_MAX_MS = "azure.retry.delay.max.ms";
-  public static final Long DEFAULT_AZURE_RETRY_DELAY_MAX_MS = Long.valueOf(120);
+  public static final Long DEFAULT_AZURE_RETRY_DELAY_MAX_MS = Long.valueOf(120); // Defaults from RequestRetryOptions
   @Config(AZURE_RETRY_POLICY)
   public final Long azureMaxRetryDelayInMs;
 

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudConfig.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudConfig.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.cloud.azure;
 
+import com.azure.storage.common.policy.RetryPolicyType;
 import com.github.ambry.config.CloudConfig;
 import com.github.ambry.config.Config;
 import com.github.ambry.config.Default;
@@ -442,6 +443,22 @@ public class AzureCloudConfig {
   @Config(AZURE_STORAGE_CLIENT_REFRESH_FACTOR)
   public double azureStorageClientRefreshFactor;
 
+
+  public static final String AZURE_RETRY_POLICY = "azure.retry.policy";
+  public static final RetryPolicyType DEFAULT_AZURE_RETRY_POLICY = RetryPolicyType.EXPONENTIAL;
+  @Config(AZURE_RETRY_POLICY)
+  public final RetryPolicyType azureRetryPolicy;
+
+  public static final String AZURE_RETRY_DELAY_MS = "azure.retry.delay.ms";
+  public static final Long DEFAULT_AZURE_RETRY_DELAY_MS = null;
+  @Config(AZURE_RETRY_POLICY)
+  public final Long azureRetryDelayInMs;
+
+  public static final String AZURE_RETRY_DELAY_MAX_MS = "azure.retry.delay.max.ms";
+  public static final Long DEFAULT_AZURE_RETRY_DELAY_MAX_MS = null;
+  @Config(AZURE_RETRY_POLICY)
+  public final Long azureMaxRetryDelayInMs;
+
   public AzureCloudConfig(VerifiableProperties verifiableProperties) {
     // 5000 is the default size of Azure blob storage
     azureBlobStorageMaxResultsPerPage = verifiableProperties.getInt(AZURE_BLOB_STORAGE_MAX_RESULTS_PER_PAGE, 5000);
@@ -456,6 +473,12 @@ public class AzureCloudConfig {
     cosmosKey = verifiableProperties.getString(COSMOS_KEY, "");
     cosmosKeySecretName = verifiableProperties.getString(COSMOS_KEY_SECRET_NAME, "");
     cosmosVaultUrl = verifiableProperties.getString(COSMOS_VAULT_URL, "");
+    azureRetryPolicy =
+        verifiableProperties.getEnum(AZURE_RETRY_POLICY, RetryPolicyType.class, DEFAULT_AZURE_RETRY_POLICY);
+    azureRetryDelayInMs =
+        verifiableProperties.getLong(AZURE_RETRY_DELAY_MS, DEFAULT_AZURE_RETRY_DELAY_MS);
+    azureMaxRetryDelayInMs =
+        verifiableProperties.getLong(AZURE_RETRY_DELAY_MAX_MS, DEFAULT_AZURE_RETRY_DELAY_MAX_MS);
     azureStorageAccountInfo = parseStorageAccountInfo(verifiableProperties.getString(AZURE_STORAGE_ACCOUNT_INFO, ""));
     azureStorageAuthority = verifiableProperties.getString(AZURE_STORAGE_AUTHORITY, "");
     azureStorageClientId = verifiableProperties.getString(AZURE_STORAGE_CLIENTID, "");

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudConfig.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudConfig.java
@@ -445,7 +445,7 @@ public class AzureCloudConfig {
 
 
   public static final String AZURE_RETRY_POLICY = "azure.retry.policy";
-  public static final RetryPolicyType DEFAULT_AZURE_RETRY_POLICY = RetryPolicyType.EXPONENTIAL;
+  public static final RetryPolicyType DEFAULT_AZURE_RETRY_POLICY = RetryPolicyType.FIXED;
   @Config(AZURE_RETRY_POLICY)
   public final RetryPolicyType azureRetryPolicy;
 

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudConfig.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudConfig.java
@@ -451,14 +451,18 @@ public class AzureCloudConfig {
 
   public static final String AZURE_RETRY_DELAY_MS = "azure.retry.delay.ms";
   public static final Long DEFAULT_AZURE_RETRY_DELAY_MS = Long.valueOf(4); // Defaults from RequestRetryOptions
-  @Config(AZURE_RETRY_POLICY)
+  @Config(AZURE_RETRY_DELAY_MS)
   public final Long azureRetryDelayInMs;
 
   public static final String AZURE_RETRY_DELAY_MAX_MS = "azure.retry.delay.max.ms";
   public static final Long DEFAULT_AZURE_RETRY_DELAY_MAX_MS = Long.valueOf(120); // Defaults from RequestRetryOptions
-  @Config(AZURE_RETRY_POLICY)
+  @Config(AZURE_RETRY_DELAY_MAX_MS)
   public final Long azureMaxRetryDelayInMs;
 
+  public static final String AZURE_MAX_TRIES = "azure.max.tries";
+  public static final int DEFAULT_AZURE_MAX_TRIES = 4; // Defaults from RequestRetryOptions
+  @Config(AZURE_MAX_TRIES)
+  public final int azureMaxTries;
   public AzureCloudConfig(VerifiableProperties verifiableProperties) {
     // 5000 is the default size of Azure blob storage
     azureBlobStorageMaxResultsPerPage = verifiableProperties.getInt(AZURE_BLOB_STORAGE_MAX_RESULTS_PER_PAGE, 5000);
@@ -473,12 +477,10 @@ public class AzureCloudConfig {
     cosmosKey = verifiableProperties.getString(COSMOS_KEY, "");
     cosmosKeySecretName = verifiableProperties.getString(COSMOS_KEY_SECRET_NAME, "");
     cosmosVaultUrl = verifiableProperties.getString(COSMOS_VAULT_URL, "");
-    azureRetryPolicy =
-        verifiableProperties.getEnum(AZURE_RETRY_POLICY, RetryPolicyType.class, DEFAULT_AZURE_RETRY_POLICY);
-    azureRetryDelayInMs =
-        verifiableProperties.getLong(AZURE_RETRY_DELAY_MS, DEFAULT_AZURE_RETRY_DELAY_MS);
-    azureMaxRetryDelayInMs =
-        verifiableProperties.getLong(AZURE_RETRY_DELAY_MAX_MS, DEFAULT_AZURE_RETRY_DELAY_MAX_MS);
+    azureMaxRetryDelayInMs = verifiableProperties.getLong(AZURE_RETRY_DELAY_MAX_MS, DEFAULT_AZURE_RETRY_DELAY_MAX_MS);
+    azureRetryPolicy = verifiableProperties.getEnum(AZURE_RETRY_POLICY, RetryPolicyType.class, DEFAULT_AZURE_RETRY_POLICY);
+    azureRetryDelayInMs = verifiableProperties.getLong(AZURE_RETRY_DELAY_MS, DEFAULT_AZURE_RETRY_DELAY_MS);
+    azureMaxTries = verifiableProperties.getInt(AZURE_MAX_TRIES, DEFAULT_AZURE_MAX_TRIES);
     azureStorageAccountInfo = parseStorageAccountInfo(verifiableProperties.getString(AZURE_STORAGE_ACCOUNT_INFO, ""));
     azureStorageAuthority = verifiableProperties.getString(AZURE_STORAGE_AUTHORITY, "");
     azureStorageClientId = verifiableProperties.getString(AZURE_STORAGE_CLIENTID, "");

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudConfig.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudConfig.java
@@ -450,12 +450,12 @@ public class AzureCloudConfig {
   public final RetryPolicyType azureRetryPolicy;
 
   public static final String AZURE_RETRY_DELAY_MS = "azure.retry.delay.ms";
-  public static final Long DEFAULT_AZURE_RETRY_DELAY_MS = null; // Defaults to 4ms for EXP and 30ms for FIXED
+  public static final Long DEFAULT_AZURE_RETRY_DELAY_MS = Long.valueOf(4);
   @Config(AZURE_RETRY_POLICY)
   public final Long azureRetryDelayInMs;
 
   public static final String AZURE_RETRY_DELAY_MAX_MS = "azure.retry.delay.max.ms";
-  public static final Long DEFAULT_AZURE_RETRY_DELAY_MAX_MS = null; // Defaults to 120ms
+  public static final Long DEFAULT_AZURE_RETRY_DELAY_MAX_MS = Long.valueOf(120);
   @Config(AZURE_RETRY_POLICY)
   public final Long azureMaxRetryDelayInMs;
 

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestinationSync.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestinationSync.java
@@ -965,7 +965,7 @@ public class AzureCloudDestinationSync implements CloudDestination {
         // Unknown error, increment the generic metric in azureMetrics
         String error = String.format("Failed to get blob metadata for %s from Azure blob storage due to %s", blobLayout, t.getMessage());
         logger.error(error);
-        throw AzureCloudDestination.toCloudStorageException(error, t, azureMetrics);
+        throw AzureCloudDestination.toCloudStorageException(error, t, null);
       }
     }
     return cloudBlobMetadataMap;

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/StorageClient.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/StorageClient.java
@@ -441,7 +441,7 @@ public abstract class StorageClient implements AzureStorageClient {
       Integer tryTimeoutInSeconds =
           Math.toIntExact(Math.max(1, TimeUnit.MILLISECONDS.toSeconds(cloudConfig.cloudRequestTimeout)));
       RequestRetryOptions retryOptions =
-          new RequestRetryOptions(azureCloudConfig.azureRetryPolicy, null, tryTimeoutInSeconds,
+          new RequestRetryOptions(azureCloudConfig.azureRetryPolicy, azureCloudConfig.azureMaxTries, tryTimeoutInSeconds,
               azureCloudConfig.azureRetryDelayInMs, azureCloudConfig.azureMaxRetryDelayInMs, null);
       return buildBlobServiceSyncClient(client, new ConfigurationBuilder().build(), retryOptions, azureCloudConfig);
     } catch (MalformedURLException | InterruptedException | ExecutionException ex) {

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/StorageClient.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/StorageClient.java
@@ -441,8 +441,8 @@ public abstract class StorageClient implements AzureStorageClient {
       Integer tryTimeoutInSeconds =
           Math.toIntExact(Math.max(1, TimeUnit.MILLISECONDS.toSeconds(cloudConfig.cloudRequestTimeout)));
       RequestRetryOptions retryOptions =
-          new RequestRetryOptions(RetryPolicyType.FIXED, null, tryTimeoutInSeconds,
-              null, null, null);
+          new RequestRetryOptions(azureCloudConfig.azureRetryPolicy, null, tryTimeoutInSeconds,
+              azureCloudConfig.azureRetryDelayInMs, azureCloudConfig.azureMaxRetryDelayInMs, null);
       return buildBlobServiceSyncClient(client, new ConfigurationBuilder().build(), retryOptions, azureCloudConfig);
     } catch (MalformedURLException | InterruptedException | ExecutionException ex) {
       logger.error("Error building ABS blob service client: {}", ex.getMessage());

--- a/build.gradle
+++ b/build.gradle
@@ -197,17 +197,6 @@ project(':ambry-utils') {
         compile "org.json:json:$jsonVersion"
         compile "net.sf.jopt-simple:jopt-simple:$joptSimpleVersion"
         compile "io.netty:netty-all:$nettyVersion"
-
-        // use compile to include these jars during compile-time and make it avlb for ambry-tools
-        // https://mvnrepository.com/artifact/com.azure/azure-sdk-bom
-        compile platform("com.azure:azure-sdk-bom:$azureSdkBom")
-        compile "com.azure:azure-cosmos"
-        compile "com.azure:azure-data-tables"
-        compile "com.azure:azure-identity"
-        compile "com.azure:azure-security-keyvault-secrets"
-        compile "com.azure:azure-storage-blob"
-        compile "com.azure:azure-storage-blob-batch"
-
         testCompile project(":ambry-test-utils")
         testCompile "io.netty:netty-transport-native-epoll:$nettyVersion"
     }
@@ -505,6 +494,16 @@ project(':ambry-cloud') {
             project(':ambry-account'),
             project(':ambry-replication'),
             project(':ambry-rest')
+
+        // use compile to include these jars during compile-time and make it avlb for ambry-tools
+        // https://mvnrepository.com/artifact/com.azure/azure-sdk-bom
+        compile platform("com.azure:azure-sdk-bom:$azureSdkBom")
+        compile "com.azure:azure-cosmos"
+        compile "com.azure:azure-data-tables"
+        compile "com.azure:azure-identity"
+        compile "com.azure:azure-security-keyvault-secrets"
+        compile "com.azure:azure-storage-blob"
+        compile "com.azure:azure-storage-blob-batch"
 
         compile "io.dropwizard.metrics:metrics-core:$metricsVersion"
         compile "io.dropwizard.metrics:metrics-jmx:$metricsVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -197,6 +197,17 @@ project(':ambry-utils') {
         compile "org.json:json:$jsonVersion"
         compile "net.sf.jopt-simple:jopt-simple:$joptSimpleVersion"
         compile "io.netty:netty-all:$nettyVersion"
+
+        // use compile to include these jars during compile-time and make it avlb for ambry-tools
+        // https://mvnrepository.com/artifact/com.azure/azure-sdk-bom
+        compile platform("com.azure:azure-sdk-bom:$azureSdkBom")
+        compile "com.azure:azure-cosmos"
+        compile "com.azure:azure-data-tables"
+        compile "com.azure:azure-identity"
+        compile "com.azure:azure-security-keyvault-secrets"
+        compile "com.azure:azure-storage-blob"
+        compile "com.azure:azure-storage-blob-batch"
+
         testCompile project(":ambry-test-utils")
         testCompile "io.netty:netty-transport-native-epoll:$nettyVersion"
     }
@@ -494,16 +505,6 @@ project(':ambry-cloud') {
             project(':ambry-account'),
             project(':ambry-replication'),
             project(':ambry-rest')
-
-        // use compile to include these jars during compile-time and make it avlb for ambry-tools
-        // https://mvnrepository.com/artifact/com.azure/azure-sdk-bom
-        compile platform("com.azure:azure-sdk-bom:$azureSdkBom")
-        compile "com.azure:azure-cosmos"
-        compile "com.azure:azure-data-tables"
-        compile "com.azure:azure-identity"
-        compile "com.azure:azure-security-keyvault-secrets"
-        compile "com.azure:azure-storage-blob"
-        compile "com.azure:azure-storage-blob-batch"
 
         compile "io.dropwizard.metrics:metrics-core:$metricsVersion"
         compile "io.dropwizard.metrics:metrics-jmx:$metricsVersion"


### PR DESCRIPTION
We are experiencing some throttling from Azure Storage as we keep expanding the VCR cluster. Azure support suggested trying exponential backoff. This patch changes the FIXED backoff policy into a configurable one allowing us to try different policies and retry-delays.