### PR TITLE
Reset replication token when recovering from partial log segment

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/store/Store.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/Store.java
@@ -228,6 +228,14 @@ public interface Store {
   boolean isDisabled();
 
   /**
+   * @return {@code true} if the store recovers from partial log segment recovery failure.
+   */
+  default boolean hasPartialRecovery() {
+    // By default it's false
+    return false;
+  }
+
+  /**
    * Shuts down the store
    */
   void shutdown() throws StoreException;

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
@@ -459,15 +459,18 @@ public abstract class ReplicationEngine implements ReplicationAPI {
           if (isTokenForRemoteReplicaInfo(remoteReplicaInfo, tokenInfo)) {
             logger.info("Read token for partition {} remote host {} port {} token {}", partitionId, hostname, port,
                 token);
-            if (!partitionInfo.getStore().isEmpty()) {
+            if (!(partitionInfo.getStore().isEmpty() && partitionInfo.getStore().hasPartialRecovery())) {
               remoteReplicaInfo.initializeTokens(token);
               remoteReplicaInfo.setTotalBytesReadFromLocalStore(tokenInfo.getTotalBytesReadFromLocalStore());
             } else {
-              // if the local replica is empty, it could have been newly created. In this case, the offset in
+              // If the local replica is empty, it could have been newly created. In this case, the offset in
               // every peer replica which the local replica lags from should be set to 0, so that the local
               // replica starts fetching from the beginning of the peer. The totalBytes the peer read from the
               // local replica should also be set to 0. During initialization these values are already set to 0,
               // so we let them be.
+              //
+              // If the local replica has partial recovery, the local replica should start fetching from the beginning
+              // of the peer to just be safe.
               tokenWasReset = true;
               logTokenReset(partitionId, hostname, port, token);
             }

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -1183,6 +1183,11 @@ public class BlobStore implements Store {
   }
 
   @Override
+  public boolean hasPartialRecovery() {
+    return index.hasPartialRecovery();
+  }
+
+  @Override
   public boolean isBootstrapInProgress() {
     return (new File(dataDir, config.storeBootstrapInProgressFile)).exists();
   }


### PR DESCRIPTION
## Summary
If blob store recovers from partial log segment, then reset the replication token, since we might miss some remote blobs


## Testing Done
unit test