### PR TITLE
Use client error when client closed connection

### DIFF
--- a/ambry-rest/src/main/java/com/github/ambry/rest/NettyResponseChannel.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/NettyResponseChannel.java
@@ -577,9 +577,12 @@ class NettyResponseChannel implements RestResponseChannel {
         errHeaders = restServiceException.getExceptionHeadersMap();
       }
     } else if (Utils.isPossibleClientTermination(cause)) {
+      // Client closed the connection, it's likely that error response won't be able to reach client.
+      // If that's the case, then set the status to client error. This would then be recorded as client error
+      // in ContainerMetrics
       nettyMetrics.clientEarlyTerminationCount.inc();
-      status = HttpResponseStatus.INTERNAL_SERVER_ERROR;
-      errorResponseStatus = ResponseStatus.InternalServerError;
+      status = HttpResponseStatus.BAD_REQUEST;
+      errorResponseStatus = ResponseStatus.BadRequest;
     } else {
       nettyMetrics.internalServerErrorCount.inc();
       status = HttpResponseStatus.INTERNAL_SERVER_ERROR;


### PR DESCRIPTION
## Summary

When client closes the connection while downloading a blob, we will set the error response status to InternalServerError and then increment a GetBlobServerError counter in ContainerMetrics. But this is not a server error, this is a client. 

This PR fixes this discrepancy. We will set error response status to client error so later it won't be counted as server error.

## Operations
This would likely to impact two operations, GetBlobOperation and PutOperation. 
For GetBlobOperations, it should be fine, since the client already closes the connection, and we already send back 200 or 206 before, so it won't affect the status code of this response. This is just for internal metric tracking.
For PutOperations, it should be fine too, since client closing connection without sending all the byte should be considered as bad request, instead of 503. This will reduce the number of 503 in public access log.

## Test
Unit test