### PR TITLE
account: fail fast on startup when account metadata cannot be deserialized

### DIFF
--- a/ambry-account/src/main/java/com/github/ambry/account/AccountMetadataStore.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/AccountMetadataStore.java
@@ -16,6 +16,7 @@ package com.github.ambry.account;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.helix.AccessOption;
@@ -82,9 +83,9 @@ abstract class AccountMetadataStore {
   abstract ZKUpdater createNewZKUpdater(Collection<Account> accounts);
 
   /**
-   * fetchAccountMetadata would fetch the latest full set of {@link Account} metadata from the store. It returns null
-   * when there is no {@link Account} created.
-   * @return A collection of {@link Account} metadata.
+   * Fetch the latest full set of {@link Account} metadata from the store.
+   * @return A collection of {@link Account} metadata, empty if ZNRecord exists but contains no account data,
+   *         or {@code null} if no ZNRecord exists.
    */
   Collection<Account> fetchAccountMetadata() {
     long startTimeMs = System.currentTimeMillis();
@@ -99,6 +100,10 @@ abstract class AccountMetadataStore {
       return null;
     }
     Map<String, String> newAccountMap = fetchAccountMetadataFromZNRecord(znRecord);
+    if (newAccountMap == null) {
+      logger.info("ZNRecord exists on path={} but contains no account metadata map. Returning empty collection.", znRecordPath);
+      return Collections.emptyList();
+    }
     Map<Short, Account> idToAccountMap = new HashMap<>();
     Map<String, Account> nameToAccountMap = new HashMap<>();
     for (Map.Entry<String, String> entry : newAccountMap.entrySet()) {
@@ -129,9 +134,7 @@ abstract class AccountMetadataStore {
       idToAccountMap.put(account.getId(), account);
       nameToAccountMap.put(account.getName(), account);
     }
-    if (newAccountMap != null) {
-      backupFileManager.persistAccountMap(idToAccountMap.values(), stat.getVersion(), stat.getMtime() / 1000);
-    }
+    backupFileManager.persistAccountMap(idToAccountMap.values(), stat.getVersion(), stat.getMtime() / 1000);
     return idToAccountMap.values();
   }
 

--- a/ambry-account/src/main/java/com/github/ambry/account/HelixAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/HelixAccountService.java
@@ -179,6 +179,18 @@ public class HelixAccountService extends AbstractAccountService {
    * at a fixed rate.
    */
   private void initialFetchAndSchedule() {
+    // Initial fetch runs WITHOUT catch-all so deserialization errors (e.g., unrecognized fields from a newer schema)
+    // propagate and prevent the service from starting with a broken/empty account cache. This is intentional:
+    // serving traffic with missing accounts causes silent 400 InvalidAccount errors for valid blobs.
+    try {
+      fetchAndUpdateCache(false);
+    } catch (Exception e) {
+      logger.error("Initial account metadata fetch failed. Service cannot start with an incomplete account cache.", e);
+      accountServiceMetrics.fetchRemoteAccountErrorCount.inc();
+      throw e;
+    }
+
+    // Background updater is lenient — it already has the old cache, so swallowing errors is safe.
     Runnable updater = () -> {
       try {
         fetchAndUpdateCache(false);
@@ -187,21 +199,13 @@ public class HelixAccountService extends AbstractAccountService {
         accountServiceMetrics.fetchRemoteAccountErrorCount.inc();
       }
     };
-    updater.run();
 
-    // If fetching account metadata failed, no matter for what reason, we use the data from local backup file.
-    // The local backup should be reasonably up-to-date.
+    // If the initial fetch succeeded but returned no accounts (no data in ZK yet), fall back to local backup.
+    // This does NOT apply when the initial fetch threw — that case is a hard failure above.
     //
     // The caveat is that when a machine used to run ambry-frontend but then got decommissioned for a long time,
     // it will have a very old account metadata in the backup. If we reschedule ambry-frontend process in this particular
-    // machine, and it fails to read the account metadata from AccountMetadataStore, then we would load stale data.
-    //
-    // One way to avoid this problem is to load latest account metadata, but not more than a month, from backup.
-
-    // accountInfoMapRef's reference is empty doesn't mean that fetchAndUpdateCache failed, it would just be that there
-    // is no account metadata for the time being. Theoretically local storage shouldn't have any backup files. So
-    // backup.getLatestAccounts should return null. And in case we have a very old backup file just mentioned above, a threshold
-    // would solve the problem.
+    // machine, it would load stale data. A 30-day threshold mitigates this.
     if (accountInfoMapRef.get().isEmpty() && config.enableServeFromBackup && !backupFileManager.isEmpty()) {
       long aMonthAgo = System.currentTimeMillis() / 1000 - TimeUnit.DAYS.toSeconds(30);
       Collection<Account> accounts = backupFileManager.getLatestAccounts(aMonthAgo);

--- a/ambry-account/src/test/java/com/github/ambry/account/HelixAccountServiceTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/HelixAccountServiceTest.java
@@ -704,6 +704,68 @@ public class HelixAccountServiceTest {
   }
 
   /**
+   * Tests that HelixAccountService fails to start when account metadata contains undeserializable JSON.
+   * This covers the version-skew scenario where a newer code version writes fields (e.g.,
+   * MigrationConfig.ReadRamp.dualHeadSyncPct) that the current code can't deserialize. Without fail-fast,
+   * the service silently starts with an empty/partial account cache and returns 400 InvalidAccount for valid blobs.
+   *
+   * Uses invalid JSON (not just unknown fields) because AccountBuilder has @JsonIgnoreProperties(ignoreUnknown=true)
+   * at the top level. The fail-fast behavior is the same regardless of what causes the deserialization failure.
+   */
+  @Test
+  public void testStartupFailsOnUndeserializableAccountMetadata() throws Exception {
+    Map<String, String> accountMap = new HashMap<>();
+    // One valid account and one corrupt account — simulates a single account with incompatible schema
+    accountMap.put(String.valueOf(refAccount.getId()), objectMapper.writeValueAsString(
+        new AccountBuilder(refAccount).snapshotVersion(refAccount.getSnapshotVersion() + 1).build()));
+    accountMap.put(String.valueOf(refAccount.getId() + 1), BAD_ACCOUNT_METADATA_STRING);
+
+    ZNRecord zNRecord;
+    if (useNewZNodePath) {
+      String blobID = RouterStore.writeAccountMapToRouter(accountMap, mockRouter);
+      List<String> list = Collections.singletonList(new RouterStore.BlobIDAndVersion(blobID, 1).toJson());
+      zNRecord = makeZNRecordWithListField(null, RouterStore.ACCOUNT_METADATA_BLOB_IDS_LIST_KEY, list);
+    } else {
+      zNRecord = makeZNRecordWithMapField(null, LegacyMetadataStore.ACCOUNT_METADATA_MAP_KEY, accountMap);
+    }
+    writeZNRecordToHelixPropertyStore(zNRecord, false);
+    try {
+      accountService = mockHelixAccountServiceFactory.getAccountService();
+      fail("HelixAccountService should fail to start when account metadata cannot be deserialized");
+    } catch (IllegalStateException e) {
+      // Expected: fail-fast prevents serving traffic with missing accounts
+    }
+  }
+
+  /**
+   * Tests that background account cache refresh tolerates deserialization errors without crashing
+   * the service. Only the initial startup fetch should be fail-fast.
+   */
+  @Test
+  public void testBackgroundRefreshToleratesDeserializationError() throws Exception {
+    // Start with good data
+    accountService = mockHelixAccountServiceFactory.getAccountService();
+    updateAccountsAndAssertAccountExistence(idToRefAccountMap.values(), NUM_REF_ACCOUNT, true);
+
+    // Now write bad data and trigger a background refresh via notification
+    Map<String, String> badAccountMap = new HashMap<>();
+    badAccountMap.put(String.valueOf(refAccount.getId()), BAD_ACCOUNT_METADATA_STRING);
+    ZNRecord badZNRecord;
+    if (useNewZNodePath) {
+      String blobID = RouterStore.writeAccountMapToRouter(badAccountMap, mockRouter);
+      List<String> list = Collections.singletonList(new RouterStore.BlobIDAndVersion(blobID, 1).toJson());
+      badZNRecord = makeZNRecordWithListField(null, RouterStore.ACCOUNT_METADATA_BLOB_IDS_LIST_KEY, list);
+    } else {
+      badZNRecord = makeZNRecordWithMapField(null, LegacyMetadataStore.ACCOUNT_METADATA_MAP_KEY, badAccountMap);
+    }
+    writeZNRecordToHelixPropertyStore(badZNRecord, true);
+
+    // Service should still be running with the old (good) account data
+    assertEquals("Service should retain previous accounts after failed background refresh", NUM_REF_ACCOUNT,
+        accountService.getAllAccounts().size());
+  }
+
+  /**
    * Tests receiving a bad message, it will not be recognized by {@link HelixAccountService}, but will also not
    * crash the service.
    * @throws Exception Any unexpected exception.
@@ -1215,11 +1277,13 @@ public class HelixAccountServiceTest {
    */
   private void readAndUpdateBadRecord(Collection<Account> accounts) throws Exception {
     writeAccountsToHelixPropertyStore(accounts, false);
-    accountService = mockHelixAccountServiceFactory.getAccountService();
-    assertEquals("Wrong number of accounts in helixAccountService", 0, accountService.getAllAccounts().size());
-    updateAccountsAndAssertAccountExistence(Collections.singletonList(refAccount), 0, false);
-    writeAccountsToHelixPropertyStore(accounts, true);
-    assertEquals("Number of account is wrong.", 0, accountService.getAllAccounts().size());
+    // Conflicting/corrupt account metadata should prevent service startup (fail-fast)
+    try {
+      accountService = mockHelixAccountServiceFactory.getAccountService();
+      fail("Expected HelixAccountService to fail startup with conflicting account metadata");
+    } catch (IllegalStateException e) {
+      // Expected — service refuses to start with corrupt/conflicting account data
+    }
   }
 
   /**
@@ -1420,15 +1484,21 @@ public class HelixAccountServiceTest {
    */
   private void updateAndWriteZNRecord(ZNRecord zNRecord, boolean isGoodZNRecord) throws Exception {
     writeZNRecordToHelixPropertyStore(zNRecord, false);
-    accountService = mockHelixAccountServiceFactory.getAccountService();
-    assertEquals("Number of account is wrong", 0, accountService.getAllAccounts().size());
-    updateAccountsAndAssertAccountExistence(Collections.singletonList(refAccount), isGoodZNRecord ? 1 : 0,
-        isGoodZNRecord);
-    writeZNRecordToHelixPropertyStore(zNRecord, true);
     if (isGoodZNRecord) {
+      accountService = mockHelixAccountServiceFactory.getAccountService();
+      assertEquals("Number of account is wrong", 0, accountService.getAllAccounts().size());
+      updateAccountsAndAssertAccountExistence(Collections.singletonList(refAccount), 1, true);
+      writeZNRecordToHelixPropertyStore(zNRecord, true);
       assertAccountInAccountService(refAccount, accountService);
     } else {
-      assertEquals("Number of accounts is wrong.", 0, accountService.getAllAccounts().size());
+      // Bad ZNRecord should prevent HelixAccountService from starting — fail-fast on corrupt account metadata
+      // rather than silently serving with an empty/incomplete cache (which causes 400 InvalidAccount for valid blobs).
+      try {
+        accountService = mockHelixAccountServiceFactory.getAccountService();
+        fail("Expected HelixAccountService to fail startup with bad account metadata in ZNRecord");
+      } catch (IllegalStateException e) {
+        // Expected — MockHelixAccountServiceFactory wraps the RuntimeException in IllegalStateException
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

When HelixAccountService starts up, it fetches account metadata from ZooKeeper and populates an in-memory cache.  If deserialization fails (e.g., due to version skew where a newer code version has written fields the running code does not recognize), the exception was caught by a blanket catch(Exception) in the background updater Runnable, logged, and silently discarded.  The service would then begin serving traffic with an empty account cache, causing every blob operation to return 400 InvalidAccount for valid blobs — a silent data-serving failure that is difficult to diagnose in production.

Separate the initial fetch from the background updater.  The initial fetch now propagates exceptions so the service refuses to start with a broken cache.  The background updater retains its catch-all since it already holds a valid cache from a prior successful fetch.

Additionally, fix a latent null-pointer dereference in AccountMetadataStore.fetchAccountMetadata(): when a ZNRecord exists but contains no account metadata map, fetchAccountMetadataFromZNRecord() returns null, which was passed unchecked into a for-each loop.  Return Collections.emptyList() instead, distinguishing "ZNRecord exists but is empty" (valid, service starts with zero accounts) from "ZNRecord does not exist" (returns null, triggers backup fallback).

Fixes: a]  silent 400 InvalidAccount on hosts deployed with older code
           when account metadata contains fields from newer versions
       b]  NullPointerException on startup when ZNRecord has no
           account metadata map

## Testing Done

Added and updated tests in `HelixAccountServiceTest.java` to validate positive and negative cases.