### PR TITLE
Return 204 in s3 delete handler for 404

### DIFF
--- a/ambry-commons/src/main/java/com/github/ambry/commons/InMemNamedBlobDb.java
+++ b/ambry-commons/src/main/java/com/github/ambry/commons/InMemNamedBlobDb.java
@@ -48,11 +48,13 @@ public class InMemNamedBlobDb implements NamedBlobDb {
   private final Map<String, Map<String, TreeMap<String, List<NamedBlobRow>>>> allRecords = new HashMap<>();
   private final Time time;
   private final int listMaxResults;
+  private final boolean enableHardDelete;
   private Exception exception;
 
-  public InMemNamedBlobDb(Time time, int listMaxResults) {
+  public InMemNamedBlobDb(Time time, int listMaxResults, boolean enableHardDelete) {
     this.time = time;
     this.listMaxResults = listMaxResults;
+    this.enableHardDelete = enableHardDelete;
   }
 
   @Override
@@ -200,6 +202,9 @@ public class InMemNamedBlobDb implements NamedBlobDb {
           updateExpirationTimeMs(row, time.milliseconds());
         }
         blobVersions.add(blobVersion);
+      }
+      if (enableHardDelete) {
+        allRecords.get(accountName).get(containerName).remove(blobName); // remove the blob from the db
       }
       future.complete(new DeleteResult(blobVersions));
     }

--- a/ambry-commons/src/main/java/com/github/ambry/commons/InMemNamedBlobDbFactory.java
+++ b/ambry-commons/src/main/java/com/github/ambry/commons/InMemNamedBlobDbFactory.java
@@ -28,7 +28,7 @@ public class InMemNamedBlobDbFactory implements NamedBlobDbFactory {
   public InMemNamedBlobDbFactory(VerifiableProperties verifiableProperties, MetricRegistry metricRegistry,
       AccountService accountService) {
     InternalConfig config = new InternalConfig(verifiableProperties);
-    namedBlobDb = new InMemNamedBlobDb(SystemTime.getInstance(), config.listMaxResults);
+    namedBlobDb = new InMemNamedBlobDb(SystemTime.getInstance(), config.listMaxResults, config.enableHardDelete);
   }
 
   @Override
@@ -38,10 +38,12 @@ public class InMemNamedBlobDbFactory implements NamedBlobDbFactory {
 
   class InternalConfig {
     public final int listMaxResults;
+    public final boolean enableHardDelete;
 
     public InternalConfig(VerifiableProperties verifiableProperties) {
       this.listMaxResults =
           verifiableProperties.getIntInRange(MySqlNamedBlobDbConfig.LIST_MAX_RESULTS, 100, 1, Integer.MAX_VALUE);
+      this.enableHardDelete = verifiableProperties.getBoolean(MySqlNamedBlobDbConfig.ENABLE_HARD_DELETE, false);
     }
   }
 }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3DeleteHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3DeleteHandler.java
@@ -83,7 +83,11 @@ public class S3DeleteHandler extends S3BaseHandler<Void> {
         restResponseChannel.setStatus(ResponseStatus.NoContent);
         finalCallback.onCompletion(null, null);
       };
+
       // Callback for failure case, Since S3 delete should be idempotent, we should return 204 on 404.
+      // TODO: deleteBlobHandler returns 400 if the account or container does not exist, but s3
+      // should return 404 with xml error content in the response body. We should return compatible response
+      // as s3.
       Callback<Void> failureCallback = (r, e) -> {
         Exception finalException = e;
         try {


### PR DESCRIPTION
## Summary
S3 delete operation should be idempotent, which means deleting a non-existent key should be treated as a success. Non-existent keys include deleted keys as well. This PR guarantees this behavior.

## Details
In this PR https://github.com/linkedin/ambry/pull/3061, we introduced a "HardDelete" configuration for MysqlNamedBlobDb. If HardDelete is enabled, we run a DELETE sql command to remove the a given blob name from named blob table when deleting this blob name. This creates a unexpected result where a delete operation on an already deleted blob, would return 404, not 204. However s3 delete operation is idempotent, we should return 204 in this case.

And not only that, a delete request for non-existent key in s3 should return no error response, but a success. This is the sdk javadoc for delete object https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/AmazonS3Client.html#deleteObject-com.amazonaws.services.s3.model.DeleteObjectRequest-


## Testing Done
Unit test
