### PR TITLE
Remove initial delay in loading json-accounts file

### DIFF
--- a/ambry-account/src/main/java/com/github/ambry/account/JsonAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/JsonAccountService.java
@@ -99,8 +99,8 @@ public final class JsonAccountService extends AbstractAccountService {
         scheduler.scheduleAtFixedRate(updater, 0, accountConfig.updaterPollingIntervalMs,
             TimeUnit.MILLISECONDS);
         logger.info(
-            "Background account updater will fetch accounts from remote starting {} ms from now and repeat with interval={} ms",
-            0, accountConfig.updaterPollingIntervalMs);
+            "Background account updater will poll for accounts every {} ms",
+            accountConfig.updaterPollingIntervalMs);
       } else {
         processAccountJsonFile();
       }

--- a/ambry-account/src/main/java/com/github/ambry/account/JsonAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/JsonAccountService.java
@@ -96,12 +96,11 @@ public final class JsonAccountService extends AbstractAccountService {
           }
         };
 
-        int initialDelay = new Random().nextInt(accountConfig.updaterPollingIntervalMs + 1);
-        scheduler.scheduleAtFixedRate(updater, initialDelay, accountConfig.updaterPollingIntervalMs,
+        scheduler.scheduleAtFixedRate(updater, 0, accountConfig.updaterPollingIntervalMs,
             TimeUnit.MILLISECONDS);
         logger.info(
             "Background account updater will fetch accounts from remote starting {} ms from now and repeat with interval={} ms",
-            initialDelay, accountConfig.updaterPollingIntervalMs);
+            0, accountConfig.updaterPollingIntervalMs);
       } else {
         processAccountJsonFile();
       }


### PR DESCRIPTION
## Summary

This unpredictable initial delay is frustrating because we can't issue any commands to Ambry until the accounts file is loaded, and we have no way of knowing when that will happen. Additionally, this delay is linked to the regular polling delay configuration, making it hard to adjust. Since I don’t want to add a separate configuration for the initial delay, I’m simply setting it to 0.




## Testing Done

Done
