### PR TITLE
Intoduce a helix task to clean up stale data in property store

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
@@ -39,7 +39,8 @@ public class ClusterMapConfig {
       "clustermap.enable.aggregated.monthly.account.report";
   public static final String ENABLE_PROPERTY_STORE_CLEAN_UP_TASK =
       "clustermap.enable.property.store.clean.up.task";
-  public static final String REGISTER_PROPERTY_STORE_TASK = "clustermap.register.property.store.task";
+  public static final String DELETE_DATA_FROM_DATANODE_CONFIG =
+      "clustermap.delete.data.from.datanode.config";
   private static final String MAX_REPLICAS_ALL_DATACENTERS = "max-replicas-all-datacenters";
 
   /**
@@ -352,10 +353,10 @@ public class ClusterMapConfig {
   public final boolean clustermapEnablePropertyStoreCleanUpTask;
 
   /**
-   * True to register property store task.
+   * True to remove data from datanode config when property store clean up task is enabled.
    */
-  @Config(REGISTER_PROPERTY_STORE_TASK)
-  public final boolean clustermapRegisterPropertyStoreTask;
+  @Config(DELETE_DATA_FROM_DATANODE_CONFIG)
+  public final boolean clustermapDeleteDataFromDatanodeConfig;
 
   public static final String DISTRIBUTED_LOCK_LEASE_TIMEOUT_IN_MS = "clustermap.distributed.lock.lease.timeout.in.ms";
   /**
@@ -443,8 +444,8 @@ public class ClusterMapConfig {
     clustermapEnableDeleteInvalidDataInMysqlAggregationTask =
         verifiableProperties.getBoolean(ENABLE_DELETE_INVALID_DATA_IN_MYSQL_AGGREGATION_TASK, false);
     clustermapEnablePropertyStoreCleanUpTask =
-        verifiableProperties.getBoolean(ENABLE_PROPERTY_STORE_CLEAN_UP_TASK, false);
-    clustermapRegisterPropertyStoreTask = verifiableProperties.getBoolean(REGISTER_PROPERTY_STORE_TASK, true);
+        verifiableProperties.getBoolean(ENABLE_PROPERTY_STORE_CLEAN_UP_TASK, true);
+    clustermapDeleteDataFromDatanodeConfig = verifiableProperties.getBoolean(DELETE_DATA_FROM_DATANODE_CONFIG, false);
     clusterMapAggregatedViewClusterName = verifiableProperties.getString(CLUSTERMAP_AGGREGATED_VIEW_CLUSTER_NAME, "");
     clusterMapUseAggregatedView = verifiableProperties.getBoolean(CLUSTERMAP_USE_AGGREGATED_VIEW, false);
     clustermapDistributedLockLeaseTimeoutInMs =

--- a/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
@@ -444,7 +444,7 @@ public class ClusterMapConfig {
     clustermapEnableDeleteInvalidDataInMysqlAggregationTask =
         verifiableProperties.getBoolean(ENABLE_DELETE_INVALID_DATA_IN_MYSQL_AGGREGATION_TASK, false);
     clustermapEnablePropertyStoreCleanUpTask =
-        verifiableProperties.getBoolean(ENABLE_PROPERTY_STORE_CLEAN_UP_TASK, true);
+        verifiableProperties.getBoolean(ENABLE_PROPERTY_STORE_CLEAN_UP_TASK, false);
     clustermapDeleteDataFromDatanodeConfig = verifiableProperties.getBoolean(DELETE_DATA_FROM_DATANODE_CONFIG, false);
     clusterMapAggregatedViewClusterName = verifiableProperties.getString(CLUSTERMAP_AGGREGATED_VIEW_CLUSTER_NAME, "");
     clusterMapUseAggregatedView = verifiableProperties.getBoolean(CLUSTERMAP_USE_AGGREGATED_VIEW, false);

--- a/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
@@ -362,7 +362,7 @@ public class ClusterMapConfig {
   @Default("false")
   public final boolean clusterMapIgnoreDownwardStateTransition;
 
-  public ClusterMapConfig(VerifiableProperties verifiableProperties, boolean clustermapEnablePropertyStoreCleanUpTask) {
+  public ClusterMapConfig(VerifiableProperties verifiableProperties) {
     clusterMapFixedTimeoutDatanodeErrorThreshold =
         verifiableProperties.getIntInRange("clustermap.fixedtimeout.datanode.error.threshold", 3, 1, 100);
     clusterMapResourceStatePolicyFactory = verifiableProperties.getString("clustermap.resourcestatepolicy.factory",

--- a/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
@@ -37,6 +37,8 @@ public class ClusterMapConfig {
       "clustermap.enable.delete.invalid.data.in.mysql.aggregation.task";
   public static final String ENABLE_AGGREGATED_MONTHLY_ACCOUNT_REPORT =
       "clustermap.enable.aggregated.monthly.account.report";
+  public static final String ENABLE_PROPERTY_STORE_CLEAN_UP_TASK =
+      "clustermap.enable.property.store.clean.up.task";
   private static final String MAX_REPLICAS_ALL_DATACENTERS = "max-replicas-all-datacenters";
 
   /**
@@ -342,6 +344,10 @@ public class ClusterMapConfig {
   @Default("false")
   public final boolean clustermapEnableDeleteInvalidDataInMysqlAggregationTask;
 
+  @Config(ENABLE_PROPERTY_STORE_CLEAN_UP_TASK)
+  @Default("false")
+  public final boolean clustermapEnablePropertyStoreCleanUpTask;
+
   public static final String DISTRIBUTED_LOCK_LEASE_TIMEOUT_IN_MS = "clustermap.distributed.lock.lease.timeout.in.ms";
   /**
    * The lease timeout for distributed lock. For now, the lock is only used for removing host from account stats store.
@@ -356,7 +362,7 @@ public class ClusterMapConfig {
   @Default("false")
   public final boolean clusterMapIgnoreDownwardStateTransition;
 
-  public ClusterMapConfig(VerifiableProperties verifiableProperties) {
+  public ClusterMapConfig(VerifiableProperties verifiableProperties, boolean clustermapEnablePropertyStoreCleanUpTask) {
     clusterMapFixedTimeoutDatanodeErrorThreshold =
         verifiableProperties.getIntInRange("clustermap.fixedtimeout.datanode.error.threshold", 3, 1, 100);
     clusterMapResourceStatePolicyFactory = verifiableProperties.getString("clustermap.resourcestatepolicy.factory",
@@ -427,6 +433,8 @@ public class ClusterMapConfig {
         verifiableProperties.getBoolean(ENABLE_AGGREGATED_MONTHLY_ACCOUNT_REPORT, false);
     clustermapEnableDeleteInvalidDataInMysqlAggregationTask =
         verifiableProperties.getBoolean(ENABLE_DELETE_INVALID_DATA_IN_MYSQL_AGGREGATION_TASK, false);
+    clustermapEnablePropertyStoreCleanUpTask =
+        verifiableProperties.getBoolean(ENABLE_PROPERTY_STORE_CLEAN_UP_TASK, false);
     clusterMapAggregatedViewClusterName = verifiableProperties.getString(CLUSTERMAP_AGGREGATED_VIEW_CLUSTER_NAME, "");
     clusterMapUseAggregatedView = verifiableProperties.getBoolean(CLUSTERMAP_USE_AGGREGATED_VIEW, false);
     clustermapDistributedLockLeaseTimeoutInMs =

--- a/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
@@ -39,8 +39,8 @@ public class ClusterMapConfig {
       "clustermap.enable.aggregated.monthly.account.report";
   public static final String ENABLE_PROPERTY_STORE_CLEAN_UP_TASK =
       "clustermap.enable.property.store.clean.up.task";
-  public static final String DELETE_DATA_FROM_DATANODE_CONFIG =
-      "clustermap.delete.data.from.datanode.config";
+  public static final String DELETE_DATA_FROM_DATANODE_CONFIG_IN_PROPERTY_STORE_CLEAN_UP_TASK =
+      "clustermap.delete.data.from.datanode.config.in.property.store.clean.up.task";
   private static final String MAX_REPLICAS_ALL_DATACENTERS = "max-replicas-all-datacenters";
 
   /**
@@ -355,8 +355,8 @@ public class ClusterMapConfig {
   /**
    * True to remove data from datanode config when property store clean up task is enabled.
    */
-  @Config(DELETE_DATA_FROM_DATANODE_CONFIG)
-  public final boolean clustermapDeleteDataFromDatanodeConfig;
+  @Config(DELETE_DATA_FROM_DATANODE_CONFIG_IN_PROPERTY_STORE_CLEAN_UP_TASK)
+  public final boolean clustermapDeleteDataFromDatanodeConfigInPropertyStoreCleanUpTask;
 
   public static final String DISTRIBUTED_LOCK_LEASE_TIMEOUT_IN_MS = "clustermap.distributed.lock.lease.timeout.in.ms";
   /**
@@ -445,7 +445,8 @@ public class ClusterMapConfig {
         verifiableProperties.getBoolean(ENABLE_DELETE_INVALID_DATA_IN_MYSQL_AGGREGATION_TASK, false);
     clustermapEnablePropertyStoreCleanUpTask =
         verifiableProperties.getBoolean(ENABLE_PROPERTY_STORE_CLEAN_UP_TASK, false);
-    clustermapDeleteDataFromDatanodeConfig = verifiableProperties.getBoolean(DELETE_DATA_FROM_DATANODE_CONFIG, false);
+    clustermapDeleteDataFromDatanodeConfigInPropertyStoreCleanUpTask = verifiableProperties
+        .getBoolean(DELETE_DATA_FROM_DATANODE_CONFIG_IN_PROPERTY_STORE_CLEAN_UP_TASK, false);
     clusterMapAggregatedViewClusterName = verifiableProperties.getString(CLUSTERMAP_AGGREGATED_VIEW_CLUSTER_NAME, "");
     clusterMapUseAggregatedView = verifiableProperties.getBoolean(CLUSTERMAP_USE_AGGREGATED_VIEW, false);
     clustermapDistributedLockLeaseTimeoutInMs =

--- a/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
@@ -39,6 +39,7 @@ public class ClusterMapConfig {
       "clustermap.enable.aggregated.monthly.account.report";
   public static final String ENABLE_PROPERTY_STORE_CLEAN_UP_TASK =
       "clustermap.enable.property.store.clean.up.task";
+  public static final String REGISTER_PROPERTY_STORE_TASK = "clustermap.register.property.store.task";
   private static final String MAX_REPLICAS_ALL_DATACENTERS = "max-replicas-all-datacenters";
 
   /**
@@ -344,9 +345,17 @@ public class ClusterMapConfig {
   @Default("false")
   public final boolean clustermapEnableDeleteInvalidDataInMysqlAggregationTask;
 
+  /**
+   * True to enable property store clean up task.
+   */
   @Config(ENABLE_PROPERTY_STORE_CLEAN_UP_TASK)
-  @Default("false")
   public final boolean clustermapEnablePropertyStoreCleanUpTask;
+
+  /**
+   * True to register property store task.
+   */
+  @Config(REGISTER_PROPERTY_STORE_TASK)
+  public final boolean clustermapRegisterPropertyStoreTask;
 
   public static final String DISTRIBUTED_LOCK_LEASE_TIMEOUT_IN_MS = "clustermap.distributed.lock.lease.timeout.in.ms";
   /**
@@ -435,6 +444,7 @@ public class ClusterMapConfig {
         verifiableProperties.getBoolean(ENABLE_DELETE_INVALID_DATA_IN_MYSQL_AGGREGATION_TASK, false);
     clustermapEnablePropertyStoreCleanUpTask =
         verifiableProperties.getBoolean(ENABLE_PROPERTY_STORE_CLEAN_UP_TASK, false);
+    clustermapRegisterPropertyStoreTask = verifiableProperties.getBoolean(REGISTER_PROPERTY_STORE_TASK, true);
     clusterMapAggregatedViewClusterName = verifiableProperties.getString(CLUSTERMAP_AGGREGATED_VIEW_CLUSTER_NAME, "");
     clusterMapUseAggregatedView = verifiableProperties.getBoolean(CLUSTERMAP_USE_AGGREGATED_VIEW, false);
     clustermapDistributedLockLeaseTimeoutInMs =

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
@@ -785,11 +785,14 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
    * @param engine
    */
   private void registerPropertyStoreCleanUpTask(StateMachineEngine engine){
-    Map<String, TaskFactory> taskFactoryMap = new HashMap<>();
-    taskFactoryMap.put(String.format("%s_%s", PropertyStoreCleanUpTask.COMMAND, "task"),
-        context -> new PropertyStoreCleanUpTask(context.getManager(), dataNodeConfigSource, clusterMapConfig, metricRegistry));
-    engine.registerStateModelFactory(TaskConstants.STATE_MODEL_NAME,
-        new TaskStateModelFactory(manager, taskFactoryMap));
+    if(clusterMapConfig.clustermapRegisterPropertyStoreTask) {
+      Map<String, TaskFactory> taskFactoryMap = new HashMap<>();
+      taskFactoryMap.put(PropertyStoreCleanUpTask.COMMAND,
+          context -> new PropertyStoreCleanUpTask(context.getManager(), dataNodeConfigSource, clusterMapConfig,
+              metricRegistry));
+      engine.registerStateModelFactory(TaskConstants.STATE_MODEL_NAME,
+          new TaskStateModelFactory(manager, taskFactoryMap), PropertyStoreCleanUpTask.COMMAND);
+    }
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
@@ -146,6 +146,7 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
     stateMachineEngine.registerStateModelFactory(clusterMapConfig.clustermapStateModelDefinition,
         new AmbryStateModelFactory(clusterMapConfig, this, clusterManager));
     registerStatsReportAggregationTasks(stateMachineEngine, ambryStatsReports, accountStatsStore, callback);
+    registerPropertyStoreCleanUpTask(stateMachineEngine);
     try {
       // register server as a participant
       manager.connect();
@@ -777,6 +778,18 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
       engine.registerStateModelFactory(TaskConstants.STATE_MODEL_NAME,
           new TaskStateModelFactory(manager, taskFactoryMap));
     }
+  }
+
+  /**
+   *
+   * @param engine
+   */
+  private void registerPropertyStoreCleanUpTask(StateMachineEngine engine){
+    Map<String, TaskFactory> taskFactoryMap = new HashMap<>();
+    taskFactoryMap.put(String.format("%s_%s", PropertyStoreCleanUpTask.COMMAND, "task"),
+        context -> new PropertyStoreCleanUpTask(context.getManager(), dataNodeConfigSource, clusterMapConfig, metricRegistry));
+    engine.registerStateModelFactory(TaskConstants.STATE_MODEL_NAME,
+        new TaskStateModelFactory(manager, taskFactoryMap));
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
@@ -781,11 +781,11 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
   }
 
   /**
-   *
-   * @param engine
+   * Register Property Store Clean Up Task for cleaning up expired properties in Property Store.
+   * @param engine the {@link StateMachineEngine} to register the task state model.
    */
   private void registerPropertyStoreCleanUpTask(StateMachineEngine engine){
-    if(clusterMapConfig.clustermapRegisterPropertyStoreTask) {
+    if(clusterMapConfig.clustermapEnablePropertyStoreCleanUpTask) {
       Map<String, TaskFactory> taskFactoryMap = new HashMap<>();
       taskFactoryMap.put(PropertyStoreCleanUpTask.COMMAND,
           context -> new PropertyStoreCleanUpTask(context.getManager(), dataNodeConfigSource, clusterMapConfig,

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
@@ -781,7 +781,7 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
   }
 
   /**
-   * Register Property Store Clean Up Task for cleaning up expired properties in Property Store.
+   * Register Property Store Clean Up Task for cleaning up expired {@link DataNodeConfig} in Property Store.
    * @param engine the {@link StateMachineEngine} to register the task state model.
    */
   private void registerPropertyStoreCleanUpTask(StateMachineEngine engine){

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PropertyStoreCleanUpTask.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PropertyStoreCleanUpTask.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
  * Task to clean up property store for instances that are not live and not present in ideal state or external view
  */
 public class PropertyStoreCleanUpTask implements Task {
-  public static String COMMAND = PropertyStoreCleanUpTask.class.getSimpleName();
+  public final static String COMMAND = PropertyStoreCleanUpTask.class.getSimpleName();
   private final HelixManager manager;
   private final DataNodeConfigSource dataNodeConfigSource;
   private final Object helixAdministrationLock = new Object();

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PropertyStoreCleanUpTask.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PropertyStoreCleanUpTask.java
@@ -1,0 +1,152 @@
+package com.github.ambry.clustermap;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.config.ClusterMapConfig;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.HelixManager;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.task.Task;
+import org.apache.helix.task.TaskResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Task to clean up property store for instances that are not live and not present in ideal state or external view
+ */
+public class PropertyStoreCleanUpTask implements Task {
+  public static String COMMAND = PropertyStoreCleanUpTask.class.getSimpleName();
+  private final HelixManager manager;
+  private final DataNodeConfigSource dataNodeConfigSource;
+  private final Object helixAdministrationLock = new Object();
+  private final ClusterMapConfig clusterMapConfig;
+  private static final Logger logger = LoggerFactory.getLogger(PropertyStoreCleanUpTask.class);
+  private final Metrics metrics;
+
+  /**
+   * Metrics for {@link PropertyStoreCleanUpTask}
+   */
+  private static class Metrics {
+    public final Histogram instancesAndLiveInstancesFetchTimeInMs;
+    public final Histogram idealStateAndExternalViewFetchTimeInMS;
+    public final Histogram propertyStoreTaskTimeInMs;
+    public final Counter propertyStoreCleanUpErrorCount;
+    public final Counter propertyStoreCleanUpSuccessCount;
+
+    public Metrics(MetricRegistry registry) {
+      instancesAndLiveInstancesFetchTimeInMs = registry.histogram(MetricRegistry
+          .name(PropertyStoreCleanUpTask.class, "InstancesAndLiveInstancesFetchTimeInMs"));
+      idealStateAndExternalViewFetchTimeInMS = registry.histogram(MetricRegistry
+          .name(PropertyStoreCleanUpTask.class, "IdealStateAndExternalViewFetchTimeInMS"));
+      propertyStoreTaskTimeInMs = registry.histogram(MetricRegistry
+          .name(PropertyStoreCleanUpTask.class, "PropertyStoreTaskTimeInMs"));
+      propertyStoreCleanUpErrorCount = registry.counter(MetricRegistry
+          .name(PropertyStoreCleanUpTask.class, "PropertyStoreCleanUpErrorCount"));
+      propertyStoreCleanUpSuccessCount = registry.counter(MetricRegistry
+          .name(PropertyStoreCleanUpTask.class, "PropertyStoreCleanUpSuccessCount"));
+    }
+  }
+
+  /**
+   * Constructor for {@link PropertyStoreCleanUpTask}
+   *
+   * @param manager
+   * @param dataNodeConfigSource
+   * @param clusterMapConfig
+   * @param registry
+   */
+  public PropertyStoreCleanUpTask(HelixManager manager, DataNodeConfigSource dataNodeConfigSource,
+      ClusterMapConfig clusterMapConfig, MetricRegistry registry) {
+    this.manager = manager;
+    this.dataNodeConfigSource = dataNodeConfigSource;
+    this.metrics = new Metrics(registry);
+    this.clusterMapConfig = clusterMapConfig;
+  }
+
+  @Override
+  public TaskResult run() {
+    long startTimeMs = System.currentTimeMillis();
+    try {
+      HelixDataAccessor dataAccessor = manager.getHelixDataAccessor();
+      HelixAdmin admin = manager.getClusterManagmentTool();
+      List<String> instances = dataAccessor.getProperty(dataAccessor.keyBuilder().instances());
+      Set<String> liveInstances = dataAccessor.getProperty(dataAccessor.keyBuilder().liveInstances());
+      metrics.instancesAndLiveInstancesFetchTimeInMs.update(System.currentTimeMillis() - startTimeMs);
+
+      Set<String> allInstancesInIdealState = new HashSet<>();
+      Set<String> allInstancesInExternalView = new HashSet<>();
+      List<String> resourcesInCluster = admin.getResourcesInCluster(manager.getClusterName());
+
+      for (String resource : resourcesInCluster) {
+        IdealState idealState = admin.getResourceIdealState(manager.getClusterName(), resource);
+        Set<String> partitions = idealState.getPartitionSet();
+        for (String partition : partitions) {
+          allInstancesInIdealState.addAll(idealState.getInstanceSet(partition));
+        }
+
+        ExternalView externalView = admin.getResourceExternalView(manager.getClusterName(), resource);
+        Set<String> partitionSet = externalView.getPartitionSet();
+        for (String partition : partitionSet) {
+          allInstancesInExternalView.addAll(externalView.getStateMap(partition).keySet());
+        }
+      }
+      metrics.idealStateAndExternalViewFetchTimeInMS.update(System.currentTimeMillis() - startTimeMs);
+
+      // Find instances that are not live and also not present in ideal state or external view
+
+      for (String instance : instances) {
+        if (!liveInstances.contains(instance) && !allInstancesInIdealState.contains(instance)
+            && !allInstancesInExternalView.contains(instance)) {
+          logger.info("Cleaning up property store for instance {}", instance);
+          // Do the cleanup
+          if(clusterMapConfig.clustermapEnablePropertyStoreCleanUpTask) {
+            try {
+              synchronized (helixAdministrationLock) {
+                DataNodeConfig dataNodeConfig = dataNodeConfigSource.get(instance);
+                if (dataNodeConfig == null) {
+                  continue;
+                }
+                boolean configChanged;
+                configChanged = TaskUtils.removeConfig(dataNodeConfig.getSealedReplicas());
+                configChanged = configChanged || TaskUtils.removeConfig(dataNodeConfig.getStoppedReplicas());
+                configChanged = configChanged || TaskUtils.removeConfig(dataNodeConfig.getPartiallySealedReplicas());
+                configChanged = configChanged || TaskUtils.removeConfig(dataNodeConfig.getDisabledReplicas());
+                Map<String, DataNodeConfig.DiskConfig> diskConfigs = dataNodeConfig.getDiskConfigs();
+                for (DataNodeConfig.DiskConfig diskConfig : diskConfigs.values()) {
+                  configChanged = configChanged || TaskUtils.removeConfig(diskConfig.getReplicaConfigs());
+                }
+                if (configChanged) {
+                  dataNodeConfigSource.set(dataNodeConfig);
+                }
+              }
+            } catch (Exception exception) {
+              logger.error("Exception thrown while cleaning PropertyStore for instance = {}", instance, exception);
+              metrics.propertyStoreCleanUpErrorCount.inc();
+            }
+          }
+        }
+      }
+      metrics.propertyStoreCleanUpSuccessCount.inc();
+      metrics.propertyStoreTaskTimeInMs.update(System.currentTimeMillis() - startTimeMs);
+      return new TaskResult(TaskResult.Status.COMPLETED, "PropertyStoreCleanUpTask completed successfully");
+    } catch (Exception exception) {
+      logger.error("Exception thrown while executing PropertyStoreCleanUpTask for cluster = {}"
+          ,manager.getClusterName(), exception);
+      metrics.propertyStoreCleanUpErrorCount.inc();
+      return new TaskResult(TaskResult.Status.FAILED, "Exception thrown");
+    }
+  }
+
+  @Override
+  public void cancel() {
+
+  }
+}

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PropertyStoreCleanUpTask.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PropertyStoreCleanUpTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2024 LinkedIn Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,13 +21,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixManager;
-import org.apache.helix.HelixProperty;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
-import org.apache.helix.model.LiveInstance;
 import org.apache.helix.task.Task;
 import org.apache.helix.task.TaskResult;
 import org.slf4j.Logger;
@@ -139,7 +136,8 @@ public class PropertyStoreCleanUpTask implements Task {
    * Cleanup property store for the given instance
    */
   private void cleanupPropertyStore(String instance) {
-    if(clusterMapConfig.clustermapEnablePropertyStoreCleanUpTask) {
+    if(clusterMapConfig.clustermapDeleteDataFromDatanodeConfig &&
+        clusterMapConfig.clusterMapDataNodeConfigSourceType == DataNodeConfigSourceType.PROPERTY_STORE) {
         synchronized (helixAdministrationLock) {
           DataNodeConfig dataNodeConfig = dataNodeConfigSource.get(instance);
           if (dataNodeConfig == null) { return;}

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/TaskUtils.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/TaskUtils.java
@@ -14,8 +14,8 @@
 package com.github.ambry.clustermap;
 
 import com.github.ambry.utils.Pair;
+import java.util.Collection;
 import java.util.Map;
-import java.util.Set;
 
 
 public class TaskUtils {
@@ -42,7 +42,7 @@ public class TaskUtils {
     return new Pair<>(hostname, port);
   }
 
-  protected static boolean removeIfPresent(Set<String> config){
+  protected static <T> boolean removeIfPresent(Collection<T> config){
     if (checkIfPresent(config)) {
       config.clear();
       return true;
@@ -50,7 +50,7 @@ public class TaskUtils {
     return false;
   }
 
-  protected static boolean removeIfPresent(Map<String, DataNodeConfig.ReplicaConfig> config){
+  protected static <K, V> boolean removeIfPresent(Map<K, V> config){
     if (checkIfPresent(config)) {
       config.clear();
       return true;
@@ -58,11 +58,11 @@ public class TaskUtils {
     return false;
   }
 
-  protected static boolean checkIfPresent(Set<String> config) {
+  protected static <T> boolean checkIfPresent(Collection<T> config) {
     return config != null && !config.isEmpty();
   }
 
-  protected static boolean checkIfPresent(Map<String, DataNodeConfig.ReplicaConfig> config) {
+  protected static <K, V> boolean checkIfPresent(Map<K, V> config) {
     return config != null && !config.isEmpty();
   }
 }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/TaskUtils.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/TaskUtils.java
@@ -42,27 +42,27 @@ public class TaskUtils {
     return new Pair<>(hostname, port);
   }
 
-  protected static boolean removeConfig(Set<String> config){
-    if (checkIfConfigPresent(config)) {
+  protected static boolean removeIfPresent(Set<String> config){
+    if (checkIfPresent(config)) {
       config.clear();
       return true;
     }
     return false;
   }
 
-  protected static boolean removeConfig(Map<String, DataNodeConfig.ReplicaConfig> config){
-    if (checkIfConfigPresent(config)) {
+  protected static boolean removeIfPresent(Map<String, DataNodeConfig.ReplicaConfig> config){
+    if (checkIfPresent(config)) {
       config.clear();
       return true;
     }
     return false;
   }
 
-  protected static boolean checkIfConfigPresent(Set<String> config) {
+  protected static boolean checkIfPresent(Set<String> config) {
     return config != null && !config.isEmpty();
   }
 
-  protected static boolean checkIfConfigPresent(Map<String, DataNodeConfig.ReplicaConfig> config) {
+  protected static boolean checkIfPresent(Map<String, DataNodeConfig.ReplicaConfig> config) {
     return config != null && !config.isEmpty();
   }
 }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/TaskUtils.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/TaskUtils.java
@@ -14,6 +14,9 @@
 package com.github.ambry.clustermap;
 
 import com.github.ambry.utils.Pair;
+import java.util.Map;
+import java.util.Set;
+
 
 public class TaskUtils {
 
@@ -37,5 +40,29 @@ public class TaskUtils {
       }
     }
     return new Pair<>(hostname, port);
+  }
+
+  protected static boolean removeConfig(Set<String> config){
+    if (checkIfConfigPresent(config)) {
+      config.clear();
+      return true;
+    }
+    return false;
+  }
+
+  protected static boolean removeConfig(Map<String, DataNodeConfig.ReplicaConfig> config){
+    if (checkIfConfigPresent(config)) {
+      config.clear();
+      return true;
+    }
+    return false;
+  }
+
+  protected static boolean checkIfConfigPresent(Set<String> config) {
+    return config != null && !config.isEmpty();
+  }
+
+  protected static boolean checkIfConfigPresent(Map<String, DataNodeConfig.ReplicaConfig> config) {
+    return config != null && !config.isEmpty();
   }
 }

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixParticipantTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixParticipantTest.java
@@ -398,7 +398,7 @@ public class HelixParticipantTest {
   public void testBadCases() {
     // Invalid state model def
     props.setProperty("clustermap.state.model.definition", "InvalidStateModelDef");
-    props.setProperty(ClusterMapConfig.REGISTER_PROPERTY_STORE_TASK, Boolean.toString(false));
+    props.setProperty(ClusterMapConfig.ENABLE_PROPERTY_STORE_CLEAN_UP_TASK, Boolean.toString(false));
     try {
       new ClusterMapConfig(new VerifiableProperties(props));
       fail("should fail due to invalid state model definition");
@@ -476,7 +476,7 @@ public class HelixParticipantTest {
    */
   @Test
   public void testHelixParticipant() throws Exception {
-    props.setProperty(ClusterMapConfig.REGISTER_PROPERTY_STORE_TASK, Boolean.toString(false));
+    props.setProperty(ClusterMapConfig.ENABLE_PROPERTY_STORE_CLEAN_UP_TASK, Boolean.toString(false));
     ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
     HelixParticipant participant =
         new HelixParticipant(mock(HelixClusterManager.class), clusterMapConfig, helixManagerFactory,
@@ -828,7 +828,7 @@ public class HelixParticipantTest {
    */
   @Test
   public void testParticipateMethodWithHelixPropertyStoreTaskEnabled() throws Exception {
-    props.setProperty(ClusterMapConfig.REGISTER_PROPERTY_STORE_TASK, Boolean.toString(true));
+    props.setProperty(ClusterMapConfig.ENABLE_PROPERTY_STORE_CLEAN_UP_TASK, Boolean.toString(true));
     ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
     MetricRegistry metricRegistry = new MetricRegistry();
     HelixParticipant helixParticipant =
@@ -848,7 +848,7 @@ public class HelixParticipantTest {
    */
   @Test
   public void testParticipateMethodWithHelixPropertyStoreTaskDisabled() throws Exception {
-    props.setProperty(ClusterMapConfig.REGISTER_PROPERTY_STORE_TASK, Boolean.toString(false));
+    props.setProperty(ClusterMapConfig.ENABLE_PROPERTY_STORE_CLEAN_UP_TASK, Boolean.toString(false));
     ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
     MetricRegistry metricRegistry = new MetricRegistry();
     HelixParticipant helixParticipant =

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixDataAccessor.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixDataAccessor.java
@@ -265,6 +265,13 @@ public class MockHelixDataAccessor implements HelixDataAccessor {
     throw new UnsupportedOperationException("Unsupported in MockHelixDataAccessor");
   }
 
+  /**
+   * Get the child values from ZK of the path specified in the key.
+   * @param key The key that specifies the path.
+   * @param throwException Whether to throw exception if the path does not exist.
+   * @return The list of child values.
+   * @param <T>
+   */
   @Override
   public <T extends HelixProperty> List<T> getChildValues(PropertyKey key, boolean throwException) {
     List<T> result = new ArrayList<>();

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/PropertyStoreCleanUpTaskTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/PropertyStoreCleanUpTaskTest.java
@@ -157,7 +157,7 @@ public class PropertyStoreCleanUpTaskTest {
   @Test
   public void testPropertyStoreCleanUpTaskDeleteDataFromDataNodeConfigFalse() throws IOException {
     Properties props = getProperties();
-    props.setProperty(ClusterMapConfig.DELETE_DATA_FROM_DATANODE_CONFIG, "false");
+    props.setProperty(ClusterMapConfig.DELETE_DATA_FROM_DATANODE_CONFIG_IN_PROPERTY_STORE_CLEAN_UP_TASK, "false");
     ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
     TestUtils.ZkInfo zkInfo =
         new TestUtils.ZkInfo(TestUtils.getTempDir(PropertyStoreCleanUpTask.COMMAND), DC, (byte) 1, ZK_PORT + '4', true);
@@ -289,7 +289,7 @@ public class PropertyStoreCleanUpTaskTest {
 
   private Properties getProperties() {
     Properties props = new Properties();
-    props.setProperty(ClusterMapConfig.DELETE_DATA_FROM_DATANODE_CONFIG, "true");
+    props.setProperty(ClusterMapConfig.DELETE_DATA_FROM_DATANODE_CONFIG_IN_PROPERTY_STORE_CLEAN_UP_TASK, "true");
     props.setProperty(ClusterMapConfig.ENABLE_PROPERTY_STORE_CLEAN_UP_TASK, "true");
     props.setProperty(ClusterMapConfig.CLUSTERMAP_DATA_NODE_CONFIG_SOURCE_TYPE,
         DataNodeConfigSourceType.PROPERTY_STORE.name());

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/PropertyStoreCleanUpTaskTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/PropertyStoreCleanUpTaskTest.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright 2024 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.clustermap;
+
+import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.config.ClusterMapConfig;
+import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.utils.TestUtils;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Properties;
+import org.apache.helix.HelixManager;
+import org.apache.helix.InstanceType;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.task.TaskResult;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+public class PropertyStoreCleanUpTaskTest {
+  private final MetricRegistry metricRegistry;
+  private static final String CLUSTER_NAME = "testCluster";
+  private static final String HOST_NAME = "localhost";
+  private static final int  PORT = 12345;
+  private static final int ZK_PORT = 1234;
+  private static final String DC = "DC1";
+  private static final String ZK_HOST = "localhost";
+
+  public PropertyStoreCleanUpTaskTest()  {
+    metricRegistry = new MetricRegistry();
+  }
+
+  /**
+   * Test the case when instance is down and not present in ideal state or external view:-
+   * Replicas should be removed from property store if they are offline
+   */
+  @Test
+  public void testPropertyStoreCleanUpTaskInstanceDownAndNotPresentInIdealState() throws IOException {
+
+    TestUtils.ZkInfo zkInfo =
+        new TestUtils.ZkInfo(TestUtils.getTempDir(PropertyStoreCleanUpTask.COMMAND), DC, (byte) 1, ZK_PORT + '1', true);
+    ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(getProperties()));
+    HelixManager helixManager = new MockHelixManager(ClusterMapUtils.getInstanceName(HOST_NAME, PORT),
+        InstanceType.PARTICIPANT, ZK_HOST + ":" + zkInfo.getPort(), CLUSTER_NAME, new MockHelixAdmin(),
+        null, null, null, false);
+    DataNodeConfigSource dataNodeConfigSource = new PropertyStoreToDataNodeConfigAdapter(
+        ZK_HOST + ":" + zkInfo.getPort(), clusterMapConfig);
+
+    testCluster1(helixManager, dataNodeConfigSource);
+
+    // Run the task
+    PropertyStoreCleanUpTask propertyStoreCleanUpTask =
+        new PropertyStoreCleanUpTask(helixManager, dataNodeConfigSource,clusterMapConfig, metricRegistry);
+    TaskResult taskResult = propertyStoreCleanUpTask.run();
+
+    //Task should be completed successfully
+    assertEquals(TaskResult.Status.COMPLETED, taskResult.getStatus());
+
+    //Replica should be removed from property store for down host -> localhost_2
+    assertTrue(dataNodeConfigSource.get(ClusterMapUtils.getInstanceName("localhost_2", PORT))
+        .getDiskConfigs().get("disk1").getReplicaConfigs().isEmpty());
+
+    //Replica should be present in property store for up hosts -> localhost_1, localhost_3
+    assertTrue(dataNodeConfigSource.get(ClusterMapUtils.getInstanceName("localhost_1", PORT))
+        .getDiskConfigs().get("disk1").getReplicaConfigs().containsKey("partition1"));
+    assertTrue(dataNodeConfigSource.get(ClusterMapUtils.getInstanceName("localhost_3", PORT))
+        .getDiskConfigs().get("disk1").getReplicaConfigs().containsKey("partition1"));
+  }
+
+  /**
+   * Test the case when instance is down but present in ideal state or external view
+   * Replicas should not be removed from property store
+   */
+  @Test
+  public void testPropertyStoreCleanUpTaskInstanceDownButPresentInIdealState() throws IOException {
+    TestUtils.ZkInfo zkInfo =
+        new TestUtils.ZkInfo(TestUtils.getTempDir(PropertyStoreCleanUpTask.COMMAND), DC, (byte) 1, ZK_PORT + '2', true);
+    ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(getProperties()));
+    HelixManager helixManager = new MockHelixManager(ClusterMapUtils.getInstanceName(HOST_NAME, PORT),
+        InstanceType.PARTICIPANT, ZK_HOST + ":" + zkInfo.getPort(), CLUSTER_NAME, new MockHelixAdmin(),
+        null, null, null, false);
+    DataNodeConfigSource dataNodeConfigSource = new PropertyStoreToDataNodeConfigAdapter(
+        ZK_HOST + ":" + zkInfo.getPort(), clusterMapConfig);
+
+    testCluster2(helixManager, dataNodeConfigSource);
+
+    // Run the task
+    PropertyStoreCleanUpTask propertyStoreCleanUpTask =
+        new PropertyStoreCleanUpTask(helixManager, dataNodeConfigSource, clusterMapConfig, metricRegistry);
+    TaskResult taskResult = propertyStoreCleanUpTask.run();
+
+    //Task should be completed successfully
+    assertEquals(TaskResult.Status.COMPLETED, taskResult.getStatus());
+
+    //Replica should be present in property store for down host -> localhost_2
+    assertTrue(dataNodeConfigSource.get(ClusterMapUtils.getInstanceName("localhost_2", PORT))
+        .getDiskConfigs().get("disk1").getReplicaConfigs().containsKey("partition1"));
+
+    //Replica should be present in property store for up hosts -> localhost_1, localhost_3
+    assertTrue(dataNodeConfigSource.get(ClusterMapUtils.getInstanceName("localhost_1", PORT))
+        .getDiskConfigs().get("disk1").getReplicaConfigs().containsKey("partition1"));
+    assertTrue(dataNodeConfigSource.get(ClusterMapUtils.getInstanceName("localhost_3", PORT))
+        .getDiskConfigs().get("disk1").getReplicaConfigs().containsKey("partition1"));
+  }
+
+  /**
+   * Test the case when no instance is down and all instances are present in ideal state or external view
+   * Replicas should not be removed from property store
+   */
+  @Test
+  public void testPropertyStoreCleanUpTaskAllInstancesUp() throws IOException {
+    TestUtils.ZkInfo zkInfo =
+        new TestUtils.ZkInfo(TestUtils.getTempDir(PropertyStoreCleanUpTask.COMMAND), DC, (byte) 1, ZK_PORT + '3', true);
+    ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(getProperties()));
+    HelixManager helixManager = new MockHelixManager(ClusterMapUtils.getInstanceName(HOST_NAME, PORT),
+        InstanceType.PARTICIPANT, ZK_HOST + ":" + zkInfo.getPort(), CLUSTER_NAME, new MockHelixAdmin(),
+        null, null, null, false);
+    DataNodeConfigSource dataNodeConfigSource = new PropertyStoreToDataNodeConfigAdapter(
+        ZK_HOST + ":" + zkInfo.getPort(), clusterMapConfig);
+
+    testCluster3(helixManager, dataNodeConfigSource);
+
+    // Run the task
+    PropertyStoreCleanUpTask propertyStoreCleanUpTask =
+        new PropertyStoreCleanUpTask(helixManager, dataNodeConfigSource, clusterMapConfig, metricRegistry);
+    TaskResult taskResult = propertyStoreCleanUpTask.run();
+
+    //Task should be completed successfully
+    assertEquals(TaskResult.Status.COMPLETED, taskResult.getStatus());
+
+    //Replica should be present in property store for all hosts -> localhost_1, localhost_2, localhost_3
+    assertTrue(dataNodeConfigSource.get(ClusterMapUtils.getInstanceName("localhost_1", PORT))
+        .getDiskConfigs().get("disk1").getReplicaConfigs().containsKey("partition1"));
+    assertTrue(dataNodeConfigSource.get(ClusterMapUtils.getInstanceName("localhost_2", PORT))
+        .getDiskConfigs().get("disk1").getReplicaConfigs().containsKey("partition1"));
+    assertTrue(dataNodeConfigSource.get(ClusterMapUtils.getInstanceName("localhost_3", PORT))
+        .getDiskConfigs().get("disk1").getReplicaConfigs().containsKey("partition1"));
+  }
+
+  /**
+   * Test case when DELETE_DATA_FROM_DATANODE_CONFIG is false
+   * Replicas should not be removed from property store
+   */
+  @Test
+  public void testPropertyStoreCleanUpTaskDeleteDataFromDataNodeConfigFalse() throws IOException {
+    Properties props = getProperties();
+    props.setProperty(ClusterMapConfig.DELETE_DATA_FROM_DATANODE_CONFIG, "false");
+    ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
+    TestUtils.ZkInfo zkInfo =
+        new TestUtils.ZkInfo(TestUtils.getTempDir(PropertyStoreCleanUpTask.COMMAND), DC, (byte) 1, ZK_PORT + '4', true);
+    HelixManager helixManager = new MockHelixManager(ClusterMapUtils.getInstanceName(HOST_NAME, PORT),
+        InstanceType.PARTICIPANT, ZK_HOST + ":" + zkInfo.getPort(), CLUSTER_NAME, new MockHelixAdmin(),
+        null, null, null, false);
+    DataNodeConfigSource dataNodeConfigSource = new PropertyStoreToDataNodeConfigAdapter(
+        ZK_HOST + ":" + zkInfo.getPort(), clusterMapConfig);
+
+    testCluster1(helixManager, dataNodeConfigSource);
+
+    // Run the task
+    PropertyStoreCleanUpTask propertyStoreCleanUpTask =
+        new PropertyStoreCleanUpTask(helixManager, dataNodeConfigSource, clusterMapConfig, metricRegistry);
+    TaskResult taskResult = propertyStoreCleanUpTask.run();
+
+    //Task should be completed successfully
+    assertEquals(TaskResult.Status.COMPLETED, taskResult.getStatus());
+
+    //Replica should be present in property store for all hosts -> localhost_1, localhost_2, localhost_3
+    assertTrue(dataNodeConfigSource.get(ClusterMapUtils.getInstanceName("localhost_1", PORT))
+        .getDiskConfigs().get("disk1").getReplicaConfigs().containsKey("partition1"));
+    assertTrue(dataNodeConfigSource.get(ClusterMapUtils.getInstanceName("localhost_2", PORT))
+        .getDiskConfigs().get("disk1").getReplicaConfigs().containsKey("partition1"));
+    assertTrue(dataNodeConfigSource.get(ClusterMapUtils.getInstanceName("localhost_3", PORT))
+        .getDiskConfigs().get("disk1").getReplicaConfigs().containsKey("partition1"));
+  }
+
+  /**
+   * Case when instance is down and not present in ideal state or external view
+   * @param helixManager
+   * @param dataNodeConfigSource
+   */
+  private void testCluster1(HelixManager helixManager, DataNodeConfigSource dataNodeConfigSource) {
+    MockHelixAdmin admin =  (MockHelixAdmin)helixManager.getClusterManagmentTool();
+    // Add 3 instances to cluster
+    addInstancesToCluster(helixManager, ClusterMapUtils.getInstanceName("localhost_1", PORT),
+        ClusterMapUtils.getInstanceName("localhost_2", PORT), ClusterMapUtils.getInstanceName("localhost_3", PORT));
+
+    // Bring down instance2
+    admin.bringInstanceDown(ClusterMapUtils.getInstanceName("localhost_2", PORT));
+
+    /* Add a resourceName to cluster with partition on localhost_1 and localhost_3
+     localhost_2 is down, hence assuming it will be removed by fullAuto from ideal state and external view
+     so we will not include it in preference list here
+     */
+    IdealState idealState = new IdealState("resource1");
+    idealState.setPreferenceList("partition1", Arrays.asList(ClusterMapUtils
+        .getInstanceName("localhost_1", PORT), ClusterMapUtils.getInstanceName("localhost_3", PORT)));
+    admin.addResource(CLUSTER_NAME, "resource1", idealState);
+
+    addReplicasToDisk(dataNodeConfigSource, "localhost_1", "disk1", "partition1");
+    addReplicasToDisk(dataNodeConfigSource, "localhost_2", "disk1", "partition1");
+    addReplicasToDisk(dataNodeConfigSource, "localhost_3", "disk1", "partition1");
+
+  }
+
+  /**
+   * Case when instance is down but present in ideal state or external view
+   * @param helixManager
+   * @param dataNodeConfigSource
+   * @return
+   */
+  private void testCluster2(HelixManager helixManager, DataNodeConfigSource dataNodeConfigSource){
+    MockHelixAdmin admin =  (MockHelixAdmin)helixManager.getClusterManagmentTool();
+    // Add 3 instances to cluster
+    addInstancesToCluster(helixManager, ClusterMapUtils.getInstanceName("localhost_1", PORT),
+        ClusterMapUtils.getInstanceName("localhost_2", PORT), ClusterMapUtils.getInstanceName("localhost_3", PORT));
+
+    // Bring down instance2
+    admin.bringInstanceDown(ClusterMapUtils.getInstanceName("localhost_2", PORT));
+
+    // Add a resourceName to cluster with partition on localhost_1 and localhost_2 and localhost_3
+    IdealState idealState = new IdealState("resource1");
+    idealState.setPreferenceList("partition1", Arrays.asList(ClusterMapUtils
+        .getInstanceName("localhost_1", PORT), ClusterMapUtils.getInstanceName("localhost_2", PORT),
+        ClusterMapUtils.getInstanceName("localhost_3", PORT)));
+    admin.addResource(CLUSTER_NAME, "resource1", idealState);
+
+    // Add replicas to property store
+    addReplicasToDisk(dataNodeConfigSource, "localhost_1", "disk1", "partition1");
+    addReplicasToDisk(dataNodeConfigSource, "localhost_2", "disk1", "partition1");
+    addReplicasToDisk(dataNodeConfigSource, "localhost_3", "disk1", "partition1");
+  }
+
+  /**
+   * Case when no instance is down and all instances are present in ideal state or external view
+   * @param helixManager
+   * @param dataNodeConfigSource
+   * @return
+   */
+  private void testCluster3(HelixManager helixManager, DataNodeConfigSource dataNodeConfigSource){
+    MockHelixAdmin admin =  (MockHelixAdmin)helixManager.getClusterManagmentTool();
+    // Add 3 instances to cluster
+    addInstancesToCluster(helixManager, ClusterMapUtils.getInstanceName("localhost_1", PORT),
+        ClusterMapUtils.getInstanceName("localhost_2", PORT), ClusterMapUtils.getInstanceName("localhost_3", PORT));
+
+    // Add a resourceName to cluster with partition on localhost_1 and localhost_2 and localhost_3
+    IdealState idealState = new IdealState("resource1");
+    idealState.setPreferenceList("partition1", Arrays.asList(ClusterMapUtils
+        .getInstanceName("localhost_1", PORT), ClusterMapUtils.getInstanceName("localhost_2", PORT),
+        ClusterMapUtils.getInstanceName("localhost_3", PORT)));
+    admin.addResource(CLUSTER_NAME, "resource1", idealState);
+
+    // Add replicas to property store
+    addReplicasToDisk(dataNodeConfigSource, "localhost_1", "disk1", "partition1");
+    addReplicasToDisk(dataNodeConfigSource, "localhost_2", "disk1", "partition1");
+    addReplicasToDisk(dataNodeConfigSource, "localhost_3", "disk1", "partition1");
+
+  }
+
+  private DataNodeConfig getDataNodeConfig(String host) {
+    String instanceName = ClusterMapUtils.getInstanceName(host, PORT);
+    return new DataNodeConfig(instanceName, host, PORT, DC, PORT + 1, PORT + 2, "rack", ClusterMapUtils.DEFAULT_XID);
+  }
+
+  private void setDataNodeConfig(DataNodeConfig dataNodeConfig, String disk, String partition, DataNodeConfigSource dataNodeConfigSource) {
+    DataNodeConfig.DiskConfig diskConfig = new DataNodeConfig.DiskConfig(HardwareState.AVAILABLE, 1000);
+    diskConfig.getReplicaConfigs().put(partition, new DataNodeConfig.ReplicaConfig(100, "maxAllReplicas"));
+    dataNodeConfig.getDiskConfigs().put(disk, diskConfig);
+    dataNodeConfigSource.set(dataNodeConfig);
+  }
+
+  private void addReplicasToDisk(DataNodeConfigSource dataNodeConfigSource, String host, String disk, String partition) {
+    // Add replicas to property store
+    DataNodeConfig dataNodeConfig = getDataNodeConfig(host);
+    setDataNodeConfig(dataNodeConfig, disk, partition, dataNodeConfigSource);
+  }
+
+  private Properties getProperties() {
+    Properties props = new Properties();
+    props.setProperty(ClusterMapConfig.DELETE_DATA_FROM_DATANODE_CONFIG, "true");
+    props.setProperty(ClusterMapConfig.ENABLE_PROPERTY_STORE_CLEAN_UP_TASK, "true");
+    props.setProperty(ClusterMapConfig.CLUSTERMAP_DATA_NODE_CONFIG_SOURCE_TYPE,
+        DataNodeConfigSourceType.PROPERTY_STORE.name());
+    props.setProperty(ClusterMapConfig.CLUSTERMAP_CLUSTER_NAME, CLUSTER_NAME);
+    props.setProperty(ClusterMapConfig.CLUSTERMAP_DATACENTER_NAME, DC);
+    props.setProperty(ClusterMapConfig.CLUSTERMAP_HOST_NAME, HOST_NAME);
+    return props;
+  }
+
+  private void addInstancesToCluster(HelixManager helixManager, String... instances) {
+    MockHelixAdmin admin =  (MockHelixAdmin)helixManager.getClusterManagmentTool();
+    for (String instance : instances) {
+      admin.addInstance(CLUSTER_NAME, new InstanceConfig(instance));
+    }
+  }
+
+}

--- a/ambry-tools/src/main/java/com/github/ambry/clustermap/HelixTaskWorkflowManagerTool.java
+++ b/ambry-tools/src/main/java/com/github/ambry/clustermap/HelixTaskWorkflowManagerTool.java
@@ -149,7 +149,7 @@ public class HelixTaskWorkflowManagerTool {
     /** Task to sync deprecated containers to cloud. */
     DEPRECATED_CONTAINER_CLOUD_SYNC_TASK,
 
-    /**Task to clean up stale property store data. */
+    /** Task to clean up stale property store data. */
     PROPERTY_STORE_CLEANUP_TASK
   }
 
@@ -269,8 +269,8 @@ public class HelixTaskWorkflowManagerTool {
     workflowBuilder.addJob(jobId, jobConfigBuilder);
   }
 
-  /** Build the workflow for property store clean up task.
-   *
+  /**
+   * Build the workflow for property store clean up task.
    * @param workflowBuilder {@link Workflow.Builder} object.
    */
   private static void buildPropertyStoreCleanUpTaskWorkflow(Workflow.Builder workflowBuilder) {

--- a/ambry-tools/src/main/java/com/github/ambry/clustermap/HelixTaskWorkflowManagerTool.java
+++ b/ambry-tools/src/main/java/com/github/ambry/clustermap/HelixTaskWorkflowManagerTool.java
@@ -147,7 +147,10 @@ public class HelixTaskWorkflowManagerTool {
     AGGREGATE_TASK,
 
     /** Task to sync deprecated containers to cloud. */
-    DEPRECATED_CONTAINER_CLOUD_SYNC_TASK
+    DEPRECATED_CONTAINER_CLOUD_SYNC_TASK,
+
+    /**Task to clean up stale property store data. */
+    PROPERTY_STORE_CLEANUP_TASK
   }
 
   /**
@@ -191,6 +194,9 @@ public class HelixTaskWorkflowManagerTool {
                 break;
               case DEPRECATED_CONTAINER_CLOUD_SYNC_TASK:
                 buildDeprecatedContainerCloudSyncTaskWorkflow(workflowBuilder);
+                break;
+              case PROPERTY_STORE_CLEANUP_TASK:
+                buildPropertyStoreCleanUpTaskWorkflow(workflowBuilder);
                 break;
               default:
                 throw new IllegalArgumentException("Invalid task type: " + config.taskType);
@@ -258,6 +264,26 @@ public class HelixTaskWorkflowManagerTool {
     JobConfig.Builder jobConfigBuilder = new JobConfig.Builder();
     jobConfigBuilder.addTaskConfigs(taskConfigs);
     jobConfigBuilder.setCommand(DeprecatedContainerCloudSyncTask.COMMAND);
+
+    // add job into workflow
+    workflowBuilder.addJob(jobId, jobConfigBuilder);
+  }
+
+  /** Build the workflow for property store clean up task.
+   *
+   * @param workflowBuilder {@link Workflow.Builder} object.
+   */
+  private static void buildPropertyStoreCleanUpTaskWorkflow(Workflow.Builder workflowBuilder) {
+    // build task
+    String taskId = String.format("%s_%s", PropertyStoreCleanUpTask.COMMAND, TASK_SUFFIX);
+    String jobId = String.format("%s_%s", PropertyStoreCleanUpTask.COMMAND, JOB_SUFFIX);
+    List<TaskConfig> taskConfigs = new ArrayList<>();
+    taskConfigs.add(
+        new TaskConfig.Builder().setTaskId(taskId).setCommand(PropertyStoreCleanUpTask.COMMAND).build());
+    // build job
+    JobConfig.Builder jobConfigBuilder = new JobConfig.Builder();
+    jobConfigBuilder.addTaskConfigs(taskConfigs);
+    jobConfigBuilder.setCommand(PropertyStoreCleanUpTask.COMMAND);
 
     // add job into workflow
     workflowBuilder.addJob(jobId, jobConfigBuilder);


### PR DESCRIPTION
***Description***
In Ambry FullAuto Clusters when a node goes offline and doesn’t come online for more than 6 hours, helix rebalances all the partitions from this node to other nodes and updates Ideal state.
But currently helix does not update the DataNodeConfig in PropertyStore. 
This PR introduces a helix task to clean up that stale data.

***Testing***
Unit test : Flow has been tested with JUnit by mocking the clusterMap for various scenarios.
Integ : N/A