### PR TITLE
[vcr-2.0] Remove unused and excessive metrics

### DIFF
--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/RecoveryManager.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/RecoveryManager.java
@@ -295,7 +295,6 @@ public class RecoveryManager extends ReplicationEngine {
     if (replicationConfig.replicationTrackPerPartitionLagFromRemote) {
       replicationMetrics.addLagMetricForPartition(partitionId, true);
     }
-    replicationMetrics.addCatchUpPointMetricForPartition(partitionId);
     logger.info("Added cloud replica for partition-{} for recovery", partitionName);
   }
 
@@ -335,7 +334,6 @@ public class RecoveryManager extends ReplicationEngine {
     PartitionId partitionId = localReplica.getPartitionId();
     stopPartitionReplication(partitionId);
     replicationMetrics.removeLagMetricForPartition(partitionId);
-    replicationMetrics.removeCatchupPointMetricForPartition(partitionId);
     logger.info("Cloud Partition {} removed from {}", partitionId, dataNodeId);
   }
 

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicationManager.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicationManager.java
@@ -421,7 +421,6 @@ public class VcrReplicationManager extends ReplicationEngine {
                 findTokenFactory.getNewFindToken(),
                 storeConfig.storeDataFlushIntervalSeconds * SystemTime.MsPerSec * Replication_Delay_Multiplier,
                 SystemTime.getInstance(), peerReplica.getDataNodeId().getPortToConnectTo());
-        replicationMetrics.addMetricsForRemoteReplicaInfo(remoteReplicaInfo, trackPerDatacenterLagInMetric);
         remoteReplicaInfos.add(remoteReplicaInfo);
       }
       rwLock.writeLock().lock();

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -761,12 +761,6 @@ public class ReplicaThread implements Runnable {
 
             replicationMetrics.updateLagMetricForRemoteReplica(remoteReplicaInfo,
                 exchangeMetadataResponse.localLagFromRemoteInBytes);
-            if (replicaMetadataResponseInfo.getMessageInfoList().size() > 0) {
-              replicationMetrics.updateCatchupPointMetricForCloudReplica(remoteReplicaInfo,
-                  replicaMetadataResponseInfo.getMessageInfoList()
-                      .get(replicaMetadataResponseInfo.getMessageInfoList().size() - 1)
-                      .getOperationTimeMs());
-            }
 
             // Add exchangeMetadataResponse to list at the end after operations such as replicaSyncUpManager(if not null)
             // has completed update, etc. The reason is we may get exceptions in between (for ex: replicaSyncUpManager may

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationMetrics.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationMetrics.java
@@ -39,7 +39,6 @@ import java.util.stream.Collectors;
 public class ReplicationMetrics {
 
   private final static String MAX_LAG_FROM_PEERS_IN_BYTE_METRIC_NAME_TEMPLATE = "Partition-%s-maxLagFromPeersInBytes";
-  private final static String CATCH_POINT_FROM_CLOUD_METRIC_NAME_TEMPLATE = "Partition-%s-catchupPointFromCloud";
 
   public final Map<String, Meter> interColoReplicationBytesRate = new HashMap<String, Meter>();
   public final Meter intraColoReplicationBytesRate;
@@ -141,7 +140,6 @@ public class ReplicationMetrics {
   private final Map<PartitionId, Counter> partitionIdToInvalidMessageStreamErrorCounter = new HashMap<>();
   // ConcurrentHashMap is used to avoid cache incoherence.
   private final Map<PartitionId, Map<DataNodeId, Long>> partitionLags = new ConcurrentHashMap<>();
-  private Map<PartitionId, Long> cloudReplicaCatchUpPoint = new ConcurrentHashMap<>();
   private final Map<String, Set<RemoteReplicaInfo>> remoteReplicaInfosByDc = new ConcurrentHashMap<>();
   private final Map<String, LongSummaryStatistics> dcToReplicaLagStats = new ConcurrentHashMap<>();
 
@@ -521,20 +519,6 @@ public class ReplicationMetrics {
   }
 
   /**
-   * Add catchup point metric(local from cloud) for given partitionId.
-   * @param partitionId partition to add metric for.
-   */
-  public void addCatchUpPointMetricForPartition(PartitionId partitionId) {
-    if (!cloudReplicaCatchUpPoint.containsKey(partitionId)) {
-      cloudReplicaCatchUpPoint.put(partitionId, 0L);
-      // Set up metrics if and only if no mapping for this partition before.
-      Gauge<Long> catchUpPoint = () -> cloudReplicaCatchUpPoint.get(partitionId);
-      registry.gauge(MetricRegistry.name(ReplicaThread.class,
-          String.format(CATCH_POINT_FROM_CLOUD_METRIC_NAME_TEMPLATE, partitionId.toPathString())), () -> catchUpPoint);
-    }
-  }
-
-  /**
    * Remove replication lag metric of given partition if it's present.
    * @param partitionId the given partition whose lag metric should be removed.
    */
@@ -542,17 +526,6 @@ public class ReplicationMetrics {
     if (partitionLags.containsKey(partitionId)) {
       registry.remove(MetricRegistry.name(ReplicaThread.class,
           String.format(MAX_LAG_FROM_PEERS_IN_BYTE_METRIC_NAME_TEMPLATE, partitionId.toPathString())));
-    }
-  }
-
-  /**
-   * Remove catch up point metric of given partition if it's present.
-   * @param partitionId the given partition whose catch up point metric should be removed.
-   */
-  public void removeCatchupPointMetricForPartition(PartitionId partitionId) {
-    if (cloudReplicaCatchUpPoint.containsKey(partitionId)) {
-      registry.remove(MetricRegistry.name(ReplicaThread.class,
-          String.format(CATCH_POINT_FROM_CLOUD_METRIC_NAME_TEMPLATE, partitionId.toPathString())));
     }
   }
 
@@ -895,19 +868,6 @@ public class ReplicationMetrics {
     });
   }
 
-  /**
-   * Update catch up point of local replica from the cloud replica.
-   * @param remoteReplicaInfo {@link RemoteReplicaInfo} of the cloud replica.
-   * @param catchUpPoint timestamp upto which local replica has caught with the cloud replica.
-   */
-  public void updateCatchupPointMetricForCloudReplica(RemoteReplicaInfo remoteReplicaInfo, long catchUpPoint) {
-    // update this metric only for cloud peer replica. There will only be one cloud replica peer per partition.
-    if (remoteReplicaInfo.getReplicaId().getReplicaType() == ReplicaType.CLOUD_BACKED
-        && cloudReplicaCatchUpPoint.containsKey(remoteReplicaInfo.getLocalReplicaId().getPartitionId())) {
-      // update the partition's catch up point if and only if it was tracked.
-      cloudReplicaCatchUpPoint.put(remoteReplicaInfo.getLocalReplicaId().getPartitionId(), catchUpPoint);
-    }
-  }
 
   /**
    * Get a partition's maximum lag between local and its {@link RemoteReplicaInfo}s.


### PR DESCRIPTION
VCR creates a lot of metrics per partition and none of these are used. Just get rid of it. We have way too many metrics causing errors when sending that message to Kafka. We have an open ticket with Kafka regarding this but the recommendation is also to reduce metrics on our side.