### PR TITLE
Batch Delete server changes

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/protocol/RequestAPI.java
+++ b/ambry-api/src/main/java/com/github/ambry/protocol/RequestAPI.java
@@ -56,6 +56,15 @@ public interface RequestAPI {
   void handleDeleteRequest(NetworkRequest request) throws IOException, InterruptedException;
 
   /**
+   * Deletes a list of blobs from the store.
+   * @param request The request that contains the list of partition and id of the blob that needs to be deleted.
+   * @throws IOException if there are I/O errors carrying our the required operation.
+   * @throws InterruptedException if request processing is interrupted.
+   */
+
+  void handleBatchDeleteRequest(NetworkRequest request) throws IOException, InterruptedException;
+
+  /**
    * Purges the blob from the store.
    * @param request The request that contains the partition and id of the blob that needs to be purged.
    * @throws IOException if there are I/O errors carrying our the required operation.

--- a/ambry-api/src/main/java/com/github/ambry/protocol/RequestAPI.java
+++ b/ambry-api/src/main/java/com/github/ambry/protocol/RequestAPI.java
@@ -56,8 +56,9 @@ public interface RequestAPI {
   void handleDeleteRequest(NetworkRequest request) throws IOException, InterruptedException;
 
   /**
-   * Deletes a list of blobs from the store.
-   * @param request The request that contains the list of partition and id of the blob that needs to be deleted.
+   * Deletes a list of blobs from the store. Also handles the scenarios of complete success, partial success and full
+   * failure by returning appropriate response {@code BatchDeleteResponse} to network channel.
+   * @param request The request that contains the list of partitions and ids of the blob that needs to be deleted.
    * @throws IOException if there are I/O errors carrying our the required operation.
    * @throws InterruptedException if request processing is interrupted.
    */

--- a/ambry-api/src/main/java/com/github/ambry/store/MessageErrorInfo.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/MessageErrorInfo.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2024 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.store;
+
+public class MessageErrorInfo {
+  private final MessageInfo messageInfo;
+  private final StoreErrorCodes error;
+
+  public MessageErrorInfo(MessageInfo messageInfo, StoreErrorCodes error) {
+    this.messageInfo = messageInfo;
+    this.error = error;
+  }
+
+  public MessageInfo getMessageInfo() {
+    return messageInfo;
+  }
+
+  public StoreErrorCodes getError() {
+    return error;
+  }
+}

--- a/ambry-api/src/main/java/com/github/ambry/store/Store.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/Store.java
@@ -63,9 +63,11 @@ public interface Store {
 
   /**
    * Deletes all the messages in the list. When the lifeVersion is {@link MessageInfo#LIFE_VERSION_FROM_FRONTEND}, this
-   * method is invoked by the responding to the frontend request. Otherwise, it's invoked in the replication thread.
+   * method is invoked by the responding to the frontend BATCH_DELETE request. Invocation in replication thread is not
+   * yet supported.
    * @param infosToDelete The list of messages that need to be deleted.
    *                      Only the StoreKey, OperationTime, LifeVersion should be used in this method.
+   * @return The {@link StoreBatchDeleteInfo} for the given ids
    * @throws StoreException
    */
   StoreBatchDeleteInfo batchDelete(List<MessageInfo> infosToDelete) throws StoreException;

--- a/ambry-api/src/main/java/com/github/ambry/store/Store.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/Store.java
@@ -62,6 +62,15 @@ public interface Store {
   void delete(List<MessageInfo> infosToDelete) throws StoreException;
 
   /**
+   * Deletes all the messages in the list. When the lifeVersion is {@link MessageInfo#LIFE_VERSION_FROM_FRONTEND}, this
+   * method is invoked by the responding to the frontend request. Otherwise, it's invoked in the replication thread.
+   * @param infosToDelete The list of messages that need to be deleted.
+   *                      Only the StoreKey, OperationTime, LifeVersion should be used in this method.
+   * @throws StoreException
+   */
+  StoreBatchDeleteInfo batchDelete(List<MessageInfo> infosToDelete) throws StoreException;
+
+  /**
    * Write a purge message for all the blob ids in the message info  list.
    * Blobs are purged when it has been determined that a chunk is no longer needed (i.e, is expired or deleted
    * and past retention window or maybe an orphan chunk). Once compaction sees a purge message, it will clean up the chunk

--- a/ambry-api/src/main/java/com/github/ambry/store/StoreBatchDeleteInfo.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/StoreBatchDeleteInfo.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2024 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.store;
+
+import com.github.ambry.clustermap.PartitionId;
+import java.util.List;
+
+
+public class StoreBatchDeleteInfo {
+  private final PartitionId partitionId;
+
+  private final List<MessageErrorInfo> messageErrorInfos;
+
+  public StoreBatchDeleteInfo(PartitionId partitionId, List<MessageErrorInfo> messageErrorInfos) {
+    this.partitionId = partitionId;
+    this.messageErrorInfos = messageErrorInfos;
+  }
+
+  public PartitionId getPartitionId() {
+    return partitionId;
+  }
+
+  public List<MessageErrorInfo> getMessageErrorInfos() {
+    return messageErrorInfos;
+  }
+
+  public void addMessageErrorInfo(MessageErrorInfo messageErrorInfo){
+    this.messageErrorInfos.add(messageErrorInfo);
+  }
+}

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobStore.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobStore.java
@@ -26,11 +26,13 @@ import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.StoreConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.messageformat.MessageFormatWriteSet;
+import com.github.ambry.protocol.BatchDeletePartitionResponseInfo;
 import com.github.ambry.replication.FindToken;
 import com.github.ambry.store.FindInfo;
 import com.github.ambry.store.MessageInfo;
 import com.github.ambry.store.MessageWriteSet;
 import com.github.ambry.store.Store;
+import com.github.ambry.store.StoreBatchDeleteInfo;
 import com.github.ambry.store.StoreErrorCodes;
 import com.github.ambry.store.StoreException;
 import com.github.ambry.store.StoreGetOptions;
@@ -717,6 +719,11 @@ public class CloudBlobStore implements Store {
       // Upload all live blobs
       return true;
     }
+  }
+
+  @Override
+  public StoreBatchDeleteInfo batchDelete(List<MessageInfo> infos) throws StoreException {
+    throw new UnsupportedOperationException("Method not supported");
   }
 
   @Override

--- a/ambry-commons/src/main/java/com/github/ambry/commons/ServerMetrics.java
+++ b/ambry-commons/src/main/java/com/github/ambry/commons/ServerMetrics.java
@@ -106,8 +106,11 @@ public class ServerMetrics {
   public final Histogram batchDeleteBlobResponseQueueTimeInMs;
   public final Histogram purgeBlobResponseQueueTimeInMs;
   public final Histogram deleteBlobSendTimeInMs;
+
+  public final Histogram batchDeleteBlobSendTimeInMs;
   public final Histogram purgeBlobSendTimeInMs;
   public final Histogram deleteBlobTotalTimeInMs;
+  public final Histogram batchDeleteBlobTotalTimeInMs;
   public final Histogram purgeBlobTotalTimeInMs;
 
   public final Histogram undeleteBlobRequestQueueTimeInMs;
@@ -262,6 +265,10 @@ public class ServerMetrics {
   public final Counter unExpectedStoreGetError;
   public final Counter unExpectedStoreTtlUpdateError;
   public final Counter unExpectedStoreDeleteError;
+
+  public final Counter unExpectedStoreDeleteErrorInBatchDelete;
+
+  public final Counter unExpectedStoreBatchDeleteError;
   public final Counter unExpectedStorePurgeError;
   public final Counter unExpectedStoreUndeleteError;
   public final Counter unExpectedAdminOperationError;
@@ -270,22 +277,31 @@ public class ServerMetrics {
   public final Counter dataCorruptError;
   public final Counter unknownFormatError;
   public final Counter idNotFoundError;
+
+  public final Counter idNotFoundErrorInBatchDelete;
   public final Counter idDeletedError;
+
+  public final Counter idDeletedErrorInBatchDelete;
   public final Counter idPurgedError;
   public final Counter idUndeletedError;
   public final Counter idNotDeletedError;
   public final Counter lifeVersionConflictError;
   public final Counter ttlExpiredError;
+
+  public final Counter ttlExpiredErrorInBatchDelete;
   public final Counter badRequestError;
   public final Counter temporarilyDisabledError;
   public final Counter getAuthorizationFailure;
   public final Counter deleteAuthorizationFailure;
+
+  public final Counter deleteAuthorizationFailureInBatchDelete;
   public final Counter purgeAuthorizationFailure;
   public final Counter undeleteAuthorizationFailure;
   public final Counter ttlUpdateAuthorizationFailure;
   public final Counter ttlAlreadyUpdatedError;
   public final Counter ttlUpdateRejectedError;
   public final Counter replicationResponseMessageSizeTooHigh;
+  public final Counter batchDeleteOperationError;
   public Counter sealedReplicasMismatchCount = null;
   public Counter partiallySealedReplicasMismatchCount = null;
   public Counter stoppedReplicasMismatchCount = null;
@@ -411,8 +427,10 @@ public class ServerMetrics {
     purgeBlobResponseQueueTimeInMs =
         registry.histogram(MetricRegistry.name(requestClass, "PurgeBlobResponseQueueTimeInMs"));
     deleteBlobSendTimeInMs = registry.histogram(MetricRegistry.name(requestClass, "DeleteBlobSendTime"));
+    batchDeleteBlobSendTimeInMs = registry.histogram(MetricRegistry.name(requestClass, "BatchDeleteBlobSendTime"));
     purgeBlobSendTimeInMs = registry.histogram(MetricRegistry.name(requestClass, "PurgeBlobSendTimeInMs"));
     deleteBlobTotalTimeInMs = registry.histogram(MetricRegistry.name(requestClass, "DeleteBlobTotalTime"));
+    batchDeleteBlobTotalTimeInMs = registry.histogram(MetricRegistry.name(requestClass, "BatchDeleteBlobTotalTime"));
     purgeBlobTotalTimeInMs = registry.histogram(MetricRegistry.name(requestClass, "PurgeBlobTotalTimeInMs"));
 
     undeleteBlobRequestQueueTimeInMs =
@@ -631,17 +649,22 @@ public class ServerMetrics {
     dataCorruptError = registry.counter(MetricRegistry.name(requestClass, "DataCorruptError"));
     unknownFormatError = registry.counter(MetricRegistry.name(requestClass, "UnknownFormatError"));
     idNotFoundError = registry.counter(MetricRegistry.name(requestClass, "IDNotFoundError"));
+    idNotFoundErrorInBatchDelete = registry.counter(MetricRegistry.name(requestClass, "IDNotFoundErrorInBatchDelete"));
     idDeletedError = registry.counter(MetricRegistry.name(requestClass, "IDDeletedError"));
+    idDeletedErrorInBatchDelete = registry.counter(MetricRegistry.name(requestClass, "IDDeletedErrorInBatchDelete"));
     idPurgedError = registry.counter(MetricRegistry.name(requestClass, "IDPurgedError"));
     idUndeletedError = registry.counter(MetricRegistry.name(requestClass, "IDUndeletedError"));
     idNotDeletedError = registry.counter(MetricRegistry.name(requestClass, "IDNotDeletedError"));
     lifeVersionConflictError = registry.counter(MetricRegistry.name(requestClass, "lifeVersionConflictError"));
     ttlExpiredError = registry.counter(MetricRegistry.name(requestClass, "TTLExpiredError"));
+    ttlExpiredErrorInBatchDelete = registry.counter(MetricRegistry.name(requestClass, "TTLExpiredErrorInBatchDelete"));
     temporarilyDisabledError = registry.counter(MetricRegistry.name(requestClass, "TemporarilyDisabledError"));
     badRequestError = registry.counter(MetricRegistry.name(requestClass, "BadRequestError"));
     unExpectedStorePutError = registry.counter(MetricRegistry.name(requestClass, "UnexpectedStorePutError"));
     unExpectedStoreGetError = registry.counter(MetricRegistry.name(requestClass, "UnexpectedStoreGetError"));
     unExpectedStoreDeleteError = registry.counter(MetricRegistry.name(requestClass, "UnexpectedStoreDeleteError"));
+    unExpectedStoreDeleteErrorInBatchDelete = registry.counter(MetricRegistry.name(requestClass, "UnexpectedStoreDeleteErrorInBatchDelete"));
+    unExpectedStoreBatchDeleteError = registry.counter(MetricRegistry.name(requestClass, "UnexpectedStoreBatchDeleteError"));
     unExpectedStorePurgeError =
         registry.counter(MetricRegistry.name(requestClass, "UnExpectedStorePurgeError"));
     unExpectedStoreUndeleteError = registry.counter(MetricRegistry.name(requestClass, "UnexpectedStoreUndeleteError"));
@@ -653,6 +676,8 @@ public class ServerMetrics {
         registry.counter(MetricRegistry.name(requestClass, "UnexpectedStoreFindEntriesError"));
     getAuthorizationFailure = registry.counter(MetricRegistry.name(requestClass, "GetAuthorizationFailure"));
     deleteAuthorizationFailure = registry.counter(MetricRegistry.name(requestClass, "DeleteAuthorizationFailure"));
+    deleteAuthorizationFailureInBatchDelete = registry.counter(MetricRegistry.name(requestClass, "DeleteAuthorizationFailureInBatchDelete"));
+    batchDeleteOperationError = registry.counter(MetricRegistry.name(requestClass, "BatchDeleteOperationError"));
     purgeAuthorizationFailure =
         registry.counter(MetricRegistry.name(requestClass, "PurgeAuthorizationFailure"));
     undeleteAuthorizationFailure = registry.counter(MetricRegistry.name(requestClass, "UndeleteAuthorizationFailure"));

--- a/ambry-commons/src/main/java/com/github/ambry/commons/ServerMetrics.java
+++ b/ambry-commons/src/main/java/com/github/ambry/commons/ServerMetrics.java
@@ -420,17 +420,17 @@ public class ServerMetrics {
     deleteBlobResponseQueueTimeInMs =
         registry.histogram(MetricRegistry.name(requestClass, "DeleteBlobResponseQueueTime"));
     batchDeleteBlobRequestQueueTimeInMs =
-        registry.histogram(MetricRegistry.name(requestClass, "BatchDeleteBlobRequestQueueTime"));
-    batchDeleteBlobProcessingTimeInMs = registry.histogram(MetricRegistry.name(requestClass, "BatchDeleteBlobProcessingTime"));
+        registry.histogram(MetricRegistry.name(requestClass, "BatchDeleteBlobRequestQueueTimeInMs"));
+    batchDeleteBlobProcessingTimeInMs = registry.histogram(MetricRegistry.name(requestClass, "BatchDeleteBlobProcessingTimeInMs"));
     batchDeleteBlobResponseQueueTimeInMs =
-        registry.histogram(MetricRegistry.name(requestClass, "BatchDeleteBlobResponseQueueTime"));
+        registry.histogram(MetricRegistry.name(requestClass, "BatchDeleteBlobResponseQueueTimeInMs"));
     purgeBlobResponseQueueTimeInMs =
         registry.histogram(MetricRegistry.name(requestClass, "PurgeBlobResponseQueueTimeInMs"));
     deleteBlobSendTimeInMs = registry.histogram(MetricRegistry.name(requestClass, "DeleteBlobSendTime"));
     batchDeleteBlobSendTimeInMs = registry.histogram(MetricRegistry.name(requestClass, "BatchDeleteBlobSendTime"));
     purgeBlobSendTimeInMs = registry.histogram(MetricRegistry.name(requestClass, "PurgeBlobSendTimeInMs"));
     deleteBlobTotalTimeInMs = registry.histogram(MetricRegistry.name(requestClass, "DeleteBlobTotalTime"));
-    batchDeleteBlobTotalTimeInMs = registry.histogram(MetricRegistry.name(requestClass, "BatchDeleteBlobTotalTime"));
+    batchDeleteBlobTotalTimeInMs = registry.histogram(MetricRegistry.name(requestClass, "BatchDeleteBlobTotalTimeInMs"));
     purgeBlobTotalTimeInMs = registry.histogram(MetricRegistry.name(requestClass, "PurgeBlobTotalTimeInMs"));
 
     undeleteBlobRequestQueueTimeInMs =

--- a/ambry-commons/src/main/java/com/github/ambry/commons/ServerMetrics.java
+++ b/ambry-commons/src/main/java/com/github/ambry/commons/ServerMetrics.java
@@ -100,6 +100,10 @@ public class ServerMetrics {
   public final Histogram deleteBlobRequestQueueTimeInMs;
   public final Histogram deleteBlobProcessingTimeInMs;
   public final Histogram deleteBlobResponseQueueTimeInMs;
+
+  public final Histogram batchDeleteBlobRequestQueueTimeInMs;
+  public final Histogram batchDeleteBlobProcessingTimeInMs;
+  public final Histogram batchDeleteBlobResponseQueueTimeInMs;
   public final Histogram purgeBlobResponseQueueTimeInMs;
   public final Histogram deleteBlobSendTimeInMs;
   public final Histogram purgeBlobSendTimeInMs;
@@ -399,6 +403,11 @@ public class ServerMetrics {
     deleteBlobProcessingTimeInMs = registry.histogram(MetricRegistry.name(requestClass, "DeleteBlobProcessingTime"));
     deleteBlobResponseQueueTimeInMs =
         registry.histogram(MetricRegistry.name(requestClass, "DeleteBlobResponseQueueTime"));
+    batchDeleteBlobRequestQueueTimeInMs =
+        registry.histogram(MetricRegistry.name(requestClass, "BatchDeleteBlobRequestQueueTime"));
+    batchDeleteBlobProcessingTimeInMs = registry.histogram(MetricRegistry.name(requestClass, "BatchDeleteBlobProcessingTime"));
+    batchDeleteBlobResponseQueueTimeInMs =
+        registry.histogram(MetricRegistry.name(requestClass, "BatchDeleteBlobResponseQueueTime"));
     purgeBlobResponseQueueTimeInMs =
         registry.histogram(MetricRegistry.name(requestClass, "PurgeBlobResponseQueueTimeInMs"));
     deleteBlobSendTimeInMs = registry.histogram(MetricRegistry.name(requestClass, "DeleteBlobSendTime"));

--- a/ambry-replication/src/test/java/com/github/ambry/replication/InMemoryStore.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/InMemoryStore.java
@@ -27,6 +27,7 @@ import com.github.ambry.store.MessageInfo;
 import com.github.ambry.store.MessageReadSet;
 import com.github.ambry.store.MessageWriteSet;
 import com.github.ambry.store.Store;
+import com.github.ambry.store.StoreBatchDeleteInfo;
 import com.github.ambry.store.StoreErrorCodes;
 import com.github.ambry.store.StoreException;
 import com.github.ambry.store.StoreGetOptions;
@@ -495,5 +496,10 @@ public class InMemoryStore implements Store {
   @Override
   public boolean isStarted() {
     return started;
+  }
+
+  @Override
+  public StoreBatchDeleteInfo batchDelete(List<MessageInfo> infos) throws StoreException {
+    throw new UnsupportedOperationException("Method not supported");
   }
 }

--- a/ambry-server/src/integration-test/java/com/github/ambry/server/ServerBatchDeleteTest.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/ServerBatchDeleteTest.java
@@ -1,0 +1,346 @@
+/**
+ * Copyright 2024 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.server;
+
+import com.github.ambry.clustermap.DataNodeId;
+import com.github.ambry.clustermap.MockClusterAgentsFactory;
+import com.github.ambry.clustermap.MockClusterMap;
+import com.github.ambry.clustermap.PartitionId;
+import com.github.ambry.commons.BlobId;
+import com.github.ambry.commons.CommonTestUtils;
+import com.github.ambry.commons.SSLFactory;
+import com.github.ambry.commons.TestSSLUtils;
+import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.messageformat.BlobProperties;
+import com.github.ambry.messageformat.BlobType;
+import com.github.ambry.network.ConnectedChannel;
+import com.github.ambry.network.Port;
+import com.github.ambry.network.PortType;
+import com.github.ambry.protocol.BatchDeletePartitionRequestInfo;
+import com.github.ambry.protocol.BatchDeleteRequest;
+import com.github.ambry.protocol.BatchDeleteResponse;
+import com.github.ambry.protocol.PutRequest;
+import com.github.ambry.protocol.PutResponse;
+import com.github.ambry.utils.MockTime;
+import com.github.ambry.utils.SystemTime;
+import com.github.ambry.utils.TestUtils;
+import com.github.ambry.utils.Utils;
+import io.netty.buffer.Unpooled;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.Random;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+
+public class ServerBatchDeleteTest {
+  private MockNotificationSystem notificationSystem;
+  private MockTime time;
+  private AmbryServer server;
+  private MockClusterAgentsFactory mockClusterAgentsFactory;
+  private MockClusterMap mockClusterMap;
+  private ArrayList<BlobProperties> properties;
+  private ArrayList<byte[]> encryptionKey;
+  private ArrayList<byte[]> usermetadata;
+  private ArrayList<byte[]> data;
+  private ArrayList<BlobId> blobIdList1;
+  private ArrayList<BlobId> blobIdList2;
+
+  @Before
+  public void initialize() throws Exception {
+    mockClusterAgentsFactory = new MockClusterAgentsFactory(false, true, 1, 1, 2);
+    mockClusterMap = mockClusterAgentsFactory.getClusterMap();
+    notificationSystem = new MockNotificationSystem(mockClusterMap);
+    time = new MockTime(SystemTime.getInstance().milliseconds());
+    Properties props = new Properties();
+    props.setProperty("host.name", mockClusterMap.getDataNodes().get(0).getHostname());
+    props.setProperty("port", Integer.toString(mockClusterMap.getDataNodes().get(0).getPort()));
+    props.setProperty("store.data.flush.interval.seconds", "1");
+    props.setProperty("store.deleted.message.retention.hours", "10080");
+    props.setProperty("server.handle.undelete.request.enabled", "true");
+    props.setProperty("clustermap.cluster.name", "test");
+    props.setProperty("clustermap.datacenter.name", "DC1");
+    props.setProperty("clustermap.host.name", "localhost");
+    props.setProperty("clustermap.default.partition.class", MockClusterMap.DEFAULT_PARTITION_CLASS);
+    TestSSLUtils.addHttp2Properties(props, SSLFactory.Mode.SERVER, true);
+    VerifiableProperties propverify = new VerifiableProperties(props);
+    server = new AmbryServer(propverify, mockClusterAgentsFactory, notificationSystem, time);
+    server.startup();
+  }
+
+  @After
+  public void cleanup() throws IOException {
+    if (server != null) {
+      server.shutdown();
+    }
+    if (mockClusterMap != null) {
+      mockClusterMap.cleanup();
+    }
+  }
+
+  /**
+   * Uploads a single blob to ambry server node
+   * @param blobId the {@link BlobId} that needs to be put
+   * @param properties the {@link BlobProperties} of the blob being uploaded
+   * @param usermetadata the user metadata of the blob being uploaded
+   * @param data the blob content of the blob being uploaded
+   * @param channel the {@link ConnectedChannel} to use to send and receive data
+   * @throws IOException
+   */
+  void putBlob(BlobId blobId, BlobProperties properties, byte[] encryptionKey, byte[] usermetadata, byte[] data,
+      ConnectedChannel channel) throws IOException {
+    PutRequest putRequest0 =
+        new PutRequest(1, "client1", blobId, properties, ByteBuffer.wrap(usermetadata), Unpooled.wrappedBuffer(data),
+            properties.getBlobSize(), BlobType.DataBlob, encryptionKey == null ? null : ByteBuffer.wrap(encryptionKey));
+    PutResponse response0 = PutResponse.readFrom(channel.sendAndReceive(putRequest0).getInputStream());
+    Assert.assertEquals(ServerErrorCode.No_Error, response0.getError());
+  }
+
+  /**
+   * Deletes a list of blobs from ambry server node
+   * @param batchDeletePartitionRequestInfos the {@link List<BatchDeletePartitionRequestInfo>} that needs to be deleted
+   * @param channel the {@link ConnectedChannel} to use to send and receive data
+   * @throws IOException
+   */
+  BatchDeleteResponse deleteBlobs(List<BatchDeletePartitionRequestInfo> batchDeletePartitionRequestInfos, ConnectedChannel channel) throws IOException {
+
+    BatchDeleteRequest batchDeleteRequest = new BatchDeleteRequest(1, "client1", batchDeletePartitionRequestInfos, time.milliseconds());
+    BatchDeleteResponse batchDeleteResponse = BatchDeleteResponse.readFrom(channel.sendAndReceive(batchDeleteRequest).getInputStream(), mockClusterMap);
+    return batchDeleteResponse;
+  }
+
+  /**
+   * Positive test for batch delete
+   * <p>
+   * This test does the following:
+   * 1. Makes 5 puts, across 2 partitions, waits for notification.
+   * 2. Creates 1 batch delete request
+   * 3. Verifies the BatchDeleteResponse
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testBatchDeleteSuccess() throws Exception {
+    DataNodeId dataNodeId = mockClusterMap.getDataNodeIds().get(0);
+    encryptionKey = new ArrayList<>(5);
+    usermetadata = new ArrayList<>(5);
+    data = new ArrayList<>(5);
+    Random random = new Random();
+    for (int i = 0; i < 5; i++) {
+      if (i % 2 == 0) {
+        encryptionKey.add(new byte[100]);
+        random.nextBytes(encryptionKey.get(i));
+      } else {
+        encryptionKey.add(null);
+      }
+      usermetadata.add(new byte[1000 + i]);
+      data.add(new byte[31870 + i]);
+      random.nextBytes(usermetadata.get(i));
+      random.nextBytes(data.get(i));
+    }
+
+    properties = new ArrayList<>(5);
+    properties.add(new BlobProperties(31870, "serviceid1", Utils.getRandomShort(TestUtils.RANDOM),
+        Utils.getRandomShort(TestUtils.RANDOM), true));
+    properties.add(new BlobProperties(31871, "serviceid1", Utils.getRandomShort(TestUtils.RANDOM),
+        Utils.getRandomShort(TestUtils.RANDOM), false));
+    properties.add(new BlobProperties(31872, "serviceid1", Utils.getRandomShort(TestUtils.RANDOM),
+        Utils.getRandomShort(TestUtils.RANDOM), true));
+    properties.add(
+        new BlobProperties(31873, "serviceid1", "ownerid", "jpeg", false, 0, Utils.getRandomShort(TestUtils.RANDOM),
+            Utils.getRandomShort(TestUtils.RANDOM), false, null, null, null));
+    properties.add(new BlobProperties(31874, "serviceid1", Utils.getRandomShort(TestUtils.RANDOM),
+        Utils.getRandomShort(TestUtils.RANDOM), true));
+
+    List<PartitionId> partitionIds = mockClusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS);
+    blobIdList1 = new ArrayList<>(3);
+    blobIdList2 = new ArrayList<>(2);
+    for (int i = 0; i < 5; i++) {
+      if (i%2 == 0) {
+        blobIdList1.add(new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
+            mockClusterMap.getLocalDatacenterId(), properties.get(i).getAccountId(), properties.get(i).getContainerId(),
+            partitionIds.get(0), false, BlobId.BlobDataType.DATACHUNK));
+      }
+      else{
+        blobIdList2.add(new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
+            mockClusterMap.getLocalDatacenterId(), properties.get(i).getAccountId(), properties.get(i).getContainerId(),
+            partitionIds.get(1), false, BlobId.BlobDataType.DATACHUNK));
+      }
+    }
+
+    ConnectedChannel channel =
+        ServerTestUtil.getBlockingChannelBasedOnPortType(new Port(dataNodeId.getPort(), PortType.PLAINTEXT),
+            "localhost", null, null);
+    channel.connect();
+    for (int i = 0; i < 3; i++) {
+      putBlob(blobIdList1.get(i), properties.get(i), encryptionKey.get(i), usermetadata.get(i), data.get(i), channel);
+    }
+    for (int i = 0; i < 2; i++) {
+      putBlob(blobIdList2.get(i), properties.get(i), encryptionKey.get(i), usermetadata.get(i), data.get(i), channel);
+    }
+    List<BatchDeletePartitionRequestInfo> batchDeletePartitionRequestInfoList = new ArrayList<>();
+    batchDeletePartitionRequestInfoList.add(new BatchDeletePartitionRequestInfo(partitionIds.get(0), blobIdList1));
+    batchDeletePartitionRequestInfoList.add(new BatchDeletePartitionRequestInfo(partitionIds.get(1), blobIdList2));
+    BatchDeleteResponse batchDeleteResponse = deleteBlobs(batchDeletePartitionRequestInfoList, channel);
+    Assert.assertEquals(ServerErrorCode.No_Error, batchDeleteResponse.getError());
+  }
+
+  /**
+   * Partial Failure test for batch delete
+   * <p>
+   * This test does the following:
+   * 1. Makes 3 puts for 1 partition, waits for notification.
+   * 2. Creates 1 batch delete request for 5 blob deletes (across 2 partitions, one of which should error out)
+   * 3. Verifies the BatchDeleteResponse
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testBatchDeletePartialFailure() throws Exception {
+    DataNodeId dataNodeId = mockClusterMap.getDataNodeIds().get(0);
+    encryptionKey = new ArrayList<>(5);
+    usermetadata = new ArrayList<>(5);
+    data = new ArrayList<>(5);
+    Random random = new Random();
+    for (int i = 0; i < 5; i++) {
+      if (i % 2 == 0) {
+        encryptionKey.add(new byte[100]);
+        random.nextBytes(encryptionKey.get(i));
+      } else {
+        encryptionKey.add(null);
+      }
+      usermetadata.add(new byte[1000 + i]);
+      data.add(new byte[31870 + i]);
+      random.nextBytes(usermetadata.get(i));
+      random.nextBytes(data.get(i));
+    }
+
+    properties = new ArrayList<>(5);
+    properties.add(new BlobProperties(31870, "serviceid1", Utils.getRandomShort(TestUtils.RANDOM),
+        Utils.getRandomShort(TestUtils.RANDOM), true));
+    properties.add(new BlobProperties(31871, "serviceid1", Utils.getRandomShort(TestUtils.RANDOM),
+        Utils.getRandomShort(TestUtils.RANDOM), false));
+    properties.add(new BlobProperties(31872, "serviceid1", Utils.getRandomShort(TestUtils.RANDOM),
+        Utils.getRandomShort(TestUtils.RANDOM), true));
+    properties.add(
+        new BlobProperties(31873, "serviceid1", "ownerid", "jpeg", false, 0, Utils.getRandomShort(TestUtils.RANDOM),
+            Utils.getRandomShort(TestUtils.RANDOM), false, null, null, null));
+    properties.add(new BlobProperties(31874, "serviceid1", Utils.getRandomShort(TestUtils.RANDOM),
+        Utils.getRandomShort(TestUtils.RANDOM), true));
+
+    List<PartitionId> partitionIds = mockClusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS);
+    blobIdList1 = new ArrayList<>(3);
+    blobIdList2 = new ArrayList<>(2);
+    for (int i = 0; i < 5; i++) {
+      if (i%2 == 0) {
+        blobIdList1.add(new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
+            mockClusterMap.getLocalDatacenterId(), properties.get(i).getAccountId(), properties.get(i).getContainerId(),
+            partitionIds.get(0), false, BlobId.BlobDataType.DATACHUNK));
+      }
+      else{
+        blobIdList2.add(new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
+            mockClusterMap.getLocalDatacenterId(), properties.get(i).getAccountId(), properties.get(i).getContainerId(),
+            partitionIds.get(1), false, BlobId.BlobDataType.DATACHUNK));
+      }
+    }
+
+    ConnectedChannel channel =
+        ServerTestUtil.getBlockingChannelBasedOnPortType(new Port(dataNodeId.getPort(), PortType.PLAINTEXT),
+            "localhost", null, null);
+    channel.connect();
+    for (int i = 0; i < 3; i++) {
+      putBlob(blobIdList1.get(i), properties.get(i), encryptionKey.get(i), usermetadata.get(i), data.get(i), channel);
+    }
+    List<BatchDeletePartitionRequestInfo> batchDeletePartitionRequestInfoList = new ArrayList<>();
+    batchDeletePartitionRequestInfoList.add(new BatchDeletePartitionRequestInfo(partitionIds.get(0), blobIdList1));
+    batchDeletePartitionRequestInfoList.add(new BatchDeletePartitionRequestInfo(partitionIds.get(1), blobIdList2));
+    BatchDeleteResponse batchDeleteResponse = deleteBlobs(batchDeletePartitionRequestInfoList, channel);
+    Assert.assertEquals(ServerErrorCode.Bad_Request, batchDeleteResponse.getError());
+  }
+
+  /**
+   * Complete Failure test for batch delete
+   * <p>
+   * This test does the following:
+   * 1. Makes 0 puts.
+   * 2. Creates 1 batch delete request for 5 blob deletes.
+   * 3. Verifies the BatchDeleteResponse
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testBatchDeleteCompleteFailure() throws Exception {
+    DataNodeId dataNodeId = mockClusterMap.getDataNodeIds().get(0);
+    encryptionKey = new ArrayList<>(5);
+    usermetadata = new ArrayList<>(5);
+    data = new ArrayList<>(5);
+    Random random = new Random();
+    for (int i = 0; i < 5; i++) {
+      if (i % 2 == 0) {
+        encryptionKey.add(new byte[100]);
+        random.nextBytes(encryptionKey.get(i));
+      } else {
+        encryptionKey.add(null);
+      }
+      usermetadata.add(new byte[1000 + i]);
+      data.add(new byte[31870 + i]);
+      random.nextBytes(usermetadata.get(i));
+      random.nextBytes(data.get(i));
+    }
+
+    properties = new ArrayList<>(5);
+    properties.add(new BlobProperties(31870, "serviceid1", Utils.getRandomShort(TestUtils.RANDOM),
+        Utils.getRandomShort(TestUtils.RANDOM), true));
+    properties.add(new BlobProperties(31871, "serviceid1", Utils.getRandomShort(TestUtils.RANDOM),
+        Utils.getRandomShort(TestUtils.RANDOM), false));
+    properties.add(new BlobProperties(31872, "serviceid1", Utils.getRandomShort(TestUtils.RANDOM),
+        Utils.getRandomShort(TestUtils.RANDOM), true));
+    properties.add(
+        new BlobProperties(31873, "serviceid1", "ownerid", "jpeg", false, 0, Utils.getRandomShort(TestUtils.RANDOM),
+            Utils.getRandomShort(TestUtils.RANDOM), false, null, null, null));
+    properties.add(new BlobProperties(31874, "serviceid1", Utils.getRandomShort(TestUtils.RANDOM),
+        Utils.getRandomShort(TestUtils.RANDOM), true));
+
+    List<PartitionId> partitionIds = mockClusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS);
+    blobIdList1 = new ArrayList<>(3);
+    blobIdList2 = new ArrayList<>(2);
+    for (int i = 0; i < 5; i++) {
+      if (i%2 == 0) {
+        blobIdList1.add(new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
+            mockClusterMap.getLocalDatacenterId(), properties.get(i).getAccountId(), properties.get(i).getContainerId(),
+            partitionIds.get(0), false, BlobId.BlobDataType.DATACHUNK));
+      }
+      else{
+        blobIdList2.add(new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
+            mockClusterMap.getLocalDatacenterId(), properties.get(i).getAccountId(), properties.get(i).getContainerId(),
+            partitionIds.get(1), false, BlobId.BlobDataType.DATACHUNK));
+      }
+    }
+
+    ConnectedChannel channel =
+        ServerTestUtil.getBlockingChannelBasedOnPortType(new Port(dataNodeId.getPort(), PortType.PLAINTEXT),
+            "localhost", null, null);
+    channel.connect();
+    List<BatchDeletePartitionRequestInfo> batchDeletePartitionRequestInfoList = new ArrayList<>();
+    batchDeletePartitionRequestInfoList.add(new BatchDeletePartitionRequestInfo(partitionIds.get(0), blobIdList1));
+    batchDeletePartitionRequestInfoList.add(new BatchDeletePartitionRequestInfo(partitionIds.get(1), blobIdList2));
+    BatchDeleteResponse batchDeleteResponse = deleteBlobs(batchDeletePartitionRequestInfoList, channel);
+    Assert.assertEquals(ServerErrorCode.Bad_Request, batchDeleteResponse.getError());
+  }
+}

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryRequests.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryRequests.java
@@ -550,7 +550,7 @@ public class AmbryRequests implements RequestAPI {
           }
           partitionResponseInfo = new BatchDeletePartitionResponseInfo(batchDeletePartitionRequestInfo.getPartition(), blobsDeleteStatuses);
         } else {
-          partitionResponseInfo = processStoreBatchDelete(batchDeleteRequest, batchDeletePartitionRequestInfo);
+          partitionResponseInfo = batchDeleteForPartition(batchDeleteRequest, batchDeletePartitionRequestInfo);
         }
       } catch (Exception e) {
         // All blobs failed to delete in a partition
@@ -592,7 +592,7 @@ public class AmbryRequests implements RequestAPI {
    * @param batchDeletePartitionRequestInfo the {@Link BatchDeletePartitionRequestInfo} for the partition where Batch_Delete is to be performed.
    * @return the {@Link BatchDeletePartitionResponseInfo} having a list of {@Link BlobDeleteStatus} for the status of blobs requested to be deleted.
    */
-  private BatchDeletePartitionResponseInfo processStoreBatchDelete(BatchDeleteRequest batchDeleteRequest, BatchDeletePartitionRequestInfo batchDeletePartitionRequestInfo)
+  private BatchDeletePartitionResponseInfo batchDeleteForPartition(BatchDeleteRequest batchDeleteRequest, BatchDeletePartitionRequestInfo batchDeletePartitionRequestInfo)
       throws Exception {
     List<MessageInfo> infoList = new ArrayList<>();
     List<StoreKey> convertedStoreKeys = getConvertedStoreKeys(batchDeletePartitionRequestInfo.getBlobIds());

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryServerRequests.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryServerRequests.java
@@ -126,8 +126,9 @@ public class AmbryServerRequests extends AmbryRequests {
     this.clusterParticipant = clusterParticipant;
 
     for (RequestOrResponseType requestType : EnumSet.of(RequestOrResponseType.PutRequest,
-        RequestOrResponseType.GetRequest, RequestOrResponseType.DeleteRequest, RequestOrResponseType.UndeleteRequest,
-        RequestOrResponseType.ReplicaMetadataRequest, RequestOrResponseType.TtlUpdateRequest)) {
+        RequestOrResponseType.GetRequest, RequestOrResponseType.DeleteRequest, RequestOrResponseType.BatchDeleteRequest,
+        RequestOrResponseType.UndeleteRequest, RequestOrResponseType.ReplicaMetadataRequest,
+        RequestOrResponseType.TtlUpdateRequest)) {
       requestsDisableInfo.put(requestType, Collections.newSetFromMap(new ConcurrentHashMap<>()));
     }
     StoreKeyJacksonConfig.setupObjectMapper(objectMapper, new BlobIdFactory(clusterMap));

--- a/ambry-server/src/test/java/com/github/ambry/server/AmbryServerRequestsTest.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/AmbryServerRequestsTest.java
@@ -56,6 +56,8 @@ import com.github.ambry.protocol.AdminRequest;
 import com.github.ambry.protocol.AdminRequestOrResponseType;
 import com.github.ambry.protocol.AdminResponse;
 import com.github.ambry.protocol.AdminResponseWithContent;
+import com.github.ambry.protocol.BatchDeletePartitionRequestInfo;
+import com.github.ambry.protocol.BatchDeleteRequest;
 import com.github.ambry.protocol.BlobStoreControlAction;
 import com.github.ambry.protocol.BlobStoreControlAdminRequest;
 import com.github.ambry.protocol.CatchupStatusAdminRequest;
@@ -284,7 +286,7 @@ public class AmbryServerRequestsTest extends ReplicationTestHelper {
     }
 
     for (RequestOrResponseType request : EnumSet.of(RequestOrResponseType.PutRequest, RequestOrResponseType.GetRequest,
-        RequestOrResponseType.DeleteRequest, RequestOrResponseType.TtlUpdateRequest,
+        RequestOrResponseType.DeleteRequest, RequestOrResponseType.BatchDeleteRequest, RequestOrResponseType.TtlUpdateRequest,
         RequestOrResponseType.UndeleteRequest)) {
       for (Map.Entry<ReplicaState, ReplicaId> entry : stateToReplica.entrySet()) {
         if (request == RequestOrResponseType.PutRequest) {
@@ -393,7 +395,8 @@ public class AmbryServerRequestsTest extends ReplicationTestHelper {
   @Test
   public void controlRequestSuccessTest() throws InterruptedException, IOException {
     RequestOrResponseType[] requestOrResponseTypes =
-        {RequestOrResponseType.PutRequest, RequestOrResponseType.DeleteRequest, RequestOrResponseType.GetRequest,
+        {  RequestOrResponseType.PutRequest, RequestOrResponseType.DeleteRequest,
+            RequestOrResponseType.BatchDeleteRequest, RequestOrResponseType.GetRequest,
             RequestOrResponseType.ReplicaMetadataRequest, RequestOrResponseType.TtlUpdateRequest,
             RequestOrResponseType.UndeleteRequest};
     for (RequestOrResponseType requestType : requestOrResponseTypes) {
@@ -1916,6 +1919,10 @@ public class AmbryServerRequestsTest extends ReplicationTestHelper {
           break;
         case DeleteRequest:
           request = new DeleteRequest(correlationId, clientId, originalBlobId, SystemTime.getInstance().milliseconds());
+          break;
+        case BatchDeleteRequest:
+          BatchDeletePartitionRequestInfo batchDeletePartitionRequestInfo = new BatchDeletePartitionRequestInfo(id, Collections.singletonList(originalBlobId));
+          request = new BatchDeleteRequest(correlationId, clientId, Collections.singletonList(batchDeletePartitionRequestInfo), SystemTime.getInstance().milliseconds());
           break;
         case UndeleteRequest:
           request =

--- a/ambry-server/src/test/java/com/github/ambry/server/StatsManagerTest.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/StatsManagerTest.java
@@ -49,6 +49,7 @@ import com.github.ambry.store.MessageWriteSet;
 import com.github.ambry.store.MockStoreKeyConverterFactory;
 import com.github.ambry.store.StorageManager;
 import com.github.ambry.store.Store;
+import com.github.ambry.store.StoreBatchDeleteInfo;
 import com.github.ambry.store.StoreErrorCodes;
 import com.github.ambry.store.StoreException;
 import com.github.ambry.store.StoreGetOptions;
@@ -597,6 +598,11 @@ public class StatsManagerTest {
 
     @Override
     public void delete(List<MessageInfo> infos) throws StoreException {
+      throw new IllegalStateException("Not implemented");
+    }
+
+    @Override
+    public StoreBatchDeleteInfo batchDelete(List<MessageInfo> infos) throws StoreException {
       throw new IllegalStateException("Not implemented");
     }
 

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -19,6 +19,8 @@ import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.clustermap.ReplicaSealStatus;
 import com.github.ambry.clustermap.ReplicaState;
 import com.github.ambry.clustermap.ReplicaStatusDelegate;
+import com.github.ambry.commons.BlobId;
+import com.github.ambry.commons.ErrorMapping;
 import com.github.ambry.config.StoreConfig;
 import com.github.ambry.messageformat.DeleteMessageFormatInputStream;
 import com.github.ambry.messageformat.MessageFormatInputStream;
@@ -27,6 +29,7 @@ import com.github.ambry.messageformat.MessageFormatWriteSet;
 import com.github.ambry.messageformat.TtlUpdateMessageFormatInputStream;
 import com.github.ambry.messageformat.UndeleteMessageFormatInputStream;
 import com.github.ambry.replication.FindToken;
+import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.utils.FileLock;
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.Time;
@@ -759,6 +762,183 @@ public class BlobStore implements Store {
         logger.trace("Store : {} delete has been marked in the index ", dataDir);
       }
       onSuccess("DELETE");
+    } catch (StoreException e) {
+      if (e.getErrorCode() == StoreErrorCodes.IOError) {
+        onError();
+      }
+      throw e;
+    } catch (Exception e) {
+      throw new StoreException("Unknown error while trying to delete blobs from store " + dataDir, e,
+          StoreErrorCodes.Unknown_Error);
+    } finally {
+      context.stop();
+    }
+  }
+
+  @Override
+  public StoreBatchDeleteInfo batchDelete(List<MessageInfo> infosToDelete) throws StoreException {
+    checkStarted();
+    checkDuplicates(infosToDelete);
+    StoreBatchDeleteInfo storeBatchDeleteInfo = new StoreBatchDeleteInfo(
+        replicaId.getPartitionId(), new ArrayList<>());
+    final Timer.Context context = metrics.batchDeleteResponse.time();
+    int i = 0;
+    List<MessageInfo> filteredInfos = null;
+    try {
+      List<IndexValue> indexValuesPriorToDelete = new ArrayList<>();
+      List<IndexValue> originalPuts = new ArrayList<>();
+      List<Short> lifeVersions = new ArrayList<>();
+      Offset indexEndOffsetBeforeCheck = index.getCurrentEndOffset();
+      filteredInfos = new ArrayList<>();
+      for (MessageInfo info : infosToDelete) {
+        try {
+          IndexValue value =
+              index.findKey(info.getStoreKey(), new FileSpan(index.getStartOffset(), indexEndOffsetBeforeCheck));
+          if (value == null) {
+            throw new StoreException(
+                "Cannot delete id " + info.getStoreKey() + " because it is not present in the index",
+                StoreErrorCodes.ID_Not_Found);
+          }
+          if (!info.getStoreKey().isAccountContainerMatch(value.getAccountId(), value.getContainerId())) {
+            if (config.storeValidateAuthorization) {
+              throw new StoreException(
+                  "DELETE authorization failure. Key: " + info.getStoreKey() + "Actually accountId: "
+                      + value.getAccountId() + "Actually containerId: " + value.getContainerId(),
+                  StoreErrorCodes.Authorization_Failure);
+            } else {
+              logger.warn("DELETE authorization failure. Key: {} Actually accountId: {} Actually containerId: {}",
+                  info.getStoreKey(), value.getAccountId(), value.getContainerId());
+              metrics.deleteAuthorizationFailureCount.inc();
+            }
+          }
+          short revisedLifeVersion = info.getLifeVersion();
+          if (info.getLifeVersion() == MessageInfo.LIFE_VERSION_FROM_FRONTEND) {
+            // This is a delete request from frontend
+            if (value.isDelete()) {
+              throw new StoreException(
+                  "Cannot delete id " + info.getStoreKey() + " since it is already deleted in the index.",
+                  StoreErrorCodes.ID_Deleted);
+            }
+            revisedLifeVersion = value.getLifeVersion();
+          } else {
+            // This is a delete request from replication
+            if (value.isDelete() && value.getLifeVersion() == info.getLifeVersion()) {
+              throw new StoreException("Cannot delete id " + info.getStoreKey()
+                  + " since it is already deleted in the index with lifeVersion " + value.getLifeVersion() + ".",
+                  StoreErrorCodes.ID_Deleted);
+            }
+            if (value.getLifeVersion() > info.getLifeVersion()) {
+              throw new StoreException("Cannot delete id " + info.getStoreKey()
+                  + " since it has a higher lifeVersion than the message info: " + value.getLifeVersion() + ">"
+                  + info.getLifeVersion(), StoreErrorCodes.Life_Version_Conflict);
+            }
+          }
+          indexValuesPriorToDelete.add(value);
+          lifeVersions.add(revisedLifeVersion);
+          if (!value.isDelete() && !value.isUndelete()) {
+            originalPuts.add(value);
+          } else {
+            originalPuts.add(index.findKey(info.getStoreKey(), new FileSpan(index.getStartOffset(), value.getOffset()),
+                EnumSet.of(PersistentIndex.IndexEntryType.PUT)));
+          }
+          i++;
+          filteredInfos.add(info);
+        } catch (StoreException e){
+          storeBatchDeleteInfo.addMessageErrorInfo(new MessageErrorInfo(info, e.getErrorCode()));
+          if (e.getErrorCode() == StoreErrorCodes.IOError) {
+            onError();
+          }
+        }
+      }
+      infosToDelete = filteredInfos;
+      if (infosToDelete.isEmpty()){
+        logger.trace("Batch Delete completely failed since all blobs failed");
+        return storeBatchDeleteInfo;
+      }
+      synchronized (storeWriteLock) {
+        Offset currentIndexEndOffset = index.getCurrentEndOffset();
+        i = 0;
+        if (!currentIndexEndOffset.equals(indexEndOffsetBeforeCheck)) {
+          FileSpan fileSpan = new FileSpan(indexEndOffsetBeforeCheck, currentIndexEndOffset);
+          filteredInfos = new ArrayList<>();
+          for (MessageInfo info : infosToDelete) {
+            try {
+              IndexValue value =
+                  index.findKey(info.getStoreKey(), fileSpan, EnumSet.allOf(PersistentIndex.IndexEntryType.class));
+              if (value != null) {
+                // There are several possible cases that can exist here. Delete has to follow either PUT, TTL_UPDATE or UNDELETE.
+                // let EOBC be end offset before check, and [RECORD] means RECORD is optional
+                // 1. PUT [TTL_UPDATE DELETE UNDELETE] EOBC DELETE
+                // 2. PUT EOBC TTL_UPDATE
+                // 3. PUT EOBC DELETE UNDELETE: this is really extreme case
+                // From these cases, we can have value being DELETE, TTL_UPDATE AND UNDELETE, we have to deal with them accordingly.
+                if (value.getLifeVersion() == lifeVersions.get(i)) {
+                  if (value.isDelete()) {
+                    throw new StoreException(
+                        "Cannot delete id " + info.getStoreKey() + " since it is already deleted in the index.",
+                        StoreErrorCodes.ID_Deleted);
+                  }
+                  // value being ttl update is fine, we can just append DELETE to it.
+                } else {
+                  // For the extreme case, we log it out and throw an exception.
+                  logger.warn("Concurrent operation for id " + info.getStoreKey() + " in store " + dataDir
+                      + ". Newly added value " + value);
+                  throw new StoreException(
+                      "Cannot delete id " + info.getStoreKey() + " since there are concurrent operation while delete",
+                      StoreErrorCodes.Life_Version_Conflict);
+                }
+                indexValuesPriorToDelete.set(i, value);
+              }
+              i++;
+              filteredInfos.add(info);
+            } catch (StoreException e){
+              storeBatchDeleteInfo.addMessageErrorInfo(new MessageErrorInfo(info, e.getErrorCode()));
+              if (e.getErrorCode() == StoreErrorCodes.IOError) {
+                onError();
+              }
+            }
+          }
+          infosToDelete = filteredInfos;
+          if (infosToDelete.isEmpty()){
+            logger.trace("Batch Delete completely failed since all blobs failed");
+            return storeBatchDeleteInfo;
+          }
+        }
+        List<InputStream> inputStreams = new ArrayList<>(infosToDelete.size());
+        List<MessageInfo> updatedInfos = new ArrayList<>(infosToDelete.size());
+        i = 0;
+        for (MessageInfo info : infosToDelete) {
+          MessageFormatInputStream stream =
+              new DeleteMessageFormatInputStream(info.getStoreKey(), info.getAccountId(), info.getContainerId(),
+                  info.getOperationTimeMs(), lifeVersions.get(i));
+          // Don't change the lifeVersion here, there are other logic in markAsDeleted that relies on this lifeVersion.
+          updatedInfos.add(
+              new MessageInfo(info.getStoreKey(), stream.getSize(), info.getAccountId(), info.getContainerId(),
+                  info.getOperationTimeMs(), info.getLifeVersion()));
+          inputStreams.add(stream);
+          i++;
+        }
+        Offset endOffsetOfLastMessage = log.getEndOffset();
+        MessageFormatWriteSet writeSet =
+            new MessageFormatWriteSet(new SequenceInputStream(Collections.enumeration(inputStreams)), updatedInfos,
+                false);
+        writeSet.writeTo(log);
+        logger.trace("Store : {} delete mark written to log", dataDir);
+        int correspondingPutIndex = 0;
+        for (MessageInfo info : updatedInfos) {
+          FileSpan fileSpan = log.getFileSpanForMessage(endOffsetOfLastMessage, info.getSize());
+          IndexValue deleteIndexValue =
+              index.markAsDeleted(info.getStoreKey(), fileSpan, null, info.getOperationTimeMs(), info.getLifeVersion());
+          endOffsetOfLastMessage = fileSpan.getEndOffset();
+          blobStoreStats.handleNewDeleteEntry(info.getStoreKey(), deleteIndexValue,
+              originalPuts.get(correspondingPutIndex), indexValuesPriorToDelete.get(correspondingPutIndex));
+          correspondingPutIndex++;
+          storeBatchDeleteInfo.addMessageErrorInfo(new MessageErrorInfo(info, null));
+        }
+        logger.trace("Store : {} delete has been marked in the index ", dataDir);
+      }
+      onSuccess("BATCH_DELETE");
+      return storeBatchDeleteInfo;
     } catch (StoreException e) {
       if (e.getErrorCode() == StoreErrorCodes.IOError) {
         onError();

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -19,17 +19,15 @@ import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.clustermap.ReplicaSealStatus;
 import com.github.ambry.clustermap.ReplicaState;
 import com.github.ambry.clustermap.ReplicaStatusDelegate;
-import com.github.ambry.commons.BlobId;
-import com.github.ambry.commons.ErrorMapping;
 import com.github.ambry.config.StoreConfig;
 import com.github.ambry.messageformat.DeleteMessageFormatInputStream;
+import com.github.ambry.messageformat.MessageFormatException;
 import com.github.ambry.messageformat.MessageFormatInputStream;
 import com.github.ambry.messageformat.MessageFormatRecord;
 import com.github.ambry.messageformat.MessageFormatWriteSet;
 import com.github.ambry.messageformat.TtlUpdateMessageFormatInputStream;
 import com.github.ambry.messageformat.UndeleteMessageFormatInputStream;
 import com.github.ambry.replication.FindToken;
-import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.utils.FileLock;
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.Time;
@@ -775,71 +773,107 @@ public class BlobStore implements Store {
     }
   }
 
-  @Override
-  public StoreBatchDeleteInfo batchDelete(List<MessageInfo> infosToDelete) throws StoreException {
-    checkStarted();
-    checkDuplicates(infosToDelete);
-    StoreBatchDeleteInfo storeBatchDeleteInfo = new StoreBatchDeleteInfo(
-        replicaId.getPartitionId(), new ArrayList<>());
-    final Timer.Context context = metrics.batchDeleteResponse.time();
+  private List<MessageInfo> getFilteredInfosForBatchDelete(List<MessageInfo> infosToDelete, Offset indexEndOffsetBeforeCheck,
+      List<IndexValue> indexValuesPriorToDelete, List<Short> lifeVersions, List<IndexValue> originalPuts,
+      StoreBatchDeleteInfo storeBatchDeleteInfo) throws StoreException {
+    List<MessageInfo> filteredInfos = new ArrayList<>();
+    for (MessageInfo info : infosToDelete) {
+      try {
+        IndexValue value =
+            index.findKey(info.getStoreKey(), new FileSpan(index.getStartOffset(), indexEndOffsetBeforeCheck));
+        if (value == null) {
+          throw new StoreException(
+              "BATCH_DELETE: Cannot delete id " + info.getStoreKey() + " because it is not present in the index",
+              StoreErrorCodes.ID_Not_Found);
+        }
+        if (!info.getStoreKey().isAccountContainerMatch(value.getAccountId(), value.getContainerId())) {
+          String errorStr = "BATCH_DELETE authorization failure. Key: " + info.getStoreKey() + "Actually accountId: "
+              + value.getAccountId() + "Actually containerId: " + value.getContainerId();
+          if (config.storeValidateAuthorization) {
+            throw new StoreException(errorStr, StoreErrorCodes.Authorization_Failure);
+          } else {
+            logger.warn(errorStr);
+            metrics.deleteAuthorizationFailureCount.inc();
+          }
+        }
+        short revisedLifeVersion = info.getLifeVersion();
+        if (info.getLifeVersion() == MessageInfo.LIFE_VERSION_FROM_FRONTEND) {
+          // This is a delete request from frontend
+          if (value.isDelete()) {
+            throw new StoreException(
+                "BATCH_DELETE: Cannot delete id " + info.getStoreKey() + " since it is already deleted in the index.",
+                StoreErrorCodes.ID_Deleted);
+          }
+          revisedLifeVersion = value.getLifeVersion();
+        } else {
+          // This is a delete request from replication
+          if (value.isDelete() && value.getLifeVersion() == info.getLifeVersion()) {
+            throw new StoreException("BATCH_DELETE: Cannot delete id " + info.getStoreKey()
+                + " since it is already deleted in the index with lifeVersion " + value.getLifeVersion() + ".",
+                StoreErrorCodes.ID_Deleted);
+          }
+          if (value.getLifeVersion() > info.getLifeVersion()) {
+            throw new StoreException("BATCH_DELETE: Cannot delete id " + info.getStoreKey()
+                + " since it has a higher lifeVersion than the message info: " + value.getLifeVersion() + ">"
+                + info.getLifeVersion(), StoreErrorCodes.Life_Version_Conflict);
+          }
+        }
+        indexValuesPriorToDelete.add(value);
+        lifeVersions.add(revisedLifeVersion);
+        if (!value.isDelete() && !value.isUndelete()) {
+          originalPuts.add(value);
+        } else {
+          originalPuts.add(index.findKey(info.getStoreKey(), new FileSpan(index.getStartOffset(), value.getOffset()),
+              EnumSet.of(PersistentIndex.IndexEntryType.PUT)));
+        }
+        filteredInfos.add(info);
+      } catch (StoreException e){
+        storeBatchDeleteInfo.addMessageErrorInfo(new MessageErrorInfo(info, e.getErrorCode()));
+        if (e.getErrorCode() == StoreErrorCodes.IOError) {
+          onError();
+        }
+      }
+    }
+    return filteredInfos;
+  }
+
+
+  private void processStoreLockOpsForBatchDelete(List<MessageInfo> infosToDelete, Offset indexEndOffsetBeforeCheck,
+      List<IndexValue> indexValuesPriorToDelete, List<Short> lifeVersions, List<IndexValue> originalPuts,
+      StoreBatchDeleteInfo storeBatchDeleteInfo, List<MessageInfo> infosToDeleteCopy)
+      throws StoreException, IOException, MessageFormatException {
+    Offset currentIndexEndOffset = index.getCurrentEndOffset();
     int i = 0;
-    List<MessageInfo> filteredInfos = null;
-    try {
-      List<IndexValue> indexValuesPriorToDelete = new ArrayList<>();
-      List<IndexValue> originalPuts = new ArrayList<>();
-      List<Short> lifeVersions = new ArrayList<>();
-      Offset indexEndOffsetBeforeCheck = index.getCurrentEndOffset();
-      filteredInfos = new ArrayList<>();
+    if (!currentIndexEndOffset.equals(indexEndOffsetBeforeCheck)) {
+      FileSpan fileSpan = new FileSpan(indexEndOffsetBeforeCheck, currentIndexEndOffset);
+      List<MessageInfo> filteredInfos = new ArrayList<>();
       for (MessageInfo info : infosToDelete) {
         try {
           IndexValue value =
-              index.findKey(info.getStoreKey(), new FileSpan(index.getStartOffset(), indexEndOffsetBeforeCheck));
-          if (value == null) {
-            throw new StoreException(
-                "Cannot delete id " + info.getStoreKey() + " because it is not present in the index",
-                StoreErrorCodes.ID_Not_Found);
-          }
-          if (!info.getStoreKey().isAccountContainerMatch(value.getAccountId(), value.getContainerId())) {
-            if (config.storeValidateAuthorization) {
-              throw new StoreException(
-                  "DELETE authorization failure. Key: " + info.getStoreKey() + "Actually accountId: "
-                      + value.getAccountId() + "Actually containerId: " + value.getContainerId(),
-                  StoreErrorCodes.Authorization_Failure);
+              index.findKey(info.getStoreKey(), fileSpan, EnumSet.allOf(PersistentIndex.IndexEntryType.class));
+          if (value != null) {
+            // There are several possible cases that can exist here. Delete has to follow either PUT, TTL_UPDATE or UNDELETE.
+            // let EOBC be end offset before check, and [RECORD] means RECORD is optional
+            // 1. PUT [TTL_UPDATE DELETE UNDELETE] EOBC DELETE
+            // 2. PUT EOBC TTL_UPDATE
+            // 3. PUT EOBC DELETE UNDELETE: this is really extreme case
+            // From these cases, we can have value being DELETE, TTL_UPDATE AND UNDELETE, we have to deal with them accordingly.
+            if (value.getLifeVersion() == lifeVersions.get(i)) {
+              if (value.isDelete()) {
+                throw new StoreException(
+                    "BATCH_DELETE: Cannot delete id " + info.getStoreKey() + " since it is already deleted in the index.",
+                    StoreErrorCodes.ID_Deleted);
+              }
+              // value being ttl update is fine, we can just append DELETE to it.
             } else {
-              logger.warn("DELETE authorization failure. Key: {} Actually accountId: {} Actually containerId: {}",
-                  info.getStoreKey(), value.getAccountId(), value.getContainerId());
-              metrics.deleteAuthorizationFailureCount.inc();
-            }
-          }
-          short revisedLifeVersion = info.getLifeVersion();
-          if (info.getLifeVersion() == MessageInfo.LIFE_VERSION_FROM_FRONTEND) {
-            // This is a delete request from frontend
-            if (value.isDelete()) {
+              // For the extreme case, we log it out and throw an exception.
+              logger.warn("BATCH_DELETE: Concurrent operation for id " + info.getStoreKey() + " in store " + dataDir
+                  + ". Newly added value " + value);
               throw new StoreException(
-                  "Cannot delete id " + info.getStoreKey() + " since it is already deleted in the index.",
-                  StoreErrorCodes.ID_Deleted);
+                  "BATCH_DELETE: Cannot delete id " + info.getStoreKey() + " since there are concurrent operation while delete",
+                  StoreErrorCodes.Life_Version_Conflict);
             }
-            revisedLifeVersion = value.getLifeVersion();
-          } else {
-            // This is a delete request from replication
-            if (value.isDelete() && value.getLifeVersion() == info.getLifeVersion()) {
-              throw new StoreException("Cannot delete id " + info.getStoreKey()
-                  + " since it is already deleted in the index with lifeVersion " + value.getLifeVersion() + ".",
-                  StoreErrorCodes.ID_Deleted);
-            }
-            if (value.getLifeVersion() > info.getLifeVersion()) {
-              throw new StoreException("Cannot delete id " + info.getStoreKey()
-                  + " since it has a higher lifeVersion than the message info: " + value.getLifeVersion() + ">"
-                  + info.getLifeVersion(), StoreErrorCodes.Life_Version_Conflict);
-            }
-          }
-          indexValuesPriorToDelete.add(value);
-          lifeVersions.add(revisedLifeVersion);
-          if (!value.isDelete() && !value.isUndelete()) {
-            originalPuts.add(value);
-          } else {
-            originalPuts.add(index.findKey(info.getStoreKey(), new FileSpan(index.getStartOffset(), value.getOffset()),
-                EnumSet.of(PersistentIndex.IndexEntryType.PUT)));
+            indexValuesPriorToDelete.set(i, value);
           }
           i++;
           filteredInfos.add(info);
@@ -852,90 +886,68 @@ public class BlobStore implements Store {
       }
       infosToDelete = filteredInfos;
       if (infosToDelete.isEmpty()){
-        logger.trace("Batch Delete completely failed since all blobs failed");
+        logger.trace("BATCH_DELETE: Operation completely failed since all blobs failed. Received InfosToDelete: {}", infosToDeleteCopy);
+        return;
+      }
+    }
+    List<InputStream> inputStreams = new ArrayList<>(infosToDelete.size());
+    List<MessageInfo> updatedInfos = new ArrayList<>(infosToDelete.size());
+    i = 0;
+    for (MessageInfo info : infosToDelete) {
+      MessageFormatInputStream stream =
+          new DeleteMessageFormatInputStream(info.getStoreKey(), info.getAccountId(), info.getContainerId(),
+              info.getOperationTimeMs(), lifeVersions.get(i));
+      // Don't change the lifeVersion here, there are other logic in markAsDeleted that relies on this lifeVersion.
+      updatedInfos.add(
+          new MessageInfo(info.getStoreKey(), stream.getSize(), info.getAccountId(), info.getContainerId(),
+              info.getOperationTimeMs(), info.getLifeVersion()));
+      inputStreams.add(stream);
+      i++;
+    }
+    Offset endOffsetOfLastMessage = log.getEndOffset();
+    MessageFormatWriteSet writeSet =
+        new MessageFormatWriteSet(new SequenceInputStream(Collections.enumeration(inputStreams)), updatedInfos,
+            false);
+    writeSet.writeTo(log);
+    logger.trace("BATCH_DELETE: Store : {} delete mark written to log", dataDir);
+    int correspondingPutIndex = 0;
+    for (MessageInfo info : updatedInfos) {
+      FileSpan fileSpan = log.getFileSpanForMessage(endOffsetOfLastMessage, info.getSize());
+      IndexValue deleteIndexValue =
+          index.markAsDeleted(info.getStoreKey(), fileSpan, null, info.getOperationTimeMs(), info.getLifeVersion());
+      endOffsetOfLastMessage = fileSpan.getEndOffset();
+      blobStoreStats.handleNewDeleteEntry(info.getStoreKey(), deleteIndexValue,
+          originalPuts.get(correspondingPutIndex), indexValuesPriorToDelete.get(correspondingPutIndex));
+      correspondingPutIndex++;
+      storeBatchDeleteInfo.addMessageErrorInfo(new MessageErrorInfo(info, null));
+    }
+    logger.trace("BATCH_DELETE: Store : {} delete has been marked in the index ", dataDir);
+  }
+
+  @Override
+  public StoreBatchDeleteInfo batchDelete(List<MessageInfo> infosToDelete) throws StoreException {
+    checkStarted();
+    List<MessageInfo> infosToDeleteCopy = new ArrayList<>(infosToDelete);
+    checkDuplicates(infosToDelete);
+    StoreBatchDeleteInfo storeBatchDeleteInfo = new StoreBatchDeleteInfo(
+        replicaId.getPartitionId(), new ArrayList<>());
+    final Timer.Context context = metrics.batchDeleteResponse.time();
+    try {
+      List<IndexValue> indexValuesPriorToDelete = new ArrayList<>();
+      List<IndexValue> originalPuts = new ArrayList<>();
+      List<Short> lifeVersions = new ArrayList<>();
+      Offset indexEndOffsetBeforeCheck = index.getCurrentEndOffset();
+      // Update infosToDelete to filteredInfosToDelete returned from this function.
+      infosToDelete = getFilteredInfosForBatchDelete(infosToDelete, indexEndOffsetBeforeCheck, indexValuesPriorToDelete, lifeVersions,
+          originalPuts, storeBatchDeleteInfo);
+      if (infosToDelete.isEmpty()){
+        logger.trace("Batch Delete completely failed since all blobs failed. Received InfosToDelete: {}", infosToDeleteCopy);
         return storeBatchDeleteInfo;
       }
       synchronized (storeWriteLock) {
-        Offset currentIndexEndOffset = index.getCurrentEndOffset();
-        i = 0;
-        if (!currentIndexEndOffset.equals(indexEndOffsetBeforeCheck)) {
-          FileSpan fileSpan = new FileSpan(indexEndOffsetBeforeCheck, currentIndexEndOffset);
-          filteredInfos = new ArrayList<>();
-          for (MessageInfo info : infosToDelete) {
-            try {
-              IndexValue value =
-                  index.findKey(info.getStoreKey(), fileSpan, EnumSet.allOf(PersistentIndex.IndexEntryType.class));
-              if (value != null) {
-                // There are several possible cases that can exist here. Delete has to follow either PUT, TTL_UPDATE or UNDELETE.
-                // let EOBC be end offset before check, and [RECORD] means RECORD is optional
-                // 1. PUT [TTL_UPDATE DELETE UNDELETE] EOBC DELETE
-                // 2. PUT EOBC TTL_UPDATE
-                // 3. PUT EOBC DELETE UNDELETE: this is really extreme case
-                // From these cases, we can have value being DELETE, TTL_UPDATE AND UNDELETE, we have to deal with them accordingly.
-                if (value.getLifeVersion() == lifeVersions.get(i)) {
-                  if (value.isDelete()) {
-                    throw new StoreException(
-                        "Cannot delete id " + info.getStoreKey() + " since it is already deleted in the index.",
-                        StoreErrorCodes.ID_Deleted);
-                  }
-                  // value being ttl update is fine, we can just append DELETE to it.
-                } else {
-                  // For the extreme case, we log it out and throw an exception.
-                  logger.warn("Concurrent operation for id " + info.getStoreKey() + " in store " + dataDir
-                      + ". Newly added value " + value);
-                  throw new StoreException(
-                      "Cannot delete id " + info.getStoreKey() + " since there are concurrent operation while delete",
-                      StoreErrorCodes.Life_Version_Conflict);
-                }
-                indexValuesPriorToDelete.set(i, value);
-              }
-              i++;
-              filteredInfos.add(info);
-            } catch (StoreException e){
-              storeBatchDeleteInfo.addMessageErrorInfo(new MessageErrorInfo(info, e.getErrorCode()));
-              if (e.getErrorCode() == StoreErrorCodes.IOError) {
-                onError();
-              }
-            }
-          }
-          infosToDelete = filteredInfos;
-          if (infosToDelete.isEmpty()){
-            logger.trace("Batch Delete completely failed since all blobs failed");
-            return storeBatchDeleteInfo;
-          }
-        }
-        List<InputStream> inputStreams = new ArrayList<>(infosToDelete.size());
-        List<MessageInfo> updatedInfos = new ArrayList<>(infosToDelete.size());
-        i = 0;
-        for (MessageInfo info : infosToDelete) {
-          MessageFormatInputStream stream =
-              new DeleteMessageFormatInputStream(info.getStoreKey(), info.getAccountId(), info.getContainerId(),
-                  info.getOperationTimeMs(), lifeVersions.get(i));
-          // Don't change the lifeVersion here, there are other logic in markAsDeleted that relies on this lifeVersion.
-          updatedInfos.add(
-              new MessageInfo(info.getStoreKey(), stream.getSize(), info.getAccountId(), info.getContainerId(),
-                  info.getOperationTimeMs(), info.getLifeVersion()));
-          inputStreams.add(stream);
-          i++;
-        }
-        Offset endOffsetOfLastMessage = log.getEndOffset();
-        MessageFormatWriteSet writeSet =
-            new MessageFormatWriteSet(new SequenceInputStream(Collections.enumeration(inputStreams)), updatedInfos,
-                false);
-        writeSet.writeTo(log);
-        logger.trace("Store : {} delete mark written to log", dataDir);
-        int correspondingPutIndex = 0;
-        for (MessageInfo info : updatedInfos) {
-          FileSpan fileSpan = log.getFileSpanForMessage(endOffsetOfLastMessage, info.getSize());
-          IndexValue deleteIndexValue =
-              index.markAsDeleted(info.getStoreKey(), fileSpan, null, info.getOperationTimeMs(), info.getLifeVersion());
-          endOffsetOfLastMessage = fileSpan.getEndOffset();
-          blobStoreStats.handleNewDeleteEntry(info.getStoreKey(), deleteIndexValue,
-              originalPuts.get(correspondingPutIndex), indexValuesPriorToDelete.get(correspondingPutIndex));
-          correspondingPutIndex++;
-          storeBatchDeleteInfo.addMessageErrorInfo(new MessageErrorInfo(info, null));
-        }
-        logger.trace("Store : {} delete has been marked in the index ", dataDir);
+        // Update storeBatchDeleteInfo for the remaining infosToDelete via store lock operations.
+        processStoreLockOpsForBatchDelete(infosToDelete, indexEndOffsetBeforeCheck, indexValuesPriorToDelete,
+            lifeVersions, originalPuts, storeBatchDeleteInfo, infosToDeleteCopy);
       }
       onSuccess("BATCH_DELETE");
       return storeBatchDeleteInfo;

--- a/ambry-store/src/main/java/com/github/ambry/store/StoreMetrics.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StoreMetrics.java
@@ -37,6 +37,8 @@ public class StoreMetrics {
   public final Timer getResponse;
   public final Timer putResponse;
   public final Timer deleteResponse;
+
+  public final Timer batchDeleteResponse;
   public final Timer ttlUpdateResponse;
   public final Timer undeleteResponse;
   public final Timer findEntriesSinceResponse;
@@ -147,6 +149,7 @@ public class StoreMetrics {
     getResponse = registry.timer(MetricRegistry.name(BlobStore.class, name + "StoreGetResponse"));
     putResponse = registry.timer(MetricRegistry.name(BlobStore.class, name + "StorePutResponse"));
     deleteResponse = registry.timer(MetricRegistry.name(BlobStore.class, name + "StoreDeleteResponse"));
+    batchDeleteResponse = registry.timer(MetricRegistry.name(BlobStore.class, name + "StoreBatchDeleteResponse"));
     ttlUpdateResponse = registry.timer(MetricRegistry.name(BlobStore.class, name + "StoreTtlUpdateResponse"));
     undeleteResponse = registry.timer(MetricRegistry.name(BlobStore.class, name + "StoreUndeleteResponse"));
     findEntriesSinceResponse =


### PR DESCRIPTION
## Summary
Ambry batch delete support - server changes

## Description
Existing delete operation handles one blob in a single request, the batch delete change introduces handling on server side of a BatchDeleteRequest received from frontend OperationController. At the store level, this includes deleting a list of blobs in a partition and handling the aggregated response in batchDelete util. This is needed for deletion of composite blobs, along with significant performance improvement on large sized composite blobs.

## Testing
Unit tests done.
Integration tests done.