### PR TITLE
Increasing default disk max size

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
@@ -416,7 +416,7 @@ public class ClusterMapConfig {
     clustermapRecoveryTestPartitionLayout =
         new JSONObject(verifiableProperties.getString("clustermap.recovery.test.partition.layout", "{}"));
     clustermapMaxDiskCapacityInBytes =
-        verifiableProperties.getLongInRange(CLUSTERMAP_MAX_DISK_CAPACITY_IN_BYTES, 20L * 1024 * 1024 * 1024 * 1024, 0,
+        verifiableProperties.getLongInRange(CLUSTERMAP_MAX_DISK_CAPACITY_IN_BYTES, 100L * 1024 * 1024 * 1024 * 1024, 0,
             Long.MAX_VALUE);
     clustermapEnableContainerDeletionAggregation =
         verifiableProperties.getBoolean("clustermap.enable.container.deletion.aggregation", false);


### PR DESCRIPTION
To address the problem of starting up a node with too large of a disk size, we are increasing the maximum disk size
```
2024/08/22 21:33:44.940 WARN [HelixAggregatedViewClusterInitializer] [main] [ambry-server] [] Exception while initializing cluster
java.lang.IllegalStateException: Invalid disk capacity: 21998830878720 is more than 21990232555520
        at com.github.ambry.clustermap.ClusterMapUtils.validateDiskCapacity(ClusterMapUtils.java:662) ~[com.github.ambry.ambry-clustermap-0.4.
445.jar:?]
        at com.github.ambry.clustermap.AmbryDisk.validate(AmbryDisk.java:91) ~[com.github.ambry.ambry-clustermap-0.4.445.jar:?]
        at com.github.ambry.clustermap.AmbryDisk.<init>(AmbryDisk.java:54) ~[com.github.ambry.ambry-clustermap-0.4.445.jar:?]
        at com.github.ambry.clustermap.HelixClusterManager$HelixClusterChangeHandler.initializeDisksAndReplicasOnNode(HelixClust
        ```