### PR TITLE
[vcr-2.0] Remove repl-until-time field

### DIFF
--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicaThread.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicaThread.java
@@ -186,12 +186,12 @@ public class VcrReplicaThread extends ReplicaThread {
     }
     logger.trace("replica = {}, token = {}", remoteReplicaInfo, token);
     // Table entity = Table row
-    // =============================================================================================================
-    // | partition-key | row-key | tokenType | logSegment | offset | storeKey | replicatedUntilUTC   | binaryToken |
-    // =============================================================================================================
-    // | partition     | host1   | Journal   | 3_14       | 12     | none     | 2024_Feb_11_14_21_00 | AAASLKJDFX  |
-    // | partition     | host2   | Index     | 2_12       | 32     | AAEWsXZ  | 2024_Jan_02_13_01_00 | AAAEWODSDS  |
-    // =============================================================================================================
+    // ======================================================================================
+    // | partition-key | row-key | tokenType | logSegment | offset | storeKey | binaryToken |
+    // ======================================================================================
+    // | partition     | host1   | Journal   | 3_14       | 12     | none     | AAASLKJDFX  |
+    // | partition     | host2   | Index     | 2_12       | 32     | AAEWsXZ  | AAAEWODSDS  |
+    // ======================================================================================
     String partitionKey = String.valueOf(remoteReplicaInfo.getReplicaId().getPartitionId().getId());
     String rowKey = remoteReplicaInfo.getReplicaId().getDataNodeId().getHostname();
     TableEntity entity = new TableEntity(partitionKey, rowKey)

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicaThread.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicaThread.java
@@ -192,10 +192,8 @@ public class VcrReplicaThread extends ReplicaThread {
     // | partition     | host1   | Journal   | 3_14       | 12     | none     | 2024_Feb_11_14_21_00 | AAASLKJDFX  |
     // | partition     | host2   | Index     | 2_12       | 32     | AAEWsXZ  | 2024_Jan_02_13_01_00 | AAAEWODSDS  |
     // =============================================================================================================
-    long lastOpTime = remoteReplicaInfo.getReplicatedUntilTime();
     String partitionKey = String.valueOf(remoteReplicaInfo.getReplicaId().getPartitionId().getId());
     String rowKey = remoteReplicaInfo.getReplicaId().getDataNodeId().getHostname();
-    DateFormat formatter = new SimpleDateFormat(VcrReplicationManager.DATE_FORMAT);
     TableEntity entity = new TableEntity(partitionKey, rowKey)
         .addProperty(VcrReplicationManager.BACKUP_NODE, dataNodeId.getHostname())
         .addProperty(VcrReplicationManager.TOKEN_TYPE,
@@ -206,9 +204,6 @@ public class VcrReplicaThread extends ReplicaThread {
             token.getOffset() == null ? "none" : token.getOffset().getOffset())
         .addProperty(VcrReplicationManager.STORE_KEY,
             token.getStoreKey() == null ? "none" : token.getStoreKey().getID())
-        .addProperty(VcrReplicationManager.REPLICATED_UNITL_UTC,
-            lastOpTime == Utils.Infinite_Time ? String.valueOf(Utils.Infinite_Time)
-                : formatter.format(lastOpTime))
         .addProperty(VcrReplicationManager.BINARY_TOKEN,
             token.toBytes());
     // Now persist the token in cloud

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicationManager.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicationManager.java
@@ -250,10 +250,6 @@ public class VcrReplicationManager extends ReplicationEngine {
         DataInputStream inputStream = new DataInputStream(
             new ByteArrayInputStream((byte[]) row.getProperty(BINARY_TOKEN)));
         replicaInfo.setToken(findTokenFactory.getFindToken(inputStream));
-        String replUntil = (String) row.getProperty(REPLICATED_UNITL_UTC);
-        DateFormat formatter = new SimpleDateFormat(DATE_FORMAT);
-        long time = replUntil.equals(String.valueOf(Utils.Infinite_Time)) ? -1 : formatter.parse(replUntil).getTime();
-        replicaInfo.setReplicatedUntilTime(time);
       } catch (Throwable t) {
         // log and metric
         azureMetrics.replicaTokenReadErrorCount.inc();

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicationManager.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicationManager.java
@@ -256,7 +256,6 @@ public class VcrReplicationManager extends ReplicationEngine {
         logger.error("Failed to deserialize token for peer replica {} due to {}", replicaInfo, t.toString());
         t.printStackTrace();
         replicaInfo.setToken(findTokenFactory.getNewFindToken());
-        replicaInfo.setReplicatedUntilTime(-1);
       } // try-catch
     } // for-loop
     return (int) azureMetrics.replicaTokenReadErrorCount.getCount();

--- a/ambry-replication/src/main/java/com/github/ambry/replication/BackupCheckerThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/BackupCheckerThread.java
@@ -359,7 +359,7 @@ public class BackupCheckerThread extends ReplicaThread {
     }
     // Maintain alphabetical order of fields for string match
     json.put("replica_token", rinfo.getToken().toString());
-\    // Pretty print with indent for easy viewing
+    // Pretty print with indent for easy viewing
     fileManager.truncateAndWriteToFile(getFilePath(rinfo, REPLICA_STATUS_FILE), json.toString(4));
   }
 

--- a/ambry-replication/src/main/java/com/github/ambry/replication/BackupCheckerThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/BackupCheckerThread.java
@@ -230,7 +230,6 @@ public class BackupCheckerThread extends ReplicaThread {
           metadata.getMessageInfoList().stream()
               .map(serverBlob -> {
                 numBlobScanned.incrementAndGet();
-                replica.setReplicatedUntilTime(serverBlob.getOperationTimeMs());
                 return mapBlob(serverBlob);
               })
               .filter(serverBlob -> serverBlob.getStoreKey() != null)
@@ -360,8 +359,7 @@ public class BackupCheckerThread extends ReplicaThread {
     }
     // Maintain alphabetical order of fields for string match
     json.put("replica_token", rinfo.getToken().toString());
-    json.put("replicated_until", rinfo.getReplicatedUntilTime());
-    // Pretty print with indent for easy viewing
+\    // Pretty print with indent for easy viewing
     fileManager.truncateAndWriteToFile(getFilePath(rinfo, REPLICA_STATUS_FILE), json.toString(4));
   }
 

--- a/ambry-replication/src/main/java/com/github/ambry/replication/RemoteReplicaInfo.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/RemoteReplicaInfo.java
@@ -71,7 +71,6 @@ public class RemoteReplicaInfo {
   private int replicationRetryCount;
   // Configurable
   protected final int maxReplicationRetryCount;
-  protected long replicatedUntilTime;
 
   // Metadata response information received for this replica in the most recent replication cycle.
   // This is used during leader based replication to store the missing store messages, remote token info and local lag
@@ -104,7 +103,6 @@ public class RemoteReplicaInfo {
     this.exchangeMetadataResponse = new ReplicaThread.ExchangeMetadataResponse(ServerErrorCode.No_Error);
     this.replicationRetryCount = 0;
     this.maxReplicationRetryCount = maxReplicationRetryCount;
-    this.replicatedUntilTime = -1L;
   }
 
   /**
@@ -218,15 +216,6 @@ public class RemoteReplicaInfo {
     // reference assignment is atomic in java but we want to be completely safe. performance is
     // not important here
     currentToken = token;
-  }
-
-  public synchronized long setReplicatedUntilTime(long time) {
-    replicatedUntilTime = time;
-    return replicatedUntilTime;
-  }
-
-  public synchronized long getReplicatedUntilTime() {
-    return replicatedUntilTime;
   }
 
   public void initializeTokens(FindToken token) {

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -913,7 +913,6 @@ public class ReplicaThread implements Runnable {
     long startTime = time.milliseconds();
     List<MessageInfo> messageInfoList = replicaMetadataResponseInfo.getMessageInfoList();
     Map<MessageInfo, StoreKey> remoteMessageToConvertedKeyNonNull = new HashMap<>();
-    long lastOpTime = remoteReplicaInfo.getReplicatedUntilTime();
     for (MessageInfo messageInfo : messageInfoList) {
       StoreKey storeKey = messageInfo.getStoreKey();
       logger.trace("Remote node: {} Thread name: {} Remote replica: {} Key from remote: {}", remoteNode, threadName,
@@ -926,14 +925,7 @@ public class ReplicaThread implements Runnable {
           || !skipPredicate.test(messageInfo))) {
         remoteMessageToConvertedKeyNonNull.put(messageInfo, convertedKey);
       }
-      /**
-       * These message_info timestamps from peer replica do not increase monotonically, rendering them useless
-       * for any practical purpose. However, we still record it here to get an idea of how far along the backup
-       * is done for a partition. Take it with a pinch of salt.
-       */
-      lastOpTime = messageInfo.getOperationTimeMs();
     }
-    remoteReplicaInfo.setReplicatedUntilTime(lastOpTime);
     Set<StoreKey> convertedMissingStoreKeys =
         remoteReplicaInfo.getLocalStore().findMissingKeys(new ArrayList<>(remoteMessageToConvertedKeyNonNull.values()));
     Set<MessageInfo> missingRemoteMessages = new HashSet<>();

--- a/ambry-vcr/src/test/java/com/github/ambry/vcr/CloudTokenPersistorTest.java
+++ b/ambry-vcr/src/test/java/com/github/ambry/vcr/CloudTokenPersistorTest.java
@@ -198,9 +198,6 @@ public class CloudTokenPersistorTest {
         Collections.emptyMap(), new SystemTime());
     vcrReplicaThread.advanceToken(replica, response);
     assertEquals(token, getTokenFromAzureTable().getSecond());
-    DateFormat formatter = new SimpleDateFormat(VcrReplicationManager.DATE_FORMAT);
-    assertEquals(formatter.format(lastOpTime),
-        getTokenFromAzureTable().getFirst().getProperty(VcrReplicationManager.REPLICATED_UNITL_UTC));
   }
 
   /**
@@ -267,7 +264,6 @@ public class CloudTokenPersistorTest {
   protected void uploadTokenToAzureTable(RemoteReplicaInfo replica, StoreFindToken token, long lastOpTime) {
     String partitionKey = String.valueOf(replica.getReplicaId().getPartitionId().getId());
     String rowKey = replica.getReplicaId().getDataNodeId().getHostname();
-    DateFormat formatter = new SimpleDateFormat(VcrReplicationManager.DATE_FORMAT);
     TableEntity entity = new TableEntity(partitionKey, rowKey)
         .addProperty(VcrReplicationManager.TOKEN_TYPE,
             token.getType().toString())
@@ -277,9 +273,6 @@ public class CloudTokenPersistorTest {
             token.getOffset() == null ? "none" : token.getOffset().getOffset())
         .addProperty(VcrReplicationManager.STORE_KEY,
             token.getStoreKey() == null ? "none" : token.getStoreKey().getID())
-        .addProperty(VcrReplicationManager.REPLICATED_UNITL_UTC,
-            lastOpTime == Utils.Infinite_Time ? String.valueOf(Utils.Infinite_Time)
-                : formatter.format(lastOpTime))
         .addProperty(VcrReplicationManager.BINARY_TOKEN,
             token.toBytes());
     azuriteClient.upsertTableEntity(azureTableNameReplicaTokens, entity);

--- a/ambry-vcr/src/test/java/com/github/ambry/vcr/CloudTokenPersistorTest.java
+++ b/ambry-vcr/src/test/java/com/github/ambry/vcr/CloudTokenPersistorTest.java
@@ -163,7 +163,6 @@ public class CloudTokenPersistorTest {
             verifiableProperties);
 
     long lastOpTime = System.currentTimeMillis();
-    replica.setReplicatedUntilTime(lastOpTime);
 
     // test 1: uninitialized token
     token =  new StoreFindToken(FindTokenType.Uninitialized, null, null, null, null,
@@ -300,7 +299,6 @@ public class CloudTokenPersistorTest {
     vcrReplicationManager.reloadReplicationTokenIfExists(
         mockPartitionId.getReplicaIds().get(0), Collections.singletonList(replica));
     assertEquals(token, replica.getToken());
-    assertEquals(Utils.getTimeInMsToTheNearestSec(lastOpTime), replica.getReplicatedUntilTime());
 
     // test 2: journal-based token w/o reset key
     lastOpTime = Utils.Infinite_Time;
@@ -310,7 +308,6 @@ public class CloudTokenPersistorTest {
     vcrReplicationManager.reloadReplicationTokenIfExists(
         mockPartitionId.getReplicaIds().get(0), Collections.singletonList(replica));
     assertEquals(token, replica.getToken());
-    assertEquals(Utils.getTimeInMsToTheNearestSec(lastOpTime), replica.getReplicatedUntilTime());
 
     // test 3: journal-based token w/ reset key
     lastOpTime = System.currentTimeMillis();
@@ -321,7 +318,6 @@ public class CloudTokenPersistorTest {
     vcrReplicationManager.reloadReplicationTokenIfExists(
         mockPartitionId.getReplicaIds().get(0), Collections.singletonList(replica));
     assertEquals(token, replica.getToken());
-    assertEquals(Utils.getTimeInMsToTheNearestSec(lastOpTime), replica.getReplicatedUntilTime());
 
     // test 4: index-based token
     lastOpTime = System.currentTimeMillis();
@@ -332,7 +328,6 @@ public class CloudTokenPersistorTest {
     vcrReplicationManager.reloadReplicationTokenIfExists(
         mockPartitionId.getReplicaIds().get(0), Collections.singletonList(replica));
     assertEquals(token, replica.getToken());
-    assertEquals(Utils.getTimeInMsToTheNearestSec(lastOpTime), replica.getReplicatedUntilTime());
   }
 
   @Test


### PR DESCRIPTION
This field ReplicateUntilUTC was meant to tell us
how far a partition has been copied to cloud. But this field is unreliable. This time is derived by getting the largest timestamp from a stream of messages from the server. But the server combines all messages pertaining to a blob into a single message with the timestamp of the last message embedded into that single message.

For example, consider this stream of messages in the server log segment.

t1(put-b1) | t2(put-b2) | t3(ttl-b1)

Assume the server sends two message m1 and m2

m1: t3(put-b1, ttl-b1)
m2: t2(put-b2)

When we receive m1, we'd think we have copied the partition until t3. But then we receive m2 and we think we have copied till t2. The time is not monotonically increasing. Hence unreliable.