### PR TITLE
[MINOR] Added initial delay for prioritization scheduler start

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/ReplicationConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/ReplicationConfig.java
@@ -383,6 +383,11 @@ public class ReplicationConfig {
   @Default(DEFAULT_DISRUPTION_FACTORY)
   public final String disruptionServiceFactory;
 
+  public static final String PRIORITIZATION_SCHEDULER_INITIAL_DELAY_MINUTES = "prioritization.scheduler.initial.delay.minutes";
+  @Config(PRIORITIZATION_SCHEDULER_INITIAL_DELAY_MINUTES)
+  @Default("10")
+  public final int prioritizationSchedulerInitialDelayMinutes;
+
   public ReplicationConfig(VerifiableProperties verifiableProperties) {
 
     maxReplicationRetryCount =
@@ -473,5 +478,7 @@ public class ReplicationConfig {
         verifiableProperties.getBoolean(ENABLE_REPLICATION_PRIORITIZATION, false);
     disruptionServiceFactory =
         verifiableProperties.getString(DISRUPTION_SERVICE_FACTORY, DEFAULT_DISRUPTION_FACTORY);
+    prioritizationSchedulerInitialDelayMinutes =
+        verifiableProperties.getInt(PRIORITIZATION_SCHEDULER_INITIAL_DELAY_MINUTES, 10);
   }
 }

--- a/ambry-prioritization/src/main/java/com/github/ambry/replica/prioritization/ReplicationPrioritizationManager.java
+++ b/ambry-prioritization/src/main/java/com/github/ambry/replica/prioritization/ReplicationPrioritizationManager.java
@@ -111,7 +111,7 @@ public class ReplicationPrioritizationManager implements Runnable {
 
     // We require this delay to ensure StoreManager is able to init all stores with correct state.
     // Otherwise, on server start all partitions store will be in BOOTSTRAP
-    int initialDelay = replicationConfig.prioritizationSchedulerInitialDelayMinutes;
+    long initialDelay = replicationConfig.prioritizationSchedulerInitialDelayMinutes;
     // Schedule periodic runs for prioritization run
     this.scheduler.scheduleAtFixedRate(this, initialDelay, scheduleIntervalMinutes, TimeUnit.MINUTES);
 

--- a/ambry-prioritization/src/main/java/com/github/ambry/replica/prioritization/ReplicationPrioritizationManager.java
+++ b/ambry-prioritization/src/main/java/com/github/ambry/replica/prioritization/ReplicationPrioritizationManager.java
@@ -109,8 +109,11 @@ public class ReplicationPrioritizationManager implements Runnable {
     this.prioritizedPartitions = new EnumMap<>(PriorityTier.class);
     this.scheduler = scheduler;
 
+    // We require this delay to ensure StoreManager is able to init all stores with correct state.
+    // Otherwise, on server start all partitions store will be in BOOTSTRAP
+    int initialDelay = replicationConfig.prioritizationSchedulerInitialDelayMinutes;
     // Schedule periodic runs for prioritization run
-    this.scheduler.scheduleAtFixedRate(this, 0, scheduleIntervalMinutes, TimeUnit.MINUTES);
+    this.scheduler.scheduleAtFixedRate(this, initialDelay, scheduleIntervalMinutes, TimeUnit.MINUTES);
 
     logger.info("ReplicationPrioritizationManager initialized with prioritization window of {} hours, schedule interval of {} minutes, " +
             "and min batch size of {} partitions", prioritizationWindowMs, scheduleIntervalMinutes,

--- a/ambry-prioritization/src/main/java/com/github/ambry/replica/prioritization/ReplicationPrioritizationManager.java
+++ b/ambry-prioritization/src/main/java/com/github/ambry/replica/prioritization/ReplicationPrioritizationManager.java
@@ -383,6 +383,7 @@ public class ReplicationPrioritizationManager implements Runnable {
       logger.info("No currently replicating partitions, disabling high-priority replication");
       isHighPriorityReplicationRunning.set(false);
     }
+    completedPartitions.clear();
   }
 
   /**

--- a/ambry-prioritization/src/test/java/com/github/ambry/replica/prioritization/ReplicationPrioritizationManagerTest.java
+++ b/ambry-prioritization/src/test/java/com/github/ambry/replica/prioritization/ReplicationPrioritizationManagerTest.java
@@ -94,7 +94,7 @@ public class ReplicationPrioritizationManagerTest {
   private final int minBatchSize = 3;
   private final long scheduleIntervalMinutes = 5;
   private final long disruptionReadinessWindowInMS = TimeUnit.HOURS.toMillis(1);
-
+  private final long prioritizationSchedulerInitialDelay = 1;
   private Map<PartitionId, Store> partitionToStoreMap;
   // Test partitions
   private PartitionId partition1, partition2, partition3, partition4, partition5;
@@ -106,6 +106,7 @@ public class ReplicationPrioritizationManagerTest {
     properties.setProperty("disruption.lookahead.window.ms", Long.toString(disruptionReadinessWindowInMS));
     properties.setProperty("prioritization.scheduler.interval.minutes", Long.toString(scheduleIntervalMinutes));
     properties.setProperty("prioritization.batch.size", Integer.toString(minBatchSize));
+    properties.setProperty("prioritization.scheduler.initial.delay.minutes", Long.toString(prioritizationSchedulerInitialDelay));
     replicationConfig = new ReplicationConfig(new VerifiableProperties(properties));
 
     // Create test partitions
@@ -170,7 +171,7 @@ public class ReplicationPrioritizationManagerTest {
   public void testConstructorInitialization() {
     // Verify the scheduler was called with correct parameters
     verify(scheduler).scheduleAtFixedRate(
-        eq(manager), eq(0L), eq(scheduleIntervalMinutes), eq(TimeUnit.MINUTES));
+        eq(manager), eq(prioritizationSchedulerInitialDelay), eq(scheduleIntervalMinutes), eq(TimeUnit.MINUTES));
   }
 
   @Test


### PR DESCRIPTION
## Summary
[MINOR] Added initial delay for prioritization scheduler start
- Ensures StoreManager is able to init all store states


## Testing Done
```./gradlew clean build```