### PR TITLE
Create throughput metric for each request.

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/frontend/ContainerMetrics.java
+++ b/ambry-api/src/main/java/com/github/ambry/frontend/ContainerMetrics.java
@@ -44,10 +44,10 @@ public class ContainerMetrics extends EntityOperationMetrics {
     this.accountMetrics = accountMetrics;
   }
 
-  public void recordMetrics(long roundTripTimeInMs, ResponseStatus responseStatus) {
-    super.recordMetrics(roundTripTimeInMs, responseStatus);
+  public void recordMetrics(long roundTripTimeInMs, ResponseStatus responseStatus, long bytesTransferred) {
+    super.recordMetrics(roundTripTimeInMs, responseStatus, bytesTransferred);
     if (accountMetrics != null) {
-      accountMetrics.recordMetrics(roundTripTimeInMs, responseStatus);
+      accountMetrics.recordMetrics(roundTripTimeInMs, responseStatus, bytesTransferred);
     }
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/frontend/EntityOperationMetrics.java
+++ b/ambry-api/src/main/java/com/github/ambry/frontend/EntityOperationMetrics.java
@@ -83,7 +83,7 @@ public class EntityOperationMetrics {
     String qpsMetricPrefix = entityName + SEPARATOR + (isGetRequest ? "GetRequest" : "PutRequest");
     totalCount = metricRegistry.counter(MetricRegistry.name(ownerClass, qpsMetricPrefix + "totalCount"));
 
-    throughput = metricRegistry.histogram(MetricRegistry.name(ownerClass, qpsMetricPrefix + "Throughput"));
+    throughput = metricRegistry.histogram(MetricRegistry.name(ownerClass, "Throughput"));
   }
 
   /**

--- a/ambry-api/src/main/java/com/github/ambry/frontend/EntityOperationMetrics.java
+++ b/ambry-api/src/main/java/com/github/ambry/frontend/EntityOperationMetrics.java
@@ -16,6 +16,7 @@ import com.codahale.metrics.Counter;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.rest.ResponseStatus;
+import com.github.ambry.rest.RestUtils;
 
 
 /**
@@ -50,6 +51,8 @@ public class EntityOperationMetrics {
 
   protected final Counter totalCount;
 
+  protected final Histogram throughput;
+
   /**
    * Constructor to create operation metrics for given entity. The entity can be an account or a container.
    *
@@ -79,6 +82,8 @@ public class EntityOperationMetrics {
     goneCount = metricRegistry.counter(MetricRegistry.name(ownerClass, metricPrefix + "GoneCount"));
     String qpsMetricPrefix = entityName + SEPARATOR + (isGetRequest ? "GetRequest" : "PutRequest");
     totalCount = metricRegistry.counter(MetricRegistry.name(ownerClass, qpsMetricPrefix + "totalCount"));
+
+    throughput = metricRegistry.histogram(MetricRegistry.name(ownerClass, qpsMetricPrefix + "Throughput"));
   }
 
   /**
@@ -87,11 +92,12 @@ public class EntityOperationMetrics {
    * @param roundTripTimeInMs the time it took to receive a request and send a response.
    * @param responseStatus    the {@link ResponseStatus} sent in the response.
    */
-  public void recordMetrics(long roundTripTimeInMs, ResponseStatus responseStatus) {
+  public void recordMetrics(long roundTripTimeInMs, ResponseStatus responseStatus, long bytesTransferred) {
     this.roundTripTimeInMs.update(roundTripTimeInMs);
     totalCount.inc();
     if (responseStatus.isSuccess()) {
       successCount.inc();
+      throughput.update(RestUtils.calculateThroughput(bytesTransferred, roundTripTimeInMs));
     } else if (responseStatus.isRedirection()) {
       redirectionCount.inc();
     } else if (responseStatus.isClientError()) {

--- a/ambry-api/src/main/java/com/github/ambry/frontend/EntityOperationMetrics.java
+++ b/ambry-api/src/main/java/com/github/ambry/frontend/EntityOperationMetrics.java
@@ -83,7 +83,7 @@ public class EntityOperationMetrics {
     String qpsMetricPrefix = entityName + SEPARATOR + (isGetRequest ? "GetRequest" : "PutRequest");
     totalCount = metricRegistry.counter(MetricRegistry.name(ownerClass, qpsMetricPrefix + "totalCount"));
 
-    throughput = metricRegistry.histogram(MetricRegistry.name(ownerClass, "Throughput"));
+    throughput = metricRegistry.histogram(MetricRegistry.name(ownerClass, metricPrefix + "Throughput"));
   }
 
   /**

--- a/ambry-api/src/main/java/com/github/ambry/rest/RestRequestMetrics.java
+++ b/ambry-api/src/main/java/com/github/ambry/rest/RestRequestMetrics.java
@@ -44,6 +44,8 @@ public class RestRequestMetrics {
   static final String UNSATISFIED_REQUEST_COUNT_SUFFIX = "UnsatisfiedRequestCount";
   static final String SATISFIED_REQUEST_COUNT_SUFFIX = "SatisfiedRequestCount";
 
+  static final String THROUGHPUT_SUFFIX = "Throughput";
+
   final Histogram nioRequestProcessingTimeInMs;
   final Histogram nioResponseProcessingTimeInMs;
   final Histogram nioRoundTripTimeInMs;
@@ -60,6 +62,8 @@ public class RestRequestMetrics {
   final Counter operationCount;
   final Counter unsatisfiedRequestCount;
   final Counter satisfiedRequestCount;
+
+  final Histogram throughput;
 
   /**
    * Creates an instance of RestRequestMetrics for {@code requestType} and attaches all the metrics related to the
@@ -103,5 +107,7 @@ public class RestRequestMetrics {
         metricRegistry.counter(MetricRegistry.name(ownerClass, requestType + UNSATISFIED_REQUEST_COUNT_SUFFIX));
     satisfiedRequestCount =
         metricRegistry.counter(MetricRegistry.name(ownerClass, requestType + SATISFIED_REQUEST_COUNT_SUFFIX));
+
+    throughput = metricRegistry.histogram(MetricRegistry.name(ownerClass, requestType + THROUGHPUT_SUFFIX));
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/rest/RestRequestMetricsTracker.java
+++ b/ambry-api/src/main/java/com/github/ambry/rest/RestRequestMetricsTracker.java
@@ -283,9 +283,11 @@ public class RestRequestMetricsTracker {
           metrics.unsatisfiedRequestCount.inc();
         }
 
-        // Only add throughput metrics when the request is successful. Recording a failure could mean we incorrectly
-        // report throughput as something higher than normal since the round trip time is likely to be shorter.
-        if (!failed) {
+        // Only add throughput metrics when the request is successful and bytes were actually transfered over the wire.
+        // Recording throughput during failure could mean we incorrectly report throughput as something higher than normal since
+        // the round trip time is likely to be shorter.
+        // We also want to make sure we aren't polluting our metrics with a bunch of 0 throughput values.
+        if (!failed && bytesTransferred > 0) {
           metrics.throughput.update(RestUtils.calculateThroughput(bytesTransferred, nioMetricsTracker.roundTripTimeInMs));
         }
       }

--- a/ambry-api/src/main/java/com/github/ambry/rest/RestRequestMetricsTracker.java
+++ b/ambry-api/src/main/java/com/github/ambry/rest/RestRequestMetricsTracker.java
@@ -60,6 +60,8 @@ public class RestRequestMetricsTracker {
   private boolean satisfied = true;
   private ResponseStatus responseStatus = ResponseStatus.Ok;
 
+  private long bytesTransferred = 0;
+
   /**
    * Tracker for updating NIO related metrics.
    * </p>
@@ -221,6 +223,11 @@ public class RestRequestMetricsTracker {
   }
 
   /**
+   * @param bytesTransferred the number of bytes that was sent by/to the client as a part of this request.
+   */
+  public void setBytesTransferred(long bytesTransferred) { this.bytesTransferred = bytesTransferred; }
+
+  /**
    * Injects a {@link RestRequestMetrics} that can be used to track the metrics of the {@link RestRequest} that this
    * instance of RestRequestMetricsTracker is attached to.
    * @param restRequestMetrics the {@link RestRequestMetrics} instance to use to track the metrics of the
@@ -268,12 +275,18 @@ public class RestRequestMetricsTracker {
           metrics.operationError.inc();
         }
         if (containerMetrics != null) {
-          containerMetrics.recordMetrics(nioMetricsTracker.roundTripTimeInMs, responseStatus);
+          containerMetrics.recordMetrics(nioMetricsTracker.roundTripTimeInMs, responseStatus, bytesTransferred);
         }
         if (satisfied) {
           metrics.satisfiedRequestCount.inc();
         } else {
           metrics.unsatisfiedRequestCount.inc();
+        }
+
+        // Only add throughput metrics when the request is successful. Recording a failure could mean we incorrectly
+        // report throughput as something higher than normal since the round trip time is likely to be shorter.
+        if (!failed) {
+          metrics.throughput.update(RestUtils.calculateThroughput(bytesTransferred, nioMetricsTracker.roundTripTimeInMs));
         }
       }
     } else {

--- a/ambry-api/src/main/java/com/github/ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com/github/ambry/rest/RestUtils.java
@@ -1593,4 +1593,19 @@ public class RestUtils {
       return valueMap;
     }
   }
+
+  /**
+   * Calculate the throughput of a request
+   * @param bytesTransferred the number of bytes that was transfered to/from the client
+   * @param transferTimeInMs the total time it took for the request to complete in milliseconds
+   * @return a throughput value in bytes/second
+   */
+  public static Long calculateThroughput(long bytesTransferred, long transferTimeInMs) {
+    // If for some reason we completed the request in less than a ms, set ms to 1 when calculating throughput
+    long msForThroughputCalculation = 1;
+    if (transferTimeInMs > 0) {
+      msForThroughputCalculation = transferTimeInMs;
+    }
+    return Math.round((double) bytesTransferred / msForThroughputCalculation / 1000.0);
+  }
 }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/GetBlobHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/GetBlobHandler.java
@@ -243,9 +243,6 @@ public class GetBlobHandler {
             ReadableStreamChannel response = result.getBlobDataChannel();
             if (subResource == null) {
               response = closeChannelIfNotModified(result);
-              if (response != null) {
-                restRequest.getMetricsTracker().setBytesTransferred(result.getBlobInfo().getBlobProperties().getBlobSize());
-              }
             } else {
               switch (subResource) {
                 case BlobInfo:

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/GetBlobHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/GetBlobHandler.java
@@ -243,6 +243,9 @@ public class GetBlobHandler {
             ReadableStreamChannel response = result.getBlobDataChannel();
             if (subResource == null) {
               response = closeChannelIfNotModified(result);
+              if (response != null) {
+                restRequest.getMetricsTracker().setBytesTransferred(result.getBlobInfo().getBlobProperties().getBlobSize());
+              }
             } else {
               switch (subResource) {
                 case BlobInfo:

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
@@ -181,6 +181,7 @@ public class NamedBlobPutHandler {
     private void start() {
       restRequest.getMetricsTracker()
           .injectMetrics(frontendMetrics.putBlobMetricsGroup.getRestRequestMetrics(restRequest.isSslUsed(), false));
+      restRequest.getMetricsTracker().setBytesTransferred(restRequest.getBytesReceived());
       try {
         // Start the callback chain by parsing blob info headers and performing request security processing.
         securityService.processRequest(restRequest, securityProcessRequestCallback());

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
@@ -181,7 +181,6 @@ public class NamedBlobPutHandler {
     private void start() {
       restRequest.getMetricsTracker()
           .injectMetrics(frontendMetrics.putBlobMetricsGroup.getRestRequestMetrics(restRequest.isSslUsed(), false));
-      restRequest.getMetricsTracker().setBytesTransferred(restRequest.getBytesReceived());
       try {
         // Start the callback chain by parsing blob info headers and performing request security processing.
         securityService.processRequest(restRequest, securityProcessRequestCallback());
@@ -249,6 +248,7 @@ public class NamedBlobPutHandler {
      */
     private Callback<String> routerPutBlobCallback(BlobInfo blobInfo) {
       return buildCallback(frontendMetrics.putRouterPutBlobMetrics, blobId -> {
+        restRequest.getMetricsTracker().setBytesTransferred(restRequest.getBytesReceived());
         restResponseChannel.setHeader(RestUtils.Headers.BLOB_SIZE, restRequest.getBlobBytesReceived());
         restResponseChannel.setHeader(RestUtils.Headers.LOCATION, blobId);
         String blobIdClean = stripPrefixAndExtension(blobId);

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/PostBlobHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/PostBlobHandler.java
@@ -154,6 +154,7 @@ class PostBlobHandler {
         // Start the callback chain by parsing blob info headers and performing request security processing.
         BlobInfo blobInfo = getBlobInfoFromRequest();
         checkUploadRequirements(blobInfo.getBlobProperties());
+        restRequest.getMetricsTracker().setBytesTransferred(restRequest.getBytesReceived());
         securityService.processRequest(restRequest, securityProcessRequestCallback(blobInfo));
       } catch (Exception e) {
         finalCallback.onCompletion(null, e);

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/PostBlobHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/PostBlobHandler.java
@@ -154,7 +154,6 @@ class PostBlobHandler {
         // Start the callback chain by parsing blob info headers and performing request security processing.
         BlobInfo blobInfo = getBlobInfoFromRequest();
         checkUploadRequirements(blobInfo.getBlobProperties());
-        restRequest.getMetricsTracker().setBytesTransferred(restRequest.getBytesReceived());
         securityService.processRequest(restRequest, securityProcessRequestCallback(blobInfo));
       } catch (Exception e) {
         finalCallback.onCompletion(null, e);
@@ -238,6 +237,7 @@ class PostBlobHandler {
     private Callback<String> routerPutBlobCallback(BlobInfo blobInfo) {
       return buildCallback(frontendMetrics.postRouterPutBlobMetrics, blobId -> {
         setSignedIdMetadataAndBlobSize(blobInfo.getBlobProperties());
+        restRequest.getMetricsTracker().setBytesTransferred(restRequest.getBytesReceived());
         idConverter.convert(restRequest, blobId, idConverterCallback(blobInfo));
       }, uri, LOGGER, finalCallback);
     }

--- a/ambry-rest/src/main/java/com/github/ambry/rest/NettyResponseChannel.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/NettyResponseChannel.java
@@ -430,6 +430,7 @@ class NettyResponseChannel implements RestResponseChannel {
           requestPerfToCheck.put(PerformanceIndex.TimeToFirstByte, timeToFirstBytesInMs);
           requestPerfToCheck.put(PerformanceIndex.AverageBandwidth,
               roundTripTimeInMs == 0L ? Long.MAX_VALUE : totalOutboundBytes * 1000L / roundTripTimeInMs);
+          restRequestMetricsTracker.setBytesTransferred(totalOutboundBytes);
         } else if (responseStatus.isClientError() || responseStatus.isRedirection()) {
           requestPerfToCheck.put(PerformanceIndex.RoundTripTime, roundTripTimeInMs);
         }


### PR DESCRIPTION
## Summary
This metric will show the blob upload/download performance for a singular request. The current metrics do not show this type of data as they only count the total number of bytes read/written


## Testing Done
./gradlew build