### PR TITLE
[mysql] Verify credentials for cert-based access

### DIFF
--- a/ambry-named-mysql/src/main/java/com/github/ambry/named/MySqlNamedBlobDbFactory.java
+++ b/ambry-named-mysql/src/main/java/com/github/ambry/named/MySqlNamedBlobDbFactory.java
@@ -63,6 +63,7 @@ public class MySqlNamedBlobDbFactory implements NamedBlobDbFactory {
     hikariConfig.setJdbcUrl(dbEndpoint.getUrl());
     hikariConfig.setUsername(dbEndpoint.getUsername());
     hikariConfig.setPassword(dbEndpoint.getPassword());
+    hikariConfig.addDataSourceProperty("sslMode", "VERIFY_CA");
     hikariConfig.setMaximumPoolSize(
         dbEndpoint.getDatacenter().equals(localDatacenter) ? config.localPoolSize : config.remotePoolSize);
     // Recommended properties for automatic prepared statement caching


### PR DESCRIPTION
This patch configures the mysql java driver to use CA certs installed on the machine to authenticate with mysql db.