### PR TITLE
util for peer selection for filecopy

### DIFF
--- a/ambry-file-transfer/src/main/java/com/github/ambry/filetransfer/FileCopyUtils.java
+++ b/ambry-file-transfer/src/main/java/com/github/ambry/filetransfer/FileCopyUtils.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2025 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.filetransfer;
+
+import com.github.ambry.clustermap.PartitionId;
+import com.github.ambry.clustermap.ReplicaId;
+import com.github.ambry.clustermap.ReplicaState;
+import java.util.List;
+
+
+public class FileCopyUtils {
+
+  /**
+   * Get the peer replica in the given datacenter for file copy. We should only copy from LEADER replicas.
+   * @param partitionId the {@link PartitionId} of the replica.
+   * @param datacenterName the name of the datacenter.
+   * @return the peer replica in the given datacenter for file copy.
+   */
+  static public ReplicaId getPeerForFileCopy(PartitionId partitionId, String datacenterName) {
+    List<? extends ReplicaId> replicaIds = partitionId.getReplicaIdsByState(ReplicaState.LEADER, datacenterName);
+    if (replicaIds.isEmpty()) {
+      return null;
+    }
+    return replicaIds.get(0);
+  }
+}

--- a/ambry-file-transfer/src/test/java/FileCopyUtilsTest.java
+++ b/ambry-file-transfer/src/test/java/FileCopyUtilsTest.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2025 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+import com.github.ambry.clustermap.MockClusterMap;
+import com.github.ambry.clustermap.MockDataNodeId;
+import com.github.ambry.clustermap.MockPartitionId;
+import com.github.ambry.clustermap.PartitionId;
+import com.github.ambry.clustermap.ReplicaId;
+import com.github.ambry.clustermap.ReplicaState;
+import com.github.ambry.filetransfer.FileCopyUtils;
+import com.github.ambry.network.Port;
+import com.github.ambry.network.PortType;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+public class FileCopyUtilsTest {
+
+  /**
+   * Test for {@link FileCopyUtils#getPeerForFileCopy(PartitionId, String)}
+   * Test if no LEADER replica is found in the given datacenter.
+   */
+  @Test
+  public void testGetPeerForFileCopyFound() {
+    MockPartitionId partitionId = new MockPartitionId(123456, "RANDOM_PARTITION_CLASS");
+    ReplicaId replicaId = FileCopyUtils.getPeerForFileCopy(partitionId, "datacenter");
+    assertNull(replicaId);
+  }
+
+  /**
+   * Test for {@link FileCopyUtils#getPeerForFileCopy(PartitionId, String)}
+   * Test if a LEADER replica is found in the given datacenter.
+   */
+  @Test
+  public void testGetPeerForFileCopyWithLeader() {
+    List<String> mountPaths = new ArrayList<>();
+    mountPaths.add("/tmp/1");
+    mountPaths.add("/tmp/2");
+    Port port = new Port(1, PortType.PLAINTEXT);
+
+    MockDataNodeId dataNodeId =
+        new MockDataNodeId("peerNode", Collections.singletonList(port), mountPaths, "peerDatacenter");
+
+    PartitionId partitionId =
+        new MockPartitionId(100, MockClusterMap.DEFAULT_PARTITION_CLASS, Collections.singletonList(dataNodeId), 0);
+
+    ReplicaId replicaId = FileCopyUtils.getPeerForFileCopy(partitionId, "peerDatacenter");
+    assertNotNull(replicaId);
+    PartitionId leaderPartition =
+        replicaId.getPartitionId().getReplicaIdsByState(ReplicaState.LEADER, "peerDatacenter").get(0).getPartitionId();
+    assertEquals(partitionId, leaderPartition);
+  }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -358,6 +358,9 @@ project (':ambry-file-transfer') {
         compile project(':ambry-commons')
         compile project(':ambry-store')
         compile project(':ambry-prioritization')
+        compile project(':ambry-clustermap')
+        testCompile project(':ambry-test-utils')
+        testCompile project(path: ':ambry-clustermap', configuration: 'testArchives')
     }
 }
 
@@ -633,6 +636,7 @@ project(':ambry-all') {
         compile project(':ambry-test-utils')
         compile project(':ambry-quota')
         compile project(':ambry-vcr')
+        compile project(':ambry-file-transfer')
     }
 }
 


### PR DESCRIPTION
## Summary

util for peer selection for filecopy. We are selecting only LEADER replica for FileCopy

## Testing Done
Unit Tests written