### PR TITLE
[vcr-2.0] Delete blob eagerly

### DIFF
--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobStore.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobStore.java
@@ -638,8 +638,7 @@ public class CloudBlobStore implements Store {
   public void delete(List<MessageInfo> infos) throws StoreException {
     try {
       for (MessageInfo msg : infos) {
-        cloudDestination.deleteBlob((BlobId) msg.getStoreKey(), msg.getOperationTimeMs(), msg.getLifeVersion(),
-            this::preDeleteValidation);
+        cloudDestination.deleteBlob((BlobId) msg.getStoreKey(), msg.getOperationTimeMs(), msg.getLifeVersion(), null);
       }
     } catch (CloudStorageException cse) {
       if (cse.getCause() instanceof StoreException) {

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureBlobDeletePolicy.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureBlobDeletePolicy.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2024 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.cloud.azure;
+
+public enum AzureBlobDeletePolicy {
+  /**
+   * Attach a delete-timestamp to azure-blob, but do not delete it.
+   * Let compaction job eventually delete the blob.
+   */
+  EVENTUAL,
+  /**
+   * Just delete the blob when a DELETE message is received from server.
+   */
+  IMMEDIATE
+}

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudConfig.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudConfig.java
@@ -463,8 +463,15 @@ public class AzureCloudConfig {
   public static final int DEFAULT_AZURE_MAX_TRIES = 4; // Defaults from RequestRetryOptions
   @Config(AZURE_MAX_TRIES)
   public final int azureMaxTries;
+
+  public static final String AZURE_BLOB_DELETE_POLICY = "azure.blob.delete.policy";
+  public final AzureBlobDeletePolicy DEFAULT_AZURE_BLOB_DELETE_POLICY = AzureBlobDeletePolicy.EVENTUAL;
+  @Config(AZURE_BLOB_DELETE_POLICY)
+  public final AzureBlobDeletePolicy azureBlobDeletePolicy;
+
   public AzureCloudConfig(VerifiableProperties verifiableProperties) {
     // 5000 is the default size of Azure blob storage
+    azureBlobDeletePolicy = verifiableProperties.getEnum(AZURE_BLOB_DELETE_POLICY, AzureBlobDeletePolicy.class, DEFAULT_AZURE_BLOB_DELETE_POLICY);
     azureBlobStorageMaxResultsPerPage = verifiableProperties.getInt(AZURE_BLOB_STORAGE_MAX_RESULTS_PER_PAGE, 5000);
     azureStorageConnectionString = verifiableProperties.getString(AZURE_STORAGE_CONNECTION_STRING, "");
     azureTableConnectionString = verifiableProperties.getString(AZURE_TABLE_CONNECTION_STRING, "");

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudConfig.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudConfig.java
@@ -470,9 +470,8 @@ public class AzureCloudConfig {
   public final AzureBlobDeletePolicy azureBlobDeletePolicy;
 
   public AzureCloudConfig(VerifiableProperties verifiableProperties) {
-    // 5000 is the default size of Azure blob storage
     azureBlobDeletePolicy = verifiableProperties.getEnum(AZURE_BLOB_DELETE_POLICY, AzureBlobDeletePolicy.class, DEFAULT_AZURE_BLOB_DELETE_POLICY);
-    azureBlobStorageMaxResultsPerPage = verifiableProperties.getInt(AZURE_BLOB_STORAGE_MAX_RESULTS_PER_PAGE, 5000);
+    azureBlobStorageMaxResultsPerPage = verifiableProperties.getInt(AZURE_BLOB_STORAGE_MAX_RESULTS_PER_PAGE, 5000); // 5000 is the default size of Azure blob storage
     azureStorageConnectionString = verifiableProperties.getString(AZURE_STORAGE_CONNECTION_STRING, "");
     azureTableConnectionString = verifiableProperties.getString(AZURE_TABLE_CONNECTION_STRING, "");
     azureTableNameCorruptBlobs = verifiableProperties.getString(AZURE_TABLE_NAME_CORRUPT_BLOBS, DEFAULT_AZURE_TABLE_NAME_CORRUPT_BLOBS);

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudConfig.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudConfig.java
@@ -471,7 +471,8 @@ public class AzureCloudConfig {
 
   public AzureCloudConfig(VerifiableProperties verifiableProperties) {
     azureBlobDeletePolicy = verifiableProperties.getEnum(AZURE_BLOB_DELETE_POLICY, AzureBlobDeletePolicy.class, DEFAULT_AZURE_BLOB_DELETE_POLICY);
-    azureBlobStorageMaxResultsPerPage = verifiableProperties.getInt(AZURE_BLOB_STORAGE_MAX_RESULTS_PER_PAGE, 5000); // 5000 is the default size of Azure blob storage
+    // 5000 is the default size of Azure blob storage
+    azureBlobStorageMaxResultsPerPage = verifiableProperties.getInt(AZURE_BLOB_STORAGE_MAX_RESULTS_PER_PAGE, 5000);
     azureStorageConnectionString = verifiableProperties.getString(AZURE_STORAGE_CONNECTION_STRING, "");
     azureTableConnectionString = verifiableProperties.getString(AZURE_TABLE_CONNECTION_STRING, "");
     azureTableNameCorruptBlobs = verifiableProperties.getString(AZURE_TABLE_NAME_CORRUPT_BLOBS, DEFAULT_AZURE_TABLE_NAME_CORRUPT_BLOBS);

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestinationSync.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestinationSync.java
@@ -708,20 +708,7 @@ public class AzureCloudDestinationSync implements CloudDestination {
       logger.trace("Successfully updated deleteTime of blob {} in Azure blob storage with statusCode = {}, etag = {}",
           blobLayout.blobFilePath, response.getStatusCode(), response.getHeaders().get(HttpHeaderName.ETAG));
       return true;
-    } catch (BlobStorageException bse) {
-      String error = String.format("Failed to update deleteTime of blob %s in Azure blob storage due to (%s)", blobLayout, bse.getMessage());
-      if (bse.getErrorCode() == BlobErrorCode.CONDITION_NOT_MET) {
-        /*
-          If we are here, it just means that two threads tried to delete concurrently. This is ok.
-         */
-        logger.trace(error);
-        return true;
-      }
-      azureMetrics.blobUpdateDeleteTimeErrorCount.inc();
-      logger.error(error);
-      throw toCloudStorageException(error, bse);
     } catch (Throwable t) {
-      // Unknown error
       azureMetrics.blobUpdateDeleteTimeErrorCount.inc();
       String error = String.format("Failed to update deleteTime of blob %s in Azure blob storage due to (%s)", blobLayout, t.getMessage());
       logger.error(error);

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestinationSync.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestinationSync.java
@@ -669,7 +669,7 @@ public class AzureCloudDestinationSync implements CloudDestination {
           "CUSTOMER_DELETE_REQUEST");
     }
 
-
+    // AzureBlobDeletePolicy.EVENTUAL
     Map<String, Object> newMetadata = new HashMap<>();
     newMetadata.put(CloudBlobMetadata.FIELD_DELETION_TIME, String.valueOf(deletionTime));
     newMetadata.put(CloudBlobMetadata.FIELD_LIFE_VERSION, lifeVersion);

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestinationSync.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestinationSync.java
@@ -690,7 +690,7 @@ public class AzureCloudDestinationSync implements CloudDestination {
         throw new StoreException(error, StoreErrorCodes.Life_Version_Conflict);
       }
 
-      if (cloudMetadata.containsKey(CloudBlobMetadata.FIELD_DELETION_TIME)) {
+      if (cloudlifeVersion == lifeVersion && cloudMetadata.containsKey(CloudBlobMetadata.FIELD_DELETION_TIME)) {
         String error = String.format("Failed to update deleteTime of blob %s as it is marked for deletion in cloud", blobIdStr);
         logger.trace(error);
         throw new StoreException(error, StoreErrorCodes.ID_Deleted);

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestinationSync.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestinationSync.java
@@ -657,6 +657,10 @@ public class AzureCloudDestinationSync implements CloudDestination {
     }
   }
 
+  CloudStorageException toCloudStorageException(String msg, Throwable t) {
+    return new CloudStorageException(msg, t);
+  }
+
   @Override
   public boolean deleteBlob(BlobId blobId, long deletionTime, short lifeVersion,
       CloudUpdateValidator cloudUpdateValidator) throws CloudStorageException {
@@ -685,16 +689,16 @@ public class AzureCloudDestinationSync implements CloudDestination {
           String error = String.format("Failed to update deleteTime of blob %s as it has a higher life version in cloud than replicated message: %s > %s",
               blobIdStr, cloudlifeVersion, lifeVersion);
           logger.trace(error);
-          throw AzureCloudDestination.toCloudStorageException(error, new StoreException(error, StoreErrorCodes.Life_Version_Conflict), null);
+          throw new StoreException(error, StoreErrorCodes.Life_Version_Conflict);
         }
         String error = String.format("Failed to update deleteTime of blob %s as it is marked for deletion in cloud", blobIdStr);
         logger.trace(error);
-        throw AzureCloudDestination.toCloudStorageException(error, new StoreException(error, StoreErrorCodes.ID_Deleted), null);
+        throw new StoreException(error, StoreErrorCodes.ID_Deleted);
       }
     } catch (StoreException e) {
       azureMetrics.blobUpdateDeleteTimeErrorCount.inc();
       String error = String.format("Failed to update deleteTime of blob %s in Azure blob storage due to (%s)", blobLayout, e.getMessage());
-      throw AzureCloudDestination.toCloudStorageException(error, e, null);
+      throw toCloudStorageException(error, e);
     }
 
     newMetadata.forEach((k,v) -> cloudMetadata.put(k, String.valueOf(v)));
@@ -717,13 +721,13 @@ public class AzureCloudDestinationSync implements CloudDestination {
       }
       azureMetrics.blobUpdateDeleteTimeErrorCount.inc();
       logger.error(error);
-      throw AzureCloudDestination.toCloudStorageException(error, bse, null);
+      throw toCloudStorageException(error, bse);
     } catch (Throwable t) {
       // Unknown error
       azureMetrics.blobUpdateDeleteTimeErrorCount.inc();
       String error = String.format("Failed to update deleteTime of blob %s in Azure blob storage due to (%s)", blobLayout, t.getMessage());
       logger.error(error);
-      throw AzureCloudDestination.toCloudStorageException(error, t, null);
+      throw toCloudStorageException(error, t);
     } finally {
       storageTimer.stop();
     } // try-catch

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestinationSync.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestinationSync.java
@@ -995,8 +995,8 @@ public class AzureCloudDestinationSync implements CloudDestination {
     storageTimer.stop();
     switch (response.getStatusCode()) {
       case HttpStatus.SC_ACCEPTED:
-        logger.trace("[ERASE] Erased blob {} from Azure blob storage, reason = {}, status = {}", blobClient.getBlobName(),
-            eraseReason, response.getStatusCode());
+        logger.trace("[ERASE] Erased blob {}/{} from Azure blob storage, reason = {}, status = {}",
+            blobClient.getContainerName(), blobClient.getBlobName(), eraseReason, response.getStatusCode());
         azureMetrics.blobCompactionSuccessRate.mark();
         isErased = true;
         break;
@@ -1005,8 +1005,8 @@ public class AzureCloudDestinationSync implements CloudDestination {
       default:
         // Just increment a counter and set an alert on it. No need to throw an error and fail the thread.
         azureMetrics.blobCompactionErrorCount.inc();
-        logger.error("[ERASE] Failed to erase blob {} from Azure blob storage with status {}", blobClient.getBlobName(),
-            response.getStatusCode());
+        logger.error("[ERASE] Failed to erase blob {}/{} from Azure blob storage with status {}",
+            blobClient.getContainerName(), blobClient.getBlobName(), response.getStatusCode());
     }
     return isErased;
   }

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestinationSync.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestinationSync.java
@@ -663,6 +663,13 @@ public class AzureCloudDestinationSync implements CloudDestination {
     Timer.Context storageTimer = azureMetrics.blobUpdateDeleteTimeLatency.time();
     AzureBlobLayoutStrategy.BlobLayout blobLayout = azureBlobLayoutStrategy.getDataBlobLayout(blobId);
     String blobIdStr = blobLayout.blobFilePath;
+
+    if (azureCloudConfig.azureBlobDeletePolicy.equals(AzureBlobDeletePolicy.IMMEDIATE)) {
+      return eraseBlob(createOrGetBlobStore(blobLayout.containerName).getBlobClient(blobLayout.blobFilePath),
+          "CUSTOMER_DELETE_REQUEST");
+    }
+
+
     Map<String, Object> newMetadata = new HashMap<>();
     newMetadata.put(CloudBlobMetadata.FIELD_DELETION_TIME, String.valueOf(deletionTime));
     newMetadata.put(CloudBlobMetadata.FIELD_LIFE_VERSION, lifeVersion);
@@ -979,6 +986,31 @@ public class AzureCloudDestinationSync implements CloudDestination {
     throw new UnsupportedOperationException("findEntriesSince will not be implemented for AzureCloudDestinationSync");
   }
 
+  protected boolean eraseBlob(BlobClient blobClient, String eraseReason) {
+    Timer.Context storageTimer = azureMetrics.blobCompactionLatency.time();
+    BlobRequestConditions blobRequestConditions = new BlobRequestConditions().setIfMatch("*");
+    Response<Void> response = blobClient.deleteWithResponse(DeleteSnapshotsOptionType.INCLUDE,
+        blobRequestConditions, Duration.ofMillis(cloudConfig.cloudRequestTimeout), Context.NONE);
+    boolean isErased = false;
+    storageTimer.stop();
+    switch (response.getStatusCode()) {
+      case HttpStatus.SC_ACCEPTED:
+        logger.trace("[ERASE] Erased blob {} from Azure blob storage, reason = {}, status = {}", blobClient.getBlobName(),
+            eraseReason, response.getStatusCode());
+        azureMetrics.blobCompactionSuccessRate.mark();
+        isErased = true;
+        break;
+      case HttpStatus.SC_NOT_FOUND:
+        // If you're trying to delete a blob, it must exist. If it doesn't, then there is something wrong in the code.
+      default:
+        // Just increment a counter and set an alert on it. No need to throw an error and fail the thread.
+        azureMetrics.blobCompactionErrorCount.inc();
+        logger.error("[ERASE] Failed to erase blob {} from Azure blob storage with status {}", blobClient.getBlobName(),
+            response.getStatusCode());
+    }
+    return isErased;
+  }
+
   /**
    * Erases blobs from a given list of blobs in cloud
    * @param blobItemList List of blobs in a container
@@ -1025,24 +1057,7 @@ public class AzureCloudDestinationSync implements CloudDestination {
           logger.trace("[DRY-RUN][COMPACT] Can erase blob {} from Azure blob storage because {}", blobItem.getName(), eraseReason);
           numBlobsPurged += 1;
         } else {
-          Timer.Context storageTimer = azureMetrics.blobCompactionLatency.time();
-          Response<Void> response = blobContainerClient.getBlobClient(blobItem.getName())
-              .deleteWithResponse(DeleteSnapshotsOptionType.INCLUDE, null, null, null);
-          storageTimer.stop();
-          switch (response.getStatusCode()) {
-            case HttpStatus.SC_ACCEPTED:
-              logger.trace("[COMPACT] Erased blob {} from Azure blob storage, reason = {}, status = {}", blobItem.getName(),
-                  eraseReason, response.getStatusCode());
-              numBlobsPurged += 1;
-              azureMetrics.blobCompactionSuccessRate.mark();
-              break;
-            case HttpStatus.SC_NOT_FOUND:
-            default:
-              // Just increment a counter and set an alert on it. No need to throw an error and fail the thread.
-              azureMetrics.blobCompactionErrorCount.inc();
-              logger.error("[COMPACT] Failed to erase blob {} from Azure blob storage with status {}", blobItem.getName(),
-                  response.getStatusCode());
-          }
+          numBlobsPurged += eraseBlob(blobContainerClient.getBlobClient(blobItem.getName()), eraseReason) ? 1 : 0;
         }
       } else {
         logger.trace("[COMPACT] Cannot erase blob {} from Azure blob storage because condition not met: {}", blobItem.getName(), eraseReason);

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestinationSync.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestinationSync.java
@@ -1001,12 +1001,13 @@ public class AzureCloudDestinationSync implements CloudDestination {
         isErased = true;
         break;
       case HttpStatus.SC_NOT_FOUND:
-        // If you're trying to delete a blob, it must exist. If it doesn't, then there is something wrong in the code.
+        // If you're trying to delete a blob, then it must exist.
+        // If it doesn't, then there is something wrong in the code. Go figure it out !
       default:
         // Just increment a counter and set an alert on it. No need to throw an error and fail the thread.
         azureMetrics.blobCompactionErrorCount.inc();
-        logger.error("[ERASE] Failed to erase blob {}/{} from Azure blob storage with status {}",
-            blobClient.getContainerName(), blobClient.getBlobName(), response.getStatusCode());
+        logger.error("[ERASE] Failed to erase blob {}/{} from Azure blob storage, reason = {}, status {}",
+            blobClient.getContainerName(), blobClient.getBlobName(), eraseReason, response.getStatusCode());
     }
     return isErased;
   }

--- a/ambry-vcr/src/test/java/com/github/ambry/vcr/CloudBlobStoreTest.java
+++ b/ambry-vcr/src/test/java/com/github/ambry/vcr/CloudBlobStoreTest.java
@@ -793,17 +793,6 @@ public class CloudBlobStoreTest {
           any(CloudUpdateValidator.class));
     }
     verifyCacheHits(count * 4 + numPuts, count * 2);
-
-    // Test 5: Try to upload a set of blobs containing duplicates. This should fail.
-    List<MessageInfo> messageInfoList = new ArrayList<>(messageInfoMap.values());
-    messageInfoList.add(messageInfoList.get(messageInfoMap.values().size() - 1));
-    try {
-      store.delete(messageInfoList);
-      fail("delete must throw an exception for duplicates");
-    } catch (IllegalArgumentException iaex) {
-      assumeTrue(iaex.getMessage().startsWith("list contains duplicates"));
-    }
-    verifyCacheHits(count * 4 + numPuts, count * 2);
   }
 
   /** Test the CloudBlobStore updateTtl method. */


### PR DESCRIPTION
Implementing immediate blob deletion from the cloud once the VCR receives a DEL message from the server via replication. This approach offers several advantages over our current method, where instead of deleting the blob outright, we currently add a delete-timestamp to Azure blob metadata. Compaction then deletes the blob later based on this timestamp.

The benefits of the new approach include:
1. Proactively reclaiming space in Azure.
2. Reducing the number of network calls required to delete a blob; currently, it involves 2 network calls to attach a timestamp and another 2 network calls from compaction to remove the blob.
3. Decreasing the size of the response from the list-metadata API used by compaction to list all blobs in an Azure partition.

Based on customer usage patterns, few customers utilize the undelete feature. If the VCR receives an undelete request after a blob has been removed from the cloud, it will be re-uploaded to the cloud using the replication protocol.

This patch also removes some unused legacy code