### PR TITLE
Use concurrent hashmap for headers in netty request

### DIFF
--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3MultipartCompleteUploadHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3MultipartCompleteUploadHandler.java
@@ -67,11 +67,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static com.github.ambry.frontend.FrontendUtils.*;
+import static com.github.ambry.frontend.s3.S3MessagePayload.*;
 import static com.github.ambry.rest.RestUtils.*;
 import static com.github.ambry.rest.RestUtils.Headers.*;
 import static com.github.ambry.rest.RestUtils.InternalKeys.*;
 import static com.github.ambry.router.RouterErrorCode.*;
-import static com.github.ambry.frontend.s3.S3MessagePayload.*;
 
 
 /**
@@ -187,7 +187,9 @@ public class S3MultipartCompleteUploadHandler {
           } else {
             restRequest.setArg(Headers.AMBRY_CONTENT_TYPE, restRequest.getArgs().get(Headers.CONTENT_TYPE));
           }
-          restRequest.setArg(Headers.AMBRY_CONTENT_ENCODING, restRequest.getArgs().get(Headers.CONTENT_ENCODING));
+          if (restRequest.getArgs().get(CONTENT_ENCODING) != null) {
+            restRequest.setArg(Headers.AMBRY_CONTENT_ENCODING, restRequest.getArgs().get(Headers.CONTENT_ENCODING));
+          }
           // Overwrites are allowed by default for S3 uploads
           restRequest.setArg(NAMED_UPSERT, true);
           BlobInfo blobInfo = getBlobInfoFromRequest();

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3MultipartUploadPartHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3MultipartUploadPartHandler.java
@@ -20,6 +20,7 @@ import com.github.ambry.frontend.AccountAndContainerInjector;
 import com.github.ambry.frontend.FrontendMetrics;
 import com.github.ambry.frontend.IdConverter;
 import com.github.ambry.frontend.NamedBlobPath;
+import com.github.ambry.frontend.PutBlobMetaInfo;
 import com.github.ambry.frontend.SecurityService;
 import com.github.ambry.messageformat.BlobInfo;
 import com.github.ambry.messageformat.BlobProperties;
@@ -30,7 +31,6 @@ import com.github.ambry.rest.RestRequest;
 import com.github.ambry.rest.RestResponseChannel;
 import com.github.ambry.rest.RestServiceException;
 import com.github.ambry.rest.RestUtils;
-import com.github.ambry.frontend.PutBlobMetaInfo;
 import com.github.ambry.router.PutBlobOptions;
 import com.github.ambry.router.PutBlobOptionsBuilder;
 import com.github.ambry.router.ReadableStreamChannel;
@@ -100,7 +100,9 @@ public class S3MultipartUploadPartHandler {
     } else {
       restRequest.setArg(Headers.AMBRY_CONTENT_TYPE, restRequest.getArgs().get(Headers.CONTENT_TYPE));
     }
-    restRequest.setArg(Headers.AMBRY_CONTENT_ENCODING, restRequest.getArgs().get(Headers.CONTENT_ENCODING));
+    if (restRequest.getArgs().get(CONTENT_ENCODING) != null) {
+      restRequest.setArg(Headers.AMBRY_CONTENT_ENCODING, restRequest.getArgs().get(Headers.CONTENT_ENCODING));
+    }
 
     // 2. Set the internal headers session id and chunk-upload. They are used during for multipart part uploads
     String uploadId = RestUtils.getHeader(restRequest.getArgs(), UPLOAD_ID_QUERY_PARAM, true);

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3PutHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3PutHandler.java
@@ -86,7 +86,9 @@ public class S3PutHandler extends S3BaseHandler<Void> {
     } else {
       restRequest.setArg(Headers.AMBRY_CONTENT_TYPE, restRequest.getArgs().get(Headers.CONTENT_TYPE));
     }
-    restRequest.setArg(Headers.AMBRY_CONTENT_ENCODING, restRequest.getArgs().get(Headers.CONTENT_ENCODING));
+    if (restRequest.getArgs().get(CONTENT_ENCODING) != null) {
+      restRequest.setArg(Headers.AMBRY_CONTENT_ENCODING, restRequest.getArgs().get(Headers.CONTENT_ENCODING));
+    }
 
     // Overwrites are allowed by default for S3 APIs https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html
     restRequest.setArg(NAMED_UPSERT, true);

--- a/ambry-rest/src/main/java/com/github/ambry/rest/NettyRequest.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/NettyRequest.java
@@ -36,12 +36,12 @@ import java.nio.channels.ClosedChannelException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -69,7 +69,7 @@ public class NettyRequest implements RestRequest {
   protected final HttpRequest request;
   protected final Channel channel;
   protected final NettyMetrics nettyMetrics;
-  protected final Map<String, Object> allArgs = new HashMap<>();
+  protected final Map<String, Object> allArgs = new ConcurrentHashMap<>();
   protected final Queue<HttpContent> requestContents = new LinkedBlockingQueue<>();
   protected final ReentrantLock contentLock = new ReentrantLock();
 

--- a/ambry-rest/src/main/java/com/github/ambry/rest/NettyRequest.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/NettyRequest.java
@@ -180,10 +180,7 @@ public class NettyRequest implements RestRequest {
       if (!denyListedQueryParams.contains(e.getKey())) {
         StringBuilder value = null;
         if (e.getValue() != null) {
-          StringBuilder combinedValues = combineVals(new StringBuilder(), e.getValue());
-          if (combinedValues.length() > 0) {
-            value = combinedValues;
-          }
+          value = combineVals(new StringBuilder(), e.getValue());
         }
         allArgs.put(e.getKey(), value);
       } else {
@@ -202,7 +199,7 @@ public class NettyRequest implements RestRequest {
         }
       } else {
         boolean valueNull = request.headers().get(e.getKey()) == null;
-        if (!valueNull && allArgs.get(e.getKey()) == null) {
+        if (!valueNull && (allArgs.get(e.getKey()) == null || allArgs.get(e.getKey()).toString().isEmpty())) {
           sb = new StringBuilder(e.getValue());
           allArgs.put(e.getKey(), sb);
         } else if (!valueNull) {

--- a/ambry-rest/src/main/java/com/github/ambry/rest/NettyRequest.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/NettyRequest.java
@@ -36,12 +36,12 @@ import java.nio.channels.ClosedChannelException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
-import java.util.TreeMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -69,7 +69,7 @@ public class NettyRequest implements RestRequest {
   protected final HttpRequest request;
   protected final Channel channel;
   protected final NettyMetrics nettyMetrics;
-  protected final Map<String, Object> allArgs = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+  protected final Map<String, Object> allArgs = new HashMap<>();
   protected final Queue<HttpContent> requestContents = new LinkedBlockingQueue<>();
   protected final ReentrantLock contentLock = new ReentrantLock();
 

--- a/ambry-rest/src/test/java/com/github/ambry/rest/NettyRequestTest.java
+++ b/ambry-rest/src/test/java/com/github/ambry/rest/NettyRequestTest.java
@@ -15,10 +15,10 @@ package com.github.ambry.rest;
 
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.commons.ByteBufferAsyncWritableChannel;
+import com.github.ambry.commons.Callback;
 import com.github.ambry.config.NettyConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.router.AsyncWritableChannel;
-import com.github.ambry.commons.Callback;
 import com.github.ambry.router.FutureResult;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
@@ -768,7 +768,8 @@ public class NettyRequestTest {
 
     assertEquals("Number of args does not match", keyValueCount.size(), receivedArgs.size());
     for (Map.Entry<String, Integer> e : keyValueCount.entrySet()) {
-      assertEquals("Value count for key " + e.getKey() + " does not match", e.getValue().intValue(),
+      assertEquals("Value count for key " + e.getKey() + " does not match",
+          e.getValue() == 0 ? 1 : e.getValue().intValue(),
           receivedArgs.get(e.getKey()).size());
     }
 


### PR DESCRIPTION
## Summary

We are not ordering the headers and query parameters in netty request, just use HashMap, not TreeMap. And since we are now modifying the map from multiple threads due to 100-continue, we should use concurrenthashmap.

## Test
Unit test