### PR TITLE
Ignore unexpected blob id in replication

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/ReplicationConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/ReplicationConfig.java
@@ -297,6 +297,16 @@ public class ReplicationConfig {
       "replication.request.network.poll.timeout.ms";
 
   /**
+   * If true, ignore the unexpected blob id when handling ReplicaMetadataResponse, and move on to other blob ids.
+   * Otherwise, throw out an exception.
+   */
+  @Config(REPLICATION_IGNORE_UNEXPECTED_BLOB_ID_ERROR)
+  @Default("false")
+  public final boolean replicationIgnoreUnexpectedBlobIdError;
+  public final static String REPLICATION_IGNORE_UNEXPECTED_BLOB_ID_ERROR =
+      "replication.ignore.unexpected.blob.id.error";
+
+  /**
    * The replication manager used to replicate objects from other backend servers.
    * DEFAULT_REPLICATION_THREAD as the name suggests is the current one.
    * BACKUP_CHECKER_THREAD is the one that checks for missing blobs in backup by comparing blobs from on-prem servers.
@@ -402,6 +412,8 @@ public class ReplicationConfig {
     replicationRequestNetworkTimeoutMs = verifiableProperties.getLong(REPLICATION_REQUEST_NETWORK_TIMEOUT_MS, 10000);
     replicationRequestNetworkPollTimeoutMs =
         verifiableProperties.getLong(REPLICATION_REQUEST_NETWORK_POLL_TIMEOUT_MS, 40);
+    replicationIgnoreUnexpectedBlobIdError =
+        verifiableProperties.getBoolean(REPLICATION_IGNORE_UNEXPECTED_BLOB_ID_ERROR, false);
     replicationUsingNonblockingNetworkClientForRemoteColo =
         verifiableProperties.getBoolean(REPLICATION_USING_NONBLOCKING_NETWORK_CLIENT_FOR_REMOTE_COLO, false);
     replicationUsingNonblockingNetworkClientForLocalColo =

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -1265,6 +1265,8 @@ public class ReplicaThread implements Runnable {
         if (replicationConfig.replicationIgnoreUnexpectedBlobIdError) {
           logger.error(errorMessage);
           replicationMetrics.unexpectedBlobIdError.inc();
+          missingRemoteStoreMessages.remove(messageInfo);
+          continue;
         } else {
           throw new IllegalStateException(errorMessage);
         }

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -1259,9 +1259,15 @@ public class ReplicaThread implements Runnable {
     for (MessageInfo messageInfo : messageInfoList) {
       BlobId blobId = (BlobId) messageInfo.getStoreKey();
       if (remoteReplicaInfo.getLocalReplicaId().getPartitionId().compareTo(blobId.getPartition()) != 0) {
-        throw new IllegalStateException(
-            "Blob id " + blobId.getID() + " is not in the expected partition Actual partition " + blobId.getPartition()
-                + " Expected partition " + remoteReplicaInfo.getLocalReplicaId().getPartitionId());
+        String errorMessage =
+            String.format("Blob id %s is not in the expected partition Actual partition %s " + " Expected partition %s",
+                blobId.getID(), blobId.getPartition(), remoteReplicaInfo.getLocalReplicaId().getPartitionId());
+        if (replicationConfig.replicationIgnoreUnexpectedBlobIdError) {
+          logger.error(errorMessage);
+          replicationMetrics.unexpectedBlobIdError.inc();
+        } else {
+          throw new IllegalStateException(errorMessage);
+        }
       }
       BlobId localKey = (BlobId) remoteKeyToLocalKeyMap.get(messageInfo.getStoreKey());
       if (localKey == null) {

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationMetrics.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationMetrics.java
@@ -22,7 +22,6 @@ import com.codahale.metrics.Timer;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.clustermap.ReplicaId;
-import com.github.ambry.clustermap.ReplicaType;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -135,6 +134,7 @@ public class ReplicationMetrics {
   public final Counter interColoContinuousReplicationReplicaThrottleCount;
   public final Counter remoteReplicaInfoRemoveError;
   public final Counter remoteReplicaInfoAddError;
+  public final Counter unexpectedBlobIdError;
   public final Counter allResponsedKeysExist;
 
   private MetricRegistry registry;
@@ -291,6 +291,7 @@ public class ReplicationMetrics {
     remoteReplicaInfoRemoveError =
         registry.counter(MetricRegistry.name(ReplicaThread.class, "RemoteReplicaInfoRemoveError"));
     remoteReplicaInfoAddError = registry.counter(MetricRegistry.name(ReplicaThread.class, "RemoteReplicaInfoAddError"));
+    unexpectedBlobIdError = registry.counter(MetricRegistry.name(ReplicaThread.class, "UnexpectedBlobIdError"));
     allResponsedKeysExist = registry.counter(MetricRegistry.name(ReplicaThread.class, "AllResponsedKeysExist"));
     intraColoReplicationErrorCount =
         registry.counter(MetricRegistry.name(ReplicaThread.class, "IntraColoReplicationErrorCount"));


### PR DESCRIPTION
## Summary 
Add a configuration to ignore unexpected blob id in replication thread. It's safe to do so because these blob ids don't belong to the partition anyway, we should just ignore it.

## Test
no tests added