### PR TITLE
Reorder disks if mounts have been shuffled

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/clustermap/ClusterParticipant.java
+++ b/ambry-api/src/main/java/com/github/ambry/clustermap/ClusterParticipant.java
@@ -207,4 +207,15 @@ public interface ClusterParticipant extends AutoCloseable {
   default boolean setDisksState(List<DiskId> diskId, HardwareState state) {
     return true;
   }
+
+  /**
+   * Given a map of old disks and new disks, swaps the old disks with the new disks in the DataNodeConfig,
+   * and persists the resulting changes to Helix.
+   * @param newDiskMapping A map of old disks to new disks.
+   * @return {@code true} if the disks order was successfully updated, {@code false} otherwise.
+   */
+  default boolean setDisksOrder(Map<DiskId, DiskId> newDiskMapping) {
+    // The default should be to do nothing about disk order, so return false.
+    return false;
+  }
 }

--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -674,6 +674,14 @@ public class StoreConfig {
   public final boolean storeBlockStaleBlobStoreToStart;
   public final static String storeBlockStaleBlobStoreToStartName = "store.block.stale.blob.store.to.start";
 
+  /**
+   * Whether to attempt reshuffling of reordered disks and subsequent process termination.
+   */
+  @Config("store.reshuffle.disks.on.reorder")
+  @Default("false")
+  public final boolean storeReshuffleDisksOnReorder;
+  public final static String storeReshuffleDisksOnReorderName = "store.reshuffle.disks.on.reorder";
+
   public StoreConfig(VerifiableProperties verifiableProperties) {
     storeKeyFactory = verifiableProperties.getString("store.key.factory", "com.github.ambry.commons.BlobIdFactory");
     storeDataFlushIntervalSeconds = verifiableProperties.getLong("store.data.flush.interval.seconds", 60);
@@ -852,5 +860,6 @@ public class StoreConfig {
         verifiableProperties.getIntInRange(storeProactiveTestDelayInSecondsName, 60, 0, Integer.MAX_VALUE);
     storeStaleTimeInDays = verifiableProperties.getIntInRange(storeStaleTimeInDaysName, 7, 0, Integer.MAX_VALUE);
     storeBlockStaleBlobStoreToStart = verifiableProperties.getBoolean(storeBlockStaleBlobStoreToStartName, false);
+    storeReshuffleDisksOnReorder = verifiableProperties.getBoolean(storeReshuffleDisksOnReorderName, false);
   }
 }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
@@ -467,7 +467,7 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
 
         // Swap the disks in the DataNodeConfig
         logger.info("Replacing disk {} with disk {}", oldDisk.getMountPath(), newDisk.getMountPath());
-        dataNodeConfig.getDiskConfigs().put(oldDisk.getMountPath(), dataNodeConfig.getDiskConfigs().get(newDisk));
+        dataNodeConfig.getDiskConfigs().put(oldDisk.getMountPath(), dataNodeConfig.getDiskConfigs().get(newDisk.getMountPath()));
       }
 
       if (!dataNodeConfigSource.set(dataNodeConfig)) {

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
@@ -452,7 +452,7 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
       DataNodeConfig dataNodeConfig = getDataNodeConfig();
 
       // Make a copy of the disk configs to avoid accidentally overwriting state.
-      Map<String, DataNodeConfig.DiskConfig> originalDiskConfigs = dataNodeConfig.getDiskConfigs();
+      Map<String, DataNodeConfig.DiskConfig> originalDiskConfigs = new HashMap<> (dataNodeConfig.getDiskConfigs());
       for (DiskId oldDisk : newDiskMapping.keySet()) {
         DiskId newDisk = newDiskMapping.get(oldDisk);
 

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
@@ -451,10 +451,8 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
     synchronized (helixAdministrationLock) {
       DataNodeConfig dataNodeConfig = getDataNodeConfig();
 
-      // Tommy: we have to have a copy of the old original disk mappings here for swapping to work!
+      // Make a copy of the disk configs to avoid accidentally overwriting state.
       Map<String, DataNodeConfig.DiskConfig> originalDiskConfigs = dataNodeConfig.getDiskConfigs();
-
-      boolean success = true;
       for (DiskId oldDisk : newDiskMapping.keySet()) {
         DiskId newDisk = newDiskMapping.get(oldDisk);
 
@@ -462,14 +460,15 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
         DataNodeConfig.DiskConfig oldDiskConfig = originalDiskConfigs.get(oldDisk.getMountPath());
         DataNodeConfig.DiskConfig newDiskConfig = originalDiskConfigs.get(newDisk.getMountPath());
         if (oldDiskConfig == null || newDiskConfig == null) {
-          throw new IllegalArgumentException("Disk " + oldDisk.getMountPath() + " or " + newDisk.getMountPath() + " can't be found in Helix (DataNodeConfig)");
+          throw new IllegalArgumentException("Disk " + oldDisk.getMountPath() + " or " + newDisk.getMountPath() + " cannot be found in Helix (DataNodeConfig)");
         }
 
         // Swap the disks in the DataNodeConfig
         logger.info("Replacing disk {} with disk {}", oldDisk.getMountPath(), newDisk.getMountPath());
-        dataNodeConfig.getDiskConfigs().put(oldDisk.getMountPath(), dataNodeConfig.getDiskConfigs().get(newDisk.getMountPath()));
+        dataNodeConfig.getDiskConfigs().put(oldDisk.getMountPath(), originalDiskConfigs.get(newDisk.getMountPath()));
       }
 
+      // Save the updated DataNodeConfig to Helix.
       if (!dataNodeConfigSource.set(dataNodeConfig)) {
         logger.error("Setting disks order failed DataNodeConfig update");
         return false;

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixParticipantTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixParticipantTest.java
@@ -763,6 +763,41 @@ public class HelixParticipantTest {
   }
 
   /**
+   * Test setting disk order in property store.
+   * @throws Exception
+   */
+  @Test
+  public void testSetDisksOrder() throws Exception {
+    assumeTrue(dataNodeConfigSourceType == DataNodeConfigSourceType.PROPERTY_STORE);
+    ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
+    HelixParticipant helixParticipant =
+        new HelixParticipant(mock(HelixClusterManager.class), clusterMapConfig, new HelixFactory(),
+            new MetricRegistry(), getDefaultZkConnectStr(clusterMapConfig), true);
+
+    // First test some basic failure cases.
+    try {
+      helixParticipant.setDisksOrder(null);
+      fail("null input map should fail");
+    } catch (Exception e) {
+    }
+    try {
+      helixParticipant.setDisksOrder(Collections.emptyMap());
+      fail("Empty input map should fail");
+    } catch (Exception e) {
+    }
+
+    DiskId oldDisk = mock(DiskId.class);
+    DiskId newDisk = mock(DiskId.class);
+    when(oldDisk.getMountPath()).thenReturn("/mnt0");
+    when(newDisk.getMountPath()).thenReturn("/mnt1");
+    Map<DiskId, DiskId> newDiskMapping = new HashMap<>();
+    newDiskMapping.put(oldDisk, newDisk);
+    newDiskMapping.put(newDisk, oldDisk);
+
+    assertTrue(helixParticipant.setDisksOrder(newDiskMapping));
+  }
+
+  /**
    * Test participate method, which triggers state transition.
    * @throws Exception
    */

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixParticipantTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixParticipantTest.java
@@ -770,9 +770,12 @@ public class HelixParticipantTest {
   public void testSetDisksOrder() throws Exception {
     assumeTrue(dataNodeConfigSourceType == DataNodeConfigSourceType.PROPERTY_STORE);
     ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
+    String instanceName = ClusterMapUtils.getInstanceName("localhost", clusterMapConfig.clusterMapPort);
     HelixParticipant helixParticipant =
         new HelixParticipant(mock(HelixClusterManager.class), clusterMapConfig, new HelixFactory(),
             new MetricRegistry(), getDefaultZkConnectStr(clusterMapConfig), true);
+    HelixAdmin helixAdmin = helixParticipant.getHelixAdmin();
+    DataNodeConfig dataNodeConfig = getDataNodeConfigInHelix(helixAdmin, instanceName);
 
     // First test some basic failure cases.
     try {
@@ -794,7 +797,22 @@ public class HelixParticipantTest {
     newDiskMapping.put(oldDisk, newDisk);
     newDiskMapping.put(newDisk, oldDisk);
 
+    // Get a copy of Helix' disk configs before attempting to update.
+    Map<String, DataNodeConfig.DiskConfig> initialDiskConfigs = dataNodeConfig.getDiskConfigs();
+    Set<String> initialReplicasMount0 = initialDiskConfigs.get("/mnt0").getReplicaConfigs().keySet();
+    Set<String> initialReplicasMount1 = initialDiskConfigs.get("/mnt1").getReplicaConfigs().keySet();
+
+    // Update the disk order in Helix
     assertTrue(helixParticipant.setDisksOrder(newDiskMapping));
+    Thread.sleep(50);
+
+    // Now read the new disk order back from Helix and verify that the desired swap has been persisted.
+    DataNodeConfig updatedDataNodeConfig = getDataNodeConfigInHelix(helixAdmin, instanceName);
+    Map<String, DataNodeConfig.DiskConfig> updatedDiskConfigs = updatedDataNodeConfig.getDiskConfigs();
+    Set<String> updatedReplicasMount0 = updatedDiskConfigs.get("/mnt0").getReplicaConfigs().keySet();
+    Set<String> updatedReplicasMount1 = updatedDiskConfigs.get("/mnt1").getReplicaConfigs().keySet();
+    assertTrue(initialReplicasMount0.equals(updatedReplicasMount1));
+    assertTrue(initialReplicasMount1.equals(updatedReplicasMount0));
   }
 
   /**

--- a/ambry-store/src/main/java/com/github/ambry/store/PartitionFinder.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/PartitionFinder.java
@@ -1,0 +1,55 @@
+package com.github.ambry.store;
+
+import com.github.ambry.clustermap.DiskId;
+import java.io.File;
+import java.util.HashSet;
+import java.util.Set;
+
+
+public class PartitionFinder {
+  /**
+   * Find all the partition directories on the disk.
+   * @param disk an instance of DiskId to search for partition directories.
+   * @return A {@code Set} of partition directories on the disk. The set will be empty if no partition
+   *        directories are found, or if something goes wrong (e.g. mount path does not exist).
+   */
+  public Set<String> findPartitionsOnDisk(DiskId disk) {
+    Set<String> partitionDirs = new HashSet<>();
+    File mount = new File(disk.getMountPath());
+
+    if(mount.exists() && mount.isDirectory())
+    {
+      File[] ambryDirs = mount.listFiles(File::isDirectory);
+      if(ambryDirs != null)
+      {
+        for(File dir : ambryDirs)
+        {
+          // Tommy: If we store just the leaf name from File.getName() will that work
+          //        when comparing with the directory names we get from ReplicaId??
+          //        AmbryPartition::toPathString() returns the partition ID as a string.
+          String dirName = dir.getName();
+          if(looksLikePartition(dirName))
+          {
+            partitionDirs.add(dirName);
+          }
+        }
+      }
+    }
+    return partitionDirs;
+  }
+
+  /**
+   * Checks whether a directory name looks like a partition.
+   * @param directoryName the name of the directory to check.
+   * @return True if the directory name looks like a partition, false otherwise.
+   */
+  private boolean looksLikePartition(String directoryName) {
+    try {
+      // The convention is simply to use Java long as partition IDs.
+      Long.parseLong(directoryName);
+    } catch (NumberFormatException e) {
+      return false;
+    }
+    return true;
+  }
+}

--- a/ambry-store/src/main/java/com/github/ambry/store/ReplicaPlacementValidator.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/ReplicaPlacementValidator.java
@@ -93,7 +93,7 @@ public class ReplicaPlacementValidator {
       Set<String> partitions = entry.getValue();
       boolean found = true;
       for (ReplicaId replica : expectedReplicas) {
-        String partitionID = replica.getPartitionId().toString();
+        String partitionID = replica.getPartitionId().toPathString();
         if(!partitions.contains(partitionID)) {
           found = false;
           break;

--- a/ambry-store/src/main/java/com/github/ambry/store/ReplicaPlacementValidator.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/ReplicaPlacementValidator.java
@@ -1,0 +1,146 @@
+/**
+ * Copyright 2024 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.store;
+
+import com.github.ambry.clustermap.DiskId;
+import com.github.ambry.clustermap.ReplicaId;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+
+/**
+ * Loop through all the host's disks and check if the replicas are placed correctly
+ * (as compared with the latest Helix state). Sometimes, disks can get re-mounted in the wrong
+ * order. This class checks for such cases and reshuffles the replicas if necessary, creating
+ * a map of the broken disks and the disks they should be reshuffled to.
+ */
+public class ReplicaPlacementValidator {
+  private final Map<DiskId, Set<String>> foundDiskToPartitionMap;
+  private Map<DiskId, List<ReplicaId>> expectedDiskToReplicaMap;
+  private Map<DiskId, List<ReplicaId>> newDiskToReplicaMap;
+  private List<DiskId> brokenDisks = new ArrayList<>();
+  public ReplicaPlacementValidator(Map<DiskId, List<ReplicaId>> expectedDiskToReplicaMap) {
+    foundDiskToPartitionMap = new HashMap<>();
+    newDiskToReplicaMap = new HashMap<>();
+    this.expectedDiskToReplicaMap = expectedDiskToReplicaMap;
+
+    for (Map.Entry<DiskId, List<ReplicaId>> entry : expectedDiskToReplicaMap.entrySet()) {
+      DiskId currentDisk = entry.getKey();
+      foundDiskToPartitionMap.put(currentDisk, findPartitionsOnDisk(currentDisk));
+      List<ReplicaId> replicas = entry.getValue();
+      for (ReplicaId replica : replicas) {
+        String partitionID = replica.getPartitionId().toString();
+        if(!foundDiskToPartitionMap.get(currentDisk).contains(partitionID)) {
+          brokenDisks.add(currentDisk);
+        }
+      }
+    }
+  }
+
+  /**
+   * Check the placement of replicas on the disks and reshuffle them if necessary.
+   * @return A map of the broken disks and the disks they should be reshuffled to.
+   *         An empty map if no reshuffling is necessary or if the reshuffling failed.
+   */
+  public Map<DiskId, DiskId> reshuffleDisks() {
+    Map<DiskId, DiskId> shuffledDisks = new HashMap<>();
+
+    // Sanity checks: - Abort if we did not find the same number of disks on the
+    //                  host as we got from Helix.
+    //                - Abort if we did not find any broken disks.
+    if ((expectedDiskToReplicaMap.size() != foundDiskToPartitionMap.size()) ||
+        brokenDisks.size() == 0) {
+      return Collections.emptyMap();
+    }
+
+    for (DiskId currentDisk : brokenDisks) {
+      List<ReplicaId> expectedReplicas = expectedDiskToReplicaMap.get(currentDisk);
+      DiskId foundDisk = findDiskWithReplicas(expectedReplicas);
+      if(foundDisk == null) {
+        return Collections.emptyMap();
+      } else {
+        shuffledDisks.put(currentDisk, foundDisk);
+      }
+    }
+    return shuffledDisks;
+  }
+
+  /**
+   * Find the disk that contains the expected replicas.
+   * @param expectedReplicas A list of replicas that should be on the disk.
+   * @return The disk that contains the expected replicas, or null if no such disk was found.
+   */
+  private DiskId findDiskWithReplicas(List<ReplicaId> expectedReplicas) {
+    for (Map.Entry<DiskId, Set<String>> entry : foundDiskToPartitionMap.entrySet()) {
+      DiskId currentDisk = entry.getKey();
+      Set<String> partitions = entry.getValue();
+      boolean found = true;
+      for (ReplicaId replica : expectedReplicas) {
+        String partitionID = replica.getPartitionId().toString();
+        if(!partitions.contains(partitionID)) {
+          found = false;
+          break;
+        }
+      }
+      if(found) {
+        return currentDisk;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Checks whether a directory name looks like a partition.
+   * @param directoryName the name of the directory to check.
+   * @return True if the directory name looks like a partition, false otherwise.
+   */
+  private boolean looksLikePartition(String directoryName) {
+    try {
+      // The convention is simply to use Java long as partition IDs.
+      Long.parseLong(directoryName);
+    } catch (NumberFormatException e) {
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Find all the partition directories on the disk.
+   * @param disk an instance of DiskId to search for partition directories.
+   * @return A list of partition directories on the disk.
+   */
+  private Set<String> findPartitionsOnDisk(DiskId disk) {
+    Set<String> partitionDirs = new HashSet<>();
+    File[] directories = new File(disk.getMountPath()).listFiles(File::isDirectory);
+
+    if (directories != null) {
+      for (File dir : directories) {
+        // Tommy: If we store just the leaf name from File.getName() will that work
+        //        when comparing with the directory names we get from ReplicaId??
+        //        AmbryPartition::toPathString() returns the partition ID as a string.
+        String dirName = dir.getName();
+        if (looksLikePartition(dirName)) {
+          partitionDirs.add(dirName);
+        }
+      }
+    }
+    return partitionDirs;
+  }
+}

--- a/ambry-store/src/main/java/com/github/ambry/store/ReplicaPlacementValidator.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/ReplicaPlacementValidator.java
@@ -124,20 +124,28 @@ public class ReplicaPlacementValidator {
   /**
    * Find all the partition directories on the disk.
    * @param disk an instance of DiskId to search for partition directories.
-   * @return A list of partition directories on the disk.
+   * @return A {@code Set} of partition directories on the disk. The set will be empty if no partition
+   *        directories are found, or if something goes wrong (e.g. mount path does not exist).
    */
   private Set<String> findPartitionsOnDisk(DiskId disk) {
     Set<String> partitionDirs = new HashSet<>();
-    File[] directories = new File(disk.getMountPath()).listFiles(File::isDirectory);
+    File mount = new File(disk.getMountPath());
 
-    if (directories != null) {
-      for (File dir : directories) {
-        // Tommy: If we store just the leaf name from File.getName() will that work
-        //        when comparing with the directory names we get from ReplicaId??
-        //        AmbryPartition::toPathString() returns the partition ID as a string.
-        String dirName = dir.getName();
-        if (looksLikePartition(dirName)) {
-          partitionDirs.add(dirName);
+    if(mount.exists() && mount.isDirectory())
+    {
+      File[] ambryDirs = mount.listFiles(File::isDirectory);
+      if(ambryDirs != null)
+      {
+        for(File dir : ambryDirs)
+        {
+          // Tommy: If we store just the leaf name from File.getName() will that work
+          //        when comparing with the directory names we get from ReplicaId??
+          //        AmbryPartition::toPathString() returns the partition ID as a string.
+          String dirName = dir.getName();
+          if(looksLikePartition(dirName))
+          {
+            partitionDirs.add(dirName);
+          }
         }
       }
     }

--- a/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
@@ -175,6 +175,7 @@ public class StorageManager implements StoreManager {
    */
   // Tommy: Make this protected so we can test it in StorageManagerTest?!?!!?!!?
   protected void reshuffleDisksAndMaybeExit(Map<DiskId, List<ReplicaId>> diskToReplicas) {
+    //System.exit(0);
     PartitionFinder partitionFinder = new PartitionFinder();
     Map<DiskId, Set<String>> disksToPartitions = new HashMap<>();
     for (DiskId currentDisk : diskToReplicas.keySet()) {

--- a/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
@@ -150,7 +150,13 @@ public class StorageManager implements StoreManager {
 
     // Assume it's safe to place the new code here, AFTER partitionNameToReplicaId is populated.
     if (storeConfig.storeReshuffleDisksOnReorder) {
-      ReplicaPlacementValidator placementValidator = new ReplicaPlacementValidator(diskToReplicaMap);
+      PartitionFinder partitionFinder = new PartitionFinder();
+      Map<DiskId, Set<String>> disksToPartitions = new HashMap<>();
+      for (DiskId currentDisk : diskToReplicaMap.keySet()) {
+        disksToPartitions.put(currentDisk, partitionFinder.findPartitionsOnDisk(currentDisk));
+      }
+
+      ReplicaPlacementValidator placementValidator = new ReplicaPlacementValidator(diskToReplicaMap, disksToPartitions);
       Map<DiskId, DiskId> disksToReshuffle = placementValidator.reshuffleDisks();
       if (!disksToReshuffle.isEmpty()) {
         logger.info("Disks need to be reshuffled: {}", disksToReshuffle);

--- a/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
@@ -147,6 +147,23 @@ public class StorageManager implements StoreManager {
       diskToReplicaMap.computeIfAbsent(disk, key -> new ArrayList<>()).add(replica);
       partitionNameToReplicaId.put(replica.getPartitionId().toPathString(), replica);
     }
+
+    // Assume it's safe to place the new code here, AFTER partitionNameToReplicaId is populated.
+    if (storeConfig.storeReshuffleDisksOnReorder) {
+      ReplicaPlacementValidator placementValidator = new ReplicaPlacementValidator(diskToReplicaMap);
+      Map<DiskId, DiskId> disksToReshuffle = placementValidator.reshuffleDisks();
+      if (!disksToReshuffle.isEmpty()) {
+        logger.info("Disks need to be reshuffled: {}", disksToReshuffle);
+        if(primaryClusterParticipant.setDisksOrder(disksToReshuffle)) {
+          logger.info(this.getClass().getSimpleName() + " - successfully reshuffled disks. Now terminating"
+              + " the process so we can restart with the new disk order.");
+          System.exit(0);
+        } else {
+          logger.error("Failed to reshuffle disks - continuing with the current disk order");
+        }
+      }
+    }
+
     for (Map.Entry<DiskId, List<ReplicaId>> entry : diskToReplicaMap.entrySet()) {
       DiskId disk = entry.getKey();
       List<ReplicaId> replicasForDisk = entry.getValue();

--- a/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
@@ -159,7 +159,7 @@ public class StorageManager implements StoreManager {
               + " the process so we can restart with the new disk order.");
           System.exit(0);
         } else {
-          logger.error("Failed to reshuffle disks - continuing with the current disk order");
+          logger.error("Failed to reshuffle disks - continuing with the current disk order.");
         }
       }
     }

--- a/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
@@ -187,7 +187,7 @@ public class StorageManager implements StoreManager {
     if (!disksToReshuffle.isEmpty()) {
       logger.info("Disks need to be reshuffled: {}", disksToReshuffle);
       if(primaryClusterParticipant.setDisksOrder(disksToReshuffle)) {
-        logger.info(this.getClass().getSimpleName() + " - successfully reshuffled disks. Now terminating"
+        logger.info("Successfully reshuffled disks. Now terminating"
             + " the process so we can restart with the new disk order.");
         System.exit(0);
       } else {


### PR DESCRIPTION
## Summary
Sometimes ambry-server machines will get reimaged and come back with disks mounted in the wrong order. Human error during certain maintenance or testing operations can also cause this to happen. Currently, these disks are simply wiped clean of data upon startup, Ambry assuming that since they do not contain the right partitions they must be completely broken. The affected disks are then re-seeded with their desired data through replication. However, replication is slow (up to several hours), and until all the data is replicated back, availability may be adversely affected.

This pull request changes the `ambry-server` startup process such that it attempts to detect a simple reordering of disk mounts. For example, if the disks that were mounted at `/mnt/u003` and `/mnt/u008` were swapped around. If such a reordering is detected, we simply update Helix (our source of truth) with the new disk order and shut down the server. The server then needs to get restarted by some manual or automated means outside of the Ambry process.

Note that this PR sets up the simplest possible automated fix for the disk mount shuffle problem:
* We will only remediate if all the partitions that exist in Helix are found on disk. So for example, if two mounts have been shuffled and there is also one missing mount, then we will not attempt any reshuffling at all.
* We issue a simple `System.exit()` to shut down the Java process without trying any clever in-place update of the state. We investigated more elegant solutions, but the code quickly becomes complex and error-prone.

We may revisit this basic process if it turns out to be inadequate in the future.

Note that all the new functionality is guarded by a config that defaults to `false`. So deploying this new code will not change anything unless the corresponding config is also explicitly turned on.

## Testing Done
New unit tests have been added.

Note that we are planning to roll out the new code in practice as follows:

1. First manually test in the Ambry perf cluster, which has no client traffic but only exists for the purpose of internal Ambry team testing. In the perf cluster, we'll swap mounts manually to confirm that the code performs as desired in a real (test) cluster.
2. Once we're confident that the perf cluster tests have all been successful, we'll move onto testing in EI. EI is the second best place to test, since it has some traffic from clients and there may be a little impact if anything goes wrong.
3. Finally, we'll roll out in production clusters, fabric by fabric, by turning on the new config.