### PR TITLE
[vcr-2.0] Increment replication error count

### DIFF
--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -822,6 +822,7 @@ public class ReplicaThread implements Runnable {
           }
         }
       } else {
+        replicationMetrics.incrementReplicationErrorCount(replicatingFromRemoteColo, datacenterName);
         replicationMetrics.updateMetadataRequestError(remoteReplicaInfo.getReplicaId());
         logger.error("Remote node: {} Thread name: {} Remote replica: {} Server metadata-response error: {}",
             remoteNode, threadName, remoteReplicaInfo.getReplicaId(), replicaMetadataResponseInfo.getError());
@@ -1379,6 +1380,7 @@ public class ReplicaThread implements Runnable {
                 remoteNode, threadName, remoteReplicaInfo.getReplicaId(),
                 exchangeMetadataResponse.getMissingStoreKeys());
           } else {
+            replicationMetrics.incrementReplicationErrorCount(replicatingFromRemoteColo, datacenterName);
             replicationMetrics.updateGetRequestError(remoteReplicaInfo.getReplicaId());
             logger.error("Remote node: {} Thread name: {} Remote replica: {} Server get-response error: {}",
                 remoteNode, threadName, remoteReplicaInfo.getReplicaId(), partitionResponseInfo.getErrorCode());

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationMetrics.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationMetrics.java
@@ -609,9 +609,8 @@ public class ReplicationMetrics {
     String metadataRequestErrorMetricName =
         remoteReplica.getDataNodeId().getHostname() + "-" + remoteReplica.getDataNodeId().getPort() + "-"
             + remoteReplica.getPartitionId().toString() + "-metadataRequestError";
-    Counter counter = metadataRequestErrorMap.get(metadataRequestErrorMetricName);
-    if (counter != null) {
-      counter.inc();
+    if (metadataRequestErrorMap.containsKey(metadataRequestErrorMetricName)) {
+      metadataRequestErrorMap.get(metadataRequestErrorMetricName).inc();
     }
   }
 


### PR DESCRIPTION
Encountering replication errors in vcr-main cluster logs but nothing shows up on the metrics because they are not incremented.