### PR TITLE
Enable container metrics for all request types.

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/FrontendConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/FrontendConfig.java
@@ -263,13 +263,6 @@ public class FrontendConfig {
   public final String accountStatsStoreFactory;
 
   /**
-   * The set of container metrics enabled request type.
-   */
-  @Config(CONTAINER_METRICS_ENABLED_REQUEST_TYPES)
-  @Default(DEFAULT_CONTAINER_METRICS_ENABLED_REQUEST_TYPES)
-  public final String containerMetricsEnabledRequestTypes;
-
-  /**
    * The set of container metrics enabled get request type.
    */
   @Config(CONTAINER_METRICS_ENABLED_GET_REQUEST_TYPES)
@@ -358,8 +351,6 @@ public class FrontendConfig {
         verifiableProperties.getBoolean("frontend.allow.service.id.based.post.request", true);
     enableBlobNameRuleCheck = verifiableProperties.getBoolean("frontend.enable.blob.name.rule.check", false);
     attachTrackingInfo = verifiableProperties.getBoolean("frontend.attach.tracking.info", true);
-    containerMetricsEnabledRequestTypes = verifiableProperties.getString(CONTAINER_METRICS_ENABLED_REQUEST_TYPES,
-        DEFAULT_CONTAINER_METRICS_ENABLED_REQUEST_TYPES);
     containerMetricsEnabledGetRequestTypes = verifiableProperties.getString(CONTAINER_METRICS_ENABLED_GET_REQUEST_TYPES,
         DEFAULT_CONTAINER_METRICS_ENABLED_GET_REQUEST_TYPES);
     oneHundredContinueEnable = nettyConfig.nettyEnableOneHundredContinue;

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/RestRequestMetricsGroup.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/RestRequestMetricsGroup.java
@@ -42,7 +42,6 @@ public class RestRequestMetricsGroup {
   private final RestRequestMetrics sslUnencryptedMetrics;
   private final RestRequestMetrics nonSslEncryptedMetrics;
   private final RestRequestMetrics sslEncryptedMetrics;
-  private final Set<String> containerMetricsEnabledRequestTypes;
   private final Set<String> containerMetricsEnabledGetRequestTypes;
 
   /**
@@ -68,8 +67,6 @@ public class RestRequestMetricsGroup {
     sslEncryptedMetrics =
         encryptedMetricsEnabled ? new RestRequestMetrics(ownerClass, requestType + SSL_SUFFIX + ENCRYPTED_SUFFIX,
             metricRegistry) : null;
-    this.containerMetricsEnabledRequestTypes =
-        new HashSet<>(Arrays.asList(frontendConfig.containerMetricsEnabledRequestTypes.split(",")));
     this.containerMetricsEnabledGetRequestTypes =
         new HashSet<>(Arrays.asList(frontendConfig.containerMetricsEnabledGetRequestTypes.split(",")));
   }
@@ -101,7 +98,7 @@ public class RestRequestMetricsGroup {
    * operation.
    */
   ContainerMetrics getContainerMetrics(String accountName, String containerName, boolean shouldIncludeAccountMetrics) {
-    return containerMetricsEnabledRequestTypes.contains(requestType) ? instantiatedContainerMetrics.computeIfAbsent(
+    return instantiatedContainerMetrics.computeIfAbsent(
         new Pair<>(accountName, containerName), k -> {
           boolean isGetRequest = containerMetricsEnabledGetRequestTypes.contains(requestType);
           AccountMetrics accountMetrics =
@@ -109,6 +106,6 @@ public class RestRequestMetricsGroup {
                   ak -> new AccountMetrics(accountName, requestType, metricRegistry, isGetRequest)) : null;
           return new ContainerMetrics(accountName, containerName, requestType, metricRegistry, isGetRequest,
               accountMetrics);
-        }) : null;
+        });
   }
 }


### PR DESCRIPTION
## Summary
Noticed that we weren't getting any container metrics for HEAD requests and tracked it down to a config that enables container metrics for only a select set of requests. Enabling it for all since there isn't a reason to not enable it for a request



## Testing Done
./gradlew build