### PR TITLE
adding logic for group generation for Continuous replication

### DIFF
--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/RecoveryThread.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/RecoveryThread.java
@@ -84,7 +84,7 @@ public class RecoveryThread extends ReplicaThread {
   }
 
   @Override
-  protected boolean getEnableContinuousReplication(ReplicationConfig replicationConfig) {
+  protected boolean isContinuousReplicationEnabled(ReplicationConfig replicationConfig) {
     return false;
   }
 

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicaThread.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicaThread.java
@@ -93,7 +93,7 @@ public class VcrReplicaThread extends ReplicaThread {
   }
 
   @Override
-  protected boolean getEnableContinuousReplication(ReplicationConfig replicationConfig) {
+  protected boolean isContinuousReplicationEnabled(ReplicationConfig replicationConfig) {
     return false;
   }
 

--- a/ambry-replication/src/main/java/com/github/ambry/replication/BackupCheckerThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/BackupCheckerThread.java
@@ -104,7 +104,7 @@ public class BackupCheckerThread extends ReplicaThread {
   }
 
   @Override
-  protected boolean getEnableContinuousReplication(ReplicationConfig replicationConfig) {
+  protected boolean isContinuousReplicationEnabled(ReplicationConfig replicationConfig) {
     return false;
   }
 

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -1969,11 +1969,11 @@ public class ReplicaThread implements Runnable {
     }
 
     /**
-     * We will create Data node trackers for every data node
-     * Every tracker will have set active groups and standby groups
-     * Active groups will have {@link #maxReplicaCountPerRequest} maximum number of preassigned replicas
-     * For each data node tracker, we will have only one stand by group
-     * Across all datanode tracker group ids will be unique
+     * Creates Data node trackers for every data node
+     * Every datanode tracker has  active groups and standby group
+     * For each data node tracker, only one stand by group is present to reduce cross colo requests
+     * Active groups have maximum {@link #maxReplicaCountPerRequest}  preassigned replicas
+     * Across all datanode tracker group ids are unique
      */
     private void fillDataNodeTrackers() {
       Map<DataNodeId, List<RemoteReplicaInfo>> dataNodeToRemoteReplicaInfo = selectReplicas(getRemoteReplicaInfos());

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -182,13 +182,13 @@ public class ReplicaThread implements Runnable {
       idleCount = replicationMetrics.intraColoReplicaThreadIdleCount;
       throttleCount = replicationMetrics.intraColoReplicaThreadThrottleCount;
     }
-    this.enableContinuousReplication = getEnableContinuousReplication(replicationConfig);
+    this.enableContinuousReplication = isContinuousReplicationEnabled(replicationConfig);
     this.maxReplicaCountPerRequest = replicationConfig.replicationMaxPartitionCountPerRequest;
     this.leaderBasedReplicationAdmin = leaderBasedReplicationAdmin;
     threadStarted = new AtomicBoolean(false);
   }
 
-  protected boolean getEnableContinuousReplication(ReplicationConfig replicationConfig) {
+  protected boolean isContinuousReplicationEnabled(ReplicationConfig replicationConfig) {
     return replicationConfig.replicationEnableContinuousReplication;
   }
 

--- a/ambry-replication/src/main/java/com/github/ambry/replication/continuous/ActiveGroupTracker.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/continuous/ActiveGroupTracker.java
@@ -18,8 +18,8 @@ import java.util.List;
 
 /**
  * This class tracks for a current state for Active groups for a continuous replication cycle.
- * Active group tracker will have preassigned replicas and from these replicas only we can create active group
- * Any remote replica group created for this tracker will have replicas with ACTIVE state only
+ * Active group tracker have preassigned replicas and from these replicas only we create active remote replica groups
+ * Any remote replica group created for this tracker has replicas with ACTIVE state only
  */
 public class ActiveGroupTracker extends GroupTracker {
   private final List<ReplicaTracker> preAssignedReplicas;

--- a/ambry-replication/src/main/java/com/github/ambry/replication/continuous/ActiveGroupTracker.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/continuous/ActiveGroupTracker.java
@@ -16,15 +16,20 @@ package com.github.ambry.replication.continuous;
 import java.util.List;
 
 
+/**
+ * This class tracks for a current state for Active groups for a continuous replication cycle.
+ * Active group tracker will have preassigned replicas and from these replicas only we can create active group
+ * Any remote replica group created for this tracker will have replicas with ACTIVE state only
+ */
 public class ActiveGroupTracker extends GroupTracker {
   private final List<ReplicaTracker> preAssignedReplicas;
 
-  ActiveGroupTracker(int groupId, List<ReplicaTracker> preAssignedReplicas) {
+  public ActiveGroupTracker(int groupId, List<ReplicaTracker> preAssignedReplicas) {
     super(groupId);
     this.preAssignedReplicas = preAssignedReplicas;
   }
 
-  List<ReplicaTracker> getPreAssignedReplicas() {
+  public List<ReplicaTracker> getPreAssignedReplica() {
     return preAssignedReplicas;
   }
 }

--- a/ambry-replication/src/main/java/com/github/ambry/replication/continuous/DataNodeTracker.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/continuous/DataNodeTracker.java
@@ -24,10 +24,10 @@ import java.util.stream.Collectors;
 
 /**
  * This class tracks for a current state for a remote host for a continuous replication cycle.
- * Each DataNode will have multiple active group trackers.
- * Each DataNode will have only one Standby group for reducing cross colo calls.
- * {@link #activeGroupTrackers} will have group trackers for groups with active replicas
- * {@link #standByGroupTracker} will have group tracker for stand by group for this data node
+ * Each DataNode has multiple active group trackers.
+ * Each DataNode has only one Standby group for reducing cross colo calls.
+ * {@link #activeGroupTrackers} has group trackers for groups with active replicas
+ * {@link #standByGroupTracker} has group tracker for stand by group for this data node
  */
 public class DataNodeTracker {
   private final DataNodeId dataNodeId;
@@ -36,7 +36,7 @@ public class DataNodeTracker {
 
   /**
    * Creating active group trackers and standByGroupTracker.
-   * All group trackers will have consecutive group id.
+   * All group trackers have consecutive group id.
    * @param dataNodeId remote host for which to create datanode tracker
    * @param remoteReplicas remote replicas for this data node
    * @param maxActiveGroupSize maximum count of replicas in active groups
@@ -62,7 +62,7 @@ public class DataNodeTracker {
       currentGroupId++;
     }
 
-    // standby group id will have maximum group id
+    // standby group id has maximum group id
     standByGroupTracker = new StandByGroupTracker(currentGroupId);
   }
 

--- a/ambry-replication/src/main/java/com/github/ambry/replication/continuous/GroupTracker.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/continuous/GroupTracker.java
@@ -22,10 +22,10 @@ import java.util.List;
  *   This class tracks for a current state for {@link com.github.ambry.replication.ReplicaThread.RemoteReplicaGroup}
  *   for continuous replication cycle.
  *
- *   {@link #groupId} will be group id assigned to remote replica group
- *   {@link #remoteReplicaGroup} will be group for which we have created this tracker
- *   {@link #inflightReplicas} will be replicas that are currently present in {@link #remoteReplicaGroup}
- *   {@link #iterations} will be total number of iterations for the group with {@link #groupId} group id
+ *   {@link #groupId} group id assigned to remote replica group
+ *   {@link #remoteReplicaGroup} group for which we have created this tracker
+ *   {@link #inflightReplicas} replicas that are currently present in {@link #remoteReplicaGroup}
+ *   {@link #iterations} total number of iterations for the remote replica group with {@link #groupId} group id
  */
 public abstract class GroupTracker {
   private final int groupId;

--- a/ambry-replication/src/main/java/com/github/ambry/replication/continuous/GroupTracker.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/continuous/GroupTracker.java
@@ -18,6 +18,15 @@ import java.util.ArrayList;
 import java.util.List;
 
 
+/**
+ *   This class tracks for a current state for {@link com.github.ambry.replication.ReplicaThread.RemoteReplicaGroup}
+ *   for continuous replication cycle.
+ *
+ *   {@link #groupId} will be group id assigned to remote replica group
+ *   {@link #remoteReplicaGroup} will be group for which we have created this tracker
+ *   {@link #inflightReplicas} will be replicas that are currently present in {@link #remoteReplicaGroup}
+ *   {@link #iterations} will be total number of iterations for the group with {@link #groupId} group id
+ */
 public abstract class GroupTracker {
   private final int groupId;
   private ReplicaThread.RemoteReplicaGroup remoteReplicaGroup;

--- a/ambry-replication/src/main/java/com/github/ambry/replication/continuous/ReplicaState.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/continuous/ReplicaState.java
@@ -13,6 +13,16 @@
  */
 package com.github.ambry.replication.continuous;
 
+/**
+ * These are states we are tracking for a continuous replication cycle
+ *
+ * UNKNOWN - We do not know the state
+ * OFFLINE - Replica is determined to be offline
+ * STANDBY - Replica is waiting for its data to come from intra colo replication, we should not pull data, valid in remote colo
+ * STANDBY_TIMED_OUT - Replica was in STANDBY, but data has not arrived for some time, so we need to pull data,
+ *                     ,valid in remote colo,
+ * ACTIVE - We can pull data for this replica , valid for remote colo leader-leader pair and intra-colo replication.
+ */
 public enum ReplicaState {
   UNKNOWN, OFFLINE, STANDBY, STANDBY_TIMED_OUT, ACTIVE
 }

--- a/ambry-replication/src/main/java/com/github/ambry/replication/continuous/ReplicaTracker.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/continuous/ReplicaTracker.java
@@ -17,6 +17,10 @@ import com.github.ambry.replication.RemoteReplicaInfo;
 import com.github.ambry.utils.Time;
 
 
+/**
+ * This class tracks for a current state for continuous replication cycle.
+ * This also tracks whether a replicas is throttled or not in a continuous replication cycle.
+ */
 public class ReplicaTracker {
   private final RemoteReplicaInfo remoteReplicaInfo;
   private ReplicaState replicaState;

--- a/ambry-replication/src/main/java/com/github/ambry/replication/continuous/StandByGroupTracker.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/continuous/StandByGroupTracker.java
@@ -13,9 +13,13 @@
  */
 package com.github.ambry.replication.continuous;
 
+/**
+ * This class tracks for a current state for StandBy groups for a continuous replication cycle.
+ * In standby group will have replicas with STANDBY_TIMED_OUT state
+ */
 public class StandByGroupTracker extends GroupTracker {
 
-  StandByGroupTracker(int groupId) {
+  public StandByGroupTracker(int groupId) {
     super(groupId);
   }
 }

--- a/ambry-replication/src/main/java/com/github/ambry/replication/continuous/StandByGroupTracker.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/continuous/StandByGroupTracker.java
@@ -15,7 +15,7 @@ package com.github.ambry.replication.continuous;
 
 /**
  * This class tracks for a current state for StandBy groups for a continuous replication cycle.
- * In standby group will have replicas with STANDBY_TIMED_OUT state
+ * Standby group has  replicas with STANDBY_TIMED_OUT state only
  */
 public class StandByGroupTracker extends GroupTracker {
 

--- a/ambry-replication/src/test/java/com/github/ambry/replication/RemoteReplicaGroupPollerTest.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/RemoteReplicaGroupPollerTest.java
@@ -214,10 +214,11 @@ public class RemoteReplicaGroupPollerTest extends ReplicationTestHelper {
       });
     });
 
-    // check if standby groups have 0 replicas and active groups have maximum replicas as maxPartitionCountPerRequest
+    // check if active groups have maximum replicas as maxPartitionCountPerRequest
     dataNodeTrackers.forEach(dataNodeTracker -> {
       dataNodeTracker.getActiveGroupTrackers().forEach(activeGroupTracker -> {
-        Assert.assertTrue("active groups should have max preassigned replicas",
+        Assert.assertTrue(
+            "active groups should have max preassigned replicas less than or equal to max partition per request",
             maxPartitionCountPerRequest >= activeGroupTracker.getPreAssignedReplica().size());
       });
     });

--- a/ambry-replication/src/test/java/com/github/ambry/replication/RemoteReplicaGroupPollerTest.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/RemoteReplicaGroupPollerTest.java
@@ -1,0 +1,225 @@
+/**
+ * Copyright 2024 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.replication;
+
+import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.clustermap.DataNodeId;
+import com.github.ambry.clustermap.MockClusterMap;
+import com.github.ambry.clustermap.MockHelixParticipant;
+import com.github.ambry.clustermap.PartitionId;
+import com.github.ambry.commons.BlobIdFactory;
+import com.github.ambry.config.ClusterMapConfig;
+import com.github.ambry.config.ReplicationConfig;
+import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.protocol.ReplicaMetadataRequest;
+import com.github.ambry.protocol.ReplicaMetadataResponse;
+import com.github.ambry.replication.continuous.DataNodeTracker;
+import com.github.ambry.replication.continuous.GroupTracker;
+import com.github.ambry.store.StorageManager;
+import com.github.ambry.store.Store;
+import com.github.ambry.utils.Pair;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+
+@RunWith(Parameterized.class)
+public class RemoteReplicaGroupPollerTest extends ReplicationTestHelper {
+  ReplicaThread intraColoReplicaThread;
+
+  ReplicaThread crossColoReplicaThread;
+
+  StorageManager storageManager;
+
+  int maxPartitionCountPerRequest;
+
+  public RemoteReplicaGroupPollerTest(short requestVersion, short responseVersion) {
+    super(requestVersion, responseVersion);
+  }
+
+  @Parameterized.Parameters
+  public static List<Object[]> data() {
+    //@formatter:off
+    return Arrays.asList(new Object[][]{
+        {ReplicaMetadataRequest.Replica_Metadata_Request_Version_V1, ReplicaMetadataResponse.REPLICA_METADATA_RESPONSE_VERSION_V_5},
+    });
+    //@formatter:on
+  }
+
+  @Before
+  public void before() throws Exception {
+    setUp();
+  }
+
+  @After
+  public void after() throws Exception {
+    storageManager.shutdown();
+  }
+
+  private void setUp() throws Exception {
+    properties.setProperty("replication.model.across.datacenters", "LEADER_BASED");
+    maxPartitionCountPerRequest = 3;
+    properties.setProperty("replication.max.partition.count.per.request", String.valueOf(maxPartitionCountPerRequest));
+
+    replicationConfig = new ReplicationConfig(new VerifiableProperties(properties));
+    // setting number of mount points to partition limit so each node can have replicas higher that limit to test group partitioning
+    MockClusterMap clusterMap =
+        new MockClusterMap(false, true, 5, replicationConfig.replicationMaxPartitionCountPerRequest, 3, false, false,
+            null);
+    ClusterMapConfig clusterMapConfig = new ClusterMapConfig(verifiableProperties);
+    MockHelixParticipant.metricRegistry = new MetricRegistry();
+    MockHelixParticipant mockHelixParticipant = new MockHelixParticipant(clusterMapConfig);
+
+    /*
+      Setup:
+      we have 3 nodes that have replicas belonging to same partitions:
+      a) localNode (local node that hosts partitions)
+      b) remoteNodeInLocalDC (remote node in local data center that shares the partitions)
+      c) remoteNodeInRemoteDC (remote node in remote data center that shares the partitions)
+      Each node have few of its partitions as leaders and others are standby. They are randomly assigned during creation
+      of replicas for mock partitions.
+     */
+    DataNodeId localNode = clusterMap.getDataNodeIds().get(0);
+    List<DataNodeId> remoteNodes = getRemoteNodesFromLocalAndRemoteDCs(clusterMap, localNode);
+    DataNodeId remoteNodeInLocalDC = remoteNodes.get(0);
+    DataNodeId remoteNodeInRemoteDC = remoteNodes.get(1);
+
+    // mock hosts for remote nodes
+    MockHost localHost = new MockHost(localNode, clusterMap);
+    MockHost remoteHostInLocalDC = new MockHost(remoteNodeInLocalDC, clusterMap);
+    MockHost remoteHostInRemoteDC = new MockHost(remoteNodeInRemoteDC, clusterMap);
+
+    int batchSize = 4;
+
+    Map<DataNodeId, MockHost> hosts = new HashMap<>();
+    hosts.put(remoteNodeInLocalDC, remoteHostInLocalDC);
+    hosts.put(remoteNodeInRemoteDC, remoteHostInRemoteDC);
+    MockNetworkClientFactory mockNetworkClientFactory = new MockNetworkClientFactory(hosts, clusterMap, batchSize,
+        new MockFindTokenHelper(new BlobIdFactory(clusterMap), replicationConfig));
+    Pair<StorageManager, ReplicationManager> managers =
+        createStorageManagerAndReplicationManager(clusterMap, clusterMapConfig, mockHelixParticipant,
+            mockNetworkClientFactory);
+    storageManager = managers.getFirst();
+    MockReplicationManager replicationManager = (MockReplicationManager) managers.getSecond();
+
+    for (PartitionId partitionId : replicationManager.partitionToPartitionInfo.keySet()) {
+      localHost.addStore(partitionId, null);
+      Store localStore = localHost.getStore(partitionId);
+      localStore.start();
+      List<RemoteReplicaInfo> remoteReplicaInfos =
+          replicationManager.partitionToPartitionInfo.get(partitionId).getRemoteReplicaInfos();
+      remoteReplicaInfos.forEach(remoteReplicaInfo -> remoteReplicaInfo.setLocalStore(localStore));
+    }
+
+    intraColoReplicaThread = replicationManager.dataNodeIdToReplicaThread.get(remoteNodeInLocalDC);
+    crossColoReplicaThread = replicationManager.dataNodeIdToReplicaThread.get(remoteNodeInRemoteDC);
+  }
+
+  @Test
+  public void trackersGenerationTest() {
+    ReplicaThread replicaThread = intraColoReplicaThread;
+    Map<DataNodeId, List<RemoteReplicaInfo>> dataNodeToReplicaMap = replicaThread.getRemoteReplicaInfos();
+
+    ReplicaThread.RemoteReplicaGroupPoller remoteReplicaGroupPoller = replicaThread.new RemoteReplicaGroupPoller();
+
+    List<DataNodeTracker> dataNodeTrackers = remoteReplicaGroupPoller.getDataNodeTrackers();
+
+    // check if data node trackers are generated correctly
+
+    Assert.assertEquals("Count of data nodes assigned to thread and count of data node trackers should be same",
+        dataNodeToReplicaMap.size(), dataNodeTrackers.size());
+
+    Set<DataNodeId> dataNodeIdsAddedInTracker =
+        dataNodeTrackers.stream().map(DataNodeTracker::getDataNodeId).collect(Collectors.toSet());
+
+    // all data nodes should have trackers created
+    dataNodeToReplicaMap.keySet().forEach(dataNodeId -> {
+      Assert.assertTrue("DataNode should be present in data node trackers created",
+          dataNodeIdsAddedInTracker.contains(dataNodeId));
+    });
+
+    // check if all group trackers are generated correctly inside data node tracker
+    dataNodeTrackers.forEach(dataNodeTracker -> {
+      TreeSet<Integer> allActiveGroupIds = dataNodeTracker.getActiveGroupTrackers()
+          .stream()
+          .map(GroupTracker::getGroupId)
+          .distinct()
+          .collect(Collectors.toCollection(TreeSet::new));
+      int minimumActiveGroupId = allActiveGroupIds.first();
+      int maximumActiveGroupId = allActiveGroupIds.last();
+
+      Assert.assertEquals("All groups ids should exits from start and should be in serial consecutive order",
+          maximumActiveGroupId - minimumActiveGroupId + 1, dataNodeTracker.getActiveGroupTrackers().size());
+
+      Assert.assertEquals("Standby group id should be maximum and one more than maximum active group id",
+          maximumActiveGroupId + 1, dataNodeTracker.getStandByGroupTracker().getGroupId());
+    });
+
+    // check if group tackers are generated correctly
+
+    // check if all groupIds are unique across datanode tracker
+    Set<Integer> allGroupIds = new HashSet<>();
+
+    dataNodeTrackers.forEach(dataNodeTracker -> {
+      dataNodeTracker.getActiveGroupTrackers().forEach(activeGroupTracker -> {
+        Assert.assertFalse("Group id for group trackers should be unique",
+            allGroupIds.contains(activeGroupTracker.getGroupId()));
+        allGroupIds.add(activeGroupTracker.getGroupId());
+      });
+
+      Assert.assertFalse("Group id for group trackers should be unique",
+          allGroupIds.contains(dataNodeTracker.getStandByGroupTracker().getGroupId()));
+      allGroupIds.add(dataNodeTracker.getStandByGroupTracker().getGroupId());
+    });
+
+    // check if all replicas are added to correct datanode tracker and all replicas are added to active group trackers
+
+    Set<RemoteReplicaInfo> allRemoteReplicasInTrackers = new HashSet<>();
+    dataNodeTrackers.forEach(dataNodeTracker -> {
+      dataNodeTracker.getActiveGroupTrackers().forEach(activeGroupTracker -> {
+        activeGroupTracker.getPreAssignedReplica().forEach(replicaTracker -> {
+          Assert.assertEquals("Replica should be added to the tracker of data node on which it exists",
+              dataNodeTracker.getDataNodeId(), replicaTracker.getRemoteReplicaInfo().getReplicaId().getDataNodeId());
+          allRemoteReplicasInTrackers.add(replicaTracker.getRemoteReplicaInfo());
+        });
+      });
+    });
+
+    dataNodeToReplicaMap.forEach((dataNodeId, remoteReplicaInfos) -> {
+      remoteReplicaInfos.forEach(remoteReplicaInfo -> {
+        Assert.assertTrue("Replicas in replica thread should be present in trackers",
+            allRemoteReplicasInTrackers.contains(remoteReplicaInfo));
+      });
+    });
+
+    // check if standby groups have 0 replicas and active groups have maximum replicas as maxPartitionCountPerRequest
+    dataNodeTrackers.forEach(dataNodeTracker -> {
+      dataNodeTracker.getActiveGroupTrackers().forEach(activeGroupTracker -> {
+        Assert.assertTrue("active groups should have max preassigned replicas",
+            maxPartitionCountPerRequest >= activeGroupTracker.getPreAssignedReplica().size());
+      });
+    });
+  }
+}


### PR DESCRIPTION
This PR adds logic for group generation for Continuous Replication
For each data node, we will have active group trackers and one stand by group tracker.
Each group across data node will have unique group id and group ids will be in serial order.

Added tests for above.

Added comments and changed some method names for better readability.