### PR TITLE
Do not return when internal dataset exist

### DIFF
--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/AccountAndContainerInjector.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/AccountAndContainerInjector.java
@@ -441,9 +441,6 @@ public class AccountAndContainerInjector {
       }
       try {
         Dataset dataset = accountService.getDataset(accountName, containerName, datasetName);
-        if (restRequest.getArgs().get(InternalKeys.TARGET_DATASET) != null) {
-          return;
-        }
         restRequest.setArg(InternalKeys.TARGET_DATASET, dataset);
         if (version != null) {
           restRequest.setArg(InternalKeys.TARGET_DATASET_VERSION, version);


### PR DESCRIPTION
dataset version need to be updated if namedPutBlobHandler call the deleteBlobHandler.
When user put with revision, we will update version to a specific value when deleteOutOfRetention dataset versions.