### PR TITLE
Add more metrics for compaction and sealed replicas and enable compaction after bootstrap

### DIFF
--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManagerMetrics.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManagerMetrics.java
@@ -181,7 +181,7 @@ class HelixClusterManagerMetrics {
 
     Gauge<Long> onHostPartitionSealedCount = clusterMapCallback::getOnHostPartitionSealedCount;
     registry.gauge(MetricRegistry.name(HelixClusterManager.class, "onHostPartitionSealedCount"),
-        () -> );
+        () -> onHostPartitionSealedCount);
 
     Gauge<Long> partitionPartiallySealedCount = clusterMapCallback::getPartitionPartiallySealedCount;
     registry.gauge(MetricRegistry.name(HelixClusterManager.class, "partitionPartiallySealedCount"),

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManagerMetrics.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManagerMetrics.java
@@ -179,6 +179,10 @@ class HelixClusterManagerMetrics {
     Gauge<Long> partitionSealedCount = clusterMapCallback::getPartitionSealedCount;
     registry.gauge(MetricRegistry.name(HelixClusterManager.class, "partitionSealedCount"), () -> partitionSealedCount);
 
+    Gauge<Long> onHostPartitionSealedCount = clusterMapCallback::getOnHostPartitionSealedCount;
+    registry.gauge(MetricRegistry.name(HelixClusterManager.class, "onHostPartitionSealedCount"),
+        () -> );
+
     Gauge<Long> partitionPartiallySealedCount = clusterMapCallback::getPartitionPartiallySealedCount;
     registry.gauge(MetricRegistry.name(HelixClusterManager.class, "partitionPartiallySealedCount"),
         () -> partitionPartiallySealedCount);

--- a/ambry-store/src/main/java/com/github/ambry/store/CompactionManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/CompactionManager.java
@@ -154,6 +154,15 @@ class CompactionManager {
   }
 
   /**
+   * Return true if the compaction is disabled for the given blob store.
+   * @param store
+   * @return
+   */
+  boolean compactionDisabledForBlobStore(BlobStore store) {
+    return compactionExecutor == null || compactionExecutor.storesDisabledCompaction.contains(store);
+  }
+
+  /**
    * Remove store from compaction manager.
    * @param store the {@link BlobStore} to remove
    * @return {@code true} if store is removed successfully. {@code false} if not.

--- a/ambry-store/src/main/java/com/github/ambry/store/CompactionManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/CompactionManager.java
@@ -237,7 +237,7 @@ class CompactionManager {
       this.triggers = triggers;
       bundleReadBuffer = bundleReadBufferSize == 0 ? null : new byte[bundleReadBufferSize];
       logger.info("Buffer size is {} in compaction thread for {}", bundleReadBufferSize, mountPath);
-      metrics.registerStoreSetToSkipInCompactionForMountPath(mountPath, storesToSkip);
+      metrics.registerStoresInCompactionForMountPath(mountPath, storesToSkip, storesDisabledCompaction);
     }
 
     /**

--- a/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
@@ -420,6 +420,24 @@ public class DiskManager {
     return succeed;
   }
 
+  /**
+   * Return true if the compaction is disabled for the given partition id.
+   * @param id
+   * @return
+   */
+  boolean compactionDisabledForBlobStore(PartitionId id) {
+    rwLock.readLock().lock();
+    try {
+      BlobStore store = stores.get(id);
+      if (store == null) {
+        throw new IllegalArgumentException("Failed to find store " + id);
+      }
+      return compactionManager.compactionDisabledForBlobStore(store);
+    } finally {
+      rwLock.readLock().unlock();
+    }
+  }
+
 
   /**
    * Add a new BlobStore with given {@link ReplicaId}.

--- a/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
@@ -457,6 +457,19 @@ public class StorageManager implements StoreManager {
     return diskManager != null && diskManager.controlCompactionForBlobStore(id, enabled);
   }
 
+  /**
+   * Return true is compaction is disabled for the given partition id.
+   * @param id
+   * @return
+   */
+  public boolean compactionDisabledForBlobStore(PartitionId id) {
+    DiskManager diskManager = partitionToDiskManager.get(id);
+    if (diskManager == null) {
+      throw new IllegalArgumentException("Failed to find disk manager for partition " + id);
+    }
+    return diskManager.compactionDisabledForBlobStore(id);
+  }
+
   @Override
   public boolean isFileExists(PartitionId partitionId, String fileName) {
     return this.getDiskManager(partitionId).isFileExists(fileName);

--- a/ambry-store/src/test/java/com/github/ambry/store/StorageManagerTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/StorageManagerTest.java
@@ -24,7 +24,6 @@ import com.github.ambry.clustermap.ClusterMapUtils;
 import com.github.ambry.clustermap.ClusterParticipant;
 import com.github.ambry.clustermap.DataNodeConfigSourceType;
 import com.github.ambry.clustermap.DataNodeId;
-import com.github.ambry.clustermap.Disk;
 import com.github.ambry.clustermap.DiskId;
 import com.github.ambry.clustermap.HardwareState;
 import com.github.ambry.clustermap.HelixAdminFactory;
@@ -550,6 +549,9 @@ public class StorageManagerTest {
         newAddedStore.isBootstrapInProgress());
     assertEquals("The store's current state should be BOOTSTRAP", ReplicaState.BOOTSTRAP,
         newAddedStore.getCurrentState());
+    // verify that compaction is disabled for the new replica
+    assertTrue("The store's compaction should be disabled",
+        storageManager.compactionDisabledForBlobStore(newPartition));
 
     // 2. test that state transition should succeed for existing non-empty replicas (we write some data into store beforehand)
     MockId id = new MockId(TestUtils.getRandomString(MOCK_ID_STRING_LENGTH), Utils.getRandomShort(TestUtils.RANDOM),
@@ -584,6 +586,34 @@ public class StorageManagerTest {
     assertEquals("The store's current state should be LEADER", ReplicaState.LEADER, localStore.getCurrentState());
 
     shutdownAndAssertStoresInaccessible(storageManager, localReplicas);
+  }
+
+  @Test
+  public void replicaFromBootstrapToStandbySuccessTest() throws Exception {
+    generateConfigs(true, false);
+    MockDataNodeId localNode = clusterMap.getDataNodes().get(0);
+    List<ReplicaId> localReplicas = clusterMap.getReplicaIds(localNode);
+    MockClusterParticipant mockHelixParticipant = new MockClusterParticipant();
+    StorageManager storageManager =
+        createStorageManager(localNode, metricRegistry, Collections.singletonList(mockHelixParticipant));
+    storageManager.start();
+
+    // 0. get listeners from Helix participant and verify there is a storageManager listener.
+    Map<StateModelListenerType, PartitionStateChangeListener> listeners =
+        mockHelixParticipant.getPartitionStateChangeListeners();
+    assertTrue("Should contain storage manager listener",
+        listeners.containsKey(StateModelListenerType.StorageManagerListener));
+
+    // 1. Test case where new replica(store) is successfully added into StorageManager
+    PartitionId newPartition = clusterMap.createNewPartition(Collections.singletonList(localNode));
+    mockHelixParticipant.onPartitionBecomeBootstrapFromOffline(newPartition.toPathString());
+    // verify that compaction is disabled for the new replica
+    assertTrue("The store's compaction should be disabled",
+        storageManager.compactionDisabledForBlobStore(newPartition));
+    // Other validation is already done in replicaFromOfflineToBoostrap test
+    mockHelixParticipant.onPartitionBecomeStandbyFromBootstrap(newPartition.toPathString());
+    assertFalse("The store's compaction should not be disabled",
+        storageManager.compactionDisabledForBlobStore(newPartition));
   }
 
   /**


### PR DESCRIPTION
## Summary
When a replica starts bootstrapping on a host, we disable compaction for this replica. This makes sense since bootstrap process employs the regular replication protocol, which would ignore expired and deleted blob. There are not many blobs to compact. However, after bootstrap finishes, this replica would start serving client requests, more blobs will be deleted and expired. We should enable compaction after bootstrap. 

This PR fixed this issue by adding logic to enable compaction in storage manager.

This PR also exposes two more metrics
1. showing how many replicas are disabled for compaction on each host
2. showing how many replicas are sealed on each host.

## Testing Done
Wait for unit test