### PR TITLE
Add blob size and modified timestamp in named blobs metadata db

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/frontend/NamedBlobListEntry.java
+++ b/ambry-api/src/main/java/com/github/ambry/frontend/NamedBlobListEntry.java
@@ -116,6 +116,6 @@ public class NamedBlobListEntry {
     }
     NamedBlobListEntry that = (NamedBlobListEntry) o;
     return expirationTimeMs == that.expirationTimeMs && Objects.equals(blobName, that.blobName)
-        && modifiedTimeMs == that.modifiedTimeMs && blobSize == that.getBlobSize();
+        && modifiedTimeMs == that.modifiedTimeMs && blobSize == that.blobSize;
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/frontend/NamedBlobListEntry.java
+++ b/ambry-api/src/main/java/com/github/ambry/frontend/NamedBlobListEntry.java
@@ -27,17 +27,21 @@ import org.json.JSONObject;
 public class NamedBlobListEntry {
   private static final String BLOB_NAME_KEY = "blobName";
   private static final String EXPIRATION_TIME_MS_KEY = "expirationTimeMs";
+  private static final String BLOB_SIZE_KEY = "blobSize";
+  private static final String MODIFIED_TIME_MS_KEY = "modifiedTimeMs";
 
   private final String blobName;
   private final long expirationTimeMs;
+  private final long blobSize;
+  private final long modifiedTimeMs;
 
   /**
    * Read a {@link NamedBlobRecord} from JSON.
    * @param jsonObject the {@link JSONObject} to deserialize.
    */
   public NamedBlobListEntry(JSONObject jsonObject) {
-    this(jsonObject.getString(BLOB_NAME_KEY),
-        jsonObject.optLong(EXPIRATION_TIME_MS_KEY, Utils.Infinite_Time));
+    this(jsonObject.getString(BLOB_NAME_KEY), jsonObject.optLong(EXPIRATION_TIME_MS_KEY, Utils.Infinite_Time),
+        jsonObject.optLong(BLOB_SIZE_KEY, 0), jsonObject.optLong(MODIFIED_TIME_MS_KEY, Utils.Infinite_Time));
   }
 
   /**
@@ -45,15 +49,20 @@ public class NamedBlobListEntry {
    * @param record the {@link NamedBlobRecord}.
    */
   NamedBlobListEntry(NamedBlobRecord record) {
-    this(record.getBlobName(), record.getExpirationTimeMs());
+    this(record.getBlobName(), record.getExpirationTimeMs(), record.getBlobSize(), record.getModifiedTimeMs());
   }
+
   /**
    * @param blobName the blob name within a container.
    * @param expirationTimeMs the expiration time in milliseconds since epoch, or -1 if the blob should be permanent.
+   * @param blobSize         the size of the blob
+   * @param modifiedTimeMs   the modified time of the blob in milliseconds since epoch
    */
-  private NamedBlobListEntry(String blobName, long expirationTimeMs) {
+  private NamedBlobListEntry(String blobName, long expirationTimeMs, long blobSize, long modifiedTimeMs) {
     this.blobName = blobName;
     this.expirationTimeMs = expirationTimeMs;
+    this.blobSize = blobSize;
+    this.modifiedTimeMs = modifiedTimeMs;
   }
 
   /**
@@ -71,6 +80,20 @@ public class NamedBlobListEntry {
   }
 
   /**
+   * @return the blob size.
+   */
+  public long getBlobSize() {
+    return blobSize;
+  }
+
+  /**
+   * @return the modified time of the blob in milliseconds since epoch
+   */
+  public long getModifiedTimeMs() {
+    return modifiedTimeMs;
+  }
+
+  /**
    * @return this list entry as a {@link JSONObject}.
    */
   public JSONObject toJson() {
@@ -78,6 +101,8 @@ public class NamedBlobListEntry {
     if (expirationTimeMs != Utils.Infinite_Time) {
       jsonObject.put(EXPIRATION_TIME_MS_KEY, expirationTimeMs);
     }
+    jsonObject.put(BLOB_SIZE_KEY, blobSize);
+    jsonObject.put(MODIFIED_TIME_MS_KEY, modifiedTimeMs);
     return jsonObject;
   }
 
@@ -90,6 +115,7 @@ public class NamedBlobListEntry {
       return false;
     }
     NamedBlobListEntry that = (NamedBlobListEntry) o;
-    return expirationTimeMs == that.expirationTimeMs && Objects.equals(blobName, that.blobName);
+    return expirationTimeMs == that.expirationTimeMs && Objects.equals(blobName, that.blobName)
+        && modifiedTimeMs == that.modifiedTimeMs && blobSize == that.getBlobSize();
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/named/NamedBlobRecord.java
+++ b/ambry-api/src/main/java/com/github/ambry/named/NamedBlobRecord.java
@@ -53,7 +53,7 @@ public class NamedBlobRecord {
    */
   public NamedBlobRecord(String accountName, String containerName, String blobName, String blobId,
       long expirationTimeMs, long version) {
-    this(accountName, containerName, blobName, blobId, expirationTimeMs, version, 0, 0);
+    this(accountName, containerName, blobName, blobId, expirationTimeMs, version, 0);
   }
 
   /**
@@ -64,6 +64,21 @@ public class NamedBlobRecord {
    * @param expirationTimeMs the expiration time in milliseconds since epoch, or -1 if the blob should be permanent.
    * @param version          the version of this named blob.
    * @param blobSize         the size of the blob.
+   */
+  public NamedBlobRecord(String accountName, String containerName, String blobName, String blobId,
+      long expirationTimeMs, long version, long blobSize) {
+    this(accountName, containerName, blobName, blobId, expirationTimeMs, version, blobSize, 0);
+  }
+
+  /**
+   * @param accountName      the account name.
+   * @param containerName    the container name.
+   * @param blobName         the blob name within the container.
+   * @param blobId           the blob ID for the blob content in ambry storage.
+   * @param expirationTimeMs the expiration time in milliseconds since epoch, or -1 if the blob should be permanent.
+   * @param version          the version of this named blob.
+   * @param blobSize         the size of the blob.
+   * @param modifiedTimeMs   the modified time of the blob in milliseconds since epoch
    */
   public NamedBlobRecord(String accountName, String containerName, String blobName, String blobId,
       long expirationTimeMs, long version, long blobSize, long modifiedTimeMs) {

--- a/ambry-api/src/main/java/com/github/ambry/named/NamedBlobRecord.java
+++ b/ambry-api/src/main/java/com/github/ambry/named/NamedBlobRecord.java
@@ -28,6 +28,8 @@ public class NamedBlobRecord {
   private final long expirationTimeMs;
   private final long version;
   private final String blobId;
+  private final long blobSize;
+  private final long modifiedTimeMs;
 
   /**
    * @param accountName the account name.
@@ -51,12 +53,28 @@ public class NamedBlobRecord {
    */
   public NamedBlobRecord(String accountName, String containerName, String blobName, String blobId,
       long expirationTimeMs, long version) {
+    this(accountName, containerName, blobName, blobId, expirationTimeMs, version, 0, 0);
+  }
+
+  /**
+   * @param accountName      the account name.
+   * @param containerName    the container name.
+   * @param blobName         the blob name within the container.
+   * @param blobId           the blob ID for the blob content in ambry storage.
+   * @param expirationTimeMs the expiration time in milliseconds since epoch, or -1 if the blob should be permanent.
+   * @param version          the version of this named blob.
+   * @param blobSize         the size of the blob.
+   */
+  public NamedBlobRecord(String accountName, String containerName, String blobName, String blobId,
+      long expirationTimeMs, long version, long blobSize, long modifiedTimeMs) {
     this.accountName = accountName;
     this.containerName = containerName;
     this.blobName = blobName;
     this.blobId = blobId;
     this.expirationTimeMs = expirationTimeMs;
     this.version = version;
+    this.blobSize = blobSize;
+    this.modifiedTimeMs = modifiedTimeMs;
   }
 
   /**
@@ -101,6 +119,13 @@ public class NamedBlobRecord {
     return expirationTimeMs;
   }
 
+  /**
+   * @return the blob size.
+   */
+  public long getBlobSize() {
+    return blobSize;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -122,7 +147,14 @@ public class NamedBlobRecord {
 
   @Override
   public String toString() {
-    return "NamedBlobRecord[accountName=" + accountName + ",containerName=" + containerName + ",blobName=" + blobName +
-        ",blobId=" + blobId + ",expirationTimeMs=" + expirationTimeMs + ",version=" + version + "]";
+    return "NamedBlobRecord[accountName=" + accountName + ",containerName=" + containerName + ",blobName=" + blobName
+        + ",blobId=" + blobId + ",expirationTimeMs=" + expirationTimeMs + ",version=" + version + "]";
+  }
+
+  /**
+   * @return the modified timestamp of this blob
+   */
+  public long getModifiedTimeMs() {
+    return modifiedTimeMs;
   }
 }

--- a/ambry-frontend/src/integration-test/java/com/github/ambry/frontend/FrontendIntegrationTestBase.java
+++ b/ambry-frontend/src/integration-test/java/com/github/ambry/frontend/FrontendIntegrationTestBase.java
@@ -1259,13 +1259,17 @@ public class FrontendIntegrationTestBase {
   static class NamedBlobEntry {
     private String blobName;
     private long expirationTimeMs;
+    private long blobSize;
+    private long modifiedTimeMs;
 
     public NamedBlobEntry() {
     }
 
-    public NamedBlobEntry(String blobName, long expiration) {
+    public NamedBlobEntry(String blobName, long expiration, long blobSize, long modifiedTimeMs) {
       this.blobName = blobName;
       this.expirationTimeMs = expiration;
+      this.blobSize = blobSize;
+      this.modifiedTimeMs = modifiedTimeMs;
     }
 
     public String getBlobName() {
@@ -1282,6 +1286,22 @@ public class FrontendIntegrationTestBase {
 
     public void setExpirationTimeMs(long expirationTimeMs) {
       this.expirationTimeMs = expirationTimeMs;
+    }
+
+    public long getBlobSize() {
+      return blobSize;
+    }
+
+    public void setBlobSize(long blobSize) {
+      this.blobSize = blobSize;
+    }
+
+    public long getModifiedTimeMs() {
+      return modifiedTimeMs;
+    }
+
+    public void setModifiedTimeMs(long modifiedTimeMs) {
+      this.modifiedTimeMs = modifiedTimeMs;
     }
   }
 

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbryIdConverterFactory.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbryIdConverterFactory.java
@@ -191,8 +191,9 @@ public class AmbryIdConverterFactory implements IdConverterFactory {
         BlobProperties properties = blobInfo.getBlobProperties();
         long expirationTimeMs =
             Utils.addSecondsToEpochTime(properties.getCreationTimeInMs(), properties.getTimeToLiveInSeconds());
+        // Please note that the modified_ts column in DB will be auto-populated by the DB server.
         NamedBlobRecord record = new NamedBlobRecord(namedBlobPath.getAccountName(), namedBlobPath.getContainerName(),
-            namedBlobPath.getBlobName(), blobId, expirationTimeMs, 0, properties.getBlobSize(), 0);
+            namedBlobPath.getBlobName(), blobId, expirationTimeMs, 0, properties.getBlobSize());
         NamedBlobState state = NamedBlobState.READY;
         if (properties.getTimeToLiveInSeconds() == Utils.Infinite_Time) {
           // Set named blob state as 'IN_PROGRESS', will set the state to be 'READY' in the ttlUpdate success callback: routerTtlUpdateCallback

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbryIdConverterFactory.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbryIdConverterFactory.java
@@ -192,7 +192,7 @@ public class AmbryIdConverterFactory implements IdConverterFactory {
         long expirationTimeMs =
             Utils.addSecondsToEpochTime(properties.getCreationTimeInMs(), properties.getTimeToLiveInSeconds());
         NamedBlobRecord record = new NamedBlobRecord(namedBlobPath.getAccountName(), namedBlobPath.getContainerName(),
-            namedBlobPath.getBlobName(), blobId, expirationTimeMs);
+            namedBlobPath.getBlobName(), blobId, expirationTimeMs, 0, properties.getBlobSize(), 0);
         NamedBlobState state = NamedBlobState.READY;
         if (properties.getTimeToLiveInSeconds() == Utils.Infinite_Time) {
           // Set named blob state as 'IN_PROGRESS', will set the state to be 'READY' in the ttlUpdate success callback: routerTtlUpdateCallback

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
@@ -249,6 +249,7 @@ public class NamedBlobPutHandler {
     private Callback<String> routerPutBlobCallback(BlobInfo blobInfo) {
       return buildCallback(frontendMetrics.putRouterPutBlobMetrics, blobId -> {
         restResponseChannel.setHeader(RestUtils.Headers.BLOB_SIZE, restRequest.getBlobBytesReceived());
+        blobInfo.getBlobProperties().setBlobSize(restRequest.getBlobBytesReceived());
         idConverter.convert(restRequest, blobId, blobInfo, idConverterCallback(blobInfo, blobId));
       }, uri, LOGGER, deleteDatasetCallback);
     }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3ListHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3ListHandler.java
@@ -33,6 +33,7 @@ import java.nio.ByteBuffer;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
 import org.json.JSONObject;
@@ -110,11 +111,11 @@ public class S3ListHandler extends S3BaseHandler<ReadableStreamChannel> {
     int keyCount = 0;
     for (NamedBlobListEntry namedBlobRecord : namedBlobRecordPage.getEntries()) {
       String blobName = namedBlobRecord.getBlobName();
-      String todayDate = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").format(Calendar.getInstance().getTime());
-      // Set size to 0 for now. Although this doesn't seem to be used by S3 clients, -1 is being treated an invalid value by s3 java client
-      // TODO: Flink team is requesting to send valid blob size and modified date in the Contents for debugging purposes.
-      //  This would need mysql schema change
-      contentsList.add(new Contents(blobName, todayDate, 0));
+      long blobSize = namedBlobRecord.getBlobSize();
+      long modifiedTimeMs = namedBlobRecord.getModifiedTimeMs();
+      Date modifiedDate = modifiedTimeMs != -1 ? new Date(modifiedTimeMs) : Calendar.getInstance().getTime();
+      String formattedModifiedDate = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").format(modifiedDate);
+      contentsList.add(new Contents(blobName, formattedModifiedDate, blobSize));
       if (++keyCount == maxKeysValue) {
         break;
       }

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/S3ListHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/S3ListHandlerTest.java
@@ -174,12 +174,13 @@ public class S3ListHandlerTest {
     // 1. Put a named blob
     String PREFIX = "directory-name";
     String KEY_NAME = PREFIX + SLASH + "key_name";
+    int BLOB_SIZE = 1024;
     String request_path =
         NAMED_BLOB_PREFIX + SLASH + account.getName() + SLASH + container.getName() + SLASH + KEY_NAME;
     JSONObject headers = new JSONObject();
     FrontendRestRequestServiceTest.setAmbryHeadersForPut(headers, TestUtils.TTL_SECS, container.isCacheable(),
         SERVICE_ID, CONTENT_TYPE, OWNER_ID, null, null, null);
-    byte[] content = TestUtils.getRandomBytes(1024);
+    byte[] content = TestUtils.getRandomBytes(BLOB_SIZE);
     RestRequest request = FrontendRestRequestServiceTest.createRestRequest(RestMethod.PUT, request_path, headers,
         new LinkedList<>(Arrays.asList(ByteBuffer.wrap(content), null)));
     request.setArg(InternalKeys.REQUEST_PATH,
@@ -224,7 +225,7 @@ public class S3ListHandlerTest {
     assertEquals("Mismatch in key count", 2, listBucketResultV2.getKeyCount());
     assertEquals("Mismatch in delimiter", "/", listBucketResultV2.getDelimiter());
     assertEquals("Mismatch in encoding type", "url", listBucketResultV2.getEncodingType());
-    assertEquals("Mismatch in size", 0, listBucketResultV2.getContents().get(0).getSize());
+    assertEquals("Mismatch in size", BLOB_SIZE, listBucketResultV2.getContents().get(0).getSize());
 
     // 4. Get list of blobs with continuation-token
     s3_list_request_uri =

--- a/ambry-named-mysql/src/integration-test/java/com/github/ambry/named/MySqlNamedBlobDbIntegrationTest.java
+++ b/ambry-named-mysql/src/integration-test/java/com/github/ambry/named/MySqlNamedBlobDbIntegrationTest.java
@@ -101,9 +101,10 @@ public class MySqlNamedBlobDbIntegrationTest {
           String blobName = "name/" + i + "/more path segments--";
           long expirationTime =
               i % 2 == 0 ? Utils.Infinite_Time : System.currentTimeMillis() + TimeUnit.HOURS.toMillis(1);
+          long blobSize = 20;
           NamedBlobRecord record =
-              new NamedBlobRecord(account.getName(), container.getName(), blobName, blobId, expirationTime);
-
+              new NamedBlobRecord(account.getName(), container.getName(), blobName, blobId, expirationTime, 0, blobSize,
+                  0);
           namedBlobDb.put(record).get();
           records.add(record);
         }
@@ -146,6 +147,15 @@ public class MySqlNamedBlobDbIntegrationTest {
             namedBlobDb.list(account.getName(), container.getName(), null, null, 1).get();
         assertEquals("Unexpected number of blobs in container", blobsPerContainer / 5,
             pageWithMaxKey.getEntries().size());
+        // Verify that blob size and modified ts is returned for all blobs
+        for (NamedBlobRecord record : pageWithToken.getEntries()) {
+          assertEquals("Mismatch in blob size", 20, record.getBlobSize());
+          assertNotEquals("Modified timestamp must be present", 0L, record.getModifiedTimeMs());
+        }
+        for (NamedBlobRecord record : pageWithMaxKey.getEntries()) {
+          assertEquals("Mismatch in blob size", 20, record.getBlobSize());
+          assertNotEquals("Modified timestamp must be present", 0L, record.getModifiedTimeMs());
+        }
       }
     }
 

--- a/ambry-named-mysql/src/integration-test/java/com/github/ambry/named/MySqlNamedBlobDbIntegrationTest.java
+++ b/ambry-named-mysql/src/integration-test/java/com/github/ambry/named/MySqlNamedBlobDbIntegrationTest.java
@@ -103,8 +103,8 @@ public class MySqlNamedBlobDbIntegrationTest {
               i % 2 == 0 ? Utils.Infinite_Time : System.currentTimeMillis() + TimeUnit.HOURS.toMillis(1);
           long blobSize = 20;
           NamedBlobRecord record =
-              new NamedBlobRecord(account.getName(), container.getName(), blobName, blobId, expirationTime, 0, blobSize,
-                  0);
+              new NamedBlobRecord(account.getName(), container.getName(), blobName, blobId, expirationTime, 0,
+                  blobSize);
           namedBlobDb.put(record).get();
           records.add(record);
         }

--- a/ambry-named-mysql/src/main/java/com/github/ambry/named/MySqlNamedBlobDb.java
+++ b/ambry-named-mysql/src/main/java/com/github/ambry/named/MySqlNamedBlobDb.java
@@ -148,7 +148,8 @@ class MySqlNamedBlobDb implements NamedBlobDb {
   // @formatter:on
 
   /**
-   * Attempt to insert a new mapping into the database.
+   * Attempt to insert a new mapping into the database. The 'modified_ts' column in the DB will be auto-populated on
+   * the server side
    */
   private static final String INSERT_QUERY_V2 =
       String.format("INSERT INTO %1$s (%2$s, %3$s, %4$s, %5$s, %6$s, %7$s, %8$s, %9$s) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",

--- a/ambry-named-mysql/src/main/resources/NamedBlobsSchema.ddl
+++ b/ambry-named-mysql/src/main/resources/NamedBlobsSchema.ddl
@@ -7,6 +7,8 @@ CREATE TABLE IF NOT EXISTS named_blobs_v2 (
     blob_id varbinary(50) NOT NULL,
     blob_state smallint NOT NULL,
     deleted_ts datetime(6) DEFAULT NULL,
+    blob_size bigint unsigned DEFAULT 0,
+    modified_ts datetime(6) DEFAULT CURRENT_TIMESTAMP(6)
     PRIMARY KEY (account_id, container_id, blob_name, version)
 )
 

--- a/ambry-named-mysql/src/main/resources/NamedBlobsSchema.ddl
+++ b/ambry-named-mysql/src/main/resources/NamedBlobsSchema.ddl
@@ -8,7 +8,7 @@ CREATE TABLE IF NOT EXISTS named_blobs_v2 (
     blob_state smallint NOT NULL,
     deleted_ts datetime(6) DEFAULT NULL,
     blob_size bigint unsigned DEFAULT 0,
-    modified_ts datetime(6) DEFAULT CURRENT_TIMESTAMP(6)
+    modified_ts datetime(6) DEFAULT CURRENT_TIMESTAMP(6),
     PRIMARY KEY (account_id, container_id, blob_name, version)
 )
 

--- a/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
@@ -457,6 +457,8 @@ class PutOperation {
       totalSize += chunkInfo.getChunkSizeInBytes();
     }
     blobSize = totalSize;
+    // Update blobSize in passedInBlobProperties. This can be used by Handlers after Router finishes stitching the blob
+    passedInBlobProperties.setBlobSize(blobSize);
     chunkFillingCompletedSuccessfully = true;
   }
 


### PR DESCRIPTION
Flink is requesting to provide blob size and modified timestamp when listing blob information (via s3 list api). 

This PR:
1. Includes blob size in the INSERT query. The modified timestamp is auto populated by the mysql server
2. Gets blob size and modified timestamp as well in SELECT query and includes them in S3 list api output