### PR TITLE
Bootstrap state build interface changes part 2/2

### DIFF
--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
@@ -863,8 +863,6 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
 
   @Override
   public void onPartitionBecomeBootstrapFromOffline(String partitionName) {
-    // TODO: Prefilecopy steps: Handle scenarios for Filceopy -> filecopy, Replication->Filecopy,
-    //  Filceopy -> replication and replication->replication rollout/rollback.
     try {
       // 1. take actions in storage manager (add new replica if necessary)
       PartitionStateChangeListener storageManagerListener =

--- a/ambry-file-transfer/src/main/java/com/github/ambry/FileCopyManager.java
+++ b/ambry-file-transfer/src/main/java/com/github/ambry/FileCopyManager.java
@@ -41,8 +41,7 @@ public class FileCopyManager {
 
     @Override
     public void onPartitionBecomeBootstrapFromOffline(String partitionName) {
-      // StateBuilding at the end of FCM's Offline->Bootstrap transition
-      storeManager.buildStateForFileCopy(partitionName);
+      // StateBuilding (storeManager.buildStateForFileCopy()) will be triggered at the end of FCM's async handler.
     }
 
     @Override

--- a/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
@@ -720,8 +720,6 @@ public class StorageManager implements StoreManager {
 
     @Override
     public void onPartitionBecomeBootstrapFromOffline(String partitionName) {
-      // For Filecopy, 4 steps to be taken up here: Prefilecopy, Filecopy, State Build, Exception handling and cleanup
-
       // check if partition exists on current node
       ReplicaId replica = partitionNameToReplicaId.get(partitionName);
       Store store;
@@ -743,8 +741,6 @@ public class StorageManager implements StoreManager {
           // Attempt to add store into storage manager. If store already exists on disk (but not in clustermap), make
           // sure old store of this replica is deleted (this store may be created in previous replica addition but failed
           // at some point). Then a brand new store associated with this replica should be created and started.
-          // TODO: For Filecopy, we do not init the BlobStore since new log/index isn't required, the files will be directly
-          //  copied from remote node.
           if (!addBlobStore(replicaToAdd)) {
             // We have decreased the available disk space in HelixClusterManager#getDiskForBootstrapReplica. Increase it
             // back since addition of store failed.


### PR DESCRIPTION
Removed trigger for buildStateForFileCopy method since FileCopyManager and removed TODOs from pre-file copy steps.