### PR TITLE
making replication log as trace when one cycle is finished

### DIFF
--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -2275,7 +2275,7 @@ public class ReplicaThread implements Runnable {
           .max(Comparator.naturalOrder())
           .orElse(0);
       if (maxIterationsDoneByAnyGroup >= continuousReplicationGroupIterationLimit) {
-        logger.info("Thread name: {} not creating new groups as iteration limit {} reached", threadName,
+        logger.trace("Thread name: {} not creating new groups as iteration limit {} reached", threadName,
             maxIterationsDoneByAnyGroup);
         return false;
       }


### PR DESCRIPTION
## Summary
making replication log as trace when one cycle is finished


## Testing Done
Unit tests and integration test