### PR TITLE
[vcr-2.0] Fix nullptr in helix path

### DIFF
--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicationManager.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicationManager.java
@@ -296,7 +296,7 @@ public class VcrReplicationManager extends ReplicationEngine {
               isAmbryListenerToUpdateVcrHelixRegistered = true;
               // Schedule a fixed rate task to check if ambry helix and vcr helix on sync.
               ambryVcrHelixSyncCheckTaskFuture = scheduler.scheduleAtFixedRate(() -> checkAmbryHelixAndVcrHelixOnSync(),
-                  cloudConfig.vcrHelixSyncCheckIntervalInSeconds, cloudConfig.vcrHelixSyncCheckIntervalInSeconds,
+                  0, cloudConfig.vcrHelixSyncCheckIntervalInSeconds,
                   TimeUnit.SECONDS);
               logger.info("VCR updater registered.");
             }
@@ -537,13 +537,13 @@ public class VcrReplicationManager extends ReplicationEngine {
       String localDcZkStr = ((HelixClusterManager) clusterMap).getLocalDcZkConnectString();
       isSrcAndDstSync = HelixVcrUtil.isSrcDestSync(localDcZkStr, clusterMapConfig.clusterMapClusterName,
           cloudConfig.vcrClusterZkConnectString, cloudConfig.vcrClusterName);
-    } catch (Exception e) {
-      logger.warn("Ambry Helix and Vcr Helix sync check runs into exception: ", e);
-    }
-    if (vcrHelixUpdateFuture == null && !isSrcAndDstSync) {
-      logger.warn("Ambry Helix cluster and VCR helix cluster are not on sync");
-      // Raise alert on this metric
-      vcrMetrics.vcrHelixNotOnSync.inc();
+      if (vcrHelixUpdateFuture == null && !isSrcAndDstSync) {
+        logger.error("Ambry Helix cluster and VCR helix cluster are not on sync");
+        // Raise alert on this metric
+        vcrMetrics.vcrHelixNotOnSync.inc();
+      }
+    } catch (Throwable e) {
+      logger.error("Ambry Helix and Vcr Helix sync check runs into exception: ", e);
     }
   }
 

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/ConnectionStringBasedStorageClient.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/ConnectionStringBasedStorageClient.java
@@ -14,6 +14,8 @@
 package com.github.ambry.cloud.azure;
 
 import com.azure.core.http.HttpClient;
+import com.azure.core.http.policy.HttpLogDetailLevel;
+import com.azure.core.http.policy.HttpLogOptions;
 import com.azure.core.http.policy.RetryOptions;
 import com.azure.core.util.Configuration;
 import com.azure.data.tables.TableClient;
@@ -106,10 +108,18 @@ public class ConnectionStringBasedStorageClient extends StorageClient {
   protected TableServiceClient buildTableServiceClient(HttpClient httpClient, Configuration configuration,
       RetryOptions retryOptions, AzureCloudConfig azureCloudConfig) {
     return new TableServiceClientBuilder().connectionString(azureCloudConfig.azureTableConnectionString)
-        .httpClient(httpClient)
-        .retryOptions(retryOptions)
-        .configuration(configuration)
-        .buildClient();
+    try {
+      return new TableServiceClientBuilder().connectionString(azureCloudConfig.azureTableConnectionString)
+          .httpClient(httpClient)
+          .retryOptions(retryOptions)
+          .configuration(configuration)
+          .buildClient();
+    } catch (Throwable e) {
+      String err = String.format("Failed to build table service client with connection string %s due to %s",
+          azureCloudConfig.azureTableConnectionString, e.getMessage());
+      logger.error(err);
+      throw e;
+    }
   }
 
   /**

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/ConnectionStringBasedStorageClient.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/ConnectionStringBasedStorageClient.java
@@ -107,7 +107,6 @@ public class ConnectionStringBasedStorageClient extends StorageClient {
   @Override
   protected TableServiceClient buildTableServiceClient(HttpClient httpClient, Configuration configuration,
       RetryOptions retryOptions, AzureCloudConfig azureCloudConfig) {
-    return new TableServiceClientBuilder().connectionString(azureCloudConfig.azureTableConnectionString)
     try {
       return new TableServiceClientBuilder().connectionString(azureCloudConfig.azureTableConnectionString)
           .httpClient(httpClient)

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/StorageClient.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/StorageClient.java
@@ -420,17 +420,16 @@ public abstract class StorageClient implements AzureStorageClient {
   }
 
   protected BlobServiceClient createBlobStorageSyncClient() {
-    try {
-      validateABSAuthConfigs(azureCloudConfig);
-      ProxyOptions proxyOptions = null;
-      if (cloudConfig.vcrProxyHost != null && !cloudConfig.vcrProxyHost.isEmpty()) {
-        logger.info("Using vcrProxyHost:vcrProxyPort {}:{}", cloudConfig.vcrProxyHost, cloudConfig.vcrProxyPort);
-        proxyOptions = new ProxyOptions(ProxyOptions.Type.HTTP,
-            new InetSocketAddress(cloudConfig.vcrProxyHost, cloudConfig.vcrProxyPort));
-      } else {
-        logger.info("No vcrProxyHost provided");
-      }
-      HttpClient client = new NettyAsyncHttpClientBuilder().proxy(proxyOptions).build();
+    validateABSAuthConfigs(azureCloudConfig);
+    ProxyOptions proxyOptions = null;
+    if (cloudConfig.vcrProxyHost != null && !cloudConfig.vcrProxyHost.isEmpty()) {
+      logger.info("Using vcrProxyHost:vcrProxyPort {}:{}", cloudConfig.vcrProxyHost, cloudConfig.vcrProxyPort);
+      proxyOptions = new ProxyOptions(ProxyOptions.Type.HTTP,
+          new InetSocketAddress(cloudConfig.vcrProxyHost, cloudConfig.vcrProxyPort));
+    } else {
+      logger.info("No vcrProxyHost provided");
+    }
+    HttpClient client = new NettyAsyncHttpClientBuilder().proxy(proxyOptions).build();
       /*
        retryPolicyType – null defaults to EXPONENTIAL
        maxTries – null defaults to 4
@@ -440,14 +439,10 @@ public abstract class StorageClient implements AzureStorageClient {
        retryDelayInMs – null defaults to 4ms when retryPolicyType is EXPONENTIAL
        maxRetryDelayInMs – null defaults to 120ms
        */
-      RequestRetryOptions retryOptions =
-          new RequestRetryOptions(azureCloudConfig.azureRetryPolicy, azureCloudConfig.azureMaxTries, null,
-              azureCloudConfig.azureRetryDelayInSec, azureCloudConfig.azureMaxRetryDelayInSec, null);
-      return buildBlobServiceSyncClient(client, new ConfigurationBuilder().build(), retryOptions, azureCloudConfig);
-    } catch (MalformedURLException | InterruptedException | ExecutionException ex) {
-      logger.error("Error building ABS blob service client: {}", ex.getMessage());
-      throw new IllegalStateException(ex);
-    }
+    RequestRetryOptions retryOptions =
+        new RequestRetryOptions(azureCloudConfig.azureRetryPolicy, azureCloudConfig.azureMaxTries, null,
+            azureCloudConfig.azureRetryDelayInSec, azureCloudConfig.azureMaxRetryDelayInSec, null);
+    return buildBlobServiceSyncClient(client, new ConfigurationBuilder().build(), retryOptions, azureCloudConfig);
   }
 
   public TableServiceClient getTableServiceClient() {
@@ -478,12 +473,7 @@ public abstract class StorageClient implements AzureStorageClient {
       default:
         throw new RuntimeException(String.format("Invalid azureRetryPolicy %s", azureCloudConfig.azureRetryPolicy));
     }
-    try {
-      return buildTableServiceClient(client, new ConfigurationBuilder().build(), retryOptions, azureCloudConfig);
-    } catch (Exception e) {
-      logger.error("Error building Azure Table Service client: {}", e.getMessage());
-      throw e;
-    }
+    return buildTableServiceClient(client, new ConfigurationBuilder().build(), retryOptions, azureCloudConfig);
   }
 
   /**
@@ -529,8 +519,7 @@ public abstract class StorageClient implements AzureStorageClient {
    * @return {@link BlobServiceAsyncClient} object.
    */
   protected BlobServiceClient buildBlobServiceSyncClient(HttpClient httpClient, Configuration configuration,
-      RequestRetryOptions retryOptions, AzureCloudConfig azureCloudConfig)
-      throws MalformedURLException, InterruptedException, ExecutionException {
+      RequestRetryOptions retryOptions, AzureCloudConfig azureCloudConfig) {
     return null;
   }
 

--- a/ambry-commons/src/main/java/com/github/ambry/clustermap/HelixVcrUtil.java
+++ b/ambry-commons/src/main/java/com/github/ambry/clustermap/HelixVcrUtil.java
@@ -309,7 +309,6 @@ public class HelixVcrUtil {
     HelixAdmin destAdmin = new ZKHelixAdmin(destZkString);
     Set<String> destResources = new HashSet<>(destAdmin.getResourcesInCluster(destClusterName));
 
-    boolean status = true;
     for (String resource : srcResources) {
       if (!isPartitionResourceName(resource)) {
         logger.error("[HelixSync] Ignore resource {} from source Ambry cluster", resource);
@@ -317,7 +316,7 @@ public class HelixVcrUtil {
       }
       if (!destResources.contains(resource)) {
         logger.error("[HelixSync] Resource {} from source Ambry cluster is absent in VCR cluster", resource);
-        status = false;
+        return false;
       }
       // check if every partition exist.
       Set<String> srcPartitions = srcAdmin.getResourceIdealState(srcClusterName, resource).getPartitionSet();
@@ -325,11 +324,11 @@ public class HelixVcrUtil {
       for (String partition : srcPartitions) {
         if (!destPartitions.contains(partition)) {
           logger.error("[HelixSync] Partition {} from source Ambry cluster is absent in VCR cluster", partition);
-          status = false;
+          return false;
         }
       }
     }
-    return status;
+    return true;
   }
 
   /**

--- a/ambry-commons/src/main/java/com/github/ambry/clustermap/HelixVcrUtil.java
+++ b/ambry-commons/src/main/java/com/github/ambry/clustermap/HelixVcrUtil.java
@@ -186,7 +186,6 @@ public class HelixVcrUtil {
     Set<String> srcResources = new HashSet<>(srcAdmin.getResourcesInCluster(srcClusterName));
     HelixAdmin destAdmin = new ZKHelixAdmin(destZkString);
     Set<String> destResources = new HashSet<>(destAdmin.getResourcesInCluster(destClusterName));
-    logger.info("========VCR Helix Update Starts========");
     // Remove stale resources
     for (String resource : destResources) {
       if (!srcResources.contains(resource)) {
@@ -202,7 +201,6 @@ public class HelixVcrUtil {
     }
     for (String resource : srcResources) {
       if (!isPartitionResourceName(resource)) {
-        logger.info("Resource {} from src cluster is ignored", resource);
         continue;
       }
       boolean createNewResource = false;
@@ -245,12 +243,9 @@ public class HelixVcrUtil {
           destAdmin.rebalance(destClusterName, resource, config.getIdealStateConfigFields().getNumReplicas(), "", "");
           logger.info("Added Resource {}  with partition {}", resource, srcPartitions);
         }
-      } else {
-        logger.info("Resource {} is up to date. No action needed.", resource);
       }
     }
     logger.info("Cluster {} is updated successfully!", destClusterName);
-    logger.info("========VCR Helix Update Ends========");
   }
 
   /**

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
@@ -804,7 +804,7 @@ public abstract class ReplicationEngine implements ReplicationAPI {
             }
           }
           removeRemoteReplicaInfoFromReplicaThread(replicaInfosToRemove);
-          if (addedReplicas.size() + removedReplicas.size() > 0) {
+          if (addedPeerReplicas.size() + removedPeerReplicas.size() > 0) {
             // print only if something is added or removed
             logger.info("{} peer replicas are added and {} peer replicas are removed in replication manager",
                 addedPeerReplicas.size(), removedPeerReplicas.size());

--- a/ambry-vcr/src/main/java/com/github/ambry/vcr/VcrServer.java
+++ b/ambry-vcr/src/main/java/com/github/ambry/vcr/VcrServer.java
@@ -222,6 +222,7 @@ public class VcrServer {
               clusterMapConfig, clusterMap, accountService, storeConfig, cloudDestination,
               registry)).getVcrClusterParticipant();
       cloudStorageManager = new CloudStorageManager(properties, vcrMetrics, cloudDestination, clusterMap);
+      scheduler = Utils.newScheduler(1, "vcr-scheduler-",true);
       vcrReplicationManager = new VcrReplicationManager(properties, cloudStorageManager, storeKeyFactory, clusterMap,
           vcrClusterParticipant, cloudDestination, scheduler, networkClientFactory, notificationSystem,
           storeKeyConverterFactory);


### PR DESCRIPTION
* Fixes nullptr in helix path
* Also removes some un-used compaction code
* Other minor logging fixes

```
java.lang.reflect.InvocationTargetException: null
        at jdk.internal.reflect.GeneratedMethodAccessor62.invoke(Unknown Source) ~[?:?]
        at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
        at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
        at org.apache.helix.messaging.handling.HelixStateTransitionHandler.invoke(HelixStateTransitionHandler.java:350) ~[org.apache.helix.helix-core-1.1.0.0.jar:1.1.0.0]
        at org.apache.helix.messaging.handling.HelixStateTransitionHandler.handleMessage(HelixStateTransitionHandler.java:278) [org.apache.helix.helix-core-1.1.0.0.jar:1.1.0.0]
        at org.apache.helix.messaging.handling.HelixTask.call(HelixTask.java:97) [org.apache.helix.helix-core-1.1.0.0.jar:1.1.0.0]
        at org.apache.helix.messaging.handling.HelixTask.call(HelixTask.java:49) [org.apache.helix.helix-core-1.1.0.0.jar:1.1.0.0]
        at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
        at java.lang.Thread.run(Thread.java:834) [?:?]
Caused by: java.lang.NullPointerException
        at com.github.ambry.cloud.VcrReplicationManager$1.onPartitionAdded(VcrReplicationManager.java:304) ~[com.github.ambry.ambry-cloud-0.4.452.jar:?]
```