### PR TITLE
Bug fix for updating configChanged

### DIFF
--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PropertyStoreCleanUpTask.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PropertyStoreCleanUpTask.java
@@ -169,14 +169,14 @@ public class PropertyStoreCleanUpTask implements Task {
           boolean configChanged;
           // Remove all sealed, stopped, partially sealed and disabled replicas from DataNodeConfig
           configChanged = TaskUtils.removeIfPresent(dataNodeConfig.getSealedReplicas());
-          configChanged = configChanged || TaskUtils.removeIfPresent(dataNodeConfig.getStoppedReplicas());
-          configChanged = configChanged || TaskUtils.removeIfPresent(dataNodeConfig.getPartiallySealedReplicas());
-          configChanged = configChanged || TaskUtils.removeIfPresent(dataNodeConfig.getDisabledReplicas());
+          configChanged = TaskUtils.removeIfPresent(dataNodeConfig.getStoppedReplicas()) || configChanged;
+          configChanged = TaskUtils.removeIfPresent(dataNodeConfig.getPartiallySealedReplicas()) || configChanged;
+          configChanged = TaskUtils.removeIfPresent(dataNodeConfig.getDisabledReplicas()) || configChanged;
           Map<String, DataNodeConfig.DiskConfig> diskConfigs = dataNodeConfig.getDiskConfigs();
 
           // Remove all replicas for each disk in the DataNodeConfig
           for (DataNodeConfig.DiskConfig diskConfig : diskConfigs.values()) {
-            configChanged = configChanged || TaskUtils.removeIfPresent(diskConfig.getReplicaConfigs());
+            configChanged = TaskUtils.removeIfPresent(diskConfig.getReplicaConfigs()) || configChanged;
           }
           // Only set the DatanodeConfig in ZK if it has changed
           if (configChanged) {

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/PropertyStoreCleanUpTaskTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/PropertyStoreCleanUpTaskTest.java
@@ -72,12 +72,19 @@ public class PropertyStoreCleanUpTaskTest {
     //Replica should be removed from property store for down host -> localhost_2
     assertTrue(dataNodeConfigSource.get(ClusterMapUtils.getInstanceName("localhost_2", PORT))
         .getDiskConfigs().get("disk1").getReplicaConfigs().isEmpty());
+    assertTrue(dataNodeConfigSource.get(ClusterMapUtils.getInstanceName("localhost_2", PORT))
+        .getDiskConfigs().get("disk2").getReplicaConfigs().isEmpty());
 
     //Replica should be present in property store for up hosts -> localhost_1, localhost_3
     assertTrue(dataNodeConfigSource.get(ClusterMapUtils.getInstanceName("localhost_1", PORT))
         .getDiskConfigs().get("disk1").getReplicaConfigs().containsKey("partition1"));
+    assertTrue(dataNodeConfigSource.get(ClusterMapUtils.getInstanceName("localhost_1", PORT))
+        .getDiskConfigs().get("disk2").getReplicaConfigs().containsKey("partition2"));
+
     assertTrue(dataNodeConfigSource.get(ClusterMapUtils.getInstanceName("localhost_3", PORT))
         .getDiskConfigs().get("disk1").getReplicaConfigs().containsKey("partition1"));
+    assertTrue(dataNodeConfigSource.get(ClusterMapUtils.getInstanceName("localhost_3", PORT))
+        .getDiskConfigs().get("disk2").getReplicaConfigs().containsKey("partition2"));
   }
 
   /**
@@ -108,12 +115,19 @@ public class PropertyStoreCleanUpTaskTest {
     //Replica should be present in property store for down host -> localhost_2
     assertTrue(dataNodeConfigSource.get(ClusterMapUtils.getInstanceName("localhost_2", PORT))
         .getDiskConfigs().get("disk1").getReplicaConfigs().containsKey("partition1"));
+    assertTrue(dataNodeConfigSource.get(ClusterMapUtils.getInstanceName("localhost_2", PORT))
+        .getDiskConfigs().get("disk2").getReplicaConfigs().containsKey("partition2"));
 
     //Replica should be present in property store for up hosts -> localhost_1, localhost_3
     assertTrue(dataNodeConfigSource.get(ClusterMapUtils.getInstanceName("localhost_1", PORT))
         .getDiskConfigs().get("disk1").getReplicaConfigs().containsKey("partition1"));
+    assertTrue(dataNodeConfigSource.get(ClusterMapUtils.getInstanceName("localhost_1", PORT))
+        .getDiskConfigs().get("disk2").getReplicaConfigs().containsKey("partition2"));
+
     assertTrue(dataNodeConfigSource.get(ClusterMapUtils.getInstanceName("localhost_3", PORT))
         .getDiskConfigs().get("disk1").getReplicaConfigs().containsKey("partition1"));
+    assertTrue(dataNodeConfigSource.get(ClusterMapUtils.getInstanceName("localhost_3", PORT))
+        .getDiskConfigs().get("disk2").getReplicaConfigs().containsKey("partition2"));
   }
 
   /**
@@ -144,10 +158,18 @@ public class PropertyStoreCleanUpTaskTest {
     //Replica should be present in property store for all hosts -> localhost_1, localhost_2, localhost_3
     assertTrue(dataNodeConfigSource.get(ClusterMapUtils.getInstanceName("localhost_1", PORT))
         .getDiskConfigs().get("disk1").getReplicaConfigs().containsKey("partition1"));
+    assertTrue(dataNodeConfigSource.get(ClusterMapUtils.getInstanceName("localhost_1", PORT))
+        .getDiskConfigs().get("disk2").getReplicaConfigs().containsKey("partition2"));
+
     assertTrue(dataNodeConfigSource.get(ClusterMapUtils.getInstanceName("localhost_2", PORT))
         .getDiskConfigs().get("disk1").getReplicaConfigs().containsKey("partition1"));
+    assertTrue(dataNodeConfigSource.get(ClusterMapUtils.getInstanceName("localhost_2", PORT))
+        .getDiskConfigs().get("disk2").getReplicaConfigs().containsKey("partition2"));
+
     assertTrue(dataNodeConfigSource.get(ClusterMapUtils.getInstanceName("localhost_3", PORT))
         .getDiskConfigs().get("disk1").getReplicaConfigs().containsKey("partition1"));
+    assertTrue(dataNodeConfigSource.get(ClusterMapUtils.getInstanceName("localhost_3", PORT))
+        .getDiskConfigs().get("disk2").getReplicaConfigs().containsKey("partition2"));
   }
 
   /**
@@ -180,10 +202,18 @@ public class PropertyStoreCleanUpTaskTest {
     //Replica should be present in property store for all hosts -> localhost_1, localhost_2, localhost_3
     assertTrue(dataNodeConfigSource.get(ClusterMapUtils.getInstanceName("localhost_1", PORT))
         .getDiskConfigs().get("disk1").getReplicaConfigs().containsKey("partition1"));
+    assertTrue(dataNodeConfigSource.get(ClusterMapUtils.getInstanceName("localhost_1", PORT))
+        .getDiskConfigs().get("disk2").getReplicaConfigs().containsKey("partition2"));
+
     assertTrue(dataNodeConfigSource.get(ClusterMapUtils.getInstanceName("localhost_2", PORT))
         .getDiskConfigs().get("disk1").getReplicaConfigs().containsKey("partition1"));
+    assertTrue(dataNodeConfigSource.get(ClusterMapUtils.getInstanceName("localhost_2", PORT))
+        .getDiskConfigs().get("disk2").getReplicaConfigs().containsKey("partition2"));
+
     assertTrue(dataNodeConfigSource.get(ClusterMapUtils.getInstanceName("localhost_3", PORT))
         .getDiskConfigs().get("disk1").getReplicaConfigs().containsKey("partition1"));
+    assertTrue(dataNodeConfigSource.get(ClusterMapUtils.getInstanceName("localhost_3", PORT))
+        .getDiskConfigs().get("disk2").getReplicaConfigs().containsKey("partition2"));
   }
 
   /**
@@ -210,8 +240,14 @@ public class PropertyStoreCleanUpTaskTest {
     admin.addResource(CLUSTER_NAME, "resource1", idealState);
 
     addReplicasToDisk(dataNodeConfigSource, "localhost_1", "disk1", "partition1");
+    addReplicasToDisk(dataNodeConfigSource, "localhost_1", "disk2", "partition2");
+
     addReplicasToDisk(dataNodeConfigSource, "localhost_2", "disk1", "partition1");
+    addReplicasToDisk(dataNodeConfigSource, "localhost_2", "disk2", "partition2");
+
     addReplicasToDisk(dataNodeConfigSource, "localhost_3", "disk1", "partition1");
+    addReplicasToDisk(dataNodeConfigSource, "localhost_3", "disk2", "partition2");
+
 
   }
 
@@ -239,8 +275,13 @@ public class PropertyStoreCleanUpTaskTest {
 
     // Add replicas to property store
     addReplicasToDisk(dataNodeConfigSource, "localhost_1", "disk1", "partition1");
+    addReplicasToDisk(dataNodeConfigSource, "localhost_1", "disk2", "partition2");
+
     addReplicasToDisk(dataNodeConfigSource, "localhost_2", "disk1", "partition1");
+    addReplicasToDisk(dataNodeConfigSource, "localhost_2", "disk2", "partition2");
+
     addReplicasToDisk(dataNodeConfigSource, "localhost_3", "disk1", "partition1");
+    addReplicasToDisk(dataNodeConfigSource, "localhost_3", "disk2", "partition2");
   }
 
   /**
@@ -264,12 +305,20 @@ public class PropertyStoreCleanUpTaskTest {
 
     // Add replicas to property store
     addReplicasToDisk(dataNodeConfigSource, "localhost_1", "disk1", "partition1");
+    addReplicasToDisk(dataNodeConfigSource, "localhost_1", "disk2", "partition2");
+
     addReplicasToDisk(dataNodeConfigSource, "localhost_2", "disk1", "partition1");
+    addReplicasToDisk(dataNodeConfigSource, "localhost_2", "disk2", "partition2");
+
     addReplicasToDisk(dataNodeConfigSource, "localhost_3", "disk1", "partition1");
+    addReplicasToDisk(dataNodeConfigSource, "localhost_3", "disk2", "partition2");
 
   }
 
-  private DataNodeConfig getDataNodeConfig(String host) {
+  private DataNodeConfig getDataNodeConfig(DataNodeConfigSource dataNodeConfigSource, String host) {
+    if(dataNodeConfigSource.get(ClusterMapUtils.getInstanceName(host, PORT)) != null) {
+      return dataNodeConfigSource.get(ClusterMapUtils.getInstanceName(host, PORT));
+    }
     String instanceName = ClusterMapUtils.getInstanceName(host, PORT);
     return new DataNodeConfig(instanceName, host, PORT, DC, PORT + 1, PORT + 2, "rack", ClusterMapUtils.DEFAULT_XID);
   }
@@ -283,7 +332,7 @@ public class PropertyStoreCleanUpTaskTest {
 
   private void addReplicasToDisk(DataNodeConfigSource dataNodeConfigSource, String host, String disk, String partition) {
     // Add replicas to property store
-    DataNodeConfig dataNodeConfig = getDataNodeConfig(host);
+    DataNodeConfig dataNodeConfig = getDataNodeConfig(dataNodeConfigSource, host);
     setDataNodeConfig(dataNodeConfig, disk, partition, dataNodeConfigSource);
   }
 


### PR DESCRIPTION
***Description***
There is bug in PropertyStoreCleanUpTaskTest. The configChanged variable which we are setting is not getting updated properly. It is due to wrong use of OR operator. This PR fixes this bug.

***Testing***
Added updated unit tests to ensure the added fix is tested.
Test added :- I have updated DataNodeConfig with multiple disks so that we can check configChanged is updated properly and all replicas are removed from DataNodeConfig when task is running.