### PR TITLE
Add partitionInfo to the map even when peers are empty

### DIFF
--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationManager.java
@@ -214,8 +214,8 @@ public class ReplicationManager extends ReplicationEngine {
       List<RemoteReplicaInfo> remoteReplicaInfos = new ArrayList<>();
       if (!peerReplicas.isEmpty()) {
         remoteReplicaInfos = createRemoteReplicaInfos(peerReplicas, replicaId);
-        updatePartitionInfoMaps(remoteReplicaInfos, replicaId);
       }
+      updatePartitionInfoMaps(remoteReplicaInfos, replicaId);
       logger.info("Assigning thread for {}", replicaId.getPartitionId());
       addRemoteReplicaInfoToReplicaThread(remoteReplicaInfos, true);
       // No need to update persistor to explicitly persist tokens for new replica because background persistor will


### PR DESCRIPTION
## Summary
Updating PartitionInfo map even there is no peers. 

## Details
In ReplicationManager, when we are adding a replica, we would also update the PartitionInfo map. But when there is no peers for this replica, we skip updating the PartitionInfo map. So there will be no PartitionInfo in this map. This is bad. Because when we create a partition and the first replica is assigned to a host (helix might assign all replicas to different hosts at the same time, so all replicas are considered as first replica in its own local state), there will be no PartitionInfo in the map. And when peers update the property store and ReplicationManager gets notified, ReplicationEngine.onReplicaAddedOrRemoved would be called to add those peers to replication thread. However, this method would check if this PartitionInfo exists or not, if it does not, we ignore the peers.  This process means, when creating a partition, the first replica would always ignore the peers for replication, and will never catch up with enough replicas.

A restart should fix this issue, but let's fix this issue in code as well.


## Test
Existing unit test