### PR TITLE
[frontend] Fix nullptr in TtlUpdate

### DIFF
--- a/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateOperation.java
@@ -376,6 +376,9 @@ class TtlUpdateOperation {
     // 3. and at least one replica returned successful status.
     // 4. and error code precedence is over AmbryUnavailable. If we have one success and one delete, shouldn't do retry.
     // @formatter:off
+    if (operationException.get() == null) {
+      return false;
+    }
     RouterErrorCode errorCode = ((RouterException) operationException.get()).getErrorCode();
     return (routerConfig.routerRepairWithReplicateBlobOnTtlUpdateEnabled
         && operationTracker.hasNotFound()

--- a/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateOperation.java
@@ -376,7 +376,7 @@ class TtlUpdateOperation {
     // 3. and at least one replica returned successful status.
     // 4. and error code precedence is over AmbryUnavailable. If we have one success and one delete, shouldn't do retry.
     // @formatter:off
-    if (operationException.get() == null) {
+    if (operationException == null || operationException.get() == null) {
       return false;
     }
     RouterErrorCode errorCode = ((RouterException) operationException.get()).getErrorCode();


### PR DESCRIPTION
A null pointer is causing TTL-UPDATES to fail. This patch fixes it.