### PR TITLE
[vcr-2.0] Fix VCR eager-delete policy

### DIFF
--- a/ambry-cloud/src/test/java/com/github/ambry/cloud/VcrReplicaThreadTest.java
+++ b/ambry-cloud/src/test/java/com/github/ambry/cloud/VcrReplicaThreadTest.java
@@ -178,8 +178,7 @@ public class VcrReplicaThreadTest {
       assertFalse(getBlobMetadata(blob).isDeleted());
       assertTrue(getBlobMetadata(blob).isUndeleted());
 
-      // fetch metadata per blob _exactly_ once, all other calls should hit cache
-      assertEquals(iter+1, azureMetrics.blobGetPropertiesSuccessRate.getCount());
+      assertEquals(3*(iter+1), azureMetrics.blobGetPropertiesSuccessRate.getCount());
       iter += 1;
     }
   }

--- a/ambry-cloud/src/test/java/com/github/ambry/cloud/VcrReplicaThreadTest.java
+++ b/ambry-cloud/src/test/java/com/github/ambry/cloud/VcrReplicaThreadTest.java
@@ -143,42 +143,42 @@ public class VcrReplicaThreadTest {
   public void testThreadLocalMetadataCache() throws CloudStorageException, StoreException {
     String data = "hello world!";
     HashMap<BlobId, CloudBlobMetadata> blobs = createBlob(data, 5);
-    int iter = 0;
+    int iter = 1;
     for (BlobId blob : blobs.keySet()) {
       CloudBlobMetadata metadata = blobs.get(blob);
       short version = metadata.getLifeVersion();
       // put blob
       azureClient.uploadBlob(blob, data.length(), metadata,
           new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8)));
-      assertEquals(metadata, getBlobMetadata(blob)); // same content
+      assertEquals(metadata, getBlobMetadata(blob)); // same content; md-cache miss
       assertFalse(getBlobMetadata(blob).isTtlUpdated());
       assertFalse(getBlobMetadata(blob).isDeleted());
       assertFalse(getBlobMetadata(blob).isUndeleted());
 
       // remove TTL
-      azureClient.updateBlobExpiration(blob, Utils.Infinite_Time, null);
-      verifyConstantMetadataFields(metadata, getBlobMetadata(blob));
+      azureClient.updateBlobExpiration(blob, Utils.Infinite_Time, null); // md-cache hit
+      verifyConstantMetadataFields(metadata, getBlobMetadata(blob)); // md-cache miss
       assertTrue(getBlobMetadata(blob).isTtlUpdated());
       assertFalse(getBlobMetadata(blob).isDeleted());
       assertFalse(getBlobMetadata(blob).isUndeleted());
 
       // delete blob
       long now = System.currentTimeMillis();
-      azureClient.deleteBlob(blob, now, (short) (version + 1), null);
-      verifyConstantMetadataFields(metadata, getBlobMetadata(blob));
+      azureClient.deleteBlob(blob, now, (short) (version + 1), null); // md-cache hit
+      verifyConstantMetadataFields(metadata, getBlobMetadata(blob)); // md-cache miss
       assertTrue(getBlobMetadata(blob).isTtlUpdated());
       assertTrue(getBlobMetadata(blob).isDeleted());
       assertFalse(getBlobMetadata(blob).isUndeleted());
       assertEquals(now, getBlobMetadata(blob).getDeletionTime());
 
       // undelete blob
-      azureClient.undeleteBlob(blob, (short) (version + 2), null);
-      verifyConstantMetadataFields(metadata, getBlobMetadata(blob));
+      azureClient.undeleteBlob(blob, (short) (version + 2), null); // md-cache hit
+      verifyConstantMetadataFields(metadata, getBlobMetadata(blob)); // md-cache miss
       assertTrue(getBlobMetadata(blob).isTtlUpdated());
       assertFalse(getBlobMetadata(blob).isDeleted());
       assertTrue(getBlobMetadata(blob).isUndeleted());
 
-      assertEquals(3*(iter+1), azureMetrics.blobGetPropertiesSuccessRate.getCount());
+      assertEquals(4*iter, azureMetrics.blobGetPropertiesSuccessRate.getCount()); // num cache_misses
       iter += 1;
     }
   }

--- a/ambry-vcr/src/main/java/com/github/ambry/vcr/VcrServer.java
+++ b/ambry-vcr/src/main/java/com/github/ambry/vcr/VcrServer.java
@@ -213,6 +213,7 @@ public class VcrServer {
           Utils.getObj(serverConfig.serverStoreKeyConverterFactory, properties, registry);
       VcrMetrics vcrMetrics = new VcrMetrics(registry);
 
+      // This statement is only for legacy reasons otherwise post-merge jobs on dev-fabric break
       CloudDestinationFactory cloudDestinationFactory = Utils.getObj(cloudConfig.cloudDestinationFactoryClass,
           properties, registry, clusterMap, accountService);
       cloudDestination = cloudDestinationFactory.getCloudDestination();


### PR DESCRIPTION
Encountered several BLOB_NOT_FOUND errors after enabling eager-delete policy. There is no data loss, but the logs are getting flooded to the point where there is no space left on disk. There are two possible reasons:

1. Each replica-thread has a thread-local cache where it stores metadata of a blob requested from Azure. Once it deletes the blob, it moves on without clearing the cache. When it encounters the same blob in another replica, the thread thinks the blob is present in azure after looking at the cache and tries to delete the blob. At this point, it receives a BLOB_NOT_FOUND from Azure and floods the logs with giant stack traces.
2. The other possibility is a race with the background compaction thread, but a bit unlikely given that its happening consistently across all hosts and threads.

The fix is to clear the cache when a thread updates the metadata of the blob while replicating a replica. If it encounters the same blob in another replica of the partition, then it starts clean. We may have a small performance hit due to cache misses, but we guarantee some isolation between replicas by clearing off any saved state in cache.

Tested overnight in corp-cluster. No errors observed.