### PR TITLE
Fail Ambry services when account-cache is empty (#ACTIONITEM-16590)

### DIFF
--- a/ambry-account/src/main/java/com/github/ambry/account/HelixAccountServiceFactory.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/HelixAccountServiceFactory.java
@@ -84,6 +84,9 @@ public class HelixAccountServiceFactory implements AccountServiceFactory {
               : null;
       HelixAccountService helixAccountService =
           new HelixAccountService(helixStore, accountServiceMetrics, notifier, scheduler, accountServiceConfig);
+      // Fail fast if the initial remote load + backup-file fallback produced an empty cache; serving requests
+      // with an empty cache would cause lookups to return null for valid accounts.
+      helixAccountService.failIfCacheIsEmpty();
       long spentTimeMs = System.currentTimeMillis() - startTimeMs;
       logger.info("HelixAccountService started, took {} ms", spentTimeMs);
       accountServiceMetrics.startupTimeInMs.update(spentTimeMs);

--- a/ambry-account/src/main/java/com/github/ambry/account/MySqlAccountServiceFactory.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/MySqlAccountServiceFactory.java
@@ -56,6 +56,9 @@ public class MySqlAccountServiceFactory implements AccountServiceFactory {
       logger.info("Starting a MySqlAccountService");
       MySqlAccountService mySqlAccountService =
           new MySqlAccountService(accountServiceMetricsWrapper, accountServiceConfig, mySqlAccountStoreFactory, notifier);
+      // Fail fast if the initial remote load + backup-file fallback produced an empty cache; serving requests
+      // with an empty cache would cause lookups to return null for valid accounts.
+      mySqlAccountService.failIfCacheIsEmpty();
       long spentTimeMs = System.currentTimeMillis() - startTimeMs;
       logger.info("MySqlAccountService started, took {} ms", spentTimeMs);
       accountServiceMetricsWrapper.getAccountServiceMetrics().startupTimeInMs.update(spentTimeMs);

--- a/ambry-api/src/main/java/com/github/ambry/account/AccountService.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/AccountService.java
@@ -22,6 +22,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -93,6 +94,40 @@ public interface AccountService extends Closeable {
    * @return A collection of {@link Account}s.
    */
   Collection<Account> getAllAccounts();
+
+  /**
+   * @return the number of accounts currently loaded by this {@code AccountService}. Used by server startup
+   * checks to detect an empty account cache. Implementations may override for efficiency.
+   */
+  default int getAccountCount() {
+    return getAllAccounts().size();
+  }
+
+  /**
+   * @return the total number of containers across all accounts currently loaded by this {@code AccountService}.
+   * Used by server startup checks to detect an empty cache. Implementations may override for efficiency.
+   */
+  default int getContainerCount() {
+    return getAllAccounts().stream().mapToInt(Account::getContainerCount).sum();
+  }
+
+  /**
+   * Fails fast if the account or container cache is empty. Intended to be called once at server startup,
+   * immediately after the initial (synchronous) fetch returns. An empty cache means the remote load failed
+   * and fell through to an empty backup file, which would cause the server to serve incorrect responses
+   * (e.g., rejecting valid requests, skipping valid replication messages).
+   * @throws IllegalStateException if the cache has zero accounts or zero containers.
+   */
+  default void failIfCacheIsEmpty() {
+    int accountCount = getAccountCount();
+    int containerCount = getContainerCount();
+    if (accountCount == 0 || containerCount == 0) {
+      String message = "AccountService cache is empty after initial load (accounts=" + accountCount
+          + ", containers=" + containerCount + ")";
+      LoggerFactory.getLogger(AccountService.class).error(message);
+      throw new IllegalStateException(message);
+    }
+  }
 
   /**
    * Adds a {@link Consumer} for newly created or updated {@link Account}s.

--- a/ambry-api/src/test/java/com/github/ambry/account/AccountServiceDefaultMethodsTest.java
+++ b/ambry-api/src/test/java/com/github/ambry/account/AccountServiceDefaultMethodsTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2026 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.account;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+/**
+ * Unit tests for the default methods on {@link AccountService}: {@link AccountService#getAccountCount()},
+ * {@link AccountService#getContainerCount()}, and {@link AccountService#failIfCacheIsEmpty()}.
+ */
+public class AccountServiceDefaultMethodsTest {
+
+  /**
+   * Empty service → zero counts.
+   */
+  @Test
+  public void emptyServiceReturnsZeroCounts() {
+    AccountService service = new FakeAccountService();
+    assertEquals(0, service.getAccountCount());
+    assertEquals(0, service.getContainerCount());
+  }
+
+  /**
+   * Populated service → correct counts.
+   */
+  @Test
+  public void populatedServiceReturnsCorrectCounts() {
+    FakeAccountService service = new FakeAccountService();
+    Container c1 = new ContainerBuilder((short) 1, "c1", Container.ContainerStatus.ACTIVE, "c1", (short) 1).build();
+    Container c2 = new ContainerBuilder((short) 2, "c2", Container.ContainerStatus.ACTIVE, "c2", (short) 1).build();
+    Container c3 = new ContainerBuilder((short) 1, "c3", Container.ContainerStatus.ACTIVE, "c3", (short) 2).build();
+    service.addAccount(
+        new AccountBuilder((short) 1, "a1", Account.AccountStatus.ACTIVE).containers(Arrays.asList(c1, c2)).build());
+    service.addAccount(
+        new AccountBuilder((short) 2, "a2", Account.AccountStatus.ACTIVE).containers(Collections.singleton(c3)).build());
+
+    assertEquals("Expected 2 accounts", 2, service.getAccountCount());
+    assertEquals("Expected 3 containers total", 3, service.getContainerCount());
+  }
+
+  /**
+   * Empty service → failIfCacheIsEmpty() throws.
+   */
+  @Test
+  public void failIfCacheIsEmptyThrowsWhenEmpty() {
+    AccountService service = new FakeAccountService();
+    try {
+      service.failIfCacheIsEmpty();
+      fail("Expected IllegalStateException");
+    } catch (IllegalStateException e) {
+      assertTrue("Message should mention accounts=0", e.getMessage().contains("accounts=0"));
+      assertTrue("Message should mention containers=0", e.getMessage().contains("containers=0"));
+    }
+  }
+
+  /**
+   * Accounts but no containers → failIfCacheIsEmpty() throws.
+   */
+  @Test
+  public void failIfCacheIsEmptyThrowsWhenAccountsPresentButNoContainers() {
+    FakeAccountService service = new FakeAccountService();
+    service.addAccount(new AccountBuilder((short) 1, "a1", Account.AccountStatus.ACTIVE).build());
+    assertEquals(1, service.getAccountCount());
+    assertEquals(0, service.getContainerCount());
+    try {
+      service.failIfCacheIsEmpty();
+      fail("Expected IllegalStateException");
+    } catch (IllegalStateException e) {
+      assertTrue("Message should mention containers=0", e.getMessage().contains("containers=0"));
+    }
+  }
+
+  /**
+   * Fully populated cache → failIfCacheIsEmpty() does not throw.
+   */
+  @Test
+  public void failIfCacheIsEmptyPassesWhenCachePopulated() {
+    FakeAccountService service = new FakeAccountService();
+    Container c = new ContainerBuilder((short) 1, "c", Container.ContainerStatus.ACTIVE, "c", (short) 1).build();
+    service.addAccount(
+        new AccountBuilder((short) 1, "a", Account.AccountStatus.ACTIVE).containers(Collections.singleton(c)).build());
+    service.failIfCacheIsEmpty();
+  }
+
+  /**
+   * Minimal {@link AccountService} implementation that only supports the 6 abstract methods; the rest rely on
+   * default implementations in the interface. Used to test the default methods under test.
+   */
+  private static final class FakeAccountService implements AccountService {
+    private final Map<Short, Account> accounts = new HashMap<>();
+
+    void addAccount(Account account) {
+      accounts.put(account.getId(), account);
+    }
+
+    @Override
+    public Account getAccountById(short accountId) {
+      return accounts.get(accountId);
+    }
+
+    @Override
+    public Account getAccountByName(String accountName) {
+      return accounts.values().stream().filter(a -> a.getName().equals(accountName)).findFirst().orElse(null);
+    }
+
+    @Override
+    public void updateAccounts(Collection<Account> toUpdate) {
+      for (Account a : toUpdate) {
+        accounts.put(a.getId(), a);
+      }
+    }
+
+    @Override
+    public Collection<Account> getAllAccounts() {
+      return new ArrayList<>(accounts.values());
+    }
+
+    @Override
+    public boolean addAccountUpdateConsumer(Consumer<Collection<Account>> accountUpdateConsumer) {
+      return false;
+    }
+
+    @Override
+    public boolean removeAccountUpdateConsumer(Consumer<Collection<Account>> accountUpdateConsumer) {
+      return false;
+    }
+
+    @Override
+    public void close() throws IOException {
+    }
+  }
+}

--- a/ambry-tools/src/integration-test/java/com/github/ambry/account/AccountUpdateToolTest.java
+++ b/ambry-tools/src/integration-test/java/com/github/ambry/account/AccountUpdateToolTest.java
@@ -37,6 +37,7 @@ import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.json.JSONArray;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -58,6 +59,10 @@ import static org.junit.Assert.*;
 public class AccountUpdateToolTest {
   private static final int NUM_REF_ACCOUNT = 10 + (int) (Math.random() * 50);
   private static final int NUM_CONTAINER_PER_ACCOUNT = 4;
+  // A dummy account seeded in ZK before each test so the HelixAccountServiceFactory non-empty-cache check passes.
+  // Its ID is excluded from generateRefAccounts() via accountIdSet so it never collides with generated accounts.
+  private static final short DUMMY_ACCOUNT_ID = Short.MAX_VALUE;
+  private static final int DUMMY_ACCOUNT_OFFSET = 1;
   private static final int ZK_SERVER_PORT = 2600;
   private static final String DC_NAME = "testDc";
   private static final byte DC_ID = (byte) 1;
@@ -114,7 +119,10 @@ public class AccountUpdateToolTest {
     this.containerJsonVersion = containerJsonVersion;
     idToRefAccountMap = new HashMap<>();
     idToRefContainerMap = new HashMap<>();
-    generateRefAccounts(idToRefAccountMap, idToRefContainerMap, new HashSet<>(), NUM_REF_ACCOUNT,
+    // Reserve DUMMY_ACCOUNT_ID so generateRefAccounts() doesn't pick it for any ref account.
+    HashSet<Short> reservedIds = new HashSet<>();
+    reservedIds.add(DUMMY_ACCOUNT_ID);
+    generateRefAccounts(idToRefAccountMap, idToRefContainerMap, reservedIds, NUM_REF_ACCOUNT,
         NUM_CONTAINER_PER_ACCOUNT);
     tempDirPath = getTempDir("accountUpdateTool-");
 
@@ -123,6 +131,11 @@ public class AccountUpdateToolTest {
     if (storeOperator.exist("/")) {
       storeOperator.delete("/");
     }
+
+    // HelixAccountServiceFactory.getAccountService() calls failIfCacheIsEmpty() which throws when the cache is
+    // empty after the initial ZK load. Seed a single dummy account so the service can start. Tests account for
+    // this dummy in their expected account counts (each expects +1 beyond the accounts they add).
+    seedDummyAccountInZk();
 
     // instantiate a HelixAccountService and listen to the change for account metadata
     notifier = new HelixNotifier(ZK_SERVER_ADDRESS, storeConfig);
@@ -150,9 +163,9 @@ public class AccountUpdateToolTest {
    */
   @Test
   public void testCreateAccount() throws Exception {
-    assertEquals("Wrong number of accounts", 0, accountService.getAllAccounts().size());
+    assertEquals("Wrong number of accounts", DUMMY_ACCOUNT_OFFSET, accountService.getAllAccounts().size());
     createOrUpdateAccountsAndWait(idToRefAccountMap.values());
-    assertAccountsInAccountService(idToRefAccountMap.values(), NUM_REF_ACCOUNT, accountService);
+    assertAccountsInAccountService(idToRefAccountMap.values(), NUM_REF_ACCOUNT + DUMMY_ACCOUNT_OFFSET, accountService);
   }
 
   /**
@@ -163,7 +176,7 @@ public class AccountUpdateToolTest {
   public void testUpdateAccount() throws Exception {
     // first, create NUM_REF_ACCOUNT accounts through the tool
     createOrUpdateAccountsAndWait(idToRefAccountMap.values());
-    assertAccountsInAccountService(idToRefAccountMap.values(), NUM_REF_ACCOUNT, accountService);
+    assertAccountsInAccountService(idToRefAccountMap.values(), NUM_REF_ACCOUNT + DUMMY_ACCOUNT_OFFSET, accountService);
 
     // then, update the name of all the accounts again through the tool
     String accountNameAppendix = "-accountNameAppendix";
@@ -178,7 +191,7 @@ public class AccountUpdateToolTest {
       updatedAccounts.add(accountBuilder.build());
     }
     createOrUpdateAccountsAndWait(updatedAccounts);
-    assertAccountsInAccountService(updatedAccounts, NUM_REF_ACCOUNT, accountService);
+    assertAccountsInAccountService(updatedAccounts, NUM_REF_ACCOUNT + DUMMY_ACCOUNT_OFFSET, accountService);
   }
 
   /**
@@ -190,7 +203,7 @@ public class AccountUpdateToolTest {
   public void testUpdateAccountSmallerSnapshotVersion() throws Exception {
     // first, create NUM_REF_ACCOUNT accounts through the tool
     createOrUpdateAccountsAndWait(idToRefAccountMap.values());
-    assertAccountsInAccountService(idToRefAccountMap.values(), NUM_REF_ACCOUNT, accountService);
+    assertAccountsInAccountService(idToRefAccountMap.values(), NUM_REF_ACCOUNT + DUMMY_ACCOUNT_OFFSET, accountService);
 
     // then, update the name of all the accounts but make the snapshot version smaller than current number.
     String accountNameAppendix = "-accountNameAppendix";
@@ -202,7 +215,7 @@ public class AccountUpdateToolTest {
       updatedAccounts.add(accountBuilder.build());
     }
     updateAccountsWithSmallerSnapshotVersionAndWait(updatedAccounts);
-    assertAccountsInAccountService(updatedAccounts, NUM_REF_ACCOUNT, accountService);
+    assertAccountsInAccountService(updatedAccounts, NUM_REF_ACCOUNT + DUMMY_ACCOUNT_OFFSET, accountService);
   }
 
   /**
@@ -218,7 +231,8 @@ public class AccountUpdateToolTest {
     TestUtils.assertException(IllegalArgumentException.class, () -> createOrUpdateAccountsAndWait(idConflictAccounts),
         null);
     Thread.sleep(100);
-    assertEquals("Wrong number of accounts in accountService", 0, accountService.getAllAccounts().size());
+    assertEquals("Wrong number of accounts in accountService", DUMMY_ACCOUNT_OFFSET,
+        accountService.getAllAccounts().size());
 
     // name conflict
     Collection<Account> nameConflictAccounts = new ArrayList<>();
@@ -227,7 +241,8 @@ public class AccountUpdateToolTest {
     TestUtils.assertException(IllegalArgumentException.class, () -> createOrUpdateAccountsAndWait(nameConflictAccounts),
         null);
     Thread.sleep(100);
-    assertEquals("Wrong number of accounts in accountService", 0, accountService.getAllAccounts().size());
+    assertEquals("Wrong number of accounts in accountService", DUMMY_ACCOUNT_OFFSET,
+        accountService.getAllAccounts().size());
   }
 
   /**
@@ -247,7 +262,8 @@ public class AccountUpdateToolTest {
       // expected
     }
     Thread.sleep(100);
-    assertEquals("Wrong number of accounts in accountService", 0, accountService.getAllAccounts().size());
+    assertEquals("Wrong number of accounts in accountService", DUMMY_ACCOUNT_OFFSET,
+        accountService.getAllAccounts().size());
   }
 
   /**
@@ -302,6 +318,27 @@ public class AccountUpdateToolTest {
    */
   private static void writeAccountsToFile(Collection<Account> accounts, String filePath) throws Exception {
     Files.write(Paths.get(filePath), new ObjectMapper().writeValueAsBytes(accounts));
+  }
+
+  /**
+   * Seed ZooKeeper with a single dummy account+container at the legacy account-metadata path so
+   * {@link HelixAccountServiceFactory#getAccountService()} can pass its non-empty-cache check on startup.
+   * Uses the same ZNRecord layout {@link LegacyMetadataStore} writes: path {@code /account_metadata/full_data},
+   * map field {@code accountMetadata} keyed by accountId → account JSON. Tests that count accounts in the service
+   * must include this dummy ({@link #DUMMY_ACCOUNT_OFFSET}).
+   */
+  private void seedDummyAccountInZk() throws Exception {
+    Container dummyContainer =
+        new ContainerBuilder((short) 1, "dummyContainer", Container.ContainerStatus.ACTIVE, "dummyContainer",
+            DUMMY_ACCOUNT_ID).build();
+    Account dummyAccount = new AccountBuilder(DUMMY_ACCOUNT_ID, "dummyAccount", Account.AccountStatus.ACTIVE)
+        .containers(java.util.Collections.singleton(dummyContainer)).build();
+    String accountJson = new ObjectMapper().writeValueAsString(dummyAccount);
+    ZNRecord record = new ZNRecord("full_account_metadata");
+    Map<String, String> accountMap = new HashMap<>();
+    accountMap.put(String.valueOf(dummyAccount.getId()), accountJson);
+    record.setMapField(LegacyMetadataStore.ACCOUNT_METADATA_MAP_KEY, accountMap);
+    storeOperator.write(LegacyMetadataStore.FULL_ACCOUNT_METADATA_PATH, record);
   }
 
   /**


### PR DESCRIPTION
MySqlAccountService and HelixAccountService load accounts synchronously in their constructors (remote fetch + backup-file fallback). If both fail, the cache is empty — which would cause the service to return null for every account/container lookup, resulting in the server rejecting valid requests and skipping valid replication messages.

Once populated, the cache cannot become empty through normal operation (CachedAccountService only adds/updates entries). So an empty cache unambiguously means the initial load failed. Fail fast at factory construction rather than running in a broken state.

## Coverage

Both **frontend** (RestServer) and **server** (AmbryServer, VcrServer) are covered because all three construct AccountService via the factory path. In AmbryLI prod, the frontend's CompositeLiAccountServiceFactory wraps MySqlAccountServiceFactory as primary, so the check fires transitively.

| App | Factory in prod | Coverage |
|---|---|---|
| OSS ambry-server (AmbryServer.startup) | MySqlAccountServiceFactory or HelixAccountServiceFactory | Direct |
| OSS ambry-frontend (RestServer) | MySqlAccountServiceFactory or HelixAccountServiceFactory | Direct |
| AmbryLI ambry-server | MySqlAccountServiceFactory | Direct |
| AmbryLI ambry-frontend (prod-lva1/lor1/ei4) | CompositeLiAccountServiceFactory | Transitive via MySql primary |
| AmbryLI ambry-frontend (qei) | MySqlAccountServiceFactory | Direct |
| AmbryLI ambry-vcr | MySqlAccountServiceFactory | Direct |

## Changes

- **AccountService** (interface): add `getAccountCount()`, `getContainerCount()`, `failIfCacheIsEmpty()` default methods. `failIfCacheIsEmpty()` logs and throws IllegalStateException.
- **MySqlAccountServiceFactory, HelixAccountServiceFactory**: call `failIfCacheIsEmpty()` before returning.
- **AccountServiceDefaultMethodsTest**: new unit tests for the interface default methods.
- **AccountUpdateToolTest**: seed ZK with a dummy account after wipe so the integration test's factory call can pass the non-empty check. Test assertions bumped by DUMMY_ACCOUNT_OFFSET (1).

Supersedes #3228.