### PR TITLE
Bound MySqlNamedBlobDb transaction-executor queue and add admission metrics

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/MySqlNamedBlobDbConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/MySqlNamedBlobDbConfig.java
@@ -77,11 +77,16 @@ public class MySqlNamedBlobDbConfig {
    * MySQL slows down: each queued task pins a Netty channel and request context, so an unbounded queue can grow
    * to multi-GB before the kubelet kills the pod.
    *
-   * <p>The default is conservatively sized for the prior unbounded behavior; raise it together with {@link #localPoolSize}
-   * when intentionally provisioning more capacity. Order-of-magnitude sizing: {@code 4 * localPoolSize * p99_query_latency_seconds}.
+   * <p><b>Sizing guidance.</b> The pre-bounded behavior was an unbounded {@code DelayedWorkQueue}, so any value
+   * here is more restrictive than what was deployed before. The default of {@code 1000} is intentionally generous
+   * relative to the steady-state heuristic ({@code 4 * localPoolSize * p99_query_latency_seconds}, typically 20-40
+   * for {@code localPoolSize=5}) so that the bounded behavior only kicks in under genuinely pathological load.
+   * Before rolling this out to a new deployment, observe {@code TransactionExecutorQueueSize.<dc>} p99 in
+   * staging/canary and tune the value if the steady-state queue depth approaches the cap. Raise this together
+   * with {@link #localPoolSize} when intentionally provisioning more capacity.
    */
   @Config(MAX_PENDING_TRANSACTIONS_PER_DATACENTER)
-  @Default("100")
+  @Default("1000")
   public final int maxPendingTransactionsPerDatacenter;
 
   /**

--- a/ambry-api/src/main/java/com/github/ambry/config/MySqlNamedBlobDbConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/MySqlNamedBlobDbConfig.java
@@ -88,8 +88,12 @@ public class MySqlNamedBlobDbConfig {
    * <p>Once a value below {@link Integer#MAX_VALUE} is set, raise it together with {@link #localPoolSize} when
    * intentionally provisioning more capacity.
    */
+  // Default Integer.MAX_VALUE: the per-datacenter queue is INITIALLY UNBOUNDED. The admission control
+  // and per-DC metrics (TransactionExecutorQueueSize/ActiveCount/RejectedCount/EnqueueWaitTimeInMs)
+  // ship in a no-op state so operators can measure the steady-state queue depth in production before
+  // tuning this knob down to a real cap. AbortPolicy does not fire until this is reduced.
   @Config(MAX_PENDING_TRANSACTIONS_PER_DATACENTER)
-  @Default("2147483647") // Integer.MAX_VALUE — see javadoc; admission control is a no-op until tuned down.
+  @Default("2147483647")
   public final int maxPendingTransactionsPerDatacenter;
 
   /**

--- a/ambry-api/src/main/java/com/github/ambry/config/MySqlNamedBlobDbConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/MySqlNamedBlobDbConfig.java
@@ -77,16 +77,19 @@ public class MySqlNamedBlobDbConfig {
    * MySQL slows down: each queued task pins a Netty channel and request context, so an unbounded queue can grow
    * to multi-GB before the kubelet kills the pod.
    *
-   * <p><b>Sizing guidance.</b> The pre-bounded behavior was an unbounded {@code DelayedWorkQueue}, so any value
-   * here is more restrictive than what was deployed before. The default of {@code 1000} is intentionally generous
-   * relative to the steady-state heuristic ({@code 4 * localPoolSize * p99_query_latency_seconds}, typically 20-40
-   * for {@code localPoolSize=5}) so that the bounded behavior only kicks in under genuinely pathological load.
-   * Before rolling this out to a new deployment, observe {@code TransactionExecutorQueueSize.<dc>} p99 in
-   * staging/canary and tune the value if the steady-state queue depth approaches the cap. Raise this together
-   * with {@link #localPoolSize} when intentionally provisioning more capacity.
+   * <p><b>Default is intentionally non-restrictive.</b> The default of {@link Integer#MAX_VALUE} makes this PR a
+   * no-op for existing deployments — the admission machinery and {@code TransactionExecutorQueueSize.<dc>},
+   * {@code TransactionExecutorActiveCount.<dc>}, {@code NamedBlobTransactionRejectedCount.<dc>}, and
+   * {@code NamedBlobEnqueueWaitTimeInMs.<dc>} metrics are wired up, but {@code AbortPolicy} will not fire under
+   * any realistic load. Operators are expected to observe queue-depth p99 in production and tune this value down
+   * to a per-deployment cap. Order-of-magnitude steady-state heuristic:
+   * {@code 4 * localPoolSize * p99_query_latency_seconds} (typically 20-40 for {@code localPoolSize=5}).
+   *
+   * <p>Once a value below {@link Integer#MAX_VALUE} is set, raise it together with {@link #localPoolSize} when
+   * intentionally provisioning more capacity.
    */
   @Config(MAX_PENDING_TRANSACTIONS_PER_DATACENTER)
-  @Default("1000")
+  @Default("2147483647") // Integer.MAX_VALUE — see javadoc; admission control is a no-op until tuned down.
   public final int maxPendingTransactionsPerDatacenter;
 
   /**
@@ -149,7 +152,8 @@ public class MySqlNamedBlobDbConfig {
     this.localPoolSize = verifiableProperties.getIntInRange(LOCAL_POOL_SIZE, 5, 1, Integer.MAX_VALUE);
     this.remotePoolSize = verifiableProperties.getIntInRange(REMOTE_POOL_SIZE, 1, 1, Integer.MAX_VALUE);
     this.maxPendingTransactionsPerDatacenter =
-        verifiableProperties.getIntInRange(MAX_PENDING_TRANSACTIONS_PER_DATACENTER, 100, 1, Integer.MAX_VALUE);
+        verifiableProperties.getIntInRange(MAX_PENDING_TRANSACTIONS_PER_DATACENTER, Integer.MAX_VALUE, 1,
+            Integer.MAX_VALUE);
     this.listMaxResults =
         verifiableProperties.getIntInRange(LIST_MAX_RESULTS, DEFAULT_MAX_KEY_VALUE, 1, Integer.MAX_VALUE);
     this.queryStaleDataMaxResults =

--- a/ambry-api/src/main/java/com/github/ambry/config/MySqlNamedBlobDbConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/MySqlNamedBlobDbConfig.java
@@ -27,6 +27,8 @@ public class MySqlNamedBlobDbConfig {
   public static final String DB_INFO = PREFIX + "db.info";
   public static final String LOCAL_POOL_SIZE = PREFIX + "local.pool.size";
   public static final String REMOTE_POOL_SIZE = PREFIX + "remote.pool.size";
+  public static final String MAX_PENDING_TRANSACTIONS_PER_DATACENTER =
+      PREFIX + "max.pending.transactions.per.datacenter";
   public static final String LIST_MAX_RESULTS = PREFIX + "list.max.results";
   public static final String QUERY_STALE_DATA_MAX_RESULTS = PREFIX + "query.stale.data.max.results";
   public static final String STALE_DATA_RETENTION_DAYS = PREFIX + "stale.data.retention.days";
@@ -67,6 +69,20 @@ public class MySqlNamedBlobDbConfig {
   @Config(REMOTE_POOL_SIZE)
   @Default("1")
   public final int remotePoolSize;
+
+  /**
+   * Maximum number of in-flight transactions allowed per datacenter (queued plus running). When the per-datacenter
+   * work queue is full, additional submissions are rejected with {@link com.github.ambry.rest.RestServiceErrorCode#ServiceUnavailable}
+   * instead of being enqueued. Bounded admission control protects the JVM from heap exhaustion when the backend
+   * MySQL slows down: each queued task pins a Netty channel and request context, so an unbounded queue can grow
+   * to multi-GB before the kubelet kills the pod.
+   *
+   * <p>The default is conservatively sized for the prior unbounded behavior; raise it together with {@link #localPoolSize}
+   * when intentionally provisioning more capacity. Order-of-magnitude sizing: {@code 4 * localPoolSize * p99_query_latency_seconds}.
+   */
+  @Config(MAX_PENDING_TRANSACTIONS_PER_DATACENTER)
+  @Default("100")
+  public final int maxPendingTransactionsPerDatacenter;
 
   /**
    * The maximum number of entries to return per response page when listing blobs.
@@ -127,6 +143,8 @@ public class MySqlNamedBlobDbConfig {
     this.dbInfo = verifiableProperties.getString(DB_INFO);
     this.localPoolSize = verifiableProperties.getIntInRange(LOCAL_POOL_SIZE, 5, 1, Integer.MAX_VALUE);
     this.remotePoolSize = verifiableProperties.getIntInRange(REMOTE_POOL_SIZE, 1, 1, Integer.MAX_VALUE);
+    this.maxPendingTransactionsPerDatacenter =
+        verifiableProperties.getIntInRange(MAX_PENDING_TRANSACTIONS_PER_DATACENTER, 100, 1, Integer.MAX_VALUE);
     this.listMaxResults =
         verifiableProperties.getIntInRange(LIST_MAX_RESULTS, DEFAULT_MAX_KEY_VALUE, 1, Integer.MAX_VALUE);
     this.queryStaleDataMaxResults =

--- a/ambry-named-mysql/src/main/java/com/github/ambry/named/Metrics.java
+++ b/ambry-named-mysql/src/main/java/com/github/ambry/named/Metrics.java
@@ -21,6 +21,9 @@ import com.codahale.metrics.MetricRegistry;
 
 
 public class Metrics {
+  private final MetricRegistry metricRegistry;
+  private final String prefix;
+
   public final Counter namedDataNotFoundGetCount;
   public final Counter namedDataErrorGetCount;
   public final Counter namedDataInconsistentGetCount;
@@ -60,11 +63,19 @@ public class Metrics {
   public final Counter namedBlobDBInsertErrorCount;
   public final Counter namedBlobDBUpdateErrorCount;
 
+  // Bounded-queue admission control metrics. These complement the per-datacenter
+  // TransactionExecutorQueueSize and TransactionExecutorActiveCount gauges registered
+  // dynamically by MySqlNamedBlobDb.TransactionExecutor.
+  public final Counter namedBlobTransactionRejectedCount;
+  public final Histogram namedBlobEnqueueWaitTimeInMs;
+
   /**
    * Constructor to create the Metrics.
    * @param metricRegistry The {@link MetricRegistry}.
    */
   public Metrics(MetricRegistry metricRegistry, String prefix) {
+    this.metricRegistry = metricRegistry;
+    this.prefix = prefix;
     namedDataNotFoundGetCount =
         metricRegistry.counter(MetricRegistry.name(MySqlNamedBlobDb.class, prefix + "NamedDataNotFoundGetCount"));
     namedDataErrorGetCount =
@@ -124,5 +135,26 @@ public class Metrics {
         metricRegistry.counter(MetricRegistry.name(MySqlNamedBlobDb.class, prefix + "NamedBlobDBInsertErrorCount"));
     namedBlobDBUpdateErrorCount =
         metricRegistry.counter(MetricRegistry.name(MySqlNamedBlobDb.class, prefix + "NamedBlobDBUpdateErrorCount"));
+
+    namedBlobTransactionRejectedCount = metricRegistry.counter(
+        MetricRegistry.name(MySqlNamedBlobDb.class, prefix + "NamedBlobTransactionRejectedCount"));
+    namedBlobEnqueueWaitTimeInMs = metricRegistry.histogram(
+        MetricRegistry.name(MySqlNamedBlobDb.class, prefix + "NamedBlobEnqueueWaitTimeInMs"));
+  }
+
+  /**
+   * @return the {@link MetricRegistry} backing this {@link Metrics} instance.
+   * Used by {@link MySqlNamedBlobDb.TransactionExecutor} to register per-datacenter gauges.
+   */
+  MetricRegistry getMetricRegistry() {
+    return metricRegistry;
+  }
+
+  /**
+   * @return the metric-name prefix supplied at construction time. Used to keep dynamically
+   * registered gauges in the same namespace as the static counters/histograms above.
+   */
+  String getPrefix() {
+    return prefix;
   }
 }

--- a/ambry-named-mysql/src/main/java/com/github/ambry/named/Metrics.java
+++ b/ambry-named-mysql/src/main/java/com/github/ambry/named/Metrics.java
@@ -63,12 +63,6 @@ public class Metrics {
   public final Counter namedBlobDBInsertErrorCount;
   public final Counter namedBlobDBUpdateErrorCount;
 
-  // Bounded-queue admission control metrics. These complement the per-datacenter
-  // TransactionExecutorQueueSize and TransactionExecutorActiveCount gauges registered
-  // dynamically by MySqlNamedBlobDb.TransactionExecutor.
-  public final Counter namedBlobTransactionRejectedCount;
-  public final Histogram namedBlobEnqueueWaitTimeInMs;
-
   /**
    * Constructor to create the Metrics.
    * @param metricRegistry The {@link MetricRegistry}.
@@ -135,11 +129,6 @@ public class Metrics {
         metricRegistry.counter(MetricRegistry.name(MySqlNamedBlobDb.class, prefix + "NamedBlobDBInsertErrorCount"));
     namedBlobDBUpdateErrorCount =
         metricRegistry.counter(MetricRegistry.name(MySqlNamedBlobDb.class, prefix + "NamedBlobDBUpdateErrorCount"));
-
-    namedBlobTransactionRejectedCount = metricRegistry.counter(
-        MetricRegistry.name(MySqlNamedBlobDb.class, prefix + "NamedBlobTransactionRejectedCount"));
-    namedBlobEnqueueWaitTimeInMs = metricRegistry.histogram(
-        MetricRegistry.name(MySqlNamedBlobDb.class, prefix + "NamedBlobEnqueueWaitTimeInMs"));
   }
 
   /**

--- a/ambry-named-mysql/src/main/java/com/github/ambry/named/MySqlNamedBlobDb.java
+++ b/ambry-named-mysql/src/main/java/com/github/ambry/named/MySqlNamedBlobDb.java
@@ -16,6 +16,8 @@
 package com.github.ambry.named;
 
 import com.codahale.metrics.Counter;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.account.Account;
 import com.github.ambry.account.AccountService;
 import com.github.ambry.account.Container;
@@ -49,7 +51,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -193,6 +197,7 @@ public class MySqlNamedBlobDb implements NamedBlobDb {
     this.LIST_WITH_PREFIX_SQL = getListWithPrefixSQLStatement(config);
     this.localDatacenter = localDatacenter;
     this.retryExecutor = new RetryExecutor(null);
+    this.metricsRecoder = metricRecorder;
     this.transactionExecutors = MySqlUtils.getDbEndpointsPerDC(config.dbInfo)
         .values()
         .stream()
@@ -201,9 +206,9 @@ public class MySqlNamedBlobDb implements NamedBlobDb {
         .collect(Collectors.toMap(DbEndpoint::getDatacenter,
             dbEndpoint -> new TransactionExecutor(dbEndpoint.getDatacenter(),
                 dataSourceFactory.getDataSource(dbEndpoint),
-                localDatacenter.equals(dbEndpoint.getDatacenter()) ? config.localPoolSize : config.remotePoolSize)));
+                localDatacenter.equals(dbEndpoint.getDatacenter()) ? config.localPoolSize : config.remotePoolSize,
+                config.maxPendingTransactionsPerDatacenter, metricRecorder)));
     this.remoteDatacenters = MySqlUtils.getRemoteDcFromDbInfo(config.dbInfo, localDatacenter);
-    this.metricsRecoder = metricRecorder;
     this.time = time;
   }
 
@@ -492,76 +497,136 @@ public class MySqlNamedBlobDb implements NamedBlobDb {
   }
 
   /**
-   * Execute transaction on datacenter.
+   * Execute transactions for a single datacenter on a bounded thread pool.
+   *
+   * <p>The pool uses a fixed number of worker threads (sized by {@code MySqlNamedBlobDbConfig.localPoolSize} /
+   * {@code remotePoolSize}) and a bounded {@link LinkedBlockingQueue} sized by
+   * {@code MySqlNamedBlobDbConfig.maxPendingTransactionsPerDatacenter}. When the queue is full, additional
+   * submissions are rejected via {@link ThreadPoolExecutor.AbortPolicy} and the rejection is reported back to
+   * the caller as a {@link RestServiceErrorCode#ServiceUnavailable} so the request fails fast instead of pinning
+   * Netty channel and request context in an unbounded queue.
    */
-  private static class TransactionExecutor implements Closeable {
+  static class TransactionExecutor implements Closeable {
+    private final String datacenter;
     private final DataSource dataSource;
-    private final ExecutorService executor;
+    private final ThreadPoolExecutor executor;
+    private final Metrics metrics;
+    private final String queueSizeMetricName;
+    private final String activeCountMetricName;
 
-    TransactionExecutor(String datacenter, DataSource dataSource, int numThreads) {
+    TransactionExecutor(String datacenter, DataSource dataSource, int numThreads, int maxPendingTransactions,
+        Metrics metrics) {
+      this.datacenter = datacenter;
       this.dataSource = dataSource;
-      executor = Utils.newScheduler(numThreads, "Thread-" + datacenter, false);
+      this.metrics = metrics;
+      this.executor = new ThreadPoolExecutor(numThreads, numThreads, 0L, TimeUnit.MILLISECONDS,
+          new LinkedBlockingQueue<>(maxPendingTransactions),
+          new Utils.SchedulerThreadFactory("Thread-" + datacenter, false), new ThreadPoolExecutor.AbortPolicy());
+
+      MetricRegistry registry = metrics.getMetricRegistry();
+      String prefix = metrics.getPrefix();
+      this.queueSizeMetricName =
+          MetricRegistry.name(MySqlNamedBlobDb.class, prefix + "TransactionExecutorQueueSize." + datacenter);
+      this.activeCountMetricName =
+          MetricRegistry.name(MySqlNamedBlobDb.class, prefix + "TransactionExecutorActiveCount." + datacenter);
+      // remove() before register() guards against duplicate-key errors when a previous instance
+      // (e.g. a test) registered the same gauge name and was not closed.
+      registry.remove(queueSizeMetricName);
+      registry.remove(activeCountMetricName);
+      registry.register(queueSizeMetricName, (Gauge<Integer>) () -> executor.getQueue().size());
+      registry.register(activeCountMetricName, (Gauge<Integer>) () -> executor.getActiveCount());
     }
 
     <T> void executeTransaction(Container container, boolean autoCommit, Transaction<T> transaction,
         Callback<T> callback) {
-      executor.submit(() -> {
-        try (Connection connection = dataSource.getConnection()) {
-          T result;
-          if (autoCommit) {
-            result = transaction.run(container.getParentAccountId(), container.getId(), connection);
-          } else {
-            // if autocommit is set to false, treat this as a multi-step txn that requires an explicit commit/rollback
-            connection.setAutoCommit(false);
-            try {
+      final long enqueueTimeMs = System.currentTimeMillis();
+      try {
+        executor.submit(() -> {
+          metrics.namedBlobEnqueueWaitTimeInMs.update(System.currentTimeMillis() - enqueueTimeMs);
+          try (Connection connection = dataSource.getConnection()) {
+            T result;
+            if (autoCommit) {
               result = transaction.run(container.getParentAccountId(), container.getId(), connection);
-              connection.commit();
-            } catch (Exception e) {
-              connection.rollback();
-              throw e;
-            } finally {
-              connection.setAutoCommit(true);
+            } else {
+              // if autocommit is set to false, treat this as a multi-step txn that requires an explicit commit/rollback
+              connection.setAutoCommit(false);
+              try {
+                result = transaction.run(container.getParentAccountId(), container.getId(), connection);
+                connection.commit();
+              } catch (Exception e) {
+                connection.rollback();
+                throw e;
+              } finally {
+                connection.setAutoCommit(true);
+              }
             }
+            callback.onCompletion(result, null);
+          } catch (Exception e) {
+            callback.onCompletion(null, e);
           }
-          callback.onCompletion(result, null);
-        } catch (Exception e) {
-          callback.onCompletion(null, e);
-        }
-      });
+        });
+      } catch (RejectedExecutionException e) {
+        rejectTransaction(callback, e);
+      }
     }
 
     <T> void executeTransactionGeneric(boolean autoCommit, TransactionGeneric<T> transaction, Callback<T> callback) {
-      executor.submit(() -> {
-        try (Connection connection = dataSource.getConnection()) {
-          T result;
-          if (autoCommit) {
-            result = transaction.run(connection);
-          } else {
-            // if autocommit is set to false, treat this as a multi-step txn that requires an explicit commit/rollback
-            connection.setAutoCommit(false);
-            try {
+      final long enqueueTimeMs = System.currentTimeMillis();
+      try {
+        executor.submit(() -> {
+          metrics.namedBlobEnqueueWaitTimeInMs.update(System.currentTimeMillis() - enqueueTimeMs);
+          try (Connection connection = dataSource.getConnection()) {
+            T result;
+            if (autoCommit) {
               result = transaction.run(connection);
-              connection.commit();
-            } catch (Exception e) {
-              connection.rollback();
-              throw e;
-            } finally {
-              connection.setAutoCommit(true);
+            } else {
+              // if autocommit is set to false, treat this as a multi-step txn that requires an explicit commit/rollback
+              connection.setAutoCommit(false);
+              try {
+                result = transaction.run(connection);
+                connection.commit();
+              } catch (Exception e) {
+                connection.rollback();
+                throw e;
+              } finally {
+                connection.setAutoCommit(true);
+              }
             }
+            callback.onCompletion(result, null);
+          } catch (Exception e) {
+            callback.onCompletion(null, e);
           }
-          callback.onCompletion(result, null);
-        } catch (Exception e) {
-          callback.onCompletion(null, e);
-        }
-      });
+        });
+      } catch (RejectedExecutionException e) {
+        rejectTransaction(callback, e);
+      }
+    }
+
+    private <T> void rejectTransaction(Callback<T> callback, RejectedExecutionException cause) {
+      metrics.namedBlobTransactionRejectedCount.inc();
+      logger.warn("Named blob DB transaction rejected for datacenter {}: queue full (size={}, capacity={})", datacenter,
+          executor.getQueue().size(), executor.getQueue().size() + executor.getQueue().remainingCapacity());
+      callback.onCompletion(null,
+          new RestServiceException("Named blob DB transaction queue full for datacenter " + datacenter, cause,
+              RestServiceErrorCode.ServiceUnavailable));
     }
 
     public DataSource getDataSource() {
       return dataSource;
     }
 
+    /**
+     * @return the {@link ThreadPoolExecutor} backing this transaction executor. Visible for tests.
+     */
+    ThreadPoolExecutor getExecutor() {
+      return executor;
+    }
+
     @Override
     public void close() {
+      MetricRegistry registry = metrics.getMetricRegistry();
+      registry.remove(queueSizeMetricName);
+      registry.remove(activeCountMetricName);
       if (dataSource instanceof Closeable) {
         try {
           ((Closeable) dataSource).close();

--- a/ambry-named-mysql/src/main/java/com/github/ambry/named/MySqlNamedBlobDb.java
+++ b/ambry-named-mysql/src/main/java/com/github/ambry/named/MySqlNamedBlobDb.java
@@ -506,19 +506,21 @@ public class MySqlNamedBlobDb implements NamedBlobDb {
    * the caller as a {@link RestServiceErrorCode#ServiceUnavailable} so the request fails fast instead of pinning
    * Netty channel and request context in an unbounded queue.
    */
-  static class TransactionExecutor implements Closeable {
+  private static class TransactionExecutor implements Closeable {
     private final String datacenter;
     private final DataSource dataSource;
     private final ThreadPoolExecutor executor;
     private final Metrics metrics;
     private final String queueSizeMetricName;
     private final String activeCountMetricName;
+    private final int maxPendingTransactions;
 
     TransactionExecutor(String datacenter, DataSource dataSource, int numThreads, int maxPendingTransactions,
         Metrics metrics) {
       this.datacenter = datacenter;
       this.dataSource = dataSource;
       this.metrics = metrics;
+      this.maxPendingTransactions = maxPendingTransactions;
       this.executor = new ThreadPoolExecutor(numThreads, numThreads, 0L, TimeUnit.MILLISECONDS,
           new LinkedBlockingQueue<>(maxPendingTransactions),
           new Utils.SchedulerThreadFactory("Thread-" + datacenter, false), new ThreadPoolExecutor.AbortPolicy());
@@ -605,7 +607,7 @@ public class MySqlNamedBlobDb implements NamedBlobDb {
     private <T> void rejectTransaction(Callback<T> callback, RejectedExecutionException cause) {
       metrics.namedBlobTransactionRejectedCount.inc();
       logger.warn("Named blob DB transaction rejected for datacenter {}: queue full (size={}, capacity={})", datacenter,
-          executor.getQueue().size(), executor.getQueue().size() + executor.getQueue().remainingCapacity());
+          executor.getQueue().size(), maxPendingTransactions);
       callback.onCompletion(null,
           new RestServiceException("Named blob DB transaction queue full for datacenter " + datacenter, cause,
               RestServiceErrorCode.ServiceUnavailable));
@@ -613,13 +615,6 @@ public class MySqlNamedBlobDb implements NamedBlobDb {
 
     public DataSource getDataSource() {
       return dataSource;
-    }
-
-    /**
-     * @return the {@link ThreadPoolExecutor} backing this transaction executor. Visible for tests.
-     */
-    ThreadPoolExecutor getExecutor() {
-      return executor;
     }
 
     @Override

--- a/ambry-named-mysql/src/main/java/com/github/ambry/named/MySqlNamedBlobDb.java
+++ b/ambry-named-mysql/src/main/java/com/github/ambry/named/MySqlNamedBlobDb.java
@@ -17,6 +17,7 @@ package com.github.ambry.named;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.account.Account;
 import com.github.ambry.account.AccountService;
@@ -513,6 +514,10 @@ public class MySqlNamedBlobDb implements NamedBlobDb {
     private final Metrics metrics;
     private final String queueSizeMetricName;
     private final String activeCountMetricName;
+    private final String rejectedCountMetricName;
+    private final String enqueueWaitTimeMetricName;
+    private final Counter rejectedCount;
+    private final Histogram enqueueWaitTimeInMs;
     private final int maxPendingTransactions;
 
     TransactionExecutor(String datacenter, DataSource dataSource, int numThreads, int maxPendingTransactions,
@@ -531,12 +536,20 @@ public class MySqlNamedBlobDb implements NamedBlobDb {
           MetricRegistry.name(MySqlNamedBlobDb.class, prefix + "TransactionExecutorQueueSize." + datacenter);
       this.activeCountMetricName =
           MetricRegistry.name(MySqlNamedBlobDb.class, prefix + "TransactionExecutorActiveCount." + datacenter);
+      this.rejectedCountMetricName =
+          MetricRegistry.name(MySqlNamedBlobDb.class, prefix + "NamedBlobTransactionRejectedCount." + datacenter);
+      this.enqueueWaitTimeMetricName =
+          MetricRegistry.name(MySqlNamedBlobDb.class, prefix + "NamedBlobEnqueueWaitTimeInMs." + datacenter);
       // remove() before register() guards against duplicate-key errors when a previous instance
-      // (e.g. a test) registered the same gauge name and was not closed.
+      // (e.g. a test) registered the same metric name and was not closed.
       registry.remove(queueSizeMetricName);
       registry.remove(activeCountMetricName);
+      registry.remove(rejectedCountMetricName);
+      registry.remove(enqueueWaitTimeMetricName);
       registry.register(queueSizeMetricName, (Gauge<Integer>) () -> executor.getQueue().size());
       registry.register(activeCountMetricName, (Gauge<Integer>) () -> executor.getActiveCount());
+      this.rejectedCount = registry.counter(rejectedCountMetricName);
+      this.enqueueWaitTimeInMs = registry.histogram(enqueueWaitTimeMetricName);
     }
 
     <T> void executeTransaction(Container container, boolean autoCommit, Transaction<T> transaction,
@@ -544,7 +557,7 @@ public class MySqlNamedBlobDb implements NamedBlobDb {
       final long enqueueTimeMs = System.currentTimeMillis();
       try {
         executor.submit(() -> {
-          metrics.namedBlobEnqueueWaitTimeInMs.update(System.currentTimeMillis() - enqueueTimeMs);
+          enqueueWaitTimeInMs.update(System.currentTimeMillis() - enqueueTimeMs);
           try (Connection connection = dataSource.getConnection()) {
             T result;
             if (autoCommit) {
@@ -576,7 +589,7 @@ public class MySqlNamedBlobDb implements NamedBlobDb {
       final long enqueueTimeMs = System.currentTimeMillis();
       try {
         executor.submit(() -> {
-          metrics.namedBlobEnqueueWaitTimeInMs.update(System.currentTimeMillis() - enqueueTimeMs);
+          enqueueWaitTimeInMs.update(System.currentTimeMillis() - enqueueTimeMs);
           try (Connection connection = dataSource.getConnection()) {
             T result;
             if (autoCommit) {
@@ -605,9 +618,12 @@ public class MySqlNamedBlobDb implements NamedBlobDb {
     }
 
     private <T> void rejectTransaction(Callback<T> callback, RejectedExecutionException cause) {
-      metrics.namedBlobTransactionRejectedCount.inc();
-      logger.warn("Named blob DB transaction rejected for datacenter {}: queue full (size={}, capacity={})", datacenter,
-          executor.getQueue().size(), maxPendingTransactions);
+      // The per-datacenter rejected counter and TransactionExecutorQueueSize.<dc> /
+      // TransactionExecutorActiveCount.<dc> gauges are the operational signal here. Logging at warn
+      // would amplify log volume on the saturated path the bounded queue is designed to shed.
+      rejectedCount.inc();
+      logger.debug("Named blob DB transaction rejected for datacenter {}: queue full (size={}, capacity={})",
+          datacenter, executor.getQueue().size(), maxPendingTransactions);
       callback.onCompletion(null,
           new RestServiceException("Named blob DB transaction queue full for datacenter " + datacenter, cause,
               RestServiceErrorCode.ServiceUnavailable));
@@ -619,9 +635,10 @@ public class MySqlNamedBlobDb implements NamedBlobDb {
 
     @Override
     public void close() {
-      MetricRegistry registry = metrics.getMetricRegistry();
-      registry.remove(queueSizeMetricName);
-      registry.remove(activeCountMetricName);
+      // Close datasource and shut down the executor first; only then deregister metrics, so the
+      // per-datacenter gauges and counter remain observable while the executor is still draining
+      // in-flight transactions. A scrape that races with close() should see the drain progress
+      // rather than a hole.
       if (dataSource instanceof Closeable) {
         try {
           ((Closeable) dataSource).close();
@@ -630,6 +647,11 @@ public class MySqlNamedBlobDb implements NamedBlobDb {
         }
       }
       Utils.shutDownExecutorService(executor, 1, TimeUnit.MINUTES);
+      MetricRegistry registry = metrics.getMetricRegistry();
+      registry.remove(queueSizeMetricName);
+      registry.remove(activeCountMetricName);
+      registry.remove(rejectedCountMetricName);
+      registry.remove(enqueueWaitTimeMetricName);
     }
   }
 

--- a/ambry-named-mysql/src/test/java/com/github/ambry/named/MySqlNamedBlobDbTest.java
+++ b/ambry-named-mysql/src/test/java/com/github/ambry/named/MySqlNamedBlobDbTest.java
@@ -15,6 +15,7 @@
 
 package com.github.ambry.named;
 
+import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.account.Account;
 import com.github.ambry.account.Container;
@@ -47,8 +48,11 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import javax.sql.DataSource;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -146,6 +150,187 @@ public class MySqlNamedBlobDbTest {
     dataSourceFactory.triggerEmptyResultSetForLocalDataCenter(datacenters);
     List<StaleNamedBlob> staleNamedBlobs = getStaleBlobList();
     namedBlobDb.cleanupStaleData(staleNamedBlobs);
+  }
+
+  /**
+   * Verify that {@link MySqlNamedBlobDb.TransactionExecutor} registers the per-datacenter queue-size and
+   * active-count gauges, plus the shared rejected-count and enqueue-wait histograms, on construction.
+   */
+  @Test
+  public void testTransactionExecutorMetricsRegistered() throws Exception {
+    MetricRegistry registry = new MetricRegistry();
+    Metrics metrics = new Metrics(registry, "");
+    MySqlNamedBlobDb db =
+        new MySqlNamedBlobDb(accountService, buildSmallPoolConfig(1, 1, 100), dataSourceFactory, localDatacenter,
+            metrics);
+    try {
+      for (String dc : datacenters) {
+        assertTrue("queue-size gauge missing for datacenter " + dc, registry.getGauges()
+            .containsKey("com.github.ambry.named.MySqlNamedBlobDb.TransactionExecutorQueueSize." + dc));
+        assertTrue("active-count gauge missing for datacenter " + dc, registry.getGauges()
+            .containsKey("com.github.ambry.named.MySqlNamedBlobDb.TransactionExecutorActiveCount." + dc));
+      }
+      assertTrue("rejected counter missing", registry.getCounters()
+          .containsKey("com.github.ambry.named.MySqlNamedBlobDb.NamedBlobTransactionRejectedCount"));
+      assertTrue("enqueue-wait histogram missing", registry.getHistograms()
+          .containsKey("com.github.ambry.named.MySqlNamedBlobDb.NamedBlobEnqueueWaitTimeInMs"));
+    } finally {
+      db.close();
+    }
+  }
+
+  /**
+   * Verify that {@link MySqlNamedBlobDb.TransactionExecutor#close()} deregisters the per-datacenter gauges so
+   * subsequent instantiations do not leak metrics or fail with duplicate-registration errors.
+   */
+  @Test
+  public void testTransactionExecutorGaugesRemovedOnClose() throws Exception {
+    MetricRegistry registry = new MetricRegistry();
+    Metrics metrics = new Metrics(registry, "");
+    MySqlNamedBlobDb db =
+        new MySqlNamedBlobDb(accountService, buildSmallPoolConfig(1, 1, 100), dataSourceFactory, localDatacenter,
+            metrics);
+    db.close();
+    for (String dc : datacenters) {
+      assertFalse("queue-size gauge for " + dc + " should be removed after close", registry.getGauges()
+          .containsKey("com.github.ambry.named.MySqlNamedBlobDb.TransactionExecutorQueueSize." + dc));
+      assertFalse("active-count gauge for " + dc + " should be removed after close", registry.getGauges()
+          .containsKey("com.github.ambry.named.MySqlNamedBlobDb.TransactionExecutorActiveCount." + dc));
+    }
+  }
+
+  /**
+   * Verify that {@link MySqlNamedBlobDb.TransactionExecutor} records enqueue-wait time on a successful submission.
+   */
+  @Test
+  public void testEnqueueWaitTimeRecordedOnSuccessfulSubmit() throws Exception {
+    MetricRegistry registry = new MetricRegistry();
+    Metrics metrics = new Metrics(registry, "");
+    dataSourceFactory.setLocalDatacenter(localDatacenter);
+    dataSourceFactory.triggerEmptyResultSetForLocalDataCenter(datacenters);
+    MySqlNamedBlobDb db =
+        new MySqlNamedBlobDb(accountService, buildSmallPoolConfig(1, 1, 100), dataSourceFactory, localDatacenter,
+            metrics);
+    try {
+      // Issue any DB call; the resolution itself does not need to succeed for the histogram update to fire.
+      try {
+        db.get(account.getName(), container.getName(), "blobName").get(10, TimeUnit.SECONDS);
+      } catch (Exception ignored) {
+        // We only care that the worker thread ran and recorded the histogram.
+      }
+      assertTrue("enqueue-wait histogram should have at least one sample",
+          metrics.namedBlobEnqueueWaitTimeInMs.getCount() >= 1);
+    } finally {
+      db.close();
+    }
+  }
+
+  /**
+   * Verify that submissions are rejected with {@link RestServiceErrorCode#ServiceUnavailable} when the per-datacenter
+   * work queue is full, and that the rejection counter increments. Uses {@code delete} (autoCommit=false) which routes
+   * directly to the local datacenter executor without the cross-DC retry policy that {@code get} applies.
+   */
+  @Test
+  public void testTransactionRejectedWhenQueueFull() throws Exception {
+    MetricRegistry registry = new MetricRegistry();
+    Metrics metrics = new Metrics(registry, "");
+    CountDownLatch workerEntered = new CountDownLatch(1);
+    CountDownLatch releaseWorker = new CountDownLatch(1);
+
+    MySqlNamedBlobDb.DataSourceFactory blockingFactory = endpoint -> {
+      DataSource ds = mock(DataSource.class);
+      try {
+        when(ds.getConnection()).thenAnswer(inv -> {
+          workerEntered.countDown();
+          if (!releaseWorker.await(30, TimeUnit.SECONDS)) {
+            throw new SQLException("test timeout waiting for release");
+          }
+          // Build a connection that yields no rows so the lambda completes once released. The
+          // delete path uses executeUpdate, which we let return 0 rows affected.
+          Connection connection = mock(Connection.class);
+          PreparedStatement statement = mock(PreparedStatement.class);
+          ResultSet resultSet = mock(ResultSet.class);
+          when(resultSet.next()).thenReturn(false);
+          when(statement.executeQuery()).thenReturn(resultSet);
+          when(statement.executeUpdate()).thenReturn(0);
+          when(connection.prepareStatement(any())).thenReturn(statement);
+          return connection;
+        });
+      } catch (SQLException e) {
+        throw new RuntimeException(e);
+      }
+      return ds;
+    };
+
+    MySqlNamedBlobDb db =
+        new MySqlNamedBlobDb(accountService, buildSmallPoolConfig(1, 1, 1), blockingFactory, localDatacenter, metrics);
+    try {
+      // Op 1: occupies the single worker (blocks on releaseWorker latch).
+      CompletableFuture<?> op1 = db.delete(account.getName(), container.getName(), "blob1");
+      assertTrue("worker did not enter dataSource.getConnection()",
+          workerEntered.await(10, TimeUnit.SECONDS));
+      // Op 2: fills the bounded queue (capacity 1).
+      CompletableFuture<?> op2 = db.delete(account.getName(), container.getName(), "blob2");
+      // Op 3: queue is full, worker is busy → AbortPolicy rejects.
+      CompletableFuture<?> op3 = db.delete(account.getName(), container.getName(), "blob3");
+
+      TestUtils.assertException(ExecutionException.class, () -> op3.get(5, TimeUnit.SECONDS), e -> {
+        RestServiceException rse = (RestServiceException) e.getCause();
+        assertEquals("rejected transaction should surface as ServiceUnavailable",
+            RestServiceErrorCode.ServiceUnavailable, rse.getErrorCode());
+      });
+      assertEquals("rejected counter should be 1 after one rejection", 1,
+          metrics.namedBlobTransactionRejectedCount.getCount());
+
+      // Confirm gauges reflect the busy/queued state before we drain.
+      Gauge<?> queueGauge = registry.getGauges()
+          .get("com.github.ambry.named.MySqlNamedBlobDb.TransactionExecutorQueueSize." + localDatacenter);
+      Gauge<?> activeGauge = registry.getGauges()
+          .get("com.github.ambry.named.MySqlNamedBlobDb.TransactionExecutorActiveCount." + localDatacenter);
+      assertNotNull("queue-size gauge missing", queueGauge);
+      assertNotNull("active-count gauge missing", activeGauge);
+      assertEquals("queue should hold op2", 1, ((Number) queueGauge.getValue()).intValue());
+      assertEquals("worker should be running op1", 1, ((Number) activeGauge.getValue()).intValue());
+
+      // Drain the worker so op1 / op2 can complete cleanly during shutdown.
+      releaseWorker.countDown();
+      try {
+        op1.get(10, TimeUnit.SECONDS);
+      } catch (Exception ignored) {
+        // delete on an empty result set typically yields NotFound; we don't care about op1's outcome here.
+      }
+      try {
+        op2.get(10, TimeUnit.SECONDS);
+      } catch (Exception ignored) {
+        // same as above.
+      }
+    } finally {
+      releaseWorker.countDown();
+      db.close();
+    }
+  }
+
+  /**
+   * Build a {@link MySqlNamedBlobDbConfig} with the test datacenters and the given pool / queue sizing.
+   */
+  private MySqlNamedBlobDbConfig buildSmallPoolConfig(int localPoolSize, int remotePoolSize,
+      int maxPendingTransactionsPerDatacenter) {
+    Properties properties = new Properties();
+    JSONArray dbInfo = new JSONArray();
+    for (String datacenter : datacenters) {
+      dbInfo.put(new JSONObject().put("url", "jdbc:mysql://" + datacenter)
+          .put("datacenter", datacenter)
+          .put("isWriteable", true)
+          .put("username", "test")
+          .put("password", "password")
+          .put("sslMode", SSLMode.NONE));
+    }
+    properties.setProperty(MySqlNamedBlobDbConfig.DB_INFO, dbInfo.toString());
+    properties.setProperty(MySqlNamedBlobDbConfig.LOCAL_POOL_SIZE, Integer.toString(localPoolSize));
+    properties.setProperty(MySqlNamedBlobDbConfig.REMOTE_POOL_SIZE, Integer.toString(remotePoolSize));
+    properties.setProperty(MySqlNamedBlobDbConfig.MAX_PENDING_TRANSACTIONS_PER_DATACENTER,
+        Integer.toString(maxPendingTransactionsPerDatacenter));
+    return new MySqlNamedBlobDbConfig(new VerifiableProperties(properties));
   }
 
 

--- a/ambry-named-mysql/src/test/java/com/github/ambry/named/MySqlNamedBlobDbTest.java
+++ b/ambry-named-mysql/src/test/java/com/github/ambry/named/MySqlNamedBlobDbTest.java
@@ -15,7 +15,9 @@
 
 package com.github.ambry.named;
 
+import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.account.Account;
 import com.github.ambry.account.Container;
@@ -154,7 +156,8 @@ public class MySqlNamedBlobDbTest {
 
   /**
    * Verify that {@link MySqlNamedBlobDb.TransactionExecutor} registers the per-datacenter queue-size and
-   * active-count gauges, plus the shared rejected-count and enqueue-wait histograms, on construction.
+   * active-count gauges, the per-datacenter rejected-count counter, and the per-datacenter enqueue-wait histogram
+   * on construction.
    */
   @Test
   public void testTransactionExecutorMetricsRegistered() throws Exception {
@@ -169,18 +172,18 @@ public class MySqlNamedBlobDbTest {
             .containsKey("com.github.ambry.named.MySqlNamedBlobDb.TransactionExecutorQueueSize." + dc));
         assertTrue("active-count gauge missing for datacenter " + dc, registry.getGauges()
             .containsKey("com.github.ambry.named.MySqlNamedBlobDb.TransactionExecutorActiveCount." + dc));
+        assertTrue("rejected counter missing for datacenter " + dc, registry.getCounters()
+            .containsKey("com.github.ambry.named.MySqlNamedBlobDb.NamedBlobTransactionRejectedCount." + dc));
+        assertTrue("enqueue-wait histogram missing for datacenter " + dc, registry.getHistograms()
+            .containsKey("com.github.ambry.named.MySqlNamedBlobDb.NamedBlobEnqueueWaitTimeInMs." + dc));
       }
-      assertTrue("rejected counter missing", registry.getCounters()
-          .containsKey("com.github.ambry.named.MySqlNamedBlobDb.NamedBlobTransactionRejectedCount"));
-      assertTrue("enqueue-wait histogram missing", registry.getHistograms()
-          .containsKey("com.github.ambry.named.MySqlNamedBlobDb.NamedBlobEnqueueWaitTimeInMs"));
     } finally {
       db.close();
     }
   }
 
   /**
-   * Verify that {@link MySqlNamedBlobDb.TransactionExecutor#close()} deregisters the per-datacenter gauges so
+   * Verify that {@link MySqlNamedBlobDb.TransactionExecutor#close()} deregisters all per-datacenter metrics so
    * subsequent instantiations do not leak metrics or fail with duplicate-registration errors.
    */
   @Test
@@ -196,6 +199,10 @@ public class MySqlNamedBlobDbTest {
           .containsKey("com.github.ambry.named.MySqlNamedBlobDb.TransactionExecutorQueueSize." + dc));
       assertFalse("active-count gauge for " + dc + " should be removed after close", registry.getGauges()
           .containsKey("com.github.ambry.named.MySqlNamedBlobDb.TransactionExecutorActiveCount." + dc));
+      assertFalse("rejected counter for " + dc + " should be removed after close", registry.getCounters()
+          .containsKey("com.github.ambry.named.MySqlNamedBlobDb.NamedBlobTransactionRejectedCount." + dc));
+      assertFalse("enqueue-wait histogram for " + dc + " should be removed after close", registry.getHistograms()
+          .containsKey("com.github.ambry.named.MySqlNamedBlobDb.NamedBlobEnqueueWaitTimeInMs." + dc));
     }
   }
 
@@ -218,8 +225,10 @@ public class MySqlNamedBlobDbTest {
       } catch (Exception ignored) {
         // We only care that the worker thread ran and recorded the histogram.
       }
-      assertTrue("enqueue-wait histogram should have at least one sample",
-          metrics.namedBlobEnqueueWaitTimeInMs.getCount() >= 1);
+      Histogram enqueueWaitTime = registry.getHistograms()
+          .get("com.github.ambry.named.MySqlNamedBlobDb.NamedBlobEnqueueWaitTimeInMs." + localDatacenter);
+      assertNotNull("per-datacenter enqueue-wait histogram missing", enqueueWaitTime);
+      assertTrue("enqueue-wait histogram should have at least one sample", enqueueWaitTime.getCount() >= 1);
     } finally {
       db.close();
     }
@@ -279,8 +288,10 @@ public class MySqlNamedBlobDbTest {
         assertEquals("rejected transaction should surface as ServiceUnavailable",
             RestServiceErrorCode.ServiceUnavailable, rse.getErrorCode());
       });
-      assertEquals("rejected counter should be 1 after one rejection", 1,
-          metrics.namedBlobTransactionRejectedCount.getCount());
+      Counter rejected = registry.getCounters()
+          .get("com.github.ambry.named.MySqlNamedBlobDb.NamedBlobTransactionRejectedCount." + localDatacenter);
+      assertNotNull("per-datacenter rejected counter missing", rejected);
+      assertEquals("rejected counter should be 1 after one rejection", 1, rejected.getCount());
 
       // Confirm gauges reflect the busy/queued state before we drain.
       Gauge<?> queueGauge = registry.getGauges()


### PR DESCRIPTION
## Summary

`MySqlNamedBlobDb.TransactionExecutor` currently uses an unbounded `ScheduledThreadPoolExecutor` (via `Utils.newScheduler`). When the named-blob MySQL backend slows down or a replica degrades, the executor's internal `DelayedWorkQueue` grows without limit. Each queued task pins a Netty channel + request context, so the queue accumulates multiple GB of retained heap until the JVM stops responding to liveness probes and is killed by the kubelet.

This PR:

1. Replaces the unbounded executor with a `ThreadPoolExecutor` backed by a bounded `LinkedBlockingQueue(N)` and `AbortPolicy`.
2. Catches `RejectedExecutionException` in `executeTransaction` / `executeTransactionGeneric` and completes the caller's `CompletableFuture` exceptionally with `RestServiceException(ServiceUnavailable)`. Existing cross-DC retry via `transactionStateTracker` remains intact, so a saturated local DC will retry to remote DCs before failing.
3. Adds the new config knob `mysql.named.blob.max.pending.transactions.per.datacenter` (default `100`). Order-of-magnitude sizing: `4 * localPoolSize * p99_query_latency_seconds`.
4. Adds metrics so the queue is observable before it overflows:
   - `MySqlNamedBlobDb.TransactionExecutorQueueSize.<datacenter>` (Gauge)
   - `MySqlNamedBlobDb.TransactionExecutorActiveCount.<datacenter>` (Gauge)
   - `MySqlNamedBlobDb.NamedBlobTransactionRejectedCount` (Counter)
   - `MySqlNamedBlobDb.NamedBlobEnqueueWaitTimeInMs` (Histogram)

Per-datacenter gauges are deregistered on `TransactionExecutor.close()` so repeated lifecycles do not leak metrics.

## Durability notes

Per the durability checklist:
- **Write path:** Rejection happens *before* the worker runs, so no DB write is performed. No partial-state risk.
- **Callback semantics:** Caller-facing change is from "future never completes (until JVM dies)" to "future completes exceptionally with `ServiceUnavailable`." Strictly improves the contract.
- **Resource cleanup:** `Connection` is acquired inside the lambda via try-with-resources; if the lambda is rejected, no connection is acquired.
- **Idempotency:** A rejection is equivalent to no work performed; client retries are safe and required.
- **`dbErrorCounter`:** Not incremented on rejection (this is admission control, not a DB error). The new `NamedBlobTransactionRejectedCount` counter tracks this case explicitly.

## Out-of-scope follow-ups

Identified during analysis but not in this PR:
- `Statement.setQueryTimeout(...)` on every `PreparedStatement` in `run_*_v2` paths.
- Hikari `connectionTimeout` / `validationTimeout` / `leakDetectionThreshold` tuning in `MySqlNamedBlobDbFactory`.
- JDBC URL `socketTimeout` / `connectTimeout` parameters in the dbInfo config.
- Capacity bump for `localPoolSize` (currently 5 — likely under-provisioned, but should be tuned together with the new queue cap once queue-depth metrics are observable).

## Testing Done

- `./gradlew :ambry-named-mysql:test` — 10 tests pass (4 new):
  - `testTransactionExecutorMetricsRegistered` — gauges + counter + histogram registered on construction.
  - `testTransactionExecutorGaugesRemovedOnClose` — gauges deregistered on close.
  - `testEnqueueWaitTimeRecordedOnSuccessfulSubmit` — histogram count > 0 after a normal submit.
  - `testTransactionRejectedWhenQueueFull` — single-thread executor with capacity 1, worker blocked: 1st submit runs, 2nd queues, 3rd rejected with `ServiceUnavailable`. Asserts gauge values reflect busy/queued state and the rejection counter increments.
- `./gradlew compileJava` — full project compiles.
