### PR TITLE
Fix StoreMetrics gauge leak causing PersistentIndex accumulation in JMX MBeanRegistrar

### DIFF
--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -370,6 +370,11 @@ public class BlobStore implements Store {
             logger.error("Failed to unlock file lock for dir " + dataDir, lockException);
           }
         }
+        // Deregister any gauges that were successfully registered before the failure. initializeCompactorGauges and
+        // initializeIndexGauges may have been called before the exception. registry.remove() is a no-op for names that
+        // were never registered, so this is safe regardless of how far load() progressed. Without this, a subsequent
+        // retry of load() would fail with "A metric named X already exists" on the registry.register() calls.
+        metrics.deregisterMetrics(storeId);
         initialized = false;
         String err = String.format("Error while starting store for dir %s due to %s", dataDir, e.getMessage());
         throw new StoreException(err, e, StoreErrorCodes.InitializationError);

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -1600,12 +1600,15 @@ public class BlobStore implements Store {
       try {
         checkStarted();
         logger.info("Store : {} shutting down", dataDir);
+        // Deregister metrics before closing sub-components. If index.close() or compactor.close() throws,
+        // deregisterMetrics must still run — otherwise orphaned gauge lambdas accumulate in the MetricRegistry
+        // and JMX MBeanRegistrar, holding strong references to PersistentIndex objects and preventing GC.
+        metrics.deregisterMetrics(storeId);
         blobStoreStats.close();
         compactor.close(30);
         index.close(skipDiskFlush);
         log.close(skipDiskFlush);
         remoteTokenTracker.close();
-        metrics.deregisterMetrics(storeId);
         setCurrentState(ReplicaState.OFFLINE);
         started = false;
       } catch (Exception e) {

--- a/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
@@ -607,10 +607,20 @@ public class DiskManager {
         succeed = true;
       }
     } catch (Exception e) {
-      stores.remove(replica.getPartitionId());
+      BlobStore store = stores.remove(replica.getPartitionId());
       partitionToReplicaMap.remove(replica.getPartitionId());
       logger.error("Failed to load new added store {} or add requirements to disk allocator", replica.getPartitionId(),
           e);
+      // If store.load() succeeded before the failure, gauges were already registered. Shut down the store to
+      // deregister them. Without this, orphaned gauge lambda closures accumulate in the MetricRegistry (and the
+      // JMX MBeanRegistrar that wraps it), holding strong references to PersistentIndex objects and preventing GC.
+      if (store != null && store.isStarted()) {
+        try {
+          store.shutdown();
+        } catch (Exception shutdownException) {
+          logger.error("Failed to shut down store {} after failed load", replica.getPartitionId(), shutdownException);
+        }
+      }
     } finally {
       rwLock.writeLock().unlock();
     }

--- a/ambry-store/src/main/java/com/github/ambry/store/StoreMetrics.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StoreMetrics.java
@@ -445,6 +445,8 @@ public class StoreMetrics {
     registry.remove(MetricRegistry.name(BlobStoreCompactor.class, prefix + "CompactionInProgress"));
     registry.remove(MetricRegistry.name(BlobStoreCompactor.class, prefix + "CompactionCost"));
     registry.remove(MetricRegistry.name(BlobStoreCompactor.class, prefix + "CompactionBenefit"));
+    registry.remove(MetricRegistry.name(BlobStoreCompactor.class, prefix + "CompactedLogCount"));
+    registry.remove(MetricRegistry.name(BlobStoreCompactor.class, prefix + "LogSegmentCount"));
   }
 
   /**

--- a/ambry-store/src/test/java/com/github/ambry/store/StoreMetricsTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/StoreMetricsTest.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2024 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.store;
+
+import com.codahale.metrics.MetricRegistry;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+/**
+ * Unit tests for {@link StoreMetrics}.
+ */
+public class StoreMetricsTest {
+
+  /**
+   * Tests that all 5 compactor gauges registered by {@link StoreMetrics#initializeCompactorGauges} are removed
+   * when {@link StoreMetrics#deregisterMetrics} is called. This guards against a memory leak where orphaned
+   * gauge lambdas accumulate across store open/close cycles (e.g. after BlobStore restart).
+   *
+   * The two gauges that were historically missing from deregistration are CompactedLogCount and LogSegmentCount.
+   */
+  @Test
+  public void testDeregisterCompactorGaugesRemovesAllFive() {
+    MetricRegistry registry = new MetricRegistry();
+    StoreMetrics metrics = new StoreMetrics(registry);
+
+    String storeId = "testPartition_0";
+    AtomicBoolean compactionInProgress = new AtomicBoolean(false);
+    AtomicReference<CompactionDetails> compactionDetails = new AtomicReference<>(null);
+    AtomicInteger compactedLogCount = new AtomicInteger(0);
+    AtomicInteger logSegmentCount = new AtomicInteger(0);
+
+    metrics.initializeCompactorGauges(storeId, compactionInProgress, compactionDetails, compactedLogCount,
+        logSegmentCount);
+
+    // Verify all 5 per-store gauges are registered
+    String prefix = storeId + ".";
+    assertTrue("CompactionInProgress gauge should be registered",
+        registry.getGauges().containsKey(MetricRegistry.name(BlobStoreCompactor.class, prefix + "CompactionInProgress")));
+    assertTrue("CompactionCost gauge should be registered",
+        registry.getGauges().containsKey(MetricRegistry.name(BlobStoreCompactor.class, prefix + "CompactionCost")));
+    assertTrue("CompactionBenefit gauge should be registered",
+        registry.getGauges().containsKey(MetricRegistry.name(BlobStoreCompactor.class, prefix + "CompactionBenefit")));
+    assertTrue("CompactedLogCount gauge should be registered",
+        registry.getGauges().containsKey(MetricRegistry.name(BlobStoreCompactor.class, prefix + "CompactedLogCount")));
+    assertTrue("LogSegmentCount gauge should be registered",
+        registry.getGauges().containsKey(MetricRegistry.name(BlobStoreCompactor.class, prefix + "LogSegmentCount")));
+
+    // Deregister and verify all 5 gauges are removed
+    metrics.deregisterMetrics(storeId);
+
+    assertFalse("CompactionInProgress gauge should be removed after deregister",
+        registry.getGauges().containsKey(MetricRegistry.name(BlobStoreCompactor.class, prefix + "CompactionInProgress")));
+    assertFalse("CompactionCost gauge should be removed after deregister",
+        registry.getGauges().containsKey(MetricRegistry.name(BlobStoreCompactor.class, prefix + "CompactionCost")));
+    assertFalse("CompactionBenefit gauge should be removed after deregister",
+        registry.getGauges().containsKey(MetricRegistry.name(BlobStoreCompactor.class, prefix + "CompactionBenefit")));
+    assertFalse("CompactedLogCount gauge should be removed after deregister",
+        registry.getGauges().containsKey(MetricRegistry.name(BlobStoreCompactor.class, prefix + "CompactedLogCount")));
+    assertFalse("LogSegmentCount gauge should be removed after deregister",
+        registry.getGauges().containsKey(MetricRegistry.name(BlobStoreCompactor.class, prefix + "LogSegmentCount")));
+  }
+
+  /**
+   * Tests that deregistering gauges for one store does not affect gauges registered for another store.
+   * This verifies the per-store prefix isolation.
+   */
+  @Test
+  public void testDeregisterCompactorGaugesOnlyAffectsTargetStore() {
+    MetricRegistry registry = new MetricRegistry();
+    StoreMetrics metrics = new StoreMetrics(registry);
+
+    String storeId1 = "partition_1";
+    String storeId2 = "partition_2";
+
+    metrics.initializeCompactorGauges(storeId1, new AtomicBoolean(), new AtomicReference<>(), new AtomicInteger(),
+        new AtomicInteger());
+    metrics.initializeCompactorGauges(storeId2, new AtomicBoolean(), new AtomicReference<>(), new AtomicInteger(),
+        new AtomicInteger());
+
+    metrics.deregisterMetrics(storeId1);
+
+    // store 2 gauges should still be present
+    String prefix2 = storeId2 + ".";
+    assertTrue("partition_2 CompactedLogCount should still be registered after partition_1 deregister",
+        registry.getGauges().containsKey(MetricRegistry.name(BlobStoreCompactor.class, prefix2 + "CompactedLogCount")));
+    assertTrue("partition_2 LogSegmentCount should still be registered after partition_1 deregister",
+        registry.getGauges().containsKey(MetricRegistry.name(BlobStoreCompactor.class, prefix2 + "LogSegmentCount")));
+  }
+}

--- a/ambry-store/src/test/java/com/github/ambry/store/StoreMetricsTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/StoreMetricsTest.java
@@ -77,6 +77,37 @@ public class StoreMetricsTest {
   }
 
   /**
+   * Tests that gauges can be re-registered for the same storeId after deregisterMetrics is called.
+   * This validates the BlobStore.load() retry path: if load() fails after registering gauges, the catch block
+   * must call deregisterMetrics so that a subsequent retry can re-register without hitting
+   * "A metric named X already exists" from MetricRegistry.register().
+   */
+  @Test
+  public void testGaugesCanBeReregisteredAfterDeregister() {
+    MetricRegistry registry = new MetricRegistry();
+    StoreMetrics metrics = new StoreMetrics(registry);
+
+    String storeId = "partition_retry";
+    AtomicBoolean inProgress = new AtomicBoolean(false);
+    AtomicReference<CompactionDetails> details = new AtomicReference<>(null);
+
+    // First registration — simulates first load() attempt that partially succeeded
+    metrics.initializeCompactorGauges(storeId, inProgress, details, new AtomicInteger(0), new AtomicInteger(0));
+
+    // Deregister — simulates load() catch block cleanup
+    metrics.deregisterMetrics(storeId);
+
+    // Re-registration — simulates retry load(). Must not throw "A metric named X already exists".
+    metrics.initializeCompactorGauges(storeId, inProgress, details, new AtomicInteger(0), new AtomicInteger(0));
+
+    String prefix = storeId + ".";
+    assertTrue("CompactedLogCount should be registered after retry",
+        registry.getGauges().containsKey(MetricRegistry.name(BlobStoreCompactor.class, prefix + "CompactedLogCount")));
+    assertTrue("LogSegmentCount should be registered after retry",
+        registry.getGauges().containsKey(MetricRegistry.name(BlobStoreCompactor.class, prefix + "LogSegmentCount")));
+  }
+
+  /**
    * Tests that deregistering gauges for one store does not affect gauges registered for another store.
    * This verifies the per-store prefix isolation.
    */


### PR DESCRIPTION
## Summary

Fixes a `StoreMetrics` gauge memory leak that caused `StoreMetrics$$Lambda` closures to accumulate
in the static JMX `MBeanRegistrar`, holding strong references to `PersistentIndex` objects (the
full in-memory blob index per partition) and preventing GC. Root cause of two production GC
incidents in prod-lor1 ambry-server within 24 hours.

---

## Root Cause

`StoreMetrics` registers per-store gauge lambdas in two methods:

- `initializeIndexGauges` — 4 gauges that **directly capture `PersistentIndex`** via method
  references (`index::getLogUsedCapacity`, `index::getLogSegmentCount`, etc.)
- `initializeCompactorGauges` — 5 gauges that capture `AtomicBoolean`, `AtomicInteger`,
  `AtomicReference`

These gauges are registered in the Dropwizard `MetricRegistry`, which is wrapped by a JMX reporter
that exposes them via `MBeanRegistrar._beanServer` (a static JVM root). When a gauge is not
deregistered before the store is discarded, its lambda closure is retained by the static JMX root
forever — preventing GC of the `PersistentIndex` it captures.

Each orphaned index gauge lambda retains an entire `PersistentIndex`, which holds the full
in-memory blob index for one partition. On a node with hundreds of partitions and repeated
bootstrap/drop cycles, thousands of these accumulate.

### Why this caused GC death spirals

With a 62 GB heap, the leaked objects (held by a GC root, non-collectible) slowly fill the heap
over days or weeks. By the time the heap is 80-90% full, most of that is non-reclaimable live
leaked objects. G1GC runs increasingly long concurrent marking cycles that cannot drain the heap
faster than the leak fills it, escalating to multi-second stop-the-world Full GC pauses and
eventually a complete JVM freeze. The node remains alive (process not killed) but unresponsive,
invisible to D2 health checks — traffic continues routing to it until the degrader eventually
reduces its weight.

---

## Heap Dump Evidence (JxRay)

Two prod-lor1 ambry-server nodes were profiled:

**Event 4214236 — lor1-app142951** (first incident, 2026-04-21 00:27 UTC):

| Finding | Value |
|---|---|
| Heap used | ~25.3 GB / 62 GB (41%) |
| Live objects | 139.1M objects / 8.6 GB |
| Garbage (not yet collected) | 251.7M objects / 16.7 GB |
| `MBeanRegistrar._beanServer` total retained | ~22 GB |
| `StoreMetrics$$Lambda` instances | 420 per type × 3 types |
| **Total lambda leak** | **7.1 GB** |
| Off-heap DirectByteBuffers | 91.9 GB allocated / 10.8 GB unreachable |

Leak chain:
```
static MBeanRegistrar._beanServer
  → JmxMBeanServer → DefaultMBeanServerInterceptor → repository
      → StoreMetrics$$Lambda$2402 (420 instances, 1,882 MB)  ← index gauge
      → StoreMetrics$$Lambda$2421 (420 instances, 1,317 MB)  ← index gauge
      → StoreMetrics$$Lambda$2426 (420 instances, 1,297 MB)  ← index gauge
          → PersistentIndex (full in-memory blob index per partition)
```

Node had a 72-second JVM freeze (00:27:30–00:28:42 UTC), ZooKeeper session expired (67.9s),
HikariPool clock leap (72s). 10 of 35 ambry-frontend pods saw ~9-second average response times
for 15 minutes.

**Event 4218024 — lor1-app153723** (second incident, 2026-04-21, taken at 21:04 UTC):

| Finding | Value |
|---|---|
| Heap used | **42.5 GB / 62 GB (69%)** |
| Live objects | 518.3M objects / 24.0 GB (56.6%) |
| Garbage (not yet collected) | 350.0M objects / 18.4 GB (43.4%) |
| `MBeanRegistrar._beanServer` total retained | **22.2 GB (52.3% of heap)** |
| `StoreMetrics$$Lambda` instances | **925 per type × 4 types** |
| **Total lambda leak** | **~19.5 GB** |
| Off-heap DirectByteBuffers | 57.6 GB |

Lambda breakdown:
```
StoreMetrics$$Lambda$2590:  925 instances → 5,324,702 KB (12.0% of heap)
StoreMetrics$$Lambda$2585:  925 instances → 5,125,583 KB (11.5% of heap)
StoreMetrics$$Lambda$2587:  925 instances → 5,094,102 KB (11.4% of heap)
StoreMetrics$$Lambda$2567:  925 instances → 4,881,124 KB (11.0% of heap)
```

This node had a 5.5k ms GC pause before the incident. At 42.5 GB used with 19.5 GB non-reclaimable
leaked objects, the effective free heap was already exhausted. 925 orphaned instances vs 420 on the first node. The exact trigger for each node's accumulation
is still under investigation (reviewer @satishkotha noted partition movements have been rare in
the last 2-3 weeks, suggesting Fix 2 — BlobStore.shutdown() ordering — is the more likely
primary driver rather than partition bootstrap failures).

---

## Four Leak Paths Fixed

### Fix 1 — `DiskManager.loadInitializedBlobStore()`: shutdown store on failed load

```java
// BEFORE — store.load() succeeds (gauges registered), but addBlobStore() throws:
} catch (Exception e) {
  stores.remove(replica.getPartitionId());   // store removed from map
  partitionToReplicaMap.remove(...);
  // ← no store.shutdown() → deregisterMetrics NEVER called
  // gauges permanently orphaned, holding PersistentIndex in memory
}

// AFTER:
} catch (Exception e) {
  BlobStore store = stores.remove(replica.getPartitionId());
  partitionToReplicaMap.remove(...);
  if (store != null && store.isStarted()) {
    store.shutdown();  // deregisters all gauges, releases PersistentIndex references
  }
}
```

Triggered during partition additions when `addBlobStore()` fails after `store.load()` succeeds.
This path requires partition movement / Helix-driven rebalancing.

### Fix 2 — `BlobStore.shutdown()`: deregister metrics before closing sub-components **[primary]**

```java
// BEFORE — if compactor.close() or index.close() throws, deregisterMetrics is never reached:
try {
  blobStoreStats.close();
  compactor.close(30);      // ← throws → caught → deregisterMetrics skipped
  index.close(skipDiskFlush);
  log.close(skipDiskFlush);
  remoteTokenTracker.close();
  metrics.deregisterMetrics(storeId);  // ← never reached on exception
  ...
}

// AFTER — deregister first, before any close that might throw:
try {
  metrics.deregisterMetrics(storeId);  // ← always runs first
  blobStoreStats.close();
  compactor.close(30);
  index.close(skipDiskFlush);
  ...
}
```

Gauges only hold lambda references to the index; deregistering before `index.close()` is safe.

This is the most likely primary cause of the observed accumulation. Any error-triggered shutdown
where `compactor.close(30)` throws `InterruptedException` (compactor didn't finish within 30s) or
`index.close()` throws an I/O error exits the `try` block before reaching `deregisterMetrics`.
Over a months-long JVM lifetime with many IO-error recovery cycles, this accumulates one orphaned
set of 4 index gauge lambdas per affected store.

### Fix 3 — `BlobStore.load()`: deregister metrics when load itself fails mid-way

If `load()` fails after `initializeCompactorGauges` or `initializeIndexGauges` have run (e.g.,
if `compactor.initialize()` registers gauges but something later throws), the catch block now
calls `deregisterMetrics(storeId)`. `registry.remove()` is a no-op for names never registered,
so this is safe regardless of how far `load()` progressed. Without this, a retry of `load()` for
the same `storeId` would fail with `"A metric named X already exists"` from `registry.register()`.

### Fix 4 — `StoreMetrics.deregisterCompactorGauges()`: two missing removes

`deregisterCompactorGauges` called `registry.remove()` for only 3 of the 5 per-store gauges
registered by `initializeCompactorGauges`. `CompactedLogCount` and `LogSegmentCount` (registered
via `registry.gauge()`) were never removed.

---

## Testing Done

Added `StoreMetricsTest` with three unit tests:

1. `testDeregisterCompactorGaugesRemovesAllFive` — verifies all 5 compactor gauges are registered
   by `initializeCompactorGauges` and all 5 are removed by `deregisterMetrics`. Would have failed
   before Fix 4.
2. `testGaugesCanBeReregisteredAfterDeregister` — verifies that re-registering the same `storeId`
   after `deregisterMetrics` does not throw. Validates the load retry path fixed by Fix 3.
3. `testDeregisterCompactorGaugesOnlyAffectsTargetStore` — verifies per-store prefix isolation.

```
./gradlew :ambry-store:test \
  --tests "com.github.ambry.store.StoreMetricsTest" \
  --tests "com.github.ambry.store.BlobStoreTest" \
  --tests "com.github.ambry.store.CompactionManagerTest"

BUILD SUCCESSFUL
```

---

## Durability Risk

- [ ] **Write path** — No
- [ ] **Metadata** — No
- [ ] **Ordering / Atomicity** — No
- [ ] **Callback semantics** — No
- [x] **Resource cleanup** — Yes: this PR changes `BlobStore.shutdown()` cleanup ordering and
  adds a `store.shutdown()` call in DiskManager error handling. Risk is low — deregistering
  metrics before `index.close()` is safe since gauges only hold lambda captures, not open
  handles. The DiskManager fix only fires when `store.isStarted() == true`, ensuring it only
  runs on the partial-success path.
- [ ] **Retries / Idempotency** — `registry.remove()` is idempotent (no-op for missing keys)
- [ ] **Partial failures** — The DiskManager fix adds a best-effort `store.shutdown()` in a
  catch block with its own error logging — failure to shut down is logged but does not mask the
  original exception.
- [ ] **Corruption handling** — No