### PR TITLE
Support to write files in the temp directory first in FCH

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/FileCopyBasedReplicationConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/FileCopyBasedReplicationConfig.java
@@ -83,6 +83,10 @@ public class FileCopyBasedReplicationConfig {
   @Default("5000")
   public final int fileCopyHandlerConnectionTimeoutMs;
 
+  public static final String FILE_COPY_TEMPORARY_DIRECTORY_NAME = "filecopy.temporary.directory.name";
+  @Config(FILE_COPY_TEMPORARY_DIRECTORY_NAME)
+  @Default("fileCopyTempDirectory")
+  public final String fileCopyTemporaryDirectoryName;
 
   public FileCopyBasedReplicationConfig(VerifiableProperties verifiableProperties) {
     fileCopyMetaDataFileName = verifiableProperties.getString(FILE_COPY_META_DATA_FILE_NAME, "segments_metadata_file");
@@ -97,5 +101,6 @@ public class FileCopyBasedReplicationConfig {
     fileCopyHandlerRetryBackoffMs = verifiableProperties.getInt(FILECOPYHANDLER_RETRY_BACKOFF_MS, 500);
     getFileCopyHandlerChunkSize = verifiableProperties.getInt(FILECOPYHANDLER_CHUNK_SIZE, 10 * 1024 * 1024); // 10 MB
     fileCopyHandlerConnectionTimeoutMs = verifiableProperties.getInt(FILECOPYHANDLER_CONNECTION_TIMEOUT_MS, 5000);
+    fileCopyTemporaryDirectoryName = verifiableProperties.getString(FILE_COPY_TEMPORARY_DIRECTORY_NAME, "fileCopyTempDirectory");
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/store/FileStoreException.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/FileStoreException.java
@@ -69,6 +69,10 @@ public class FileStoreException extends RuntimeException {
      */
     FileStoreReadError,
     /**
+     * Indicates that the FileStore service encountered an error during files move
+     */
+    FileStoreMoveFilesError,
+    /**
      * Indicates that the FileStore service encountered an error during delete
      */
     UnknownError

--- a/ambry-api/src/main/java/com/github/ambry/store/PartitionFileStore.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/PartitionFileStore.java
@@ -42,4 +42,14 @@ public interface PartitionFileStore {
    * @throws IOException
    */
   void writeStoreFileChunkToDisk(String outputFilePath, StoreFileChunk storeFileChunk) throws IOException;
+
+  /**
+   * Moves all regular files from the given source directory to the destination directory. This throws an exception in
+   * case any file already exists with the same name in the destination.
+   *
+   * @param srcDirPath   the path to the source directory
+   * @param destDirPath  the path to the destination directory
+   * @throws IOException if an I/O error occurs during the move operation
+   */
+  void moveAllRegularFiles(String srcDirPath, String destDirPath) throws IOException;
 }

--- a/ambry-file-transfer/src/main/java/com/github/ambry/filetransfer/handler/StoreFileCopyHandler.java
+++ b/ambry-file-transfer/src/main/java/com/github/ambry/filetransfer/handler/StoreFileCopyHandler.java
@@ -165,9 +165,19 @@ public class StoreFileCopyHandler implements FileCopyHandler {
     final FileCopyGetMetaDataResponse metadataResponse = getFileCopyGetMetaDataResponse(fileCopyInfo);
 
     metadataResponse.getLogInfos().forEach(logInfo -> {
+      // Process the respective files and copy it to the temporary path.
+      final String partitionToMountTempFilePath = partitionToMountFilePath + File.separator + config.fileCopyTemporaryDirectoryName;
       logInfo.getIndexSegments().forEach(indexFile ->
-        processIndexFile(indexFile, partitionToMountFilePath, fileCopyInfo, fileStore));
-      processLogSegment(logInfo, partitionToMountFilePath, fileCopyInfo, fileStore);
+        processIndexFile(indexFile, partitionToMountTempFilePath, fileCopyInfo, fileStore));
+      processLogSegment(logInfo, partitionToMountTempFilePath, fileCopyInfo, fileStore);
+
+      // Move all files to actual path.
+      try {
+        fileStore.moveAllRegularFiles(partitionToMountTempFilePath, partitionToMountFilePath);
+      } catch (IOException e) {
+        logMessageAndThrow("MoveFilesOperation", "Error moving files", e,
+            FileCopyHandlerException.FileCopyHandlerErrorCode.FileCopyHandlerWriteToDiskError);
+      }
     });
   }
 

--- a/ambry-file-transfer/src/test/java/com/github/ambry/filetransfer/handler/StoreFileCopyHandlerIntegTest.java
+++ b/ambry-file-transfer/src/test/java/com/github/ambry/filetransfer/handler/StoreFileCopyHandlerIntegTest.java
@@ -153,7 +153,12 @@ public class StoreFileCopyHandlerIntegTest extends StoreFileCopyHandlerTest {
         .getFileCopyGetChunkResponse(any(), any(), any(), anyBoolean());
 
     // Act - Run FCHandler.copy using Spy handler
+    // TODO: Temporary directory should have been created before FileCopyHandler.copy() is called.
+    File fileCopyTempDirectory = new File(sourcePartitionDir, "fileCopyTempDirectory");
+    assertFalse("Temporary directory already exists!", fileCopyTempDirectory.exists());
+    assertTrue(fileCopyTempDirectory.mkdirs());
     spyHandler.copy(fileCopyInfo);
+    assertTrue(fileCopyTempDirectory.delete());
 
     // Assert -
     // 1. Check that no sub-directories are created in the source directory
@@ -214,7 +219,12 @@ public class StoreFileCopyHandlerIntegTest extends StoreFileCopyHandlerTest {
         .getFileCopyGetChunkResponse(any(), any(), any(), anyBoolean());
 
     // Act - Run FCHandler.copy using Spy handler
+    // TODO: Temporary directory should have been created before FileCopyHandler.copy() is called.
+    File fileCopyTempDirectory = new File(sourcePartitionDir, "fileCopyTempDirectory");
+    assertFalse("Temporary directory already exists!", fileCopyTempDirectory.exists());
+    assertTrue(fileCopyTempDirectory.mkdirs());
     spyHandler.copy(fileCopyInfo);
+    assertTrue(fileCopyTempDirectory.delete());
 
     // Assert -
     // 1. Check that no sub-directories are created in the source directory


### PR DESCRIPTION
## Summary
Adds support for writing currently being processed files related to a LogSegment to a temporary directory on the bootstrapping node before moving them to their final location. This helps handle cleanup scenarios during server restarts.

## Testing Done
./gradlew clean build

