### PR TITLE
Add config to control secondary traffic

### DIFF
--- a/ambry-account/src/main/java/com/github/ambry/account/AccountInfoMap.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/AccountInfoMap.java
@@ -276,6 +276,7 @@ class AccountInfoMap {
             .snapshotVersion(account.getSnapshotVersion())
             .lastModifiedTime(account.getLastModifiedTime())
             .aclInheritedByContainer(account.isAclInheritedByContainer())
+            .rampControl(account.getRampControl())
             .quotaResourceType(account.getQuotaResourceType());
         account.getAllContainers().forEach(accountBuilder::addOrUpdateContainer);
         accountToUpdate = accountBuilder.build();

--- a/ambry-api/src/main/java/com/github/ambry/account/AccountBuilder.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/AccountBuilder.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.account;
 
+import com.github.ambry.account.RampControl;
 import com.github.ambry.quota.QuotaResourceType;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -22,7 +23,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static com.github.ambry.account.Account.*;
-
 
 /**
  * A builder class for {@link Account}. Since {@link Account} is immutable, modifying an {@link Account} needs to
@@ -40,6 +40,7 @@ public class AccountBuilder {
   private int snapshotVersion = SNAPSHOT_VERSION_DEFAULT_VALUE;
   private long lastModifiedTime = LAST_MODIFIED_TIME_DEFAULT_VALUE;
   private boolean aclInheritedByContainer = ACL_INHERITED_BY_CONTAINER_DEFAULT_VALUE;
+  private RampControl rampControl = null;
   private final Map<Short, Container> idToContainerMetadataMap = new HashMap<>();
 
   /**
@@ -61,6 +62,7 @@ public class AccountBuilder {
       idToContainerMetadataMap.put(container.getId(), container);
     }
     quotaResourceType = origin.getQuotaResourceType();
+    rampControl = origin.getRampControl();
   }
 
   /**
@@ -172,6 +174,33 @@ public class AccountBuilder {
   }
 
   /**
+   * Sets ramp control config for the account.
+   * @param rampControl ramp control object
+   * @return This builder.
+   */
+  public AccountBuilder rampControl(RampControl rampControl) {
+    this.rampControl = rampControl;
+    return this;
+  }
+
+  /**
+   * Sets ramp control from JSON.
+   */
+  @JsonProperty("rampControl")
+  public AccountBuilder rampControlFromJson(RampControl rampControl) {
+    this.rampControl = rampControl;
+    return this;
+  }
+
+  /**
+   * Gets whether secondary is enabled for the account.
+   * @return whether secondary is enabled for the account.
+   */
+  public boolean isSecondaryEnabled() {
+    return rampControl != null && rampControl.isSecondaryEnabled();
+  }
+
+  /**
    * Clear the set of containers for the {@link Account} to build and add the provided ones.
    * @param containers A collection of {@link Container}s to use. Can be {@code null} to just remove all containers.
    * @return This builder.
@@ -235,6 +264,6 @@ public class AccountBuilder {
       }
     }
     return new Account(id, name, status, aclInheritedByContainer, snapshotVersion, idToContainerMetadataMap.values(),
-        lastModifiedTime, quotaResourceType);
+        lastModifiedTime, quotaResourceType, rampControl);
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/account/RampControl.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/RampControl.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class RampControl {
+  public static final String SECONDARY_ENABLED_KEY = "secondaryEnabled";
+  @JsonProperty(SECONDARY_ENABLED_KEY)
+  private final boolean secondaryEnabled;
+
+  @JsonCreator
+  public RampControl(@JsonProperty(SECONDARY_ENABLED_KEY) boolean secondaryEnabled) {
+    this.secondaryEnabled = secondaryEnabled;
+  }
+
+  public boolean isSecondaryEnabled() {
+    return secondaryEnabled;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    RampControl that = (RampControl) o;
+    return secondaryEnabled == that.secondaryEnabled;
+  }
+
+  @Override
+  public int hashCode() {
+    return Boolean.hashCode(secondaryEnabled);
+  }
+}

--- a/ambry-api/src/test/java/com/github/ambry/account/AccountContainerTest.java
+++ b/ambry-api/src/test/java/com/github/ambry/account/AccountContainerTest.java
@@ -788,6 +788,42 @@ public class AccountContainerTest {
     }
   }
 
+  @Test
+  public void testSecondaryEnabledSerialization() throws IOException {
+    ObjectMapper mapper = new ObjectMapper();
+    // Account with secondaryEnabled true
+    Account accountWithSecondary = new AccountBuilder()
+        .id((short) 1)
+        .name("testAccount")
+        .status(AccountStatus.ACTIVE)
+        .rampControl(new RampControl(true))
+        .build();
+    String jsonWithSecondary = mapper.writeValueAsString(accountWithSecondary);
+    Account deserializedWithSecondary = mapper.readValue(jsonWithSecondary, Account.class);
+    assertTrue(deserializedWithSecondary.isSecondaryEnabled());
+
+    // Account with secondaryEnabled false
+    Account accountWithoutSecondary = new AccountBuilder()
+        .id((short) 2)
+        .name("testAccount2")
+        .status(AccountStatus.INACTIVE)
+        .rampControl(new RampControl(false))
+        .build();
+    String jsonWithoutSecondary = mapper.writeValueAsString(accountWithoutSecondary);
+    Account deserializedWithoutSecondary = mapper.readValue(jsonWithoutSecondary, Account.class);
+    assertFalse(deserializedWithoutSecondary.isSecondaryEnabled());
+
+    // Account with secondaryEnabled not set (should default to false)
+    Account accountDefault = new AccountBuilder()
+        .id((short) 3)
+        .name("testAccount3")
+        .status(AccountStatus.INACTIVE)
+        .build();
+    String jsonDefault = mapper.writeValueAsString(accountDefault);
+    Account deserializedDefault = mapper.readValue(jsonDefault, Account.class);
+    assertFalse(deserializedDefault.isSecondaryEnabled());
+  }
+
   /**
    * Asserts an {@link Account} against the reference account.
    * @param account The {@link Account} to assert.


### PR DESCRIPTION

## Summary
Add config to control secondary traffic

This is just introducing the config in the account. There will be follow up PR for using the config

## Testing Done
Unit tests added and ran service locally.