### PR TITLE
Recover from last log segment with invalid messages

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -636,6 +636,15 @@ public class StoreConfig {
   public static final String storeRemoveDirectoryAndRestartBlobStoreName =
       "store.remove.directory.and.restart.blob.store";
 
+  @Config(storeEnablePartialLogSegmentRecoveryName)
+  public final boolean storeEnablePartialLogSegmentRecovery;
+  public static final String storeEnablePartialLogSegmentRecoveryName = "store.enable.partial.log.segment.recovery";
+
+  @Config(storePartialLogSegmentRecoveryRemainingDataSizeThresholdName)
+  public final long storePartialLogSegmentRecoveryRemainingDataSizeThreshold;
+  public static final String storePartialLogSegmentRecoveryRemainingDataSizeThresholdName =
+      "store.partial.log.segment.recovery.remaining.data.size.threshold";
+
   /**
    * True to restore disk's availability on data node config when an unavailable disk is fixed in FULL AUTO mode.
    */
@@ -877,6 +886,11 @@ public class StoreConfig {
         verifiableProperties.getBoolean(storeRemoveUnexpectedDirsInFullAutoName, false);
     storeRemoveDirectoryAndRestartBlobStore =
         verifiableProperties.getBoolean(storeRemoveDirectoryAndRestartBlobStoreName, false);
+    storeEnablePartialLogSegmentRecovery =
+        verifiableProperties.getBoolean(storeEnablePartialLogSegmentRecoveryName, false);
+    storePartialLogSegmentRecoveryRemainingDataSizeThreshold =
+        verifiableProperties.getIntInRange(storePartialLogSegmentRecoveryRemainingDataSizeThresholdName,
+            5 * 1024 * 1024, 0, 1024 * 1024 * 1024);
     storeRestoreUnavailableDiskInFullAuto =
         verifiableProperties.getBoolean(storeRestoreUnavailableDiskInFullAutoName, false);
     storeProactivelyTestStorageAvailability =

--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -636,10 +636,18 @@ public class StoreConfig {
   public static final String storeRemoveDirectoryAndRestartBlobStoreName =
       "store.remove.directory.and.restart.blob.store";
 
+  /**
+   * True to enable partial log segment recovery. If in the last log segment, there are invalid messages, then as long
+   * as these invalid messages are smaller than the given threshold, we should continue recovery and truncate the file.
+   */
   @Config(storeEnablePartialLogSegmentRecoveryName)
   public final boolean storeEnablePartialLogSegmentRecovery;
   public static final String storeEnablePartialLogSegmentRecoveryName = "store.enable.partial.log.segment.recovery";
 
+  /**
+   * The threshold for partial log segment recovery. If there are more bytes in the remaining log segment than the given
+   * threshold, then don't recover. The default value is 5MB, which is a bit larger than the largest put blob.
+   */
   @Config(storePartialLogSegmentRecoveryRemainingDataSizeThresholdName)
   public final long storePartialLogSegmentRecoveryRemainingDataSizeThreshold;
   public static final String storePartialLogSegmentRecoveryRemainingDataSizeThresholdName =

--- a/ambry-api/src/main/java/com/github/ambry/store/MessageStoreRecovery.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/MessageStoreRecovery.java
@@ -13,26 +13,57 @@
  */
 package com.github.ambry.store;
 
-import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 
 
 /**
- * The recovery component used by the store to recover
- * the index from the log.
+ * The recovery component used by the store to recover the index from the log.
  */
 public interface MessageStoreRecovery {
   /**
    * Recovers the messages from the underlying store using the read interface. It recovers from the startOffset
-   * till the endOffset. The expectation of this interface is that read never blocks
+   * till the endOffset. The expectation of this interface is that read never blocks and all the messages between
+   * {@code startOffset} and {@code endOffset} should be valid messages. If any message is invalid, the recovery
+   * implementation should stop right away and return the corresponding {@link RecoveryResult}.
    * @param read The read interface that represents the underlying store
    * @param startOffset The start offset from where the recovery needs to begin
-   * @param endOffset The end offset where the recovery needs to complete. The recovery can end before this offset if
+   * @param endOffset The end offset where the recovery needs to complete. The recovery has to stop before this offset if
    *                  there were malformed messages
    * @param factory The store key factory used to create the store key
-   * @return A list of messages that were successfully recovered
-   * @throws IOException
+   * @return an object of {@link RecoveryResult}.
    */
-  List<MessageInfo> recover(Read read, long startOffset, long endOffset, StoreKeyFactory factory)
-      throws IOException, StoreException;
+  RecoveryResult recover(Read read, long startOffset, long endOffset, StoreKeyFactory factory);
+
+  /**
+   * A data class to represent the result of a {@link MessageStoreRecovery}. All the fields in this class is public and
+   * immutable.
+   */
+  class RecoveryResult {
+    /**
+     * The valid messages recovered from the {@link MessageStoreRecovery}. The messages in the list should be ordered as
+     * the same order from the underlying storage.
+     */
+    public final List<MessageInfo> recovered;
+    /**
+     * Any exception encountered when recovering the messages. Once encountering exception, the recovery process should stop
+     * and return with proper start offset. Exception includes, but not limited to
+     * 1. IOException
+     * 2. Invalid messages, including format error, CRC error etc.
+     * If there is no exception while recovering messages, this field should be Null and the {@link #currentStartOffset} should
+     * equals to the given {@code endOffset}.
+     */
+    public final StoreException recoveryException;
+    /**
+     * The start offset of current message. This is only useful when there is an exception while recovering messages. This field
+     * should be the start offset of the invalid message.
+     */
+    public final long currentStartOffset;
+
+    public RecoveryResult(List<MessageInfo> recovered, StoreException recoveryException, long currentStartOffset) {
+      this.recovered = Collections.unmodifiableList(recovered);
+      this.recoveryException = recoveryException;
+      this.currentStartOffset = currentStartOffset;
+    }
+  }
 }

--- a/ambry-api/src/main/java/com/github/ambry/store/StoreErrorCodes.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/StoreErrorCodes.java
@@ -45,6 +45,7 @@ public enum StoreErrorCodes {
   LogFileFormatError,
   IndexFileFormatError,
   LogEndOffsetError,
-  IndexRecoveryError
+  IndexRecoveryError,
+  StoreStaleError
 }
 //@formatter:on

--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageFormatRecord.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageFormatRecord.java
@@ -1813,7 +1813,13 @@ public class MessageFormatRecord {
       if (dataSize > Integer.MAX_VALUE) {
         throw new IOException("We only support data of max size == MAX_INT. Error while reading blob from store");
       }
-      ByteBuf byteBuf = Utils.readNettyByteBufFromCrcInputStream(crcStream, (int) dataSize);
+      ByteBuf byteBuf = null;
+      try {
+        byteBuf = Utils.readNettyByteBufFromCrcInputStream(crcStream, (int) dataSize);
+      } catch (RuntimeException e) {
+        logger.error("Failed to read ByteBuf from crc input stream with size: {}", dataSize);
+        throw e;
+      }
       long crc = crcStream.getValue();
       long streamCrc = dataStream.readLong();
       if (crc != streamCrc) {

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -400,7 +400,7 @@ public class BlobStore implements Store {
       logger.error("checkIfStoreIsStale " + replicaId.getReplicaPath() + " is stale. ");
       BlobStore.staleBlobCount.getAndIncrement();
       if (config.storeBlockStaleBlobStoreToStart) {
-        throw new StoreException("BlobStore " + dataDir + " is stale ", StoreErrorCodes.InitializationError);
+        throw new StoreException("BlobStore " + dataDir + " is stale ", StoreErrorCodes.StoreStaleError);
       }
     }
   }

--- a/ambry-store/src/main/java/com/github/ambry/store/LogSegment.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/LogSegment.java
@@ -214,6 +214,23 @@ class LogSegment implements Read, Write {
     return new DirectIOBufferedExecutor(bufferSize);
   }
 
+  void truncateTo(long offset) throws IOException {
+    long currentFileSize = sizeInBytes();
+    if (currentFileSize < offset) {
+      throw new IllegalArgumentException(
+          "Illegal offset to truncate to, current file size is " + currentFileSize + " new offset is " + offset);
+    }
+    if (currentFileSize == offset) {
+      return;
+    }
+    long endOffset = getEndOffset();
+    if (endOffset != 0 && endOffset != HEADER_SIZE) {
+      throw new IllegalStateException("Truncate Log segment can only happen before end offset is set");
+    }
+    fileChannel.truncate(offset);
+    fileChannel.force(true);
+  }
+
   /**
    * {@inheritDoc}
    * <p/>

--- a/ambry-store/src/main/java/com/github/ambry/store/LogSegment.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/LogSegment.java
@@ -214,6 +214,12 @@ class LogSegment implements Read, Write {
     return new DirectIOBufferedExecutor(bufferSize);
   }
 
+  /**
+   * Truncate the log segment file to the given offset. If the endOffset is already set, then this operation
+   * should be illegal.
+   * @param offset
+   * @throws IOException
+   */
   void truncateTo(long offset) throws IOException {
     long currentFileSize = sizeInBytes();
     if (currentFileSize < offset) {

--- a/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
@@ -273,7 +273,6 @@ public class PersistentIndex implements LogSegmentSizeProvider {
       }
 
       if (recovery != null) {
-        metrics.initializeRecoveryMetrics(recoveryFromPartialLogSegmentCounter);
         recover(recovery);
       }
       //Journal should only include the index entry which belongs to the last log segment to make sure it only prevents the last log segment
@@ -506,7 +505,7 @@ public class PersistentIndex implements LogSegmentSizeProvider {
    * from the given {@link com.github.ambry.store.MessageStoreRecovery.RecoveryResult}.
    * If there is no exception in the result, then continue.
    * If partial recovery is not enable, or the log segment is not the last log segment, don't continue;
-   * If there are too many bytes in the remaining file, don't continue;
+   * If there are too many bytes in the remainiikng file, don't continue;
    * @param logSegmentToRecover
    * @param recoveryResult
    * @throws StoreException
@@ -532,6 +531,8 @@ public class PersistentIndex implements LogSegmentSizeProvider {
     logger.info("Index: {} Partial LogSegment recovery, log segment {} has valid message until {}, the file size is {}",
         dataDir, logSegmentToRecover.getName(), startOffsetForBrokenMessage, endOffset);
     recoveryFromPartialLogSegmentCounter.incrementAndGet();
+    // Since we use fallocate --keep-size to preallocate log segment file, we can truncate log segment file here
+    // It will only change the logical file size, not the preallocated disk space.
     logSegmentToRecover.truncateTo(startOffsetForBrokenMessage);
   }
 

--- a/ambry-store/src/main/java/com/github/ambry/store/StoreMetrics.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StoreMetrics.java
@@ -346,6 +346,12 @@ public class StoreMetrics {
     indexes.remove(storeId);
   }
 
+  void initializeRecoveryMetrics(AtomicInteger partialLogSegmentCounter) {
+    Gauge<Integer> recoveryFromPartialLogSegmentGauge = partialLogSegmentCounter::get;
+    registry.gauge(MetricRegistry.name(PersistentIndex.class, "recoveryFromPartialLogSegmentCount"),
+        () -> recoveryFromPartialLogSegmentGauge);
+  }
+
   void initializeHardDeleteMetric(String storeId, final HardDeleter hardDeleter, final PersistentIndex index) {
     String prefix = storeId + SEPARATOR;
     Gauge<Long> currentHardDeleteProgress = hardDeleter::getProgress;

--- a/ambry-store/src/test/java/com/github/ambry/store/CuratedLogIndexState.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CuratedLogIndexState.java
@@ -229,7 +229,9 @@ class CuratedLogIndexState {
    */
   void destroy() throws IOException, StoreException {
     shutDownExecutorService(scheduler, 30, TimeUnit.SECONDS);
-    index.close(false);
+    if (index != null) {
+      index.close(false);
+    }
     log.close(false);
     assertTrue(tempDir + " could not be cleaned", StoreTestUtils.cleanDirectory(tempDir, false));
   }
@@ -1093,7 +1095,9 @@ class CuratedLogIndexState {
    */
   void reloadLog(boolean initIndex) throws IOException, StoreException {
     long segmentCapacity = log.getSegmentCapacity();
-    index.close(false);
+    if (index != null) {
+      index.close(false);
+    }
     log.close(false);
     log = new Log(tempDirStr, LOG_CAPACITY, StoreTestUtils.DEFAULT_DISK_SPACE_ALLOCATOR,
         createStoreConfig(segmentCapacity, true), metrics, null);

--- a/ambry-store/src/test/java/com/github/ambry/store/DummyMessageStoreRecovery.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/DummyMessageStoreRecovery.java
@@ -13,16 +13,13 @@
  */
 package com.github.ambry.store;
 
-import java.io.IOException;
 import java.util.ArrayList;
-import java.util.List;
 
 
 public class DummyMessageStoreRecovery implements MessageStoreRecovery {
 
   @Override
-  public List<MessageInfo> recover(Read read, long startOffset, long endOffset, StoreKeyFactory factory)
-      throws IOException {
-    return new ArrayList<MessageInfo>();
+  public RecoveryResult recover(Read read, long startOffset, long endOffset, StoreKeyFactory factory) {
+    return new RecoveryResult(new ArrayList<MessageInfo>(), null, endOffset);
   }
 }


### PR DESCRIPTION
## Summary
Since we don't ignore invalid log segment from this PR https://github.com/linkedin/ambry/pull/2744, we run into lots of error replicas due to invalid messages in last log segment when power outage happens. This PR adds configuration and logic to deal with those errors. 

When there are invalid messages in the log segment when persistent index is trying to recover index segment files, we check if the log segment is the last log segment and if the amount of remaining bytes are small, if so, we just ignore the invalid message and move on with the valid message.


## Testing Done
Added unit tests.
