### PR TITLE
Fix S3 HeadBucket 500 error by injecting account and container info

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com/github/ambry/rest/RestUtils.java
@@ -546,6 +546,11 @@ public class RestUtils {
      * Is the request a list request
      */
     public static final String LIST_REQUEST = KEY_PREFIX + "is-list-request";
+
+    /**
+     * Is the request a head bucket request
+     */
+    public static final String HEAD_BUCKET_REQUEST = KEY_PREFIX + "is-head-bucket-request";
   }
 
   /**

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestService.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestService.java
@@ -242,7 +242,7 @@ class FrontendRestRequestService implements RestRequestService {
     postAccountsHandler = new PostAccountsHandler(securityService, accountService, frontendConfig, frontendMetrics);
     postDatasetsHandler = new PostDatasetsHandler(securityService, accountService, frontendConfig, frontendMetrics,
         accountAndContainerInjector);
-    s3HeadHandler = new S3HeadHandler(headBlobHandler, securityService, frontendMetrics, accountService);
+    s3HeadHandler = new S3HeadHandler(headBlobHandler, securityService, frontendMetrics, accountService, accountAndContainerInjector);
     s3MultipartUploadHandler =
         new S3MultipartUploadHandler(securityService, frontendMetrics, accountAndContainerInjector, frontendConfig,
             namedBlobDb, idConverter, router, quotaManager);

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/S3HeadHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/S3HeadHandlerTest.java
@@ -166,7 +166,7 @@ public class S3HeadHandlerTest {
       // Expected - should get RestServiceException with NotFound error
       assertTrue("Should contain RestServiceException", e.getCause() instanceof RestServiceException);
       RestServiceException rse = (RestServiceException) e.getCause();
-      assertEquals("Should be NotFound", RestServiceErrorCode.NotFound, rse.getErrorCode());
+      assertEquals("Should be InvalidContainer", RestServiceErrorCode.InvalidContainer, rse.getErrorCode());
     }
   }
 
@@ -240,7 +240,7 @@ public class S3HeadHandlerTest {
     HeadBlobHandler headBlobHandler = new HeadBlobHandler(frontendConfig, router,
         securityService, ambryIdConverterFactory.getIdConverter(), injector,
         metrics, new MockClusterMap(), QuotaTestUtils.createDummyQuotaManager());
-    s3HeadHandler = new S3HeadHandler(headBlobHandler, securityService, metrics, ACCOUNT_SERVICE);
+    s3HeadHandler = new S3HeadHandler(headBlobHandler, securityService, metrics, ACCOUNT_SERVICE, injector);
   }
 
   private void putABlob() throws Exception {


### PR DESCRIPTION
## Summary

This commit fixes S3 HeadBucket 500 internal server error by properly injecting account and container info before security processing.

**Root Cause**: `S3HeadBucketHandler` was invoking `securityService.processRequest` before injecting account and container into the `RestRequest`.

## Changes Made

- Updated `S3HeadBucketHandler` to follow standard S3 handler pattern: set flag, parse path, inject account container, process security
- Added `HEAD_BUCKET_REQUEST` constant to `RestUtils` for consistency  
- Updated `NamedBlobPath.parseS3` to support 3-segment HeadBucket paths
- Updated `S3HeadHandler` constructor calls and test expectations

## Testing Done

* S3HeadHandlerTest passes: `./gradlew ambry-frontend:test --tests S3HeadHandlerTest`
* Full frontend module test suite passes: `./gradlew :ambry-frontend:test`
