### PR TITLE
Split STANDBY->LEADER promotion lag metric by peer DC

### DIFF
--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationManager.java
@@ -366,12 +366,19 @@ public class ReplicationManager extends ReplicationEngine {
      * Helix transitions STANDBY -> LEADER without any data-parity check; we emit metrics here so we can
      * verify in production that promoted leaders are actually caught up (or flag when they aren't).
      *
-     * Two mutually exclusive signals per promotion:
-     * - {@link ReplicationMetrics#standbyToLeaderPromotionLagBytes}: max cached lag across peers whose lag
-     *   is known (>= 0). A single known peer is enough to attest readiness, so unknown (-1) peers are
-     *   ignored when at least one peer has a known lag.
+     * Lag against local-DC peers and lag against remote-DC peers carry different operational meaning:
+     * intra-DC replication is all-to-all in both ALL_TO_ALL and LEADER_BASED modes, so a healthy leader
+     * should be ~0 against local peers, while remote-DC lag reflects cross-DC propagation delay and is
+     * non-zero in steady state by design. They are reported as separate histograms.
+     *
+     * Signals per promotion:
+     * - {@link ReplicationMetrics#standbyToLeaderPromotionLocalDcLagBytes}: max cached lag across LOCAL-DC
+     *   peers whose lag is known (>= 0).
+     * - {@link ReplicationMetrics#standbyToLeaderPromotionRemoteDcLagBytes}: max cached lag across REMOTE-DC
+     *   peers whose lag is known (>= 0).
      * - {@link ReplicationMetrics#standbyToLeaderPromotionUnknownLagPeerCount}: incremented when every peer
-     *   of the partition has an unknown cached lag — no peer can attest to the replica's sync state.
+     *   of the partition (local and remote DC) has an unknown cached lag — no peer can attest to the
+     *   replica's sync state.
      */
     private void recordStandbyToLeaderPromotionLag(String partitionName) {
       ReplicaId localReplica = storeManager.getReplica(partitionName);
@@ -382,16 +389,27 @@ public class ReplicationManager extends ReplicationEngine {
       if (partitionInfo == null) {
         return;
       }
-      long maxKnownLag = -1L;
+      String localDc = dataNodeId.getDatacenterName();
+      long maxKnownLocalDcLag = -1L;
+      long maxKnownRemoteDcLag = -1L;
       for (RemoteReplicaInfo remoteReplicaInfo : partitionInfo.getRemoteReplicaInfos()) {
         long lag = remoteReplicaInfo.getLocalLagFromRemoteInBytes();
-        if (lag >= 0) {
-          maxKnownLag = Math.max(maxKnownLag, lag);
+        if (lag < 0) {
+          continue;
+        }
+        if (localDc.equals(remoteReplicaInfo.getReplicaId().getDataNodeId().getDatacenterName())) {
+          maxKnownLocalDcLag = Math.max(maxKnownLocalDcLag, lag);
+        } else {
+          maxKnownRemoteDcLag = Math.max(maxKnownRemoteDcLag, lag);
         }
       }
-      if (maxKnownLag >= 0) {
-        replicationMetrics.standbyToLeaderPromotionLagBytes.update(maxKnownLag);
-      } else {
+      if (maxKnownLocalDcLag >= 0) {
+        replicationMetrics.standbyToLeaderPromotionLocalDcLagBytes.update(maxKnownLocalDcLag);
+      }
+      if (maxKnownRemoteDcLag >= 0) {
+        replicationMetrics.standbyToLeaderPromotionRemoteDcLagBytes.update(maxKnownRemoteDcLag);
+      }
+      if (maxKnownLocalDcLag < 0 && maxKnownRemoteDcLag < 0) {
         replicationMetrics.standbyToLeaderPromotionUnknownLagPeerCount.inc();
       }
     }

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationMetrics.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationMetrics.java
@@ -184,21 +184,31 @@ public class ReplicationMetrics {
 
   public final Counter backupIntegrityError;
 
-  // Max RemoteReplicaInfo.getLocalLagFromRemoteInBytes() across peers of a partition at the moment it transitions
-  // STANDBY -> LEADER, considering only peers with a known (non-negative) cached lag. A well-caught-up STANDBY
-  // should be ~0; non-zero values indicate the replica was promoted before it was fully synced. If any peer
-  // reports a known lag, unknown peers are ignored since one known data point is enough to assess readiness.
-  public final Histogram standbyToLeaderPromotionLagBytes;
+  // Max RemoteReplicaInfo.getLocalLagFromRemoteInBytes() across LOCAL-DC peers of a partition at the moment it
+  // transitions STANDBY -> LEADER, considering only peers with a known (non-negative) cached lag. Intra-DC
+  // replication is all-to-all in both ALL_TO_ALL and LEADER_BASED modes, so a well-caught-up STANDBY should be
+  // ~0 against its local-DC peers; this is the primary signal for promotion fitness. Unknown (-1) peers are
+  // ignored when at least one local-DC peer has a known lag.
+  public final Histogram standbyToLeaderPromotionLocalDcLagBytes;
 
-  // Incremented once per STANDBY -> LEADER promotion when NO peer of the partition has a known cached lag
-  // (every peer is at the -1 sentinel). The replica was promoted with no attested sync signal from any peer.
+  // Max RemoteReplicaInfo.getLocalLagFromRemoteInBytes() across REMOTE-DC peers of a partition at the moment it
+  // transitions STANDBY -> LEADER, considering only peers with a known (non-negative) cached lag. This reflects
+  // cross-DC propagation delay and is non-zero in steady state by design, so it is reported separately from the
+  // local-DC signal. Unknown (-1) peers are ignored when at least one remote-DC peer has a known lag.
+  public final Histogram standbyToLeaderPromotionRemoteDcLagBytes;
+
+  // Incremented once per STANDBY -> LEADER promotion when NO peer of the partition (local or remote DC) has a
+  // known cached lag (every peer is at the -1 sentinel). The replica was promoted with no attested sync signal
+  // from any peer.
   public final Counter standbyToLeaderPromotionUnknownLagPeerCount;
 
   public ReplicationMetrics(MetricRegistry registry, List<? extends ReplicaId> replicaIds) {
     backupIntegrityError =
         registry.counter(MetricRegistry.name(ReplicationMetrics.class, "BackupIntegrityError"));
-    standbyToLeaderPromotionLagBytes =
-        registry.histogram(MetricRegistry.name(ReplicationManager.class, "StandbyToLeaderPromotionLagBytes"));
+    standbyToLeaderPromotionLocalDcLagBytes = registry.histogram(
+        MetricRegistry.name(ReplicationManager.class, "StandbyToLeaderPromotionLocalDcLagBytes"));
+    standbyToLeaderPromotionRemoteDcLagBytes = registry.histogram(
+        MetricRegistry.name(ReplicationManager.class, "StandbyToLeaderPromotionRemoteDcLagBytes"));
     standbyToLeaderPromotionUnknownLagPeerCount =
         registry.counter(MetricRegistry.name(ReplicationManager.class, "StandbyToLeaderPromotionUnknownLagPeerCount"));
     intraColoReplicationBytesRate =

--- a/ambry-replication/src/test/java/com/github/ambry/replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/ReplicationTest.java
@@ -849,43 +849,60 @@ public class ReplicationTest extends ReplicationTestHelper {
   }
 
   /**
-   * When a replica transitions STANDBY -> LEADER with all peers having known (>= 0) cached lag,
-   * the lag histogram should record the max lag across peers and the unknown-lag counter should not move.
+   * When a replica transitions STANDBY -> LEADER with both local-DC and remote-DC peers having known
+   * (>= 0) cached lag, each histogram should record the max lag over its own peer class and the
+   * unknown-lag counter should not move.
    */
   @Test
   public void standbyToLeaderPromotionMetricsKnownLagTest() throws Exception {
-    runStandbyToLeaderPromotionMetricsTest(new long[]{100L, 150L, 200L}, 1, 200L, 0);
+    runStandbyToLeaderPromotionMetricsTest(100L, 50L, 200L, 250L, 1, 100L, 1, 250L, 0);
   }
 
   /**
-   * When a replica transitions STANDBY -> LEADER with all peers at the -1 sentinel (never synced),
-   * the unknown-lag counter should increment and the lag histogram should not record.
+   * When every peer (local-DC and remote-DC) is at the -1 sentinel, the unknown-lag counter should
+   * increment exactly once and neither histogram should record.
    */
   @Test
   public void standbyToLeaderPromotionMetricsAllUnknownLagTest() throws Exception {
-    runStandbyToLeaderPromotionMetricsTest(new long[]{-1L, -1L, -1L}, 0, -1L, 1);
+    runStandbyToLeaderPromotionMetricsTest(-1L, -1L, -1L, -1L, 0, -1L, 0, -1L, 1);
   }
 
   /**
-   * When peers have a mix of known and unknown lag, the histogram records the max over only the known
-   * values and the unknown-lag counter does not move (a single known peer is enough to attest readiness).
+   * When only local-DC peers have known lag (all remote-DC peers unknown), only the local-DC histogram
+   * records; the unknown-lag counter does not move because at least one peer can attest sync state.
    */
   @Test
-  public void standbyToLeaderPromotionMetricsMixedLagTest() throws Exception {
-    runStandbyToLeaderPromotionMetricsTest(new long[]{250L, -1L, -1L}, 1, 250L, 0);
+  public void standbyToLeaderPromotionMetricsLocalDcOnlyKnownTest() throws Exception {
+    runStandbyToLeaderPromotionMetricsTest(75L, 125L, -1L, -1L, 1, 125L, 0, -1L, 0);
   }
 
   /**
-   * Drives one STANDBY -> LEADER promotion with per-peer cached lags and asserts histogram/counter state.
-   * A {@code peerLag} of -1 leaves the peer at its default (unknown) value; any other value is applied
-   * via {@link RemoteReplicaInfo#setLocalLagFromRemoteInBytes(long)}.
-   * @param peerLags per-peer lag values to assign (in {@link PartitionInfo#getRemoteReplicaInfos()} order)
-   * @param expectedHistogramCount expected observation count on standbyToLeaderPromotionLagBytes
-   * @param expectedHistogramMax expected histogram max; ignored when expectedHistogramCount is 0
+   * When only remote-DC peers have known lag (all local-DC peers unknown), only the remote-DC histogram
+   * records; the unknown-lag counter does not move.
+   */
+  @Test
+  public void standbyToLeaderPromotionMetricsRemoteDcOnlyKnownTest() throws Exception {
+    runStandbyToLeaderPromotionMetricsTest(-1L, -1L, 300L, 400L, 0, -1L, 1, 400L, 0);
+  }
+
+  /**
+   * Drives one STANDBY -> LEADER promotion with per-peer-class cached lags and asserts histogram/counter
+   * state. Each {@code lag} value of -1 leaves that peer at its default (unknown) value; any other value
+   * is applied via {@link RemoteReplicaInfo#setLocalLagFromRemoteInBytes(long)}. At most two peers per
+   * class are exercised; this is sufficient to validate per-class max selection.
+   * @param localPeerLag1 lag for the first local-DC peer ({@code -1} leaves it unknown)
+   * @param localPeerLag2 lag for the second local-DC peer ({@code -1} leaves it unknown)
+   * @param remotePeerLag1 lag for the first remote-DC peer ({@code -1} leaves it unknown)
+   * @param remotePeerLag2 lag for the second remote-DC peer ({@code -1} leaves it unknown)
+   * @param expectedLocalHistogramCount expected observation count on standbyToLeaderPromotionLocalDcLagBytes
+   * @param expectedLocalHistogramMax expected local-DC histogram max; ignored when count is 0
+   * @param expectedRemoteHistogramCount expected observation count on standbyToLeaderPromotionRemoteDcLagBytes
+   * @param expectedRemoteHistogramMax expected remote-DC histogram max; ignored when count is 0
    * @param expectedUnknownLagCount expected value of standbyToLeaderPromotionUnknownLagPeerCount
    */
-  private void runStandbyToLeaderPromotionMetricsTest(long[] peerLags, int expectedHistogramCount,
-      long expectedHistogramMax, int expectedUnknownLagCount) throws Exception {
+  private void runStandbyToLeaderPromotionMetricsTest(long localPeerLag1, long localPeerLag2, long remotePeerLag1,
+      long remotePeerLag2, int expectedLocalHistogramCount, long expectedLocalHistogramMax,
+      int expectedRemoteHistogramCount, long expectedRemoteHistogramMax, int expectedUnknownLagCount) throws Exception {
     MockClusterMap clusterMap = new MockClusterMap();
     ClusterMapConfig clusterMapConfig = new ClusterMapConfig(verifiableProperties);
     MockHelixParticipant.metricRegistry = new MetricRegistry();
@@ -895,25 +912,48 @@ public class ReplicationTest extends ReplicationTestHelper {
     StorageManager storageManager = managers.getFirst();
     MockReplicationManager replicationManager = (MockReplicationManager) managers.getSecond();
 
+    String localDc = clusterMap.getDataNodeIds().get(0).getDatacenterName();
     PartitionId partitionId = replicationManager.partitionToPartitionInfo.keySet().iterator().next();
     List<RemoteReplicaInfo> remoteReplicaInfos =
         replicationManager.partitionToPartitionInfo.get(partitionId).getRemoteReplicaInfos();
-    assertTrue("Test requires partition to have at least " + peerLags.length + " peers",
-        remoteReplicaInfos.size() >= peerLags.length);
-    for (int i = 0; i < peerLags.length; i++) {
-      if (peerLags[i] >= 0) {
-        remoteReplicaInfos.get(i).setLocalLagFromRemoteInBytes(peerLags[i]);
+    List<RemoteReplicaInfo> localDcPeers = new ArrayList<>();
+    List<RemoteReplicaInfo> remoteDcPeers = new ArrayList<>();
+    for (RemoteReplicaInfo info : remoteReplicaInfos) {
+      if (localDc.equals(info.getReplicaId().getDataNodeId().getDatacenterName())) {
+        localDcPeers.add(info);
+      } else {
+        remoteDcPeers.add(info);
       }
     }
+    assertTrue("Test requires partition to have at least 2 local-DC peers", localDcPeers.size() >= 2);
+    assertTrue("Test requires partition to have at least 2 remote-DC peers", remoteDcPeers.size() >= 2);
+    if (localPeerLag1 >= 0) {
+      localDcPeers.get(0).setLocalLagFromRemoteInBytes(localPeerLag1);
+    }
+    if (localPeerLag2 >= 0) {
+      localDcPeers.get(1).setLocalLagFromRemoteInBytes(localPeerLag2);
+    }
+    if (remotePeerLag1 >= 0) {
+      remoteDcPeers.get(0).setLocalLagFromRemoteInBytes(remotePeerLag1);
+    }
+    if (remotePeerLag2 >= 0) {
+      remoteDcPeers.get(1).setLocalLagFromRemoteInBytes(remotePeerLag2);
+    }
 
-    Histogram histogram = replicationManager.replicationMetrics.standbyToLeaderPromotionLagBytes;
+    Histogram localDcHistogram = replicationManager.replicationMetrics.standbyToLeaderPromotionLocalDcLagBytes;
+    Histogram remoteDcHistogram = replicationManager.replicationMetrics.standbyToLeaderPromotionRemoteDcLagBytes;
     Counter counter = replicationManager.replicationMetrics.standbyToLeaderPromotionUnknownLagPeerCount;
 
     mockHelixParticipant.onPartitionBecomeLeaderFromStandby(partitionId.toPathString());
 
-    assertEquals("Lag histogram observation count", expectedHistogramCount, histogram.getCount());
-    if (expectedHistogramCount > 0) {
-      assertEquals("Lag histogram max", expectedHistogramMax, histogram.getSnapshot().getMax());
+    assertEquals("Local-DC lag histogram observation count", expectedLocalHistogramCount, localDcHistogram.getCount());
+    if (expectedLocalHistogramCount > 0) {
+      assertEquals("Local-DC lag histogram max", expectedLocalHistogramMax, localDcHistogram.getSnapshot().getMax());
+    }
+    assertEquals("Remote-DC lag histogram observation count", expectedRemoteHistogramCount,
+        remoteDcHistogram.getCount());
+    if (expectedRemoteHistogramCount > 0) {
+      assertEquals("Remote-DC lag histogram max", expectedRemoteHistogramMax, remoteDcHistogram.getSnapshot().getMax());
     }
     assertEquals("Unknown-lag counter", expectedUnknownLagCount, counter.getCount());
 


### PR DESCRIPTION
The single max-across-all-peers histogram conflates two signals with different operational meanings: 
- Lag against local-DC peers 
- LEADER_BASED modes

Splitting the two into different metrics
