### PR TITLE
Always create bootstrap marker file to prevent serving stale data after restart

### DIFF
--- a/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
@@ -1010,20 +1010,19 @@ public class StorageManager implements StoreManager {
           ((BlobStore) store).setRecoverFromDecommission(false);
         }
 
-        // if store's used capacity is less than or equal to header size, we create a bootstrap_in_progress file and force
-        // it to stay in BOOTSTRAP state when catching up with peers.
+        // Always create the bootstrap_in_progress file to force the store through the sync-up check before
+        // transitioning to STANDBY. This ensures a restarted replica catches up with peers even if it has stale data
+        // on disk (e.g., after a rolling restart where blobs were written to other replicas during downtime).
+        // For stores that are already caught up, the sync-up check completes in <1 second.
         long storeUsedCapacity = store.getSizeInBytes();
-        if (storeUsedCapacity <= HEADER_SIZE) {
-          logger.info(
-              "Store {} has used capacity {} less than or equal to {} bytes, consider it recently created and make it go through bootstrap process.",
-              partitionName, storeUsedCapacity, HEADER_SIZE);
-          try {
-            createBootstrapFileIfAbsent(replica);
-          } catch (IOException e) {
-            logger.error("Failed to create bootstrap file for store {}", partitionName);
-            throw new StateTransitionException("Failed to create bootstrap file for " + partitionName,
-                ReplicaOperationFailure);
-          }
+        logger.info("Store {} has used capacity {} bytes, creating bootstrap file to ensure sync-up with peers.",
+            partitionName, storeUsedCapacity);
+        try {
+          createBootstrapFileIfAbsent(replica);
+        } catch (IOException e) {
+          logger.error("Failed to create bootstrap file for store {}", partitionName);
+          throw new StateTransitionException("Failed to create bootstrap file for " + partitionName,
+              ReplicaOperationFailure);
         }
       }
     }

--- a/ambry-store/src/test/java/com/github/ambry/store/StorageManagerTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/StorageManagerTest.java
@@ -1002,7 +1002,7 @@ public class StorageManagerTest {
     Store storeToWrite = storageManager.getStore(localReplicas.get(1).getPartitionId());
     storeToWrite.put(writeSet);
     mockHelixParticipant.onPartitionBecomeBootstrapFromOffline(localReplicas.get(1).getPartitionId().toPathString());
-    assertFalse("There should not be any bootstrap file for existing non-empty store",
+    assertTrue("There should be a bootstrap file for existing non-empty store to ensure sync-up with peers",
         storeToWrite.isBootstrapInProgress());
     assertEquals("The store's current state should be BOOTSTRAP", ReplicaState.BOOTSTRAP,
         storeToWrite.getCurrentState());


### PR DESCRIPTION
## Summary
Previously, the bootstrap marker file was only created when store capacity was <= HEADER_SIZE (18 bytes), intended to catch disk replacements. This meant stores with existing data skipped sync-up entirely after restart, transitioning directly to STANDBY with stale data and serving 404s for blobs written during downtime.

Remove the HEADER_SIZE conditional so every OFFLINE -> BOOTSTRAP transition goes through the ReplicaSyncUpManager. Stores that are already caught up complete sync-up in <1 second. Stores with stale data correctly wait for peer catch-up before serving reads.

Every store restart now goes through sync-up. For caught-up stores this adds <1s. For stale stores, this correctly blocks until caught up.


## Testing Done
covered by existing unit tests