### PR TITLE
[Ambry Partial Disk Failure] Add disksMoreThanThresholdFailureCount

### DIFF
--- a/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
@@ -1223,6 +1223,7 @@ public class StorageManager implements StoreManager {
           .collect(Collectors.toList())
           .size();
       if (tooManyFailedDisks(unavailableDiskCount)) {
+        storeMainMetrics.disksMoreThanThresholdFailureCount.inc();
         System.exit(1);
       }
 

--- a/ambry-store/src/main/java/com/github/ambry/store/StoreMetrics.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StoreMetrics.java
@@ -105,6 +105,7 @@ public class StoreMetrics {
   public final Counter handleDiskFailureErrorCount;
   public final Histogram handleDiskFailureDuration;
   public final Counter handleDiskFailureRetryLockCount;
+  public final Counter disksMoreThanThresholdFailureCount;
 
   // Compaction related metrics
   public final Counter compactionFixStateCount;
@@ -287,6 +288,8 @@ public class StoreMetrics {
         registry.counter(MetricRegistry.name(StorageManager.class, "HandleDiskFailureErrorCount"));
     handleDiskFailureRetryLockCount =
         registry.counter(MetricRegistry.name(StorageManager.class, "HandleDiskFailureRetryLockCount"));
+    disksMoreThanThresholdFailureCount =
+        registry.counter(MetricRegistry.name(StorageManager.class, "disksMoreThanThresholdFailureCount"));
     blobStoreStatsQueueProcessorErrorCount =
         registry.counter(MetricRegistry.name(BlobStoreStats.class, name + "BlobStoreStatsQueueProcessorErrorCount"));
     statsOnDemandScanTotalTimeMs =


### PR DESCRIPTION
## Summary
Adds a metric for the event when number of failed disks > Ambry's threshold


## Testing Done
NA