### PR TITLE
Add support for a semantic+revision version scheme

### DIFF
--- a/ambry-account/src/integration-test/java/com/github/ambry/account/MySqlAccountServiceIntegrationTest.java
+++ b/ambry-account/src/integration-test/java/com/github/ambry/account/MySqlAccountServiceIntegrationTest.java
@@ -76,6 +76,7 @@ public class MySqlAccountServiceIntegrationTest {
   private static final String DATASET_NAME_NOT_EXIST = "testDatasetNotExist";
   private static final String DATASET_NAME_WITH_TTL = "testDatasetWithTtl";
   private static final String DATASET_NAME_WITH_SEMANTIC = "testDatasetWithSemantic";
+  private static final String DATASET_NAME_WITH_SEMANTIC_LONG = "testDatasetWithSemanticLong";
   private static final String DATASET_NAME_EXPIRED = "testDatasetExpired";
 
   public MySqlAccountServiceIntegrationTest() throws Exception {
@@ -949,8 +950,10 @@ public class MySqlAccountServiceIntegrationTest {
     verifyDatasetProperties(dataset, datasetFromMysql);
   }
 
+// region Latest Version Support Tests
+
   /**
-   * Test add and get latest version.
+   * Test add and get latest version with monotonic format.
    * @throws Exception
    */
   @Test
@@ -1009,18 +1012,28 @@ public class MySqlAccountServiceIntegrationTest {
             testContainer.getName(), DATASET_NAME, version, -1, System.currentTimeMillis(), false,
             DatasetVersionState.READY);
     assertEquals("Mismatch in dataset", expectedDatasetVersionRecord, datasetVersionRecordFromMysql);
+  }
 
+  /**
+   * Test add and get latest version with semantic versioning format.
+   * @throws Exception
+   */
+  @Test
+  public void testLatestSemanticVersionSupport() throws Exception {
+    Account testAccount = makeTestAccountWithContainer();
+    Container testContainer = new ArrayList<>(testAccount.getAllContainers()).get(0);
     // Add a dataset with semantic version
-    dataset =
+    Dataset dataset =
         new DatasetBuilder(testAccount.getName(), testContainer.getName(), DATASET_NAME_WITH_SEMANTIC).setVersionSchema(
             Dataset.VersionSchema.SEMANTIC).build();
     mySqlAccountStore.addDataset(testAccount.getId(), testContainer.getId(), dataset);
 
     // get a latest dataset version when no version exist, should fail.
-    version = "LATEST";
+    String version = "LATEST";
+    DatasetVersionRecord datasetVersionRecordFromMysql;
     try {
       mySqlAccountStore.getDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
-          testContainer.getName(), DATASET_NAME_WITH_SEMANTIC, version);
+          testContainer.getName(), DATASET_NAME, version);
       fail();
     } catch (AccountServiceException e) {
       assertEquals("Mismatch on error code", AccountServiceErrorCode.NotFound, e.getErrorCode());
@@ -1030,7 +1043,7 @@ public class MySqlAccountServiceIntegrationTest {
 
     // add a major version.
     version = "MAJOR";
-    expectedDatasetVersionRecord =
+    DatasetVersionRecord expectedDatasetVersionRecord =
         new DatasetVersionRecord(testAccount.getId(), testContainer.getId(), DATASET_NAME_WITH_SEMANTIC, "1.0.0", -1);
     datasetVersionRecordFromMysql =
         mySqlAccountStore.addDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
@@ -1121,10 +1134,151 @@ public class MySqlAccountServiceIntegrationTest {
   }
 
   /**
-   * Test add and get dataset version with different input.
+   * Test add and get latest version with semantic long versioning format.
+   * @throws Exception
    */
   @Test
-  public void testAddAndGetDatasetVersion() throws Exception {
+  public void testLatestSemanticLongVersionSupport() throws Exception {
+    Account testAccount = makeTestAccountWithContainer();
+    Container testContainer = new ArrayList<>(testAccount.getAllContainers()).get(0);
+    // Add a dataset with semantic version
+    Dataset dataset =
+        new DatasetBuilder(testAccount.getName(), testContainer.getName(), DATASET_NAME_WITH_SEMANTIC_LONG)
+            .setVersionSchema(Dataset.VersionSchema.SEMANTIC_LONG).build();
+    mySqlAccountStore.addDataset(testAccount.getId(), testContainer.getId(), dataset);
+
+    // get a latest dataset version when no version exist, should fail.
+    String version = "LATEST";
+    DatasetVersionRecord datasetVersionRecordFromMysql;
+    try {
+      mySqlAccountStore.getDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
+          testContainer.getName(), DATASET_NAME, version);
+      fail();
+    } catch (AccountServiceException e) {
+      assertEquals("Mismatch on error code", AccountServiceErrorCode.NotFound, e.getErrorCode());
+    }
+
+    // add a major version for timestamp schema, should fail.
+
+    // add a major version.
+    version = "MAJOR";
+    DatasetVersionRecord expectedDatasetVersionRecord =
+        new DatasetVersionRecord(testAccount.getId(), testContainer.getId(), DATASET_NAME_WITH_SEMANTIC_LONG, "1.0.0.0", -1);
+    datasetVersionRecordFromMysql =
+        mySqlAccountStore.addDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
+            testContainer.getName(), DATASET_NAME_WITH_SEMANTIC_LONG, version, -1, System.currentTimeMillis(), false,
+            DatasetVersionState.READY);
+    assertEquals("Mismatch in dataset", expectedDatasetVersionRecord, datasetVersionRecordFromMysql);
+    // add second major version
+    expectedDatasetVersionRecord =
+        new DatasetVersionRecord(testAccount.getId(), testContainer.getId(), DATASET_NAME_WITH_SEMANTIC_LONG, "2.0.0.0", -1);
+    datasetVersionRecordFromMysql =
+        mySqlAccountStore.addDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
+            testContainer.getName(), DATASET_NAME_WITH_SEMANTIC_LONG, version, -1, System.currentTimeMillis(), false,
+            DatasetVersionState.READY);
+    assertEquals("Mismatch in dataset", expectedDatasetVersionRecord, datasetVersionRecordFromMysql);
+
+    // add a revision version.
+    version = "REVISION";
+    expectedDatasetVersionRecord =
+        new DatasetVersionRecord(testAccount.getId(), testContainer.getId(), DATASET_NAME_WITH_SEMANTIC_LONG, "2.0.0.1", -1);
+    datasetVersionRecordFromMysql =
+        mySqlAccountStore.addDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
+            testContainer.getName(), DATASET_NAME_WITH_SEMANTIC_LONG, version, -1, System.currentTimeMillis(), false,
+            DatasetVersionState.READY);
+    assertEquals("Mismatch in dataset", expectedDatasetVersionRecord, datasetVersionRecordFromMysql);
+    // add second revision version
+    expectedDatasetVersionRecord =
+        new DatasetVersionRecord(testAccount.getId(), testContainer.getId(), DATASET_NAME_WITH_SEMANTIC_LONG, "2.0.0.2", -1);
+    datasetVersionRecordFromMysql =
+        mySqlAccountStore.addDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
+            testContainer.getName(), DATASET_NAME_WITH_SEMANTIC_LONG, version, -1, System.currentTimeMillis(), false,
+            DatasetVersionState.READY);
+    assertEquals("Mismatch in dataset", expectedDatasetVersionRecord, datasetVersionRecordFromMysql);
+
+    // add a patch version.
+    version = "PATCH";
+    expectedDatasetVersionRecord =
+        new DatasetVersionRecord(testAccount.getId(), testContainer.getId(), DATASET_NAME_WITH_SEMANTIC_LONG, "2.0.1.0", -1);
+    datasetVersionRecordFromMysql =
+        mySqlAccountStore.addDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
+            testContainer.getName(), DATASET_NAME_WITH_SEMANTIC_LONG, version, -1, System.currentTimeMillis(), false,
+            DatasetVersionState.READY);
+    assertEquals("Mismatch in dataset", expectedDatasetVersionRecord, datasetVersionRecordFromMysql);
+    // add second path version
+    expectedDatasetVersionRecord =
+        new DatasetVersionRecord(testAccount.getId(), testContainer.getId(), DATASET_NAME_WITH_SEMANTIC_LONG, "2.0.2.0", -1);
+    datasetVersionRecordFromMysql =
+        mySqlAccountStore.addDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
+            testContainer.getName(), DATASET_NAME_WITH_SEMANTIC_LONG, version, -1, System.currentTimeMillis(), false,
+            DatasetVersionState.READY);
+    assertEquals("Mismatch in dataset", expectedDatasetVersionRecord, datasetVersionRecordFromMysql);
+
+    // add a minor version.
+    version = "MINOR";
+    expectedDatasetVersionRecord =
+        new DatasetVersionRecord(testAccount.getId(), testContainer.getId(), DATASET_NAME_WITH_SEMANTIC_LONG, "2.1.0.0", -1);
+    datasetVersionRecordFromMysql =
+        mySqlAccountStore.addDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
+            testContainer.getName(), DATASET_NAME_WITH_SEMANTIC_LONG, version, -1, System.currentTimeMillis(), false,
+            DatasetVersionState.READY);
+    assertEquals("Mismatch in dataset", expectedDatasetVersionRecord, datasetVersionRecordFromMysql);
+    // add second minor version
+    expectedDatasetVersionRecord =
+        new DatasetVersionRecord(testAccount.getId(), testContainer.getId(), DATASET_NAME_WITH_SEMANTIC_LONG, "2.2.0.0", -1);
+    datasetVersionRecordFromMysql =
+        mySqlAccountStore.addDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
+            testContainer.getName(), DATASET_NAME_WITH_SEMANTIC_LONG, version, -1, System.currentTimeMillis(), false,
+            DatasetVersionState.READY);
+    assertEquals("Mismatch in dataset", expectedDatasetVersionRecord, datasetVersionRecordFromMysql);
+
+    //get the latest version.
+    version = "LATEST";
+    expectedDatasetVersionRecord =
+        new DatasetVersionRecord(testAccount.getId(), testContainer.getId(), DATASET_NAME_WITH_SEMANTIC_LONG, "2.2.0.0", -1);
+    datasetVersionRecordFromMysql =
+        mySqlAccountStore.getDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
+            testContainer.getName(), DATASET_NAME_WITH_SEMANTIC_LONG, version);
+    assertEquals("Mismatch in dataset", expectedDatasetVersionRecord, datasetVersionRecordFromMysql);
+
+    //list all dataset versions
+    Page<String> allDatasetVersions =
+        mySqlAccountStore.listAllValidDatasetVersions(testAccount.getId(), testContainer.getId(),
+            DATASET_NAME_WITH_SEMANTIC_LONG, null);
+    List<String> expectedDatasetVersions = Arrays.asList("1.0.0.0", "2.0.0.0", "2.0.0.1", "2.0.0.2", "2.0.1.0", "2.0.2.0", "2.1.0.0", "2.2.0.0");
+    assertEquals("Mismatch for dataset version list", expectedDatasetVersions, allDatasetVersions.getEntries());
+
+    //update the listDatasetVersionsMaxResult
+    mySqlConfigProps.setProperty(LIST_DATASET_VERSIONS_MAX_RESULT, "3");
+    mySqlAccountStore = spy(new MySqlAccountStoreFactory(new VerifiableProperties(mySqlConfigProps),
+        new MetricRegistry()).getMySqlAccountStore());
+    when(mockMySqlAccountStoreFactory.getMySqlAccountStore()).thenReturn(mySqlAccountStore);
+    mySqlAccountService = getAccountService();
+    Page<String> partialDatasetVersions =
+        mySqlAccountStore.listAllValidDatasetVersions(testAccount.getId(), testContainer.getId(),
+            DATASET_NAME_WITH_SEMANTIC_LONG, null);
+    expectedDatasetVersions = Arrays.asList("1.0.0.0", "2.0.0.0", "2.0.0.1");
+    assertEquals("Mismatch for datasets list", expectedDatasetVersions, partialDatasetVersions.getEntries());
+    assertEquals("Mismatch on next page token", "2.0.0.2", partialDatasetVersions.getNextPageToken());
+
+    //listing dataset version with page token provided.
+    partialDatasetVersions =
+        mySqlAccountStore.listAllValidDatasetVersions(testAccount.getId(), testContainer.getId(),
+            DATASET_NAME_WITH_SEMANTIC_LONG, "2.0.0.0");
+    expectedDatasetVersions = Arrays.asList("2.0.0.0", "2.0.0.1", "2.0.0.2");
+    assertEquals("Mismatch for datasets list", expectedDatasetVersions, partialDatasetVersions.getEntries());
+    assertEquals("Mismatch on next page token", "2.0.1.0", partialDatasetVersions.getNextPageToken());
+  }
+
+// endregion Latest Version Support Tests
+
+// region Add/Get Version Tests
+
+  /**
+   * Test add and get dataset monotonic version with different input.
+   */
+  @Test
+  public void testAddAndGetDatasetMonotonicVersion() throws Exception {
     Account testAccount = makeTestAccountWithContainer();
     Container testContainer = new ArrayList<>(testAccount.getAllContainers()).get(0);
     Map<String, String> userTags = new HashMap<>();
@@ -1208,13 +1362,57 @@ public class MySqlAccountServiceIntegrationTest {
     assertEquals("Mismatch in dataset expirationTimeMs", (long) dataset.getRetentionTimeInSeconds(),
         TimeUnit.MILLISECONDS.toSeconds(datasetVersionRecordWithTtl.getExpirationTimeMs() - creationTimeInMs));
 
+    //delete the dataset, and can't add or get any dataset version.
+    mySqlAccountStore.deleteDataset(testAccount.getId(), testContainer.getId(), DATASET_NAME);
+    version = "1";
+    try {
+      mySqlAccountStore.addDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
+          testContainer.getName(), DATASET_NAME, version, -1, System.currentTimeMillis(), false,
+          DatasetVersionState.READY);
+      fail("Should fail due to the dataset already gone");
+    } catch (AccountServiceException e) {
+      assertEquals("Unexpected error code", AccountServiceErrorCode.Deleted, e.getErrorCode());
+    }
+
+    try {
+      mySqlAccountStore.getDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
+          testContainer.getName(), DATASET_NAME, version);
+      fail("Should fail due to the dataset already gone");
+    } catch (AccountServiceException e) {
+      assertEquals("Unexpected error code", AccountServiceErrorCode.Deleted, e.getErrorCode());
+    }
+
+    List<DatasetVersionRecord> datasetVersionRecords =
+        mySqlAccountStore.getAllValidVersionForDatasetDeletion(testAccount.getId(), testContainer.getId(),
+            DATASET_NAME);
+    assertEquals("Mismatch on number of valid dataset versions", 4, datasetVersionRecords.size());
+
+    mySqlAccountStore.deleteDatasetVersion(testAccount.getId(), testContainer.getId(), DATASET_NAME, "1");
+
+    datasetVersionRecords =
+        mySqlAccountStore.getAllValidVersionForDatasetDeletion(testAccount.getId(), testContainer.getId(),
+            DATASET_NAME);
+    assertEquals("Mismatch on number of valid dataset versions", 3, datasetVersionRecords.size());
+  }
+
+  /**
+   * Test add and get dataset semantic version with different input.
+   */
+  @Test
+  public void testAddAndGetDatasetSemanticVersion() throws Exception {
+    Account testAccount = makeTestAccountWithContainer();
+    Container testContainer = new ArrayList<>(testAccount.getAllContainers()).get(0);
+    Map<String, String> userTags = new HashMap<>();
+    userTags.put("userTag", "tagValue");
+    long datasetTtl = 3600L;
+
     //Test semantic version.
-    dataset =
+    Dataset dataset =
         new DatasetBuilder(testAccount.getName(), testContainer.getName(), DATASET_NAME_WITH_SEMANTIC).setVersionSchema(
             Dataset.VersionSchema.SEMANTIC).setRetentionTimeInSeconds((long) -1).setUserTags(userTags).build();
     // Add a dataset to db
     mySqlAccountStore.addDataset(testAccount.getId(), testContainer.getId(), dataset);
-    version = "1.2.4";
+    String version = "1.2.3";
     mySqlAccountStore.addDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
         testContainer.getName(), DATASET_NAME_WITH_SEMANTIC, version, -1, System.currentTimeMillis(), false,
         DatasetVersionState.READY);
@@ -1267,11 +1465,11 @@ public class MySqlAccountServiceIntegrationTest {
     }
 
     //delete the dataset, and can't add or get any dataset version.
-    mySqlAccountStore.deleteDataset(testAccount.getId(), testContainer.getId(), DATASET_NAME);
-    version = "1";
+    mySqlAccountStore.deleteDataset(testAccount.getId(), testContainer.getId(), DATASET_NAME_WITH_SEMANTIC);
+    version = "1.2.4";
     try {
       mySqlAccountStore.addDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
-          testContainer.getName(), DATASET_NAME, version, -1, System.currentTimeMillis(), false,
+          testContainer.getName(), DATASET_NAME_WITH_SEMANTIC, version, -1, System.currentTimeMillis(), false,
           DatasetVersionState.READY);
       fail("Should fail due to the dataset already gone");
     } catch (AccountServiceException e) {
@@ -1280,7 +1478,7 @@ public class MySqlAccountServiceIntegrationTest {
 
     try {
       mySqlAccountStore.getDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
-          testContainer.getName(), DATASET_NAME, version);
+          testContainer.getName(), DATASET_NAME_WITH_SEMANTIC, version);
       fail("Should fail due to the dataset already gone");
     } catch (AccountServiceException e) {
       assertEquals("Unexpected error code", AccountServiceErrorCode.Deleted, e.getErrorCode());
@@ -1288,22 +1486,108 @@ public class MySqlAccountServiceIntegrationTest {
 
     List<DatasetVersionRecord> datasetVersionRecords =
         mySqlAccountStore.getAllValidVersionForDatasetDeletion(testAccount.getId(), testContainer.getId(),
-            DATASET_NAME);
-    assertEquals("Mismatch on number of valid dataset versions", 4, datasetVersionRecords.size());
-
-    mySqlAccountStore.deleteDatasetVersion(testAccount.getId(), testContainer.getId(), DATASET_NAME, "1");
-
-    datasetVersionRecords =
-        mySqlAccountStore.getAllValidVersionForDatasetDeletion(testAccount.getId(), testContainer.getId(),
-            DATASET_NAME);
-    assertEquals("Mismatch on number of valid dataset versions", 3, datasetVersionRecords.size());
-
-    datasetVersionRecords =
-        mySqlAccountStore.getAllValidVersionForDatasetDeletion(testAccount.getId(), testContainer.getId(),
             DATASET_NAME_WITH_SEMANTIC);
     assertEquals("Mismatch on number of valid dataset versions", 1, datasetVersionRecords.size());
-    assertEquals("Mismatch on valid dataset versions", "1.2.4", datasetVersionRecords.get(0).getVersion());
+    assertEquals("Mismatch on valid dataset versions", "1.2.3", datasetVersionRecords.get(0).getVersion());
   }
+
+  /**
+   * Test add and get dataset semantic long version with different input.
+   */
+  @Test
+  public void testAddAndGetDatasetSemanticLongVersion() throws Exception {
+    Account testAccount = makeTestAccountWithContainer();
+    Container testContainer = new ArrayList<>(testAccount.getAllContainers()).get(0);
+    Map<String, String> userTags = new HashMap<>();
+    userTags.put("userTag", "tagValue");
+    long datasetTtl = 3600L;
+
+    //Test semantic long version.
+    Dataset dataset =
+        new DatasetBuilder(testAccount.getName(), testContainer.getName(), DATASET_NAME_WITH_SEMANTIC_LONG).setVersionSchema(
+            Dataset.VersionSchema.SEMANTIC_LONG).setRetentionTimeInSeconds((long) -1).setUserTags(userTags).build();
+    // Add a dataset to db
+    mySqlAccountStore.addDataset(testAccount.getId(), testContainer.getId(), dataset);
+    String version = "1.2.3.4";
+    mySqlAccountStore.addDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
+        testContainer.getName(), DATASET_NAME_WITH_SEMANTIC_LONG, version, -1, System.currentTimeMillis(), false,
+        DatasetVersionState.READY);
+    DatasetVersionRecord datasetVersionRecordWithSemanticVersion =
+        mySqlAccountStore.getDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
+            testContainer.getName(), DATASET_NAME_WITH_SEMANTIC_LONG, version);
+    assertEquals("Mismatch in dataset version", version, datasetVersionRecordWithSemanticVersion.getVersion());
+
+    // Add dataset version for non-existing dataset.
+    try {
+      mySqlAccountStore.addDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
+          testContainer.getName(), "NonExistingDataset", version, -1, System.currentTimeMillis(), false,
+          DatasetVersionState.READY);
+      fail("Add dataset version should fail without dataset");
+    } catch (AccountServiceException e) {
+      assertEquals("Unexpected ErrorCode", AccountServiceErrorCode.NotFound, e.getErrorCode());
+    }
+
+    //add same dataset version, should fail
+    try {
+      mySqlAccountStore.addDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
+          testContainer.getName(), DATASET_NAME_WITH_SEMANTIC_LONG, version, -1, 0, false, DatasetVersionState.READY);
+      fail("Should fail due to dataset version already exist");
+    } catch (AccountServiceException e) {
+      assertEquals("Unexpected error code", AccountServiceErrorCode.ResourceConflict, e.getErrorCode());
+    }
+
+    //Delete dataset version
+    mySqlAccountStore.deleteDatasetVersion(testAccount.getId(), testContainer.getId(), DATASET_NAME_WITH_SEMANTIC_LONG,
+        version);
+
+    //add dataset version again, should succeed.
+    mySqlAccountStore.addDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
+        testContainer.getName(), DATASET_NAME_WITH_SEMANTIC_LONG, version, -1, System.currentTimeMillis(), false,
+        DatasetVersionState.READY);
+
+    //get the new added dataset version, should not fail.
+    mySqlAccountStore.getDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
+        testContainer.getName(), DATASET_NAME_WITH_SEMANTIC_LONG, version);
+
+    // Add dataset version which didn't follow the semantic long format.
+    version = "1.2.3";
+    try {
+      mySqlAccountStore.addDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
+          testContainer.getName(), DATASET_NAME_WITH_SEMANTIC_LONG, version, -1, System.currentTimeMillis(), false,
+          DatasetVersionState.READY);
+      fail("Add dataset version should fail with wrong format of semantic version");
+    } catch (IllegalArgumentException e) {
+      // do nothing
+    }
+
+    //delete the dataset, and can't add or get any dataset version.
+    mySqlAccountStore.deleteDataset(testAccount.getId(), testContainer.getId(), DATASET_NAME_WITH_SEMANTIC_LONG);
+    version = "1.2.3.5";
+    try {
+      mySqlAccountStore.addDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
+          testContainer.getName(), DATASET_NAME_WITH_SEMANTIC_LONG, version, -1, System.currentTimeMillis(), false,
+          DatasetVersionState.READY);
+      fail("Should fail due to the dataset already gone");
+    } catch (AccountServiceException e) {
+      assertEquals("Unexpected error code", AccountServiceErrorCode.Deleted, e.getErrorCode());
+    }
+
+    try {
+      mySqlAccountStore.getDatasetVersion(testAccount.getId(), testContainer.getId(), testAccount.getName(),
+          testContainer.getName(), DATASET_NAME_WITH_SEMANTIC_LONG, version);
+      fail("Should fail due to the dataset already gone");
+    } catch (AccountServiceException e) {
+      assertEquals("Unexpected error code", AccountServiceErrorCode.Deleted, e.getErrorCode());
+    }
+
+    List<DatasetVersionRecord> datasetVersionRecords =
+        mySqlAccountStore.getAllValidVersionForDatasetDeletion(testAccount.getId(), testContainer.getId(),
+            DATASET_NAME_WITH_SEMANTIC_LONG);
+    assertEquals("Mismatch on number of valid dataset versions", 1, datasetVersionRecords.size());
+    assertEquals("Mismatch on valid dataset versions", "1.2.3.4", datasetVersionRecords.get(0).getVersion());
+  }
+
+// endregion Add/Get Version Tests
 
   @Test
   public void testUpdateTtlForDatasetVersions() throws Exception {

--- a/ambry-account/src/main/java/com/github/ambry/account/mysql/DatasetDao.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/mysql/DatasetDao.java
@@ -312,7 +312,7 @@ public class DatasetDao {
     DatasetVersionRecord datasetVersionRecord;
     try {
       dataset = getDatasetHelper(accountId, containerId, accountName, containerName, datasetName, true);
-      if (isAutoCreatedVersionForUpload(version, dataset.getVersionSchema())) {
+      if (isAutoCreatedVersionForUpload(version)) {
         datasetVersionRecord =
             retryWithLatestAutoIncrementedVersion(accountId, containerId, dataset, version, timeToLiveInSeconds,
                 creationTimeInMs, datasetVersionTtlEnabled, datasetVersionState);
@@ -1067,15 +1067,14 @@ public class DatasetDao {
 
   /**
    * @param version the version string.
-   * @param versionSchema the {@link com.github.ambry.account.Dataset.VersionSchema} from dataset level.
    * @return {@code} true if the version is auto created version for upload.
    */
-  private boolean isAutoCreatedVersionForUpload(String version, Dataset.VersionSchema versionSchema) {
-    boolean isAutoCreated = LATEST.equals(version)
+  private boolean isAutoCreatedVersionForUpload(String version) {
+    return LATEST.equals(version)
         || MAJOR.equals(version)
         || MINOR.equals(version)
-        || PATCH.equals(version);
-    return versionSchema == Dataset.VersionSchema.SEMANTIC_LONG ? isAutoCreated || REVISION.equals(version) : isAutoCreated;
+        || PATCH.equals(version)
+        || REVISION.equals(version);
   }
 
   /**

--- a/ambry-api/src/main/java/com/github/ambry/account/Dataset.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/Dataset.java
@@ -116,7 +116,7 @@ public class Dataset {
   }
 
   public enum VersionSchema {
-    TIMESTAMP, MONOTONIC, SEMANTIC
+    TIMESTAMP, MONOTONIC, SEMANTIC, SEMANTIC_LONG
   }
 
   /**


### PR DESCRIPTION
## Summary

Add support in `DatasetDao` for a dataset version scheme that includes a semantic version and a revision number. In other words, a user-facing version that looks like 1.2.3.4. 

## Details

The code follows similar structure to that of the existing semantic version type, except the major/minor/patch version parts are all shifted left by an additional 3 digits, i.e. multiplied by 1000. This makes room for a revision number.

We are storing and using long values, so there is not a risk for integer overflow.

## Testing Done

I added integration tests specifically for the new version type, mapping closely to the tests that we perform for the traditional semantic type. Please inform if there are other tests we need to run.