### PR TITLE
[vcr-2.0] Fix lag metric

### DIFF
--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicationManager.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicationManager.java
@@ -219,7 +219,6 @@ public class VcrReplicationManager extends ReplicationEngine {
       rinfo.setReplicaThread(rthread);
       logger.info("[PARTITION] Added replica {} to thread {}", rinfo, rthread.getName());
     }
-    azureStorageContainerMetricsCollector.addPartitionReplicas(remoteReplicaInfos);
     partitionToPartitionInfo.get(partitionId).setReplicaThread(rthread);
     rthread.startThread();
   }
@@ -250,7 +249,6 @@ public class VcrReplicationManager extends ReplicationEngine {
           }
           rthread.addRemoteReplicaInfo(rinfo);
           rinfo.setReplicaThread(rthread);
-          azureStorageContainerMetricsCollector.addPartitionReplicas(Collections.singletonList(rinfo));
           logger.info("[REPLICA] Added replica {} to thread {}", rinfo, rthread.getName());
         } catch (Throwable e) {
           vcrMetrics.addPartitionErrorCount.inc();

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureStorageContainerMetrics.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureStorageContainerMetrics.java
@@ -42,9 +42,7 @@ public class AzureStorageContainerMetrics {
   }
 
   public Long getPartitionLag() {
-    // -1L is returned if and only if there are no replicas for this partition.
-    // this may indicate an error with replication or cluster management.
-    return replicaLag.values().stream().map(AtomicLong::get).min(Long::compareTo).orElse(-1L);
+    return replicaLag.values().stream().map(AtomicLong::get).min(Long::compareTo).orElse(0L);
   }
 
   public AzureStorageContainerMetrics setPartitionReplicaLag(String hostname, long update) {

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureStorageContainerMetrics.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureStorageContainerMetrics.java
@@ -42,7 +42,7 @@ public class AzureStorageContainerMetrics {
   }
 
   public Long getPartitionLag() {
-    return replicaLag.values().stream().map(AtomicLong::get).reduce(Long.MAX_VALUE, Long::min);
+    return replicaLag.values().stream().map(AtomicLong::get).min(Long::compareTo).get();
   }
 
   public AzureStorageContainerMetrics setPartitionReplicaLag(String hostname, long update) {

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureStorageContainerMetrics.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureStorageContainerMetrics.java
@@ -37,10 +37,6 @@ public class AzureStorageContainerMetrics {
     replicaLag = new ConcurrentHashMap<>();
   }
 
-  public void addPartitionReplica(String hostname) {
-    replicaLag.putIfAbsent(hostname, new AtomicLong(Long.MAX_VALUE));
-  }
-
   public void removePartitionReplica(String hostname) {
     replicaLag.remove(hostname);
   }
@@ -49,8 +45,16 @@ public class AzureStorageContainerMetrics {
     return replicaLag.values().stream().map(AtomicLong::get).reduce(Long.MAX_VALUE, Long::min);
   }
 
-  public void setPartitionReplicaLag(String hostname, long update) {
-    this.replicaLag.get(hostname).compareAndSet(this.replicaLag.get(hostname).get(), update);
+  public AzureStorageContainerMetrics setPartitionReplicaLag(String hostname, long update) {
+    this.replicaLag.compute(hostname, (key, value) -> {
+      if (value == null) {
+        return new AtomicLong(update);
+      } else {
+        value.set(update);
+        return value;
+      }
+    });
+    return this;
   }
 
 }

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureStorageContainerMetrics.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureStorageContainerMetrics.java
@@ -42,7 +42,7 @@ public class AzureStorageContainerMetrics {
   }
 
   public Long getPartitionLag() {
-    return replicaLag.values().stream().map(AtomicLong::get).min(Long::compareTo).get();
+    return replicaLag.values().stream().map(AtomicLong::get).min(Long::compareTo).orElse(0L);
   }
 
   public AzureStorageContainerMetrics setPartitionReplicaLag(String hostname, long update) {

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureStorageContainerMetrics.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureStorageContainerMetrics.java
@@ -42,7 +42,9 @@ public class AzureStorageContainerMetrics {
   }
 
   public Long getPartitionLag() {
-    return replicaLag.values().stream().map(AtomicLong::get).min(Long::compareTo).orElse(0L);
+    // -1L is returned if and only if there are no replicas for this partition.
+    // this may indicate an error with replication or cluster management.
+    return replicaLag.values().stream().map(AtomicLong::get).min(Long::compareTo).orElse(-1L);
   }
 
   public AzureStorageContainerMetrics setPartitionReplicaLag(String hostname, long update) {

--- a/ambry-cloud/src/test/java/com/github/ambry/cloud/azure/AzureStorageContainerMetricsTest.java
+++ b/ambry-cloud/src/test/java/com/github/ambry/cloud/azure/AzureStorageContainerMetricsTest.java
@@ -1,7 +1,19 @@
+/**
+ * Copyright 2024 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
 package com.github.ambry.cloud.azure;
 
 import java.util.Optional;
-import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.*;

--- a/ambry-cloud/src/test/java/com/github/ambry/cloud/azure/AzureStorageContainerMetricsTest.java
+++ b/ambry-cloud/src/test/java/com/github/ambry/cloud/azure/AzureStorageContainerMetricsTest.java
@@ -1,0 +1,45 @@
+package com.github.ambry.cloud.azure;
+
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+public class AzureStorageContainerMetricsTest {
+
+  private AzureStorageContainerMetrics partitionMetrics;
+
+  public AzureStorageContainerMetricsTest() {
+    partitionMetrics = new AzureStorageContainerMetrics(314L);
+  }
+
+  @Test
+  public void testAzureStorageContainerMetrics() {
+    // no replicas
+    assertEquals(Optional.of(0L).get(), partitionMetrics.getPartitionLag());
+
+    // one replica
+    partitionMetrics.setPartitionReplicaLag("localhost1", 100);
+    assertEquals(Optional.of(100L).get(), partitionMetrics.getPartitionLag());
+
+    // two replicas
+    partitionMetrics.setPartitionReplicaLag("localhost1", 100);
+    partitionMetrics.setPartitionReplicaLag("localhost2", 1000);
+    assertEquals(Optional.of(100L).get(), partitionMetrics.getPartitionLag());
+
+    // two replicas, lag changes
+    partitionMetrics.setPartitionReplicaLag("localhost2", 10);
+    assertEquals(Optional.of(10L).get(), partitionMetrics.getPartitionLag());
+
+    // one replica removed
+    partitionMetrics.removePartitionReplica("localhost2");
+    assertEquals(Optional.of(100L).get(), partitionMetrics.getPartitionLag());
+
+    // both replicas removed
+    partitionMetrics.removePartitionReplica("localhost1");
+    assertEquals(Optional.of(0L).get(), partitionMetrics.getPartitionLag());
+  }
+
+}

--- a/ambry-cloud/src/test/java/com/github/ambry/cloud/azure/AzureStorageContainerMetricsTest.java
+++ b/ambry-cloud/src/test/java/com/github/ambry/cloud/azure/AzureStorageContainerMetricsTest.java
@@ -30,7 +30,7 @@ public class AzureStorageContainerMetricsTest {
   @Test
   public void testAzureStorageContainerMetrics() {
     // no replicas
-    assertEquals(Optional.of(-1L).get(), partitionMetrics.getPartitionLag());
+    assertEquals(Optional.of(0L).get(), partitionMetrics.getPartitionLag());
 
     // one replica
     partitionMetrics.setPartitionReplicaLag("localhost1", 100);
@@ -51,7 +51,7 @@ public class AzureStorageContainerMetricsTest {
 
     // both replicas removed
     partitionMetrics.removePartitionReplica("localhost1");
-    assertEquals(Optional.of(-1L).get(), partitionMetrics.getPartitionLag());
+    assertEquals(Optional.of(0L).get(), partitionMetrics.getPartitionLag());
   }
 
 }

--- a/ambry-cloud/src/test/java/com/github/ambry/cloud/azure/AzureStorageContainerMetricsTest.java
+++ b/ambry-cloud/src/test/java/com/github/ambry/cloud/azure/AzureStorageContainerMetricsTest.java
@@ -18,7 +18,7 @@ public class AzureStorageContainerMetricsTest {
   @Test
   public void testAzureStorageContainerMetrics() {
     // no replicas
-    assertEquals(Optional.of(0L).get(), partitionMetrics.getPartitionLag());
+    assertEquals(Optional.of(-1L).get(), partitionMetrics.getPartitionLag());
 
     // one replica
     partitionMetrics.setPartitionReplicaLag("localhost1", 100);
@@ -39,7 +39,7 @@ public class AzureStorageContainerMetricsTest {
 
     // both replicas removed
     partitionMetrics.removePartitionReplica("localhost1");
-    assertEquals(Optional.of(0L).get(), partitionMetrics.getPartitionLag());
+    assertEquals(Optional.of(-1L).get(), partitionMetrics.getPartitionLag());
   }
 
 }

--- a/ambry-vcr/src/test/java/com/github/ambry/vcr/CloudTokenPersistorTest.java
+++ b/ambry-vcr/src/test/java/com/github/ambry/vcr/CloudTokenPersistorTest.java
@@ -145,8 +145,6 @@ public class CloudTokenPersistorTest {
     // Create remote-replica info
     replica = new RemoteReplicaInfo(mockPartitionId.getReplicaIds().get(0), null, null,
         null, Long.MAX_VALUE, SystemTime.getInstance(), null);
-    AzureStorageContainerMetricsCollector.getInstance(mockClusterMap.getMetricRegistry(), verifiableProperties)
-        .addPartitionReplicas(Collections.singletonList(replica));
   }
 
   protected Pair<TableEntity, StoreFindToken> getTokenFromAzureTable() throws IOException {


### PR DESCRIPTION
Initializing the lag metric to Long.MAX emits a high value initiailly. Although this eventually goes down as replication starts, it skews the graph upon each deployment. 

The fix is to create and emit the metric only when it is set. Until then, the metric doesn't exist.