### PR TITLE
Add in-memory database for named-blobs

### DIFF
--- a/ambry-commons/src/main/java/com/github/ambry/commons/InMemNamedBlobDbFactory.java
+++ b/ambry-commons/src/main/java/com/github/ambry/commons/InMemNamedBlobDbFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 LinkedIn Corp. All rights reserved.
+ * Copyright 2025 LinkedIn Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -11,7 +11,7 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  */
-package com.github.ambry.frontend;
+package com.github.ambry.commons;
 
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.account.AccountService;
@@ -22,13 +22,13 @@ import com.github.ambry.named.NamedBlobDbFactory;
 import com.github.ambry.utils.SystemTime;
 
 
-public class TestNamedBlobDbFactory implements NamedBlobDbFactory {
-  private final TestNamedBlobDb namedBlobDb;
+public class InMemNamedBlobDbFactory implements NamedBlobDbFactory {
+  private final InMemNamedBlobDb namedBlobDb;
 
-  public TestNamedBlobDbFactory(VerifiableProperties verifiableProperties, MetricRegistry metricRegistry,
+  public InMemNamedBlobDbFactory(VerifiableProperties verifiableProperties, MetricRegistry metricRegistry,
       AccountService accountService) {
     InternalConfig config = new InternalConfig(verifiableProperties);
-    namedBlobDb = new TestNamedBlobDb(SystemTime.getInstance(), config.listMaxResults);
+    namedBlobDb = new InMemNamedBlobDb(SystemTime.getInstance(), config.listMaxResults);
   }
 
   @Override

--- a/ambry-frontend/src/integration-test/java/com/github/ambry/frontend/FrontendIntegrationTest.java
+++ b/ambry-frontend/src/integration-test/java/com/github/ambry/frontend/FrontendIntegrationTest.java
@@ -737,7 +737,7 @@ public class FrontendIntegrationTest extends FrontendIntegrationTestBase {
     properties.setProperty("clustermap.datacenter.name", DATA_CENTER_NAME);
     properties.setProperty("clustermap.host.name", HOST_NAME);
     properties.setProperty(FrontendConfig.ENABLE_UNDELETE, Boolean.toString(enableUndelete));
-    properties.setProperty(FrontendConfig.NAMED_BLOB_DB_FACTORY, "com.github.ambry.frontend.TestNamedBlobDbFactory");
+    properties.setProperty(FrontendConfig.NAMED_BLOB_DB_FACTORY, "com.github.ambry.commons.InMemNamedBlobDbFactory");
     properties.setProperty(MySqlNamedBlobDbConfig.LIST_MAX_RESULTS, String.valueOf(NAMED_BLOB_LIST_RESULT_MAX));
     properties.setProperty(FrontendConfig.LIST_MAX_RESULTS, String.valueOf(NAMED_BLOB_LIST_RESULT_MAX));
     return new VerifiableProperties(properties);

--- a/ambry-frontend/src/integration-test/java/com/github/ambry/frontend/FrontendQuotaIntegrationTest.java
+++ b/ambry-frontend/src/integration-test/java/com/github/ambry/frontend/FrontendQuotaIntegrationTest.java
@@ -184,7 +184,7 @@ public class FrontendQuotaIntegrationTest extends FrontendIntegrationTestBase {
     properties.setProperty("clustermap.host.name", HOST_NAME);
     properties.setProperty("clustermap.port", String.valueOf(PORT));
     properties.setProperty(FrontendConfig.ENABLE_UNDELETE, Boolean.toString(enableUndelete));
-    properties.setProperty(FrontendConfig.NAMED_BLOB_DB_FACTORY, "com.github.ambry.frontend.TestNamedBlobDbFactory");
+    properties.setProperty(FrontendConfig.NAMED_BLOB_DB_FACTORY, "com.github.ambry.commons.InMemNamedBlobDbFactory");
     return properties;
   }
 

--- a/ambry-frontend/src/integration-test/java/com/github/ambry/frontend/S3IntegrationTest.java
+++ b/ambry-frontend/src/integration-test/java/com/github/ambry/frontend/S3IntegrationTest.java
@@ -377,7 +377,7 @@ public class S3IntegrationTest extends FrontendIntegrationTestBase {
     properties.setProperty("clustermap.datacenter.name", DATA_CENTER_NAME);
     properties.setProperty("clustermap.host.name", HOST_NAME);
     properties.setProperty(FrontendConfig.ENABLE_UNDELETE, Boolean.toString(true));
-    properties.setProperty(FrontendConfig.NAMED_BLOB_DB_FACTORY, "com.github.ambry.frontend.TestNamedBlobDbFactory");
+    properties.setProperty(FrontendConfig.NAMED_BLOB_DB_FACTORY, "com.github.ambry.commons.InMemNamedBlobDbFactory");
     properties.setProperty(MySqlNamedBlobDbConfig.LIST_MAX_RESULTS, String.valueOf(NAMED_BLOB_LIST_RESULT_MAX));
     return properties;
   }

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/NamedBlobPutHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/NamedBlobPutHandlerTest.java
@@ -26,6 +26,7 @@ import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.commons.ByteBufferReadableStreamChannel;
 import com.github.ambry.commons.CommonTestUtils;
+import com.github.ambry.commons.InMemNamedBlobDbFactory;
 import com.github.ambry.config.FrontendConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.messageformat.BlobProperties;
@@ -156,7 +157,7 @@ public class NamedBlobPutHandlerTest {
         NAMED_BLOB_PREFIX + SLASH + REF_ACCOUNT.getName() + SLASH + REF_CONTAINER.getName() + SLASH + DATASET_NAME
             + SLASH + VERSION;
     NamedBlobDbFactory namedBlobDbFactory =
-        new TestNamedBlobDbFactory(verifiableProperties, new MetricRegistry(), ACCOUNT_SERVICE);
+        new InMemNamedBlobDbFactory(verifiableProperties, new MetricRegistry(), ACCOUNT_SERVICE);
     namedBlobDb = namedBlobDbFactory.getNamedBlobDb();
     initNamedBlobPutHandler(props);
   }

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/S3BatchDeleteHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/S3BatchDeleteHandlerTest.java
@@ -13,6 +13,7 @@
  *
  */
 package com.github.ambry.frontend;
+import com.github.ambry.commons.InMemNamedBlobDbFactory;
 import java.nio.charset.StandardCharsets;
 
 import com.codahale.metrics.MetricRegistry;
@@ -237,7 +238,7 @@ public class S3BatchDeleteHandlerTest {
             idSigningService, injector, QuotaTestUtils.createDummyQuotaManager());
     SecurityService securityService = securityServiceFactory.getSecurityService();
     NamedBlobDbFactory namedBlobDbFactory =
-        new TestNamedBlobDbFactory(verifiableProperties, new MetricRegistry(), ACCOUNT_SERVICE);
+        new InMemNamedBlobDbFactory(verifiableProperties, new MetricRegistry(), ACCOUNT_SERVICE);
     NamedBlobDb namedBlobDb = namedBlobDbFactory.getNamedBlobDb();
     AmbryIdConverterFactory ambryIdConverterFactory =
         new AmbryIdConverterFactory(verifiableProperties, new MetricRegistry(), idSigningService, namedBlobDb);

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/S3BatchDeleteHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/S3BatchDeleteHandlerTest.java
@@ -119,7 +119,7 @@ public class S3BatchDeleteHandlerTest {
     S3MessagePayload.DeleteResult response =
         xmlMapper.readValue(byteBuffer.array(), S3MessagePayload.DeleteResult.class);
     assertEquals(response.getDeleted().get(0).getKey(), KEY_NAME);
-    assertEquals(response.getErrors().get(0).toString(), new S3MessagePayload.S3ErrorObject("key-error","InternalServerError").toString());
+    assertEquals(response.getErrors().get(0).toString(), new S3MessagePayload.S3ErrorObject("key-error","NotFound").toString());
     assertEquals("Mismatch on status", ResponseStatus.Ok, restResponseChannel.getStatus());
   }
 

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/S3DeleteHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/S3DeleteHandlerTest.java
@@ -21,6 +21,7 @@ import com.github.ambry.account.ContainerBuilder;
 import com.github.ambry.account.InMemAccountService;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.commons.CommonTestUtils;
+import com.github.ambry.commons.InMemNamedBlobDbFactory;
 import com.github.ambry.config.FrontendConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.frontend.s3.S3DeleteHandler;
@@ -104,7 +105,7 @@ public class S3DeleteHandlerTest {
             idSigningService, injector, QuotaTestUtils.createDummyQuotaManager());
     SecurityService securityService = securityServiceFactory.getSecurityService();
     NamedBlobDbFactory namedBlobDbFactory =
-        new TestNamedBlobDbFactory(verifiableProperties, new MetricRegistry(), ACCOUNT_SERVICE);
+        new InMemNamedBlobDbFactory(verifiableProperties, new MetricRegistry(), ACCOUNT_SERVICE);
     NamedBlobDb namedBlobDb = namedBlobDbFactory.getNamedBlobDb();
     AmbryIdConverterFactory ambryIdConverterFactory =
         new AmbryIdConverterFactory(verifiableProperties, new MetricRegistry(), idSigningService, namedBlobDb);

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/S3HeadHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/S3HeadHandlerTest.java
@@ -21,6 +21,7 @@ import com.github.ambry.account.ContainerBuilder;
 import com.github.ambry.account.InMemAccountService;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.commons.CommonTestUtils;
+import com.github.ambry.commons.InMemNamedBlobDbFactory;
 import com.github.ambry.config.FrontendConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.frontend.s3.S3HeadHandler;
@@ -154,7 +155,7 @@ public class S3HeadHandlerTest {
         QuotaTestUtils.createDummyQuotaManager());
     SecurityService securityService = securityServiceFactory.getSecurityService();
     NamedBlobDbFactory namedBlobDbFactory =
-        new TestNamedBlobDbFactory(verifiableProperties, new MetricRegistry(), ACCOUNT_SERVICE);
+        new InMemNamedBlobDbFactory(verifiableProperties, new MetricRegistry(), ACCOUNT_SERVICE);
     NamedBlobDb namedBlobDb = namedBlobDbFactory.getNamedBlobDb();
     AmbryIdConverterFactory ambryIdConverterFactory =
         new AmbryIdConverterFactory(verifiableProperties, new MetricRegistry(), idSigningService, namedBlobDb);

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/S3ListHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/S3ListHandlerTest.java
@@ -25,6 +25,7 @@ import com.github.ambry.account.InMemAccountService;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.commons.ByteBufferReadableStreamChannel;
 import com.github.ambry.commons.CommonTestUtils;
+import com.github.ambry.commons.InMemNamedBlobDbFactory;
 import com.github.ambry.config.FrontendConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.frontend.s3.S3ListHandler;
@@ -552,7 +553,7 @@ public class S3ListHandlerTest {
     IdSigningService idSigningService = new AmbryIdSigningService();
     FrontendTestSecurityServiceFactory securityServiceFactory = new FrontendTestSecurityServiceFactory();
     NamedBlobDbFactory namedBlobDbFactory =
-        new TestNamedBlobDbFactory(verifiableProperties, new MetricRegistry(), ACCOUNT_SERVICE);
+        new InMemNamedBlobDbFactory(verifiableProperties, new MetricRegistry(), ACCOUNT_SERVICE);
     NamedBlobDb namedBlobDb = namedBlobDbFactory.getNamedBlobDb();
     AmbryIdConverterFactory ambryIdConverterFactory =
         new AmbryIdConverterFactory(verifiableProperties, new MetricRegistry(), idSigningService, namedBlobDb);

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/S3MultipartUploadTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/S3MultipartUploadTest.java
@@ -26,6 +26,7 @@ import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.commons.ByteBufferReadableStreamChannel;
 import com.github.ambry.commons.CommonTestUtils;
+import com.github.ambry.commons.InMemNamedBlobDbFactory;
 import com.github.ambry.config.FrontendConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.frontend.s3.S3Constants;
@@ -346,7 +347,7 @@ public class S3MultipartUploadTest {
     FrontendTestSecurityServiceFactory securityServiceFactory = new FrontendTestSecurityServiceFactory();
     SecurityService securityService = securityServiceFactory.getSecurityService();
     NamedBlobDbFactory namedBlobDbFactory =
-        new TestNamedBlobDbFactory(verifiableProperties, new MetricRegistry(), ACCOUNT_SERVICE);
+        new InMemNamedBlobDbFactory(verifiableProperties, new MetricRegistry(), ACCOUNT_SERVICE);
     namedBlobDb = namedBlobDbFactory.getNamedBlobDb();
     AmbryIdConverterFactory ambryIdConverterFactory =
         new AmbryIdConverterFactory(verifiableProperties, new MetricRegistry(), idSigningService, namedBlobDb);

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/S3PutHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/S3PutHandlerTest.java
@@ -23,6 +23,7 @@ import com.github.ambry.account.InMemAccountService;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.commons.CommonTestUtils;
+import com.github.ambry.commons.InMemNamedBlobDbFactory;
 import com.github.ambry.config.FrontendConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.frontend.s3.S3GetHandler;
@@ -161,7 +162,7 @@ public class S3PutHandlerTest {
     FrontendTestSecurityServiceFactory securityServiceFactory = new FrontendTestSecurityServiceFactory();
     SecurityService securityService = securityServiceFactory.getSecurityService();
     NamedBlobDbFactory namedBlobDbFactory =
-        new TestNamedBlobDbFactory(verifiableProperties, new MetricRegistry(), ACCOUNT_SERVICE);
+        new InMemNamedBlobDbFactory(verifiableProperties, new MetricRegistry(), ACCOUNT_SERVICE);
     namedBlobDb = namedBlobDbFactory.getNamedBlobDb();
     AmbryIdConverterFactory ambryIdConverterFactory =
         new AmbryIdConverterFactory(verifiableProperties, new MetricRegistry(), idSigningService, namedBlobDb);


### PR DESCRIPTION
## Summary

This patch pulls the test in-memory db to the common package for wider adoption.


## Testing Done

Done