### PR TITLE
Providing version to NamedBlobDb and add error count metrics to mysql named blob db

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/named/NamedBlobRecord.java
+++ b/ambry-api/src/main/java/com/github/ambry/named/NamedBlobRecord.java
@@ -22,6 +22,7 @@ import java.util.Objects;
  * Represents a metadata record in a {@link NamedBlobDb} implementation.
  */
 public class NamedBlobRecord {
+  public static final long UNINITIALIZED_VERSION = 0L;
   private final String accountName;
   private final String containerName;
   private final String blobName;

--- a/ambry-api/src/main/java/com/github/ambry/named/NamedBlobRecord.java
+++ b/ambry-api/src/main/java/com/github/ambry/named/NamedBlobRecord.java
@@ -15,6 +15,7 @@
 
 package com.github.ambry.named;
 
+import com.github.ambry.utils.Utils;
 import java.util.Objects;
 
 
@@ -34,6 +35,34 @@ public class NamedBlobRecord {
   private final boolean isDirectory;
 
   /**
+   * A helper method to create a {@link NamedBlobRecord} for Put operation.
+   * @param accountName      the account name.
+   * @param containerName    the container name.
+   * @param blobName         the blob name within the container.
+   * @param blobId           the blob ID for the blob content in ambry storage.
+   * @param expirationTimeMs the expiration time in milliseconds since epoch, or -1 if the blob should be permanent.
+   * @param blobSize         the size of the blob.
+   * @return
+   */
+  public static NamedBlobRecord forPut(String accountName, String containerName, String blobName, String blobId,
+      long expirationTimeMs, long blobSize) {
+    return new NamedBlobRecord(accountName, containerName, blobName, blobId, expirationTimeMs, UNINITIALIZED_VERSION,
+        blobSize, 0, false);
+  }
+
+  /**
+   * A helper method to create a {@link NamedBlobRecord} for ttl update operation.
+   * @param accountName      the account name.
+   * @param containerName    the container name.
+   * @param blobName         the blob name within the container.
+   * @param version          the version of this named blob.
+   * @return
+   */
+  public static NamedBlobRecord forUpdate(String accountName, String containerName, String blobName, long version) {
+    return new NamedBlobRecord(accountName, containerName, blobName, null, Utils.Infinite_Time, version, 0, 0, false);
+  }
+
+  /**
    * @param accountName the account name.
    * @param containerName the container name.
    * @param blobName the blob name within the container.
@@ -42,7 +71,7 @@ public class NamedBlobRecord {
    */
   public NamedBlobRecord(String accountName, String containerName, String blobName, String blobId,
       long expirationTimeMs) {
-    this(accountName, containerName, blobName, blobId, expirationTimeMs, 0);
+    this(accountName, containerName, blobName, blobId, expirationTimeMs, UNINITIALIZED_VERSION);
   }
 
   /**

--- a/ambry-commons/src/main/java/com/github/ambry/commons/InMemNamedBlobDb.java
+++ b/ambry-commons/src/main/java/com/github/ambry/commons/InMemNamedBlobDb.java
@@ -146,7 +146,7 @@ public class InMemNamedBlobDb implements NamedBlobDb {
         return future;
       }
     }
-    if (record.getVersion() == 0) {
+    if (record.getVersion() == NamedBlobRecord.UNINITIALIZED_VERSION) {
       record = new NamedBlobRecord(record.getAccountName(), record.getContainerName(), record.getBlobName(),
           record.getBlobId(), record.getExpirationTimeMs(), time.milliseconds(), record.getBlobSize(),
           record.getModifiedTimeMs(), record.isDirectory());

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbryIdConverterFactory.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbryIdConverterFactory.java
@@ -207,7 +207,8 @@ public class AmbryIdConverterFactory implements IdConverterFactory {
               Utils.addSecondsToEpochTime(blobProperties.getCreationTimeInMs(), blobProperties.getTimeToLiveInSeconds());
           // Please note that the modified_ts column in DB will be auto-populated by the DB server.
           NamedBlobRecord record = new NamedBlobRecord(namedBlobPath.getAccountName(), namedBlobPath.getContainerName(),
-              namedBlobPath.getBlobName(), blobId, expirationTimeMs, 0, blobProperties.getBlobSize());
+              namedBlobPath.getBlobName(), blobId, expirationTimeMs, NamedBlobRecord.UNINITIALIZED_VERSION,
+              blobProperties.getBlobSize());
           NamedBlobState state = NamedBlobState.READY;
           if (blobProperties.getTimeToLiveInSeconds() == Utils.Infinite_Time) {
             // Set named blob state as 'IN_PROGRESS', will set the state to be 'READY' in the ttlUpdate success callback: routerTtlUpdateCallback

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobPutHandler.java
@@ -234,8 +234,9 @@ public class NamedBlobPutHandler {
             addDatasetVersion(blobInfo.getBlobProperties(), restRequest);
           }
           PutBlobOptions options = getPutBlobOptionsFromRequest();
-          router.putBlob(restRequest, getPropertiesForRouterUpload(blobInfo), blobInfo.getUserMetadata(), restRequest, options,
-              routerPutBlobCallback(blobInfo), QuotaUtils.buildQuotaChargeCallback(restRequest, quotaManager, true));
+          router.putBlob(restRequest, getPropertiesForRouterUpload(blobInfo), blobInfo.getUserMetadata(), restRequest,
+              options, routerPutBlobCallback(blobInfo),
+              QuotaUtils.buildQuotaChargeCallback(restRequest, quotaManager, true));
         }
       }, uri, LOGGER, deleteDatasetCallback);
     }
@@ -258,8 +259,8 @@ public class NamedBlobPutHandler {
           String serviceId = blobInfo.getBlobProperties().getServiceId();
           retryExecutor.runWithRetries(retryPolicy,
               callback -> router.updateBlobTtl(restRequest, blobIdClean, serviceId, Utils.Infinite_Time, callback,
-                  QuotaUtils.buildQuotaChargeCallback(restRequest, quotaManager, false)),
-              this::isRetriable, routerTtlUpdateCallbackForPut(blobInfo));
+                  QuotaUtils.buildQuotaChargeCallback(restRequest, quotaManager, false)), this::isRetriable,
+              routerTtlUpdateCallbackForPut(blobInfo));
         } else {
           if (RestUtils.isDatasetVersionQueryEnabled(restRequest.getArgs())) {
             //Make sure to process response after delete finished
@@ -381,10 +382,10 @@ public class NamedBlobPutHandler {
               + " is required in Named Blob TTL update callback!", RestServiceErrorCode.InternalServerError);
         }
         long namedBlobVersion = (long) restRequest.getArgs().get(NAMED_BLOB_VERSION);
-        String blobIdClean = RestUtils.stripSlashAndExtensionFromId(blobId);
         NamedBlobPath namedBlobPath = NamedBlobPath.parse(RestUtils.getRequestPath(restRequest), restRequest.getArgs());
-        NamedBlobRecord record = new NamedBlobRecord(namedBlobPath.getAccountName(), namedBlobPath.getContainerName(),
-            namedBlobPath.getBlobName(), blobIdClean, Utils.Infinite_Time, namedBlobVersion);
+        NamedBlobRecord record =
+            NamedBlobRecord.forUpdate(namedBlobPath.getAccountName(), namedBlobPath.getContainerName(),
+                namedBlobPath.getBlobName(), namedBlobVersion);
         namedBlobDb.updateBlobTtlAndStateToReady(record).get();
         if (RestUtils.isDatasetVersionQueryEnabled(restRequest.getArgs())) {
           //Make sure to process response after delete finished

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/TtlUpdateHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/TtlUpdateHandler.java
@@ -13,10 +13,8 @@
  */
 package com.github.ambry.frontend;
 
-import com.github.ambry.account.Account;
 import com.github.ambry.account.AccountService;
 import com.github.ambry.account.AccountServiceException;
-import com.github.ambry.account.Container;
 import com.github.ambry.account.DatasetVersionRecord;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.commons.BlobId;
@@ -41,7 +39,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static com.github.ambry.frontend.FrontendUtils.*;
-import static com.github.ambry.rest.RestUtils.*;
 import static com.github.ambry.rest.RestUtils.InternalKeys.*;
 
 
@@ -195,8 +192,9 @@ class TtlUpdateHandler {
           }
           long namedBlobVersion = (long) restRequest.getArgs().get(NAMED_BLOB_VERSION);
           NamedBlobPath namedBlobPath = NamedBlobPath.parse(blobIdStr, restRequest.getArgs());
-          NamedBlobRecord record = new NamedBlobRecord(namedBlobPath.getAccountName(), namedBlobPath.getContainerName(),
-              namedBlobPath.getBlobName(), convertedBlobId.getID(), Utils.Infinite_Time, namedBlobVersion);
+          NamedBlobRecord record =
+              NamedBlobRecord.forUpdate(namedBlobPath.getAccountName(), namedBlobPath.getContainerName(),
+                  namedBlobPath.getBlobName(), namedBlobVersion);
           CallbackUtils.callCallbackAfter(namedBlobDb.updateBlobTtlAndStateToReady(record),
               updateNamedBlobTtlCallback());
         } else {

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3MultipartCompleteUploadHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3MultipartCompleteUploadHandler.java
@@ -284,10 +284,10 @@ public class S3MultipartCompleteUploadHandler<R> {
               RestServiceErrorCode.InternalServerError);
         }
         long namedBlobVersion = (long) restRequest.getArgs().get(NAMED_BLOB_VERSION);
-        String blobIdClean = stripSlashAndExtensionFromId(blobId);
         NamedBlobPath namedBlobPath = NamedBlobPath.parse(getRequestPath(restRequest), restRequest.getArgs());
-        NamedBlobRecord record = new NamedBlobRecord(namedBlobPath.getAccountName(), namedBlobPath.getContainerName(),
-            namedBlobPath.getBlobName(), blobIdClean, Utils.Infinite_Time, namedBlobVersion);
+        NamedBlobRecord record =
+            NamedBlobRecord.forUpdate(namedBlobPath.getAccountName(), namedBlobPath.getContainerName(),
+                namedBlobPath.getBlobName(), namedBlobVersion);
         namedBlobDb.updateBlobTtlAndStateToReady(record).get();
         securityService.processResponse(restRequest, restResponseChannel, blobInfo, securityProcessResponseCallback());
       }, uri, LOGGER, finalCallback);

--- a/ambry-named-mysql/src/integration-test/java/com/github/ambry/named/MySqlNamedBlobDbIntergrationBase.java
+++ b/ambry-named-mysql/src/integration-test/java/com/github/ambry/named/MySqlNamedBlobDbIntergrationBase.java
@@ -59,7 +59,7 @@ public class MySqlNamedBlobDbIntergrationBase {
     MockClusterMap clusterMap = new MockClusterMap();
     partitionId = clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0);
     MySqlNamedBlobDbFactory namedBlobDbFactory =
-        new MySqlNamedBlobDbFactory(verifiableProperties, new MetricRegistry(), accountService, time);
+        new MySqlNamedBlobDbFactory(verifiableProperties, new MetricRegistry(), accountService, time, "");
     namedBlobDb = namedBlobDbFactory.getNamedBlobDb();
   }
 

--- a/ambry-named-mysql/src/main/java/com/github/ambry/named/Metrics.java
+++ b/ambry-named-mysql/src/main/java/com/github/ambry/named/Metrics.java
@@ -1,3 +1,17 @@
+/**
+ * Copyright 2025 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ */
 package com.github.ambry.named;
 
 import com.codahale.metrics.Counter;

--- a/ambry-named-mysql/src/main/java/com/github/ambry/named/Metrics.java
+++ b/ambry-named-mysql/src/main/java/com/github/ambry/named/Metrics.java
@@ -1,0 +1,94 @@
+package com.github.ambry.named;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+
+
+public class Metrics {
+  public final Counter namedDataNotFoundGetCount;
+  public final Counter namedDataErrorGetCount;
+  public final Counter namedDataInconsistentGetCount;
+
+  public final Counter namedDataInconsistentListCount;
+
+  public final Counter namedDataNotFoundDeleteCount;
+  public final Counter namedDataErrorDeleteCount;
+  public final Counter namedDataInconsistentDeleteCount;
+
+  public final Counter namedDataErrorPutCount;
+
+  public final Counter namedTtlupdateErrorCount;
+
+  public final Histogram namedBlobGetTimeInMs;
+  public final Histogram namedBlobListTimeInMs;
+  public final Histogram namedBlobPutTimeInMs;
+  public final Histogram namedBlobDeleteTimeInMs;
+
+  public final Histogram namedBlobPullStaleTimeInMs;
+  public final Histogram namedBlobCleanupTimeInMs;
+
+  public final Histogram namedTtlupdateTimeInMs;
+
+  public final Meter namedBlobGetRate;
+  public final Meter namedBlobListRate;
+  public final Meter namedBlobDeleteRate;
+  public final Meter namedBlobInsertRate;
+  public final Meter namedBlobUpdateRate;
+
+  /**
+   * Constructor to create the Metrics.
+   * @param metricRegistry The {@link MetricRegistry}.
+   */
+  public Metrics(MetricRegistry metricRegistry, String prefix) {
+    namedDataNotFoundGetCount =
+        metricRegistry.counter(MetricRegistry.name(MySqlNamedBlobDb.class, prefix + "NamedDataNotFoundGetCount"));
+    namedDataErrorGetCount =
+        metricRegistry.counter(MetricRegistry.name(MySqlNamedBlobDb.class, prefix + "NamedDataErrorGetCount"));
+    namedDataInconsistentGetCount =
+        metricRegistry.counter(MetricRegistry.name(MySqlNamedBlobDb.class, prefix + "NamedDataInconsistentGetCount"));
+
+    namedDataInconsistentListCount =
+        metricRegistry.counter(MetricRegistry.name(MySqlNamedBlobDb.class, prefix + "NamedDataInconsistentListCount"));
+
+    namedDataNotFoundDeleteCount =
+        metricRegistry.counter(MetricRegistry.name(MySqlNamedBlobDb.class, prefix + "NamedDataNotFoundDeleteCount"));
+    namedDataErrorDeleteCount =
+        metricRegistry.counter(MetricRegistry.name(MySqlNamedBlobDb.class, prefix + "NamedDataErrorDeleteCount"));
+    namedDataInconsistentDeleteCount = metricRegistry.counter(
+        MetricRegistry.name(MySqlNamedBlobDb.class, prefix + "NamedDataInconsistentDeleteCount"));
+
+    namedDataErrorPutCount =
+        metricRegistry.counter(MetricRegistry.name(MySqlNamedBlobDb.class, prefix + "NamedDataErrorPutCount"));
+
+    namedTtlupdateErrorCount =
+        metricRegistry.counter(MetricRegistry.name(MySqlNamedBlobDb.class, prefix + "NamedTtlupdateErrorCount"));
+
+    namedBlobGetTimeInMs =
+        metricRegistry.histogram(MetricRegistry.name(MySqlNamedBlobDb.class, prefix + "NamedBlobGetTimeInMs"));
+    namedBlobListTimeInMs =
+        metricRegistry.histogram(MetricRegistry.name(MySqlNamedBlobDb.class, prefix + "NamedBlobListTimeInMs"));
+    namedBlobPutTimeInMs =
+        metricRegistry.histogram(MetricRegistry.name(MySqlNamedBlobDb.class, prefix + "NamedBlobPutTimeInMs"));
+    namedBlobDeleteTimeInMs =
+        metricRegistry.histogram(MetricRegistry.name(MySqlNamedBlobDb.class, prefix + "NamedBlobDeleteTimeInMs"));
+
+    namedBlobPullStaleTimeInMs =
+        metricRegistry.histogram(MetricRegistry.name(MySqlNamedBlobDb.class, prefix + "NamedBlobPullStaleTimeInMs"));
+    namedBlobCleanupTimeInMs =
+        metricRegistry.histogram(MetricRegistry.name(MySqlNamedBlobDb.class, prefix + "NamedBlobCleanupTimeInMs"));
+
+    namedTtlupdateTimeInMs =
+        metricRegistry.histogram(MetricRegistry.name(MySqlNamedBlobDb.class, prefix + "NamedTtlupdateTimeInMs"));
+
+    namedBlobGetRate = metricRegistry.meter(MetricRegistry.name(MySqlNamedBlobDb.class, prefix + "NamedBlobGetRate"));
+    namedBlobListRate = metricRegistry.meter(MetricRegistry.name(MySqlNamedBlobDb.class, prefix + "NamedBlobListRate"));
+    namedBlobDeleteRate =
+        metricRegistry.meter(MetricRegistry.name(MySqlNamedBlobDb.class, prefix + "NamedBlobDeleteRate"));
+    namedBlobInsertRate =
+        metricRegistry.meter(MetricRegistry.name(MySqlNamedBlobDb.class, prefix + "NamedBlobPutRate"));
+    namedBlobUpdateRate =
+        metricRegistry.meter(MetricRegistry.name(MySqlNamedBlobDb.class, prefix + "NamedBlobUpdateRate"));
+  }
+}

--- a/ambry-named-mysql/src/main/java/com/github/ambry/named/Metrics.java
+++ b/ambry-named-mysql/src/main/java/com/github/ambry/named/Metrics.java
@@ -37,6 +37,15 @@ public class Metrics {
   public final Meter namedBlobInsertRate;
   public final Meter namedBlobUpdateRate;
 
+  // This list of DBxxxErrorCount metrics records the error count
+  // when performancing db operations on named blobs. It doesn't include
+  // the error for argument validation, state validation etc.
+  public final Counter namedBlobDBGetErrorCount;
+  public final Counter namedBlobDBListErrorCount;
+  public final Counter namedBlobDBDeleteErrorCount;
+  public final Counter namedBlobDBInsertErrorCount;
+  public final Counter namedBlobDBUpdateErrorCount;
+
   /**
    * Constructor to create the Metrics.
    * @param metricRegistry The {@link MetricRegistry}.
@@ -90,5 +99,16 @@ public class Metrics {
         metricRegistry.meter(MetricRegistry.name(MySqlNamedBlobDb.class, prefix + "NamedBlobPutRate"));
     namedBlobUpdateRate =
         metricRegistry.meter(MetricRegistry.name(MySqlNamedBlobDb.class, prefix + "NamedBlobUpdateRate"));
+
+    namedBlobDBGetErrorCount =
+        metricRegistry.counter(MetricRegistry.name(MySqlNamedBlobDb.class, prefix + "NamedBlobDBGetErrorCount"));
+    namedBlobDBListErrorCount =
+        metricRegistry.counter(MetricRegistry.name(MySqlNamedBlobDb.class, prefix + "NamedBlobDBListErrorCount"));
+    namedBlobDBDeleteErrorCount =
+        metricRegistry.counter(MetricRegistry.name(MySqlNamedBlobDb.class, prefix + "NamedBlobDBDeleteErrorCount"));
+    namedBlobDBInsertErrorCount =
+        metricRegistry.counter(MetricRegistry.name(MySqlNamedBlobDb.class, prefix + "NamedBlobDBInsertErrorCount"));
+    namedBlobDBUpdateErrorCount =
+        metricRegistry.counter(MetricRegistry.name(MySqlNamedBlobDb.class, prefix + "NamedBlobDBUpdateErrorCount"));
   }
 }

--- a/ambry-named-mysql/src/main/java/com/github/ambry/named/MySqlNamedBlobDb.java
+++ b/ambry-named-mysql/src/main/java/com/github/ambry/named/MySqlNamedBlobDb.java
@@ -67,7 +67,7 @@ import org.slf4j.LoggerFactory;
  * It uses the Hikari library for connection pooling, which is a widely used and performant JDBC connection pool
  * implementation.
  */
-class MySqlNamedBlobDb implements NamedBlobDb {
+public class MySqlNamedBlobDb implements NamedBlobDb {
   private static final Logger logger = LoggerFactory.getLogger(MySqlNamedBlobDb.class);
   private static final int MAX_NUMBER_OF_VERSIONS_IN_DELETE = 1000;
   private static final int VERSION_BASE = 100000;

--- a/ambry-named-mysql/src/main/java/com/github/ambry/named/MySqlNamedBlobDbFactory.java
+++ b/ambry-named-mysql/src/main/java/com/github/ambry/named/MySqlNamedBlobDbFactory.java
@@ -31,27 +31,29 @@ import com.zaxxer.hikari.HikariDataSource;
 public class MySqlNamedBlobDbFactory implements NamedBlobDbFactory {
   private final MySqlNamedBlobDbConfig config;
   private final String localDatacenter;
-  private final MetricRegistry metricRegistry;
   private final AccountService accountService;
+  private final MetricRegistry metricRegistry;
+  private final Metrics metricRecorder;
   private final Time time;
 
   public MySqlNamedBlobDbFactory(VerifiableProperties verifiableProperties, MetricRegistry metricRegistry,
-      AccountService accountService, Time time) {
+      AccountService accountService, Time time, String metricPrefix) {
     config = new MySqlNamedBlobDbConfig(verifiableProperties);
     localDatacenter = verifiableProperties.getString(ClusterMapConfig.CLUSTERMAP_DATACENTER_NAME);
     this.metricRegistry = metricRegistry;
+    this.metricRecorder = new Metrics(metricRegistry, metricPrefix);
     this.accountService = accountService;
     this.time = time;
   }
 
   public MySqlNamedBlobDbFactory(VerifiableProperties verifiableProperties, MetricRegistry metricRegistry,
       AccountService accountService) {
-    this(verifiableProperties, metricRegistry, accountService, SystemTime.getInstance());
+    this(verifiableProperties, metricRegistry, accountService, SystemTime.getInstance(), "");
   }
 
   @Override
   public MySqlNamedBlobDb getNamedBlobDb() {
-    return new MySqlNamedBlobDb(accountService, config, this::buildDataSource, localDatacenter, metricRegistry,
+    return new MySqlNamedBlobDb(accountService, config, this::buildDataSource, localDatacenter, metricRecorder,
         this.time);
   }
 

--- a/ambry-named-mysql/src/test/java/com/github/ambry/named/MySqlNamedBlobDbTest.java
+++ b/ambry-named-mysql/src/test/java/com/github/ambry/named/MySqlNamedBlobDbTest.java
@@ -29,7 +29,6 @@ import com.github.ambry.protocol.NamedBlobState;
 import com.github.ambry.rest.RestServiceErrorCode;
 import com.github.ambry.rest.RestServiceException;
 import com.github.ambry.utils.TestUtils;
-import com.github.ambry.utils.Utils;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -86,7 +85,7 @@ public class MySqlNamedBlobDbTest {
     }
     properties.setProperty(MySqlNamedBlobDbConfig.DB_INFO, dbInfo.toString());
     namedBlobDb = new MySqlNamedBlobDb(accountService, new MySqlNamedBlobDbConfig(new VerifiableProperties(properties)),
-        dataSourceFactory, localDatacenter, new MetricRegistry());
+        dataSourceFactory, localDatacenter, new Metrics(new MetricRegistry(), ""));
     account = accountService.createAndAddRandomAccount();
     container = account.getAllContainers().iterator().next();
     MockClusterMap clusterMap = new MockClusterMap();

--- a/ambry-tools/src/main/java/com/github/ambry/tools/perf/NamedBlobMysqlDatabasePerf.java
+++ b/ambry-tools/src/main/java/com/github/ambry/tools/perf/NamedBlobMysqlDatabasePerf.java
@@ -225,7 +225,8 @@ public class NamedBlobMysqlDatabasePerf {
     // Mock an account service
     AccountService accountService = createInMemoryAccountService();
     MySqlNamedBlobDbFactory factory =
-        new MySqlNamedBlobDbFactory(new VerifiableProperties(newProperties), registry, accountService, SystemTime.getInstance());
+        new MySqlNamedBlobDbFactory(new VerifiableProperties(newProperties), registry, accountService,
+            SystemTime.getInstance(), "");
     DataSource dataSource = factory.buildDataSource(dbEndpoint);
     NamedBlobDb namedBlobDb = factory.getNamedBlobDb();
 

--- a/ambry-tools/src/main/java/com/github/ambry/tools/perf/NamedBlobMysqlDatabasePerf.java
+++ b/ambry-tools/src/main/java/com/github/ambry/tools/perf/NamedBlobMysqlDatabasePerf.java
@@ -144,18 +144,21 @@ public class NamedBlobMysqlDatabasePerf {
     ArgumentAcceptingOptionSpec<String> dbHostOpt =
         parser.accepts(DB_HOST, "Database host").withRequiredArg().describedAs("db_host").ofType(String.class);
 
-    ArgumentAcceptingOptionSpec<Integer> parallelismOpt = parser.accepts(PARALLELISM, "Number of thread to execute sql statement")
-        .withRequiredArg()
-        .describedAs("parallelism")
-        .ofType(Integer.class);
+    ArgumentAcceptingOptionSpec<Integer> parallelismOpt =
+        parser.accepts(PARALLELISM, "Number of thread to execute sql statement")
+            .withRequiredArg()
+            .describedAs("parallelism")
+            .ofType(Integer.class);
 
     ArgumentAcceptingOptionSpec<Integer> targetMRowsOpt = parser.accepts(TARGET_ROWS,
-            "Number of rows to insert so the total database rows would reach this target." + "Notice that this target is in in millions. If the value is 1, this command would make sure database would have 1 million rows.")
+            "Number of rows to insert so the total database rows would reach this target."
+                + "Notice that this target is in in millions. If the value is 1, this command would make sure database would have 1 million rows.")
         .withRequiredArg()
         .describedAs("target_rows")
         .ofType(Integer.class);
 
-    OptionSpec<Void> includeListTestOpt = parser.accepts(INCLUDE_LIST, "Including list operation in the performance tests.");
+    OptionSpec<Void> includeListTestOpt =
+        parser.accepts(INCLUDE_LIST, "Including list operation in the performance tests.");
 
     OptionSet options = parser.parse(args);
     Properties props = new Properties();
@@ -192,10 +195,12 @@ public class NamedBlobMysqlDatabasePerf {
       props.setProperty(INCLUDE_LIST, "false");
     }
 
-    List<String> requiredArguments = Arrays.asList(DB_USERNAME, DB_DATACENTER, DB_NAME, DB_HOST, PARALLELISM, TARGET_ROWS, INCLUDE_LIST);
+    List<String> requiredArguments =
+        Arrays.asList(DB_USERNAME, DB_DATACENTER, DB_NAME, DB_HOST, PARALLELISM, TARGET_ROWS, INCLUDE_LIST);
     for (String requiredArgument : requiredArguments) {
       if (!props.containsKey(requiredArgument)) {
-        System.err.println("Missing " + requiredArgument + "! Please provide it through property file or the command line argument");
+        System.err.println(
+            "Missing " + requiredArgument + "! Please provide it through property file or the command line argument");
         parser.printHelpOn(System.err);
         System.exit(1);
       }
@@ -203,20 +208,24 @@ public class NamedBlobMysqlDatabasePerf {
 
     // Now ask for password if it's not provided in the propFile
     if (!props.containsKey(DB_PASSWORD)) {
-      String password = ToolUtils.passwordInput("Please input database password for user " + props.getProperty(DB_USERNAME) + ": ");
+      String password =
+          ToolUtils.passwordInput("Please input database password for user " + props.getProperty(DB_USERNAME) + ": ");
       props.setProperty(DB_PASSWORD, password);
     }
 
     // Now create a mysql named blob data accessor
     Properties newProperties = new Properties();
-    String dbUrl = "jdbc:mysql://" + props.getProperty(DB_HOST) + "/" + props.getProperty(DB_NAME) + "?serverTimezone=UTC";
+    String dbUrl =
+        "jdbc:mysql://" + props.getProperty(DB_HOST) + "/" + props.getProperty(DB_NAME) + "?serverTimezone=UTC";
     MySqlUtils.DbEndpoint dbEndpoint =
-        new MySqlUtils.DbEndpoint(dbUrl, props.getProperty(DB_DATACENTER), true, props.getProperty(DB_USERNAME), props.getProperty(DB_PASSWORD));
+        new MySqlUtils.DbEndpoint(dbUrl, props.getProperty(DB_DATACENTER), true, props.getProperty(DB_USERNAME),
+            props.getProperty(DB_PASSWORD));
     JSONArray jsonArray = new JSONArray();
     jsonArray.put(dbEndpoint.toJson());
     System.out.println("DB_INFO: " + jsonArray);
     newProperties.setProperty(MySqlNamedBlobDbConfig.DB_INFO, jsonArray.toString());
-    newProperties.setProperty(MySqlNamedBlobDbConfig.LOCAL_POOL_SIZE, String.valueOf(2 * Integer.valueOf(props.getProperty(PARALLELISM))));
+    newProperties.setProperty(MySqlNamedBlobDbConfig.LOCAL_POOL_SIZE,
+        String.valueOf(2 * Integer.valueOf(props.getProperty(PARALLELISM))));
     newProperties.setProperty(ClusterMapConfig.CLUSTERMAP_DATACENTER_NAME, props.getProperty(DB_DATACENTER));
 
     int numThreads = Integer.valueOf(props.getProperty(PARALLELISM));
@@ -267,9 +276,11 @@ public class NamedBlobMysqlDatabasePerf {
       for (int j = 0; j < numContainer; j++) {
         short containerId = (short) (j + 2);
         String containerName = String.format(CONTAINER_NAME_FORMAT, containerId);
-        containers.add(new ContainerBuilder(containerId, containerName, Container.ContainerStatus.ACTIVE, "", accountId).build());
+        containers.add(
+            new ContainerBuilder(containerId, containerName, Container.ContainerStatus.ACTIVE, "", accountId).build());
       }
-      Account account = new AccountBuilder(accountId, accountName, Account.AccountStatus.ACTIVE).containers(containers).build();
+      Account account =
+          new AccountBuilder(accountId, accountName, Account.AccountStatus.ACTIVE).containers(containers).build();
       accounts.add(account);
     }
     // Now add the special account
@@ -391,7 +402,8 @@ public class NamedBlobMysqlDatabasePerf {
         new BlobId(BlobId.BLOB_ID_V6, BlobId.BlobIdType.NATIVE, (byte) 1, account.getId(), container.getId(),
             PARTITION_ID, false, BlobId.BlobDataType.DATACHUNK);
     NamedBlobRecord record =
-        new NamedBlobRecord(account.getName(), container.getName(), blobName, blobId.toString(), -1);
+        NamedBlobRecord.forPut(account.getName(), container.getName(), blobName, blobId.toString(), Utils.Infinite_Time,
+            1024);
     return record;
   }
 


### PR DESCRIPTION
## Summary
There are two changes in this PR

### Self-provide version in the `NamedBlobRecord` to `NamedBlobDB`.
If the version is provided by caller to `NamedBlobDb`, than use this version and add it directly to database

### Add error count metrics to `MysqlNamedBlobDb`.
Adding more metrics 


## Testing Done
Unit tests
