### PR TITLE
Include content-length header for S3 GET responses

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com/github/ambry/rest/RestUtils.java
@@ -497,6 +497,12 @@ public class RestUtils {
      * Boolean field set to "true" if this is a S3 request.
      */
     public static final String S3_REQUEST = KEY_PREFIX + "is-s3-request";
+
+    /**
+     * Use to store size of the blob for range requests. This is an internal key and used later to set the
+     * content-length header
+     */
+    public static final String CONTENT_RANGE_LENGTH = KEY_PREFIX + "content-range-length";
   }
 
   /**

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbrySecurityService.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbrySecurityService.java
@@ -52,6 +52,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static com.github.ambry.rest.RestUtils.*;
+import static com.github.ambry.rest.RestUtils.InternalKeys.*;
 import static com.github.ambry.router.GetBlobOptions.*;
 
 
@@ -394,9 +395,10 @@ class AmbrySecurityService implements SecurityService {
           RestUtils.buildContentRangeAndLength(options.getRange(), contentLength, options.resolveRangeOnEmptyBlob());
       restResponseChannel.setHeader(RestUtils.Headers.CONTENT_RANGE, rangeAndLength.getFirst());
       contentLength = rangeAndLength.getSecond();
+      // Store the calculated range size in an internal key. This can be used later if needed.
+      restRequest.setArg(CONTENT_RANGE_LENGTH, String.valueOf(contentLength));
     }
-    if (contentLength < frontendConfig.chunkedGetResponseThresholdInBytes || RestUtils.isS3Request(restRequest)) {
-      // If it is a S3 GetBlob API, always send content-length header. Else, S3 java client seems to be failing.
+    if (contentLength < frontendConfig.chunkedGetResponseThresholdInBytes) {
       restResponseChannel.setHeader(RestUtils.Headers.CONTENT_LENGTH, contentLength);
     }
     if (blobProperties.getContentType() != null) {

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendMetrics.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendMetrics.java
@@ -19,6 +19,7 @@ import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.config.FrontendConfig;
 import com.github.ambry.frontend.s3.S3DeleteHandler;
+import com.github.ambry.frontend.s3.S3GetHandler;
 import com.github.ambry.frontend.s3.S3ListHandler;
 import com.github.ambry.frontend.s3.S3PutHandler;
 import com.github.ambry.utils.AsyncOperationTracker;
@@ -162,6 +163,7 @@ public class FrontendMetrics {
   public final AsyncOperationTracker.Metrics s3DeleteHandleMetrics;
   public final AsyncOperationTracker.Metrics s3ListHandleMetrics;
   public final AsyncOperationTracker.Metrics s3PutHandleMetrics;
+  public final AsyncOperationTracker.Metrics s3GetHandleMetrics;
 
   // Rates
   // AmbrySecurityService
@@ -488,12 +490,10 @@ public class FrontendMetrics {
     deleteDatasetOutOfRetentionRequestMetrics =
         new AsyncOperationTracker.Metrics(NamedBlobPutHandler.class, "RetentionRequest", metricRegistry);
 
-    s3DeleteHandleMetrics =
-        new AsyncOperationTracker.Metrics(S3DeleteHandler.class, "S3Handle", metricRegistry);
-    s3ListHandleMetrics =
-        new AsyncOperationTracker.Metrics(S3ListHandler.class, "S3Handle", metricRegistry);
-    s3PutHandleMetrics =
-        new AsyncOperationTracker.Metrics(S3PutHandler.class, "S3Handle", metricRegistry);
+    s3DeleteHandleMetrics = new AsyncOperationTracker.Metrics(S3DeleteHandler.class, "S3Handle", metricRegistry);
+    s3ListHandleMetrics = new AsyncOperationTracker.Metrics(S3ListHandler.class, "S3Handle", metricRegistry);
+    s3PutHandleMetrics = new AsyncOperationTracker.Metrics(S3PutHandler.class, "S3Handle", metricRegistry);
+    s3GetHandleMetrics = new AsyncOperationTracker.Metrics(S3GetHandler.class, "S3Handle", metricRegistry);
 
     getStatsReportSecurityProcessRequestMetrics =
         new AsyncOperationTracker.Metrics(GetStatsReportHandler.class, "SecurityProcessRequest", metricRegistry);

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3ListHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3ListHandler.java
@@ -111,8 +111,10 @@ public class S3ListHandler extends S3BaseHandler<ReadableStreamChannel> {
     for (NamedBlobListEntry namedBlobRecord : namedBlobRecordPage.getEntries()) {
       String blobName = namedBlobRecord.getBlobName();
       String todayDate = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").format(Calendar.getInstance().getTime());
-      //Set size to -1 due to current use case don't need this value.
-      contentsList.add(new Contents(blobName, todayDate, -1));
+      // Set size to 0 for now. Although this doesn't seem to be used by S3 clients, -1 is being treated an invalid value by s3 java client
+      // TODO: Flink team is requesting to send valid blob size and modified date in the Contents for debugging purposes.
+      //  This would need mysql schema change
+      contentsList.add(new Contents(blobName, todayDate, 0));
       if (++keyCount == maxKeysValue) {
         break;
       }

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/S3ListHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/S3ListHandlerTest.java
@@ -224,7 +224,7 @@ public class S3ListHandlerTest {
     assertEquals("Mismatch in key count", 2, listBucketResultV2.getKeyCount());
     assertEquals("Mismatch in delimiter", "/", listBucketResultV2.getDelimiter());
     assertEquals("Mismatch in encoding type", "url", listBucketResultV2.getEncodingType());
-    assertEquals("Mismatch in size", -1, listBucketResultV2.getContents().get(0).getSize());
+    assertEquals("Mismatch in size", 0, listBucketResultV2.getContents().get(0).getSize());
 
     // 4. Get list of blobs with continuation-token
     s3_list_request_uri =


### PR DESCRIPTION
S3 Java client seem to be expecting content-length header for GET requests. This change is to include it for S3 requests 