### PR TITLE
Support for Helix Auto Registration

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
@@ -42,6 +42,7 @@ public class ClusterMapConfig {
   public static final String DELETE_DATA_FROM_DATANODE_CONFIG_IN_PROPERTY_STORE_CLEAN_UP_TASK =
       "clustermap.delete.data.from.datanode.config.in.property.store.clean.up.task";
   private static final String MAX_REPLICAS_ALL_DATACENTERS = "max-replicas-all-datacenters";
+  public static final String IS_AUTO_REGISTRATION_ENABLED = "clustermap.auto.registration.enabled";
 
   /**
    * The factory class used to get the resource state policies.
@@ -372,6 +373,10 @@ public class ClusterMapConfig {
   @Default("false")
   public final boolean clusterMapIgnoreDownwardStateTransition;
 
+  @Config(IS_AUTO_REGISTRATION_ENABLED)
+  @Default("false")
+  public final boolean clusterMapAutoRegistrationEnabled;
+
   public ClusterMapConfig(VerifiableProperties verifiableProperties) {
     clusterMapFixedTimeoutDatanodeErrorThreshold =
         verifiableProperties.getIntInRange("clustermap.fixedtimeout.datanode.error.threshold", 3, 1, 100);
@@ -455,5 +460,6 @@ public class ClusterMapConfig {
         verifiableProperties.getLongInRange("clustermap.default.replica.capacity.in.bytes", 384L * 1024 * 1024 * 1024,
             0, Long.MAX_VALUE);
     clusterMapIgnoreDownwardStateTransition = verifiableProperties.getBoolean(IGNORE_DOWNWARD_STATE_TRANSITION, false);
+    clusterMapAutoRegistrationEnabled = verifiableProperties.getBoolean(IS_AUTO_REGISTRATION_ENABLED, false);
   }
 }

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/HelixVcrClusterSpectator.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/HelixVcrClusterSpectator.java
@@ -64,7 +64,7 @@ public class HelixVcrClusterSpectator implements VcrClusterSpectator {
     // Once we add more fabrics, we should revisit this.
     HelixManager helixManager =
         helixFactory.getZkHelixManagerAndConnect(cloudConfig.vcrClusterName, selfInstanceName, InstanceType.SPECTATOR,
-            cloudConfig.vcrClusterZkConnectString);
+            cloudConfig.vcrClusterZkConnectString, clusterMapConfig);
 
     helixManager.addInstanceConfigChangeListener(this);
     helixManager.addLiveInstanceChangeListener(this);

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
@@ -110,6 +110,7 @@ public class ClusterMapUtils {
   static final int CURRENT_SCHEMA_VERSION = 0;
   static final String WRITABLE_LOG_STR = "writable";
   static final String FULLY_WRITABLE_LOG_STR = "fully writable";
+  private static final String INSTANCE_NAME_DELIMITER = "_";
   private static final Logger logger = LoggerFactory.getLogger(ClusterMapUtils.class);
 
   /**
@@ -160,7 +161,7 @@ public class ClusterMapUtils {
    * @return the constructed instance name.
    */
   public static String getInstanceName(String host, Integer port) {
-    return port == null ? host : host + "_" + port;
+    return port == null ? host : host + INSTANCE_NAME_DELIMITER + port;
   }
 
   /**
@@ -170,6 +171,10 @@ public class ClusterMapUtils {
    */
   public static String getInstanceName(DataNodeId dataNodeId) {
     return getInstanceName(dataNodeId.getHostname(), dataNodeId.getPort());
+  }
+
+  public static String getPortFromInstanceName(String instanceName) {
+    return instanceName.contains(INSTANCE_NAME_DELIMITER) ? instanceName.split(INSTANCE_NAME_DELIMITER)[1] : null;
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixAggregatedViewClusterInitializer.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixAggregatedViewClusterInitializer.java
@@ -106,7 +106,7 @@ class HelixAggregatedViewClusterInitializer {
     String localZkConnectStr = localDcZkInfo.getZkConnectStrs().get(0);
     HelixManager helixManager =
         helixFactory.getZkHelixManagerAndConnect(aggregatedViewClusterName, selfInstanceName, InstanceType.SPECTATOR,
-            localZkConnectStr);
+            localZkConnectStr, clusterMapConfig);
     logger.info("Helix cluster name {}", helixManager.getClusterName());
 
     clusterChangeHandler =
@@ -242,7 +242,7 @@ class HelixAggregatedViewClusterInitializer {
     String zkConnectStr = dataCenterToZkAddress.get(dcName).getZkConnectStrs().get(0);
     HelixManager manager =
         helixFactory.getZkHelixManagerAndConnect(clusterMapConfig.clusterMapClusterName, selfInstanceName,
-            InstanceType.SPECTATOR, zkConnectStr);
+            InstanceType.SPECTATOR, zkConnectStr, clusterMapConfig);
     manager.addIdealStateChangeListener(
         (IdealStateChangeListener) (idealState, changeContext) -> clusterChangeHandler.handleIdealStateChange(
             idealState, dcName));
@@ -254,7 +254,7 @@ class HelixAggregatedViewClusterInitializer {
     String zkConnectStr = dataCenterToZkAddress.get(dcName).getZkConnectStrs().get(0);
     HelixManager manager =
         helixFactory.getZkHelixManagerAndConnect(clusterMapConfig.clusterMapClusterName, selfInstanceName,
-            InstanceType.SPECTATOR, zkConnectStr);
+            InstanceType.SPECTATOR, zkConnectStr, clusterMapConfig);
     manager.addInstanceConfigChangeListener(clusterChangeHandler);
     logger.info("Registered instance config change listeners for cluster {} via Helix manager at {}",
         clusterMapConfig.clusterMapClusterName, zkConnectStr);

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
@@ -266,7 +266,7 @@ public class HelixClusterManager implements ClusterMap {
     // doesn't support multiple HelixClusterManagers(spectators) on same node.
     String zkConnectStr = dcZkInfo.getZkConnectStrs().get(0);
     HelixManager manager =
-        helixFactory.getZkHelixManagerAndConnect(clusterName, instanceName, InstanceType.SPECTATOR, zkConnectStr);
+        helixFactory.getZkHelixManagerAndConnect(clusterName, instanceName, InstanceType.SPECTATOR, zkConnectStr, clusterMapConfig);
     helixPropertyStoreInLocalDc = manager.getHelixPropertyStore();
     logger.info("HelixPropertyStore from local datacenter {} is: {}", dcZkInfo.getDcName(),
         helixPropertyStoreInLocalDc);

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixDatacenterInitializer.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixDatacenterInitializer.java
@@ -130,7 +130,7 @@ class HelixDatacenterInitializer {
       manager = Objects.requireNonNull(localManager, "localManager should have been set");
     } else {
       manager = helixFactory.getZkHelixManagerAndConnect(clusterMapConfig.clusterMapClusterName, selfInstanceName,
-          InstanceType.SPECTATOR, zkConnectStr);
+          InstanceType.SPECTATOR, zkConnectStr, clusterMapConfig);
     }
     HelixClusterChangeHandler clusterChangeHandler =
         helixClusterManager.new HelixClusterChangeHandler(dcName, clusterMapConfig.clusterMapClusterName,

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixFactory.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixFactory.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.helix.HelixManager;
+import org.apache.helix.HelixManagerFactory;
 import org.apache.helix.HelixManagerProperty;
 import org.apache.helix.InstanceType;
 import org.apache.helix.constants.InstanceConstants;
@@ -48,10 +49,10 @@ public class HelixFactory {
    * @return the constructed {@link HelixManager}.
    */
   public HelixManager getZKHelixManager(String clusterName, String instanceName, InstanceType instanceType,
-      String zkAddr) {
+      String zkAddr, ClusterMapConfig clusterMapConfig) {
     ManagerKey managerKey = new ManagerKey(clusterName, instanceName, instanceType, zkAddr);
     return helixManagers.computeIfAbsent(managerKey,
-        k -> buildZKHelixManager(clusterName, instanceName, instanceType, zkAddr));
+        k -> buildZKHelixManager(clusterName, instanceName, instanceType, zkAddr, clusterMapConfig));
   }
 
   /**
@@ -64,8 +65,8 @@ public class HelixFactory {
    * @throws Exception if connecting failed.
    */
   public HelixManager getZkHelixManagerAndConnect(String clusterName, String instanceName, InstanceType instanceType,
-      String zkAddr) throws Exception {
-    HelixManager manager = getZKHelixManager(clusterName, instanceName, instanceType, zkAddr);
+      String zkAddr, ClusterMapConfig clusterMapConfig) throws Exception {
+    HelixManager manager = getZKHelixManager(clusterName, instanceName, instanceType, zkAddr, clusterMapConfig);
     synchronized (manager) {
       if (!manager.isConnected()) {
         LOGGER.info("Connecting to HelixManager at {}", zkAddr);
@@ -100,21 +101,31 @@ public class HelixFactory {
    * @param zkAddr the address identifying the zk service to which this request is to be made.
    * @return a new instance of {@link HelixManager}.
    */
-  HelixManager buildZKHelixManager(String clusterName, String instanceName, InstanceType instanceType, String zkAddr) {
+  HelixManager buildZKHelixManager(String clusterName, String instanceName, InstanceType instanceType, String zkAddr
+  , ClusterMapConfig clusterMapConfig) {
+    HelixManager helixManager;
+    if (clusterMapConfig != null && clusterMapConfig.clusterMapAutoRegistrationEnabled) {
+      LOGGER.info("Autoregistration enabled for cluster {} with instanceName {} and instanceType {}", clusterName, instanceName, instanceType);
 
-    String port = getPortFromInstanceName(instanceName);
+      String port = getPortFromInstanceName(instanceName);
 
-    InstanceConfig.Builder instanceConfigBuilder = new InstanceConfig.Builder().setInstanceOperation(InstanceConstants.InstanceOperation.UNKNOWN);
-    if (port != null && !port.isEmpty()) {
-      instanceConfigBuilder.setPort(port);
+      InstanceConfig.Builder instanceConfigBuilder = new InstanceConfig.Builder().setInstanceOperation(InstanceConstants.InstanceOperation.UNKNOWN);
+      if (port != null && !port.isEmpty()) {
+        instanceConfigBuilder.setPort(port);
+      }
+
+      HelixManagerProperty participantHelixProperty = new HelixManagerProperty.Builder().setDefaultInstanceConfigBuilder(instanceConfigBuilder).build();
+      HelixManagerProperty defaultHelixManagerProperty = new HelixManagerProperty.Builder().setDefaultInstanceConfigBuilder(new InstanceConfig.Builder()).build();
+
+      helixManager = new ZKHelixManager(clusterName, instanceName, instanceType, zkAddr, null,
+          instanceType == InstanceType.PARTICIPANT ?  participantHelixProperty : defaultHelixManagerProperty);
+      LOGGER.info("Created HelixManager for cluster {} with instanceName {} and instanceType {}", clusterName, instanceName, instanceType);
+
+    } else {
+      helixManager =  HelixManagerFactory.getZKHelixManager(clusterName, instanceName, instanceType, zkAddr);
     }
 
-    HelixManagerProperty participantHelixProperty = new HelixManagerProperty.Builder().setDefaultInstanceConfigBuilder(instanceConfigBuilder).build();
-    HelixManagerProperty defaultHelixManagerProperty = new HelixManagerProperty.Builder().setDefaultInstanceConfigBuilder(new InstanceConfig.Builder()).build();
 
-    HelixManager helixManager = new ZKHelixManager(clusterName, instanceName, instanceType, zkAddr, null,
-        instanceType == InstanceType.PARTICIPANT ?  participantHelixProperty : defaultHelixManagerProperty);
-    LOGGER.info("Created HelixManager for cluster {} with instanceName {} and instanceType {}", clusterName, instanceName, instanceType);
     return helixManager;
   }
 
@@ -133,7 +144,7 @@ public class HelixFactory {
         instanceConfigSource = new InstanceConfigToDataNodeConfigAdapter(
             getZkHelixManagerAndConnect(clusterMapConfig.clusterMapClusterName,
                 ClusterMapUtils.getInstanceName(clusterMapConfig.clusterMapHostName, clusterMapConfig.clusterMapPort),
-                InstanceType.SPECTATOR, zkAddr), clusterMapConfig);
+                InstanceType.SPECTATOR, zkAddr, clusterMapConfig), clusterMapConfig);
       }
       PropertyStoreToDataNodeConfigAdapter propertyStoreSource = null;
       if (clusterMapConfig.clusterMapDataNodeConfigSourceType.isPropertyStoreAware()) {

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixFactory.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixFactory.java
@@ -102,11 +102,12 @@ public class HelixFactory {
    */
   HelixManager buildZKHelixManager(String clusterName, String instanceName, InstanceType instanceType, String zkAddr) {
     HelixManagerProperty participantHelixProperty = new HelixManagerProperty.Builder().setDefaultInstanceConfigBuilder(
-        new InstanceConfig.Builder().setInstanceOperation(InstanceConstants.InstanceOperation.UNKNOWN).setPort(INSTANCE_CONFIG_HELIX_PORT)).build();
+        new InstanceConfig.Builder().setInstanceOperation(InstanceConstants.InstanceOperation.UNKNOWN)).build();
+
+    HelixManagerProperty defaultHelixManagerProperty = new HelixManagerProperty.Builder().setDefaultInstanceConfigBuilder(new InstanceConfig.Builder()).build();
 
     HelixManager helixManager = new ZKHelixManager(clusterName, instanceName, instanceType, zkAddr, null,
-        instanceType == InstanceType.PARTICIPANT ?  participantHelixProperty :
-            new HelixManagerProperty.Builder().setDefaultInstanceConfigBuilder(new InstanceConfig.Builder()).build());
+        instanceType == InstanceType.PARTICIPANT ?  participantHelixProperty : defaultHelixManagerProperty);
     LOGGER.info("Created HelixManager for cluster {} with instanceName {} and instanceType {}", clusterName, instanceName, instanceType);
     return helixManager;
   }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixFactory.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixFactory.java
@@ -19,8 +19,11 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.helix.HelixManager;
-import org.apache.helix.HelixManagerFactory;
+import org.apache.helix.HelixManagerProperty;
 import org.apache.helix.InstanceType;
+import org.apache.helix.constants.InstanceConstants;
+import org.apache.helix.manager.zk.ZKHelixManager;
+import org.apache.helix.model.InstanceConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,6 +36,7 @@ public class HelixFactory {
   // exposed for use in testing
   private final Map<ManagerKey, HelixManager> helixManagers = new ConcurrentHashMap<>();
   private final Map<String, DataNodeConfigSource> dataNodeConfigSources = new ConcurrentHashMap<>();
+  private static final String INSTANCE_CONFIG_HELIX_PORT = "15088";
 
   /**
    * Get a reference to a {@link HelixManager}
@@ -96,7 +100,9 @@ public class HelixFactory {
    * @return a new instance of {@link HelixManager}.
    */
   HelixManager buildZKHelixManager(String clusterName, String instanceName, InstanceType instanceType, String zkAddr) {
-    return HelixManagerFactory.getZKHelixManager(clusterName, instanceName, instanceType, zkAddr);
+    return new ZKHelixManager(clusterName, instanceName, instanceType, zkAddr, null,
+        instanceType == InstanceType.PARTICIPANT ? new HelixManagerProperty.Builder().setDefaultInstanceConfigBuilder(
+        new InstanceConfig.Builder().setInstanceOperation(InstanceConstants.InstanceOperation.UNKNOWN).setPort(INSTANCE_CONFIG_HELIX_PORT)).build() : null);
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixFactory.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixFactory.java
@@ -19,7 +19,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.helix.HelixManager;
-import org.apache.helix.HelixManagerFactory;
 import org.apache.helix.HelixManagerProperty;
 import org.apache.helix.InstanceType;
 import org.apache.helix.constants.InstanceConstants;
@@ -39,7 +38,6 @@ public class HelixFactory {
   // exposed for use in testing
   private final Map<ManagerKey, HelixManager> helixManagers = new ConcurrentHashMap<>();
   private final Map<String, DataNodeConfigSource> dataNodeConfigSources = new ConcurrentHashMap<>();
-  private static final String INSTANCE_CONFIG_HELIX_PORT = "15088";
 
   /**
    * Get a reference to a {@link HelixManager}

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixFactory.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixFactory.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.helix.HelixManager;
+import org.apache.helix.HelixManagerFactory;
 import org.apache.helix.HelixManagerProperty;
 import org.apache.helix.InstanceType;
 import org.apache.helix.constants.InstanceConstants;
@@ -100,9 +101,14 @@ public class HelixFactory {
    * @return a new instance of {@link HelixManager}.
    */
   HelixManager buildZKHelixManager(String clusterName, String instanceName, InstanceType instanceType, String zkAddr) {
-    return new ZKHelixManager(clusterName, instanceName, instanceType, zkAddr, null,
-        instanceType == InstanceType.PARTICIPANT ? new HelixManagerProperty.Builder().setDefaultInstanceConfigBuilder(
-        new InstanceConfig.Builder().setInstanceOperation(InstanceConstants.InstanceOperation.UNKNOWN).setPort(INSTANCE_CONFIG_HELIX_PORT)).build() : null);
+    HelixManagerProperty participantHelixProperty = new HelixManagerProperty.Builder().setDefaultInstanceConfigBuilder(
+        new InstanceConfig.Builder().setInstanceOperation(InstanceConstants.InstanceOperation.UNKNOWN).setPort(INSTANCE_CONFIG_HELIX_PORT)).build();
+
+    HelixManager helixManager = new ZKHelixManager(clusterName, instanceName, instanceType, zkAddr, null,
+        instanceType == InstanceType.PARTICIPANT ?  participantHelixProperty :
+            new HelixManagerProperty.Builder().setDefaultInstanceConfigBuilder(new InstanceConfig.Builder()).build());
+    LOGGER.info("Created HelixManager for cluster {} with instanceName {} and instanceType {}", clusterName, instanceName, instanceType);
+    return helixManager;
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixFactory.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixFactory.java
@@ -28,6 +28,8 @@ import org.apache.helix.model.InstanceConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.github.ambry.clustermap.ClusterMapUtils.*;
+
 
 /**
  * A factory class to construct and get a reference to a {@link HelixManager}
@@ -101,9 +103,15 @@ public class HelixFactory {
    * @return a new instance of {@link HelixManager}.
    */
   HelixManager buildZKHelixManager(String clusterName, String instanceName, InstanceType instanceType, String zkAddr) {
-    HelixManagerProperty participantHelixProperty = new HelixManagerProperty.Builder().setDefaultInstanceConfigBuilder(
-        new InstanceConfig.Builder().setInstanceOperation(InstanceConstants.InstanceOperation.UNKNOWN)).build();
 
+    String port = getPortFromInstanceName(instanceName);
+
+    InstanceConfig.Builder instanceConfigBuilder = new InstanceConfig.Builder().setInstanceOperation(InstanceConstants.InstanceOperation.UNKNOWN);
+    if (port != null && !port.isEmpty()) {
+      instanceConfigBuilder.setPort(port);
+    }
+
+    HelixManagerProperty participantHelixProperty = new HelixManagerProperty.Builder().setDefaultInstanceConfigBuilder(instanceConfigBuilder).build();
     HelixManagerProperty defaultHelixManagerProperty = new HelixManagerProperty.Builder().setDefaultInstanceConfigBuilder(new InstanceConfig.Builder()).build();
 
     HelixManager helixManager = new ZKHelixManager(clusterName, instanceName, instanceType, zkAddr, null,

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
@@ -107,7 +107,7 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
     if (clusterName.isEmpty()) {
       throw new IllegalStateException("Cluster name is empty in clusterMapConfig");
     }
-    manager = helixFactory.getZKHelixManager(clusterName, instanceName, InstanceType.PARTICIPANT, zkConnectStr);
+    manager = helixFactory.getZKHelixManager(clusterName, instanceName, InstanceType.PARTICIPANT, zkConnectStr, clusterMapConfig);
     replicaSyncUpManager = new AmbryReplicaSyncUpManager(clusterMapConfig);
     partitionStateChangeListeners = new HashMap<>();
     try {
@@ -115,7 +115,7 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
       // SPECTATOR instance that is also used by HelixClusterManager. This avoids the need to start participating in a
       // cluster before reading/writing from zookeeper.
       HelixManager spectatorManager =
-          helixFactory.getZkHelixManagerAndConnect(clusterName, instanceName, InstanceType.SPECTATOR, zkConnectStr);
+          helixFactory.getZkHelixManagerAndConnect(clusterName, instanceName, InstanceType.SPECTATOR, zkConnectStr, clusterMapConfig);
       helixAdmin = spectatorManager.getClusterManagmentTool();
       dataNodeConfigSource = helixFactory.getDataNodeConfigSource(clusterMapConfig, zkConnectStr,
           new DataNodeConfigSourceMetrics(metricRegistry));

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixClusterManagerTest.java
@@ -2353,7 +2353,7 @@ public class HelixClusterManagerTest {
 
     @Override
     HelixManager buildZKHelixManager(String clusterName, String instanceName, InstanceType instanceType,
-        String zkAddr) {
+        String zkAddr, ClusterMapConfig clusterMapConfig1) {
       if (!helixCluster.getZkAddrs().contains(zkAddr)) {
         throw new IllegalArgumentException("Invalid ZkAddr");
       }

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixParticipantTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixParticipantTest.java
@@ -34,6 +34,7 @@ import java.util.stream.Collectors;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixManager;
 import org.apache.helix.InstanceType;
+import org.apache.helix.constants.InstanceConstants;
 import org.apache.helix.lock.LockScope;
 import org.apache.helix.lock.helix.HelixLockScope;
 import org.apache.helix.lock.helix.ZKDistributedNonblockingLock;
@@ -818,6 +819,29 @@ public class HelixParticipantTest {
     Thread.sleep(500);
     getNumberOfReplicaInStateFromMetric("offline", metricRegistry);
     assertEquals(replicaIds.size(), getNumberOfReplicaInStateFromMetric("offline", metricRegistry));
+
+    helixParticipant.close();
+  }
+
+
+  @Test
+  public void testEnableStatePostParticipate() throws IOException {
+    assumeTrue(stateModelDef.equals(ClusterMapConfig.AMBRY_STATE_MODEL_DEF));
+    ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
+    MetricRegistry metricRegistry = new MetricRegistry();
+    HelixParticipant helixParticipant =
+        new HelixParticipant(mock(HelixClusterManager.class), clusterMapConfig, new HelixFactory(), metricRegistry,
+            getDefaultZkConnectStr(clusterMapConfig), true);
+    HelixManager manager = helixParticipant.getHelixManager();
+
+    assertEquals(manager.getInstanceType(), InstanceType.PARTICIPANT);
+    assertNotNull("HelixManager cannot be null", manager);
+
+    helixParticipant.participate(Collections.emptyList(), null, null);
+
+    // Without cloud config, instances should still be in ENABLE state
+    assertEquals(InstanceConstants.InstanceOperation.ENABLE,
+        manager.getConfigAccessor().getInstanceConfig(clusterName, manager.getInstanceName()).getInstanceOperation().getOperation());
 
     helixParticipant.close();
   }

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixAdmin.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixAdmin.java
@@ -89,6 +89,12 @@ public class MockHelixAdmin implements HelixAdmin {
   }
 
   @Override
+  public void setPartitionsToError(String clusterName, String instanceName, String resourceName,
+      List<String> partitionNames) {
+    throw new IllegalStateException("Not implemented");
+  }
+
+  @Override
   public void enableInstance(String clusterName, String instanceName, boolean enabled,
       InstanceConstants.InstanceDisabledType disabledType, String reason) {
   }
@@ -633,6 +639,24 @@ public class MockHelixAdmin implements HelixAdmin {
   }
 
   @Override
+  public void setInstanceOperation(String clusterName, String instanceName,
+      InstanceConstants.InstanceOperation instanceOperation) {
+    setInstanceOperation(clusterName, instanceName, instanceOperation, "Not Implemented");
+  }
+
+  @Override
+  public void setInstanceOperation(String clusterName, String instanceName,
+      InstanceConstants.InstanceOperation instanceOperation, String reason) {
+    setInstanceOperation(clusterName, instanceName, instanceOperation, reason, false);
+  }
+
+  @Override
+  public void setInstanceOperation(String clusterName, String instanceName,
+      InstanceConstants.InstanceOperation instanceOperation, String reason, boolean overrideAll) {
+    throw new IllegalStateException("Not implemented");
+  }
+
+  @Override
   public void enableResource(String clusterName, String resourceName, boolean enabled) {
     throw new IllegalStateException("Not implemented");
   }
@@ -763,6 +787,11 @@ public class MockHelixAdmin implements HelixAdmin {
   }
 
   @Override
+  public void onDemandRebalance(String s) {
+    throw new IllegalStateException("Not implemented");
+  }
+
+  @Override
   public void addIdealState(String clusterName, String resourceName, String idealStateFile) throws IOException {
     throw new IllegalStateException("Not implemented");
   }
@@ -868,6 +897,26 @@ public class MockHelixAdmin implements HelixAdmin {
   @Override
   public Map<String, Boolean> validateInstancesForWagedRebalance(String clusterName, List<String> instancesNames) {
     return null;
+  }
+
+  @Override
+  public boolean isEvacuateFinished(String clusterName, String instancesNames) {
+    throw new IllegalStateException("Not implemented");
+  }
+
+  @Override
+  public boolean canCompleteSwap(String clusterName, String instanceName) {
+    throw new IllegalStateException("Not implemented");
+  }
+
+  @Override
+  public boolean completeSwapIfPossible(String clusterName, String instanceName, boolean forceComplete) {
+    throw new IllegalStateException("Not implemented");
+  }
+
+  @Override
+  public boolean isReadyForPreparingJoiningCluster(String clusterName, String instancesNames) {
+    throw new IllegalStateException("Not implemented");
   }
 
   /**

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixManager.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixManager.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -29,6 +30,7 @@ import org.apache.helix.AccessOption;
 import org.apache.helix.ClusterMessagingService;
 import org.apache.helix.ConfigAccessor;
 import org.apache.helix.HelixAdmin;
+import org.apache.helix.HelixConstants;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixManager;
 import org.apache.helix.HelixManagerProperties;
@@ -62,6 +64,7 @@ import org.apache.helix.spectator.RoutingTableProvider;
 import org.apache.helix.store.HelixPropertyStore;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.zookeeper.Watcher;
 
 import static org.mockito.Mockito.*;
 
@@ -180,6 +183,12 @@ class MockHelixManager implements HelixManager {
     }
     helixPropertyStore.stop();
     helixPropertyStore.close();
+  }
+
+  @Override
+  public void addListener(Object o, PropertyKey propertyKey, HelixConstants.ChangeType changeType,
+      Watcher.Event.EventType[] eventTypes) {
+    throw new IllegalStateException("Not implemented");
   }
 
   @Override
@@ -371,6 +380,12 @@ class MockHelixManager implements HelixManager {
   }
 
   @Override
+  public void addTaskCurrentStateChangeListener(CurrentStateChangeListener listener, String instanceName,
+      String sessionId) throws Exception {
+    throw new IllegalStateException("Not implemented");
+  }
+
+  @Override
   public void addCustomizedStateRootChangeListener(CustomizedStateRootChangeListener listener, String instanceName)
       throws Exception {
     throw new IllegalStateException("Not implemented");
@@ -486,6 +501,11 @@ class MockHelixManager implements HelixManager {
 
   @Override
   public Long getSessionStartTime() {
+    throw new IllegalStateException("Not implemented");
+  }
+
+  @Override
+  public Optional<String> getSessionIdIfLead() {
     throw new IllegalStateException("Not implemented");
   }
 

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixManagerFactory.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixManagerFactory.java
@@ -90,7 +90,7 @@ public class MockHelixManagerFactory extends HelixFactory {
    */
   @Override
   public HelixManager getZKHelixManager(String clusterName, String instanceName, InstanceType instanceType,
-      String zkAddr) {
+      String zkAddr, ClusterMapConfig clusterMapConfig) {
     return getHelixManager(instanceType);
   }
 
@@ -109,11 +109,11 @@ public class MockHelixManagerFactory extends HelixFactory {
 
   @Override
   public HelixManager getZkHelixManagerAndConnect(String clusterName, String instanceName, InstanceType instanceType,
-      String zkAddr) throws Exception {
+      String zkAddr, ClusterMapConfig clusterMapConfig) throws Exception {
     if (overrideGetHelixManager) {
       return mockHelixManager;
     }
-    return super.getZkHelixManagerAndConnect(clusterName, instanceName, instanceType, zkAddr);
+    return super.getZkHelixManagerAndConnect(clusterName, instanceName, instanceType, zkAddr, clusterMapConfig);
   }
 
   /**

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixManagerFactory.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixManagerFactory.java
@@ -16,6 +16,7 @@ package com.github.ambry.clustermap;
 import com.github.ambry.config.ClusterMapConfig;
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import org.apache.helix.ClusterMessagingService;
 import org.apache.helix.ConfigAccessor;
@@ -23,6 +24,7 @@ import org.apache.helix.ControllerChangeListener;
 import org.apache.helix.CurrentStateChangeListener;
 import org.apache.helix.ExternalViewChangeListener;
 import org.apache.helix.HelixAdmin;
+import org.apache.helix.HelixConstants;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixManager;
 import org.apache.helix.HelixManagerProperties;
@@ -54,6 +56,7 @@ import org.apache.helix.participant.statemachine.StateModel;
 import org.apache.helix.participant.statemachine.StateModelFactory;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.zookeeper.Watcher;
 
 
 public class MockHelixManagerFactory extends HelixFactory {
@@ -189,6 +192,11 @@ public class MockHelixManagerFactory extends HelixFactory {
     }
 
     @Override
+    public Optional<String> getSessionIdIfLead() {
+      throw new IllegalStateException("Not implemented");
+    }
+
+    @Override
     public void connect() throws Exception {
       if (beBad) {
         throw new IOException("Being bad");
@@ -205,6 +213,12 @@ public class MockHelixManagerFactory extends HelixFactory {
     @Override
     public void disconnect() {
       isConnected = false;
+    }
+
+    @Override
+    public void addListener(Object o, PropertyKey propertyKey, HelixConstants.ChangeType changeType,
+        Watcher.Event.EventType[] eventTypes) {
+      throw new IllegalStateException("Not implemented");
     }
 
     String getStateModelDef() {
@@ -307,6 +321,12 @@ public class MockHelixManagerFactory extends HelixFactory {
     @Override
     public void addCurrentStateChangeListener(CurrentStateChangeListener listener, String instanceName,
         String sessionId) throws Exception {
+      throw new IllegalStateException("Not implemented");
+    }
+
+    @Override
+    public void addTaskCurrentStateChangeListener(org.apache.helix.api.listeners.CurrentStateChangeListener listener,
+        String instanceName, String sessionId) throws Exception {
       throw new IllegalStateException("Not implemented");
     }
 

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
@@ -2273,7 +2273,7 @@ public class BlobStoreTest {
     HelixFactory mockHelixFactory = new HelixFactory() {
       @Override
       public HelixManager getZKHelixManager(String clusterName, String instanceName, InstanceType instanceType,
-          String zkAddr) {
+          String zkAddr, ClusterMapConfig clusterMapConfig1) {
         return mockHelixManager;
       }
     };

--- a/build.gradle
+++ b/build.gradle
@@ -262,7 +262,11 @@ project(':ambry-commons') {
         compile "io.netty:netty-all:$nettyVersion"
         compile "io.netty:netty-tcnative-boringssl-static:$nettyTcNativeBoringSSLStatic_linux_x86_64"
         compile "io.netty:netty-tcnative-boringssl-static:$nettyTcNativeBoringSSLStatic_osx_aarch_64"
-        compile "org.apache.helix:helix-core:$helixVersion"
+        compile "org.apache.helix:helix-core:$helixVersion" exclude group: 'org.apache.helix'
+        compile "org.apache.helix:helix-common:$helixVersion" exclude group: 'org.apache.helix'
+        compile "org.apache.helix:zookeeper-api:$helixVersion" exclude group: 'org.apache.helix'
+        compile "org.apache.helix:metadata-store-directory-common:$helixVersion" exclude group: 'org.apache.helix'
+        compile "org.apache.helix:metrics-common:$helixVersion" exclude group: 'org.apache.helix'
         compile "com.github.ben-manes.caffeine:caffeine:$caffeineVersion"
         testCompile project(':ambry-test-utils')
         testCompile project(path: ':ambry-clustermap', configuration: 'testArchives')
@@ -276,7 +280,11 @@ project(':ambry-account') {
                 project(':ambry-utils'),
                 project(':ambry-commons'),
                 project(':ambry-mysql')
-        compile "org.apache.helix:helix-core:$helixVersion"
+        compile "org.apache.helix:helix-core:$helixVersion" exclude group: 'org.apache.helix'
+        compile "org.apache.helix:helix-common:$helixVersion" exclude group: 'org.apache.helix'
+        compile "org.apache.helix:zookeeper-api:$helixVersion" exclude group: 'org.apache.helix'
+        compile "org.apache.helix:metadata-store-directory-common:$helixVersion" exclude group: 'org.apache.helix'
+        compile "org.apache.helix:metrics-common:$helixVersion" exclude group: 'org.apache.helix'
         compile "io.dropwizard.metrics:metrics-core:$metricsVersion"
         compile "org.json:json:$jsonVersion"
         testCompile project(':ambry-test-utils')
@@ -290,8 +298,12 @@ project(':ambry-clustermap') {
         compile project(':ambry-api'),
                 project(':ambry-commons'),
                 project(':ambry-utils')
-        compile "org.apache.helix:helix-core:$helixVersion"
-        compile "org.apache.helix:helix-lock:$helixVersion"
+        compile "org.apache.helix:helix-core:$helixVersion" exclude group: 'org.apache.helix'
+        compile "org.apache.helix:helix-common:$helixVersion" exclude group: 'org.apache.helix'
+        compile "org.apache.helix:helix-lock:$helixLockVersion" exclude group: 'org.apache.helix'
+        compile "org.apache.helix:zookeeper-api:$helixVersion" exclude group: 'org.apache.helix'
+        compile "org.apache.helix:metadata-store-directory-common:$helixVersion" exclude group: 'org.apache.helix'
+        compile "org.apache.helix:metrics-common:$helixVersion" exclude group: 'org.apache.helix'
         compile "com.fasterxml.jackson.core:jackson-core:$jacksonVersion"
         compile "com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion"
         compile "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
@@ -301,7 +313,6 @@ project(':ambry-clustermap') {
         testCompile project(':ambry-test-utils')
         testCompile project(':ambry-mysql')
         testCompile project(path: ':ambry-api', configuration: 'testArchives')
-
     }
 }
 
@@ -382,6 +393,7 @@ project(':ambry-replication') {
                 project(':ambry-network'),
                 project(':ambry-clustermap')
         compile "io.dropwizard.metrics:metrics-core:$metricsVersion"
+        compile "org.apache.commons:commons-lang3:$commonsLangVersion"
         testCompile project(':ambry-store')
         testCompile project(':ambry-clustermap')
         testCompile project(':ambry-test-utils')
@@ -508,7 +520,7 @@ project(':ambry-cloud') {
         compile "io.dropwizard.metrics:metrics-core:$metricsVersion"
         compile "io.dropwizard.metrics:metrics-jmx:$metricsVersion"
         compile "com.microsoft.azure:msal4j:$azureMsal4jVersion"
-        compile "org.apache.helix:helix-lock:$helixVersion"
+        compile "org.apache.helix:helix-lock:$helixLockVersion" exclude group: "org.apache.helix"
         testCompile project(':ambry-router')
         testCompile project(':ambry-store')
         testCompile project(':ambry-test-utils')
@@ -549,7 +561,11 @@ project(':ambry-quota') {
             project(':ambry-commons'),
             project(':ambry-mysql'),
             project(':ambry-clustermap')
-        compile "org.apache.helix:helix-core:$helixVersion"
+        compile "org.apache.helix:helix-core:$helixVersion" exclude group: 'org.apache.helix'
+        compile "org.apache.helix:helix-common:$helixVersion" exclude group: 'org.apache.helix'
+        compile "org.apache.helix:zookeeper-api:$helixVersion" exclude group: 'org.apache.helix'
+        compile "org.apache.helix:metadata-store-directory-common:$helixVersion" exclude group: 'org.apache.helix'
+        compile "org.apache.helix:metrics-common:$helixVersion" exclude group: 'org.apache.helix'
         testCompile project(':ambry-test-utils')
         testCompile project(':ambry-account')
         testCompile project(path: ':ambry-clustermap', configuration: 'testArchives')
@@ -562,7 +578,11 @@ project(':ambry-mysql') {
         compile project(':ambry-utils')
         compile project(':ambry-commons')
         compile "mysql:mysql-connector-java:$mysqlConnectorVersion"
-        compile "org.apache.helix:helix-core:$helixVersion"
+        compile "org.apache.helix:helix-core:$helixVersion" exclude group: 'org.apache.helix'
+        compile "org.apache.helix:helix-common:$helixVersion" exclude group: 'org.apache.helix'
+        compile "org.apache.helix:zookeeper-api:$helixVersion" exclude group: 'org.apache.helix'
+        compile "org.apache.helix:metadata-store-directory-common:$helixVersion" exclude group: 'org.apache.helix'
+        compile "org.apache.helix:metrics-common:$helixVersion" exclude group: 'org.apache.helix'
         compile "com.zaxxer:HikariCP:$hikariVersion"
         testCompile project(':ambry-test-utils')
         testCompile project(path: ':ambry-clustermap', configuration: 'testArchives')

--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -21,7 +21,7 @@ ext {
     nettyVersion = "4.1.79.Final"
     nettyTcNativeBoringSSLStatic_linux_x86_64 = "2.0.61.Final:linux-x86_64"
     nettyTcNativeBoringSSLStatic_osx_aarch_64 = "2.0.61.Final:osx-aarch_64"
-    helixLockVersion = "1.1.0"
+    helixLockVersion = "1.4.3:jdk8"
     helixVersion = "1.4.1:jdk8"
     jacksonVersion = "2.13.5"
     jaydioVersion = "0.1"

--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -21,7 +21,7 @@ ext {
     nettyVersion = "4.1.79.Final"
     nettyTcNativeBoringSSLStatic_linux_x86_64 = "2.0.61.Final:linux-x86_64"
     nettyTcNativeBoringSSLStatic_osx_aarch_64 = "2.0.61.Final:osx-aarch_64"
-    helixVersion = "1.1.0"
+    helixVersion = "1.4.0"
     jacksonVersion = "2.13.5"
     jaydioVersion = "0.1"
     azureMsal4jVersion="1.7.1"

--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -21,7 +21,8 @@ ext {
     nettyVersion = "4.1.79.Final"
     nettyTcNativeBoringSSLStatic_linux_x86_64 = "2.0.61.Final:linux-x86_64"
     nettyTcNativeBoringSSLStatic_osx_aarch_64 = "2.0.61.Final:osx-aarch_64"
-    helixVersion = "1.4.0"
+    helixLockVersion = "1.1.0"
+    helixVersion = "1.4.1:jdk8"
     jacksonVersion = "2.13.5"
     jaydioVersion = "0.1"
     azureMsal4jVersion="1.7.1"
@@ -36,4 +37,5 @@ ext {
     powermockVersion = "2.+"
     caffeineVersion = "2.9.3"
     hadoopCommonVersion = "3.3.6"
+    commonsLangVersion = "3.12.0"
 }


### PR DESCRIPTION
## Summary
Support for Helix Auto Registration. This will enable Ambry DataNodes to auto-join Helix cluster. AutoRegistration changes were available in `helix-core@1.4.0` which is only Java11 compatible so I had to pin down dependency of this version to Java8 supported snapshot

## Testing

`./gradlew clean build`