### PR TITLE
Fail AccountServiceFactory.getAccountService when cache is empty

### DIFF
--- a/ambry-account/src/main/java/com/github/ambry/account/HelixAccountServiceFactory.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/HelixAccountServiceFactory.java
@@ -84,6 +84,9 @@ public class HelixAccountServiceFactory implements AccountServiceFactory {
               : null;
       HelixAccountService helixAccountService =
           new HelixAccountService(helixStore, accountServiceMetrics, notifier, scheduler, accountServiceConfig);
+      // Fail fast if the initial remote load + backup-file fallback produced an empty cache; serving requests
+      // with an empty cache would cause lookups to return null for valid accounts.
+      helixAccountService.failIfCacheIsEmpty();
       long spentTimeMs = System.currentTimeMillis() - startTimeMs;
       logger.info("HelixAccountService started, took {} ms", spentTimeMs);
       accountServiceMetrics.startupTimeInMs.update(spentTimeMs);

--- a/ambry-account/src/main/java/com/github/ambry/account/MySqlAccountServiceFactory.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/MySqlAccountServiceFactory.java
@@ -56,6 +56,9 @@ public class MySqlAccountServiceFactory implements AccountServiceFactory {
       logger.info("Starting a MySqlAccountService");
       MySqlAccountService mySqlAccountService =
           new MySqlAccountService(accountServiceMetricsWrapper, accountServiceConfig, mySqlAccountStoreFactory, notifier);
+      // Fail fast if the initial remote load + backup-file fallback produced an empty cache; serving requests
+      // with an empty cache would cause lookups to return null for valid accounts.
+      mySqlAccountService.failIfCacheIsEmpty();
       long spentTimeMs = System.currentTimeMillis() - startTimeMs;
       logger.info("MySqlAccountService started, took {} ms", spentTimeMs);
       accountServiceMetricsWrapper.getAccountServiceMetrics().startupTimeInMs.update(spentTimeMs);

--- a/ambry-api/src/main/java/com/github/ambry/account/AccountService.java
+++ b/ambry-api/src/main/java/com/github/ambry/account/AccountService.java
@@ -22,6 +22,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -93,6 +94,40 @@ public interface AccountService extends Closeable {
    * @return A collection of {@link Account}s.
    */
   Collection<Account> getAllAccounts();
+
+  /**
+   * @return the number of accounts currently loaded by this {@code AccountService}. Used by server startup
+   * checks to detect an empty account cache. Implementations may override for efficiency.
+   */
+  default int getAccountCount() {
+    return getAllAccounts().size();
+  }
+
+  /**
+   * @return the total number of containers across all accounts currently loaded by this {@code AccountService}.
+   * Used by server startup checks to detect an empty cache. Implementations may override for efficiency.
+   */
+  default int getContainerCount() {
+    return getAllAccounts().stream().mapToInt(Account::getContainerCount).sum();
+  }
+
+  /**
+   * Fails fast if the account or container cache is empty. Intended to be called once at server startup,
+   * immediately after the initial (synchronous) fetch returns. An empty cache means the remote load failed
+   * and fell through to an empty backup file, which would cause the server to serve incorrect responses
+   * (e.g., rejecting valid requests, skipping valid replication messages).
+   * @throws IllegalStateException if the cache has zero accounts or zero containers.
+   */
+  default void failIfCacheIsEmpty() {
+    int accountCount = getAccountCount();
+    int containerCount = getContainerCount();
+    if (accountCount == 0 || containerCount == 0) {
+      String message = "AccountService cache is empty after initial load (accounts=" + accountCount
+          + ", containers=" + containerCount + ")";
+      LoggerFactory.getLogger(AccountService.class).error(message);
+      throw new IllegalStateException(message);
+    }
+  }
 
   /**
    * Adds a {@link Consumer} for newly created or updated {@link Account}s.

--- a/ambry-api/src/test/java/com/github/ambry/account/AccountServiceDefaultMethodsTest.java
+++ b/ambry-api/src/test/java/com/github/ambry/account/AccountServiceDefaultMethodsTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2026 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.account;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+/**
+ * Unit tests for the default methods on {@link AccountService}: {@link AccountService#getAccountCount()},
+ * {@link AccountService#getContainerCount()}, and {@link AccountService#failIfCacheIsEmpty()}.
+ */
+public class AccountServiceDefaultMethodsTest {
+
+  /**
+   * Empty service → zero counts.
+   */
+  @Test
+  public void emptyServiceReturnsZeroCounts() {
+    AccountService service = new FakeAccountService();
+    assertEquals(0, service.getAccountCount());
+    assertEquals(0, service.getContainerCount());
+  }
+
+  /**
+   * Populated service → correct counts.
+   */
+  @Test
+  public void populatedServiceReturnsCorrectCounts() {
+    FakeAccountService service = new FakeAccountService();
+    Container c1 = new ContainerBuilder((short) 1, "c1", Container.ContainerStatus.ACTIVE, "c1", (short) 1).build();
+    Container c2 = new ContainerBuilder((short) 2, "c2", Container.ContainerStatus.ACTIVE, "c2", (short) 1).build();
+    Container c3 = new ContainerBuilder((short) 1, "c3", Container.ContainerStatus.ACTIVE, "c3", (short) 2).build();
+    service.addAccount(
+        new AccountBuilder((short) 1, "a1", Account.AccountStatus.ACTIVE).containers(Arrays.asList(c1, c2)).build());
+    service.addAccount(
+        new AccountBuilder((short) 2, "a2", Account.AccountStatus.ACTIVE).containers(Collections.singleton(c3)).build());
+
+    assertEquals("Expected 2 accounts", 2, service.getAccountCount());
+    assertEquals("Expected 3 containers total", 3, service.getContainerCount());
+  }
+
+  /**
+   * Empty service → failIfCacheIsEmpty() throws.
+   */
+  @Test
+  public void failIfCacheIsEmptyThrowsWhenEmpty() {
+    AccountService service = new FakeAccountService();
+    try {
+      service.failIfCacheIsEmpty();
+      fail("Expected IllegalStateException");
+    } catch (IllegalStateException e) {
+      assertTrue("Message should mention accounts=0", e.getMessage().contains("accounts=0"));
+      assertTrue("Message should mention containers=0", e.getMessage().contains("containers=0"));
+    }
+  }
+
+  /**
+   * Accounts but no containers → failIfCacheIsEmpty() throws.
+   */
+  @Test
+  public void failIfCacheIsEmptyThrowsWhenAccountsPresentButNoContainers() {
+    FakeAccountService service = new FakeAccountService();
+    service.addAccount(new AccountBuilder((short) 1, "a1", Account.AccountStatus.ACTIVE).build());
+    assertEquals(1, service.getAccountCount());
+    assertEquals(0, service.getContainerCount());
+    try {
+      service.failIfCacheIsEmpty();
+      fail("Expected IllegalStateException");
+    } catch (IllegalStateException e) {
+      assertTrue("Message should mention containers=0", e.getMessage().contains("containers=0"));
+    }
+  }
+
+  /**
+   * Fully populated cache → failIfCacheIsEmpty() does not throw.
+   */
+  @Test
+  public void failIfCacheIsEmptyPassesWhenCachePopulated() {
+    FakeAccountService service = new FakeAccountService();
+    Container c = new ContainerBuilder((short) 1, "c", Container.ContainerStatus.ACTIVE, "c", (short) 1).build();
+    service.addAccount(
+        new AccountBuilder((short) 1, "a", Account.AccountStatus.ACTIVE).containers(Collections.singleton(c)).build());
+    service.failIfCacheIsEmpty();
+  }
+
+  /**
+   * Minimal {@link AccountService} implementation that only supports the 6 abstract methods; the rest rely on
+   * default implementations in the interface. Used to test the default methods under test.
+   */
+  private static final class FakeAccountService implements AccountService {
+    private final Map<Short, Account> accounts = new HashMap<>();
+
+    void addAccount(Account account) {
+      accounts.put(account.getId(), account);
+    }
+
+    @Override
+    public Account getAccountById(short accountId) {
+      return accounts.get(accountId);
+    }
+
+    @Override
+    public Account getAccountByName(String accountName) {
+      return accounts.values().stream().filter(a -> a.getName().equals(accountName)).findFirst().orElse(null);
+    }
+
+    @Override
+    public void updateAccounts(Collection<Account> toUpdate) {
+      for (Account a : toUpdate) {
+        accounts.put(a.getId(), a);
+      }
+    }
+
+    @Override
+    public Collection<Account> getAllAccounts() {
+      return new ArrayList<>(accounts.values());
+    }
+
+    @Override
+    public boolean addAccountUpdateConsumer(Consumer<Collection<Account>> accountUpdateConsumer) {
+      return false;
+    }
+
+    @Override
+    public boolean removeAccountUpdateConsumer(Consumer<Collection<Account>> accountUpdateConsumer) {
+      return false;
+    }
+
+    @Override
+    public void close() throws IOException {
+    }
+  }
+}


### PR DESCRIPTION
MySqlAccountService and HelixAccountService load accounts synchronously in their constructors (remote fetch + backup-file fallback). If both fail, the cache is empty — which would cause the service to return null for every account/container lookup, resulting in the server rejecting valid requests and skipping valid replication messages.

Once populated, the cache cannot become empty through normal operation (CachedAccountService only adds/updates entries). So an empty cache unambiguously means the initial load failed. Fail fast at factory construction time rather than running in a broken state.

Changes:
- Add getAccountCount(), getContainerCount(), failIfCacheIsEmpty() default methods to AccountService interface. failIfCacheIsEmpty() logs and throws IllegalStateException.
- MySqlAccountServiceFactory.getAccountService() calls failIfCacheIsEmpty() before returning; existing catch wraps any throwable in IllegalStateException.
- Same for HelixAccountServiceFactory.
- CompositeAccountServiceFactory is transitively covered via its inner primary/secondary factories.
- In-memory test factories intentionally skipped (tests start empty).

Companion to #3227 (adds an empty-cache check on the client/fetch side). Independent — either PR can merge first.