### PR TITLE
Add stale error to recoverable exception

### DIFF
--- a/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
@@ -93,9 +93,15 @@ public class DiskManager {
   private final DiskHealthCheck diskHealthCheck;
   // Have a dedicated scheduler for persisting index segments to ensure index segments are always persisted
   private final ScheduledExecutorService indexPersistScheduler;
+  //@formatter:off
   private final EnumSet<StoreErrorCodes> recoverableStoreErrorCodes =
-      EnumSet.of(StoreErrorCodes.LogFileFormatError, StoreErrorCodes.IndexFileFormatError,
-          StoreErrorCodes.LogEndOffsetError, StoreErrorCodes.IndexRecoveryError);
+      EnumSet.of(
+          StoreErrorCodes.LogFileFormatError,
+          StoreErrorCodes.IndexFileFormatError,
+          StoreErrorCodes.LogEndOffsetError,
+          StoreErrorCodes.IndexRecoveryError,
+          StoreErrorCodes.StoreStaleError);
+  //@formatter:on
 
   private final AtomicBoolean ioErrorCheckerScheduled = new AtomicBoolean(false);
 


### PR DESCRIPTION
## Summary
When a blob store didn't start in the last 7(by default) days, we would consider this blob store "stale" and if the `StoreConfig.storeBlockStaleBlobStoreToStart` is true, we would block this blobstore to start by throwing a `StoreException` with `StoreStaleError`. 

This PR would try this error as recoveriable error and remove the directory for the blob store and restart the blob store automatically.



## Testing Done
Unit test