### PR TITLE
State Build implementation for File Copy based replication

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/server/StoreManager.java
+++ b/ambry-api/src/main/java/com/github/ambry/server/StoreManager.java
@@ -31,6 +31,13 @@ import java.util.regex.Pattern;
 public interface StoreManager {
 
   /**
+   * Add a new BlobStore for FileCopy based replication with given {@link ReplicaId}.
+   * @param replica the {@link ReplicaId} of the {@link Store} which would be added.
+   * @return {@code true} if adding store was successful. {@code false} if not.
+   */
+  boolean addBlobStoreForFileCopy(ReplicaId replica);
+
+  /**
    * Add a new BlobStore with given {@link ReplicaId}.
    * @param replica the {@link ReplicaId} of the {@link Store} which would be added.
    * @return {@code true} if adding store was successful. {@code false} if not.
@@ -43,6 +50,12 @@ public interface StoreManager {
    * @return {@code true} if adding FileStore was successful. {@code false} if not.
    */
   boolean addFileStore(ReplicaId replicaId);
+
+  /**
+   * Build state after filecopy is completed
+   * @param replica the {@link ReplicaId} of the {@link Store} for which store needs to be built
+   */
+  void buildStateForFileCopy(ReplicaId replica);
 
   /**
    * Remove store from storage manager.

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudStorageManager.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudStorageManager.java
@@ -58,8 +58,17 @@ public class CloudStorageManager implements StoreManager {
   }
 
   @Override
+  public boolean addBlobStoreForFileCopy(ReplicaId replica) {
+    throw new UnsupportedOperationException("Method not supported");
+  }
+
+  @Override
   public boolean addBlobStore(ReplicaId replica) {
     return createAndStartBlobStoreIfAbsent(replica.getPartitionId()) != null;
+  }
+  @Override
+  public void buildStateForFileCopy(ReplicaId replica){
+    throw new UnsupportedOperationException("Method not supported");
   }
 
   /**

--- a/ambry-server/src/test/java/com/github/ambry/server/MockStorageManager.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/MockStorageManager.java
@@ -627,6 +627,15 @@ class MockStorageManager extends StorageManager {
   }
 
   @Override
+  public void buildStateForFileCopy(ReplicaId replica) {
+    throw new UnsupportedOperationException("Method not supported");
+  }
+  @Override
+  public boolean addBlobStoreForFileCopy(ReplicaId replica) {
+    throw new UnsupportedOperationException("Method not supported");
+  }
+
+  @Override
   public boolean addBlobStore(ReplicaId id) {
     updatePartitionToDiskManager(id);
     partitionNameToReplicaId.put(id.getPartitionId().toPathString(), id);

--- a/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
@@ -442,15 +442,14 @@ public class DiskManager {
         compactionManager.addBlobStore(store);
         // add new created store into in-memory data structures.
         stores.put(replica.getPartitionId(), store);
-        partitionToReplicaMap.put(replica.getPartitionId(), replica);
         // create a bootstrap-in-progress file to distinguish it from regular stores (the file will be checked during
         // BOOTSTRAP -> STANDBY transition)
         createBootstrapFileIfAbsent(replica);
-        logger.info("New store is successfully added into DiskManager.");
+        logger.info("New store for partitionId {} is successfully added into DiskManager.", replica.getPartitionId());
         succeed = true;
       }
     } catch (Exception e) {
-      logger.error("Failed to start new added store {} or add requirements to disk allocator", replica.getPartitionId(),
+      logger.error("Failed to start new added store for partitionId {} for FileCopy based replication", replica.getPartitionId(),
           e);
     } finally {
       rwLock.writeLock().unlock();
@@ -498,7 +497,7 @@ public class DiskManager {
         // create a bootstrap-in-progress file to distinguish it from regular stores (the file will be checked during
         // BOOTSTRAP -> STANDBY transition)
         createBootstrapFileIfAbsent(replica);
-        logger.info("New store is successfully added into DiskManager.");
+        logger.info("New store is successfully added into DiskManager for partitionId {}.", replica.getPartitionId());
         succeed = true;
       }
     } catch (Exception e) {

--- a/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
@@ -420,6 +420,44 @@ public class DiskManager {
     return succeed;
   }
 
+
+  /**
+   * Add a new BlobStore with given {@link ReplicaId}.
+   * @param replica the {@link ReplicaId} of the {@link Store} which would be added.
+   * @return {@code true} if adding store was successful. {@code false} if not.
+   */
+  boolean addBlobStoreForFileCopy(ReplicaId replica) {
+    rwLock.writeLock().lock();
+    boolean succeed = false;
+    try {
+      if (!running) {
+        logger.error("Failed to add {} because disk manager is not running", replica.getPartitionId());
+      } else {
+        // Directory is already created in prefilecopy steps. So no directory cleanup required.
+        BlobStore store = new BlobStore(replica, storeConfig, scheduler, longLivedTaskScheduler, this, diskIOScheduler,
+            diskSpaceAllocator, storeMainMetrics, storeUnderCompactionMetrics, keyFactory, recovery, hardDelete,
+            replicaStatusDelegates, time, accountService, null, indexPersistScheduler);
+        store.start();
+        // add store into CompactionManager
+        compactionManager.addBlobStore(store);
+        // add new created store into in-memory data structures.
+        stores.put(replica.getPartitionId(), store);
+        partitionToReplicaMap.put(replica.getPartitionId(), replica);
+        // create a bootstrap-in-progress file to distinguish it from regular stores (the file will be checked during
+        // BOOTSTRAP -> STANDBY transition)
+        createBootstrapFileIfAbsent(replica);
+        logger.info("New store is successfully added into DiskManager.");
+        succeed = true;
+      }
+    } catch (Exception e) {
+      logger.error("Failed to start new added store {} or add requirements to disk allocator", replica.getPartitionId(),
+          e);
+    } finally {
+      rwLock.writeLock().unlock();
+    }
+    return succeed;
+  }
+
   /**
    * Add a new BlobStore with given {@link ReplicaId}.
    * @param replica the {@link ReplicaId} of the {@link Store} which would be added.

--- a/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
@@ -536,7 +536,11 @@ public class StorageManager implements StoreManager {
     });
   }
 
-
+  /**
+   * Add a new store to the storage manager for file copy based replication post filecopy is completed.
+   * @param replica the {@link ReplicaId} of the {@link Store} which would be added.
+   * @return
+   */
   @Override
   public boolean addBlobStoreForFileCopy(ReplicaId replica) {
     if (partitionToDiskManager.containsKey(replica.getPartitionId())) {
@@ -571,19 +575,22 @@ public class StorageManager implements StoreManager {
     return true;
   }
 
+  /**
+   * Build inmemory state for file copy based replication post filecopy is completed.
+   * @param replica the {@link ReplicaId} of the {@link Store} for which store needs to be built
+   */
   @Override
   public boolean addFileStore(ReplicaId replicaId) {
     //TODO: Implementation To Be added.
     return false;
   }
   public void buildStateForFileCopy(ReplicaId replica){
+    if (replica == null) {
+      logger.error("ReplicaId is null");
+      throw new StateTransitionException("ReplicaId null is not found in clustermap for " + currentNode, ReplicaNotFound);
+    }
     PartitionId partitionId = replica.getPartitionId();
 
-    if (replica == null) {
-      logger.error("No existing replica found for partition {} in partitionNameToReplicaId", partitionId.getId());
-      throw new StateTransitionException(
-          "Existing replica " + partitionId.getId() + " is not found in clustermap for " + currentNode, ReplicaNotFound);
-    }
     if (!addBlobStoreForFileCopy(replica)){
       // We have decreased the available disk space in HelixClusterManager#getDiskForBootstrapReplica. Increase it
       // back since addition of store failed.

--- a/ambry-store/src/test/java/com/github/ambry/store/StorageManagerTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/StorageManagerTest.java
@@ -68,6 +68,7 @@ import java.security.Permission;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -268,6 +269,62 @@ public class StorageManagerTest {
     replicas.remove(replicas.size() - 1);
     shutdownAndAssertStoresInaccessible(storageManager, replicas);
   }
+
+  public MockId addRandomBlobToStore(Store store, long size, long expiresAtMs) throws StoreException {
+    final Random random = new Random();
+    short accountId = Utils.getRandomShort(TestUtils.RANDOM);
+    short containerId = Utils.getRandomShort(TestUtils.RANDOM);
+    short lifeVersion = MessageInfo.LIFE_VERSION_FROM_FRONTEND;
+
+    MockId id = new MockId(TestUtils.getRandomString(MOCK_ID_STRING_LENGTH), accountId, containerId);
+    long crc = random.nextLong();
+    MessageInfo info =
+        new MessageInfo(id, size, false, false, false, expiresAtMs, crc, id.getAccountId(), id.getContainerId(),
+            Utils.Infinite_Time, lifeVersion);
+    ByteBuffer buffer = ByteBuffer.wrap(TestUtils.getRandomBytes((int) size));
+    store.put(new MockMessageWriteSet(Collections.singletonList(info), Collections.singletonList(buffer)));
+    return id;
+  }
+
+  /**
+   * Test buildStateForFileCopy with newly created {@link ReplicaId}.
+   */
+  @Test
+  public void buildStateForFileCopyTest() throws Exception {
+    generateConfigs(true, false);
+    MockDataNodeId localNode = clusterMap.getDataNodes().get(0);
+    int newMountPathIndex = 3;
+    // add new MountPath to local node
+    File f = File.createTempFile("ambry", ".tmp");
+    File mountFile =
+        new File(f.getParent(), "mountpathfile" + MockClusterMap.PLAIN_TEXT_PORT_START_NUMBER + newMountPathIndex);
+    MockClusterMap.deleteFileOrDirectory(mountFile);
+    assertTrue("Couldn't create mount path directory", mountFile.mkdir());
+    localNode.addMountPaths(Collections.singletonList(mountFile.getAbsolutePath()));
+    int newPartitionId = 803;
+    PartitionId newPartition =
+        new MockPartitionId(newPartitionId, MockClusterMap.DEFAULT_PARTITION_CLASS, clusterMap.getDataNodes(), newMountPathIndex);
+    StorageManager storageManager = createStorageManager(localNode, metricRegistry, null);
+    storageManager.start();
+    // test add store onto a new disk, which should succeed
+    assertTrue("Add new store should succeed", storageManager.addBlobStore(newPartition.getReplicaIds().get(0)));
+    assertNotNull("The store shouldn't be null because new store is successfully added",
+        storageManager.getStore(newPartition, false));
+    DiskManager dm = storageManager.getDiskManager(newPartition);
+    Store store = dm.getStore(newPartition, false);
+    MockId id1 = addRandomBlobToStore(store, 100, Utils.Infinite_Time);
+    MockId id2 = addRandomBlobToStore(store, 200, Utils.Infinite_Time);
+    // Create storage manager again to create disk managers again
+    storageManager.shutdown();
+    storageManager = createStorageManager(localNode, metricRegistry, null);
+    storageManager.start();
+    storageManager.buildStateForFileCopy(newPartition.getReplicaIds().get(0));
+    dm = storageManager.getDiskManager(newPartition);
+    store = dm.getStore(newPartition, false);
+    assertNotNull(store.get(Collections.singletonList(id1), EnumSet.noneOf(StoreGetOptions.class)));
+    assertNotNull(store.get(Collections.singletonList(id2), EnumSet.noneOf(StoreGetOptions.class)));
+  }
+
 
   /**
    * Test add new BlobStore with given {@link ReplicaId}.


### PR DESCRIPTION
This PR handles initializing BlobStore with Log, Index, BlobStoreCompactor, RemoteTokenTracker, etc post filecopy is completed in the filecopy based replication. 


[Bootstrap State Build Design Doc](https://docs.google.com/document/d/1pb8KuA2vT8L5FrxCobuT_IHWMtnWnNF0uKPHtqcMXN0/edit?tab=t.0)

Key Changes:
1. **buildStateForFileCopy**: New method to build in-memory state when a file copy completes under file copy based replication. It throws an exception if ReplicaId is null and adjusts disk space on failure.
2. **addBlobStoreForFileCopy**: Added to DiskManager and StorageManager for adding BlobStores during file copy replication. It includes initializing of BlobStore with Log, Index, BlobStoreCompactor and RemoteTokenTracker, etc. It includes error handling for failed store creation.
3. **Error Handling**: Enhanced logging and handling for failed store additions and bootstrap replica issues.

**Test Coverage:**
1. Added tests for various file copy scenarios, including successful and failed store additions and handling null ReplicaId, successful state build post blob writes to a new store, etc.
2. Testing with sealed log files with setting of active segments and rollover of files is working correctly in local testing.

