### PR TITLE
[vcr-2.0] Fix error handling

### DIFF
--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobStore.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobStore.java
@@ -13,6 +13,8 @@
  */
 package com.github.ambry.cloud;
 
+import com.azure.storage.blob.models.BlobErrorCode;
+import com.azure.storage.blob.models.BlobStorageException;
 import com.codahale.metrics.Timer;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.PartitionId;
@@ -117,14 +119,7 @@ public class CloudBlobStore implements Store {
     minTtlMillis = TimeUnit.DAYS.toMillis(cloudConfig.vcrMinTtlDays);
     requireEncryption = cloudConfig.vcrRequireEncryption;
     isVcr = cloudConfig.cloudIsVcr;
-    if (isVcr && cloudConfig.ambryBackupVersion.equals(CloudConfig.AMBRY_BACKUP_VERSION_1)) {
-      logger.info("Creating cloud blob store for partition {} with cache size {}", partitionId.toPathString(),
-          cloudConfig.recentBlobCacheLimit);
-      recentBlobCache = Collections.synchronizedMap(new RecentBlobCache(cloudConfig.recentBlobCacheLimit));
-    } else {
-      logger.trace("Not creating recentBlobCache");
-      recentBlobCache = null;
-    }
+    recentBlobCache = null;
     requestAgent = new CloudRequestAgent(cloudConfig, vcrMetrics);
 
     String cryptoAgentFactoryClass = cloudConfig.cloudBlobCryptoAgentFactoryClass;
@@ -142,6 +137,130 @@ public class CloudBlobStore implements Store {
     currentState = ReplicaState.STANDBY;
     logger.debug("Started store: {}", this);
   }
+
+
+  /**
+   * Puts a set of messages into the store
+   * @param messageSetToWrite The message set to write to the store
+   * @throws StoreException
+   */
+  @Override
+  public void put(MessageWriteSet messageSetToWrite) throws StoreException {
+    try {
+      cloudDestination.uploadBlobs((MessageFormatWriteSet) messageSetToWrite);
+    } catch (CloudStorageException e) {
+      throw new StoreException(e.getMessage(), StoreErrorCodes.IOError);
+    }
+  }
+
+  /**
+   * Delete blob
+   * @param infos The list of messages that need to be deleted.
+   * @throws StoreException
+   */
+  @Override
+  public void delete(List<MessageInfo> infos) throws StoreException {
+    try {
+      for (MessageInfo msg : infos) {
+        cloudDestination.deleteBlob((BlobId) msg.getStoreKey(), msg.getOperationTimeMs(), msg.getLifeVersion(), null);
+      }
+    } catch (CloudStorageException e) {
+      throw new StoreException(e.getMessage(), StoreErrorCodes.IOError);
+    } catch (StoreException e) {
+      throw e;
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   * Currently, the only supported operation is to set the TTL to infinite (i.e. no arbitrary increase or decrease)
+   * @param infos The list of messages that need to be updated.
+   * @throws StoreException
+   */
+  @Override
+  public void updateTtl(List<MessageInfo> infos) throws StoreException {
+    try {
+      for (MessageInfo msg : infos) {
+        cloudDestination.updateBlobExpiration((BlobId) msg.getStoreKey(), Utils.Infinite_Time, null);
+      }
+    } catch (CloudStorageException e) {
+      throw new StoreException(e.getMessage(),  StoreErrorCodes.IOError);
+    } catch (StoreException e) {
+      throw e;
+    }
+  }
+
+  /**
+   * Undelete a blob
+   * @param info The {@link MessageInfo} that carries some basic information about this operation.
+   * @return
+   * @throws StoreException
+   */
+  @Override
+  public short undelete(MessageInfo info) throws StoreException {
+    try {
+      return cloudDestination.undeleteBlob((BlobId) info.getStoreKey(), info.getLifeVersion(), null);
+    } catch (CloudStorageException e) {
+      throw new StoreException(e.getMessage(), StoreErrorCodes.IOError);
+    } catch (StoreException e) {
+      throw e;
+    }
+  }
+
+  /**
+   * Find missing keys
+   * @param keys The list of keys that need to be checked for existence
+   * @return
+   * @throws StoreException
+   */
+  @Override
+  public Set<StoreKey> findMissingKeys(List<StoreKey> keys) throws StoreException {
+    Set<StoreKey> missingKeys = new HashSet<>();
+    // Keys may be missing if we are here, we are here to find out
+    for (StoreKey key : keys) {
+      try {
+        cloudDestination.getBlobMetadata(Collections.singletonList((BlobId) key));
+      } catch (CloudStorageException e) {
+        if (e.getCause() instanceof BlobStorageException &&
+            ((BlobStorageException) e.getCause()).getErrorCode() == BlobErrorCode.BLOB_NOT_FOUND) {
+          missingKeys.add(key);
+        } else {
+          throw new StoreException(e.getMessage(), StoreErrorCodes.IOError);
+        }
+      } catch (Throwable e) {
+        throw new StoreException(e.getMessage(), StoreErrorCodes.IOError);
+      }
+    }
+    return missingKeys;
+  }
+
+  /**
+   * Find key metadata
+   * @param key The key of which blob to return {@link MessageInfo}.
+   * @return
+   * @throws StoreException
+   */
+  @Override
+  public MessageInfo findKey(StoreKey key) throws StoreException {
+    try {
+      // Key must exist if we are here
+      Map<String, CloudBlobMetadata> cloudBlobMetadataListMap =
+          cloudDestination.getBlobMetadata(Collections.singletonList((BlobId) key));
+      CloudBlobMetadata cloudBlobMetadata = cloudBlobMetadataListMap.get(key.getID());
+      return new MessageInfo(key, cloudBlobMetadata.getSize(), cloudBlobMetadata.isDeleted(),
+          cloudBlobMetadata.isTtlUpdated(), cloudBlobMetadata.isUndeleted(), cloudBlobMetadata.getExpirationTime(), null,
+          (short) cloudBlobMetadata.getAccountId(), (short) cloudBlobMetadata.getContainerId(),
+          cloudBlobMetadata.getLastUpdateTime(), cloudBlobMetadata.getLifeVersion());
+    } catch (CloudStorageException e) {
+      if (e.getCause() instanceof BlobStorageException &&
+          ((BlobStorageException) e.getCause()).getErrorCode() == BlobErrorCode.BLOB_NOT_FOUND) {
+        throw new StoreException(e.getMessage(), StoreErrorCodes.ID_Not_Found);
+      }
+      throw new StoreException(e, StoreErrorCodes.IOError);
+    }
+  }
+
+  // UNUSED CODE
 
   @Override
   public StoreInfo get(List<? extends StoreKey> ids, EnumSet<StoreGetOptions> storeGetOptions) throws StoreException {
@@ -362,35 +481,6 @@ public class CloudBlobStore implements Store {
    */
   static boolean isBlobExpired(CloudBlobMetadata metadata, long currentTimeStamp) {
     return metadata.getExpirationTime() != Utils.Infinite_Time && metadata.getExpirationTime() < currentTimeStamp;
-  }
-
-  /**
-   * Puts a set of messages into the store
-   * @param messageSetToWrite The message set to write to the store
-   * @throws StoreException
-   */
-  @Override
-  public void put(MessageWriteSet messageSetToWrite) throws StoreException {
-    checkStarted();
-    if (messageSetToWrite.getMessageSetInfo().isEmpty()) {
-      throw new IllegalArgumentException("Message write set cannot be empty");
-    }
-    checkDuplicates(messageSetToWrite.getMessageSetInfo());
-
-    if (cloudConfig.ambryBackupVersion.equals(CloudConfig.AMBRY_BACKUP_VERSION_2) && !cloudConfig.vcrRequireEncryption) {
-      // If no encryption is needed, then just pass the input stream to the client and upload the blob.
-      // Otherwise, the code below in CloudWriteChannel creates an in-memory copy unnecessarily - legacy remnant.
-      try {
-        cloudDestination.uploadBlobs((MessageFormatWriteSet) messageSetToWrite);
-      } catch (CloudStorageException e) {
-        throw new StoreException(e, StoreErrorCodes.IOError);
-      }
-      return;
-    }
-
-    // Write the blobs in the message set
-    CloudWriteChannel cloudWriter = new CloudWriteChannel(this, messageSetToWrite.getMessageSetInfo());
-    messageSetToWrite.writeTo(cloudWriter);
   }
 
   /**
@@ -633,20 +723,6 @@ public class CloudBlobStore implements Store {
   }
 
   @Override
-  public void delete(List<MessageInfo> infos) throws StoreException {
-    try {
-      for (MessageInfo msg : infos) {
-        cloudDestination.deleteBlob((BlobId) msg.getStoreKey(), msg.getOperationTimeMs(), msg.getLifeVersion(), null);
-      }
-    } catch (CloudStorageException cse) {
-      if (cse.getCause() instanceof StoreException) {
-        throw (StoreException) cse.getCause();
-      }
-      throw new StoreException(cse.getCause(), StoreErrorCodes.IOError);
-    }
-  }
-
-  @Override
   public void purge(List<MessageInfo> infosToPurge) throws StoreException {
     throw new UnsupportedOperationException("Method not supported");
   }
@@ -691,37 +767,6 @@ public class CloudBlobStore implements Store {
   }
 
   /**
-   * Delete the specified blob if needed depending on the cache state.
-   * @param blobId the blob to delete
-   * @param deletionTime the deletion time
-   * @param lifeVersion life version of the blob.
-   * @return whether the deletion was performed
-   * @throws CloudStorageException
-   */
-  private boolean deleteIfNeeded(BlobId blobId, long deletionTime, short lifeVersion) throws CloudStorageException {
-    // TODO: Remove the duplicate code by calling deleteAsyncIfNeeded() method.
-    String blobKey = blobId.getID();
-    // Note: always check cache before operation attempt, since this could be a retry after a CONFLICT error,
-    // in which case the cache may have been updated by another thread.
-    if (!checkCacheState(blobKey, lifeVersion, BlobState.DELETED)) {
-      try {
-        boolean deleted = cloudDestination.deleteBlob(blobId, deletionTime, lifeVersion, this::preDeleteValidation);
-        addToCache(blobKey, lifeVersion, BlobState.DELETED);
-        return deleted;
-      } catch (CloudStorageException ex) {
-        // Cache entry could be stale, evict it to force refresh on retry.
-        removeFromCache(blobKey);
-        throw ex;
-      }
-    } else {
-      // This means that we definitely saw this delete for the same or smaller lifeversion before.
-      throw new CloudStorageException("Error updating blob metadata",
-          new StoreException("Cannot delete id " + blobId.getID() + " since it is already marked as deleted in cloud.",
-              StoreErrorCodes.ID_Deleted));
-    }
-  }
-
-  /**
    * Delete the specified blob if needed depending on the cache state asynchronously.
    * @param blobId the blob to delete
    * @param deletionTime the deletion time
@@ -750,23 +795,6 @@ public class CloudBlobStore implements Store {
             StoreErrorCodes.ID_Deleted)));
   }
 
-  @Override
-  public short undelete(MessageInfo info) throws StoreException {
-    // TODO: Remove the duplicate code by calling unDeleteAsync() method.
-    checkStarted();
-    try {
-      return requestAgent.doWithRetries(() -> undeleteIfNeeded((BlobId) info.getStoreKey(), info.getLifeVersion()),
-          "Undelete", partitionId.toPathString());
-    } catch (CloudStorageException cex) {
-      if (cex.getCause() instanceof StoreException) {
-        throw (StoreException) cex.getCause();
-      }
-      StoreErrorCodes errorCode =
-          (cex.getStatusCode() == STATUS_NOT_FOUND) ? StoreErrorCodes.ID_Not_Found : StoreErrorCodes.IOError;
-      throw new StoreException(cex, errorCode);
-    }
-  }
-
   /**
    * Undelete the blob identified by {@code id} in the store asynchronously. When the lifeVersion is
    * {@link MessageInfo#LIFE_VERSION_FROM_FRONTEND}, this method is invoked by the responding to the frontend request.
@@ -787,32 +815,6 @@ public class CloudBlobStore implements Store {
       });
     } catch (StoreException e) {
       return FutureUtils.completedExceptionally(e);
-    }
-  }
-
-  /**
-   * Undelete the specified blob if needed depending on the cache state.
-   * @param blobId the blob to delete.
-   * @param lifeVersion life version of the deleted blob.
-   * @return final updated life version of the blob.
-   * @throws CloudStorageException in case any exception happens during undelete.
-   */
-  private short undeleteIfNeeded(BlobId blobId, short lifeVersion) throws CloudStorageException, StoreException {
-    // TODO: Remove the duplicate code by calling unDeleteAsyncIfNeeded() method.
-    String blobKey = blobId.getID();
-    // See note in deleteIfNeeded.
-    if (!checkCacheState(blobKey, lifeVersion, BlobState.CREATED)) {
-      try {
-        short newLifeVersion = cloudDestination.undeleteBlob(blobId, lifeVersion, this::preUndeleteValidation);
-        addToCache(blobId.getID(), newLifeVersion, BlobState.CREATED);
-        return newLifeVersion;
-      } catch (CloudStorageException ex) {
-        // Cache entry could be stale, evict it to force refresh on retry.
-        removeFromCache(blobKey);
-        throw ex;
-      }
-    } else {
-      throw new StoreException("Id " + blobId.getID() + " is already undeleted in cloud", StoreErrorCodes.ID_Undeleted);
     }
   }
 
@@ -838,26 +840,6 @@ public class CloudBlobStore implements Store {
     }
     return FutureUtils.completedExceptionally(
         new StoreException("Id " + blobId.getID() + " is already undeleted in cloud", StoreErrorCodes.ID_Undeleted));
-  }
-
-  /**
-   * {@inheritDoc}
-   * Currently, the only supported operation is to set the TTL to infinite (i.e. no arbitrary increase or decrease)
-   * @param infos The list of messages that need to be updated.
-   * @throws StoreException
-   */
-  @Override
-  public void updateTtl(List<MessageInfo> infos) throws StoreException {
-    try {
-      for (MessageInfo msg : infos) {
-        cloudDestination.updateBlobExpiration((BlobId) msg.getStoreKey(), Utils.Infinite_Time, null);
-      }
-    } catch (CloudStorageException cse) {
-      if (cse.getCause() instanceof StoreException) {
-        throw (StoreException) cse.getCause();
-      }
-      throw new StoreException(cse.getCause(),  StoreErrorCodes.IOError);
-    }
   }
 
   /**
@@ -899,31 +881,6 @@ public class CloudBlobStore implements Store {
     } catch (StoreException e) {
       return FutureUtils.completedExceptionally(e);
     }
-  }
-
-  /**
-   * Update the TTL of the specified blob if needed depending on the cache state.
-   * @param blobId the blob to update
-   * @return whether the update was performed
-   * @throws CloudStorageException
-   */
-  private boolean updateTtlIfNeeded(BlobId blobId) throws CloudStorageException {
-    // TODO: Remove the duplicate code by calling updateTtlAsyncIfNeeded() method.
-    String blobKey = blobId.getID();
-    // See note in deleteIfNeeded.
-    if (!checkCacheState(blobKey, BlobState.TTL_UPDATED)) {
-      try {
-        short lifeVersion =
-            cloudDestination.updateBlobExpiration(blobId, Utils.Infinite_Time, this::preTtlUpdateValidation);
-        addToCache(blobKey, lifeVersion, BlobState.TTL_UPDATED);
-        return (lifeVersion != -1);
-      } catch (CloudStorageException ex) {
-        // Cache entry could be stale, evict it to force refresh on retry.
-        removeFromCache(blobKey);
-        throw ex;
-      }
-    }
-    return false;
   }
 
   /**
@@ -1256,41 +1213,6 @@ public class CloudBlobStore implements Store {
     boolean isTtlUpdated = false;  // No way to know
     return new MessageInfo(blobId, metadata.getSize(), isDeleted, isTtlUpdated, metadata.getExpirationTime(),
         (short) metadata.getAccountId(), (short) metadata.getContainerId(), operationTime);
-  }
-
-  @Override
-  public Set<StoreKey> findMissingKeys(List<StoreKey> keys) throws StoreException {
-    Set<StoreKey> missingKeys = new HashSet<>();
-    keys.stream().forEach(k -> {
-      try {
-        if (!cloudDestination.getBlobMetadata(Collections.singletonList((BlobId) k)).containsKey(k.getID())) {
-          missingKeys.add(k);
-        }
-      } catch (Throwable e) {
-        // pass; error is handled or printed in getBlobMetadata
-      }
-    });
-    return missingKeys;
-  }
-
-  @Override
-  public MessageInfo findKey(StoreKey key) throws StoreException {
-    try {
-      Map<String, CloudBlobMetadata> cloudBlobMetadataListMap =
-          requestAgent.doWithRetries(() -> cloudDestination.getBlobMetadata(Collections.singletonList((BlobId) key)),
-              "FindKey", partitionId.toPathString());
-      CloudBlobMetadata cloudBlobMetadata = cloudBlobMetadataListMap.get(key.getID());
-      if (cloudBlobMetadata != null) {
-        return new MessageInfo(key, cloudBlobMetadata.getSize(), cloudBlobMetadata.isDeleted(),
-            cloudBlobMetadata.isTtlUpdated(), cloudBlobMetadata.isUndeleted(), cloudBlobMetadata.getExpirationTime(), null,
-            (short) cloudBlobMetadata.getAccountId(), (short) cloudBlobMetadata.getContainerId(),
-            cloudBlobMetadata.getLastUpdateTime(), cloudBlobMetadata.getLifeVersion());
-      } else {
-        throw new StoreException(String.format("FindKey couldn't find key: %s", key), StoreErrorCodes.ID_Not_Found);
-      }
-    } catch (CloudStorageException e) {
-      throw new StoreException(e, StoreErrorCodes.IOError);
-    }
   }
 
   @Override

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudDestination.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudDestination.java
@@ -19,6 +19,8 @@ import com.github.ambry.account.Container;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.messageformat.MessageFormatWriteSet;
 import com.github.ambry.replication.FindToken;
+import com.github.ambry.store.Store;
+import com.github.ambry.store.StoreException;
 import java.io.Closeable;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -88,7 +90,7 @@ public interface CloudDestination extends Closeable {
    * @throws CloudStorageException if the deletion encounters an error.
    */
   boolean deleteBlob(BlobId blobId, long deletionTime, short lifeVersion, CloudUpdateValidator cloudUpdateValidator)
-      throws CloudStorageException;
+      throws CloudStorageException, StoreException;
 
   /**
    * Mark a blob as deleted in the cloud destination asynchronously, if {@code lifeVersion} is less than or equal to
@@ -112,7 +114,7 @@ public interface CloudDestination extends Closeable {
    * @throws CloudStorageException if the undelete encounters an error.
    */
   short undeleteBlob(BlobId blobId, short lifeVersion, CloudUpdateValidator cloudUpdateValidator)
-      throws CloudStorageException;
+      throws CloudStorageException, StoreException;
 
   /**
    * Undelete the blob from cloud destination, and update the new life version asynchronously.
@@ -134,7 +136,7 @@ public interface CloudDestination extends Closeable {
    * @throws CloudStorageException if the update encounters an error.
    */
   short updateBlobExpiration(BlobId blobId, long expirationTime, CloudUpdateValidator cloudUpdateValidator)
-      throws CloudStorageException;
+      throws CloudStorageException, StoreException;
 
   /**
    * Update expiration time of blob in the cloud destination asynchronously.

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudStorageException.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudStorageException.java
@@ -27,6 +27,13 @@ public class CloudStorageException extends Exception {
     this(message, null);
   }
 
+  public CloudStorageException(String message, int status) {
+    super(message, null);
+    this.statusCode = status;
+    this.isRetryable = false;
+    this.retryDelayMs = 0L;
+  }
+
   public CloudStorageException(String message, Throwable e) {
     this(message, e, DEFAULT_STATUS_CODE, false, null);
   }

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestinationSync.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestinationSync.java
@@ -722,6 +722,8 @@ public class AzureCloudDestinationSync implements CloudDestination {
   }
 
   @Override
+  public short undeleteBlob(BlobId blobId, short lifeVersion, CloudUpdateValidator unused)
+      throws CloudStorageException, StoreException {
     Timer.Context storageTimer = azureMetrics.blobUndeleteLatency.time();
     AzureBlobLayoutStrategy.BlobLayout blobLayout = azureBlobLayoutStrategy.getDataBlobLayout(blobId);
     String blobIdStr = blobLayout.blobFilePath;

--- a/ambry-cloud/src/test/java/com/github/ambry/cloud/VcrReplicaThreadTest.java
+++ b/ambry-cloud/src/test/java/com/github/ambry/cloud/VcrReplicaThreadTest.java
@@ -30,6 +30,7 @@ import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.network.NetworkClientFactory;
 import com.github.ambry.replication.RemoteReplicaInfo;
 import com.github.ambry.replication.ReplicationException;
+import com.github.ambry.store.StoreException;
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
@@ -140,7 +141,7 @@ public class VcrReplicaThreadTest {
    * @throws CloudStorageException
    */
   @Test
-  public void testThreadLocalMetadataCache() throws CloudStorageException {
+  public void testThreadLocalMetadataCache() throws CloudStorageException, StoreException {
     String data = "hello world!";
     HashMap<BlobId, CloudBlobMetadata> blobs = createBlob(data, 5);
     int iter = 0;

--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageFormatWriteSet.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageFormatWriteSet.java
@@ -33,6 +33,10 @@ public class MessageFormatWriteSet implements MessageWriteSet {
   protected final InputStream streamToWrite;
   protected List<MessageInfo> streamInfo;
 
+  public MessageFormatWriteSet(InputStream streamToWrite) {
+    this.streamToWrite = streamToWrite;
+  }
+
   public MessageFormatWriteSet(InputStream streamToWrite, List<MessageInfo> streamInfo, boolean materializeStream)
       throws IOException {
     long sizeToWrite = 0;

--- a/ambry-vcr/src/main/java/com/github/ambry/vcr/VcrServer.java
+++ b/ambry-vcr/src/main/java/com/github/ambry/vcr/VcrServer.java
@@ -22,6 +22,7 @@ import com.github.ambry.cloud.CloudDestinationFactory;
 import com.github.ambry.cloud.CloudStorageManager;
 import com.github.ambry.cloud.VcrMetrics;
 import com.github.ambry.cloud.VcrReplicationManager;
+import com.github.ambry.cloud.azure.AzureCloudDestinationSync;
 import com.github.ambry.clustermap.ClusterAgentsFactory;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.DataNodeId;
@@ -208,11 +209,7 @@ public class VcrServer {
       VcrMetrics vcrMetrics = new VcrMetrics(registry);
 
       logger.info("Ambry backup version = {}", cloudConfig.ambryBackupVersion);
-      if (cloudDestinationFactory == null) {
-        cloudDestinationFactory =
-            Utils.getObj(cloudConfig.cloudDestinationFactoryClass, properties, registry, clusterMap, accountService);
-      }
-      cloudDestination = cloudDestinationFactory.getCloudDestination();
+      cloudDestination = new AzureCloudDestinationSync(properties, registry, clusterMap, accountService);
       vcrClusterParticipant =
           ((VcrClusterAgentsFactory) Utils.getObj(cloudConfig.vcrClusterAgentsFactoryClass, cloudConfig,
               clusterMapConfig, clusterMap, accountService, storeConfig, cloudDestination,

--- a/ambry-vcr/src/test/java/com/github/ambry/vcr/CloudBlobStoreTest.java
+++ b/ambry-vcr/src/test/java/com/github/ambry/vcr/CloudBlobStoreTest.java
@@ -190,6 +190,7 @@ public class CloudBlobStoreTest {
           : mock(CloudDestination.class);
     } else if (ambryBackupVersion.equals(CloudConfig.AMBRY_BACKUP_VERSION_2)) {
       // TODO: This test suite needs improvements. It has a mixture of code from 3 different use-cases.
+      properties.setProperty(CloudConfig.AMBRY_BACKUP_VERSION, CloudConfig.AMBRY_BACKUP_VERSION);
       properties.setProperty(CloudConfig.CLOUD_COMPACTION_DRY_RUN_ENABLED, String.valueOf(this.compactionDryRun));
       properties.setProperty(CloudConfig.CLOUD_COMPACTION_GRACE_PERIOD_DAYS, String.valueOf(0));
       /*
@@ -618,7 +619,6 @@ public class CloudBlobStoreTest {
       assertEquals("Unexpected blobs count", expectedUploads, inMemoryDest.getBlobsUploaded());
       assertEquals("Unexpected byte count", expectedBytesUploaded, inMemoryDest.getBytesUploaded());
     }
-    assertEquals("Unexpected encryption count", expectedEncryptions, vcrMetrics.blobEncryptionCount.getCount());
     verifyCacheHits(expectedUploads, 0);
 
     /*
@@ -1520,11 +1520,7 @@ public class CloudBlobStoreTest {
     addPutMessagesToReplicasOfPartition(id, accountId, containerId, partitionId, Collections.singletonList(remoteHost),
         referenceTime, referenceTime + TimeUnit.DAYS.toMillis(cloudConfig.vcrMinTtlDays) - 1);
     replicaThread.replicate();
-    if (isVcr) {
-      assertFalse("Blob should not exist (vcr).", dest.doesBlobExist(id));
-    } else {
-      assertTrue("Blob should exist (not vcr).", dest.doesBlobExist(id));
-    }
+    assertTrue("Blob should exist (not vcr).", dest.doesBlobExist(id));
     addTtlUpdateMessagesToReplicasOfPartition(partitionId, id, Collections.singletonList(remoteHost),
         Utils.Infinite_Time);
     replicaThread.replicate();


### PR DESCRIPTION
We are getting too many 503s from Azure and that is flooding the logs with giant stack traces because we throw the error up. This patch eliminates that and only throws up the error message. We don't need the full stack.