### PR TITLE
Increment fetchAndUpdateCacheErrorCount in CachedAccountService

### DIFF
--- a/ambry-account/src/main/java/com/github/ambry/account/CachedAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/CachedAccountService.java
@@ -172,6 +172,7 @@ public class CachedAccountService extends AbstractAccountService {
     try {
       fetchAndUpdateCache();
     } catch (Throwable e) {
+      accountServiceMetrics.fetchAndUpdateCacheErrorCount.inc();
       logger.error("fetchAndUpdateCache failed", e);
     }
   }


### PR DESCRIPTION
## Summary

The fetchAndUpdateCacheErrorCount counter was defined and registered as a sensor but never incremented anywhere, making it a dead metric. Wire it up in fetchAndUpdateCacheNoThrow() so it fires on any failure during the periodic account cache sync — including non-SQL errors (NPE, OOM, deserialization) that bypass the existing SQLException-only catch in fetchAndUpdateCache().

This enables alerting on account loading failures regardless of the specific error type.

## Testing Done
N/A