### PR TITLE
Add certificate based authencation to namedblob db

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/MySqlNamedBlobDbConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/MySqlNamedBlobDbConfig.java
@@ -23,6 +23,13 @@ import static com.github.ambry.rest.RestUtils.*;
 
 
 public class MySqlNamedBlobDbConfig {
+  /**
+   * SSLMode when it's enabled
+   */
+  public enum SSLMode {
+    VERIFY_CA, VERIFY_IDENTITY
+  }
+
   private static final String PREFIX = "mysql.named.blob.";
   public static final String DB_INFO = PREFIX + "db.info";
   public static final String LOCAL_POOL_SIZE = PREFIX + "local.pool.size";
@@ -35,6 +42,7 @@ public class MySqlNamedBlobDbConfig {
   public static final String ENABLE_HARD_DELETE = PREFIX + "enable.hard.delete";
   public static final String ENABLE_CERTIFICATE_BASED_AUTHENTICATION =
       PREFIX + "enable.certificate.based.authentication";
+  public static final String SSL_MODE = PREFIX + "ssl.mode";
 
   /**
    * Option to pick the SQL query to use for listing named blobs.
@@ -117,6 +125,12 @@ public class MySqlNamedBlobDbConfig {
   @Config(ENABLE_CERTIFICATE_BASED_AUTHENTICATION)
   public final boolean enableCertificateBasedAuthentication;
 
+  /**
+   * SSL Mode when certificate based authentication is enabled.
+   */
+  @Config(SSL_MODE)
+  public final SSLMode sslMode;
+
   public final SSLConfig sslConfig;
 
   public MySqlNamedBlobDbConfig(VerifiableProperties verifiableProperties) {
@@ -139,6 +153,8 @@ public class MySqlNamedBlobDbConfig {
     this.enableCertificateBasedAuthentication =
         verifiableProperties.getBoolean(ENABLE_CERTIFICATE_BASED_AUTHENTICATION, false);
     this.sslConfig = this.enableCertificateBasedAuthentication ? new SSLConfig(verifiableProperties) : null;
+    this.sslMode = this.enableCertificateBasedAuthentication ? verifiableProperties.getEnum(SSL_MODE, SSLMode.class,
+        SSLMode.VERIFY_CA) : null;
     if (this.enableCertificateBasedAuthentication) {
       // validate the sslConfig is valid
       validateFilePath(this.sslConfig.sslKeystorePath, "ssl.keystore.path");

--- a/ambry-api/src/main/java/com/github/ambry/config/MySqlNamedBlobDbConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/MySqlNamedBlobDbConfig.java
@@ -16,6 +16,8 @@
 package com.github.ambry.config;
 
 import com.github.ambry.named.TransactionIsolationLevel;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 import static com.github.ambry.rest.RestUtils.*;
 
@@ -23,8 +25,6 @@ import static com.github.ambry.rest.RestUtils.*;
 public class MySqlNamedBlobDbConfig {
   private static final String PREFIX = "mysql.named.blob.";
   public static final String DB_INFO = PREFIX + "db.info";
-  public static final String DB_TRANSITION = PREFIX + "db.transition";
-  public static final String DB_RELY_ON_NEW_TABLE = PREFIX + "db.rely.on.new.table";
   public static final String LOCAL_POOL_SIZE = PREFIX + "local.pool.size";
   public static final String REMOTE_POOL_SIZE = PREFIX + "remote.pool.size";
   public static final String LIST_MAX_RESULTS = PREFIX + "list.max.results";
@@ -33,6 +33,8 @@ public class MySqlNamedBlobDbConfig {
   public static final String TRANSACTION_ISOLATION_LEVEL = PREFIX + "transaction.isolation.level";
   public static final String LIST_NAMED_BLOBS_SQL_OPTION = "list.named.blobs.sql.option";
   public static final String ENABLE_HARD_DELETE = PREFIX + "enable.hard.delete";
+  public static final String ENABLE_CERTIFICATE_BASED_AUTHENTICATION =
+      PREFIX + "enable.certificate.based.authentication";
 
   /**
    * Option to pick the SQL query to use for listing named blobs.
@@ -99,6 +101,24 @@ public class MySqlNamedBlobDbConfig {
   @Config(ENABLE_HARD_DELETE)
   public final boolean enableHardDelete;
 
+  /**
+   * True to use certificate based authentication for MYSQL connections. SSL certificates must be configured in the
+   * configuration files. The keys are the same as keys in {@link SSLConfig}. We are expecting the following keys
+   * to be set:
+   * <ul>
+   *   <li>{@link SSLConfig#sslKeystoreType}</li>
+   *   <li>{@link SSLConfig#sslKeystorePath}</li>
+   *   <li>{@link SSLConfig#sslKeystorePassword}</li>
+   *   <li>{@link SSLConfig#sslTruststoreType}</li>
+   *   <li>{@link SSLConfig#sslTruststorePath}</li>
+   *   <li>{@link SSLConfig#sslTruststorePassword}</li>
+   * </ul>
+   */
+  @Config(ENABLE_CERTIFICATE_BASED_AUTHENTICATION)
+  public final boolean enableCertificateBasedAuthentication;
+
+  public final SSLConfig sslConfig;
+
   public MySqlNamedBlobDbConfig(VerifiableProperties verifiableProperties) {
     this.listNamedBlobsSQLOption =
         verifiableProperties.getIntInRange(LIST_NAMED_BLOBS_SQL_OPTION, DEFAULT_LIST_NAMED_BLOBS_SQL_OPTION,
@@ -116,5 +136,22 @@ public class MySqlNamedBlobDbConfig {
         verifiableProperties.getEnum(TRANSACTION_ISOLATION_LEVEL, TransactionIsolationLevel.class,
             TransactionIsolationLevel.TRANSACTION_NONE);
     this.enableHardDelete = verifiableProperties.getBoolean(ENABLE_HARD_DELETE, false);
+    this.enableCertificateBasedAuthentication =
+        verifiableProperties.getBoolean(ENABLE_CERTIFICATE_BASED_AUTHENTICATION, false);
+    this.sslConfig = this.enableCertificateBasedAuthentication ? new SSLConfig(verifiableProperties) : null;
+    if (this.enableCertificateBasedAuthentication) {
+      // validate the sslConfig is valid
+      validateFilePath(this.sslConfig.sslKeystorePath, "ssl.keystore.path");
+      validateFilePath(this.sslConfig.sslTruststorePath, "ssl.truststore.path");
+    }
+  }
+
+  private void validateFilePath(String filePath, String configName) {
+    if (filePath == null || filePath.isEmpty()) {
+      throw new IllegalArgumentException(configName + " cannot be null or empty");
+    }
+    if (Files.notExists(Paths.get(filePath))) {
+      throw new IllegalArgumentException(configName + "'s file " + filePath + " does not exist");
+    }
   }
 }

--- a/ambry-mysql/src/main/java/com/github/ambry/mysql/MySqlUtils.java
+++ b/ambry-mysql/src/main/java/com/github/ambry/mysql/MySqlUtils.java
@@ -81,7 +81,8 @@ public class MySqlUtils {
    */
   public static String addSslSettingsToUrl(String url, SSLConfig sslConfig) {
     //@formatter:off
-    String sslSuffix = "&useSSL=true&requireSSL=true&enabledTLSProtocols=TLSv1.2"
+    String delimiter = url.contains("?") ? "&" : "?";
+    String sslSuffix = delimiter + "useSSL=true&requireSSL=true&enabledTLSProtocols=TLSv1.2"
         + "&clientCertificateKeyStoreType=" + sslConfig.sslKeystoreType
         + "&clientCertificateKeyStoreUrl=file:" + sslConfig.sslKeystorePath
         + "&clientCertificateKeyStorePassword=" + sslConfig.sslKeystorePassword

--- a/ambry-mysql/src/main/java/com/github/ambry/mysql/MySqlUtils.java
+++ b/ambry-mysql/src/main/java/com/github/ambry/mysql/MySqlUtils.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.mysql;
 
+import com.github.ambry.config.SSLConfig;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -70,6 +71,25 @@ public class MySqlUtils {
     }
     Collections.sort(remoteDatacenters);
     return Collections.unmodifiableList(remoteDatacenters);
+  }
+
+  /**
+   * Adding ssl settings to url to enable ssl certificate based authentication.
+   * @param url The original url
+   * @param sslConfig The {@link SSLConfig} that contains the ssl settings.
+   * @return The new url with ssl settings
+   */
+  public static String addSslSettingsToUrl(String url, SSLConfig sslConfig) {
+    //@formatter:off
+    String sslSuffix = "&useSSL=true&requireSSL=true&enabledTLSProtocols=TLSv1.2"
+        + "&clientCertificateKeyStoreType=" + sslConfig.sslKeystoreType
+        + "&clientCertificateKeyStoreUrl=file:" + sslConfig.sslKeystorePath
+        + "&clientCertificateKeyStorePassword=" + sslConfig.sslKeystorePassword
+        + "&trustCertificateKeyStoreType=" + sslConfig.sslTruststoreType
+        + "&trustCertificateKeyStoreUrl=file:" + sslConfig.sslTruststorePath
+        + "&trustCertificateKeyStorePassword=" + sslConfig.sslTruststorePassword;
+    return url + sslSuffix;
+    //@formatter:on
   }
 
   /**

--- a/ambry-mysql/src/main/java/com/github/ambry/mysql/MySqlUtils.java
+++ b/ambry-mysql/src/main/java/com/github/ambry/mysql/MySqlUtils.java
@@ -35,6 +35,15 @@ public class MySqlUtils {
   static final String USERNAME_STR = "username";
   static final String PASSWORD_STR = "password";
 
+  // SSL connection static values
+  static final String SSL_SETTING_USE_SSL = "useSSL=true&requireSSL=true&enabledTLSProtocols=TLSv1.2";
+  static final String SSL_SETTING_CLIENT_CERTIFICATE_KEY_STORE_TYPE = "&clientCertificateKeyStoreType=";
+  static final String SSL_SETTING_CLIENT_CERTIFICATE_KEY_STORE_URL = "&clientCertificateKeyStoreUrl=file:";
+  static final String SSL_SETTING_CLIENT_CERTIFICATE_KEY_STORE_PASSWORD = "&clientCertificateKeyStorePassword=";
+  static final String SSL_SETTING_TRUST_CERTIFICATE_KEY_STORE_TYPE = "&trustCertificateKeyStoreType=";
+  static final String SSL_SETTING_TRUST_CERTIFICATE_KEY_STORE_URL = "&trustCertificateKeyStoreUrl=file:";
+  static final String SSL_SETTING_TRUST_CERTIFICATE_KEY_STORE_PASSWORD = "&trustCertificateKeyStorePassword=";
+
   /**
    * Parses DB information JSON string and returns a map of datacenter name to list of {@link DbEndpoint}s.
    * @param dbInfoJsonString the string containing the MySql DB info.
@@ -82,13 +91,13 @@ public class MySqlUtils {
   public static String addSslSettingsToUrl(String url, SSLConfig sslConfig) {
     //@formatter:off
     String delimiter = url.contains("?") ? "&" : "?";
-    String sslSuffix = delimiter + "useSSL=true&requireSSL=true&enabledTLSProtocols=TLSv1.2"
-        + "&clientCertificateKeyStoreType=" + sslConfig.sslKeystoreType
-        + "&clientCertificateKeyStoreUrl=file:" + sslConfig.sslKeystorePath
-        + "&clientCertificateKeyStorePassword=" + sslConfig.sslKeystorePassword
-        + "&trustCertificateKeyStoreType=" + sslConfig.sslTruststoreType
-        + "&trustCertificateKeyStoreUrl=file:" + sslConfig.sslTruststorePath
-        + "&trustCertificateKeyStorePassword=" + sslConfig.sslTruststorePassword;
+    String sslSuffix = delimiter + SSL_SETTING_USE_SSL
+        + SSL_SETTING_CLIENT_CERTIFICATE_KEY_STORE_TYPE + sslConfig.sslKeystoreType
+        + SSL_SETTING_CLIENT_CERTIFICATE_KEY_STORE_URL + sslConfig.sslKeystorePath
+        + SSL_SETTING_CLIENT_CERTIFICATE_KEY_STORE_PASSWORD + sslConfig.sslKeystorePassword
+        + SSL_SETTING_TRUST_CERTIFICATE_KEY_STORE_TYPE + sslConfig.sslTruststoreType
+        + SSL_SETTING_TRUST_CERTIFICATE_KEY_STORE_URL + sslConfig.sslTruststorePath
+        + SSL_SETTING_TRUST_CERTIFICATE_KEY_STORE_PASSWORD + sslConfig.sslTruststorePassword;
     return url + sslSuffix;
     //@formatter:on
   }

--- a/ambry-mysql/src/main/java/com/github/ambry/mysql/MySqlUtils.java
+++ b/ambry-mysql/src/main/java/com/github/ambry/mysql/MySqlUtils.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.mysql;
 
+import com.github.ambry.config.MySqlNamedBlobDbConfig;
 import com.github.ambry.config.SSLConfig;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -37,6 +38,7 @@ public class MySqlUtils {
 
   // SSL connection static values
   static final String SSL_SETTING_USE_SSL = "useSSL=true&requireSSL=true&enabledTLSProtocols=TLSv1.2";
+  static final String SSL_SETTING_SSL_MODE = "&sslMode=";
   static final String SSL_SETTING_CLIENT_CERTIFICATE_KEY_STORE_TYPE = "&clientCertificateKeyStoreType=";
   static final String SSL_SETTING_CLIENT_CERTIFICATE_KEY_STORE_URL = "&clientCertificateKeyStoreUrl=file:";
   static final String SSL_SETTING_CLIENT_CERTIFICATE_KEY_STORE_PASSWORD = "&clientCertificateKeyStorePassword=";
@@ -88,10 +90,11 @@ public class MySqlUtils {
    * @param sslConfig The {@link SSLConfig} that contains the ssl settings.
    * @return The new url with ssl settings
    */
-  public static String addSslSettingsToUrl(String url, SSLConfig sslConfig) {
+  public static String addSslSettingsToUrl(String url, SSLConfig sslConfig, MySqlNamedBlobDbConfig.SSLMode sslMode) {
     //@formatter:off
     String delimiter = url.contains("?") ? "&" : "?";
     String sslSuffix = delimiter + SSL_SETTING_USE_SSL
+        + SSL_SETTING_SSL_MODE + sslMode.name()
         + SSL_SETTING_CLIENT_CERTIFICATE_KEY_STORE_TYPE + sslConfig.sslKeystoreType
         + SSL_SETTING_CLIENT_CERTIFICATE_KEY_STORE_URL + sslConfig.sslKeystorePath
         + SSL_SETTING_CLIENT_CERTIFICATE_KEY_STORE_PASSWORD + sslConfig.sslKeystorePassword

--- a/ambry-named-mysql/src/main/java/com/github/ambry/named/MySqlNamedBlobDbFactory.java
+++ b/ambry-named-mysql/src/main/java/com/github/ambry/named/MySqlNamedBlobDbFactory.java
@@ -20,6 +20,7 @@ import com.github.ambry.account.AccountService;
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.MySqlNamedBlobDbConfig;
 import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.mysql.MySqlUtils;
 import com.github.ambry.mysql.MySqlUtils.DbEndpoint;
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.Time;
@@ -58,9 +59,14 @@ public class MySqlNamedBlobDbFactory implements NamedBlobDbFactory {
    * @param dbEndpoint struct containing JDBC connection information.
    * @return the {@link HikariDataSource} for the {@link DbEndpoint}.
    */
+  //TODO: Build a util method to reuse HikariDataSource creation logic across Ambry modules.
   public HikariDataSource buildDataSource(DbEndpoint dbEndpoint) {
+    String url = dbEndpoint.getUrl();
+    if (config.enableCertificateBasedAuthentication) {
+      url = MySqlUtils.addSslSettingsToUrl(url, config.sslConfig);
+    }
     HikariConfig hikariConfig = new HikariConfig();
-    hikariConfig.setJdbcUrl(dbEndpoint.getUrl());
+    hikariConfig.setJdbcUrl(url);
     hikariConfig.setUsername(dbEndpoint.getUsername());
     hikariConfig.setPassword(dbEndpoint.getPassword());
     hikariConfig.setMaximumPoolSize(

--- a/ambry-named-mysql/src/main/java/com/github/ambry/named/MySqlNamedBlobDbFactory.java
+++ b/ambry-named-mysql/src/main/java/com/github/ambry/named/MySqlNamedBlobDbFactory.java
@@ -63,7 +63,7 @@ public class MySqlNamedBlobDbFactory implements NamedBlobDbFactory {
   public HikariDataSource buildDataSource(DbEndpoint dbEndpoint) {
     String url = dbEndpoint.getUrl();
     if (config.enableCertificateBasedAuthentication) {
-      url = MySqlUtils.addSslSettingsToUrl(url, config.sslConfig);
+      url = MySqlUtils.addSslSettingsToUrl(url, config.sslConfig, config.sslMode);
     }
     HikariConfig hikariConfig = new HikariConfig();
     hikariConfig.setJdbcUrl(url);

--- a/ambry-tools/src/main/java/com/github/ambry/tools/perf/NamedBlobMysqlDatabasePerf.java
+++ b/ambry-tools/src/main/java/com/github/ambry/tools/perf/NamedBlobMysqlDatabasePerf.java
@@ -216,7 +216,6 @@ public class NamedBlobMysqlDatabasePerf {
     jsonArray.put(dbEndpoint.toJson());
     System.out.println("DB_INFO: " + jsonArray);
     newProperties.setProperty(MySqlNamedBlobDbConfig.DB_INFO, jsonArray.toString());
-    newProperties.setProperty(MySqlNamedBlobDbConfig.DB_RELY_ON_NEW_TABLE, "true");
     newProperties.setProperty(MySqlNamedBlobDbConfig.LOCAL_POOL_SIZE, String.valueOf(2 * Integer.valueOf(props.getProperty(PARALLELISM))));
     newProperties.setProperty(ClusterMapConfig.CLUSTERMAP_DATACENTER_NAME, props.getProperty(DB_DATACENTER));
 


### PR DESCRIPTION
## Summary
For named blob mysql database factory, we are adding a new configuration to enable certificate based authentication.


## Testing Done
Tested with the named blob perf cli with a mysql instance that has enabled certificate based authentication.
