### PR TITLE
Revert "Pass in uuid in blob property before construct the blobId (#2901)

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/messageformat/BlobProperties.java
+++ b/ambry-api/src/main/java/com/github/ambry/messageformat/BlobProperties.java
@@ -38,7 +38,6 @@ public class BlobProperties {
   // Non persistent blob properties.
   private final String externalAssetTag;
   private final String reservedMetadataBlobId;
-  private final String reservedUuid;
 
   /**
    * @param blobSize The size of the blob in bytes
@@ -49,7 +48,7 @@ public class BlobProperties {
    */
   public BlobProperties(long blobSize, String serviceId, short accountId, short containerId, boolean isEncrypted) {
     this(blobSize, serviceId, null, null, false, Utils.Infinite_Time, SystemTime.getInstance().milliseconds(),
-        accountId, containerId, isEncrypted, null, null, null, null, null);
+        accountId, containerId, isEncrypted, null, null, null, null);
   }
 
   /**
@@ -63,7 +62,7 @@ public class BlobProperties {
   public BlobProperties(long blobSize, String serviceId, short accountId, short containerId, boolean isEncrypted,
       long creationTimeInMs) {
     this(blobSize, serviceId, null, null, false, Utils.Infinite_Time, creationTimeInMs, accountId, containerId,
-        isEncrypted, null, null, null, null, null);
+        isEncrypted, null, null, null, null);
   }
 
   /**
@@ -85,56 +84,51 @@ public class BlobProperties {
       String contentEncoding, String filename) {
     this(blobSize, serviceId, ownerId, contentType, isPrivate, timeToLiveInSeconds,
         SystemTime.getInstance().milliseconds(), accountId, containerId, isEncrypted, externalAssetTag, contentEncoding,
-        filename, null, null);
+        filename, null);
   }
 
   /**
-   * @param blobSize               The size of the blob in bytes
-   * @param serviceId              The service id that is creating this blob
-   * @param ownerId                The owner of the blob (For example , memberId or groupId)
-   * @param contentType            The content type of the blob (eg: mime). Can be Null
-   * @param isPrivate              Is the blob secure
-   * @param timeToLiveInSeconds    The time to live, in seconds, relative to blob creation time.
-   * @param accountId              accountId of the user who owns the blob
-   * @param containerId            containerId of the blob
-   * @param isEncrypted            whether this blob is encrypted.
-   * @param externalAssetTag       externalAssetTag for this blob. This is a non-persistent field.
-   * @param contentEncoding        the field to identify if the blob is compressed.
-   * @param filename               the name of the file.
-   * @param reservedMetadataBlobId the reserved metadata blob id for chunked uploads or stitched blobs. Can be
-   *                               {@code null}.
-   * @param reservedUuid           the reserved uuid for blob id.
+   * @param blobSize The size of the blob in bytes
+   * @param serviceId The service id that is creating this blob
+   * @param ownerId The owner of the blob (For example , memberId or groupId)
+   * @param contentType The content type of the blob (eg: mime). Can be Null
+   * @param isPrivate Is the blob secure
+   * @param timeToLiveInSeconds The time to live, in seconds, relative to blob creation time.
+   * @param accountId accountId of the user who owns the blob
+   * @param containerId containerId of the blob
+   * @param isEncrypted whether this blob is encrypted.
+   * @param externalAssetTag externalAssetTag for this blob. This is a non-persistent field.
+   * @param contentEncoding the field to identify if the blob is compressed.
+   * @param reservedMetadataBlobId the reserved metadata blob id for chunked uploads or stitched blobs. Can be {@code null}.
+   * @param filename the name of the file.
    */
   public BlobProperties(long blobSize, String serviceId, String ownerId, String contentType, boolean isPrivate,
       long timeToLiveInSeconds, short accountId, short containerId, boolean isEncrypted, String externalAssetTag,
-      String contentEncoding, String filename, String reservedMetadataBlobId, String reservedUuid) {
+      String contentEncoding, String filename, String reservedMetadataBlobId) {
     this(blobSize, serviceId, ownerId, contentType, isPrivate, timeToLiveInSeconds,
         SystemTime.getInstance().milliseconds(), accountId, containerId, isEncrypted, externalAssetTag, contentEncoding,
-        filename, reservedMetadataBlobId, reservedUuid);
+        filename, reservedMetadataBlobId);
   }
 
   /**
-   * @param blobSize               The size of the blob in bytes
-   * @param serviceId              The service id that is creating this blob
-   * @param ownerId                The owner of the blob (For example , memberId or groupId)
-   * @param contentType            The content type of the blob (eg: mime). Can be Null
-   * @param isPrivate              Is the blob secure
-   * @param timeToLiveInSeconds    The time to live, in seconds, relative to blob creation time.
-   * @param creationTimeInMs       The time at which the blob is created.
-   * @param accountId              accountId of the user who owns the blob
-   * @param containerId            containerId of the blob
-   * @param isEncrypted            whether this blob is encrypted.
-   * @param externalAssetTag       externalAssetTag for this blob. This is a non-persistent field.
-   * @param contentEncoding        the field to identify if the blob is compressed.
-   * @param filename               the name of the file.
-   * @param reservedMetadataBlobId the reserved metadata blob id for chunked uploads or stitched blobs. Can be
-   *                               {@code null}.
-   * @param reservedUuid           the reserved uuid for blob id.
+   * @param blobSize The size of the blob in bytes
+   * @param serviceId The service id that is creating this blob
+   * @param ownerId The owner of the blob (For example , memberId or groupId)
+   * @param contentType The content type of the blob (eg: mime). Can be Null
+   * @param isPrivate Is the blob secure
+   * @param timeToLiveInSeconds The time to live, in seconds, relative to blob creation time.
+   * @param creationTimeInMs The time at which the blob is created.
+   * @param accountId accountId of the user who owns the blob
+   * @param containerId containerId of the blob
+   * @param isEncrypted whether this blob is encrypted.
+   * @param externalAssetTag externalAssetTag for this blob. This is a non-persistent field.
+   * @param contentEncoding the field to identify if the blob is compressed.
+   * @param filename the name of the file.
+   * @param reservedMetadataBlobId the reserved metadata blob id for chunked uploads or stitched blobs. Can be {@code null}.
    */
   public BlobProperties(long blobSize, String serviceId, String ownerId, String contentType, boolean isPrivate,
       long timeToLiveInSeconds, long creationTimeInMs, short accountId, short containerId, boolean isEncrypted,
-      String externalAssetTag, String contentEncoding, String filename, String reservedMetadataBlobId,
-      String reservedUuid) {
+      String externalAssetTag, String contentEncoding, String filename, String reservedMetadataBlobId) {
     this.blobSize = blobSize;
     this.serviceId = serviceId;
     this.ownerId = ownerId;
@@ -149,7 +143,6 @@ public class BlobProperties {
     this.contentEncoding = contentEncoding;
     this.filename = filename;
     this.reservedMetadataBlobId = reservedMetadataBlobId;
-    this.reservedUuid = reservedUuid;
   }
 
   /**
@@ -159,7 +152,7 @@ public class BlobProperties {
   public BlobProperties(BlobProperties other) {
     this(other.blobSize, other.serviceId, other.ownerId, other.contentType, other.isPrivate, other.timeToLiveInSeconds,
         other.creationTimeInMs, other.accountId, other.containerId, other.isEncrypted, other.externalAssetTag,
-        other.contentEncoding, other.filename, other.reservedMetadataBlobId, other.reservedUuid);
+        other.contentEncoding, other.filename, other.reservedMetadataBlobId);
   }
 
   public long getTimeToLiveInSeconds() {
@@ -169,8 +162,6 @@ public class BlobProperties {
   public long getBlobSize() {
     return blobSize;
   }
-
-  public String getReservedUuid() { return reservedUuid; }
 
   /**
    * This should only be used to determine the "virtual container" for blobs with V1 IDs.
@@ -272,8 +263,7 @@ public class BlobProperties {
     sb.append(", ").append("Filename=").append(getFilename());
     sb.append(", ")
         .append("ReservedMetadataBlobId=")
-        .append(nullOrEmptry(getReservedMetadataBlobId()) ? "null" : getReservedMetadataBlobId());
-    sb.append(", ").append("ReservedUuId=").append(nullOrEmptry(getReservedUuid()) ? "null" : getReservedUuid());
+        .append(nullOrEmptry(getReservedMetadataBlobId())? "null" : getReservedMetadataBlobId());
     sb.append("]");
     return sb.toString();
   }
@@ -292,8 +282,7 @@ public class BlobProperties {
         && timeToLiveInSeconds == that.timeToLiveInSeconds && Objects.equals(serviceId, that.serviceId)
         && Objects.equals(ownerId, that.ownerId) && Objects.equals(contentType, that.contentType) && Objects.equals(
         contentEncoding, that.contentEncoding) && Objects.equals(filename, that.filename) && Objects.equals(
-        externalAssetTag, that.externalAssetTag) && Objects.equals(reservedMetadataBlobId, that.reservedMetadataBlobId)
-        && Objects.equals(reservedUuid, that.reservedUuid);
+        externalAssetTag, that.externalAssetTag) && Objects.equals(reservedMetadataBlobId, that.reservedMetadataBlobId);
   }
 
   /**
@@ -331,7 +320,6 @@ public class BlobProperties {
         && Objects.equals(contentEncoding, that.contentEncoding)
         && Objects.equals(filename, that.filename)
         && Objects.equals(externalAssetTag, that.externalAssetTag)
-        && Objects.equals(reservedMetadataBlobId, that.reservedMetadataBlobId)
-        && Objects.equals(reservedUuid, that.reservedUuid);
+        && Objects.equals(reservedMetadataBlobId, that.reservedMetadataBlobId);
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com/github/ambry/rest/RestUtils.java
@@ -43,7 +43,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.zip.CRC32;
@@ -597,7 +596,7 @@ public class RestUtils {
     // based on the container properties and ACLs. For now, BlobProperties still includes this field, though.
     boolean isPrivate = !container.isCacheable();
     return new BlobProperties(-1, serviceId, ownerId, contentType, isPrivate, ttl, account.getId(), container.getId(),
-        container.isEncrypted(), externalAssetTag, contentEncoding, filename, reservedMetadataBlobid, UUID.randomUUID().toString());
+        container.isEncrypted(), externalAssetTag, contentEncoding, filename, reservedMetadataBlobid);
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
@@ -241,21 +241,19 @@ public class ClusterMapUtils {
   /**
    * Choose a random {@link PartitionId} for putting the metadata chunk and return a {@link BlobId} that belongs to the
    * chosen partition id.
-   *
-   * @param partitionClass            the partition class to choose partitions from.
-   * @param partitionIdsToExclude     the list of {@link PartitionId}s that should be excluded from consideration.
+   * @param partitionClass the partition class to choose partitions from.
+   * @param partitionIdsToExclude the list of {@link PartitionId}s that should be excluded from consideration.
    * @param reservedMetadataIdMetrics the {@link ReservedMetadataIdMetrics} object.
-   * @param clusterMap                the {@link ClusterMap} object.
-   * @param accountId                 the account id to be encoded in the blob id.
-   * @param containerId               the container id to be encoded in the blob id.
-   * @param isEncrypted               {@code true} is the blob is encrypted. {@code false} otherwise.
-   * @param routerConfig              the {@link RouterConfig} object.
-   * @param reservedUuid
+   * @param clusterMap the {@link ClusterMap} object.
+   * @param accountId the account id to be encoded in the blob id.
+   * @param containerId the container id to be encoded in the blob id.
+   * @param isEncrypted {@code true} is the blob is encrypted. {@code false} otherwise.
+   * @param routerConfig the {@link RouterConfig} object.
    * @return the chosen {@link BlobId}.
    */
   public static BlobId reserveMetadataBlobId(String partitionClass, List<PartitionId> partitionIdsToExclude,
       ReservedMetadataIdMetrics reservedMetadataIdMetrics, ClusterMap clusterMap, short accountId, short containerId,
-      boolean isEncrypted, RouterConfig routerConfig, String reservedUuid) {
+      boolean isEncrypted, RouterConfig routerConfig) {
     PartitionId selected = clusterMap.getRandomFullyWritablePartition(partitionClass, partitionIdsToExclude);
     if (selected == null) {
       reservedMetadataIdMetrics.numFailedPartitionReserveAttempts.inc();
@@ -266,11 +264,6 @@ public class ClusterMapUtils {
           "While reserving metadata chunk id, no partitions for partitionClass='{}' found, partitionClass='{}' used"
               + " instead for metadata chunk.", partitionClass, selected.getPartitionClass());
       reservedMetadataIdMetrics.numUnexpectedReservedPartitionClassCount.inc();
-    }
-    if (reservedUuid != null) {
-      return new BlobId(routerConfig.routerBlobidCurrentVersion, BlobId.BlobIdType.NATIVE,
-          clusterMap.getLocalDatacenterId(), accountId, containerId, selected, isEncrypted,
-          BlobId.BlobDataType.METADATA, reservedUuid);
     }
     return new BlobId(routerConfig.routerBlobidCurrentVersion, BlobId.BlobIdType.NATIVE,
         clusterMap.getLocalDatacenterId(), accountId, containerId, selected, isEncrypted,

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/ClusterMapUtilsTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/ClusterMapUtilsTest.java
@@ -264,7 +264,7 @@ public class ClusterMapUtilsTest {
     // test a simple success case.
     BlobId blobId =
         ClusterMapUtils.reserveMetadataBlobId(partitionClass, partitionsToExclude, reservedMetadataIdMetrics,
-            clusterMap, accountId, containerId, isEncrypted, routerConfig, null);
+            clusterMap, accountId, containerId, isEncrypted, routerConfig);
     assertNotNull(blobId);
     assertEquals(partitionClass, blobId.getPartition().getPartitionClass());
     assertEquals(0, reservedMetadataIdMetrics.numFailedPartitionReserveAttempts.getCount());
@@ -273,7 +273,7 @@ public class ClusterMapUtilsTest {
     // test for non-existent partition class.
     blobId =
         ClusterMapUtils.reserveMetadataBlobId(invalidPartitionClass, partitionsToExclude, reservedMetadataIdMetrics,
-            clusterMap, accountId, containerId, isEncrypted, routerConfig, null);
+            clusterMap, accountId, containerId, isEncrypted, routerConfig);
     assertNotNull(blobId);
     assertNotEquals(partitionClass, blobId.getPartition().getPartitionClass());
     assertEquals(MockClusterMap.DEFAULT_PARTITION_CLASS, blobId.getPartition().getPartitionClass());
@@ -284,7 +284,7 @@ public class ClusterMapUtilsTest {
     List<PartitionId> partitionIdList = clusterMap.getAllPartitionIds(null).stream().map(p -> ((PartitionId) p)).collect(
         Collectors.toList());
     assertNull(ClusterMapUtils.reserveMetadataBlobId(partitionClass, partitionIdList, reservedMetadataIdMetrics,
-        clusterMap, accountId, containerId, isEncrypted, routerConfig, null));
+        clusterMap, accountId, containerId, isEncrypted, routerConfig));
     assertEquals(1, reservedMetadataIdMetrics.numFailedPartitionReserveAttempts.getCount());
     assertEquals(1, reservedMetadataIdMetrics.numUnexpectedReservedPartitionClassCount.getCount());
   }

--- a/ambry-commons/src/main/java/com/github/ambry/commons/BlobId.java
+++ b/ambry-commons/src/main/java/com/github/ambry/commons/BlobId.java
@@ -212,9 +212,6 @@ public class BlobId extends StoreKey {
     if (partitionId == null) {
       throw new IllegalArgumentException("partitionId cannot be null");
     }
-    if (uuidStr == null) {
-      throw new IllegalArgumentException("uuidStr cannot be null");
-    }
     switch (version) {
       case BLOB_ID_V1:
         this.type = BlobIdType.NATIVE;

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbryUrlSigningService.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbryUrlSigningService.java
@@ -168,7 +168,7 @@ public class AmbryUrlSigningService implements UrlSigningService {
         BlobId reservedMetadataBlobId = ClusterMapUtils.reserveMetadataBlobId(
             ClusterMapUtils.getPartitionClass(account, container, clusterMapConfig.clusterMapDefaultPartitionClass),
             null, ReservedMetadataIdMetrics.getReservedMetadataIdMetrics(clusterMap.getMetricRegistry()), clusterMap,
-            account.getId(), container.getId(), container.isEncrypted(), routerConfig, null);
+            account.getId(), container.getId(), container.isEncrypted(), routerConfig);
         if (reservedMetadataBlobId == null) {
           ReservedMetadataIdMetrics.getReservedMetadataIdMetrics(
               clusterMap.getMetricRegistry()).reserveMetadataIdFailedForPostSignedUrlCount.inc();

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/AmbrySecurityServiceTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/AmbrySecurityServiceTest.java
@@ -156,8 +156,7 @@ public class AmbrySecurityServiceTest {
           RestUtils.buildUserMetadata(USER_METADATA), DEFAULT_LIFEVERSION);
       RESERVED_METADATA_INFO = new BlobInfo(
           new BlobProperties(Utils.getRandomLong(TestUtils.RANDOM, 1000) + 100, SERVICE_ID, OWNER_ID, "image/gif",
-              false, Utils.Infinite_Time, REF_ACCOUNT.getId(), REF_CONTAINER.getId(), false, null, null, null, DEFAULT_RESERVED_METADATAID,
-              null),
+              false, Utils.Infinite_Time, REF_ACCOUNT.getId(), REF_CONTAINER.getId(), false, null, null, null, DEFAULT_RESERVED_METADATAID),
           RestUtils.buildUserMetadata(USER_METADATA), DEFAULT_LIFEVERSION);
       RANDOM_INFO = new BlobInfo(
           new BlobProperties(Utils.getRandomLong(TestUtils.RANDOM, 1000) + 100, SERVICE_ID, OWNER_ID, "image/gif",

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/NamedBlobPutHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/NamedBlobPutHandlerTest.java
@@ -24,12 +24,10 @@ import com.github.ambry.account.DatasetBuilder;
 import com.github.ambry.account.InMemAccountService;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.MockClusterMap;
-import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.ByteBufferReadableStreamChannel;
 import com.github.ambry.commons.CommonTestUtils;
 import com.github.ambry.config.FrontendConfig;
 import com.github.ambry.config.VerifiableProperties;
-import com.github.ambry.messageformat.BlobInfo;
 import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.named.NamedBlobDb;
 import com.github.ambry.named.NamedBlobDbFactory;
@@ -51,9 +49,7 @@ import com.github.ambry.utils.MockTime;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.ThrowingConsumer;
 import com.github.ambry.utils.Utils;
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.DataInputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
@@ -242,36 +238,6 @@ public class NamedBlobPutHandlerTest {
     idConverterFactory.returnInputIfTranslationNull = true;
     putBlobAndVerify(null, TestUtils.TTL_SECS);
     putBlobAndVerify(null, Utils.Infinite_Time);
-  }
-
-  /**
-   * Test put named blob with reserved UUID in blob properties.
-   * @throws Exception
-   */
-  @Test
-  public void putNamedBlobTestWithReservedUuid() throws Exception {
-    idConverterFactory.returnInputIfTranslationNull = true;
-    JSONObject headers = new JSONObject();
-    FrontendRestRequestServiceTest.setAmbryHeadersForPut(headers, Utils.Infinite_Time, !REF_CONTAINER.isCacheable(),
-        SERVICE_ID, CONTENT_TYPE, OWNER_ID, null, null, null);
-    byte[] content = TestUtils.getRandomBytes(10);
-    RestRequest request = getRestRequest(headers, request_path, content);
-    RestResponseChannel restResponseChannel = new MockRestResponseChannel();
-    FutureResult<Void> future = new FutureResult<>();
-    idConverterFactory.lastInput = null;
-    idConverterFactory.lastBlobProperties = null;
-    idConverterFactory.lastConvertedId = null;
-    namedBlobPutHandler.handle(request, restResponseChannel, future::done);
-    future.get(TIMEOUT_SECS, TimeUnit.SECONDS);
-    String blobId = (String) restResponseChannel.getHeader(RestUtils.Headers.LOCATION);
-    InMemoryRouter.InMemoryBlob blob = router.getActiveBlobs().get(idConverterFactory.lastInput);
-    BlobProperties blobProperties = blob.getBlobProperties();
-    ClusterMap referenceClusterMap = new MockClusterMap();
-    BlobId blobIdSerDed =
-        new BlobId(new DataInputStream(new ByteArrayInputStream(new BlobId(blobId, referenceClusterMap).toBytes())),
-            referenceClusterMap);
-    assertEquals("blobId's UUID should match with the blob properties", blobIdSerDed.getUuid(),
-        blobProperties.getReservedUuid());
   }
 
   /**
@@ -603,7 +569,7 @@ public class NamedBlobPutHandlerTest {
       BlobProperties blobProperties =
           new BlobProperties(-1, SERVICE_ID, OWNER_ID, CONTENT_TYPE, !container.isCacheable(), blobTtlSecs,
               creationTimeMs, container.getParentAccountId(), container.getId(), container.isEncrypted(), null, null,
-              null, null, null);
+              null, null);
       String blobId =
           router.putBlob(blobProperties, null, new ByteBufferReadableStreamChannel(ByteBuffer.wrap(content)),
               new PutBlobOptionsBuilder().chunkUpload(true).build()).get(TIMEOUT_SECS, TimeUnit.SECONDS);

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/PostBlobHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/PostBlobHandlerTest.java
@@ -500,7 +500,7 @@ public class PostBlobHandlerTest {
       BlobProperties blobProperties =
           new BlobProperties(-1, SERVICE_ID, OWNER_ID, CONTENT_TYPE, !container.isCacheable(), blobTtlSecs,
               creationTimeMs, container.getParentAccountId(), container.getId(), container.isEncrypted(), null, null,
-              null, null, null);
+              null, null);
       String blobId =
           router.putBlob(blobProperties, null, new ByteBufferReadableStreamChannel(ByteBuffer.wrap(content)),
               new PutBlobOptionsBuilder().chunkUpload(true).build()).get(TIMEOUT_SECS, TimeUnit.SECONDS);

--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/BlobPropertiesSerDe.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/BlobPropertiesSerDe.java
@@ -72,7 +72,7 @@ public class BlobPropertiesSerDe {
     String filename = version > VERSION_3 ? Utils.readNullableIntString(stream) : null;
     String reservedMetadataBlobId = version > VERSION_4 ? Utils.readNullableIntString(stream) : null;
     return new BlobProperties(blobSize, serviceId, ownerId, contentType, isPrivate, ttl, creationTime, accountId,
-        containerId, isEncrypted, null, contentEncoding, filename, reservedMetadataBlobId, null);
+        containerId, isEncrypted, null, contentEncoding, filename, reservedMetadataBlobId);
   }
 
   /**

--- a/ambry-messageformat/src/test/java/com/github/ambry/messageformat/BlobPropertiesTest.java
+++ b/ambry-messageformat/src/test/java/com/github/ambry/messageformat/BlobPropertiesTest.java
@@ -88,8 +88,7 @@ public class BlobPropertiesTest {
         new MockPartitionId(), false, BlobId.BlobDataType.METADATA).getID();
 
     BlobProperties blobProperties = new BlobProperties(blobSize, serviceId, null, null, false, Utils.Infinite_Time,
-        SystemTime.getInstance().milliseconds(), accountId, containerId, isEncrypted, externalAssetTag, null, null, null,
-        null);
+        SystemTime.getInstance().milliseconds(), accountId, containerId, isEncrypted, externalAssetTag, null, null, null);
     System.out.println(blobProperties.toString()); // Provide example of BlobProperties.toString()
     ByteBuffer serializedBuffer = serializeBlobPropertiesInVersion(blobProperties);
     blobProperties = BlobPropertiesSerDe.getBlobPropertiesFromStream(
@@ -99,7 +98,7 @@ public class BlobPropertiesTest {
 
     blobProperties = new BlobProperties(blobSize, serviceId, null, null, false, Utils.Infinite_Time,
         SystemTime.getInstance().milliseconds(), accountId, containerId, isEncrypted, externalAssetTag, contentEncoding,
-        filename, null, null);
+        filename, null);
     System.out.println(blobProperties.toString()); // Provide example of BlobProperties.toString()
     serializedBuffer = serializeBlobPropertiesInVersion(blobProperties);
     blobProperties = BlobPropertiesSerDe.getBlobPropertiesFromStream(
@@ -111,7 +110,7 @@ public class BlobPropertiesTest {
 
     blobProperties = new BlobProperties(blobSize, serviceId, null, null, false, Utils.Infinite_Time,
         SystemTime.getInstance().milliseconds(), accountId, containerId, isEncrypted, externalAssetTag, contentEncoding,
-        filename, null, null);
+        filename, null);
     serializedBuffer = serializeBlobPropertiesInVersion(blobProperties);
     blobProperties = BlobPropertiesSerDe.getBlobPropertiesFromStream(
         new DataInputStream(new ByteBufferInputStream(serializedBuffer)));
@@ -134,7 +133,7 @@ public class BlobPropertiesTest {
     long creationTimeMs = SystemTime.getInstance().milliseconds();
     blobProperties =
         new BlobProperties(blobSize, serviceId, ownerId, contentType, true, timeToLiveInSeconds, creationTimeMs,
-            accountId, containerId, isEncrypted, "some-external-asset-tag", contentEncoding, filename, null, null);
+            accountId, containerId, isEncrypted, "some-external-asset-tag", contentEncoding, filename, null);
     System.out.println(blobProperties.toString()); // Provide example of BlobProperties.toString()
     serializedBuffer = serializeBlobPropertiesInVersion(blobProperties);
 
@@ -156,7 +155,7 @@ public class BlobPropertiesTest {
     for (long ttl : validTTLs) {
       blobProperties =
           new BlobProperties(blobSize, serviceId, ownerId, contentType, true, ttl, creationTimeMs, accountId,
-              containerId, isEncrypted, null, contentEncoding, filename, null, null);
+              containerId, isEncrypted, null, contentEncoding, filename, null);
       serializedBuffer = serializeBlobPropertiesInVersion(blobProperties);
       blobProperties = BlobPropertiesSerDe.getBlobPropertiesFromStream(
           new DataInputStream(new ByteBufferInputStream(serializedBuffer)));
@@ -166,7 +165,7 @@ public class BlobPropertiesTest {
 
     blobProperties =
         new BlobProperties(blobSize, serviceId, null, null, false, timeToLiveInSeconds, creationTimeMs, accountId,
-            containerId, isEncrypted, externalAssetTag, contentEncoding, filename, null, null);
+            containerId, isEncrypted, externalAssetTag, contentEncoding, filename, null);
     verifyBlobProperties(blobProperties, blobSize, serviceId, null, null, false, timeToLiveInSeconds, accountId,
         containerId, isEncrypted, externalAssetTag, contentEncodingToExpect, filenameToExpect, null);
     blobProperties.setTimeToLiveInSeconds(timeToLiveInSeconds + 1);
@@ -189,8 +188,7 @@ public class BlobPropertiesTest {
 
     blobProperties =
         new BlobProperties(blobSize, serviceId, null, null, false, timeToLiveInSeconds,
-            creationTimeMs, accountId, containerId, isEncrypted, externalAssetTag, contentEncoding, filename, blobId,
-            null);
+            creationTimeMs, accountId, containerId, isEncrypted, externalAssetTag, contentEncoding, filename, blobId);
     verifyBlobProperties(blobProperties, blobSize, serviceId, null, null, false, timeToLiveInSeconds, accountId,
         containerId, isEncrypted, externalAssetTag, contentEncodingToExpect, filenameToExpect, blobId);
     blobProperties.setTimeToLiveInSeconds(timeToLiveInSeconds + 1);

--- a/ambry-replication/src/main/java/com/github/ambry/replication/BlobIdTransformer.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/BlobIdTransformer.java
@@ -251,7 +251,7 @@ public class BlobIdTransformer implements Transformer {
               oldProperties.getContentType(), oldProperties.isPrivate(), oldProperties.getTimeToLiveInSeconds(),
               oldProperties.getCreationTimeInMs(), newBlobId.getAccountId(), newBlobId.getContainerId(),
               oldProperties.isEncrypted(), oldProperties.getExternalAssetTag(), oldProperties.getContentEncoding(),
-              oldProperties.getFilename(), oldProperties.getReservedMetadataBlobId(), oldProperties.getReservedUuid());
+              oldProperties.getFilename(), oldProperties.getReservedMetadataBlobId());
 
       // BlobIDTransformer only exists on ambry-server and replication between servers is relying on blocking channel
       // which is still using java ByteBuffer. So, no need to consider releasing stuff.

--- a/ambry-replication/src/test/java/com/github/ambry/replication/BlobIdTransformerTest.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/BlobIdTransformerTest.java
@@ -527,7 +527,7 @@ public class BlobIdTransformerTest {
       MessageInfo messageInfo;
       BlobProperties blobProperties =
           new BlobProperties(blobPropertiesSize, "serviceId", "ownerId", "contentType", false, 0, 0,
-              blobId.getAccountId(), blobId.getContainerId(), hasEncryption, null, "gzip", "filename", null, null);
+              blobId.getAccountId(), blobId.getContainerId(), hasEncryption, null, "gzip", "filename", null);
       if (clazz != null) {
         MessageFormatInputStream messageFormatInputStream;
         if (clazz == PutMessageFormatInputStream.class) {

--- a/ambry-replication/src/test/java/com/github/ambry/replication/ReplicationTestHelper.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/ReplicationTestHelper.java
@@ -944,7 +944,7 @@ public class ReplicationTestHelper {
     blobIdRandom.nextBytes(usermetadata);
     BlobProperties blobProperties =
         new BlobProperties(blobSize, "test", null, null, false, EXPIRY_TIME_MS - CONSTANT_TIME_MS, CONSTANT_TIME_MS,
-            accountId, containerId, encryptionKey != null, null, null, null, null, null);
+            accountId, containerId, encryptionKey != null, null, null, null, null);
     MessageFormatInputStream stream =
         new PutMessageFormatInputStream(id, encryptionKey == null ? null : ByteBuffer.wrap(encryptionKey),
             blobProperties, ByteBuffer.wrap(usermetadata), new ByteBufferInputStream(ByteBuffer.wrap(blob)), blobSize,

--- a/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
@@ -1357,18 +1357,10 @@ class PutOperation {
           chunkBlobId = metadataPutChunk.reservedMetadataChunkId;
         } else {
           partitionId = getPartitionForPut(partitionClass, attemptedPartitionIds);
-          if (BlobDataType.DATACHUNK.equals(blobDataType) || passedInBlobProperties.getReservedUuid() == null) {
-            chunkBlobId = new BlobId(routerConfig.routerBlobidCurrentVersion, BlobIdType.NATIVE,
-                clusterMap.getLocalDatacenterId(), passedInBlobProperties.getAccountId(),
-                passedInBlobProperties.getContainerId(), partitionId, passedInBlobProperties.isEncrypted(),
-                blobDataType);
-          } else {
-            //We should only reserve uuid for METADATA and SIMPLE blob type.
-            chunkBlobId = new BlobId(routerConfig.routerBlobidCurrentVersion, BlobIdType.NATIVE,
-                clusterMap.getLocalDatacenterId(), passedInBlobProperties.getAccountId(),
-                passedInBlobProperties.getContainerId(), partitionId, passedInBlobProperties.isEncrypted(),
-                blobDataType, passedInBlobProperties.getReservedUuid());
-          }
+          chunkBlobId =
+              new BlobId(routerConfig.routerBlobidCurrentVersion, BlobIdType.NATIVE, clusterMap.getLocalDatacenterId(),
+                  passedInBlobProperties.getAccountId(), passedInBlobProperties.getContainerId(), partitionId,
+                  passedInBlobProperties.isEncrypted(), blobDataType);
         }
 
         // To ensure previously attempted partitions are not retried for this PUT after a failure.
@@ -1380,7 +1372,7 @@ class PutOperation {
             passedInBlobProperties.getCreationTimeInMs(), passedInBlobProperties.getAccountId(),
             passedInBlobProperties.getContainerId(), passedInBlobProperties.isEncrypted(),
             passedInBlobProperties.getExternalAssetTag(), passedInBlobProperties.getContentEncoding(),
-            passedInBlobProperties.getFilename(), resolveReservedMetadataId(), null);
+            passedInBlobProperties.getFilename(), resolveReservedMetadataId());
         operationTracker = getOperationTracker();
         correlationIdToChunkPutRequestInfo.clear();
         logger.trace("{}: Chunk {} is ready for sending out to server", loggingContext, chunkIndex);
@@ -2083,7 +2075,7 @@ class PutOperation {
           reservedMetadataChunkId =
               ClusterMapUtils.reserveMetadataBlobId(partitionClass, Collections.emptyList(), reservedMetadataIdMetrics,
                   clusterMap, passedInBlobProperties.getAccountId(), passedInBlobProperties.getContainerId(),
-                  passedInBlobProperties.isEncrypted(), routerConfig, passedInBlobProperties.getReservedUuid());
+                  passedInBlobProperties.isEncrypted(), routerConfig);
         } else if (!chunksToStitch.isEmpty() && !RestUtils.isS3Request(restRequest)) {
           // Empty chunksToStitch list is already handled in PutOperation constructor by now.
           setReservedMetadataChunkId(chunksToStitch.get(0).getReservedMetadataId());
@@ -2244,7 +2236,7 @@ class PutOperation {
               passedInBlobProperties.getTimeToLiveInSeconds(), passedInBlobProperties.getCreationTimeInMs(),
               passedInBlobProperties.getAccountId(), passedInBlobProperties.getContainerId(),
               passedInBlobProperties.isEncrypted(), passedInBlobProperties.getExternalAssetTag(),
-              passedInBlobProperties.getContentEncoding(), passedInBlobProperties.getFilename(), null, null);
+              passedInBlobProperties.getContentEncoding(), passedInBlobProperties.getFilename(), null);
 
       if (options.skipCompositeChunk()) {
         // close the request as the single blob. we don't generate the composite blob.

--- a/ambry-router/src/test/java/com/github/ambry/router/PutOperationTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/PutOperationTest.java
@@ -677,7 +677,7 @@ public class PutOperationTest {
               false, BlobId.BlobDataType.METADATA);
       BlobProperties blobPropertiesWithId =
           new BlobProperties(-1, "serviceId", "memberId", "contentType", false, Utils.Infinite_Time, Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM), false, null, null, null,
-              reservedMetadataId.getID(), null);
+              reservedMetadataId.getID());
       BlobId altReservedMetadataId =
           new BlobId(BlobId.BLOB_ID_V6, BlobId.BlobIdType.NATIVE, (byte) 0, (short) 1, (short) 1, new MockPartitionId(),
               true, BlobId.BlobDataType.METADATA);

--- a/ambry-test-utils/src/main/java/com/github/ambry/router/InMemoryRouter.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/router/InMemoryRouter.java
@@ -149,7 +149,7 @@ public class InMemoryRouter implements Router {
               blobProperties.getContentType(), blobProperties.isPrivate(), blobProperties.getTimeToLiveInSeconds(),
               blobProperties.getCreationTimeInMs(), blobProperties.getAccountId(), blobProperties.getContainerId(),
               blobProperties.isEncrypted(), blobProperties.getExternalAssetTag(), blobProperties.getContentEncoding(),
-              blobProperties.getFilename(), blobProperties.getReservedMetadataBlobId(), blobProperties.getReservedUuid());
+              blobProperties.getFilename(), blobProperties.getReservedMetadataBlobId());
       this.userMetadata = userMetadata;
       this.blob = blob;
       this.stitchedChunks = stitchedChunks;
@@ -629,17 +629,9 @@ public class InMemoryRouter implements Router {
       String operationResult = null;
       Exception exception = null;
       try {
-        String blobId = null;
-        if (postData.getBlobProperties().getReservedUuid() != null) {
-          blobId = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, ClusterMap.UNKNOWN_DATACENTER_ID,
-              postData.getBlobProperties().getAccountId(), postData.getBlobProperties().getContainerId(),
-              getPartitionForPut(), false, BlobId.BlobDataType.DATACHUNK,
-              postData.getBlobProperties().getReservedUuid()).getID();
-        } else {
-          blobId = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, ClusterMap.UNKNOWN_DATACENTER_ID,
-              postData.getBlobProperties().getAccountId(), postData.getBlobProperties().getContainerId(),
-              getPartitionForPut(), false, BlobId.BlobDataType.DATACHUNK).getID();
-        }
+        String blobId = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, ClusterMap.UNKNOWN_DATACENTER_ID,
+            postData.getBlobProperties().getAccountId(), postData.getBlobProperties().getContainerId(),
+            getPartitionForPut(), false, BlobId.BlobDataType.DATACHUNK).getID();
         if (blobs.containsKey(blobId)) {
           exception = new RouterException("Blob ID duplicate created.", RouterErrorCode.UnexpectedInternalError);
         }

--- a/ambry-test-utils/src/main/java/com/github/ambry/server/ServerTestUtil.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/server/ServerTestUtil.java
@@ -225,7 +225,7 @@ public final class ServerTestUtil {
       // put blob 2 with an expiry time and apply TTL update later
       BlobProperties propertiesForTtlUpdate =
           new BlobProperties(31870, "serviceid1", "ownerid", "image/png", false, TestUtils.TTL_SECS,
-              cluster.time.milliseconds(), accountId, containerId, testEncryption, null, null, null, null, null);
+              cluster.time.milliseconds(), accountId, containerId, testEncryption, null, null, null, null);
       long ttlUpdateBlobExpiryTimeMs = getExpiryTimeMs(propertiesForTtlUpdate);
       PutRequest putRequest2 =
           new PutRequest(1, "client1", blobId2, propertiesForTtlUpdate, ByteBuffer.wrap(userMetadata),
@@ -247,7 +247,7 @@ public final class ServerTestUtil {
       // put blob 4 that is expired
       BlobProperties propertiesExpired =
           new BlobProperties(31870, "serviceid1", "ownerid", "jpeg", false, 0, cluster.time.milliseconds(), accountId,
-              containerId, testEncryption, null, null, null, null, null);
+              containerId, testEncryption, null, null, null, null);
       PutRequest putRequest4 = new PutRequest(1, "client1", blobId4, propertiesExpired, ByteBuffer.wrap(userMetadata),
           Unpooled.wrappedBuffer(data), properties.getBlobSize(), BlobType.DataBlob,
           testEncryption ? ByteBuffer.wrap(encryptionKey) : null);
@@ -795,7 +795,7 @@ public final class ServerTestUtil {
     short containerId = Utils.getRandomShort(TestUtils.RANDOM);
     BlobProperties properties =
         new BlobProperties(100, "serviceid1", null, null, false, TestUtils.TTL_SECS, cluster.time.milliseconds(),
-            accountId, containerId, false, null, null, null, null, null);
+            accountId, containerId, false, null, null, null, null);
     long expectedExpiryTimeMs = getExpiryTimeMs(properties);
     TestUtils.RANDOM.nextBytes(usermetadata);
     TestUtils.RANDOM.nextBytes(data);
@@ -1475,7 +1475,7 @@ public final class ServerTestUtil {
       int size = new Random().nextInt(5000);
       final BlobProperties properties =
           new BlobProperties(size, "service1", "owner id check", "image/jpeg", false, TestUtils.TTL_SECS,
-              cluster.time.milliseconds(), accountId, containerId, false, null, null, null, null, null);
+              cluster.time.milliseconds(), accountId, containerId, false, null, null, null, null);
       final byte[] metadata = new byte[new Random().nextInt(1000)];
       final byte[] blob = new byte[size];
       TestUtils.RANDOM.nextBytes(metadata);
@@ -1664,7 +1664,7 @@ public final class ServerTestUtil {
         short containerId = Utils.getRandomShort(TestUtils.RANDOM);
         propertyList.add(
             new BlobProperties(1000, "serviceid1", null, null, false, TestUtils.TTL_SECS, cluster.time.milliseconds(),
-                accountId, containerId, testEncryption, null, null, null, null, null));
+                accountId, containerId, testEncryption, null, null, null, null));
         blobIdList.add(new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
             clusterMap.getLocalDatacenterId(), accountId, containerId, partition, false,
             BlobId.BlobDataType.DATACHUNK));
@@ -2430,7 +2430,7 @@ public final class ServerTestUtil {
       long ttl = 24 * 60 * 60 + 5;
       BlobProperties propertiesExpired =
           new BlobProperties(31870, "serviceid1", "ownerid", "jpeg", false, ttl, cluster.time.milliseconds(), accountId,
-              containerId, false, null, null, null, null, null);
+              containerId, false, null, null, null, null);
       BlobId blobId2 = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, clusterMap.getLocalDatacenterId(),
           propertiesExpired.getAccountId(), propertiesExpired.getContainerId(), partitionIds.get(0), false,
           BlobId.BlobDataType.DATACHUNK);
@@ -2553,12 +2553,12 @@ public final class ServerTestUtil {
       // property with 7days expiration
       BlobProperties propertiesWithTtl =
           new BlobProperties(dataSize, "serviceid1", "ownerid", "image/png", false, TestUtils.TTL_SECS,
-              cluster.time.milliseconds(), accountId, containerId, testEncryption, null, null, null, null, null);
+              cluster.time.milliseconds(), accountId, containerId, testEncryption, null, null, null, null);
       long ttlUpdateBlobExpiryTimeMs = getExpiryTimeMs(propertiesWithTtl);
       // property of expired blob
       BlobProperties propertiesExpired =
           new BlobProperties(dataSize, "serviceid1", "ownerid", "jpeg", false, 0, cluster.time.milliseconds(),
-              accountId, containerId, testEncryption, null, null, null, null, null);
+              accountId, containerId, testEncryption, null, null, null, null);
       // property of blob with the infinite TTL
       BlobProperties properties = new BlobProperties(dataSize, "serviceid1", accountId, containerId, testEncryption,
           cluster.time.milliseconds());
@@ -3487,7 +3487,7 @@ public final class ServerTestUtil {
       // property with 7days expiration
       BlobProperties propertiesWithTtl =
           new BlobProperties(dataSize, "serviceid1", "ownerid", "image/png", false, TestUtils.TTL_SECS,
-              cluster.time.milliseconds(), accountId, containerId, testEncryption, null, null, null, null, null);
+              cluster.time.milliseconds(), accountId, containerId, testEncryption, null, null, null, null);
       long ttlUpdateBlobExpiryTimeMs = getExpiryTimeMs(propertiesWithTtl);
       // property of blob with the infinite TTL
       BlobProperties properties = new BlobProperties(dataSize, "serviceid1", accountId, containerId, testEncryption,
@@ -4925,7 +4925,7 @@ public final class ServerTestUtil {
     byte[] data = new byte[blobSize];
     BlobProperties blobProperties =
         new BlobProperties(blobSize, "serviceid1", null, null, false, Utils.Infinite_Time, accountId, containerId,
-            false, null, null, null, null, null);
+            false, null, null, null, null);
     TestUtils.RANDOM.nextBytes(data);
     blobIdToSizeMap.put(blobId, blobSize);
     return new PutMessageFormatInputStream(blobId, null, blobProperties, ByteBuffer.wrap(userMetadata),
@@ -5030,7 +5030,7 @@ public final class ServerTestUtil {
     // property with 7days expiration
     BlobProperties propertiesWithTtl =
         new BlobProperties(dataSize, "serviceid1", "ownerid", "image/png", false, TestUtils.TTL_SECS,
-            cluster.time.milliseconds(), accountId, containerId, testEncryption, null, null, null, null, null);
+            cluster.time.milliseconds(), accountId, containerId, testEncryption, null, null, null, null);
     long ttlUpdateBlobExpiryTimeMs = getExpiryTimeMs(propertiesWithTtl);
     // property of blob with the infinite TTL
     BlobProperties properties =
@@ -5134,7 +5134,7 @@ public final class ServerTestUtil {
       // propertiesWithExpiredTtl will expire is 2s.
       BlobProperties propertiesWithExpiredTtl =
           new BlobProperties(dataSize, "serviceid1", "ownerid", "image/png", false, TimeUnit.SECONDS.toSeconds(2),
-              cluster.time.milliseconds(), accountId, containerId, testEncryption, null, null, null, null, null);
+              cluster.time.milliseconds(), accountId, containerId, testEncryption, null, null, null, null);
       // write to both source and target nodes.
       putRequest = new PutRequest(1, "client1", blobId, propertiesWithExpiredTtl, ByteBuffer.wrap(userMetadata),
           Unpooled.wrappedBuffer(data), properties.getBlobSize(), BlobType.DataBlob,

--- a/ambry-test-utils/src/main/java/com/github/ambry/server/Verifier.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/server/Verifier.java
@@ -36,6 +36,7 @@ import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
 import io.netty.buffer.ByteBuf;
 import java.io.DataInputStream;
+import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
@@ -261,7 +262,7 @@ class Verifier implements Runnable {
                     new BlobProperties(old.getBlobSize(), old.getServiceId(), old.getOwnerId(), old.getContentType(),
                         old.isEncrypted(), Utils.Infinite_Time, old.getCreationTimeInMs(), old.getAccountId(),
                         old.getContainerId(), old.isEncrypted(), old.getExternalAssetTag(), old.getContentEncoding(),
-                        old.getFilename(), old.getReservedMetadataBlobId(), old.getReservedUuid());
+                        old.getFilename(), old.getReservedMetadataBlobId());
               }
             } catch (Exception e) {
               if (channel1 != null) {

--- a/ambry-vcr/src/test/java/com/github/ambry/vcr/VcrTestUtil.java
+++ b/ambry-vcr/src/test/java/com/github/ambry/vcr/VcrTestUtil.java
@@ -36,6 +36,7 @@ import com.github.ambry.server.MockNotificationSystem;
 import com.github.ambry.utils.HelixControllerManager;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -59,9 +60,11 @@ import org.apache.helix.model.builder.HelixConfigScopeBuilder;
 import org.apache.helix.tools.ClusterSetup;
 import org.apache.helix.zookeeper.api.client.HelixZkClient;
 import org.apache.helix.zookeeper.impl.factory.DedicatedZkClientFactory;
+import org.junit.Test;
 
 import static com.github.ambry.server.ServerTestUtil.*;
 import static org.junit.Assert.*;
+import static org.junit.Assume.*;
 
 
 /**
@@ -242,7 +245,7 @@ public class VcrTestUtil {
     long ttl = doTtlUpdate ? TimeUnit.DAYS.toMillis(1) : Utils.Infinite_Time;
     BlobProperties properties =
         new BlobProperties(blobSize, "serviceid1", null, null, false, ttl, cluster.time.milliseconds(), accountId,
-            containerId, false, null, null, null, null, null);
+            containerId, false, null, null, null, null);
     TestUtils.RANDOM.nextBytes(userMetadata);
     TestUtils.RANDOM.nextBytes(data);
 


### PR DESCRIPTION
This reverts commit 526d79a296e79c290c122a613da2fe0cf4b63f11.
https://github.com/linkedin/ambry/pull/2901
We want to see if this is causing the wrong partition issue.