### PR TITLE
Require multi-DC catchup during bootstrap when local DC peers unavailable

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
@@ -296,6 +296,17 @@ public class ClusterMapConfig {
   public final int clustermapReplicaCatchupTargetForDownwardTransition;
 
   /**
+   * When enabled and a bootstrapping replica has no local DC peers in STANDBY/LEADER state, require caught-up peers
+   * from at least 2 distinct remote DCs before completing bootstrap. This prevents a replica from transitioning to
+   * STANDBY after syncing with a single remote DC that may itself be recovering with empty/stale data (e.g., during a
+   * multi-fabric crash). Only applies when the number of distinct remote DCs with peers is >= 2. Property key:
+   * {@code clustermap.replica.catchup.require.multi.dc.for.bootstrap}. Default: false.
+   */
+  @Config("clustermap.replica.catchup.require.multi.dc.for.bootstrap")
+  @Default("false")
+  public final boolean clustermapReplicaCatchupRequireMultiDcForBootstrap;
+
+  /**
    * The minimum number of replicas in local datacenter required for a partition to serve PUT request. This is used to
    * get writable partitions for PUT operation. Any partition with replica count larger than or equal to this number is
    * acceptable to be considered as a candidate.
@@ -477,6 +488,8 @@ public class ClusterMapConfig {
     clustermapReplicaCatchupTargetForDownwardTransition =
         verifiableProperties.getIntInRange("clustermap.replica.catchup.target.for.downward.transition", 2, 0,
             Integer.MAX_VALUE);
+    clustermapReplicaCatchupRequireMultiDcForBootstrap =
+        verifiableProperties.getBoolean("clustermap.replica.catchup.require.multi.dc.for.bootstrap", false);
     clustermapWritablePartitionMinReplicaCount =
         verifiableProperties.getIntInRange("clustermap.writable.partition.min.replica.count", 3, 0, Integer.MAX_VALUE);
     clustermapUpdateDatanodeInfo = verifiableProperties.getBoolean("clustermap.update.datanode.info", false);

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryReplicaSyncUpManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryReplicaSyncUpManager.java
@@ -420,7 +420,36 @@ public class AmbryReplicaSyncUpManager implements ReplicaSyncUpManager {
       }
       // We don't need to check if replicas, which have been caught up with, are up or down currently. As long as, the
       // peer replica has been put into catchup set, this means it has been caught up sometime before it went down.
-      return localDcCaughtUpReplicas.size() + remoteDcCaughtUpReplicas.size() >= catchupTarget;
+      int totalCaughtUp = localDcCaughtUpReplicas.size() + remoteDcCaughtUpReplicas.size();
+      if (totalCaughtUp < catchupTarget) {
+        return false;
+      }
+      // When enabled, during bootstrap with no local DC peers in STANDBY/LEADER, require caught-up peers from at least
+      // 2 distinct remote DCs. This prevents completing bootstrap by syncing with a single remote DC that may itself be
+      // recovering with empty data (e.g., multi-fabric crash where lor1 syncs with empty lva1 replicas while ltx1 has
+      // the real data).
+      if (clusterMapConfig.clustermapReplicaCatchupRequireMultiDcForBootstrap
+          && currentState == ReplicaState.BOOTSTRAP
+          && localDcCaughtUpReplicas.isEmpty()) {
+        long distinctRemoteDcsWithPeers = remoteDcPeerReplicaAndLag.keySet().stream()
+            .map(r -> r.getDataNodeId().getDatacenterName())
+            .distinct()
+            .count();
+        // Only enforce multi-DC check when there are at least 2 remote DCs with peers
+        if (distinctRemoteDcsWithPeers >= 2) {
+          long distinctCaughtUpDcs = remoteDcCaughtUpReplicas.stream()
+              .map(r -> r.getDataNodeId().getDatacenterName())
+              .distinct()
+              .count();
+          if (distinctCaughtUpDcs < 2) {
+            logger.info("Partition {} bootstrap sync-up: caught up with {} peers but only from {} distinct remote DC(s),"
+                    + " requiring at least 2. LocalDcPeers: {}, RemoteDcCaughtUp: {}", replicaOnCurrentNode.getPartitionId().toPathString(),
+                totalCaughtUp, distinctCaughtUpDcs, localDcPeerReplicaAndLag.size(), remoteDcCaughtUpReplicas);
+            return false;
+          }
+        }
+      }
+      return true;
     }
 
     @Override

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryReplicaSyncUpManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryReplicaSyncUpManager.java
@@ -411,7 +411,14 @@ public class AmbryReplicaSyncUpManager implements ReplicaSyncUpManager {
     }
 
     /**
-     * @return whether current replica has caught up with enough peers
+     *
+     * Returns true when this replica has synced up with enough peers to complete its state transition. Specifically, the total number of caught-up peers (local + remote) must meet catchupTarget, AND one of the following must hold:
+     *
+     *  1. At least one local-DC peer has caught up (satisfied by local alone, or local plus remote).
+     *  2. No local-DC peer has caught up, but caught-up peers span at least 2 distinct remote DCs (enforced only when clustermap.replica.catchup.require.multi.dc.for.bootstrap=true and currentState == BOOTSTRAP).
+     *
+     *  Why the asymmetry: Helix's ExternalView for local-DC peers is treated as reliable since same-DC state changes propagate quickly. The view of remote-DC peers can be stale — reporting them as STANDBY/LEADER while they are actually still in
+     *  BOOTSTRAP with empty data. Requiring two distinct remote DCs reduces the chance of completing bootstrap against a single stale view (e.g., during a multi-fabric recovery where empty replicas appear caught-up against each other).
      */
     boolean hasSyncedUpWithEnoughPeers() {
       // If there are no peers at all (single-replica partition), sync-up is trivially complete.
@@ -449,6 +456,9 @@ public class AmbryReplicaSyncUpManager implements ReplicaSyncUpManager {
           }
         }
       }
+      logger.info("Partition {} sync-up complete: state {}, localDcCaughtUp {}, remoteDcCaughtUp {}, catchupTarget {}",
+          replicaOnCurrentNode.getPartitionId().toPathString(), currentState, localDcCaughtUpReplicas,
+          remoteDcCaughtUpReplicas, catchupTarget);
       return true;
     }
 

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/AmbryReplicaSyncUpManagerTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/AmbryReplicaSyncUpManagerTest.java
@@ -386,28 +386,34 @@ public class AmbryReplicaSyncUpManagerTest {
 
     testWithMultiDc.replicaSyncUpService.initiateBootstrap(testWithMultiDc.currentReplica);
 
-    // Separate remote peers by DC
-    List<ReplicaId> dc2Peers = testWithMultiDc.remoteDcPeerReplicas.stream()
-        .filter(r -> r.getDataNodeId().getDatacenterName().equals("DC2"))
+    // Separate remote peers by DC (use actual DC names, not hardcoded, since currentReplica DC varies)
+    List<String> remoteDcNames = testWithMultiDc.remoteDcPeerReplicas.stream()
+        .map(r -> r.getDataNodeId().getDatacenterName())
+        .distinct()
+        .sorted()
         .collect(Collectors.toList());
-    List<ReplicaId> dc3Peers = testWithMultiDc.remoteDcPeerReplicas.stream()
-        .filter(r -> r.getDataNodeId().getDatacenterName().equals("DC3"))
+    assertTrue("Test requires at least 2 remote DCs", remoteDcNames.size() >= 2);
+    String firstRemoteDc = remoteDcNames.get(0);
+    String secondRemoteDc = remoteDcNames.get(1);
+    List<ReplicaId> firstDcPeers = testWithMultiDc.remoteDcPeerReplicas.stream()
+        .filter(r -> r.getDataNodeId().getDatacenterName().equals(firstRemoteDc))
         .collect(Collectors.toList());
-    assertTrue("Test requires peers in DC2", dc2Peers.size() > 0);
-    assertTrue("Test requires peers in DC3", dc3Peers.size() > 0);
+    List<ReplicaId> secondDcPeers = testWithMultiDc.remoteDcPeerReplicas.stream()
+        .filter(r -> r.getDataNodeId().getDatacenterName().equals(secondRemoteDc))
+        .collect(Collectors.toList());
 
-    // Catch up with 2 peers from DC2 only (simulates syncing with a single recovering fabric)
-    assertFalse("Should not complete: caught up with only 1 DC2 peer",
+    // Catch up with 2 peers from first remote DC only (simulates syncing with a single recovering fabric)
+    assertFalse("Should not complete: caught up with only 1 peer from " + firstRemoteDc,
         testWithMultiDc.replicaSyncUpService.updateReplicaLagAndCheckSyncStatus(
-            testWithMultiDc.currentReplica, dc2Peers.get(0), 0L, ReplicaState.STANDBY));
-    assertFalse("Should not complete: caught up with 2 DC2 peers but all from same DC",
+            testWithMultiDc.currentReplica, firstDcPeers.get(0), 0L, ReplicaState.STANDBY));
+    assertFalse("Should not complete: caught up with 2 peers but all from same DC " + firstRemoteDc,
         testWithMultiDc.replicaSyncUpService.updateReplicaLagAndCheckSyncStatus(
-            testWithMultiDc.currentReplica, dc2Peers.get(1), 0L, ReplicaState.STANDBY));
+            testWithMultiDc.currentReplica, firstDcPeers.get(1), 0L, ReplicaState.STANDBY));
 
-    // Now catch up with 1 peer from DC3 — should complete because we have 2 distinct DCs
+    // Now catch up with 1 peer from second remote DC — should complete because we have 2 distinct DCs
     assertTrue("Should complete: caught up with peers from 2 distinct remote DCs",
         testWithMultiDc.replicaSyncUpService.updateReplicaLagAndCheckSyncStatus(
-            testWithMultiDc.currentReplica, dc3Peers.get(0), 0L, ReplicaState.STANDBY));
+            testWithMultiDc.currentReplica, secondDcPeers.get(0), 0L, ReplicaState.STANDBY));
 
     testWithMultiDc.replicaSyncUpService.reset();
   }
@@ -457,18 +463,19 @@ public class AmbryReplicaSyncUpManagerTest {
 
     testWithoutMultiDc.replicaSyncUpService.initiateBootstrap(testWithoutMultiDc.currentReplica);
 
-    // Separate remote peers by DC
-    List<ReplicaId> dc2Peers = testWithoutMultiDc.remoteDcPeerReplicas.stream()
-        .filter(r -> r.getDataNodeId().getDatacenterName().equals("DC2"))
+    // Separate remote peers by DC (use actual DC names, not hardcoded)
+    String firstRemoteDc = testWithoutMultiDc.remoteDcPeerReplicas.get(0).getDataNodeId().getDatacenterName();
+    List<ReplicaId> firstDcPeers = testWithoutMultiDc.remoteDcPeerReplicas.stream()
+        .filter(r -> r.getDataNodeId().getDatacenterName().equals(firstRemoteDc))
         .collect(Collectors.toList());
-    assertTrue("Test requires at least 2 DC2 peers", dc2Peers.size() >= 2);
+    assertTrue("Test requires at least 2 peers in " + firstRemoteDc, firstDcPeers.size() >= 2);
 
-    // Catch up with 2 peers from DC2 only — should complete because flag is off
+    // Catch up with 2 peers from a single remote DC — should complete because flag is off
     testWithoutMultiDc.replicaSyncUpService.updateReplicaLagAndCheckSyncStatus(
-        testWithoutMultiDc.currentReplica, dc2Peers.get(0), 0L, ReplicaState.STANDBY);
+        testWithoutMultiDc.currentReplica, firstDcPeers.get(0), 0L, ReplicaState.STANDBY);
     assertTrue("Should complete with single-DC remote peers when multi-DC check is disabled",
         testWithoutMultiDc.replicaSyncUpService.updateReplicaLagAndCheckSyncStatus(
-            testWithoutMultiDc.currentReplica, dc2Peers.get(1), 0L, ReplicaState.STANDBY));
+            testWithoutMultiDc.currentReplica, firstDcPeers.get(1), 0L, ReplicaState.STANDBY));
 
     testWithoutMultiDc.replicaSyncUpService.reset();
   }

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/AmbryReplicaSyncUpManagerTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/AmbryReplicaSyncUpManagerTest.java
@@ -53,6 +53,13 @@ public class AmbryReplicaSyncUpManagerTest {
   private Message mockMessage;
 
   public AmbryReplicaSyncUpManagerTest() throws IOException {
+    this(new Properties());
+  }
+
+  /**
+   * Constructor that accepts additional properties for test customization.
+   */
+  AmbryReplicaSyncUpManagerTest(Properties extraProperties) throws IOException {
     clusterMap = new MockClusterMap();
     // clustermap setup: 3 data centers(DC1/DC2/DC3), each data center has 3 replicas
     PartitionId partition = clusterMap.getAllPartitionIds(null).get(0);
@@ -76,6 +83,7 @@ public class AmbryReplicaSyncUpManagerTest {
     properties.setProperty("clustermap.replica.catchup.acceptable.lag.bytes", Long.toString(100L));
     properties.setProperty("clustermap.enable.state.model.listener", Boolean.toString(true));
     properties.setProperty("clustermap.dcs.zk.connect.strings", zkJson.toString(2));
+    properties.putAll(extraProperties);
     ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(properties));
     MockHelixParticipant.metricRegistry = new MetricRegistry();
     mockHelixParticipant = new MockHelixParticipant(clusterMapConfig);
@@ -350,5 +358,118 @@ public class AmbryReplicaSyncUpManagerTest {
     assertTrue("Disconnection should complete immediately for single-replica partition",
         disconnectionLatch.await(1, TimeUnit.SECONDS));
     replicaSyncUpService.reset();
+  }
+
+  /**
+   * Test that when multi-DC bootstrap safety check is enabled and all local DC peers are bootstrapping (not in
+   * STANDBY/LEADER), catching up with peers from only one remote DC is insufficient. The bootstrapping replica must
+   * catch up with peers from at least 2 distinct remote DCs before completing bootstrap.
+   *
+   * This simulates a multi-fabric crash where lor1 and lva1 are both down: a lor1 replica could sync with empty
+   * lva1 replicas (stale ExternalView shows them as STANDBY) and prematurely transition to STANDBY with no data.
+   * Requiring 2 distinct remote DCs ensures at least one healthy fabric contributes to catchup.
+   */
+  @Test
+  public void testMultiDcBootstrapSafetyCheck() throws Exception {
+    // Create a new SyncUpManager with the multi-DC safety check enabled and catchup target=2
+    Properties multiDcProps = new Properties();
+    multiDcProps.setProperty("clustermap.replica.catchup.require.multi.dc.for.bootstrap", "true");
+    multiDcProps.setProperty("clustermap.replica.catchup.target", "2");
+    AmbryReplicaSyncUpManagerTest testWithMultiDc = new AmbryReplicaSyncUpManagerTest(multiDcProps);
+
+    // Simulate: all local DC peers are in BOOTSTRAP (not STANDBY/LEADER), so they won't appear in peer list.
+    // Set local peers' state to BOOTSTRAP so getReplicaIdsByState(STANDBY/LEADER) won't include them.
+    MockPartitionId partition = (MockPartitionId) testWithMultiDc.currentReplica.getPartitionId();
+    for (ReplicaId localPeer : testWithMultiDc.localDcPeerReplicas) {
+      partition.replicaAndState.put(localPeer, ReplicaState.BOOTSTRAP);
+    }
+
+    testWithMultiDc.replicaSyncUpService.initiateBootstrap(testWithMultiDc.currentReplica);
+
+    // Separate remote peers by DC
+    List<ReplicaId> dc2Peers = testWithMultiDc.remoteDcPeerReplicas.stream()
+        .filter(r -> r.getDataNodeId().getDatacenterName().equals("DC2"))
+        .collect(Collectors.toList());
+    List<ReplicaId> dc3Peers = testWithMultiDc.remoteDcPeerReplicas.stream()
+        .filter(r -> r.getDataNodeId().getDatacenterName().equals("DC3"))
+        .collect(Collectors.toList());
+    assertTrue("Test requires peers in DC2", dc2Peers.size() > 0);
+    assertTrue("Test requires peers in DC3", dc3Peers.size() > 0);
+
+    // Catch up with 2 peers from DC2 only (simulates syncing with a single recovering fabric)
+    assertFalse("Should not complete: caught up with only 1 DC2 peer",
+        testWithMultiDc.replicaSyncUpService.updateReplicaLagAndCheckSyncStatus(
+            testWithMultiDc.currentReplica, dc2Peers.get(0), 0L, ReplicaState.STANDBY));
+    assertFalse("Should not complete: caught up with 2 DC2 peers but all from same DC",
+        testWithMultiDc.replicaSyncUpService.updateReplicaLagAndCheckSyncStatus(
+            testWithMultiDc.currentReplica, dc2Peers.get(1), 0L, ReplicaState.STANDBY));
+
+    // Now catch up with 1 peer from DC3 — should complete because we have 2 distinct DCs
+    assertTrue("Should complete: caught up with peers from 2 distinct remote DCs",
+        testWithMultiDc.replicaSyncUpService.updateReplicaLagAndCheckSyncStatus(
+            testWithMultiDc.currentReplica, dc3Peers.get(0), 0L, ReplicaState.STANDBY));
+
+    testWithMultiDc.replicaSyncUpService.reset();
+  }
+
+  /**
+   * Test that the multi-DC safety check does NOT apply when local DC peers are available (normal case).
+   * Even with the flag enabled, if local peers are caught up, bootstrap should complete normally.
+   */
+  @Test
+  public void testMultiDcCheckSkippedWhenLocalPeersAvailable() throws Exception {
+    Properties multiDcProps = new Properties();
+    multiDcProps.setProperty("clustermap.replica.catchup.require.multi.dc.for.bootstrap", "true");
+    multiDcProps.setProperty("clustermap.replica.catchup.target", "2");
+    AmbryReplicaSyncUpManagerTest testWithMultiDc = new AmbryReplicaSyncUpManagerTest(multiDcProps);
+
+    testWithMultiDc.replicaSyncUpService.initiateBootstrap(testWithMultiDc.currentReplica);
+
+    // Catch up with 2 local DC peers — should complete without needing multi-DC remote peers
+    ReplicaId localPeer1 = testWithMultiDc.localDcPeerReplicas.get(0);
+    ReplicaId localPeer2 = testWithMultiDc.localDcPeerReplicas.get(1);
+    assertFalse("Should not complete: only 1 local peer caught up",
+        testWithMultiDc.replicaSyncUpService.updateReplicaLagAndCheckSyncStatus(
+            testWithMultiDc.currentReplica, localPeer1, 50L, ReplicaState.STANDBY));
+    assertTrue("Should complete: 2 local peers caught up, multi-DC check should not apply",
+        testWithMultiDc.replicaSyncUpService.updateReplicaLagAndCheckSyncStatus(
+            testWithMultiDc.currentReplica, localPeer2, 10L, ReplicaState.STANDBY));
+
+    testWithMultiDc.replicaSyncUpService.reset();
+  }
+
+  /**
+   * Test that the multi-DC safety check is not enforced when the flag is disabled (default behavior).
+   * Catching up with peers from a single remote DC should be sufficient.
+   */
+  @Test
+  public void testMultiDcCheckDisabledByDefault() throws Exception {
+    // Create a SyncUpManager with catchup target=2 but multi-DC check disabled
+    Properties props = new Properties();
+    props.setProperty("clustermap.replica.catchup.target", "2");
+    AmbryReplicaSyncUpManagerTest testWithoutMultiDc = new AmbryReplicaSyncUpManagerTest(props);
+
+    // Simulate: all local DC peers are in BOOTSTRAP
+    MockPartitionId partition = (MockPartitionId) testWithoutMultiDc.currentReplica.getPartitionId();
+    for (ReplicaId localPeer : testWithoutMultiDc.localDcPeerReplicas) {
+      partition.replicaAndState.put(localPeer, ReplicaState.BOOTSTRAP);
+    }
+
+    testWithoutMultiDc.replicaSyncUpService.initiateBootstrap(testWithoutMultiDc.currentReplica);
+
+    // Separate remote peers by DC
+    List<ReplicaId> dc2Peers = testWithoutMultiDc.remoteDcPeerReplicas.stream()
+        .filter(r -> r.getDataNodeId().getDatacenterName().equals("DC2"))
+        .collect(Collectors.toList());
+    assertTrue("Test requires at least 2 DC2 peers", dc2Peers.size() >= 2);
+
+    // Catch up with 2 peers from DC2 only — should complete because flag is off
+    testWithoutMultiDc.replicaSyncUpService.updateReplicaLagAndCheckSyncStatus(
+        testWithoutMultiDc.currentReplica, dc2Peers.get(0), 0L, ReplicaState.STANDBY);
+    assertTrue("Should complete with single-DC remote peers when multi-DC check is disabled",
+        testWithoutMultiDc.replicaSyncUpService.updateReplicaLagAndCheckSyncStatus(
+            testWithoutMultiDc.currentReplica, dc2Peers.get(1), 0L, ReplicaState.STANDBY));
+
+    testWithoutMultiDc.replicaSyncUpService.reset();
   }
 }

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/AmbryReplicaSyncUpManagerTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/AmbryReplicaSyncUpManagerTest.java
@@ -471,8 +471,9 @@ public class AmbryReplicaSyncUpManagerTest {
     assertTrue("Test requires at least 2 peers in " + firstRemoteDc, firstDcPeers.size() >= 2);
 
     // Catch up with 2 peers from a single remote DC — should complete because flag is off
-    testWithoutMultiDc.replicaSyncUpService.updateReplicaLagAndCheckSyncStatus(
-        testWithoutMultiDc.currentReplica, firstDcPeers.get(0), 0L, ReplicaState.STANDBY);
+    assertFalse("Should not complete: only 1 peer caught up",
+        testWithoutMultiDc.replicaSyncUpService.updateReplicaLagAndCheckSyncStatus(
+            testWithoutMultiDc.currentReplica, firstDcPeers.get(0), 0L, ReplicaState.STANDBY));
     assertTrue("Should complete with single-DC remote peers when multi-DC check is disabled",
         testWithoutMultiDc.replicaSyncUpService.updateReplicaLagAndCheckSyncStatus(
             testWithoutMultiDc.currentReplica, firstDcPeers.get(1), 0L, ReplicaState.STANDBY));


### PR DESCRIPTION
## Summary

During multi-fabric crashes, bootstrapping replicas could sync with empty replicas from a single recovering DC (stale ExternalView shows them as STANDBY) and transition to STANDBY with no data, causing 404s.

Add config flag clustermap.replica.catchup.require.multi.dc.for.bootstrap (default: false) that requires caught-up peers from at least 2 distinct remote DCs when no local DC peers are in STANDBY/LEADER.


## Testing Done
added unit tests. all tests pass.