### PR TITLE
Fix missing data chunk metric again

### DIFF
--- a/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
@@ -1307,11 +1307,6 @@ class GetBlobOperation extends GetOperation {
               }
             }
           } else {
-            if (chunkBlobId.getBlobDataType() == BlobId.BlobDataType.DATACHUNK
-                && getError == ServerErrorCode.Blob_Not_Found) {
-              // Missing a data chunk
-              routerMetrics.missingDataChunkErrorCount.inc();
-            }
             // process and set the most relevant exception.
             RouterErrorCode routerErrorCode = processServerError(getError);
             if (getError == ServerErrorCode.Disk_Unavailable) {


### PR DESCRIPTION
## Summary

In https://github.com/linkedin/ambry/pull/2867, we move the missing data chunk metric to the right place, but forgot to remove it from the processGetBlobResponse function. This PR fixes it.

## Test
unit test