### PR TITLE
Metric for idle time for remote replica group

### DIFF
--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -1975,7 +1975,7 @@ public class ReplicaThread implements Runnable {
     private long getRequestStartTimeMs;
     private long exchangeMetadataStartTimeInMs;
     private long fixMissingStoreKeysStartTimeInMs;
-    long finishTime;
+    private long finishTime;
 
     /**
      * Constructor of {@link RemoteReplicaGroup}.

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -476,7 +476,7 @@ public class ReplicaThread implements Runnable {
 
     long totalIdleTime = 0;
     for (RemoteReplicaGroup group : groups) {
-      totalIdleTime = totalIdleTime + group.getFinishTime() - roundStartTime;
+      totalIdleTime = totalIdleTime + roundEndTime - group.getFinishTime();
     }
     replicationMetrics.updateReplicaBatchTotalIdleTimeMs(totalIdleTime, replicatingFromRemoteColo, datacenterName);
 

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -467,20 +467,20 @@ public class ReplicaThread implements Runnable {
    * 2. Cumulative time groups are idle in a cycle i.e groups are in DONE state but cycle continues
    * 3. Cumulative percentage of time per cycle groups are idle
    * @param groups list of RemoteReplicaGroups
-   * @param roundStartTime start time of replication cycle
-   * @param roundEndTime end time of replication cycle
+   * @param cycleStartTime start time of replication cycle
+   * @param cycleEndTime end time of replication cycle
    */
-  private void emitReplicationCycleMetrics(List<RemoteReplicaGroup> groups, long roundStartTime, long roundEndTime) {
-    replicationMetrics.updateOneCycleReplicationTime(roundEndTime - roundStartTime, replicatingFromRemoteColo,
+  private void emitReplicationCycleMetrics(List<RemoteReplicaGroup> groups, long cycleStartTime, long cycleEndTime) {
+    replicationMetrics.updateOneCycleReplicationTime(cycleEndTime - cycleStartTime, replicatingFromRemoteColo,
         datacenterName);
 
     long totalIdleTime = 0;
     for (RemoteReplicaGroup group : groups) {
-      totalIdleTime = totalIdleTime + roundEndTime - group.getFinishTime();
+      totalIdleTime = totalIdleTime + cycleEndTime - group.getFinishTime();
     }
     replicationMetrics.updateReplicaBatchTotalIdleTimeMs(totalIdleTime, replicatingFromRemoteColo, datacenterName);
 
-    long cumulativeTime = groups.size() * (roundEndTime - roundStartTime);
+    long cumulativeTime = groups.size() * (cycleEndTime - cycleStartTime);
     if (cumulativeTime > 0) {
       long idleTimePercentage = (totalIdleTime * 100) / cumulativeTime;
       replicationMetrics.updateReplicaBatchTotalIdleTimePercentage(idleTimePercentage, replicatingFromRemoteColo,

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -417,10 +417,6 @@ public class ReplicaThread implements Runnable {
       // A map from correlation id to RequestInfo. This is used to find timed out RequestInfos.
       Map<Integer, RequestInfo> correlationIdToRequestInfo = new LinkedHashMap<>();
 
-      remoteReplicaGroups.stream().filter(RemoteReplicaGroup::isDone).forEach(group -> {
-        groupFinishTime.putIfAbsent(group.getId(), time.milliseconds());
-      });
-
       while (remoteReplicaGroups.size() > 0 && !remoteReplicaGroups.stream().allMatch(RemoteReplicaGroup::isDone)) {
         if (!running) {
           break;
@@ -448,6 +444,9 @@ public class ReplicaThread implements Runnable {
         // still be able to handle duplicate response infos for the same request.
         responseInfos.addAll(responseInfosForTimedOutRequests);
         onResponses(responseInfos, correlationIdToRequestInfo, correlationIdToReplicaGroup);
+        remoteReplicaGroups.stream().filter(RemoteReplicaGroup::isDone).forEach(group -> {
+          groupFinishTime.putIfAbsent(group.getId(), time.milliseconds());
+        });
       }
       logger.trace("Thread name: {} Finish all RemoteReplicaGroup replication", threadName);
       remoteReplicaGroups.stream()

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -440,7 +440,7 @@ public class ReplicaThread implements Runnable {
         // still be able to handle duplicate response infos for the same request.
         responseInfos.addAll(responseInfosForTimedOutRequests);
         onResponses(responseInfos, correlationIdToRequestInfo, correlationIdToReplicaGroup);
-        if((fastestReplicaFinishTime == null) && remoteReplicaGroups.stream().anyMatch(RemoteReplicaGroup::isDone)){
+        if ((fastestReplicaFinishTime == null) && remoteReplicaGroups.stream().anyMatch(RemoteReplicaGroup::isDone)) {
           fastestReplicaFinishTime = time.milliseconds();
         }
         remoteReplicaGroups.stream().filter(RemoteReplicaGroup::isDone).forEach(group -> {

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -422,10 +422,6 @@ public class ReplicaThread implements Runnable {
           break;
         }
 
-        if((fastestReplicaFinishTime == null) && remoteReplicaGroups.stream().anyMatch(RemoteReplicaGroup::isDone)){
-          fastestReplicaFinishTime = time.milliseconds();
-        }
-
         List<RequestInfo> requestInfos =
             pollRemoteReplicaGroups(remoteReplicaGroups, correlationIdToRequestInfo, correlationIdToReplicaGroup);
         List<ResponseInfo> responseInfosForTimedOutRequests =
@@ -444,6 +440,9 @@ public class ReplicaThread implements Runnable {
         // still be able to handle duplicate response infos for the same request.
         responseInfos.addAll(responseInfosForTimedOutRequests);
         onResponses(responseInfos, correlationIdToRequestInfo, correlationIdToReplicaGroup);
+        if((fastestReplicaFinishTime == null) && remoteReplicaGroups.stream().anyMatch(RemoteReplicaGroup::isDone)){
+          fastestReplicaFinishTime = time.milliseconds();
+        }
         remoteReplicaGroups.stream().filter(RemoteReplicaGroup::isDone).forEach(group -> {
           groupFinishTime.putIfAbsent(group.getId(), time.milliseconds());
         });

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -480,9 +480,12 @@ public class ReplicaThread implements Runnable {
     }
     replicationMetrics.updateReplicaBatchTotalIdleTimeMs(totalIdleTime, replicatingFromRemoteColo, datacenterName);
 
-    long idleTimePercentage = (totalIdleTime * 100) / (groups.size() * (roundEndTime - roundStartTime));
-    replicationMetrics.updateReplicaBatchTotalIdleTimePercentage(idleTimePercentage, replicatingFromRemoteColo,
-        datacenterName);
+    long cumulativeTime = groups.size() * (roundEndTime - roundStartTime);
+    if (cumulativeTime > 0) {
+      long idleTimePercentage = (totalIdleTime * 100) / cumulativeTime;
+      replicationMetrics.updateReplicaBatchTotalIdleTimePercentage(idleTimePercentage, replicatingFromRemoteColo,
+          datacenterName);
+    }
   }
 
   void setExchangeMetadataListener(ExchangeMetadataListener exchangeMetadataListener) {

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationMetrics.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationMetrics.java
@@ -113,12 +113,12 @@ public class ReplicationMetrics {
   public final Histogram sslIntraColoBatchStoreWriteTime;
   public final Map<String, Histogram> interColoTotalReplicationTime = new HashMap<>();
   public final Map<String, Histogram> interColoOneCycleReplicationTime = new HashMap<>();
-  public final Map<String, Histogram> interColoFastestSlowestReplicaPerCycleTimeDifference = new HashMap<>();
-  public final Map<String, Histogram> interColoRemoteReplicaGroupIdleTime = new HashMap<>();
+  public final Map<String, Histogram> interColoReplicaBatchTotalIdleTimePercentage = new HashMap<>();
+  public final Map<String, Histogram> interColoReplicaBatchTotalIdleTimeMs = new HashMap<>();
   public final Histogram intraColoTotalReplicationTime;
   public final Histogram intraColoOneCycleReplicationTime;
-  public final Histogram intraColoFastestSlowestReplicaPerCycleTimeDifference;
-  public final Histogram intraColoRemoteReplicaGroupIdleTime;
+  public final Histogram intraColoReplicaBatchTotalIdleTimePercentage;
+  public final Histogram intraColoReplicaBatchTotalIdleTimeMs;
   public final Map<String, Histogram> plainTextInterColoTotalReplicationTime = new HashMap<String, Histogram>();
   public final Histogram plainTextIntraColoTotalReplicationTime;
   public final Map<String, Histogram> sslInterColoTotalReplicationTime = new HashMap<String, Histogram>();
@@ -259,10 +259,10 @@ public class ReplicationMetrics {
         registry.histogram(MetricRegistry.name(ReplicaThread.class, "IntraColoTotalReplicationTime"));
     intraColoOneCycleReplicationTime =
         registry.histogram(MetricRegistry.name(ReplicaThread.class, "IntraColoOneCycleReplicationTime"));
-    intraColoFastestSlowestReplicaPerCycleTimeDifference =
-        registry.histogram(MetricRegistry.name(ReplicaThread.class, "IntraColoFastestSlowestReplicaPerCycleTimeDifference"));
-    intraColoRemoteReplicaGroupIdleTime =
-        registry.histogram(MetricRegistry.name(ReplicaThread.class, "IntraColoRemoteReplicaGroupIdleTime"));
+    intraColoReplicaBatchTotalIdleTimePercentage =
+        registry.histogram(MetricRegistry.name(ReplicaThread.class, "IntraColoReplicaBatchTotalIdleTimePercentage"));
+    intraColoReplicaBatchTotalIdleTimeMs =
+        registry.histogram(MetricRegistry.name(ReplicaThread.class, "IntraColoReplicaBatchTotalIdleTimeMs"));
     plainTextIntraColoTotalReplicationTime =
         registry.histogram(MetricRegistry.name(ReplicaThread.class, "PlainTextIntraColoTotalReplicationTime"));
     sslIntraColoTotalReplicationTime =
@@ -402,12 +402,12 @@ public class ReplicationMetrics {
     Histogram interColoOneCycleReplicationTimePerDC = registry.histogram(
         MetricRegistry.name(ReplicaThread.class, "Inter-" + datacenter + "-OneCycleReplicationTime"));
     interColoOneCycleReplicationTime.put(datacenter, interColoOneCycleReplicationTimePerDC);
-    Histogram interColoFastestSlowestReplicaPerCycleTimeDifferencePerDC = registry.histogram(
-        MetricRegistry.name(ReplicaThread.class, "Inter-" + datacenter + "-FastestSlowestReplicaPerCycleTimeDifference"));
-    interColoFastestSlowestReplicaPerCycleTimeDifference.put(datacenter, interColoFastestSlowestReplicaPerCycleTimeDifferencePerDC);
-    Histogram interColoRemoteReplicaGroupIdleTimePerDC = registry.histogram(
-        MetricRegistry.name(ReplicaThread.class, "Inter-" + datacenter + "RemoteReplicaGroupIdleTime"));
-    interColoRemoteReplicaGroupIdleTime.put(datacenter, interColoRemoteReplicaGroupIdleTimePerDC);
+    Histogram interColoReplicaBatchTotalIdleTimePercentagePerDC = registry.histogram(
+        MetricRegistry.name(ReplicaThread.class, "Inter-" + datacenter + "ReplicaBatchTotalIdleTimePercentage"));
+    interColoReplicaBatchTotalIdleTimePercentage.put(datacenter, interColoReplicaBatchTotalIdleTimePercentagePerDC);
+    Histogram interColoReplicaBatchTotalIdleTimeMsPerDC = registry.histogram(
+        MetricRegistry.name(ReplicaThread.class, "Inter-" + datacenter + "ReplicaBatchTotalIdleTimeMs"));
+    interColoReplicaBatchTotalIdleTimeMs.put(datacenter, interColoReplicaBatchTotalIdleTimeMsPerDC);
     Histogram plainTextInterColoTotalReplicationTimePerDC = registry.histogram(
         MetricRegistry.name(ReplicaThread.class, "PlainTextInter-" + datacenter + "-TotalReplicationTime"));
     plainTextInterColoTotalReplicationTime.put(datacenter, plainTextInterColoTotalReplicationTimePerDC);
@@ -702,20 +702,20 @@ public class ReplicationMetrics {
     }
   }
 
-  public void updateFastestSlowestReplicaPerCycleTimeDifference(long timeDifference, boolean remoteColo,
+  public void updateReplicaBatchTotalIdleTimePercentage(long idleTimePercentage, boolean remoteColo,
       String datacenter) {
     if (remoteColo) {
-      interColoFastestSlowestReplicaPerCycleTimeDifference.get(datacenter).update(timeDifference);
+      interColoReplicaBatchTotalIdleTimePercentage.get(datacenter).update(idleTimePercentage);
     } else {
-      intraColoFastestSlowestReplicaPerCycleTimeDifference.update(timeDifference);
+      intraColoReplicaBatchTotalIdleTimePercentage.update(idleTimePercentage);
     }
   }
 
-  public void updateRemoteReplicaGroupIdleTime(long idleTime, boolean remoteColo, String datacenter) {
+  public void updateReplicaBatchTotalIdleTimeMs(long idleTime, boolean remoteColo, String datacenter) {
     if (remoteColo) {
-      interColoRemoteReplicaGroupIdleTime.get(datacenter).update(idleTime);
+      interColoReplicaBatchTotalIdleTimeMs.get(datacenter).update(idleTime);
     } else {
-      intraColoRemoteReplicaGroupIdleTime.update(idleTime);
+      intraColoReplicaBatchTotalIdleTimeMs.update(idleTime);
     }
   }
 

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationMetrics.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationMetrics.java
@@ -114,9 +114,11 @@ public class ReplicationMetrics {
   public final Map<String, Histogram> interColoTotalReplicationTime = new HashMap<>();
   public final Map<String, Histogram> interColoOneCycleReplicationTime = new HashMap<>();
   public final Map<String, Histogram> interColoFastestSlowestReplicaPerCycleTimeDifference = new HashMap<>();
+  public final Map<String, Histogram> interColoRemoteReplicaGroupIdleTime = new HashMap<>();
   public final Histogram intraColoTotalReplicationTime;
   public final Histogram intraColoOneCycleReplicationTime;
   public final Histogram intraColoFastestSlowestReplicaPerCycleTimeDifference;
+  public final Histogram intraColoRemoteReplicaGroupIdleTime;
   public final Map<String, Histogram> plainTextInterColoTotalReplicationTime = new HashMap<String, Histogram>();
   public final Histogram plainTextIntraColoTotalReplicationTime;
   public final Map<String, Histogram> sslInterColoTotalReplicationTime = new HashMap<String, Histogram>();
@@ -259,6 +261,8 @@ public class ReplicationMetrics {
         registry.histogram(MetricRegistry.name(ReplicaThread.class, "IntraColoOneCycleReplicationTime"));
     intraColoFastestSlowestReplicaPerCycleTimeDifference =
         registry.histogram(MetricRegistry.name(ReplicaThread.class, "IntraColoFastestSlowestReplicaPerCycleTimeDifference"));
+    intraColoRemoteReplicaGroupIdleTime =
+        registry.histogram(MetricRegistry.name(ReplicaThread.class, "IntraColoRemoteReplicaGroupIdleTime"));
     plainTextIntraColoTotalReplicationTime =
         registry.histogram(MetricRegistry.name(ReplicaThread.class, "PlainTextIntraColoTotalReplicationTime"));
     sslIntraColoTotalReplicationTime =
@@ -401,6 +405,9 @@ public class ReplicationMetrics {
     Histogram interColoFastestSlowestReplicaPerCycleTimeDifferencePerDC = registry.histogram(
         MetricRegistry.name(ReplicaThread.class, "Inter-" + datacenter + "-FastestSlowestReplicaPerCycleTimeDifference"));
     interColoFastestSlowestReplicaPerCycleTimeDifference.put(datacenter, interColoFastestSlowestReplicaPerCycleTimeDifferencePerDC);
+    Histogram interColoRemoteReplicaGroupIdleTimePerDC = registry.histogram(
+        MetricRegistry.name(ReplicaThread.class, "Inter-" + datacenter + "-interColoRemoteReplicaGroupIdleTime"));
+    interColoRemoteReplicaGroupIdleTime.put(datacenter, interColoRemoteReplicaGroupIdleTimePerDC);
     Histogram plainTextInterColoTotalReplicationTimePerDC = registry.histogram(
         MetricRegistry.name(ReplicaThread.class, "PlainTextInter-" + datacenter + "-TotalReplicationTime"));
     plainTextInterColoTotalReplicationTime.put(datacenter, plainTextInterColoTotalReplicationTimePerDC);
@@ -701,6 +708,14 @@ public class ReplicationMetrics {
       interColoFastestSlowestReplicaPerCycleTimeDifference.get(datacenter).update(timeDifference);
     } else {
       intraColoFastestSlowestReplicaPerCycleTimeDifference.update(timeDifference);
+    }
+  }
+
+  public void updateRemoteReplicaGroupIdleTime(long idleTime, boolean remoteColo, String datacenter) {
+    if(remoteColo) {
+      interColoRemoteReplicaGroupIdleTime.get(datacenter).update(idleTime);
+    } else {
+      intraColoRemoteReplicaGroupIdleTime.update(idleTime);
     }
   }
 

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationMetrics.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationMetrics.java
@@ -406,7 +406,7 @@ public class ReplicationMetrics {
         MetricRegistry.name(ReplicaThread.class, "Inter-" + datacenter + "-FastestSlowestReplicaPerCycleTimeDifference"));
     interColoFastestSlowestReplicaPerCycleTimeDifference.put(datacenter, interColoFastestSlowestReplicaPerCycleTimeDifferencePerDC);
     Histogram interColoRemoteReplicaGroupIdleTimePerDC = registry.histogram(
-        MetricRegistry.name(ReplicaThread.class, "Inter-" + datacenter + "-interColoRemoteReplicaGroupIdleTime"));
+        MetricRegistry.name(ReplicaThread.class, "Inter-" + datacenter + "RemoteReplicaGroupIdleTime"));
     interColoRemoteReplicaGroupIdleTime.put(datacenter, interColoRemoteReplicaGroupIdleTimePerDC);
     Histogram plainTextInterColoTotalReplicationTimePerDC = registry.histogram(
         MetricRegistry.name(ReplicaThread.class, "PlainTextInter-" + datacenter + "-TotalReplicationTime"));

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationMetrics.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationMetrics.java
@@ -712,7 +712,7 @@ public class ReplicationMetrics {
   }
 
   public void updateRemoteReplicaGroupIdleTime(long idleTime, boolean remoteColo, String datacenter) {
-    if(remoteColo) {
+    if (remoteColo) {
       interColoRemoteReplicaGroupIdleTime.get(datacenter).update(idleTime);
     } else {
       intraColoRemoteReplicaGroupIdleTime.update(idleTime);


### PR DESCRIPTION
Publishing metric for idle time for remote replica group i.e. time difference b/w when group is finished and when cycle is finished.
Added metric for cumulative time groups spend in a cycle idle (doing nothing i.e time after group is done)
Added metric for percentage of time groups spend in a cycle idle (total cumlative time / (groups count * total cycle time))