### PR TITLE
Allow overwrites by default for S3 uploads

### DIFF
--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3MultipartCompleteUploadHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3MultipartCompleteUploadHandler.java
@@ -188,6 +188,8 @@ public class S3MultipartCompleteUploadHandler {
             restRequest.setArg(Headers.AMBRY_CONTENT_TYPE, restRequest.getArgs().get(Headers.CONTENT_TYPE));
           }
           restRequest.setArg(Headers.AMBRY_CONTENT_ENCODING, restRequest.getArgs().get(Headers.CONTENT_ENCODING));
+          // Overwrites are allowed by default for S3 uploads
+          restRequest.setArg(NAMED_UPSERT, true);
           BlobInfo blobInfo = getBlobInfoFromRequest();
           securityService.postProcessRequest(restRequest, securityPostProcessRequestCallback(blobInfo));
         }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3PutHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3PutHandler.java
@@ -88,6 +88,9 @@ public class S3PutHandler extends S3BaseHandler<Void> {
     }
     restRequest.setArg(Headers.AMBRY_CONTENT_ENCODING, restRequest.getArgs().get(Headers.CONTENT_ENCODING));
 
+    // Overwrites are allowed by default for S3 APIs https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html
+    restRequest.setArg(NAMED_UPSERT, true);
+
     // 2. Upload the blob by following named blob PUT path
     namedBlobPutHandler.handle(restRequest, restResponseChannel, buildCallback(metrics.s3PutHandleMetrics, (r) -> {
       if (restResponseChannel.getStatus() == ResponseStatus.Created) {

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/S3MultipartUploadTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/S3MultipartUploadTest.java
@@ -60,6 +60,7 @@ import org.json.JSONObject;
 import org.junit.Test;
 
 import static com.github.ambry.rest.RestUtils.*;
+import static com.github.ambry.rest.RestUtils.Headers.*;
 import static org.junit.Assert.*;
 import static com.github.ambry.frontend.s3.S3MessagePayload.*;
 
@@ -186,14 +187,15 @@ public class S3MultipartUploadTest {
     restResponseChannel = new MockRestResponseChannel();
     postResult = new FutureResult<>();
     s3PostHandler.handle(request, restResponseChannel, postResult::done);
+    // Verify Upsert header is set by default for S3 multipart uploads.
+    assertTrue("Upsert header must be present", request.getArgs().containsKey(NAMED_UPSERT));
     readableStreamChannel = postResult.get();
     byteBuffer = ((ByteBufferReadableStreamChannel) readableStreamChannel).getContent();
     byte[] byteArray = byteBuffer.array();
     CompleteMultipartUploadResult completeMultipartUploadResult =
         xmlMapper.readValue(byteArray, CompleteMultipartUploadResult.class);
     assertEquals("Mismatch on status", ResponseStatus.Ok, restResponseChannel.getStatus());
-    assertEquals("Mismatch in content type", XML_CONTENT_TYPE,
-        restResponseChannel.getHeader(Headers.CONTENT_TYPE));
+    assertEquals("Mismatch in content type", XML_CONTENT_TYPE, restResponseChannel.getHeader(Headers.CONTENT_TYPE));
     assertEquals("Mismatch on CompleteMultipartUploadResult.bucket", containerName,
         completeMultipartUploadResult.getBucket());
     assertEquals("Mismatch on CompleteMultipartUploadResult.key", blobName, completeMultipartUploadResult.getKey());

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/S3PutHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/S3PutHandlerTest.java
@@ -51,6 +51,7 @@ import java.util.Properties;
 import org.json.JSONObject;
 import org.junit.Test;
 
+import static com.github.ambry.rest.RestUtils.Headers.*;
 import static com.github.ambry.rest.RestUtils.InternalKeys.*;
 import static org.junit.Assert.*;
 
@@ -99,6 +100,9 @@ public class S3PutHandlerTest {
     FutureResult<Void> putResult = new FutureResult<>();
     s3PutHandler.handle(request, restResponseChannel, putResult::done);
     putResult.get();
+
+    // Verify Upsert header is set by default for S3 uploads.
+    assertTrue("Upsert header must be present", request.getArgs().containsKey(NAMED_UPSERT));
 
     // 2. Verify upload was successful
     String blobId = (String) restResponseChannel.getHeader(RestUtils.Headers.LOCATION);


### PR DESCRIPTION
Reference: https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html  (_If it receives multiple write requests for the same object simultaneously, it overwrites all but the last object written._)