### PR TITLE
return empty array when replica ids are null

### DIFF
--- a/ambry-file-transfer/src/main/java/com/github/ambry/filetransfer/FileCopyBasedReplicationSchedulerImpl.java
+++ b/ambry-file-transfer/src/main/java/com/github/ambry/filetransfer/FileCopyBasedReplicationSchedulerImpl.java
@@ -125,8 +125,9 @@ class FileCopyBasedReplicationSchedulerImpl implements FileCopyBasedReplicationS
 
   List<ReplicaId> getNextReplicaToHydrate(DiskId diskId, int numberOfReplicasOnDisk) {
     List<ReplicaId> replicaIds = prioritizationManager.getPartitionListForDisk(diskId, numberOfReplicasOnDisk);
-    if(replicaIds == null || replicaIds.isEmpty())
-      return null;
+    if (replicaIds == null) {
+      return new ArrayList<>();
+    }
     return replicaIds;
   }
 


### PR DESCRIPTION
## Summary

return empty array when replica ids are null in FileCopyScheduler

## Testing Done
unit tests