### PR TITLE
[vcr-2.0] Delay replica-thread start and token init

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/CloudConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/CloudConfig.java
@@ -376,13 +376,6 @@ public class CloudConfig {
   @Default(DEFAULT_VCR_CLUSTER_AGENTS_FACTORY_CLASS)
   public final String vcrClusterAgentsFactoryClass;
 
-  /**
-   * Comma separated set of datacenters which can act as peer for cross colo replication.
-   */
-  @Config(VCR_SOURCE_DATACENTERS)
-  @Default("")
-  public final Set<String> vcrSourceDatacenters;
-
   @Config(CLOUD_COMPACTION_NUM_THREADS)
   public final int cloudCompactionNumThreads;
 
@@ -470,6 +463,10 @@ public class CloudConfig {
   @Config(BACKUP_NODE_CPU_SCALE)
   public final double backupNodeCpuScale;
 
+  public static final String BACKUP_STARTUP_DELAY_SECS = "backup.startup.delay.secs";
+  public static final int DEFAULT_BACKUP_STARTUP_DELAY_SECS = 900;
+  @Config(BACKUP_STARTUP_DELAY_SECS)
+  public final int backupStartupDelaySecs;
   /**
    * Specifies how the backup-node must select server replicas to replicate from
    */
@@ -479,6 +476,7 @@ public class CloudConfig {
   public ReplicaSelectionPolicy replicaSelectionPolicy;
 
   public CloudConfig(VerifiableProperties verifiableProperties) {
+    backupStartupDelaySecs = verifiableProperties.getInt(BACKUP_STARTUP_DELAY_SECS, DEFAULT_BACKUP_STARTUP_DELAY_SECS);;
     replicaSelectionPolicy = verifiableProperties.getEnum(REPLICA_SELECTION_POLICY, ReplicaSelectionPolicy.class,
         DEFAULT_REPLICA_SELECTION_POLICY);
     backupNodeCpuScale = verifiableProperties.getDoubleInRange(BACKUP_NODE_CPU_SCALE,
@@ -534,12 +532,8 @@ public class CloudConfig {
     // Proxy settings
     vcrProxyHost = verifiableProperties.getString(VCR_PROXY_HOST, null);
     vcrProxyPort = verifiableProperties.getInt(VCR_PROXY_PORT, DEFAULT_VCR_PROXY_PORT);
-
     vcrClusterAgentsFactoryClass =
         verifiableProperties.getString(VCR_CLUSTER_AGENTS_FACTORY_CLASS, DEFAULT_VCR_CLUSTER_AGENTS_FACTORY_CLASS);
-
-    vcrSourceDatacenters =
-        Utils.splitString(verifiableProperties.getString(VCR_SOURCE_DATACENTERS, ""), ",", HashSet::new);
     vcrHelixStateModelFactoryClass = verifiableProperties.getString(VCR_HELIX_STATE_MODEL_FACTORY_CLASS,
         DEFAULT_VCR_HELIX_STATE_MODEL_FACTORY_CLASS);
     vcrHelixUpdaterPartitionId = verifiableProperties.getString(VCR_HELIX_UPDATER_PARTITION_ID, "");

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/RecoveryManager.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/RecoveryManager.java
@@ -313,11 +313,6 @@ public class RecoveryManager extends ReplicationEngine {
     return tokenInfo.getPartitionId().equals(remoteReplicaInfo.getReplicaId().getPartitionId());
   }
 
-  @Override
-  protected boolean shouldReplicateFromDc(String datacenterName) {
-    return true;
-  }
-
   /**
    * Remove a replica of given partition and its {@link RemoteReplicaInfo}s from the backup list.
    * @param partitionName the partition of the replica to be removed.

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicaThread.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicaThread.java
@@ -117,6 +117,10 @@ public class VcrReplicaThread extends ReplicaThread {
     super.run();
   }
 
+  /**
+   * Fetch replica-token from Azure and set it in the thread
+   * @param replicaInfo
+   */
   void setReplicaToken(RemoteReplicaInfo replicaInfo) {
     String partitionKey = String.valueOf(replicaInfo.getReplicaId().getPartitionId().getId());
     String rowKey = replicaInfo.getReplicaId().getDataNodeId().getHostname();
@@ -127,6 +131,7 @@ public class VcrReplicaThread extends ReplicaThread {
         logger.warn("Resetting token for replica {}/{} because no token found", partitionKey, rowKey);
         replicaInfo.setToken(findTokenFactory.getNewFindToken());
       } else {
+        logger.info("Loading token for replica {}/{}", partitionKey, rowKey);
         DataInputStream inputStream = new DataInputStream(
             new ByteArrayInputStream((byte[]) row.getProperty(VcrReplicationManager.BINARY_TOKEN)));
         replicaInfo.setToken(findTokenFactory.getFindToken(inputStream));
@@ -223,10 +228,10 @@ public class VcrReplicaThread extends ReplicaThread {
       return;
     }
     if (token.equals(oldToken)) {
-      logger.info("Skipping token upload due to unchanged token, oldToken = {}, newToken = {}", oldToken, token);
+      logger.trace("Skipping token upload due to unchanged token, oldToken = {}, newToken = {}", oldToken, token);
       return;
     }
-    logger.info("[snkt] replica = {}, token = {}", remoteReplicaInfo, token);
+    logger.trace("Uploading token = {} for replica = {}", token, remoteReplicaInfo);
     // Table entity = Table row
     // ======================================================================================
     // | partition-key | row-key | tokenType | logSegment | offset | storeKey | binaryToken |

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicaThread.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicaThread.java
@@ -104,11 +104,12 @@ public class VcrReplicaThread extends ReplicaThread {
   @Override
   public void run() {
     try {
+      // sleep here with a random delay to spread out the thread load on Azure
       int delay = new Random().nextInt(vcrNodeConfig.backupStartupDelaySecs) + 10; // +delta for non-zero delay
       logger.info("Starting replica thread {} in {} seconds", Thread.currentThread().getName(), delay);
       Thread.sleep(TimeUnit.SECONDS.toMillis(delay));
     } catch (InterruptedException e) {
-      throw new RuntimeException(e);
+      // pass; just start the thread
     }
     super.run();
   }

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicaThread.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicaThread.java
@@ -31,7 +31,6 @@ import com.github.ambry.replication.FindTokenFactory;
 import com.github.ambry.replication.FindTokenHelper;
 import com.github.ambry.replication.RemoteReplicaInfo;
 import com.github.ambry.replication.ReplicaThread;
-import com.github.ambry.replication.ReplicaTokenPersistor;
 import com.github.ambry.replication.ReplicationManager;
 import com.github.ambry.replication.ReplicationMetrics;
 import com.github.ambry.store.MessageInfo;

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicaThread.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicaThread.java
@@ -47,6 +47,8 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 import org.slf4j.Logger;
@@ -97,6 +99,18 @@ public class VcrReplicaThread extends ReplicaThread {
       String d2 = r2.getReplicaId().getDataNodeId().getHostname();
       return d1.compareTo(d2);
     }
+  }
+
+  @Override
+  public void run() {
+    try {
+      int delay = new Random().nextInt(900) + 1;
+      logger.info("Starting replica thread {} in {} seconds", Thread.currentThread().getName(), delay);
+      Thread.sleep(TimeUnit.SECONDS.toMillis(delay));
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+    super.run();
   }
 
   /**
@@ -181,10 +195,10 @@ public class VcrReplicaThread extends ReplicaThread {
       return;
     }
     if (token.equals(oldToken)) {
-      logger.trace("Skipping token upload due to unchanged token, oldToken = {}, newToken = {}", oldToken, token);
+      logger.info("Skipping token upload due to unchanged token, oldToken = {}, newToken = {}", oldToken, token);
       return;
     }
-    logger.trace("replica = {}, token = {}", remoteReplicaInfo, token);
+    logger.info("[snkt] replica = {}, token = {}", remoteReplicaInfo, token);
     // Table entity = Table row
     // ======================================================================================
     // | partition-key | row-key | tokenType | logSegment | offset | storeKey | binaryToken |

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicaThread.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicaThread.java
@@ -104,7 +104,7 @@ public class VcrReplicaThread extends ReplicaThread {
   @Override
   public void run() {
     try {
-      int delay = new Random().nextInt(vcrNodeConfig.backupStartupDelaySecs) + 10;
+      int delay = vcrNodeConfig.backupStartupDelaySecs + new Random().nextInt(180); // fixed + small random delay
       logger.info("Starting replica thread {} in {} seconds", Thread.currentThread().getName(), delay);
       Thread.sleep(TimeUnit.SECONDS.toMillis(delay));
     } catch (InterruptedException e) {

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicaThread.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicaThread.java
@@ -104,7 +104,7 @@ public class VcrReplicaThread extends ReplicaThread {
   @Override
   public void run() {
     try {
-      int delay = vcrNodeConfig.backupStartupDelaySecs + new Random().nextInt(180); // fixed + small random delay
+      int delay = new Random().nextInt(vcrNodeConfig.backupStartupDelaySecs) + 10; // +delta for non-zero delay
       logger.info("Starting replica thread {} in {} seconds", Thread.currentThread().getName(), delay);
       Thread.sleep(TimeUnit.SECONDS.toMillis(delay));
     } catch (InterruptedException e) {

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicaThread.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicaThread.java
@@ -104,7 +104,7 @@ public class VcrReplicaThread extends ReplicaThread {
   @Override
   public void run() {
     try {
-      int delay = new Random().nextInt(900) + 1;
+      int delay = new Random().nextInt(vcrNodeConfig.backupStartupDelaySecs) + 10;
       logger.info("Starting replica thread {} in {} seconds", Thread.currentThread().getName(), delay);
       Thread.sleep(TimeUnit.SECONDS.toMillis(delay));
     } catch (InterruptedException e) {

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicaThread.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicaThread.java
@@ -127,10 +127,10 @@ public class VcrReplicaThread extends ReplicaThread {
         logger.warn("Resetting token for replica {}/{} because no token found", partitionKey, rowKey);
         replicaInfo.setToken(findTokenFactory.getNewFindToken());
       } else {
-        logger.info("Loading token for replica {}/{}", partitionKey, rowKey);
         DataInputStream inputStream = new DataInputStream(
             new ByteArrayInputStream((byte[]) row.getProperty(VcrReplicationManager.BINARY_TOKEN)));
         replicaInfo.setToken(findTokenFactory.getFindToken(inputStream));
+        logger.info("Loaded token for replica {}/{}, token = {}", partitionKey, rowKey, replicaInfo.getToken());
       }
     } catch (Throwable t) {
       azureMetrics.replicaTokenReadErrorCount.inc();

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicaThread.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicaThread.java
@@ -23,7 +23,6 @@ import com.github.ambry.clustermap.ReplicaSyncUpManager;
 import com.github.ambry.clustermap.ReplicaType;
 import com.github.ambry.commons.ResponseHandler;
 import com.github.ambry.config.CloudConfig;
-import com.github.ambry.config.ReplicaSelectionPolicy;
 import com.github.ambry.config.ReplicationConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.network.NetworkClient;
@@ -43,8 +42,6 @@ import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -79,7 +76,7 @@ public class VcrReplicaThread extends ReplicaThread {
       NotificationSystem notification, StoreKeyConverter storeKeyConverter, Transformer transformer,
       boolean replicatingOverSsl, String datacenterName, ResponseHandler responseHandler, Time time,
       ReplicaSyncUpManager replicaSyncUpManager, Predicate<MessageInfo> skipPredicate,
-      ReplicationManager.LeaderBasedReplicationAdmin leaderBasedReplicationAdmin, ReplicaTokenPersistor tokenWriter,
+      ReplicationManager.LeaderBasedReplicationAdmin leaderBasedReplicationAdmin,
       CloudDestination cloudDestination, VerifiableProperties properties) {
     super(threadName, findTokenHelper, clusterMap, correlationIdGenerator, dataNodeId, networkClient,
         new ReplicationConfig(properties),

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicaThread.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicaThread.java
@@ -20,6 +20,7 @@ import com.github.ambry.cloud.azure.AzureMetrics;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.ReplicaSyncUpManager;
+import com.github.ambry.clustermap.ReplicaType;
 import com.github.ambry.commons.ResponseHandler;
 import com.github.ambry.config.CloudConfig;
 import com.github.ambry.config.ReplicaSelectionPolicy;
@@ -27,6 +28,7 @@ import com.github.ambry.config.ReplicationConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.network.NetworkClient;
 import com.github.ambry.notification.NotificationSystem;
+import com.github.ambry.replication.FindTokenFactory;
 import com.github.ambry.replication.FindTokenHelper;
 import com.github.ambry.replication.RemoteReplicaInfo;
 import com.github.ambry.replication.ReplicaThread;
@@ -39,6 +41,8 @@ import com.github.ambry.store.StoreKeyConverter;
 import com.github.ambry.store.Transformer;
 import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -113,6 +117,27 @@ public class VcrReplicaThread extends ReplicaThread {
     super.run();
   }
 
+  void setReplicaToken(RemoteReplicaInfo replicaInfo) {
+    String partitionKey = String.valueOf(replicaInfo.getReplicaId().getPartitionId().getId());
+    String rowKey = replicaInfo.getReplicaId().getDataNodeId().getHostname();
+    FindTokenFactory findTokenFactory = findTokenHelper.getFindTokenFactoryFromReplicaType(ReplicaType.DISK_BACKED);
+    try {
+      TableEntity row = cloudDestination.getTableEntity(azureTableNameReplicaTokens, partitionKey, rowKey);
+      if (row == null) {
+        logger.warn("Resetting token for replica {}/{} because no token found", partitionKey, rowKey);
+        replicaInfo.setToken(findTokenFactory.getNewFindToken());
+      } else {
+        DataInputStream inputStream = new DataInputStream(
+            new ByteArrayInputStream((byte[]) row.getProperty(VcrReplicationManager.BINARY_TOKEN)));
+        replicaInfo.setToken(findTokenFactory.getFindToken(inputStream));
+      }
+    } catch (Throwable t) {
+      azureMetrics.replicaTokenReadErrorCount.inc();
+      logger.error("Resetting token for replica {}/{} due to {}", partitionKey, rowKey, t.toString());
+      replicaInfo.setToken(findTokenFactory.getNewFindToken());
+    } // try-catch
+  }
+
   /**
    * Selects replicas R1, R2, and R3 of a partition P in distinct iterations of the replication loop.
    * As the loop is continuous, each replica gets its turn.
@@ -146,6 +171,9 @@ public class VcrReplicaThread extends ReplicaThread {
           logger.trace("{} replicaSelectionPolicy picked {} for partition-{}",
               vcrNodeConfig.DEFAULT_REPLICA_SELECTION_POLICY, replica.getReplicaId().getDataNodeId().getHostname(),
               replica.getReplicaId().getPartitionId().getId());
+      }
+      if (replica.getToken() == null) {
+        setReplicaToken(replica);
       }
       // Group by data node
       nodes.computeIfAbsent(replica.getReplicaId().getDataNodeId(), k -> new ArrayList<>()).add(replica);

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicationManager.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicationManager.java
@@ -198,8 +198,7 @@ public class VcrReplicationManager extends ReplicationEngine {
 
   @Override
   protected void createThread(ReplicaThread replicaThread, boolean unused) {
-    Thread thread = Utils.daemonThread(replicaThread.getName(), replicaThread);
-    replicaThread.setThread(thread);
+    replicaThread.setThread(Utils.daemonThread(replicaThread.getName(), replicaThread));
     logger.info("Created replica thread {}", replicaThread.getName());
   }
 
@@ -231,10 +230,7 @@ public class VcrReplicationManager extends ReplicationEngine {
           key -> replicaThreads.get(getReplicaThreadIndexToUse(dc)));
       rthread.addRemoteReplicaInfo(rinfo);
       rinfo.setReplicaThread(rthread);
-      // Start the thread when the first replica is added to this thread
-      if (rthread.getThread().getState() == Thread.State.NEW) {
-        rthread.getThread().start();
-      }
+      rthread.startThread();
       logger.info("Added replica {} to thread {}", rinfo, rthread.getName());
     }
   }

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicationManager.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicationManager.java
@@ -160,9 +160,9 @@ public class VcrReplicationManager extends ReplicationEngine {
     azureTableNameReplicaTokens = this.azureCloudConfig.azureTableNameReplicaTokens;
     this.cloudDestination.getTableClient(azureTableNameReplicaTokens);
     String datacenter = clusterMap.getDatacenterName(clusterMap.getLocalDatacenterId());
-    logger.info("Local datacenter = {}", datacenter);
-    replicaThreadPoolByDc.computeIfAbsent(datacenter,
-        key -> createThreadPool(datacenter, getNumReplThreads(cloudConfig.backupNodeCpuScale), true));
+    logger.info("Local datacenter id = {}, Local datacenter name = {}", clusterMap.getLocalDatacenterId(), datacenter);
+    replicaThreadPoolByDc.put(datacenter,
+        createThreadPool(datacenter, getNumReplThreads(cloudConfig.backupNodeCpuScale), true));
   }
 
   /**

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicationManager.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicationManager.java
@@ -165,7 +165,7 @@ public class VcrReplicationManager extends ReplicationEngine {
     logger.info("Local datacenter id = {}, Local datacenter name = {}", clusterMap.getLocalDatacenterId(),
         localDatacenterName);
     replicaThreadPoolByDc.put(localDatacenterName,
-        createThreadPool(localDatacenterName, getNumReplThreads(cloudConfig.backupNodeCpuScale), false));
+        createThreadPool(localDatacenterName, getNumReplThreads(cloudConfig.backupNodeCpuScale), true));
   }
 
   /**
@@ -198,8 +198,7 @@ public class VcrReplicationManager extends ReplicationEngine {
 
   @Override
   protected void createThread(ReplicaThread replicaThread, boolean unused) {
-    Thread thread = Utils.daemonThread(replicaThread.getName(), replicaThread);
-    replicaThread.setThread(thread);
+    Utils.daemonThread(replicaThread.getName(), replicaThread).start();
     logger.info("Created replica thread {}", replicaThread.getName());
   }
 
@@ -231,10 +230,6 @@ public class VcrReplicationManager extends ReplicationEngine {
           key -> replicaThreads.get(getReplicaThreadIndexToUse(dc)));
       rthread.addRemoteReplicaInfo(rinfo);
       rinfo.setReplicaThread(rthread);
-      // Start the thread when the first replica is added to this thread
-      if (rthread.getThread().getState() == Thread.State.NEW) {
-        rthread.getThread().start();
-      }
       logger.info("Added replica {} to thread {}", rinfo, rthread.getName());
     }
   }

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicationManager.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicationManager.java
@@ -174,7 +174,7 @@ public class VcrReplicationManager extends ReplicationEngine {
       ReplicationManager.LeaderBasedReplicationAdmin leaderBasedReplicationAdmin) {
     return new VcrReplicaThread(threadName, tokenHelper, clusterMap, correlationIdGenerator, dataNodeId, networkClient,
         notification, storeKeyConverter, transformer, replicatingOverSsl, datacenterName, responseHandler, time,
-        replicaSyncUpManager, skipPredicate, leaderBasedReplicationAdmin, this.persistor, cloudDestination, properties);
+        replicaSyncUpManager, skipPredicate, leaderBasedReplicationAdmin, cloudDestination, properties);
   }
 
   /**

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicationManager.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicationManager.java
@@ -237,8 +237,7 @@ public class VcrReplicationManager extends ReplicationEngine {
 
   @Override
   public int reloadReplicationTokenIfExists(ReplicaId localReplica, List<RemoteReplicaInfo> peerReplicas) {
-    // pass; reload just before replication
-    return 0;
+    throw new UnsupportedOperationException("Reload replication-tokens just before replication");
   }
 
   @Override

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicationManager.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicationManager.java
@@ -197,7 +197,7 @@ public class VcrReplicationManager extends ReplicationEngine {
 
   @Override
   protected void createThread(ReplicaThread replicaThread, boolean unused) {
-    replicaThread.setThread(Utils.daemonThread(replicaThread.getName(), replicaThread));
+    replicaThread.setThread(Utils.newThread(replicaThread.getName(), replicaThread, false));
   }
 
   /**

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestinationSync.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestinationSync.java
@@ -302,17 +302,11 @@ public class AzureCloudDestinationSync implements CloudDestination {
    * @param tableName Name of the table in Azure Table Service
    */
   public TableEntity getTableEntity(String tableName, String partitionKey, String rowKey) {
-    Throwable throwable = null;
     try {
       return getTableClient(tableName).getEntity(partitionKey, rowKey);
     } catch (Throwable e) {
-      throwable = e;
-    } finally {
-      if (throwable != null) {
-        logger.error("Failed to fetch table entity {}/{} from {} due to {}",
-            partitionKey, rowKey, tableName, throwable);
-        throwable.printStackTrace();
-      }
+      logger.error("Failed to fetch table entity {}/{} from {} due to {}",
+          partitionKey, rowKey, tableName, e.getMessage());
     }
     return null;
   }

--- a/ambry-cloud/src/test/java/com/github/ambry/cloud/VcrReplicaThreadTest.java
+++ b/ambry-cloud/src/test/java/com/github/ambry/cloud/VcrReplicaThreadTest.java
@@ -22,18 +22,28 @@ import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.clustermap.PartitionId;
+import com.github.ambry.clustermap.ReplicaSyncUpManager;
 import com.github.ambry.clustermap.VcrClusterParticipant;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.CommonTestUtils;
+import com.github.ambry.commons.ResponseHandler;
 import com.github.ambry.config.CloudConfig;
 import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.network.NetworkClient;
 import com.github.ambry.network.NetworkClientFactory;
+import com.github.ambry.notification.NotificationSystem;
+import com.github.ambry.replication.FindTokenHelper;
 import com.github.ambry.replication.MockFindTokenHelper;
 import com.github.ambry.replication.RemoteReplicaInfo;
 import com.github.ambry.replication.ReplicationException;
+import com.github.ambry.replication.ReplicationManager;
+import com.github.ambry.store.MessageInfo;
 import com.github.ambry.store.StoreException;
+import com.github.ambry.store.StoreKeyConverter;
+import com.github.ambry.store.Transformer;
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.TestUtils;
+import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -197,7 +207,7 @@ public class VcrReplicaThreadTest {
             new AtomicInteger(0), clustermap.getDataNodes().get(0), null, null,
             null, null, false,
             clustermap.getDataNodes().get(0).getDatacenterName(), null, null,
-            null, null, null, null, null,
+            null, null, null, null,
             properties);
 
     // Assign replicas to test-thread

--- a/ambry-cloud/src/test/java/com/github/ambry/cloud/VcrReplicaThreadTest.java
+++ b/ambry-cloud/src/test/java/com/github/ambry/cloud/VcrReplicaThreadTest.java
@@ -40,6 +40,7 @@ import com.github.ambry.replication.ReplicationManager;
 import com.github.ambry.store.MessageInfo;
 import com.github.ambry.store.StoreException;
 import com.github.ambry.store.StoreKeyConverter;
+import com.github.ambry.store.StoreKeyConverterFactory;
 import com.github.ambry.store.Transformer;
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.TestUtils;
@@ -257,11 +258,16 @@ public class VcrReplicaThreadTest {
    * @throws ReplicationException
    */
   @Test
-  public void testNumReplThreads() throws ReplicationException {
+  public void testNumReplThreads() throws ReplicationException, InstantiationException {
+    VcrClusterParticipant vcrClusterParticipant = mock(VcrClusterParticipant.class);
+    when(vcrClusterParticipant.getCurrentDataNodeId()).thenReturn(clustermap.getCurrentDataNodeId());
+    StoreKeyConverterFactory storeKeyConverterFactory = mock(StoreKeyConverterFactory.class);
+    StoreKeyConverter storeKeyConverter = mock(StoreKeyConverter.class);
+    when(storeKeyConverterFactory.getStoreKeyConverter()).thenReturn(storeKeyConverter);
     VcrReplicationManager manager =
         new VcrReplicationManager(properties, null, null, clustermap,
-            mock(VcrClusterParticipant.class), mock(AzureCloudDestinationSync.class), null,
-            mock(NetworkClientFactory.class), null, null);
+            vcrClusterParticipant, mock(AzureCloudDestinationSync.class), null,
+            mock(NetworkClientFactory.class), null, storeKeyConverterFactory);
     assertEquals(0, manager.getNumReplThreads(0));
     assertEquals(2, manager.getNumReplThreads(-2.5));
     assertEquals((int) (Double.valueOf(Runtime.getRuntime().availableProcessors()) * 2.5),

--- a/ambry-cloud/src/test/java/com/github/ambry/cloud/VcrReplicaThreadTest.java
+++ b/ambry-cloud/src/test/java/com/github/ambry/cloud/VcrReplicaThreadTest.java
@@ -28,6 +28,7 @@ import com.github.ambry.commons.CommonTestUtils;
 import com.github.ambry.config.CloudConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.network.NetworkClientFactory;
+import com.github.ambry.replication.MockFindTokenHelper;
 import com.github.ambry.replication.RemoteReplicaInfo;
 import com.github.ambry.replication.ReplicationException;
 import com.github.ambry.store.StoreException;
@@ -184,7 +185,7 @@ public class VcrReplicaThreadTest {
   }
 
   @Test
-  public void testSelectReplicas() {
+  public void testSelectReplicas() throws ReflectiveOperationException {
     // Give hosts a name
     AtomicInteger ai = new AtomicInteger(0);
     int Z = 'Z';
@@ -192,7 +193,7 @@ public class VcrReplicaThreadTest {
 
     // Create a test-thread
     VcrReplicaThread rthread =
-        new VcrReplicaThread("vcrReplicaThreadTest", null, clustermap,
+        new VcrReplicaThread("vcrReplicaThreadTest", new MockFindTokenHelper(), clustermap,
             new AtomicInteger(0), clustermap.getDataNodes().get(0), null, null,
             null, null, false,
             clustermap.getDataNodes().get(0).getDatacenterName(), null, null,

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -73,6 +73,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
@@ -124,6 +125,7 @@ public class ReplicaThread implements Runnable {
   private volatile boolean allDisabled = false;
   private final ReplicationManager.LeaderBasedReplicationAdmin leaderBasedReplicationAdmin;
   protected Thread thread;
+  protected AtomicBoolean threadStarted;
 
   // This is used in the test cases
   private Map<DataNodeId, List<ExchangeMetadataResponse>> exchangeMetadataResponsesInEachCycle = null;
@@ -181,6 +183,15 @@ public class ReplicaThread implements Runnable {
     }
     this.maxReplicaCountPerRequest = replicationConfig.replicationMaxPartitionCountPerRequest;
     this.leaderBasedReplicationAdmin = leaderBasedReplicationAdmin;
+    threadStarted = new AtomicBoolean(false);
+  }
+
+  public boolean startThread() {
+   if (threadStarted.compareAndSet(false, true)) {
+     thread.start();
+     return true;
+   }
+   return false;
   }
 
   public void setThread(Thread thread) {

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -94,7 +94,7 @@ public class ReplicaThread implements Runnable {
   private final Set<PartitionId> allReplicatedPartitions = new HashSet<>();
   private final CountDownLatch shutdownLatch = new CountDownLatch(1);
   private volatile boolean running;
-  private final FindTokenHelper findTokenHelper;
+  protected final FindTokenHelper findTokenHelper;
   private final ClusterMap clusterMap;
   private final AtomicInteger correlationIdGenerator;
   protected final DataNodeId dataNodeId;

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -123,7 +123,6 @@ public class ReplicaThread implements Runnable {
   private final Predicate<MessageInfo> skipPredicate;
   private volatile boolean allDisabled = false;
   private final ReplicationManager.LeaderBasedReplicationAdmin leaderBasedReplicationAdmin;
-  protected Thread thread;
 
   // This is used in the test cases
   private Map<DataNodeId, List<ExchangeMetadataResponse>> exchangeMetadataResponsesInEachCycle = null;
@@ -181,14 +180,6 @@ public class ReplicaThread implements Runnable {
     }
     this.maxReplicaCountPerRequest = replicationConfig.replicationMaxPartitionCountPerRequest;
     this.leaderBasedReplicationAdmin = leaderBasedReplicationAdmin;
-  }
-
-  public void setThread(Thread thread) {
-    this.thread = thread;
-  }
-
-  public Thread getThread() {
-    return thread;
   }
 
   /**

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -123,6 +123,7 @@ public class ReplicaThread implements Runnable {
   private final Predicate<MessageInfo> skipPredicate;
   private volatile boolean allDisabled = false;
   private final ReplicationManager.LeaderBasedReplicationAdmin leaderBasedReplicationAdmin;
+  protected Thread thread;
 
   // This is used in the test cases
   private Map<DataNodeId, List<ExchangeMetadataResponse>> exchangeMetadataResponsesInEachCycle = null;
@@ -180,6 +181,14 @@ public class ReplicaThread implements Runnable {
     }
     this.maxReplicaCountPerRequest = replicationConfig.replicationMaxPartitionCountPerRequest;
     this.leaderBasedReplicationAdmin = leaderBasedReplicationAdmin;
+  }
+
+  public void setThread(Thread thread) {
+    this.thread = thread;
+  }
+
+  public Thread getThread() {
+    return thread;
   }
 
   /**

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
@@ -400,9 +400,7 @@ public abstract class ReplicationEngine implements ReplicationAPI {
                 responseHandler, time, replicaSyncUpManager, skipPredicate, leaderBasedReplicationAdmin);
         replicaThreads.add(replicaThread);
         if (startThread) {
-          Thread thread = Utils.newThread(replicaThread.getName(), replicaThread, false);
-          thread.start();
-          logger.info("Started replica thread {}", thread.getName());
+          runThread(replicaThread);
         }
       } catch (Exception e) {
         throw new RuntimeException("Encountered exception instantiating ReplicaThread", e);
@@ -410,6 +408,12 @@ public abstract class ReplicationEngine implements ReplicationAPI {
     }
     replicationMetrics.trackLiveThreadsCount(replicaThreads, datacenter);
     return replicaThreads;
+  }
+
+  protected void runThread(ReplicaThread replicaThread) {
+    Thread thread = Utils.newThread(replicaThread.getName(), replicaThread, false);
+    thread.start();
+    logger.info("Started replica thread {}", thread.getName());
   }
 
   /**

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationManager.java
@@ -192,11 +192,6 @@ public class ReplicationManager extends ReplicationEngine {
     return started;
   }
 
-  @Override
-  protected boolean shouldReplicateFromDc(String datacenterName) {
-    return true;
-  }
-
   /**
    * Add given replica into replication manager.
    * @param replicaId the replica to add

--- a/ambry-replication/src/test/java/com/github/ambry/replication/MockFindTokenHelper.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/MockFindTokenHelper.java
@@ -24,6 +24,9 @@ public class MockFindTokenHelper extends FindTokenHelper {
       throws ReflectiveOperationException {
   }
 
+  public MockFindTokenHelper() {
+  }
+
   @Override
   public FindTokenFactory getFindTokenFactoryFromReplicaType(ReplicaType replicaType) {
     return new MockFindTokenFactory();

--- a/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockClusterMap.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockClusterMap.java
@@ -77,6 +77,7 @@ public class MockClusterMap implements ClusterMap {
 
   private RuntimeException exceptionOnSnapshot = null;
   private volatile boolean shouldDataNodeBeInFullAuto = false;
+  private DataNodeId currentDataNodeId;
 
   /**
    * The default constructor sets up a 9 node cluster with 3 mount points in each, with 3 default partitions/replicas
@@ -170,6 +171,10 @@ public class MockClusterMap implements ClusterMap {
     if (localDcName != null) {
       // if caller specifies the local data center name, use the one specified.
       localDatacenterName = localDcName;
+      dataCentersInClusterMap.add(localDcName);
+      currentDataNodeId = createDataNode(
+          getListOfPorts(currentPlainTextPort++, currentSSLPort++, enableHttp2Ports ? currentHttp2Port++ : null),
+          localDcName, numMountPointsPerNode);
     }
     partitions = new HashMap<>();
 
@@ -209,6 +214,9 @@ public class MockClusterMap implements ClusterMap {
             Math.min(defaultPartition.getReplicaIds().size(), 3), DEFAULT_PARTITION_CLASS, null);
   }
 
+  public DataNodeId getCurrentDataNodeId() {
+    return currentDataNodeId;
+  }
   /**
    * Creates a mock cluster map with given list of data nodes and partitions.
    * @param enableSSLPorts whether to enable SSL port.

--- a/ambry-vcr/src/test/java/com/github/ambry/vcr/CloudTokenPersistorTest.java
+++ b/ambry-vcr/src/test/java/com/github/ambry/vcr/CloudTokenPersistorTest.java
@@ -32,6 +32,7 @@ import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.clustermap.MockPartitionId;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.clustermap.ReplicaId;
+import com.github.ambry.clustermap.ReplicaSyncUpManager;
 import com.github.ambry.clustermap.VcrClusterParticipant;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.BlobIdFactory;
@@ -40,21 +41,28 @@ import com.github.ambry.config.CloudConfig;
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.ReplicationConfig;
 import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.network.NetworkClient;
 import com.github.ambry.network.NetworkClientFactory;
+import com.github.ambry.notification.NotificationSystem;
 import com.github.ambry.replication.FindTokenHelper;
 import com.github.ambry.replication.FindTokenType;
 import com.github.ambry.replication.PartitionInfo;
 import com.github.ambry.replication.RemoteReplicaInfo;
 import com.github.ambry.replication.ReplicaThread;
 import com.github.ambry.replication.ReplicationException;
+import com.github.ambry.replication.ReplicationManager;
 import com.github.ambry.replication.ReplicationMetrics;
 import com.github.ambry.store.LogSegmentName;
+import com.github.ambry.store.MessageInfo;
 import com.github.ambry.store.Offset;
 import com.github.ambry.store.PersistentIndex;
 import com.github.ambry.store.StoreFindToken;
 import com.github.ambry.store.StoreFindTokenFactory;
+import com.github.ambry.store.StoreKeyConverter;
+import com.github.ambry.store.Transformer;
 import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.SystemTime;
+import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
@@ -159,7 +167,7 @@ public class CloudTokenPersistorTest {
             null,
             null, null, false,
             "localhost", new ResponseHandler(mockClusterMap), new SystemTime(), null,
-            null, null, null, azuriteClient,
+            null, null, azuriteClient,
             verifiableProperties);
 
     long lastOpTime = System.currentTimeMillis();
@@ -216,7 +224,7 @@ public class CloudTokenPersistorTest {
             null,
             null, null, false,
             "localhost", new ResponseHandler(mockClusterMap), new SystemTime(), null,
-            null, null, null, azuriteClient,
+            null, null, azuriteClient,
             verifiableProperties);
 
     // upload a dummy token; this must remain unchange in Azure Table through this test

--- a/ambry-vcr/src/test/java/com/github/ambry/vcr/CloudTokenPersistorTest.java
+++ b/ambry-vcr/src/test/java/com/github/ambry/vcr/CloudTokenPersistorTest.java
@@ -286,6 +286,7 @@ public class CloudTokenPersistorTest {
   }
 
   @Test
+  @Ignore("Moved token reload to VcrReplicaThread just before replication")
   public void testRetrieveToken() throws ReplicationException {
     StoreFindToken token;
     long lastOpTime;


### PR DESCRIPTION
There is a burst of calls to Azure to reload replica tokens when a node starts because helix adds replicas very quickly. Due to this, there are a lot of errors resulting in a token reset. To avoid this, let's add a small random delay before a replica thread starts and delay the token initialization until necessary.

Also remove a bunch of unwanted configs and code. 