### PR TITLE
Add account level metrics for container metrics

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/FrontendConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/FrontendConfig.java
@@ -41,6 +41,7 @@ public class FrontendConfig {
   public static final String ENABLE_UNDELETE = PREFIX + "enable.undelete";
   public static final String NAMED_BLOB_DB_FACTORY = PREFIX + "named.blob.db.factory";
   public static final String CONTAINER_METRICS_EXCLUDED_ACCOUNTS = PREFIX + "container.metrics.excluded.accounts";
+  public static final String CONTAINER_METRICS_AGGREGATED_ACCOUNTS = PREFIX + "container.metrics.aggregated.accounts";
   public static final String ACCOUNT_STATS_STORE_FACTORY = PREFIX + "account.stats.store.factory";
   public static final String CONTAINER_METRICS_ENABLED_REQUEST_TYPES = PREFIX + "container.metrics.enabled.request.types";
   public static final String CONTAINER_METRICS_ENABLED_GET_REQUEST_TYPES = PREFIX + "container.metrics.enabled.get.request.types";
@@ -280,6 +281,15 @@ public class FrontendConfig {
   public final List<String> containerMetricsExcludedAccounts;
 
   /**
+   * The comma separated list of account names for which container metrics should be aggregated. If account A is in the
+   * list, then an account metrics would be created for each container metrics under this account. And all the container
+   * metrics would be aggregated to this account metrics.
+   */
+  @Config(CONTAINER_METRICS_AGGREGATED_ACCOUNTS)
+  @Default("")
+  public final List<String> containerMetricsAggregatedAccounts;
+
+  /**
    * This should be controlled by {@link NettyConfig}.nettyEnableOneHundredContinue
    */
   public final boolean oneHundredContinueEnable;
@@ -345,6 +355,8 @@ public class FrontendConfig {
     namedBlobDbFactory = verifiableProperties.getString(NAMED_BLOB_DB_FACTORY, null);
     containerMetricsExcludedAccounts =
         Utils.splitString(verifiableProperties.getString(CONTAINER_METRICS_EXCLUDED_ACCOUNTS, ""), ",");
+    containerMetricsAggregatedAccounts =
+        Utils.splitString(verifiableProperties.getString(CONTAINER_METRICS_AGGREGATED_ACCOUNTS, ""), ",");
   }
 
   /**

--- a/ambry-api/src/main/java/com/github/ambry/frontend/AccountMetrics.java
+++ b/ambry-api/src/main/java/com/github/ambry/frontend/AccountMetrics.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2024 LinkedIn Corp. All rights reserved.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package com.github.ambry.frontend;
+
+import com.codahale.metrics.MetricRegistry;
+
+
+/**
+ * Metrics for an operation on a specific account.
+ */
+public class AccountMetrics extends EntityOperationMetrics {
+
+  /**
+   * Metric names will be in the following format:
+   * {@code com.github.ambry.frontend.AccountMetrics.{accountName}___{operationType}{metric}} For example:
+   * {@code com.github.ambry.frontend.ContainerMetrics.account-a___GetBlobSuccessCount}
+   *
+   * @param accountName    the account name to use for naming metrics.
+   * @param operationType  the operation type to use for naming metrics.
+   * @param metricRegistry the {@link MetricRegistry}.
+   * @param isGetRequest   the request operationType is get.
+   */
+  AccountMetrics(String accountName, String operationType, MetricRegistry metricRegistry, boolean isGetRequest) {
+    super(accountName, AccountMetrics.class, operationType, metricRegistry, isGetRequest);
+  }
+}

--- a/ambry-api/src/main/java/com/github/ambry/frontend/AccountMetrics.java
+++ b/ambry-api/src/main/java/com/github/ambry/frontend/AccountMetrics.java
@@ -23,7 +23,7 @@ public class AccountMetrics extends EntityOperationMetrics {
   /**
    * Metric names will be in the following format:
    * {@code com.github.ambry.frontend.AccountMetrics.{accountName}___{operationType}{metric}} For example:
-   * {@code com.github.ambry.frontend.ContainerMetrics.account-a___GetBlobSuccessCount}
+   * {@code com.github.ambry.frontend.AccountMetrics.account-a___GetBlobSuccessCount}
    *
    * @param accountName    the account name to use for naming metrics.
    * @param operationType  the operation type to use for naming metrics.

--- a/ambry-api/src/main/java/com/github/ambry/frontend/EntityOperationMetrics.java
+++ b/ambry-api/src/main/java/com/github/ambry/frontend/EntityOperationMetrics.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright 2024 LinkedIn Corp. All rights reserved.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package com.github.ambry.frontend;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.rest.ResponseStatus;
+
+
+/**
+ * Metrics for an operation on a specific entity.
+ */
+public class EntityOperationMetrics {
+  public static final String SEPARATOR = "___";
+
+  protected final Histogram roundTripTimeInMs;
+
+  // counts by status code type
+  // 2xx
+  protected final Counter successCount;
+  // 3xx
+  protected final Counter redirectionCount;
+  // 4xx
+  protected final Counter clientErrorCount;
+  // 5xx
+  protected final Counter serverErrorCount;
+
+  // counts for individual status codes
+  // 400
+  protected final Counter badRequestCount;
+  // 401
+  protected final Counter unauthorizedCount;
+  // 403
+  protected final Counter forbiddenCount;
+  // 404
+  protected final Counter notFoundCount;
+  // 410
+  protected final Counter goneCount;
+
+  protected final Counter totalCount;
+
+  /**
+   * Constructor to create operation metrics for given entity. The entity can be an account or a container.
+   *
+   * @param entityName     the name of the given entity.
+   * @param ownerClass     the owner class of the given entity.
+   * @param operationType  the operation type to use for naming metrics.
+   * @param metricRegistry the {@link MetricRegistry}.
+   * @param isGetRequest   the request operationType is get.
+   */
+  EntityOperationMetrics(String entityName, Class<?> ownerClass, String operationType, MetricRegistry metricRegistry,
+      boolean isGetRequest) {
+    String metricPrefix = entityName + SEPARATOR + operationType;
+    if (ownerClass == null) {
+      ownerClass = EntityOperationMetrics.class;
+    }
+    roundTripTimeInMs = metricRegistry.histogram(MetricRegistry.name(ownerClass, metricPrefix + "RoundTripTimeInMs"));
+    // counts by status code type
+    successCount = metricRegistry.counter(MetricRegistry.name(ownerClass, metricPrefix + "SuccessCount"));
+    redirectionCount = metricRegistry.counter(MetricRegistry.name(ownerClass, metricPrefix + "RedirectionCount"));
+    clientErrorCount = metricRegistry.counter(MetricRegistry.name(ownerClass, metricPrefix + "ClientErrorCount"));
+    serverErrorCount = metricRegistry.counter(MetricRegistry.name(ownerClass, metricPrefix + "ServerErrorCount"));
+    // counts for individual status codes
+    badRequestCount = metricRegistry.counter(MetricRegistry.name(ownerClass, metricPrefix + "BadRequestCount"));
+    unauthorizedCount = metricRegistry.counter(MetricRegistry.name(ownerClass, metricPrefix + "UnauthorizedCount"));
+    forbiddenCount = metricRegistry.counter(MetricRegistry.name(ownerClass, metricPrefix + "ForbiddenCount"));
+    notFoundCount = metricRegistry.counter(MetricRegistry.name(ownerClass, metricPrefix + "NotFoundCount"));
+    goneCount = metricRegistry.counter(MetricRegistry.name(ownerClass, metricPrefix + "GoneCount"));
+    String qpsMetricPrefix = entityName + SEPARATOR + (isGetRequest ? "GetRequest" : "PutRequest");
+    totalCount = metricRegistry.counter(MetricRegistry.name(ownerClass, qpsMetricPrefix + "totalCount"));
+  }
+
+  /**
+   * Emit metrics for an operation on this entity.
+   *
+   * @param roundTripTimeInMs the time it took to receive a request and send a response.
+   * @param responseStatus    the {@link ResponseStatus} sent in the response.
+   */
+  public void recordMetrics(long roundTripTimeInMs, ResponseStatus responseStatus) {
+    this.roundTripTimeInMs.update(roundTripTimeInMs);
+    totalCount.inc();
+    if (responseStatus.isSuccess()) {
+      successCount.inc();
+    } else if (responseStatus.isRedirection()) {
+      redirectionCount.inc();
+    } else if (responseStatus.isClientError()) {
+      clientErrorCount.inc();
+      switch (responseStatus) {
+        case BadRequest:
+          badRequestCount.inc();
+          break;
+        case Unauthorized:
+          unauthorizedCount.inc();
+          break;
+        case Forbidden:
+          forbiddenCount.inc();
+          break;
+        case NotFound:
+          notFoundCount.inc();
+          break;
+        case Gone:
+          goneCount.inc();
+          break;
+      }
+    } else if (responseStatus.isServerError()) {
+      serverErrorCount.inc();
+    }
+  }
+}

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/AccountAndContainerInjector.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/AccountAndContainerInjector.java
@@ -31,7 +31,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -413,9 +412,11 @@ public class AccountAndContainerInjector {
         restRequest);
     if (metricsGroup != null) {
       if (!frontendConfig.containerMetricsExcludedAccounts.contains(targetAccount.getName())) {
+        boolean shouldIncludeAccountMetrics =
+            frontendConfig.containerMetricsAggregatedAccounts.contains(targetAccount.getName());
         restRequest.getMetricsTracker()
-            .injectContainerMetrics(
-                metricsGroup.getContainerMetrics(targetAccount.getName(), targetContainer.getName()));
+            .injectContainerMetrics(metricsGroup.getContainerMetrics(targetAccount.getName(), targetContainer.getName(),
+                shouldIncludeAccountMetrics));
       }
     }
   }


### PR DESCRIPTION
## Summary
Add account level metric to aggregate its containers' metrics.

## Details
Some accounts have lots of containers and it's very hard those those accounts to aggregate all the metrics for 40x, 50x and latency etc. This PR adds an **AccountMetrics** class and have its **ContainerMetrics** to record metrics for **AccountMetrics**.

This PR also adds a configuration to only enable some accounts to have this **AccountMetrics** as most accounts have very small set of containers that they just don't need extra metrics.

## Test
Unit test