### PR TITLE
Bind EchoServer to an OS-assigned port to avoid TIME_WAIT hangs

### DIFF
--- a/ambry-network/src/test/java/com/github/ambry/network/EchoServer.java
+++ b/ambry-network/src/test/java/com/github/ambry/network/EchoServer.java
@@ -51,7 +51,6 @@ public class EchoServer extends Thread {
    * Create an EchoServer that supports SSL connections
    */
   public EchoServer(SSLFactory sslFactory, int port) throws Exception {
-    this.port = port;
     if (sslFactory == null) {
       this.serverSocket = new ServerSocket(port);
     } else {
@@ -61,6 +60,8 @@ public class EchoServer extends Thread {
       // enable mutual authentication
       ((SSLServerSocket) this.serverSocket).setNeedClientAuth(true);
     }
+    // Resolve from the bound socket so callers passing 0 get the OS-assigned port.
+    this.port = serverSocket.getLocalPort();
     this.threads = Collections.synchronizedList(new ArrayList<Thread>());
     this.sockets = Collections.synchronizedList(new ArrayList<Socket>());
     this.exceptions = Collections.synchronizedList(new ArrayList<Exception>());

--- a/ambry-network/src/test/java/com/github/ambry/network/SSLSelectorTest.java
+++ b/ambry-network/src/test/java/com/github/ambry/network/SSLSelectorTest.java
@@ -105,7 +105,9 @@ public class SSLSelectorTest {
     SSLConfig clientSSLConfig = new SSLConfig(new VerifiableProperties(clientProps));
     SSLFactory serverSSLFactory = SSLFactory.getNewInstance(sslConfig);
     clientSSLFactory = SSLFactory.getNewInstance(clientSSLConfig);
-    server = new EchoServer(serverSSLFactory, 18383);
+    // Bind to an OS-assigned port. A hard-coded port triggers Address-already-in-use / TIME_WAIT
+    // stalls when each parameterized run rebinds the same port back-to-back.
+    server = new EchoServer(serverSSLFactory, 0);
     server.start();
     applicationBufferSize = clientSSLFactory.createSSLEngine("localhost", server.port, SSLFactory.Mode.CLIENT)
         .getSession()

--- a/ambry-network/src/test/java/com/github/ambry/network/SelectorTest.java
+++ b/ambry-network/src/test/java/com/github/ambry/network/SelectorTest.java
@@ -69,7 +69,9 @@ public class SelectorTest {
 
   @Before
   public void setup() throws Exception {
-    this.server = new EchoServer(18283);
+    // Bind to an OS-assigned port. A hard-coded port triggers Address-already-in-use / TIME_WAIT
+    // stalls when @Before rebinds the same port across parameterized test methods.
+    this.server = new EchoServer(0);
     this.server.start();
     Properties props = new Properties();
     props.setProperty("selector.executor.pool.size", Integer.toString(selectorExecutorPoolSize));


### PR DESCRIPTION
## Summary

Right now the pr workflow consistently fails at the same spot

https://github.com/linkedin/ambry/actions/runs/25126043114/job/73678904124
https://github.com/linkedin/ambry/actions/runs/25063003695/job/73620213308


SSLSelectorTest and SelectorTest re-create an EchoServer for every parameterized test method, each time on the same hard-coded port (18383 and 18283). Between runs the previous bind sits in TIME_WAIT, so the next ServerSocket(port) call intermittently stalls on Ubuntu CI runners and the unit-test job hangs until GitHub kills it. Reproduced as the "last test event = SSLBlockingChannelTest > testRenegotiation, then silence" pattern in recent master CI runs.

Pass 0 to let the OS pick a free port, and resolve EchoServer.port from the bound ServerSocket so callers still read the actual port via server.port. Existing fixed-port callers (SSLBlockingChannelTest's @BeforeClass) keep their behavior.


## Testing Done
- ./gradlew :ambry-network:test --rerun-tasks --tests SSLSelectorTest --tests SelectorTest --tests SSLBlockingChannelTest on JDK 11: BUILD SUCCESSFUL, all parameter sets pass.


