### PR TITLE
Handle all socket close failures in EchoServer.closeConnections

### DIFF
--- a/ambry-network/src/test/java/com/github/ambry/network/EchoServer.java
+++ b/ambry-network/src/test/java/com/github/ambry/network/EchoServer.java
@@ -119,8 +119,20 @@ public class EchoServer extends Thread {
   }
 
   public void closeConnections() throws IOException {
+    IOException first = null;
     for (Socket socket : sockets) {
-      socket.close();
+      try {
+        socket.close();
+      } catch (Exception e) {
+        if (first == null) {
+          first = e;
+        } else {
+          first.addSuppressed(e);
+        }
+      }
+      if (first != null) {
+        return first;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Update `EchoServer.closeConnections()` to attempt closing every socket even if one of the close operations throws.

## Motivation

Previously, `closeConnections()` would stop at the first `IOException`, which could leave later sockets unclosed during shutdown. This change preserves the failure while still continuing cleanup for the remaining sockets.

## Changes

* wrap each `socket.close()` in a `try/catch`
* accumulate the first `IOException`
* add later close failures as suppressed exceptions
* throw the aggregated exception after all sockets have been processed
