### PR TITLE
Add replica lag metrics during STANDBY->LEADER promotion

### DIFF
--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationManager.java
@@ -354,6 +354,46 @@ public class ReplicationManager extends ReplicationEngine {
         // leaderBasedReplicationAdmin. LeaderBasedReplicationAdmin::addLeaderPartition is thread safe.
         leaderBasedReplicationAdmin.addLeaderPartition(partitionName);
       }
+      try {
+        recordStandbyToLeaderPromotionLag(partitionName);
+      } catch (Exception e) {
+        logger.warn("Failed to record lag metric on STANDBY->LEADER promotion for partition {}", partitionName, e);
+      }
+    }
+
+    /**
+     * Detects whether a replica was behind its peers at the moment Helix promoted it STANDBY -> LEADER.
+     * Helix transitions STANDBY -> LEADER without any data-parity check; we emit metrics here so we can
+     * verify in production that promoted leaders are actually caught up (or flag when they aren't).
+     *
+     * Two mutually exclusive signals per promotion:
+     * - {@link ReplicationMetrics#standbyToLeaderPromotionLagBytes}: max cached lag across peers whose lag
+     *   is known (>= 0). A single known peer is enough to attest readiness, so unknown (-1) peers are
+     *   ignored when at least one peer has a known lag.
+     * - {@link ReplicationMetrics#standbyToLeaderPromotionUnknownLagPeerCount}: incremented when every peer
+     *   of the partition has an unknown cached lag — no peer can attest to the replica's sync state.
+     */
+    private void recordStandbyToLeaderPromotionLag(String partitionName) {
+      ReplicaId localReplica = storeManager.getReplica(partitionName);
+      if (localReplica == null) {
+        return;
+      }
+      PartitionInfo partitionInfo = partitionToPartitionInfo.get(localReplica.getPartitionId());
+      if (partitionInfo == null) {
+        return;
+      }
+      long maxKnownLag = -1L;
+      for (RemoteReplicaInfo remoteReplicaInfo : partitionInfo.getRemoteReplicaInfos()) {
+        long lag = remoteReplicaInfo.getLocalLagFromRemoteInBytes();
+        if (lag >= 0) {
+          maxKnownLag = Math.max(maxKnownLag, lag);
+        }
+      }
+      if (maxKnownLag >= 0) {
+        replicationMetrics.standbyToLeaderPromotionLagBytes.update(maxKnownLag);
+      } else {
+        replicationMetrics.standbyToLeaderPromotionUnknownLagPeerCount.inc();
+      }
     }
 
     @Override

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationMetrics.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationMetrics.java
@@ -184,9 +184,23 @@ public class ReplicationMetrics {
 
   public final Counter backupIntegrityError;
 
+  // Max RemoteReplicaInfo.getLocalLagFromRemoteInBytes() across peers of a partition at the moment it transitions
+  // STANDBY -> LEADER, considering only peers with a known (non-negative) cached lag. A well-caught-up STANDBY
+  // should be ~0; non-zero values indicate the replica was promoted before it was fully synced. If any peer
+  // reports a known lag, unknown peers are ignored since one known data point is enough to assess readiness.
+  public final Histogram standbyToLeaderPromotionLagBytes;
+
+  // Incremented once per STANDBY -> LEADER promotion when NO peer of the partition has a known cached lag
+  // (every peer is at the -1 sentinel). The replica was promoted with no attested sync signal from any peer.
+  public final Counter standbyToLeaderPromotionUnknownLagPeerCount;
+
   public ReplicationMetrics(MetricRegistry registry, List<? extends ReplicaId> replicaIds) {
     backupIntegrityError =
         registry.counter(MetricRegistry.name(ReplicationMetrics.class, "BackupIntegrityError"));
+    standbyToLeaderPromotionLagBytes =
+        registry.histogram(MetricRegistry.name(ReplicationManager.class, "StandbyToLeaderPromotionLagBytes"));
+    standbyToLeaderPromotionUnknownLagPeerCount =
+        registry.counter(MetricRegistry.name(ReplicationManager.class, "StandbyToLeaderPromotionUnknownLagPeerCount"));
     intraColoReplicationBytesRate =
         registry.meter(MetricRegistry.name(ReplicaThread.class, "IntraColoReplicationBytesRate"));
     plainTextIntraColoReplicationBytesRate =

--- a/ambry-replication/src/test/java/com/github/ambry/replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/ReplicationTest.java
@@ -13,6 +13,8 @@
  */
 package com.github.ambry.replication;
 
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Histogram;
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.account.Account;
 import com.github.ambry.account.Container;
@@ -844,6 +846,78 @@ public class ReplicationTest extends ReplicationTestHelper {
     storageManager.shutdown();
 
     replicationConfig = initialReplicationConfig;
+  }
+
+  /**
+   * When a replica transitions STANDBY -> LEADER with all peers having known (>= 0) cached lag,
+   * the lag histogram should record the max lag across peers and the unknown-lag counter should not move.
+   */
+  @Test
+  public void standbyToLeaderPromotionMetricsKnownLagTest() throws Exception {
+    runStandbyToLeaderPromotionMetricsTest(new long[]{100L, 150L, 200L}, 1, 200L, 0);
+  }
+
+  /**
+   * When a replica transitions STANDBY -> LEADER with all peers at the -1 sentinel (never synced),
+   * the unknown-lag counter should increment and the lag histogram should not record.
+   */
+  @Test
+  public void standbyToLeaderPromotionMetricsAllUnknownLagTest() throws Exception {
+    runStandbyToLeaderPromotionMetricsTest(new long[]{-1L, -1L, -1L}, 0, -1L, 1);
+  }
+
+  /**
+   * When peers have a mix of known and unknown lag, the histogram records the max over only the known
+   * values and the unknown-lag counter does not move (a single known peer is enough to attest readiness).
+   */
+  @Test
+  public void standbyToLeaderPromotionMetricsMixedLagTest() throws Exception {
+    runStandbyToLeaderPromotionMetricsTest(new long[]{250L, -1L, -1L}, 1, 250L, 0);
+  }
+
+  /**
+   * Drives one STANDBY -> LEADER promotion with per-peer cached lags and asserts histogram/counter state.
+   * A {@code peerLag} of -1 leaves the peer at its default (unknown) value; any other value is applied
+   * via {@link RemoteReplicaInfo#setLocalLagFromRemoteInBytes(long)}.
+   * @param peerLags per-peer lag values to assign (in {@link PartitionInfo#getRemoteReplicaInfos()} order)
+   * @param expectedHistogramCount expected observation count on standbyToLeaderPromotionLagBytes
+   * @param expectedHistogramMax expected histogram max; ignored when expectedHistogramCount is 0
+   * @param expectedUnknownLagCount expected value of standbyToLeaderPromotionUnknownLagPeerCount
+   */
+  private void runStandbyToLeaderPromotionMetricsTest(long[] peerLags, int expectedHistogramCount,
+      long expectedHistogramMax, int expectedUnknownLagCount) throws Exception {
+    MockClusterMap clusterMap = new MockClusterMap();
+    ClusterMapConfig clusterMapConfig = new ClusterMapConfig(verifiableProperties);
+    MockHelixParticipant.metricRegistry = new MetricRegistry();
+    MockHelixParticipant mockHelixParticipant = new MockHelixParticipant(clusterMapConfig);
+    Pair<StorageManager, ReplicationManager> managers =
+        createStorageManagerAndReplicationManager(clusterMap, clusterMapConfig, mockHelixParticipant);
+    StorageManager storageManager = managers.getFirst();
+    MockReplicationManager replicationManager = (MockReplicationManager) managers.getSecond();
+
+    PartitionId partitionId = replicationManager.partitionToPartitionInfo.keySet().iterator().next();
+    List<RemoteReplicaInfo> remoteReplicaInfos =
+        replicationManager.partitionToPartitionInfo.get(partitionId).getRemoteReplicaInfos();
+    assertTrue("Test requires partition to have at least " + peerLags.length + " peers",
+        remoteReplicaInfos.size() >= peerLags.length);
+    for (int i = 0; i < peerLags.length; i++) {
+      if (peerLags[i] >= 0) {
+        remoteReplicaInfos.get(i).setLocalLagFromRemoteInBytes(peerLags[i]);
+      }
+    }
+
+    Histogram histogram = replicationManager.replicationMetrics.standbyToLeaderPromotionLagBytes;
+    Counter counter = replicationManager.replicationMetrics.standbyToLeaderPromotionUnknownLagPeerCount;
+
+    mockHelixParticipant.onPartitionBecomeLeaderFromStandby(partitionId.toPathString());
+
+    assertEquals("Lag histogram observation count", expectedHistogramCount, histogram.getCount());
+    if (expectedHistogramCount > 0) {
+      assertEquals("Lag histogram max", expectedHistogramMax, histogram.getSnapshot().getMax());
+    }
+    assertEquals("Unknown-lag counter", expectedUnknownLagCount, counter.getCount());
+
+    storageManager.shutdown();
   }
 
   /**


### PR DESCRIPTION
## Summary

Helix transitions STANDBY->LEADER without any data-parity check. Add two mutually exclusive observability signals at the moment of promotion so we can verify in production that promoted leaders are actually caught up:

- StandbyToLeaderPromotionLagBytes (histogram): max cached lag across peers whose lag is known (>= 0). A single known peer is enough to attest readiness, so peers at the -1 sentinel are ignored when at least one peer has a known lag.
- StandbyToLeaderPromotionUnknownLagPeerCount (counter): incremented when every peer of the partition has an unknown cached lag -- no peer can attest to the replica's sync state.

The measurement is wrapped in try/catch with warn-level logging so a metrics path failure cannot propagate into the Helix state transition.

We are going to review the metrics once become unavailable, then determine how to catch premature state transition based on that