### PR TITLE
Exclude dependencies on avro-parent and protobuf-parent

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,11 @@ allprojects {
         mavenCentral()
         mavenLocal()
     }
+
+    configurations.all {
+        exclude group: "org.apache.avro", module: "avro-parent"
+        exclude group: "com.google.protobuf", module: "protobuf-parent"
+    }
 }
 
 subprojects {


### PR DESCRIPTION
## Summary
There seems to be some vulnerabilities in avro-parent:1.7.7 and protobuf-parent:3.11.4. But, we don't seem to be using them (Didn't find them in dependency graph scan). Planning to exclude them via this change


## Testing Done
./gradlew build