### PR TITLE
Add metrics for multipart requests

### DIFF
--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendMetrics.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendMetrics.java
@@ -63,9 +63,9 @@ public class FrontendMetrics {
   public final RestRequestMetricsGroup postBlobMetricsGroup;
   public final RestRequestMetricsGroup postAccountsMetricsGroup;
   public final RestRequestMetricsGroup postDatasetsMetricsGroup;
-  public final RestRequestMetricsGroup postMultipartAbortMetricsGroup;
-  public final RestRequestMetricsGroup postMultipartCompleteMetricsGroup;
-  public final RestRequestMetricsGroup postMultipartCreateMetricsGroup;
+  public final RestRequestMetricsGroup s3MultipartAbortMetricsGroup;
+  public final RestRequestMetricsGroup s3MultipartCompleteMetricsGroup;
+  public final RestRequestMetricsGroup s3MultipartCreateMetricsGroup;
 
   // PUT
   public final RestRequestMetricsGroup updateBlobTtlMetricsGroup;
@@ -376,14 +376,14 @@ public class FrontendMetrics {
         new RestRequestMetricsGroup(PostAccountsHandler.class, "PostAccounts", false, metricRegistry, frontendConfig);
     postDatasetsMetricsGroup =
         new RestRequestMetricsGroup(PostDatasetsHandler.class, "PostDatasets", false, metricRegistry, frontendConfig);
-    postMultipartAbortMetricsGroup =
-        new RestRequestMetricsGroup(FrontendRestRequestService.class, "PostMultipartAbort", false, metricRegistry,
+    s3MultipartAbortMetricsGroup =
+        new RestRequestMetricsGroup(FrontendRestRequestService.class, "S3MultipartAbort", false, metricRegistry,
             frontendConfig);
-    postMultipartCompleteMetricsGroup =
-        new RestRequestMetricsGroup(FrontendRestRequestService.class, "PostMultipartComplete", false, metricRegistry,
+    s3MultipartCompleteMetricsGroup =
+        new RestRequestMetricsGroup(FrontendRestRequestService.class, "S3MultipartComplete", false, metricRegistry,
             frontendConfig);
-    postMultipartCreateMetricsGroup =
-        new RestRequestMetricsGroup(FrontendRestRequestService.class, "PostMultipartCreate", false, metricRegistry,
+    s3MultipartCreateMetricsGroup =
+        new RestRequestMetricsGroup(FrontendRestRequestService.class, "S3MultipartCreate", false, metricRegistry,
             frontendConfig);
 
     // PUT

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendMetrics.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendMetrics.java
@@ -63,6 +63,9 @@ public class FrontendMetrics {
   public final RestRequestMetricsGroup postBlobMetricsGroup;
   public final RestRequestMetricsGroup postAccountsMetricsGroup;
   public final RestRequestMetricsGroup postDatasetsMetricsGroup;
+  public final RestRequestMetricsGroup postMultipartAbortMetricsGroup;
+  public final RestRequestMetricsGroup postMultipartCompleteMetricsGroup;
+  public final RestRequestMetricsGroup postMultipartCreateMetricsGroup;
 
   // PUT
   public final RestRequestMetricsGroup updateBlobTtlMetricsGroup;
@@ -135,7 +138,6 @@ public class FrontendMetrics {
   public final AsyncOperationTracker.Metrics getDatasetsSecurityProcessRequestMetrics;
   public final AsyncOperationTracker.Metrics getDatasetsSecurityPostProcessRequestMetrics;
   public final AsyncOperationTracker.Metrics copyDatasetsSecurityPostProcessRequestMetrics;
-
 
   public final AsyncOperationTracker.Metrics listDatasetsSecurityProcessRequestMetrics;
   public final AsyncOperationTracker.Metrics listDatasetsSecurityPostProcessRequestMetrics;
@@ -374,6 +376,16 @@ public class FrontendMetrics {
         new RestRequestMetricsGroup(PostAccountsHandler.class, "PostAccounts", false, metricRegistry, frontendConfig);
     postDatasetsMetricsGroup =
         new RestRequestMetricsGroup(PostDatasetsHandler.class, "PostDatasets", false, metricRegistry, frontendConfig);
+    postMultipartAbortMetricsGroup =
+        new RestRequestMetricsGroup(FrontendRestRequestService.class, "PostMultipartAbort", false, metricRegistry,
+            frontendConfig);
+    postMultipartCompleteMetricsGroup =
+        new RestRequestMetricsGroup(FrontendRestRequestService.class, "PostMultipartComplete", false, metricRegistry,
+            frontendConfig);
+    postMultipartCreateMetricsGroup =
+        new RestRequestMetricsGroup(FrontendRestRequestService.class, "PostMultipartCreate", false, metricRegistry,
+            frontendConfig);
+
     // PUT
     updateBlobTtlMetricsGroup =
         new RestRequestMetricsGroup(TtlUpdateHandler.class, "UpdateBlobTtl", false, metricRegistry, frontendConfig);
@@ -381,7 +393,6 @@ public class FrontendMetrics {
         new RestRequestMetricsGroup(UndeleteHandler.class, "UndeleteBlob", false, metricRegistry, frontendConfig);
     putBlobMetricsGroup =
         new RestRequestMetricsGroup(NamedBlobPutHandler.class, "PutBlob", false, metricRegistry, frontendConfig);
-
 
     // AsyncOperationTracker.Metrics instances
     postSecurityProcessRequestMetrics =
@@ -511,7 +522,8 @@ public class FrontendMetrics {
         new AsyncOperationTracker.Metrics(NamedBlobPutHandler.class, "RetentionRequest", metricRegistry);
 
     s3DeleteHandleMetrics = new AsyncOperationTracker.Metrics(S3DeleteHandler.class, "S3Handle", metricRegistry);
-    s3BatchDeleteHandleMetrics = new AsyncOperationTracker.Metrics(S3BatchDeleteHandler.class, "S3Handle", metricRegistry);
+    s3BatchDeleteHandleMetrics =
+        new AsyncOperationTracker.Metrics(S3BatchDeleteHandler.class, "S3Handle", metricRegistry);
     s3ListHandleMetrics = new AsyncOperationTracker.Metrics(S3ListHandler.class, "S3Handle", metricRegistry);
     s3PutHandleMetrics = new AsyncOperationTracker.Metrics(S3PutHandler.class, "S3Handle", metricRegistry);
     s3GetHandleMetrics = new AsyncOperationTracker.Metrics(S3GetHandler.class, "S3Handle", metricRegistry);

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3MultipartAbortUploadHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3MultipartAbortUploadHandler.java
@@ -88,7 +88,10 @@ public class S3MultipartAbortUploadHandler<R> {
     private void start() {
       try {
         accountAndContainerInjector.injectAccountContainerForNamedBlob(restRequest,
-            frontendMetrics.deleteBlobMetricsGroup);
+            frontendMetrics.postMultipartAbortMetricsGroup);
+        restRequest.getMetricsTracker()
+            .injectMetrics(
+                frontendMetrics.postMultipartAbortMetricsGroup.getRestRequestMetrics(restRequest.isSslUsed(), false));
         securityService.processRequest(restRequest, securityProcessRequestCallback());
       } catch (Exception e) {
         finalCallback.onCompletion(null, e);

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3MultipartAbortUploadHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3MultipartAbortUploadHandler.java
@@ -88,10 +88,10 @@ public class S3MultipartAbortUploadHandler<R> {
     private void start() {
       try {
         accountAndContainerInjector.injectAccountContainerForNamedBlob(restRequest,
-            frontendMetrics.postMultipartAbortMetricsGroup);
+            frontendMetrics.s3MultipartAbortMetricsGroup);
         restRequest.getMetricsTracker()
             .injectMetrics(
-                frontendMetrics.postMultipartAbortMetricsGroup.getRestRequestMetrics(restRequest.isSslUsed(), false));
+                frontendMetrics.s3MultipartAbortMetricsGroup.getRestRequestMetrics(restRequest.isSslUsed(), false));
         securityService.processRequest(restRequest, securityProcessRequestCallback());
       } catch (Exception e) {
         finalCallback.onCompletion(null, e);

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3MultipartCompleteUploadHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3MultipartCompleteUploadHandler.java
@@ -156,10 +156,10 @@ public class S3MultipartCompleteUploadHandler<R> {
     private void start() {
       try {
         accountAndContainerInjector.injectAccountContainerForNamedBlob(restRequest,
-            frontendMetrics.postMultipartCompleteMetricsGroup);
+            frontendMetrics.s3MultipartCompleteMetricsGroup);
         restRequest.getMetricsTracker()
             .injectMetrics(
-                frontendMetrics.postMultipartCompleteMetricsGroup.getRestRequestMetrics(restRequest.isSslUsed(),
+                frontendMetrics.s3MultipartCompleteMetricsGroup.getRestRequestMetrics(restRequest.isSslUsed(),
                     false));
         securityService.processRequest(restRequest, securityProcessRequestCallback());
       } catch (Exception e) {

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3MultipartCompleteUploadHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3MultipartCompleteUploadHandler.java
@@ -78,7 +78,6 @@ import static com.github.ambry.router.RouterErrorCode.*;
 /**
  * Handles a request for s3 Complete/AbortMultipartUploads according to the
  * <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html">...</a>
- * TODO [S3] Add support for Abort multipart uploads.
  */
 public class S3MultipartCompleteUploadHandler<R> {
   private static final Logger LOGGER = LoggerFactory.getLogger(S3MultipartCompleteUploadHandler.class);
@@ -125,8 +124,7 @@ public class S3MultipartCompleteUploadHandler<R> {
    * @param restResponseChannel the {@link RestResponseChannel} where headers should be set.
    * @param callback the {@link Callback} to invoke when the response is ready (or if there is an exception).
    */
-  void handle(RestRequest restRequest, RestResponseChannel restResponseChannel,
-      Callback<R> callback) {
+  void handle(RestRequest restRequest, RestResponseChannel restResponseChannel, Callback<R> callback) {
     new S3MultipartCompleteUploadHandler.CallbackChain(restRequest, restResponseChannel, callback).start();
   }
 
@@ -158,7 +156,11 @@ public class S3MultipartCompleteUploadHandler<R> {
     private void start() {
       try {
         accountAndContainerInjector.injectAccountContainerForNamedBlob(restRequest,
-            frontendMetrics.postBlobMetricsGroup);
+            frontendMetrics.postMultipartCompleteMetricsGroup);
+        restRequest.getMetricsTracker()
+            .injectMetrics(
+                frontendMetrics.postMultipartCompleteMetricsGroup.getRestRequestMetrics(restRequest.isSslUsed(),
+                    false));
         securityService.processRequest(restRequest, securityProcessRequestCallback());
       } catch (Exception e) {
         finalCallback.onCompletion(null, e);

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3MultipartCreateUploadHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3MultipartCreateUploadHandler.java
@@ -40,6 +40,7 @@ import static com.github.ambry.rest.RestUtils.*;
 import static com.github.ambry.rest.RestUtils.InternalKeys.*;
 import static com.github.ambry.frontend.s3.S3MessagePayload.*;
 
+
 /**
  * Handles a request for s3 CreateMultipartUploads according to the
  * <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">...</a>
@@ -70,8 +71,7 @@ public class S3MultipartCreateUploadHandler<R> {
    * @param restResponseChannel the {@link RestResponseChannel} where headers should be set.
    * @param callback the {@link Callback} to invoke when the response is ready (or if there is an exception).
    */
-  void handle(RestRequest restRequest, RestResponseChannel restResponseChannel,
-      Callback<R> callback) {
+  void handle(RestRequest restRequest, RestResponseChannel restResponseChannel, Callback<R> callback) {
     new S3MultipartCreateUploadHandler.CallbackChain(restRequest, restResponseChannel, callback).start();
   }
 
@@ -103,7 +103,10 @@ public class S3MultipartCreateUploadHandler<R> {
     private void start() {
       try {
         accountAndContainerInjector.injectAccountContainerForNamedBlob(restRequest,
-            frontendMetrics.postBlobMetricsGroup);
+            frontendMetrics.postMultipartCreateMetricsGroup);
+        restRequest.getMetricsTracker()
+            .injectMetrics(
+                frontendMetrics.postMultipartCreateMetricsGroup.getRestRequestMetrics(restRequest.isSslUsed(), false));
         securityService.processRequest(restRequest, securityProcessRequestCallback());
       } catch (Exception e) {
         finalCallback.onCompletion(null, e);

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3MultipartCreateUploadHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3MultipartCreateUploadHandler.java
@@ -26,7 +26,6 @@ import com.github.ambry.rest.RequestPath;
 import com.github.ambry.rest.ResponseStatus;
 import com.github.ambry.rest.RestRequest;
 import com.github.ambry.rest.RestResponseChannel;
-import com.github.ambry.rest.RestUtils;
 import com.github.ambry.router.ReadableStreamChannel;
 import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
@@ -103,10 +102,10 @@ public class S3MultipartCreateUploadHandler<R> {
     private void start() {
       try {
         accountAndContainerInjector.injectAccountContainerForNamedBlob(restRequest,
-            frontendMetrics.postMultipartCreateMetricsGroup);
+            frontendMetrics.s3MultipartCreateMetricsGroup);
         restRequest.getMetricsTracker()
             .injectMetrics(
-                frontendMetrics.postMultipartCreateMetricsGroup.getRestRequestMetrics(restRequest.isSslUsed(), false));
+                frontendMetrics.s3MultipartCreateMetricsGroup.getRestRequestMetrics(restRequest.isSslUsed(), false));
         securityService.processRequest(restRequest, securityProcessRequestCallback());
       } catch (Exception e) {
         finalCallback.onCompletion(null, e);


### PR DESCRIPTION
## Summary
Metrics for these operations were coupled together with POST, separate them into their own groups since they are substantially different from normal POST requests which upload a blob.


## Testing Done
./gradlew build