### PR TITLE
Fix missing data chunk metric

### DIFF
--- a/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
@@ -1066,6 +1066,10 @@ class GetBlobOperation extends GetOperation {
           if (chunkOperationTracker.hasFailedOnNotFound()) {
             chunkException =
                 buildChunkException("Get Chunk failed because of BlobNotFound", RouterErrorCode.BlobDoesNotExist);
+            if (!chunkBlobId.equals(blobId) && chunkBlobId.getBlobDataType() == BlobId.BlobDataType.DATACHUNK) {
+              // Metadata exist but missing a data chunk
+              routerMetrics.missingDataChunkErrorCount.inc();
+            }
           } else if (chunkOperationTracker.hasSomeUnavailability()) {
             setChunkException(
                 buildChunkException("Get Chunk failed because of offline replicas", RouterErrorCode.AmbryUnavailable));
@@ -1455,7 +1459,7 @@ class GetBlobOperation extends GetOperation {
      * @return a {@link RouterException} with additional info about the chunk that failed.
      */
     private RouterException buildChunkException(String message, Throwable cause, RouterErrorCode errorCode) {
-      return new RouterException(message + ". Chunk ID: " + chunkBlobId, cause, errorCode);
+      return new RouterException(message + ". Chunk ID: " + chunkBlobId + " Blob ID: " + blobId, cause, errorCode);
     }
 
     /**
@@ -1464,7 +1468,7 @@ class GetBlobOperation extends GetOperation {
      * @return a {@link RouterException} with additional info about the chunk that failed.
      */
     private RouterException buildChunkException(String message, RouterErrorCode errorCode) {
-      return new RouterException(message + ". Chunk ID: " + chunkBlobId, errorCode);
+      return new RouterException(message + ". Chunk ID: " + chunkBlobId + " Blob ID: " + blobId, errorCode);
     }
 
     /**


### PR DESCRIPTION
## Summary

We have a missing data chunk error count metric to record the number of get blob operations that encountered a missing data chunk error. However, this metric is incremented in the wrong place, we increment it every time we see a NOT_FOUND response from any replica, this is not very useful.

This PR fixes that and only increments this counter metric at the end of get chunk operation when it fails with Blob_Not_Found error. 

##Test

Unit test