### PR TITLE
Config for using default catchup target

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
@@ -273,11 +273,20 @@ public class ClusterMapConfig {
   public final long clustermapReplicaCatchupAcceptableLagBytes;
 
   /**
-   * The minimum number of peers that a bootstrap replica is required to catch up with. If target is set to 0, then
-   * {@link com.github.ambry.clustermap.ReplicaSyncUpManager} will use number of replicas in local dc as catchup target.
+   * The minimum number of peers that a bootstrap replica is required to catch up with.
    */
   @Config("clustermap.replica.catchup.target")
   public final int clustermapReplicaCatchupTarget;
+
+  /**
+   * If this is set to true, while determining the catchup target, @link com.github.ambry.clustermap.ReplicaSyncUpManager}
+   *
+   *  will use number of replicas in local dc as catchup target.
+   */
+  @Config("clustermap.replica.catchup.target.count.local.peers")
+  @Default("true")
+  public final boolean clustermapReplicaCatchupTargetCountLocalPeers;
+
   /**
    * The minimum number of peers that a replica is required to catch up with when it's downward transition from leader/standby
    * to inactive, offline and dropped. If target is set to 0, then * {@link com.github.ambry.clustermap.ReplicaSyncUpManager}
@@ -447,6 +456,8 @@ public class ClusterMapConfig {
         verifiableProperties.getLongInRange("clustermap.replica.catchup.acceptable.lag.bytes", 0L, 0L, Long.MAX_VALUE);
     clustermapReplicaCatchupTarget =
         verifiableProperties.getIntInRange("clustermap.replica.catchup.target", 0, 0, Integer.MAX_VALUE);
+    clustermapReplicaCatchupTargetCountLocalPeers =
+        verifiableProperties.getBoolean("clustermap.replica.catchup.target.count.local.peers", true);
     clustermapReplicaCatchupTargetForDownwardTransition =
         verifiableProperties.getIntInRange("clustermap.replica.catchup.target.for.downward.transition", 2, 0,
             Integer.MAX_VALUE);

--- a/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
@@ -279,9 +279,8 @@ public class ClusterMapConfig {
   public final int clustermapReplicaCatchupTarget;
 
   /**
-   * If this is set to true, while determining the catchup target, @link com.github.ambry.clustermap.ReplicaSyncUpManager}
-   *
-   *  will use number of replicas in local dc as catchup target.
+   * If this is set to true, while determining the catchup target, {@link com.github.ambry.clustermap.ReplicaSyncUpManager}
+   *  will take count of maximum of count replicas in local dc as catchup target and {@link #clustermapReplicaCatchupTarget} .
    */
   @Config("clustermap.replica.catchup.target.count.local.peers")
   @Default("true")

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryReplicaSyncUpManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryReplicaSyncUpManager.java
@@ -356,7 +356,13 @@ public class AmbryReplicaSyncUpManager implements ReplicaSyncUpManager {
       int defaultCatchUpTarget =
           currentState == ReplicaState.BOOTSTRAP ? clusterMapConfig.clustermapReplicaCatchupTarget
               : clusterMapConfig.clustermapReplicaCatchupTargetForDownwardTransition;
-      catchupTarget = Math.max(defaultCatchUpTarget, localDcPeerReplicaAndLag.size());
+
+      if (clusterMapConfig.clustermapReplicaCatchupTargetCountLocalPeers) {
+        catchupTarget = Math.max(defaultCatchUpTarget, localDcPeerReplicaAndLag.size());
+      } else {
+        catchupTarget = defaultCatchUpTarget;
+      }
+
       logger.info(
           "LocalReplicaLagInfo: Partition {}, current state {}, LocalDcPeers {}, RemoteDcPeers: {}, defaultCatchupTarget: {}, catchupTarget: {}",
           localReplica.getPartitionId().toPathString(), currentState, localDcPeerReplicaAndLag.keySet(),


### PR DESCRIPTION
## Summary

Added a config to check which will enable to take local peers in the catchup target
This will work in both cases of upward and downward transition.

## Testing Done
Existing tests are covering this.