### PR TITLE
divide blobstore start method

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/store/Store.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/Store.java
@@ -189,6 +189,9 @@ public interface Store {
    */
   boolean isEmpty();
 
+
+  boolean isInitialized();
+
   /**
    * @return true if the store is started
    */

--- a/ambry-api/src/main/java/com/github/ambry/store/Store.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/Store.java
@@ -28,12 +28,20 @@ import java.util.Set;
  */
 public interface Store {
 
+  /**
+   * Initializes the store without starting it.
+   * @throws StoreException
+   */
   void initialize() throws StoreException;
 
+  /**
+   * Starts the store if it is initialized.
+   * @throws StoreException
+   */
   void load() throws StoreException;
 
   /**
-   * Starts the store
+   * Starts the store. It will initialize the store and then load the store.
    * @throws StoreException
    */
   void start() throws StoreException;
@@ -189,7 +197,9 @@ public interface Store {
    */
   boolean isEmpty();
 
-
+  /**
+   * @return true if the store is initialized
+   */
   boolean isInitialized();
 
   /**

--- a/ambry-api/src/main/java/com/github/ambry/store/Store.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/Store.java
@@ -28,6 +28,10 @@ import java.util.Set;
  */
 public interface Store {
 
+  void initialize() throws StoreException;
+
+  void load() throws StoreException;
+
   /**
    * Starts the store
    * @throws StoreException

--- a/ambry-api/src/main/java/com/github/ambry/store/StoreErrorCodes.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/StoreErrorCodes.java
@@ -26,6 +26,8 @@ public enum StoreErrorCodes {
   AlreadyExist,
   StoreNotStarted,
   StoreAlreadyStarted,
+  StoreNotInitialized,
+  StoreAlreadyInitialized,
   StoreShuttingDown,
   IllegalIndexOperation,
   IllegalIndexState,

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobStore.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobStore.java
@@ -134,8 +134,19 @@ public class CloudBlobStore implements Store {
   }
 
   @Override
-  public void start() {
+  public void initialize() throws StoreException {
+    logger.debug("Initialized store: {}", this);
+  }
+
+  public void load() throws StoreException {
     currentState = ReplicaState.STANDBY;
+    logger.debug("Loaded the store: {}", this);
+  }
+
+  @Override
+  public void start() throws StoreException {
+    initialize();
+    load();
     logger.debug("Started store: {}", this);
   }
 

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobStore.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobStore.java
@@ -134,17 +134,18 @@ public class CloudBlobStore implements Store {
   }
 
   @Override
-  public void initialize() throws StoreException {
+  public void initialize() {
     logger.debug("Initialized store: {}", this);
   }
 
-  public void load() throws StoreException {
+  @Override
+  public void load() {
     currentState = ReplicaState.STANDBY;
     logger.debug("Loaded the store: {}", this);
   }
 
   @Override
-  public void start() throws StoreException {
+  public void start() {
     initialize();
     load();
     logger.debug("Started store: {}", this);

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobStore.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobStore.java
@@ -1311,6 +1311,11 @@ public class CloudBlobStore implements Store {
     return true;
   }
 
+  @Override
+  public boolean isInitialized() {
+    return true;
+  }
+
   private void checkStarted() throws StoreException {
     // There is no concept of start/stop Azure cloud partition
   }

--- a/ambry-replication/src/test/java/com/github/ambry/replication/InMemoryStore.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/InMemoryStore.java
@@ -185,9 +185,20 @@ public class InMemoryStore implements Store {
   }
 
   @Override
-  public void start() {
+  public void initialize(){
+
+  }
+
+  @Override
+  public void load(){
     started = true;
     currentState = ReplicaState.STANDBY;
+  }
+
+  @Override
+  public void start() {
+    initialize();
+    load();
   }
 
   @Override

--- a/ambry-replication/src/test/java/com/github/ambry/replication/InMemoryStore.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/InMemoryStore.java
@@ -171,6 +171,7 @@ public class InMemoryStore implements Store {
   private final DummyLog log;
   final List<MessageInfo> messageInfos;
   final PartitionId id;
+  private boolean initialized;
   private boolean started;
 
   public InMemoryStore(PartitionId id, List<MessageInfo> messageInfos, List<ByteBuffer> buffers,
@@ -186,7 +187,7 @@ public class InMemoryStore implements Store {
 
   @Override
   public void initialize(){
-
+    initialized = true;
   }
 
   @Override
@@ -503,6 +504,11 @@ public class InMemoryStore implements Store {
   public void shutdown() {
     started = false;
     currentState = ReplicaState.OFFLINE;
+  }
+
+  @Override
+  public boolean isInitialized() {
+    return initialized;
   }
 
   @Override

--- a/ambry-server/src/test/java/com/github/ambry/server/MockStorageManager.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/MockStorageManager.java
@@ -102,9 +102,20 @@ class MockStorageManager extends StorageManager {
     }
 
     @Override
+    public void initialize() throws StoreException {
+
+    }
+
+    @Override
+    public void load() throws StoreException {
+      started = true;
+    }
+
+    @Override
     public void start() throws StoreException {
       throwExceptionIfRequired();
-      started = true;
+      initialize();
+      load();
     }
 
     @Override

--- a/ambry-server/src/test/java/com/github/ambry/server/MockStorageManager.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/MockStorageManager.java
@@ -90,6 +90,7 @@ class MockStorageManager extends StorageManager {
    */
   private class TestStore extends BlobStore {
     boolean started;
+    boolean initialized;
     ReplicaState currentState = ReplicaState.STANDBY;
 
     TestStore(ReplicaId replicaId, ClusterParticipant clusterParticipant) throws StoreException {
@@ -103,7 +104,7 @@ class MockStorageManager extends StorageManager {
 
     @Override
     public void initialize() throws StoreException {
-
+      initialized= true;
     }
 
     @Override
@@ -358,6 +359,11 @@ class MockStorageManager extends StorageManager {
     @Override
     public ReplicaState getCurrentState() {
       return currentState;
+    }
+
+    @Override
+    public boolean isInitialized() {
+      return initialized;
     }
 
     @Override

--- a/ambry-server/src/test/java/com/github/ambry/server/StatsManagerTest.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/StatsManagerTest.java
@@ -583,6 +583,16 @@ public class StatsManagerTest {
     }
 
     @Override
+    public void initialize() throws StoreException {
+      throw new IllegalStateException("Not implemented");
+    }
+
+    @Override
+    public void load() throws StoreException {
+      throw new IllegalStateException("Not implemented");
+    }
+
+    @Override
     public void start() throws StoreException {
       throw new IllegalStateException("Not implemented");
     }

--- a/ambry-server/src/test/java/com/github/ambry/server/StatsManagerTest.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/StatsManagerTest.java
@@ -726,6 +726,11 @@ public class StatsManagerTest {
     }
 
     @Override
+    public boolean isInitialized() {
+      throw new IllegalStateException("Not implemented");
+    }
+
+    @Override
     public boolean isStarted() {
       throw new IllegalStateException("Not implemented");
     }

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -255,6 +255,7 @@ public class BlobStore implements Store {
     recoverFromDecommission = isDecommissionInProgress();
   }
 
+  @Override
   public void initialize() throws StoreException {
     synchronized (storeWriteLock) {
       if (started) {
@@ -302,6 +303,7 @@ public class BlobStore implements Store {
     }
   }
 
+  @Override
   public void load() throws StoreException {
     synchronized (storeWriteLock) {
       if (started) {

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -1677,6 +1677,9 @@ public class BlobStore implements Store {
     return started;
   }
 
+  /**
+   * @return {@code true} if this store has been initialized successfully.
+   */
   public boolean isInitialized(){
     return initialized;
   }

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -255,12 +255,11 @@ public class BlobStore implements Store {
     recoverFromDecommission = isDecommissionInProgress();
   }
 
-  public void initialize() throws StoreException{
+  public void initialize() throws StoreException {
     synchronized (storeWriteLock) {
       if (started) {
         throw new StoreException("Store already started", StoreErrorCodes.StoreAlreadyStarted);
       }
-  //TODO    final Timer.Context context = metrics.storeStartTime.time();
       try {
         // Check if the data dir exist. If it does not exist, create it
         File dataFile = new File(dataDir);
@@ -288,8 +287,7 @@ public class BlobStore implements Store {
         }
 
         storeDescriptor = new StoreDescriptor(dataDir, config);
-
-      }catch (Exception e) {
+      } catch (Exception e) {
         if (fileLock != null) {
           // Release the file lock
           try {
@@ -300,13 +298,11 @@ public class BlobStore implements Store {
           String err = String.format("Error while starting store for dir %s due to %s", dataDir, e.getMessage());
           throw new StoreException(err, e, StoreErrorCodes.InitializationError);
         }
-      }finally {
-        //TODO context.stop();
       }
     }
   }
 
-  public void load() throws StoreException{
+  public void load() throws StoreException {
     synchronized (storeWriteLock) {
       if (started) {
         throw new StoreException("Store already started", StoreErrorCodes.StoreAlreadyStarted);
@@ -342,7 +338,7 @@ public class BlobStore implements Store {
           replicaId.markDiskUp();
         }
         enableReplicaIfNeeded();
-      }catch (Exception e) {
+      } catch (Exception e) {
         if (fileLock != null) {
           // Release the file lock
           try {
@@ -350,18 +346,22 @@ public class BlobStore implements Store {
           } catch (Exception lockException) {
             logger.error("Failed to unlock file lock for dir " + dataDir, lockException);
           }
-          String err = String.format("Error while starting store for dir %s due to %s", dataDir, e.getMessage());
-          throw new StoreException(err, e, StoreErrorCodes.InitializationError);
         }
-      }finally {
-        //TODO context.stop();
+        String err = String.format("Error while starting store for dir %s due to %s", dataDir, e.getMessage());
+        throw new StoreException(err, e, StoreErrorCodes.InitializationError);
       }
     }
   }
+
   @Override
   public void start() throws StoreException {
-    initialize();
-    load();
+    final Timer.Context context = metrics.storeStartTime.time();
+    try {
+      initialize();
+      load();
+    } finally {
+      context.stop();
+    }
   }
 
   /**

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -296,9 +296,9 @@ public class BlobStore implements Store {
           } catch (Exception lockException) {
             logger.error("Failed to unlock file lock for dir " + dataDir, lockException);
           }
-          String err = String.format("Error while starting store for dir %s due to %s", dataDir, e.getMessage());
-          throw new StoreException(err, e, StoreErrorCodes.InitializationError);
         }
+        String err = String.format("Error while starting store for dir %s due to %s", dataDir, e.getMessage());
+        throw new StoreException(err, e, StoreErrorCodes.InitializationError);
       }
     }
   }

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
@@ -2768,6 +2768,7 @@ public class BlobStoreTest {
     assertTrue("Could not make readable", invalidDir.setReadable(true));
 
     testStore.deleteStoreFiles();
+    assertFalse("store directory should not exist", storeDir.exists());
   }
 
   /**

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
@@ -4150,12 +4150,22 @@ public class BlobStoreTest {
     }
   }
 
+  /**
+   * Verifies that {@link BlobStore#initialize()} executes successfully and shuts down the store
+   * @param blobStore the {@link BlobStore} to start.
+   * @throws StoreException
+   */
   private void verifyInitializeSuccess(BlobStore blobStore) throws StoreException {
     blobStore.initialize();
     assertTrue("Store has not been initialized", blobStore.isInitialized());
     blobStore.shutdown();
   }
 
+  /**
+   * Verifies that {@link BlobStore#start()} fails.
+   * @param blobStore the {@link BlobStore} to start
+   * @param expectedErrorCode the expected {@link StoreErrorCodes} for the failure
+   */
   private void verifyInitializeFailure(BlobStore blobStore, StoreErrorCodes expectedErrorCode) {
     try {
       blobStore.initialize();
@@ -4165,12 +4175,23 @@ public class BlobStoreTest {
     }
   }
 
+  /**
+   * Verifies that {@link BlobStore#load()} executes successfully and shuts down the store
+   * @param blobStore the {@link BlobStore} to load
+   * @throws StoreException
+   */
   private void verifyLoadSuccess(BlobStore blobStore) throws StoreException {
     blobStore.load();
     assertTrue("Store has not been loaded", blobStore.isInitialized());
     blobStore.shutdown();
   }
 
+  /**
+   * Verifies that {@link BlobStore#load()} fails.
+   * @param blobStore the {@link BlobStore} to start
+   * @param expectedErrorCode the expected {@link StoreErrorCodes} for the failure
+   * @throws StoreException
+   */
   private void verifyLoadFailure(BlobStore blobStore, StoreErrorCodes expectedErrorCode) throws StoreException {
     try {
       blobStore.load();

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
@@ -2792,20 +2792,28 @@ public class BlobStoreTest {
             time, new InMemAccountService(false, false), null, scheduler);
     testStore.initialize();
     testStore.load();
-
-    // test that deletion on initialized store should fail
+    DiskSpaceRequirements diskSpaceRequirements = testStore.getDiskSpaceRequirements();
+    diskAllocator.initializePool(diskSpaceRequirements == null ? Collections.emptyList()
+        : Collections.singletonList(testStore.getDiskSpaceRequirements()));
+    // ensure store directory and file exist
+    assertTrue("Store directory doesn't exist", storeDir.exists());
+    File storeSegmentDir = new File(reserveDir, DiskSpaceAllocator.STORE_DIR_PREFIX + storeId);
+    if (isLogSegmented) {
+      assertTrue("Store segment directory doesn't exist", storeSegmentDir.exists());
+      assertTrue("In-mem store file map should contain entry associated with test store",
+          diskAllocator.getStoreReserveFileMap().containsKey(storeId));
+    }
+    // test that deletion on started store should fail
     try {
       testStore.deleteStoreFiles();
     } catch (IllegalStateException e) {
       //expected
     }
-
     // create a unreadable dir in store dir to induce deletion failure
     File invalidDir = new File(storeDir, "invalidDir");
     assertTrue("Couldn't create dir within store dir", invalidDir.mkdir());
     assertTrue("Could not make unreadable", invalidDir.setReadable(false));
     testStore.shutdown();
-
     try {
       testStore.deleteStoreFiles();
       fail("should fail because one invalid dir is unreadable");
@@ -2816,7 +2824,21 @@ public class BlobStoreTest {
     // reset permission to allow deletion to succeed.
     assertTrue("Could not make readable", invalidDir.setReadable(true));
 
+    // put a swap segment into store dir
+    File tempFile = File.createTempFile("sample-swap",
+        LogSegmentName.SUFFIX + BlobStoreCompactor.TEMP_LOG_SEGMENT_NAME_SUFFIX, storeDir);
+    // test success case (swap segment is returned and store dir is correctly deleted)
+    assertEquals("Swap reserve dir should be empty initially", 0,
+        diskAllocator.getSwapReserveFileMap().getFileSizeSet().size());
     testStore.deleteStoreFiles();
+    assertFalse("swap segment still exists", tempFile.exists());
+    assertEquals("Swap reserve dir should have one swap segment", 1,
+        diskAllocator.getSwapReserveFileMap().getFileSizeSet().size());
+    assertFalse("store directory shouldn't exist", storeDir.exists());
+    assertFalse("store segment directory shouldn't exist", storeSegmentDir.exists());
+    assertFalse("test store entry should have been removed from in-mem store file map ",
+        diskAllocator.getStoreReserveFileMap().containsKey(storeId));
+    reloadStore();
   }
 
   /**

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
@@ -2306,9 +2306,13 @@ public class BlobStoreTest {
     File cleanShutDownFile = new File(tempDir, PersistentIndex.CLEAN_SHUTDOWN_FILENAME);
     assertTrue("Clean shutdown file should exist.", cleanShutDownFile.exists());
     // no operations should be possible if store is not up or has been shutdown
-    verifyOperationFailuresOnInactiveStore(store);
+    verifyOperationFailuresOnInactiveStore(store, StoreErrorCodes.StoreNotInitialized);
     store = createBlobStore(getMockReplicaId(tempDirStr));
-    verifyOperationFailuresOnInactiveStore(store);
+    verifyOperationFailuresOnInactiveStore(store, StoreErrorCodes.StoreNotInitialized);
+
+    store = createBlobStore(getMockReplicaId(tempDirStr));
+    store.initialize();
+    verifyOperationFailuresOnInactiveStore(store, StoreErrorCodes.StoreNotStarted);
   }
 
   /**
@@ -4402,7 +4406,7 @@ public class BlobStoreTest {
    * Verifies that operations on {@link BlobStore} fail because it is inactive.
    * @param blobStore the inactive {@link BlobStore} on which the operations are performed.
    */
-  private void verifyOperationFailuresOnInactiveStore(BlobStore blobStore) {
+  private void verifyOperationFailuresOnInactiveStore(BlobStore blobStore, StoreErrorCodes shutdownErrorCode) {
     try {
       blobStore.get(Collections.EMPTY_LIST, EnumSet.noneOf(StoreGetOptions.class));
       fail("Operation should have failed because store is inactive");
@@ -4461,7 +4465,7 @@ public class BlobStoreTest {
     try {
       blobStore.shutdown();
     } catch (StoreException e) {
-      assertEquals("Unexpected StoreErrorCode", StoreErrorCodes.StoreNotStarted, e.getErrorCode());
+      assertEquals("Unexpected StoreErrorCode", shutdownErrorCode, e.getErrorCode());
     }
   }
 

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
@@ -2771,6 +2771,55 @@ public class BlobStoreTest {
   }
 
   /**
+   * Test both success and failure cases when deleting store files when store is initialized and loaded
+   * @throws Exception
+   */
+  @Test
+  public void deleteStoreFilesInitializedAndLoadedBlobStore() throws Exception {
+    store.shutdown();
+    // create test store directory
+    File storeDir = createTempDirectory("store-" + storeId);
+    File reserveDir = createTempDirectory("reserve-pool");
+    reserveDir.deleteOnExit();
+    DiskSpaceAllocator diskAllocator =
+        new DiskSpaceAllocator(true, reserveDir, 0, new StorageManagerMetrics(new MetricRegistry()));
+    StoreConfig config = new StoreConfig(new VerifiableProperties(properties));
+    MetricRegistry registry = new MetricRegistry();
+    storeMetrics = new StoreMetrics(registry);
+    BlobStore testStore =
+        new BlobStore(getMockReplicaId(storeDir.getAbsolutePath()), config, scheduler, storeStatsScheduler, null,
+            diskIOScheduler, diskAllocator, storeMetrics, storeMetrics, STORE_KEY_FACTORY, recovery, hardDelete, null,
+            time, new InMemAccountService(false, false), null, scheduler);
+    testStore.initialize();
+    testStore.load();
+
+    // test that deletion on initialized store should fail
+    try {
+      testStore.deleteStoreFiles();
+    } catch (IllegalStateException e) {
+      //expected
+    }
+
+    // create a unreadable dir in store dir to induce deletion failure
+    File invalidDir = new File(storeDir, "invalidDir");
+    assertTrue("Couldn't create dir within store dir", invalidDir.mkdir());
+    assertTrue("Could not make unreadable", invalidDir.setReadable(false));
+    testStore.shutdown();
+
+    try {
+      testStore.deleteStoreFiles();
+      fail("should fail because one invalid dir is unreadable");
+    } catch (Exception e) {
+      // expected
+    }
+    assertTrue("store directory should exist because deletion failed", storeDir.exists());
+    // reset permission to allow deletion to succeed.
+    assertTrue("Could not make readable", invalidDir.setReadable(true));
+
+    testStore.deleteStoreFiles();
+  }
+
+  /**
    * test store in bootstrap and store completes bootstrap behaviors.
    * @throws Exception
    */


### PR DESCRIPTION
## Summary
divide start method for blobstore into two methods 
Initialize and load 

Initialize - This method will create the directory for partition, add store descriptor and takes the filelock.
load- Checks and loads existing logs or creates new log segments.

Logic is added in shutdown to shutdown properly in case store is initialized.


## Testing Done
Unit tests