### PR TITLE
Add parameter to GET /accounts API to ignore containers information

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/account/AccountCollectionSerde.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/AccountCollectionSerde.java
@@ -44,25 +44,16 @@ public class AccountCollectionSerde {
 
   /**
    * Serialize a collection of accounts to json bytes that can be used in requests/responses.
-   * @param accounts the {@link Account}s to serialize.
+   * @param accounts         the {@link Account}s to serialize.
+   * @param ignoreContainers  {@code true} to ignore containers in the serialization, {@code false} otherwise.
    * @return the serialized bytes in json format.
    */
-  public static byte[] serializeAccountsInJson(Collection<Account> accounts) throws IOException {
+  public static byte[] serializeAccountsInJson(Collection<Account> accounts, boolean ignoreContainers)
+      throws IOException {
     Map<String, Collection<Account>> resultObj = new HashMap<>();
     resultObj.put(ACCOUNTS_KEY, accounts);
-    return objectMapper.writeValueAsBytes(resultObj);
-  }
-
-  /**
-   * Serialize a collection of accounts ignoring containers to json bytes that can be used in requests/responses.
-   * @param accounts the {@link Account}s to serialize.
-   * @return the serialized bytes in json format.
-   * @throws IOException
-   */
-  public static byte[] serializeAccountsInJsonNoContainers(Collection<Account> accounts) throws IOException {
-    Map<String, Collection<Account>> resultObj = new HashMap<>();
-    resultObj.put(ACCOUNTS_KEY, accounts);
-    return objectMapperWithoutContainer.writeValueAsBytes(resultObj);
+    return ignoreContainers ? objectMapperWithoutContainer.writeValueAsBytes(resultObj)
+        : objectMapper.writeValueAsBytes(resultObj);
   }
 
   /**

--- a/ambry-api/src/main/java/com/github/ambry/account/AccountCollectionSerde.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/AccountCollectionSerde.java
@@ -54,6 +54,18 @@ public class AccountCollectionSerde {
   }
 
   /**
+   * Serialize a collection of accounts ignoring containers to json bytes that can be used in requests/responses.
+   * @param accounts the {@link Account}s to serialize.
+   * @return the serialized bytes in json format.
+   * @throws IOException
+   */
+  public static byte[] serializeAccountsInJsonNoContainers(Collection<Account> accounts) throws IOException {
+    Map<String, Collection<Account>> resultObj = new HashMap<>();
+    resultObj.put(ACCOUNTS_KEY, accounts);
+    return objectMapperWithoutContainer.writeValueAsBytes(resultObj);
+  }
+
+  /**
    * Serialize an account to bytes in json, stripping out its containers.
    * @param account the {@link Account}s to serialize.
    * @return the serialized bytes in json format.

--- a/ambry-api/src/main/java/com/github/ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com/github/ambry/rest/RestUtils.java
@@ -365,6 +365,11 @@ public class RestUtils {
      * Request header to carry hostname (with port);
      */
     public final static String HOSTNAME = "x-ambry-hostname";
+
+    /**
+     * Boolean field set to "true" for ignoring containers when fetching accounts information via GET /accounts API.
+     */
+    public static final String IGNORE_CONTAINERS = "x-ambry-ignore-containers";
   }
 
   public static final class TrackingHeaders {

--- a/ambry-frontend/src/integration-test/java/com/github/ambry/frontend/FrontendIntegrationTestBase.java
+++ b/ambry-frontend/src/integration-test/java/com/github/ambry/frontend/FrontendIntegrationTestBase.java
@@ -1825,7 +1825,7 @@ public class FrontendIntegrationTestBase {
    * @param accounts the accounts to replace or add using the {@code POST /accounts} call.
    */
   void updateAccountsAndVerify(AccountService accountService, Account... accounts) throws Exception {
-    byte[] accountUpdateJson = AccountCollectionSerde.serializeAccountsInJson(Arrays.asList(accounts));
+    byte[] accountUpdateJson = AccountCollectionSerde.serializeAccountsInJson(Arrays.asList(accounts), false);
     FullHttpRequest request =
         buildRequest(HttpMethod.POST, Operations.ACCOUNTS, null, ByteBuffer.wrap(accountUpdateJson));
     NettyClient.ResponseParts responseParts = nettyClient.sendRequest(request, null, null).get();

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/GetAccountsHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/GetAccountsHandler.java
@@ -128,7 +128,13 @@ class GetAccountsHandler {
           serialized = AccountCollectionSerde.serializeContainersInJson(Collections.singletonList(container));
           restResponseChannel.setHeader(RestUtils.Headers.TARGET_ACCOUNT_ID, container.getParentAccountId());
         } else {
-          serialized = AccountCollectionSerde.serializeAccountsInJson(getAccounts());
+          boolean ignoreContainers =
+              RestUtils.getBooleanHeader(restRequest.getArgs(), RestUtils.Headers.IGNORE_CONTAINERS, false);
+          if (ignoreContainers) {
+            serialized = AccountCollectionSerde.serializeAccountsInJsonNoContainers(getAccounts());
+          } else {
+            serialized = AccountCollectionSerde.serializeAccountsInJson(getAccounts());
+          }
         }
         ReadableStreamChannel channel = new ByteBufferReadableStreamChannel(ByteBuffer.wrap(serialized));
         restResponseChannel.setHeader(RestUtils.Headers.DATE, new GregorianCalendar().getTime());

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/GetAccountsHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/GetAccountsHandler.java
@@ -120,18 +120,19 @@ class GetAccountsHandler {
      */
     private Callback<Void> securityPostProcessRequestCallback() {
       return buildCallback(frontendMetrics.getAccountsSecurityPostProcessRequestMetrics, securityCheckResult -> {
-        byte[] serialized;
+        byte[] serializedAccountsOrContainers;
         if (RestUtils.getRequestPath(restRequest).matchesOperation(ACCOUNTS_CONTAINERS)) {
           LOGGER.debug("Received request for getting single container with arguments: {}", restRequest.getArgs());
           Container container = getContainer();
-          serialized = AccountCollectionSerde.serializeContainersInJson(Collections.singletonList(container));
+          serializedAccountsOrContainers = AccountCollectionSerde.serializeContainersInJson(Collections.singletonList(container));
           restResponseChannel.setHeader(RestUtils.Headers.TARGET_ACCOUNT_ID, container.getParentAccountId());
         } else {
           boolean ignoreContainers =
               RestUtils.getBooleanHeader(restRequest.getArgs(), RestUtils.Headers.IGNORE_CONTAINERS, false);
-          serialized = AccountCollectionSerde.serializeAccountsInJson(getAccounts(), ignoreContainers);
+          serializedAccountsOrContainers = AccountCollectionSerde.serializeAccountsInJson(getAccounts(), ignoreContainers);
         }
-        ReadableStreamChannel channel = new ByteBufferReadableStreamChannel(ByteBuffer.wrap(serialized));
+        ReadableStreamChannel channel = new ByteBufferReadableStreamChannel(ByteBuffer.wrap(
+            serializedAccountsOrContainers));
         restResponseChannel.setHeader(RestUtils.Headers.DATE, new GregorianCalendar().getTime());
         restResponseChannel.setHeader(RestUtils.Headers.CONTENT_TYPE, RestUtils.JSON_CONTENT_TYPE);
         restResponseChannel.setHeader(RestUtils.Headers.CONTENT_LENGTH, channel.getSize());

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/GetAccountsHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/GetAccountsHandler.java
@@ -19,7 +19,6 @@ import com.github.ambry.account.AccountCollectionSerde;
 import com.github.ambry.account.AccountService;
 import com.github.ambry.account.AccountServiceException;
 import com.github.ambry.account.Container;
-import com.github.ambry.account.Dataset;
 import com.github.ambry.commons.ByteBufferReadableStreamChannel;
 import com.github.ambry.commons.Callback;
 import com.github.ambry.rest.RestRequest;
@@ -130,11 +129,7 @@ class GetAccountsHandler {
         } else {
           boolean ignoreContainers =
               RestUtils.getBooleanHeader(restRequest.getArgs(), RestUtils.Headers.IGNORE_CONTAINERS, false);
-          if (ignoreContainers) {
-            serialized = AccountCollectionSerde.serializeAccountsInJsonNoContainers(getAccounts());
-          } else {
-            serialized = AccountCollectionSerde.serializeAccountsInJson(getAccounts());
-          }
+          serialized = AccountCollectionSerde.serializeAccountsInJson(getAccounts(), ignoreContainers);
         }
         ReadableStreamChannel channel = new ByteBufferReadableStreamChannel(ByteBuffer.wrap(serialized));
         restResponseChannel.setHeader(RestUtils.Headers.DATE, new GregorianCalendar().getTime());

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
@@ -2349,7 +2349,8 @@ public class FrontendRestRequestServiceTest {
   public void postAccountsTest() throws Exception {
     Account accountToAdd = accountService.generateRandomAccount();
     List<ByteBuffer> body = new LinkedList<>();
-    body.add(ByteBuffer.wrap(AccountCollectionSerde.serializeAccountsInJson(Collections.singleton(accountToAdd))));
+    body.add(
+        ByteBuffer.wrap(AccountCollectionSerde.serializeAccountsInJson(Collections.singleton(accountToAdd), false)));
     body.add(null);
     RestRequest restRequest = createRestRequest(RestMethod.POST, Operations.ACCOUNTS, null, body);
     MockRestResponseChannel restResponseChannel = new MockRestResponseChannel();

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/GetAccountsHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/GetAccountsHandlerTest.java
@@ -170,6 +170,33 @@ public class GetAccountsHandlerTest {
         existingContainer);
   }
 
+  @Test
+  public void getAccountsWithoutContainersTest() throws Exception {
+    Account account = accountService.createAndAddRandomAccount();
+    ThrowingConsumer<RestRequest> testAction = (request) -> {
+      // Set the header to ignore containers
+      request.setArg(RestUtils.Headers.IGNORE_CONTAINERS, true);
+      RestResponseChannel restResponseChannel = new MockRestResponseChannel();
+      ReadableStreamChannel channel = sendRequestGetResponse(request, restResponseChannel);
+      assertNotNull("There should be a response", channel);
+      Assert.assertNotNull("Date has not been set", restResponseChannel.getHeader(RestUtils.Headers.DATE));
+      assertEquals("Content-type is not as expected", RestUtils.JSON_CONTENT_TYPE,
+          restResponseChannel.getHeader(RestUtils.Headers.CONTENT_TYPE));
+      assertEquals("Content-length is not as expected", channel.getSize(),
+          Integer.parseInt((String) restResponseChannel.getHeader(RestUtils.Headers.CONTENT_LENGTH)));
+      RetainingAsyncWritableChannel asyncWritableChannel = new RetainingAsyncWritableChannel((int) channel.getSize());
+      channel.readInto(asyncWritableChannel, null).get();
+      Account receivedAccount =
+          AccountCollectionSerde.accountsFromInputStreamInJson(asyncWritableChannel.consumeContentAsInputStream())
+              .iterator()
+              .next();
+      assertTrue("Accounts do not match", account.equalsWithoutContainers(receivedAccount));
+      assertTrue("Containers should not be present", receivedAccount.getAllContainers().isEmpty());
+    };
+    testAction.accept(createRestRequest(account.getName(), null, null, Operations.ACCOUNTS));
+    testAction.accept(createRestRequest(null, Short.toString(account.getId()), null, Operations.ACCOUNTS));
+  }
+
   /**
    * Test failure case of getting single container.
    * @throws Exception

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/GetAccountsHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/GetAccountsHandlerTest.java
@@ -179,7 +179,7 @@ public class GetAccountsHandlerTest {
       RestResponseChannel restResponseChannel = new MockRestResponseChannel();
       ReadableStreamChannel channel = sendRequestGetResponse(request, restResponseChannel);
       assertNotNull("There should be a response", channel);
-      Assert.assertNotNull("Date has not been set", restResponseChannel.getHeader(RestUtils.Headers.DATE));
+      assertNotNull("Date has not been set", restResponseChannel.getHeader(RestUtils.Headers.DATE));
       assertEquals("Content-type is not as expected", RestUtils.JSON_CONTENT_TYPE,
           restResponseChannel.getHeader(RestUtils.Headers.CONTENT_TYPE));
       assertEquals("Content-length is not as expected", channel.getSize(),

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/PostAccountsHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/PostAccountsHandlerTest.java
@@ -73,7 +73,7 @@ public class PostAccountsHandlerTest {
   @Test
   public void validRequestsTest() throws Exception {
     ThrowingConsumer<Collection<Account>> testAction = accountsToUpdate -> {
-      String requestBody = new String(AccountCollectionSerde.serializeAccountsInJson(accountsToUpdate));
+      String requestBody = new String(AccountCollectionSerde.serializeAccountsInJson(accountsToUpdate, false));
       RestResponseChannel restResponseChannel = new MockRestResponseChannel();
       sendRequestGetResponse(requestBody, restResponseChannel);
       assertNotNull("Date has not been set", restResponseChannel.getHeader(RestUtils.Headers.DATE));
@@ -111,7 +111,7 @@ public class PostAccountsHandlerTest {
     testAction.accept(new JSONObject().append("accounts", "ABC").toString(), RestServiceErrorCode.BadRequest);
     // AccountService update failure
     accountService.setShouldUpdateSucceed(false);
-    testAction.accept(new String(AccountCollectionSerde.serializeAccountsInJson(Collections.emptyList())),
+    testAction.accept(new String(AccountCollectionSerde.serializeAccountsInJson(Collections.emptyList(), false)),
         RestServiceErrorCode.InternalServerError);
   }
 
@@ -123,7 +123,7 @@ public class PostAccountsHandlerTest {
   public void securityServiceDenialTest() throws Exception {
     IllegalStateException injectedException = new IllegalStateException("@@expected");
     TestUtils.ThrowingRunnable testAction = () -> sendRequestGetResponse(
-        new String(AccountCollectionSerde.serializeAccountsInJson(Collections.emptyList())),
+        new String(AccountCollectionSerde.serializeAccountsInJson(Collections.emptyList(), false)),
         new MockRestResponseChannel());
     ThrowingConsumer<IllegalStateException> errorChecker = e -> assertEquals("Wrong exception", injectedException, e);
     securityServiceFactory.exceptionToReturn = injectedException;


### PR DESCRIPTION
## Summary
Add parameter in GET /accounts API to ignore containers information. This is useful for fetching fields of Account (such as quotaResourceType, aclInheritedByContainer) without overhead of containers information.

## Testing Done
Tested in locally deployed Ambry

1. With container information
```
> curl "http://localhost:1174/accounts" -H "x-ambry-target-account-name: named-blob-sandbox" | jq .
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   889  100   889    0     0   3108      0 --:--:-- --:--:-- --:--:--  3108
{
  "accounts": [
    {
      "snapshotVersion": 0,
      "lastModifiedTime": 0,
      "status": "ACTIVE",
      "aclInheritedByContainer": false,
      "quotaResourceType": "ACCOUNT",
      "accountId": 101,
      "accountName": "named-blob-sandbox",
      "containers": [
        {
          "status": "ACTIVE",
          "deleteTriggerTime": 0,
          "description": "This is a container for the blobs without specifying a target account and container when they are put",
          "encrypted": false,
          "cacheable": true,
          "backupEnabled": false,
          "mediaScanDisabled": false,
          "paranoidDurabilityEnabled": false,
          "replicationPolicy": null,
          "ttlRequired": true,
          "securePathRequired": false,
          "namedBlobMode": "OPTIONAL",
          "accessControlAllowOrigin": "",
          "contentTypeWhitelistForFilenamesOnDownload": [],
          "lastModifiedTime": 0,
          "snapshotVersion": 0,
          "cacheTtlInSecond": null,
          "userMetadataKeysToNotPrefixInResponse": [],
          "containerId": 8,
          "containerName": "container-a",
          "previouslyEncrypted": false,
          "overrideAccountAcl": false,
          "version": 2
        }
      ],
      "version": 1
    }
  ]
}

```

2. Without container information
```
> curl "http://localhost:1174/accounts" -H "x-ambry-target-account-name: named-blob-sandbox" -H "x-ambry-ignore-containers:true" | jq .
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   200  100   200    0     0   2387      0 --:--:-- --:--:-- --:--:--  2380
{
  "accounts": [
    {
      "snapshotVersion": 0,
      "lastModifiedTime": 0,
      "status": "ACTIVE",
      "aclInheritedByContainer": false,
      "quotaResourceType": "ACCOUNT",
      "accountId": 101,
      "accountName": "named-blob-sandbox",
      "version": 1
    }
  ]
}

```
