### PR TITLE
Ambry batch delete support - protocol changes

### DIFF
--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/BatchDeletePartitionRequestInfo.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/BatchDeletePartitionRequestInfo.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.protocol;
+
+import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.clustermap.PartitionId;
+import com.github.ambry.commons.BlobId;
+import com.github.ambry.store.StoreKey;
+import io.netty.buffer.ByteBuf;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+
+/**
+ * Represents a partition and a list of blob ids that need to be deleted from that partition.
+ */
+public class BatchDeletePartitionRequestInfo {
+  private static final int BLOB_ID_LIST_SIZE_IN_BYTES = Integer.BYTES;
+  private final PartitionId partitionId;
+  private final List<BlobId> blobIds;
+  private long totalBlobIdsSizeInBytes;
+
+  public BatchDeletePartitionRequestInfo(PartitionId partitionId, List<BlobId> blobIds) {
+    this.partitionId = partitionId;
+    this.blobIds = blobIds;
+    totalBlobIdsSizeInBytes = 0;
+    for (BlobId id : blobIds) {
+      totalBlobIdsSizeInBytes += id.sizeInBytes();
+      if (!partitionId.toPathString().equals(id.getPartition().toPathString())) {
+        throw new IllegalArgumentException("Not all blob IDs in BatchDeleteRequest are from the same partition.");
+      }
+    }
+  }
+
+  /**
+   * @return the {@link PartitionId} of the partition from which blobs need to be deleted.
+   */
+  public PartitionId getPartition() {
+    return partitionId;
+  }
+
+  /**
+   * @return the list of blob ids that need to be deleted from the partition.
+   */
+  public List<? extends StoreKey> getBlobIds() {
+    return blobIds;
+  }
+
+  /**
+   * Reads from a stream and constructs a {@link BatchDeletePartitionRequestInfo}.
+   * @param stream the {@link DataInputStream} to read from
+   * @param clusterMap the {@link ClusterMap} to use
+   * @return the constructed {@link BatchDeletePartitionRequestInfo}
+   * @throws IOException
+   */
+  public static BatchDeletePartitionRequestInfo readFrom(DataInputStream stream, ClusterMap clusterMap)
+      throws IOException {
+    int blobCount = stream.readInt();
+    List<BlobId> blobIds = new ArrayList<>(blobCount);
+    PartitionId partitionId = null;
+    for (int i = 0; i < blobCount; i++) {
+      BlobId blobId = new BlobId(stream, clusterMap);
+      if (partitionId == null) {
+        partitionId = blobId.getPartition();
+      }
+      blobIds.add(blobId);
+    }
+    return new BatchDeletePartitionRequestInfo(partitionId, blobIds);
+  }
+
+  /**
+   * Writes the constituents of {@link BatchDeletePartitionRequestInfo} to the given {@link ByteBuf}.
+   * @param byteBuf the {@link ByteBuf} to write to.
+   */
+  public void writeTo(ByteBuf byteBuf) {
+    byteBuf.writeInt(blobIds.size());
+    for (BlobId blobId : blobIds) {
+      byteBuf.writeBytes(blobId.toBytes());
+    }
+  }
+
+  /**
+   * Returns the size of the serialized form of this {@link BatchDeletePartitionRequestInfo} in bytes.
+   * @return the size of the serialized form of this {@link BatchDeletePartitionRequestInfo} in bytes.
+   */
+  public long sizeInBytes() {
+    return BLOB_ID_LIST_SIZE_IN_BYTES + totalBlobIdsSizeInBytes;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("PartitionId=").append(partitionId);
+    sb.append(", ").append("BlobIds=[").append(blobIds);
+    sb.append("]");
+    return sb.toString();
+  }
+}

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/BatchDeletePartitionRequestInfo.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/BatchDeletePartitionRequestInfo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 LinkedIn Corp. All rights reserved.
+ * Copyright 2024 LinkedIn Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/BatchDeletePartitionResponseInfo.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/BatchDeletePartitionResponseInfo.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.protocol;
+
+import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.clustermap.PartitionId;
+import io.netty.buffer.ByteBuf;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+
+public class BatchDeletePartitionResponseInfo {
+  private final PartitionId partitionId;
+  private final List<BlobDeleteStatus> blobsDeleteStatus;
+
+  public BatchDeletePartitionResponseInfo(PartitionId partitionId, List<BlobDeleteStatus> deleteStatuses) {
+    this.partitionId = partitionId;
+    this.blobsDeleteStatus = deleteStatuses;
+  }
+
+  public PartitionId getPartition() {
+    return partitionId;
+  }
+
+  /** Returns the delete status for the blobs.
+   * @return the list of {@link BlobDeleteStatus}
+   */
+  public List<BlobDeleteStatus> getBlobsDeleteStatus() {
+    return blobsDeleteStatus;
+  }
+
+  /**
+   * Reads from a stream and constructs a {@link BatchDeletePartitionResponseInfo}.
+   * @param stream the {@link DataInputStream} to read from
+   * @param clusterMap the {@link ClusterMap} to use
+   * @return the constructed {@link BatchDeletePartitionResponseInfo}
+   * @throws IOException
+   */
+  public static BatchDeletePartitionResponseInfo readFrom(DataInputStream stream, ClusterMap clusterMap)
+      throws IOException {
+    int messageCount = stream.readInt();
+    PartitionId partitionId = clusterMap.getPartitionIdFromStream(stream);
+    ArrayList<BlobDeleteStatus> blobDeleteStatuses = new ArrayList<>(messageCount);
+    for (int i = 0; i < messageCount; i++) {
+      BlobDeleteStatus deleteStatus = BlobDeleteStatus.readFrom(stream, clusterMap);
+      blobDeleteStatuses.add(deleteStatus);
+    }
+    return new BatchDeletePartitionResponseInfo(partitionId, blobDeleteStatuses);
+  }
+
+  /**
+   * Writes the constituents of {@link BatchDeletePartitionResponseInfo} to the given {@link ByteBuf}.
+   * @param byteBuf the {@link ByteBuf} to write to.
+   */
+  public void writeTo(ByteBuf byteBuf) {
+    byteBuf.writeInt(blobsDeleteStatus.size());
+    byteBuf.writeBytes(partitionId.getBytes());
+    for (int i = 0; i < blobsDeleteStatus.size(); i++) {
+      blobsDeleteStatus.get(i).writeTo(byteBuf);
+    }
+  }
+
+  /**
+   * Returns the size of the serialized form of this {@link BatchDeletePartitionResponseInfo} in bytes.
+   * @return the size of the serialized form of this {@link BatchDeletePartitionResponseInfo} in bytes.
+   */
+  public long sizeInBytes() {
+    long size = 0;
+    size += Integer.BYTES;
+    size += partitionId.getBytes().length;
+    for (BlobDeleteStatus status : blobsDeleteStatus) {
+      size += status.sizeInBytes();
+    }
+    return size;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("BatchDeletePartitionResponseInfo[");
+    sb.append("PartitionId=").append(partitionId);
+    sb.append(" BlobsDeleteStatus=").append(blobsDeleteStatus);
+    sb.append("]");
+    return sb.toString();
+  }
+}

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/BatchDeletePartitionResponseInfo.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/BatchDeletePartitionResponseInfo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 LinkedIn Corp. All rights reserved.
+ * Copyright 2024 LinkedIn Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/BatchDeleteRequest.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/BatchDeleteRequest.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.protocol;
+
+import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.utils.Utils;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+
+/**
+ * Delete request to delete a list of blobs that spans multiple partitions of a data node.
+ */
+public class BatchDeleteRequest extends RequestOrResponse {
+  private final static short BATCH_DELETE_REQUEST_VERSION_1 = 1;
+  private final static short CURRENT_VERSION = BATCH_DELETE_REQUEST_VERSION_1;
+  private static final int BATCH_DELETE_PARTITION_REQUEST_INFO_LIST_SIZE_IN_BYTES = Integer.BYTES;
+  private static final int DELETION_TIME_FIELD_SIZE_IN_BYTES = Long.BYTES;
+  private List<BatchDeletePartitionRequestInfo> batchDeletePartitionRequestInfos;
+  private final long deletionTimeInMs;
+  private int totalPartitionRequestInfoListSizeInBytes;
+
+  /**
+   * Constructs {@link BatchDeleteRequest} in {@link #BATCH_DELETE_REQUEST_VERSION_1}
+   * @param correlationId correlationId of the delete request
+   * @param clientId clientId of the delete request
+   * @param batchDeletePartitionRequestInfos blobIds of the delete request
+   * @param deletionTimeInMs deletion time of the blob in ms
+   */
+  public BatchDeleteRequest(int correlationId, String clientId,
+      List<BatchDeletePartitionRequestInfo> batchDeletePartitionRequestInfos, long deletionTimeInMs) {
+    this(correlationId, clientId, batchDeletePartitionRequestInfos, deletionTimeInMs, CURRENT_VERSION);
+  }
+
+  /**
+   * Constructs {@link BatchDeleteRequest} in given version.
+   * @param correlationId correlationId of the batch delete request
+   * @param clientId clientId of the batch delete request
+   * @param batchDeletePartitionRequestInfos blobIds grouped by partitions
+   * @param deletionTimeInMs deletion time of the blobs in ms
+   * @param version version of the {@link BatchDeleteRequest}
+   */
+  protected BatchDeleteRequest(int correlationId, String clientId,
+      List<BatchDeletePartitionRequestInfo> batchDeletePartitionRequestInfos, long deletionTimeInMs, short version) {
+    super(RequestOrResponseType.DeleteRequest, version, correlationId, clientId);
+    this.batchDeletePartitionRequestInfos = batchDeletePartitionRequestInfos;
+    if (batchDeletePartitionRequestInfos == null) {
+      throw new IllegalArgumentException("No partition info specified in BatchDeleteRequest");
+    }
+    for (BatchDeletePartitionRequestInfo partitionRequestInfo : batchDeletePartitionRequestInfos) {
+      totalPartitionRequestInfoListSizeInBytes += partitionRequestInfo.sizeInBytes();
+    }
+    this.deletionTimeInMs = deletionTimeInMs;
+  }
+
+  /**
+   * Constructs {@link BatchDeleteRequest} reading from a stream {@link DataInputStream}
+   * @param stream the stream to read from
+   * @param clusterMap the {@link ClusterMap} to use
+   * @return the constructed {@link BatchDeleteRequest}
+   */
+  public static BatchDeleteRequest readFrom(DataInputStream stream, ClusterMap clusterMap) throws IOException {
+    Short version = stream.readShort();
+    int correlationId = stream.readInt();
+    String clientId = Utils.readIntString(stream);
+    int totalNumberOfPartitionInfo = stream.readInt();
+    ArrayList<BatchDeletePartitionRequestInfo> partitionRequestInfoList = new ArrayList<>(totalNumberOfPartitionInfo);
+    for (int i = 0; i < totalNumberOfPartitionInfo; i++) {
+      BatchDeletePartitionRequestInfo partitionRequestInfo =
+          BatchDeletePartitionRequestInfo.readFrom(stream, clusterMap);
+      partitionRequestInfoList.add(partitionRequestInfo);
+    }
+    long deletionTimeInMs = stream.readLong();
+    return new BatchDeleteRequest(correlationId, clientId, partitionRequestInfoList, deletionTimeInMs);
+  }
+
+  @Override
+  public void accept(RequestVisitor visitor) {
+    visitor.visit(this);
+  }
+
+  @Override
+  protected void prepareBuffer() {
+    super.prepareBuffer();
+    bufferToSend.writeInt(batchDeletePartitionRequestInfos.size());
+    for (BatchDeletePartitionRequestInfo partitionRequestInfo : batchDeletePartitionRequestInfos) {
+      partitionRequestInfo.writeTo(bufferToSend);
+    }
+    bufferToSend.writeLong(deletionTimeInMs);
+  }
+
+  /**
+   * Gets the list of {@link BatchDeletePartitionRequestInfo} in the {@link BatchDeleteRequest}
+   * @return the list of {@link BatchDeletePartitionRequestInfo}
+   */
+  public List<BatchDeletePartitionRequestInfo> getPartitionRequestInfoList() {
+    return batchDeletePartitionRequestInfos;
+  }
+
+  /**
+   * Gets the deletion time in ms
+   * @return the deletion time in ms
+   */
+  public long getDeletionTimeInMs() {
+    return deletionTimeInMs;
+  }
+
+  @Override
+  public long sizeInBytes() {
+    return super.sizeInBytes() + BATCH_DELETE_PARTITION_REQUEST_INFO_LIST_SIZE_IN_BYTES
+        + totalPartitionRequestInfoListSizeInBytes + DELETION_TIME_FIELD_SIZE_IN_BYTES;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("BatchDeleteRequest[");
+    for (BatchDeletePartitionRequestInfo partitionRequestInfo : batchDeletePartitionRequestInfos) {
+      sb.append(partitionRequestInfo.toString());
+    }
+    sb.append(", ").append("ClientId=").append(clientId);
+    sb.append(", ").append("CorrelationId=").append(correlationId);
+    sb.append(", ").append("Version=").append(CURRENT_VERSION);
+    sb.append("]");
+    return sb.toString();
+  }
+}

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/BatchDeleteRequest.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/BatchDeleteRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 LinkedIn Corp. All rights reserved.
+ * Copyright 2024 LinkedIn Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/BatchDeleteRequest.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/BatchDeleteRequest.java
@@ -55,7 +55,7 @@ public class BatchDeleteRequest extends RequestOrResponse {
    */
   protected BatchDeleteRequest(int correlationId, String clientId,
       List<BatchDeletePartitionRequestInfo> batchDeletePartitionRequestInfos, long deletionTimeInMs, short version) {
-    super(RequestOrResponseType.DeleteRequest, version, correlationId, clientId);
+    super(RequestOrResponseType.BatchDeleteRequest, version, correlationId, clientId);
     this.batchDeletePartitionRequestInfos = batchDeletePartitionRequestInfos;
     if (batchDeletePartitionRequestInfos == null) {
       throw new IllegalArgumentException("No partition info specified in BatchDeleteRequest");

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/BatchDeleteResponse.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/BatchDeleteResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 LinkedIn Corp. All rights reserved.
+ * Copyright 2024 LinkedIn Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/BatchDeleteResponse.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/BatchDeleteResponse.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.protocol;
+
+import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.server.ServerErrorCode;
+import com.github.ambry.utils.Utils;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+
+/**
+ * Response of batch delete request
+ */
+public class BatchDeleteResponse extends Response {
+  private static final short Batch_Delete_Response_Version_V1 = 1;
+  private static int PARTITION_RESPONSE_INFO_LIST_SIZE_IN_BYTES = Integer.BYTES;
+  private final List<BatchDeletePartitionResponseInfo> partitionResponseInfoList;
+  private int batchDeleteResponseSizeInBytes = 0;
+
+  public BatchDeleteResponse(int correlationId, String clientId,
+      List<BatchDeletePartitionResponseInfo> partitionResponseInfoList, ServerErrorCode error) {
+    this(Batch_Delete_Response_Version_V1, correlationId, clientId, partitionResponseInfoList, error);
+  }
+
+  public BatchDeleteResponse(short versionId, int correlationId, String clientId,
+      List<BatchDeletePartitionResponseInfo> partitionResponseInfoList, ServerErrorCode error) {
+    super(RequestOrResponseType.BatchDeleteResponse, versionId, correlationId, clientId, error);
+    this.partitionResponseInfoList = partitionResponseInfoList;
+    for (BatchDeletePartitionResponseInfo partitionResponseInfo : partitionResponseInfoList) {
+      batchDeleteResponseSizeInBytes += partitionResponseInfo.sizeInBytes();
+    }
+  }
+
+  /**
+   * Reads from a stream and constructs a {@link BatchDeleteResponse}.
+   * @param stream the {@link DataInputStream} to read from
+   * @param clusterMap the {@link ClusterMap} to use
+   * @return the constructed {@link BatchDeleteResponse}
+   * @throws IOException
+   */
+  public static BatchDeleteResponse readFrom(DataInputStream stream, ClusterMap clusterMap) throws IOException {
+    RequestOrResponseType type = RequestOrResponseType.values()[stream.readShort()];
+    if (type != RequestOrResponseType.BatchDeleteResponse) {
+      throw new IllegalArgumentException("The type of request response is not compatible");
+    }
+    Short versionId = stream.readShort();
+    int correlationId = stream.readInt();
+    String clientId = Utils.readIntString(stream);
+    ServerErrorCode error = ServerErrorCode.values()[stream.readShort()];
+
+    int partitionResponseInfoCount = stream.readInt();
+    ArrayList<BatchDeletePartitionResponseInfo> partitionResponseInfoList = new ArrayList<>(partitionResponseInfoCount);
+    for (int i = 0; i < partitionResponseInfoCount; i++) {
+      BatchDeletePartitionResponseInfo partitionResponseInfo =
+          BatchDeletePartitionResponseInfo.readFrom(stream, clusterMap);
+      partitionResponseInfoList.add(partitionResponseInfo);
+    }
+    return new BatchDeleteResponse(versionId, correlationId, clientId, partitionResponseInfoList, error);
+  }
+
+  @Override
+  protected void prepareBuffer() {
+    super.prepareBuffer();
+    if (partitionResponseInfoList != null) {
+      bufferToSend.writeInt(partitionResponseInfoList.size());
+      for (BatchDeletePartitionResponseInfo partitionResponseInfo : partitionResponseInfoList) {
+        partitionResponseInfo.writeTo(bufferToSend);
+      }
+    } else {
+      bufferToSend.writeInt(0);
+    }
+  }
+
+  @Override
+  public long sizeInBytes() {
+    return super.sizeInBytes() + PARTITION_RESPONSE_INFO_LIST_SIZE_IN_BYTES + batchDeleteResponseSizeInBytes;
+  }
+
+  /**
+   * Gets the delete partition response info list
+   * @return the partition response info list
+   */
+  public List<BatchDeletePartitionResponseInfo> getPartitionResponseInfoList() {
+    return partitionResponseInfoList;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("BatchDeleteResponse[");
+    sb.append("ServerErrorCode=").append(getError());
+    sb.append(", PartitionResponseInfoList=").append(partitionResponseInfoList);
+    sb.append("]");
+    return sb.toString();
+  }
+}

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/BlobDeleteStatus.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/BlobDeleteStatus.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2024 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
 package com.github.ambry.protocol;
 
 import com.github.ambry.clustermap.ClusterMap;

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/BlobDeleteStatus.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/BlobDeleteStatus.java
@@ -1,0 +1,72 @@
+package com.github.ambry.protocol;
+
+import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.commons.BlobId;
+import com.github.ambry.server.ServerErrorCode;
+import io.netty.buffer.ByteBuf;
+import java.io.DataInputStream;
+import java.io.IOException;
+
+
+/**
+ * Delete status for a blob
+ */
+public class BlobDeleteStatus {
+  private final BlobId blobId;
+  private final ServerErrorCode status;
+
+  public BlobDeleteStatus(BlobId blobId, ServerErrorCode status) {
+    this.blobId = blobId;
+    this.status = status;
+  }
+
+  /**
+   * @return the {@link BlobId} of the blob that was deleted
+   */
+  public BlobId getBlobId() {
+    return blobId;
+  }
+
+  /**
+   * @return the {@link ServerErrorCode} that represents the status of the delete operation
+   */
+  public ServerErrorCode getStatus() {
+    return status;
+  }
+
+  /**
+   * Reads the serialized form of {@link BlobDeleteStatus} from the given {@link DataInputStream}.
+   * @param stream the stream to read from
+   * @param clusterMap the {@link ClusterMap} to use to deserialize the {@link BlobId}
+   * @return a {@link BlobDeleteStatus} object
+   * @throws IOException
+   */
+  public static BlobDeleteStatus readFrom(DataInputStream stream, ClusterMap clusterMap) throws IOException {
+    BlobId blobId = new BlobId(stream, clusterMap);
+    ServerErrorCode status = ServerErrorCode.values()[stream.readShort()];
+    return new BlobDeleteStatus(blobId, status);
+  }
+
+  /**
+   * Writes the serialized form of {@link BlobDeleteStatus} to the given {@link ByteBuf}.
+   * @param byteBuf the buffer to write to
+   */
+  public void writeTo(ByteBuf byteBuf) {
+    byteBuf.writeBytes(blobId.toBytes());
+    byteBuf.writeShort(status.ordinal());
+  }
+
+  /**
+   * @return the size of the serialized form of this object in bytes
+   */
+  public long sizeInBytes() {
+    return blobId.sizeInBytes() + Short.BYTES;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("BlobId=").append(blobId).append(", Status=").append(status);
+    return sb.toString();
+  }
+}

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/RequestOrResponseType.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/RequestOrResponseType.java
@@ -35,5 +35,7 @@ public enum RequestOrResponseType {
   ReplicateBlobRequest,
   ReplicateBlobResponse,
   PurgeRequest,
-  PurgeResponse
+  PurgeResponse,
+  BatchDeleteRequest,
+  BatchDeleteResponse
 }

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/RequestVisitor.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/RequestVisitor.java
@@ -43,6 +43,12 @@ public interface RequestVisitor {
   void visit(DeleteRequest deleteRequest);
 
   /**
+   * Performs any actions related to Batch Delete request.
+   * @param deleteRequest to visit.
+   */
+  void visit(BatchDeleteRequest deleteRequest);
+
+  /**
    * Performs any actions related to Un-delete request.
    * @param undeleteRequest to visit.
    */

--- a/ambry-protocol/src/test/java/com/github/ambry/protocol/RequestResponseTest.java
+++ b/ambry-protocol/src/test/java/com/github/ambry/protocol/RequestResponseTest.java
@@ -41,7 +41,6 @@ import com.github.ambry.utils.NettyByteBufLeakHelper;
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
-import com.google.common.collect.Lists;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryRequests.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryRequests.java
@@ -51,6 +51,7 @@ import com.github.ambry.notification.UpdateType;
 import com.github.ambry.protocol.AdminRequest;
 import com.github.ambry.protocol.AdminRequestOrResponseType;
 import com.github.ambry.protocol.AdminResponseWithContent;
+import com.github.ambry.protocol.BatchDeleteRequest;
 import com.github.ambry.protocol.BlobIndexAdminRequest;
 import com.github.ambry.protocol.CompositeSend;
 import com.github.ambry.protocol.DeleteRequest;
@@ -1858,6 +1859,11 @@ public class AmbryRequests implements RequestAPI {
         metrics.deleteBlobDroppedRate.mark();
         metrics.totalRequestDroppedRate.mark();
       }
+    }
+
+    @Override
+    public void visit(BatchDeleteRequest deleteRequest) {
+      
     }
 
     @Override


### PR DESCRIPTION
**Summary**
Ambry batch delete support - protocol changes

**Description**
Existing delete protocol handles one blob in a single request, this change introduces new protocol BatchDeleteRequest and BatchDeleteResponse that handles a list of blobs in a single request. This is needed for deletion of composite blobs. 

**Testing**
1) Unit tests done. 
2) Datanode enhancements for supporting batch deletes were verified using the patch. 