### PR TITLE
[vcr-2.0] Remove unnecessary sleep in azure-client

### DIFF
--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/StorageClient.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/StorageClient.java
@@ -435,8 +435,8 @@ public abstract class StorageClient implements AzureStorageClient {
        retryPolicyType – null defaults to EXPONENTIAL
        maxTries – null defaults to 4
        tryTimeoutInSeconds –
-       - null defaults to Integer.MAX_VALUE seconds, so set to cloudRequestTimeout. Should be between 1 and 2147483647
-       - Azure SDK disregards MAX_VALUE and does not sleep. We are using sync-calls that block anyways for a specified duration.
+       - null defaults to Integer.MAX_VALUE seconds.
+       - Azure SDK disregards MAX_VALUE and does not sleep. We are using sync-calls that block for a specified duration.
        retryDelayInMs – null defaults to 4ms when retryPolicyType is EXPONENTIAL
        maxRetryDelayInMs – null defaults to 120ms
        */

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/StorageClient.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/StorageClient.java
@@ -442,7 +442,7 @@ public abstract class StorageClient implements AzureStorageClient {
        */
       RequestRetryOptions retryOptions =
           new RequestRetryOptions(azureCloudConfig.azureRetryPolicy, azureCloudConfig.azureMaxTries, null,
-              azureCloudConfig.azureRetryDelayInMs, azureCloudConfig.azureMaxRetryDelayInMs, null);
+              azureCloudConfig.azureRetryDelayInSec, azureCloudConfig.azureMaxRetryDelayInSec, null);
       return buildBlobServiceSyncClient(client, new ConfigurationBuilder().build(), retryOptions, azureCloudConfig);
     } catch (MalformedURLException | InterruptedException | ExecutionException ex) {
       logger.error("Error building ABS blob service client: {}", ex.getMessage());

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/StorageClient.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/StorageClient.java
@@ -434,14 +434,14 @@ public abstract class StorageClient implements AzureStorageClient {
       /*
        retryPolicyType – null defaults to EXPONENTIAL
        maxTries – null defaults to 4
-       tryTimeoutInSeconds – null defaults to Integer.MAX_VALUE seconds, so set to cloudRequestTimeout. Should be between 1 and 2147483647
+       tryTimeoutInSeconds –
+       - null defaults to Integer.MAX_VALUE seconds, so set to cloudRequestTimeout. Should be between 1 and 2147483647
+       - Azure SDK disregards MAX_VALUE and does not sleep. We are using sync-calls that block anyways for a specified duration.
        retryDelayInMs – null defaults to 4ms when retryPolicyType is EXPONENTIAL
        maxRetryDelayInMs – null defaults to 120ms
        */
-      Integer tryTimeoutInSeconds =
-          Math.toIntExact(Math.max(1, TimeUnit.MILLISECONDS.toSeconds(cloudConfig.cloudRequestTimeout)));
       RequestRetryOptions retryOptions =
-          new RequestRetryOptions(azureCloudConfig.azureRetryPolicy, azureCloudConfig.azureMaxTries, tryTimeoutInSeconds,
+          new RequestRetryOptions(azureCloudConfig.azureRetryPolicy, azureCloudConfig.azureMaxTries, null,
               azureCloudConfig.azureRetryDelayInMs, azureCloudConfig.azureMaxRetryDelayInMs, null);
       return buildBlobServiceSyncClient(client, new ConfigurationBuilder().build(), retryOptions, azureCloudConfig);
     } catch (MalformedURLException | InterruptedException | ExecutionException ex) {


### PR DESCRIPTION
The Azure SDK interprets the tryTimeoutInSeconds as sleep duration after each request to Azure. However, we are using a sync-client which blocks for the same duration waiting on a response. So we don't need an additional sleep in the client due to tryTimeoutInSeconds. 

The above is azure-blob-client. Also, fixes azure-table-client similarly.