### PR TITLE
Dont fail on the unresolved hostname

### DIFF
--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManagerMetrics.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManagerMetrics.java
@@ -140,7 +140,7 @@ class HelixClusterManagerMetrics {
   /**
    * Initialize datanode related metrics.
    */
-  void initializeDataNodeMetrics() {
+  void initializeDataNodeMetrics(AtomicLong dataNodeInitializationFailureCount) {
     Gauge<Long> dataNodeCount = clusterMapCallback::getDatanodeCount;
     registry.gauge(MetricRegistry.name(HelixClusterManager.class, "dataNodeCount"), () -> dataNodeCount);
 
@@ -152,6 +152,10 @@ class HelixClusterManagerMetrics {
       Gauge<Long> dataNodeState = () -> datanode.getState() == HardwareState.AVAILABLE ? 1L : 0L;
       registry.gauge(MetricRegistry.name(HelixClusterManager.class, metricName), () -> dataNodeState);
     }
+
+    Gauge<Long> dataNodeInitializationFailureCountGauge = dataNodeInitializationFailureCount::get;
+    registry.gauge(MetricRegistry.name(HelixClusterManager.class, "dataNodeInitializationFailureCount"),
+        () -> dataNodeInitializationFailureCountGauge);
   }
 
   /**


### PR DESCRIPTION
## Summary
If we have an unresolvable hostname from property store data node configs, we will fail helix cluster manager and kill all the frontend and server instance when booting up the process. Let's don't do this. We should create an alert for those hosts.


## Testing Done
No need for tests