### PR TITLE
Format modified time in S3 List API correctly as per RFC 3339

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/frontend/s3/S3MessagePayload.java
+++ b/ambry-api/src/main/java/com/github/ambry/frontend/s3/S3MessagePayload.java
@@ -317,6 +317,10 @@ public class S3MessagePayload {
 
     public long getSize() { return size; }
 
+    public String getLastModified() {
+      return lastModified;
+    }
+
     @Override
     public String toString() {
       return "Key=" + key + ", " + "LastModified=" + lastModified + ", " + "Size=" + size;

--- a/ambry-api/src/main/java/com/github/ambry/named/NamedBlobRecord.java
+++ b/ambry-api/src/main/java/com/github/ambry/named/NamedBlobRecord.java
@@ -29,7 +29,7 @@ public class NamedBlobRecord {
   private final long version;
   private final String blobId;
   private final long blobSize;
-  private final long modifiedTimeMs;
+  private long modifiedTimeMs;
 
   /**
    * @param accountName the account name.
@@ -171,5 +171,13 @@ public class NamedBlobRecord {
    */
   public long getModifiedTimeMs() {
     return modifiedTimeMs;
+  }
+
+  /**
+   * Set the modified timestamp of this blob. Exposed for testing
+   * @param modifiedTimeMs the modified timestamp to set in milliseconds since epoch
+   */
+  public void setModifiedTimeMs(long modifiedTimeMs) {
+    this.modifiedTimeMs = modifiedTimeMs;
   }
 }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3ListHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3ListHandler.java
@@ -31,6 +31,12 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
@@ -60,6 +66,7 @@ public class S3ListHandler extends S3BaseHandler<ReadableStreamChannel> {
   public static final String ENCODING_TYPE_PARAM_NAME = "encoding-type";
   private final NamedBlobListHandler namedBlobListHandler;
   private final FrontendMetrics metrics;
+  public static final DateTimeFormatter TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssXXX");
 
   /**
    * Constructs a handler for handling s3 requests for listing blobs.
@@ -103,7 +110,7 @@ public class S3ListHandler extends S3BaseHandler<ReadableStreamChannel> {
     String maxKeys = getHeader(restRequest.getArgs(), MAXKEYS_PARAM_NAME, false);
     String marker = getHeader(restRequest.getArgs(), MARKER, false);
     String continuationToken = getHeader(restRequest.getArgs(), CONTINUATION_TOKEN, false);
-        //By default S3 list returns up to 1000 key names.
+    //By default S3 list returns up to 1000 key names.
     int maxKeysValue = maxKeys == null ? DEFAULT_MAX_KEY_VALUE : Integer.parseInt(maxKeys);
     // Iterate through list of blob names.
     List<Contents> contentsList = new ArrayList<>();
@@ -112,9 +119,12 @@ public class S3ListHandler extends S3BaseHandler<ReadableStreamChannel> {
       String blobName = namedBlobRecord.getBlobName();
       long blobSize = namedBlobRecord.getBlobSize();
       long modifiedTimeMs = namedBlobRecord.getModifiedTimeMs();
-      Date modifiedDate = modifiedTimeMs != -1 ? new Date(modifiedTimeMs) : Calendar.getInstance().getTime();
-      String formattedModifiedDate = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").format(modifiedDate);
-      contentsList.add(new Contents(blobName, formattedModifiedDate, blobSize));
+      if (modifiedTimeMs == -1) {
+        modifiedTimeMs = System.currentTimeMillis();
+      }
+      ZonedDateTime zonedDateTime = Instant.ofEpochMilli(modifiedTimeMs).atZone(ZoneId.of("UTC"));
+      String formattedDate = zonedDateTime.format(TIMESTAMP_FORMATTER);
+      contentsList.add(new Contents(blobName, formattedDate, blobSize));
       if (++keyCount == maxKeysValue) {
         break;
       }

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/S3ListHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/S3ListHandlerTest.java
@@ -42,6 +42,10 @@ import com.github.ambry.router.InMemoryRouter;
 import com.github.ambry.router.ReadableStreamChannel;
 import com.github.ambry.utils.TestUtils;
 import java.nio.ByteBuffer;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -226,6 +230,11 @@ public class S3ListHandlerTest {
     assertEquals("Mismatch in delimiter", "/", listBucketResultV2.getDelimiter());
     assertEquals("Mismatch in encoding type", "url", listBucketResultV2.getEncodingType());
     assertEquals("Mismatch in size", BLOB_SIZE, listBucketResultV2.getContents().get(0).getSize());
+    // Verify the modified timestamp is formatted correctly
+    String lastModified = listBucketResultV2.getContents().get(0).getLastModified();
+    assertNotEquals( "Last modified should not be -1", "-1", lastModified);
+    // Attempt to parse the string. This should throw DateTimeParseException if the format is incorrect.
+    ZonedDateTime.parse(lastModified, S3ListHandler.TIMESTAMP_FORMATTER);
 
     // 4. Get list of blobs with continuation-token
     s3_list_request_uri =

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/TestNamedBlobDb.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/TestNamedBlobDb.java
@@ -266,6 +266,7 @@ public class TestNamedBlobDb implements NamedBlobDb {
   }
 
   private void putInternal(NamedBlobRecord record, NamedBlobState state, long deleteTs) {
+    record.setModifiedTimeMs(time.milliseconds());
     Pair<NamedBlobState, Long> stateAndDeleteTs = new Pair<>(state, deleteTs);
     Pair<NamedBlobRecord, Pair<NamedBlobState, Long>> newRecord = new Pair<>(record, stateAndDeleteTs);
     List<Pair<NamedBlobRecord, Pair<NamedBlobState, Long>>> recordList =


### PR DESCRIPTION
S3 List API currently returns timezone of a blob in `LastModified` field as +0000 (Example: `<LastModified>2024-08-26T18:20:55+0000</LastModified>`). But per RFC 3339 section 5.6, the time zone must either be represented as 'Z' or +00:00 (with colons).  Reference https://pkg.go.dev/github.com/aws/smithy-go/time#ParseDateTime

It is a known issue that `SimpleDateFormat` in java doesn't comply with it and returns it as +0000. Updating the code to use java `DateTimeFormatter` instead.