### PR TITLE
Fix name in S3 List API

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/frontend/s3/S3MessagePayload.java
+++ b/ambry-api/src/main/java/com/github/ambry/frontend/s3/S3MessagePayload.java
@@ -220,6 +220,10 @@ public class S3MessagePayload {
       return isTruncated;
     }
 
+    public String getName() {
+      return name;
+    }
+
     @Override
     public String toString() {
       return "Name=" + name + ", Prefix=" + prefix + ", MaxKeys=" + maxKeys + ", KeyCount=" + keyCount + ", Delimiter="

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3ListHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3ListHandler.java
@@ -16,6 +16,7 @@ package com.github.ambry.frontend.s3;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.github.ambry.account.Container;
 import com.github.ambry.commons.ByteBufferReadableStreamChannel;
 import com.github.ambry.commons.Callback;
 import com.github.ambry.frontend.FrontendMetrics;
@@ -104,6 +105,8 @@ public class S3ListHandler extends S3BaseHandler<ReadableStreamChannel> {
   private ReadableStreamChannel serializeAsXml(RestRequest restRequest, Page<NamedBlobListEntry> namedBlobRecordPage)
       throws IOException, RestServiceException {
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    Container container = (Container) restRequest.getArgs().get(InternalKeys.TARGET_CONTAINER_KEY);
+    String containerName = container.getName();
     String prefix = getHeader(restRequest.getArgs(), PREFIX_PARAM_NAME, false);
     String delimiter = getHeader(restRequest.getArgs(), DELIMITER_PARAM_NAME, false);
     String encodingType = getHeader(restRequest.getArgs(), ENCODING_TYPE_PARAM_NAME, false);
@@ -131,7 +134,7 @@ public class S3ListHandler extends S3BaseHandler<ReadableStreamChannel> {
     }
     if (LIST_TYPE_VERSION_2.equals(getHeader(restRequest.getArgs(), LIST_TYPE, false))) {
       ListBucketResultV2 resultV2 =
-          new ListBucketResultV2(restRequest.getPath(), prefix, maxKeysValue, keyCount, delimiter, contentsList,
+          new ListBucketResultV2(containerName, prefix, maxKeysValue, keyCount, delimiter, contentsList,
               encodingType, continuationToken, namedBlobRecordPage.getNextPageToken(),
               namedBlobRecordPage.getNextPageToken() != null);
       LOGGER.debug("Sending response for S3 ListObjects {}", resultV2);
@@ -139,7 +142,7 @@ public class S3ListHandler extends S3BaseHandler<ReadableStreamChannel> {
       xmlMapper.writeValue(outputStream, resultV2);
     } else {
       ListBucketResult result =
-          new ListBucketResult(restRequest.getPath(), prefix, maxKeysValue, keyCount, delimiter, contentsList,
+          new ListBucketResult(containerName, prefix, maxKeysValue, keyCount, delimiter, contentsList,
               encodingType, marker, namedBlobRecordPage.getNextPageToken(),
               namedBlobRecordPage.getNextPageToken() != null);
       LOGGER.debug("Sending response for S3 ListObjects {}", result);

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/S3ListHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/S3ListHandlerTest.java
@@ -166,6 +166,7 @@ public class S3ListHandlerTest {
     listBucketResult = xmlMapper.readValue(byteBuffer.array(), ListBucketResult.class);
     assertEquals("Mismatch on status", ResponseStatus.Ok, restResponseChannel.getStatus());
     assertEquals("Mismatch in content type", XML_CONTENT_TYPE, restResponseChannel.getHeader(Headers.CONTENT_TYPE));
+    assertEquals("Mismatch in bucket name", container.getName(), listBucketResult.getName());
     assertEquals("Mismatch in key name", KEY_NAME, listBucketResult.getContents().get(0).getKey());
     assertEquals("Mismatch in key count", 1, listBucketResult.getKeyCount());
     assertEquals("Mismatch in next token", KEY_NAME, listBucketResult.getMarker());
@@ -224,6 +225,7 @@ public class S3ListHandlerTest {
     ListBucketResultV2 listBucketResultV2 = xmlMapper.readValue(byteBuffer.array(), ListBucketResultV2.class);
     assertEquals("Mismatch on status", ResponseStatus.Ok, restResponseChannel.getStatus());
     assertEquals("Mismatch in content type", XML_CONTENT_TYPE, restResponseChannel.getHeader(Headers.CONTENT_TYPE));
+    assertEquals("Mismatch in bucket name", container.getName(), listBucketResultV2.getName());
     assertEquals("Mismatch in key name", KEY_NAME, listBucketResultV2.getContents().get(0).getKey());
     assertEquals("Mismatch in key name", KEY_NAME1, listBucketResultV2.getContents().get(1).getKey());
     assertEquals("Mismatch in key count", 2, listBucketResultV2.getKeyCount());


### PR DESCRIPTION
## Summary
The `Name` element in S3 List xml response must be the Bucket (Ambry container name). Currently, we include the entire request URI (S3 path and account name).

Reference: https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjects.html


## Testing Done
Added unit tests.
