### PR TITLE
[vcr-2.0] Fix nullptr in ReplicationMetrics

### DIFF
--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationMetrics.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationMetrics.java
@@ -639,7 +639,9 @@ public class ReplicationMetrics {
     String getRequestErrorMetricName =
         remoteReplica.getDataNodeId().getHostname() + "-" + remoteReplica.getDataNodeId().getPort() + "-"
             + remoteReplica.getPartitionId().toString() + "-getRequestError";
-    getRequestErrorMap.get(getRequestErrorMetricName).inc();
+    if (getRequestErrorMap.containsKey(getRequestErrorMetricName)) {
+      getRequestErrorMap.get(getRequestErrorMetricName).inc();
+    }
   }
 
   public void updateLocalStoreError(ReplicaId remoteReplica) {


### PR DESCRIPTION
Encountering missing metric in VCR. Not sure why because the code that adds it seems to be ok. We don't really rely on this metric in VCR, so just patching up the code to not run into a nullptr.