### PR TITLE
[Paranoid Durability] Limit the number of remote PUT attempts.

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
@@ -63,6 +63,7 @@ public class RouterConfig {
   public static final String ROUTER_PUT_REMOTE_REQUEST_PARALLELISM = "router.put.remote.request.parallelism";
   public static final String ROUTER_PUT_SUCCESS_TARGET = "router.put.success.target";
   public static final String ROUTER_PUT_REMOTE_SUCCESS_TARGET = "router.put.remote.success.target";
+  public static final String ROUTER_PUT_REMOTE_ATTEMPT_LIMIT = "router.put.remote.attempt.limit";
   public static final String ROUTER_REPLICATE_BLOB_REQUEST_PARALLELISM = "router.replicate.blob.request.parallelism";
   public static final String ROUTER_REPLICATE_BLOB_SUCCESS_TARGET = "router.replicate.blob.success.target";
   public static final String ROUTER_MAX_SLIPPED_PUT_ATTEMPTS = "router.max.slipped.put.attempts";
@@ -279,6 +280,14 @@ public class RouterConfig {
   @Config(ROUTER_PUT_REMOTE_SUCCESS_TARGET)
   @Default("1")
   public final int routerPutRemoteSuccessTarget;
+
+  /**
+   * Paranoid durability: The maximum number of write attempts in remote data centers for a put operation. Once exceeded,
+   * no more remote writes will be attempted.
+   */
+  @Config(ROUTER_PUT_REMOTE_ATTEMPT_LIMIT)
+  @Default("2")
+  public final int routerPutRemoteAttemptLimit;
 
   /**
    * The maximum number of parallel requests issued at a time by the ReplicateBlob manager.
@@ -792,6 +801,7 @@ public class RouterConfig {
         verifiableProperties.getIntInRange(ROUTER_PUT_REMOTE_REQUEST_PARALLELISM, 1, 1, Integer.MAX_VALUE);
     routerPutSuccessTarget = verifiableProperties.getIntInRange(ROUTER_PUT_SUCCESS_TARGET, 2, 1, Integer.MAX_VALUE);
     routerPutRemoteSuccessTarget = verifiableProperties.getIntInRange(ROUTER_PUT_REMOTE_SUCCESS_TARGET, 1, 1, Integer.MAX_VALUE);
+    routerPutRemoteAttemptLimit = verifiableProperties.getIntInRange(ROUTER_PUT_REMOTE_ATTEMPT_LIMIT, 2, 1, Integer.MAX_VALUE);
     routerReplicateBlobRequestParallelism =
         verifiableProperties.getIntInRange(ROUTER_REPLICATE_BLOB_REQUEST_PARALLELISM, 3, 1, Integer.MAX_VALUE);
     routerReplicateBlobSuccessTarget =

--- a/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterMetrics.java
@@ -257,6 +257,8 @@ public class NonBlockingRouterMetrics {
 
   // Number of times there are not enough replicas available to satisfy paranoid durability write requirements
   public final Counter paranoidDurabilityNotEnoughReplicasCount;
+  // Number of times we gave up on trying to satisfy paranoid durability write requirements
+  public final Counter paranoidDurabilityRemoteRetriesExceededCount;
 
 
   // Workload characteristics
@@ -640,7 +642,8 @@ public class NonBlockingRouterMetrics {
         metricRegistry.counter(MetricRegistry.name(ParanoidDurabilityOperationTracker.class, "ParanoidDurabilitySuccessCount"));
     paranoidDurabilityNotEnoughReplicasCount =
         metricRegistry.counter(MetricRegistry.name(ParanoidDurabilityOperationTracker.class, "ParanoidDurabilityNotEnoughReplicasCount"));
-
+    paranoidDurabilityRemoteRetriesExceededCount =
+        metricRegistry.counter(MetricRegistry.name(ParanoidDurabilityOperationTracker.class, "ParanoidDurabilityRemoteRetriesExceededCount"));
 
     // Workload
     ageAtGet = new AgeAtAccessMetrics(metricRegistry, "OnGet");

--- a/ambry-router/src/main/java/com/github/ambry/router/ParanoidDurabilityOperationTracker.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/ParanoidDurabilityOperationTracker.java
@@ -254,12 +254,10 @@ public class ParanoidDurabilityOperationTracker extends SimpleOperationTracker {
   private boolean hasSucceededRemotely() {
     if (remoteReplicaSuccessCount >= remoteReplicaSuccessTarget) {
       return true;
-    }
-    else if(remoteAttempts >= remoteAttemptLimit) {
+    } else if(remoteAttempts >= remoteAttemptLimit) {
       // We want to limit the number of retries that we issue to remote colos. At times of excessive network latency,
       // we may end up issuing a large number of retries to remote colos. This is undesirable, since it will lead to
       // excessive direct memory usage, because ambry-frontend will hold the state for every request until it is completed.
-      // In incident-1455, this caused ambry-frontend to run out of direct memory.
       logger.error("Paranoid durability PUT failed in remote data centers for partition "
           + partitionId + " - gave up after " + remoteAttempts + " attempts. If the local writes succeeded, "
           + "we will still return success to the client. This is likely a network issue.");
@@ -355,8 +353,7 @@ public class ParanoidDurabilityOperationTracker extends SimpleOperationTracker {
     // retries to remote colos. This is undesirable, since it will lead to excessive direct memory usage (incident-1455).
     if (remoteAttempts >= remoteAttemptLimit) {
       return false;
-    }
-    else if ((remoteReplicaSuccessCount + remoteInflightCount + remoteReplicas.size()) < remoteReplicaSuccessTarget) {
+    } else if ((remoteReplicaSuccessCount + remoteInflightCount + remoteReplicas.size()) < remoteReplicaSuccessTarget) {
       logger.error("Paranoid durability PUT failed in remote data centers for partition " + partitionId);
       routerMetrics.paranoidDurabilityFailureCount.inc();
       return true;

--- a/ambry-router/src/main/java/com/github/ambry/router/ParanoidDurabilityOperationTracker.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/ParanoidDurabilityOperationTracker.java
@@ -298,6 +298,7 @@ public class ParanoidDurabilityOperationTracker extends SimpleOperationTracker {
       localInflightCount--;
     } else {
       remoteInflightCount--;
+      remoteAttempts++;
     }
 
     switch (trackedRequestFinalState) {
@@ -419,7 +420,6 @@ public class ParanoidDurabilityOperationTracker extends SimpleOperationTracker {
         localReplicas.remove(lastReturnedByIterator);
       } else {
         remoteInflightCount++;
-        remoteAttempts++;
         remoteReplicas.remove(lastReturnedByIterator);
       }
     }


### PR DESCRIPTION
This PR adds a new config and code for limiting the number of times we attempt to PUT to a remote colo. The intention is to limit the memory usage during times of extra high network latency. When the network is slow or failing, ambry-frontend will hold request attempts in memory, which can lead to exhaustion of Java direct memory.

If we reach the limit for remote writes, but local writes are successful, we will still return success to the client. The assumption here is that it is better to degrade performance than to completely fail, since we assume that network latency/error spikes will be fairly brief.

A new metric and log message is added to allow debugging. Also, an old log message is removed because it was found to make the logs noisy without adding much value.