### PR TITLE
[vcr-2.0] Remove ReplEngine logs

### DIFF
--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
@@ -803,8 +803,11 @@ public abstract class ReplicationEngine implements ReplicationAPI {
             }
           }
           removeRemoteReplicaInfoFromReplicaThread(replicaInfosToRemove);
-          logger.info("{} peer replicas are added and {} peer replicas are removed in replication manager",
-              addedPeerReplicas.size(), removedPeerReplicas.size());
+          if (addedReplicas.size() + removedReplicas.size() > 0) {
+            // print only if something is added or removed
+            logger.info("{} peer replicas are added and {} peer replicas are removed in replication manager",
+                addedPeerReplicas.size(), removedPeerReplicas.size());
+          }
         } finally {
           rwLock.readLock().unlock();
         }


### PR DESCRIPTION
Some of these logs just flood vcr.log for no reason.