### PR TITLE
fix logs getting printed when queue is same

### DIFF
--- a/ambry-prioritization/src/main/java/com/github/ambry/replica/prioritization/FileCopyDisruptionBasedPrioritizationManager.java
+++ b/ambry-prioritization/src/main/java/com/github/ambry/replica/prioritization/FileCopyDisruptionBasedPrioritizationManager.java
@@ -164,7 +164,7 @@ public class FileCopyDisruptionBasedPrioritizationManager extends Thread impleme
     List<ReplicaId> newQueueList = new ArrayList<>(newQueue);
 
     for (int i = 0; i < previousQueueList.size(); i++) {
-      if (previousQueueList.get(i).equals(newQueueList.get(i))) {
+      if (!previousQueueList.get(i).equals(newQueueList.get(i))) {
         logger.info("For disk {} queue has changed from {} to {}", diskId, previousQueue, newQueue);
         break;
       }


### PR DESCRIPTION
## Summary
fix logs getting printed when queue is same in FC Pz


## Testing Done
Not required