### PR TITLE
Upgrade some transitive dependencies to later versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,8 +41,11 @@ allprojects {
     }
 
     configurations.all {
-        exclude group: "org.apache.avro", module: "avro-parent"
-        exclude group: "com.google.protobuf", module: "protobuf-parent"
+        // Force avro-parent to version 1.11.4. Currently, a vulnerable version 1.7.7 is being picked up transitively.
+        force 'org.apache.avro:avro-parent:1.11.4'
+        // Force protobuf-parent to version 3.15.0. Currently, a vulnerable version 3.11.4 is being picked up
+        // transitively.
+        force 'com.google.protobuf:protobuf-parent:3.15.0'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -41,11 +41,13 @@ allprojects {
     }
 
     configurations.all {
-        // Force avro-parent to version 1.11.4. Currently, a vulnerable version 1.7.7 is being picked up transitively.
-        force 'org.apache.avro:avro-parent:1.11.4'
-        // Force protobuf-parent to version 3.15.0. Currently, a vulnerable version 3.11.4 is being picked up
-        // transitively.
-        force 'com.google.protobuf:protobuf-parent:3.15.0'
+        resolutionStrategy {
+            // Force avro-parent to version 1.11.4. Currently, a vulnerable version 1.7.7 is being picked up transitively.
+            force 'org.apache.avro:avro-parent:1.11.4'
+            // Force protobuf-parent to version 3.15.0. Currently, a vulnerable version 3.11.4 is being picked up
+            // transitively.
+            force 'com.google.protobuf:protobuf-parent:3.15.0'
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
Ambry seems to be transitively depending on `org.apache.avro:avro-parent` and `com.google.protobuf:protobuf-parent`. Upgrading them to non-vulnerable versions


## Testing Done
./gradlew build