### PR TITLE
Issue manual disk flush for each chunk in FCH

### DIFF
--- a/ambry-store/src/main/java/com/github/ambry/store/FileStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/FileStore.java
@@ -210,7 +210,7 @@ public class FileStore implements PartitionFileStore {
         }
         // Write content to file with create and append options, which will create a new file if file doesn't exist
         // and append to the existing file if file exists
-        Files.write(outputPath, content, StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+        Files.write(outputPath, content, StandardOpenOption.CREATE, StandardOpenOption.APPEND, StandardOpenOption.SYNC);
       }
     } catch (Exception e) {
       logger.error("Error while writing chunk to file: {}", outputFilePath, e);


### PR DESCRIPTION
## Summary
This change ensures that each data chunk written is flushed to disk immediately by using the SYNC option (force flush to disk). This guarantees that both file content and metadata are durably persisted, minimizing the risk of data loss in the event of a sudden node restart or crash.


## Testing Done
./gradlew clean build