### PR TITLE
Return 5xx instead of 404 when named blob metadata exists but storage replicas return NOT_FOUND

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/router/Router.java
+++ b/ambry-api/src/main/java/com/github/ambry/router/Router.java
@@ -153,26 +153,19 @@ public interface Router extends Closeable {
   }
 
   /**
-   * Variant of {@link #getBlob(String, GetBlobOptions, Callback, QuotaChargeCallback)} that accepts a
-   * {@link RestRequest} so the router can resolve a named-blob path (e.g. {@code /named/{account}/{container}/{name}})
-   * to a concrete blob ID via the configured {@code IdConverter} before issuing the storage GET. The simpler
-   * {@code String}-based overload should be used when the caller already has a resolved blob ID.
+   * Variant that accepts a {@link RestRequest} so the router can resolve a named-blob path
+   * (e.g. {@code /named/{account}/{container}/{name}}) via {@code IdConverter} before the storage GET.
+   * Use the {@code String}-only overload when the caller already has a resolved blob ID.
    * <p/>
-   * <strong>Named-blob inconsistency translation:</strong> when the {@code IdConverter} successfully resolves
-   * the named-blob metadata but the storage layer subsequently returns
-   * {@link RouterErrorCode#BlobDoesNotExist} on every replica, implementations may translate the failure to
-   * {@link RouterErrorCode#AmbryUnavailable} so the response surfaces as a retryable 503 rather than an
-   * authoritative 404. This is consistent with the contract that named-blob metadata, once resolved, should
-   * be treated as a strong claim that the blob exists; a missing storage replica response is therefore
-   * reported as transient unavailability, not absence.
-   * @param restRequest The {@link RestRequest} associated with the operation; used by the router to invoke
-   *                    the {@code IdConverter} when {@code blobId} is a named-blob path.
-   * @param blobId The ID of the blob for which blob data is requested, or a named-blob path when paired with
-   *               a non-null {@code restRequest}.
-   * @param options The options associated with the request.
-   * @param callback The {@link Callback} which will be invoked on the completion of the request.
-   * @param quotaChargeCallback The {@link QuotaChargeCallback} for accounting against the request's quota.
-   * @return A future that will eventually contain the {@link GetBlobResult} or an exception.
+   * After {@code IdConverter} resolves named-blob metadata, implementations may translate a subsequent
+   * {@link RouterErrorCode#BlobDoesNotExist} from storage to {@link RouterErrorCode#AmbryUnavailable}
+   * (retryable 503) — once metadata says the blob exists, a missing storage response is treated as transient.
+   * @param restRequest used to invoke {@code IdConverter} for named-blob paths.
+   * @param blobId blob ID, or a named-blob path when {@code restRequest} is non-null.
+   * @param options request options.
+   * @param callback invoked on completion.
+   * @param quotaChargeCallback for quota accounting.
+   * @return future containing the {@link GetBlobResult} or an exception.
    */
   default Future<GetBlobResult> getBlob(RestRequest restRequest, String blobId, GetBlobOptions options, Callback<GetBlobResult> callback,
       QuotaChargeCallback quotaChargeCallback) {

--- a/ambry-api/src/main/java/com/github/ambry/router/Router.java
+++ b/ambry-api/src/main/java/com/github/ambry/router/Router.java
@@ -152,6 +152,28 @@ public interface Router extends Closeable {
     return future;
   }
 
+  /**
+   * Variant of {@link #getBlob(String, GetBlobOptions, Callback, QuotaChargeCallback)} that accepts a
+   * {@link RestRequest} so the router can resolve a named-blob path (e.g. {@code /named/{account}/{container}/{name}})
+   * to a concrete blob ID via the configured {@code IdConverter} before issuing the storage GET. The simpler
+   * {@code String}-based overload should be used when the caller already has a resolved blob ID.
+   * <p/>
+   * <strong>Named-blob inconsistency translation:</strong> when the {@code IdConverter} successfully resolves
+   * the named-blob metadata but the storage layer subsequently returns
+   * {@link RouterErrorCode#BlobDoesNotExist} on every replica, implementations may translate the failure to
+   * {@link RouterErrorCode#AmbryUnavailable} so the response surfaces as a retryable 503 rather than an
+   * authoritative 404. This is consistent with the contract that named-blob metadata, once resolved, should
+   * be treated as a strong claim that the blob exists; a missing storage replica response is therefore
+   * reported as transient unavailability, not absence.
+   * @param restRequest The {@link RestRequest} associated with the operation; used by the router to invoke
+   *                    the {@code IdConverter} when {@code blobId} is a named-blob path.
+   * @param blobId The ID of the blob for which blob data is requested, or a named-blob path when paired with
+   *               a non-null {@code restRequest}.
+   * @param options The options associated with the request.
+   * @param callback The {@link Callback} which will be invoked on the completion of the request.
+   * @param quotaChargeCallback The {@link QuotaChargeCallback} for accounting against the request's quota.
+   * @return A future that will eventually contain the {@link GetBlobResult} or an exception.
+   */
   default Future<GetBlobResult> getBlob(RestRequest restRequest, String blobId, GetBlobOptions options, Callback<GetBlobResult> callback,
       QuotaChargeCallback quotaChargeCallback) {
     return getBlob(blobId, options, callback, quotaChargeCallback);

--- a/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouter.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouter.java
@@ -322,14 +322,47 @@ public class NonBlockingRouter implements Router {
     if (restRequest != null) {
       idConverter.convert(restRequest, blobIdStr).whenComplete((convertedId, exception) -> {
         if (exception != null) {
-          completeOperation(futureResult, callback, null, (Exception) exception);
+          // The operations counter is only incremented inside getBlobHelper; if idConverter
+          // fails we never reached that path, so do not decrement here.
+          completeOperation(futureResult, callback, null, (Exception) exception, false);
         } else {
-          getBlobHelper(convertedId, options, callback, quotaChargeCallback, futureResult);
+          // Named blob metadata was resolved successfully. If the storage layer then
+          // returns BlobDoesNotExist, treat it as transient (replication lag, in-flight
+          // delete race, or replica outage) and translate to AmbryUnavailable so clients
+          // receive a retryable 503 rather than an authoritative 404 — the named blob
+          // metadata says the blob exists, so a missing storage replica response is
+          // inconsistent with metadata and should not be reported as permanent absence.
+          FutureResult<GetBlobResult> innerFuture = new FutureResult<>();
+          Callback<GetBlobResult> wrappedCallback = (result, e) -> {
+            Exception translated = translateNamedBlobMissingInStorage(e);
+            futureResult.done(result, translated);
+            if (callback != null) {
+              callback.onCompletion(result, translated);
+            }
+          };
+          getBlobHelper(convertedId, options, wrappedCallback, quotaChargeCallback, innerFuture);
         }
       });
     }
     // Direct path when blobIdStr is already provided
     return futureResult;
+  }
+
+  /**
+   * If {@code e} is a {@link RouterException} with {@link RouterErrorCode#BlobDoesNotExist}
+   * raised after a successful named-blob metadata lookup, translate it to
+   * {@link RouterErrorCode#AmbryUnavailable} so the response surfaces as a retryable
+   * 503 rather than an authoritative 404. Other exceptions and {@code null} pass through.
+   */
+  private Exception translateNamedBlobMissingInStorage(Exception e) {
+    if (e instanceof RouterException
+        && ((RouterException) e).getErrorCode() == RouterErrorCode.BlobDoesNotExist) {
+      routerMetrics.namedBlobMetadataExistsButStorageNotFoundCount.inc();
+      return new RouterException(
+          "Named blob metadata exists but storage returned BlobNotFound; treating as transient.",
+          RouterErrorCode.AmbryUnavailable);
+    }
+    return e;
   }
 
   private void getBlobHelper(String blobIdStr, GetBlobOptions options, Callback<GetBlobResult> callback,

--- a/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouter.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouter.java
@@ -359,7 +359,7 @@ public class NonBlockingRouter implements Router {
         && ((RouterException) e).getErrorCode() == RouterErrorCode.BlobDoesNotExist) {
       routerMetrics.namedBlobMetadataExistsButStorageNotFoundCount.inc();
       return new RouterException(
-          "Named blob metadata exists but storage returned BlobNotFound; treating as transient.",
+          "Named blob metadata exists but storage returned BlobNotFound for the resolved blob ID.",
           RouterErrorCode.AmbryUnavailable);
     }
     return e;

--- a/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouter.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouter.java
@@ -329,7 +329,7 @@ public class NonBlockingRouter implements Router {
           // AmbryUnavailable so clients retry (503) instead of getting 404.
           FutureResult<GetBlobResult> innerFuture = new FutureResult<>();
           Callback<GetBlobResult> wrappedCallback = (result, e) -> {
-            Exception translated = translateNamedBlobMissingInStorage(e);
+            Exception translated = translateNamedBlobMissingInStorage(convertedId, e);
             futureResult.done(result, translated);
             if (callback != null) {
               callback.onCompletion(result, translated);
@@ -347,10 +347,12 @@ public class NonBlockingRouter implements Router {
    * Translate {@link RouterErrorCode#BlobDoesNotExist} to {@link RouterErrorCode#AmbryUnavailable}
    * (retryable 503, not authoritative 404). Other exceptions pass through.
    */
-  private Exception translateNamedBlobMissingInStorage(Exception e) {
+  private Exception translateNamedBlobMissingInStorage(String resolvedBlobId, Exception e) {
     if (e instanceof RouterException
         && ((RouterException) e).getErrorCode() == RouterErrorCode.BlobDoesNotExist) {
       routerMetrics.namedBlobMetadataExistsButStorageNotFoundCount.inc();
+      logger.warn("Named blob metadata exists but storage returned BlobNotFound for blob {}; "
+          + "translating to AmbryUnavailable (retryable 503)", resolvedBlobId);
       return new RouterException(
           "Named blob metadata exists but storage returned BlobNotFound for the resolved blob ID.",
           RouterErrorCode.AmbryUnavailable);

--- a/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouter.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouter.java
@@ -322,16 +322,11 @@ public class NonBlockingRouter implements Router {
     if (restRequest != null) {
       idConverter.convert(restRequest, blobIdStr).whenComplete((convertedId, exception) -> {
         if (exception != null) {
-          // The operations counter is only incremented inside getBlobHelper; if idConverter
-          // fails we never reached that path, so do not decrement here.
+          // Skip decrement: only getBlobHelper increments, and we never reached it.
           completeOperation(futureResult, callback, null, (Exception) exception, false);
         } else {
-          // Named blob metadata was resolved successfully. If the storage layer then
-          // returns BlobDoesNotExist, treat it as transient (replication lag, in-flight
-          // delete race, or replica outage) and translate to AmbryUnavailable so clients
-          // receive a retryable 503 rather than an authoritative 404 — the named blob
-          // metadata says the blob exists, so a missing storage replica response is
-          // inconsistent with metadata and should not be reported as permanent absence.
+          // Metadata says the blob exists. Translate storage BlobDoesNotExist to
+          // AmbryUnavailable so clients retry (503) instead of getting 404.
           FutureResult<GetBlobResult> innerFuture = new FutureResult<>();
           Callback<GetBlobResult> wrappedCallback = (result, e) -> {
             Exception translated = translateNamedBlobMissingInStorage(e);
@@ -349,10 +344,8 @@ public class NonBlockingRouter implements Router {
   }
 
   /**
-   * If {@code e} is a {@link RouterException} with {@link RouterErrorCode#BlobDoesNotExist}
-   * raised after a successful named-blob metadata lookup, translate it to
-   * {@link RouterErrorCode#AmbryUnavailable} so the response surfaces as a retryable
-   * 503 rather than an authoritative 404. Other exceptions and {@code null} pass through.
+   * Translate {@link RouterErrorCode#BlobDoesNotExist} to {@link RouterErrorCode#AmbryUnavailable}
+   * (retryable 503, not authoritative 404). Other exceptions pass through.
    */
   private Exception translateNamedBlobMissingInStorage(Exception e) {
     if (e instanceof RouterException

--- a/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterMetrics.java
@@ -138,6 +138,7 @@ public class NonBlockingRouterMetrics {
   public final Counter forceDeleteBlobErrorCount;
   public final Counter backgroundDeleterNotFoundCount;
   public final Counter backgroundDeleterExceptionCount;
+  public final Counter namedBlobMetadataExistsButStorageNotFoundCount;
   public final Counter operationAbortCount;
   public final Counter routerRequestErrorCount;
 
@@ -450,6 +451,8 @@ public class NonBlockingRouterMetrics {
     operationAbortCount = metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "OperationAbortCount"));
     routerRequestErrorCount =
         metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "RouterRequestErrorCount"));
+    namedBlobMetadataExistsButStorageNotFoundCount = metricRegistry.counter(
+        MetricRegistry.name(NonBlockingRouter.class, "NamedBlobMetadataExistsButStorageNotFoundCount"));
 
     // Counters for various errors.
     ambryUnavailableErrorCount =

--- a/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTest.java
@@ -1239,11 +1239,7 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
     }
   }
 
-  /**
-   * When idConverter resolves named blob metadata successfully but the storage layer
-   * returns BlobNotFound, the router translates the response to AmbryUnavailable so
-   * the response surfaces as a retryable 503 rather than an authoritative 404.
-   */
+  /** Storage NOT_FOUND after metadata resolves → AmbryUnavailable (retryable 503). */
   @Test
   public void testNamedBlobMissingInStorageTranslatedToAmbryUnavailable() throws Exception {
     Properties props = getNonBlockingRouterProperties(localDcName);
@@ -1253,7 +1249,7 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
     IdConverterFactory mockIdConverterFactory = mock(IdConverterFactory.class);
     IdConverter mockIdConverter = mock(IdConverter.class);
     when(mockIdConverterFactory.getIdConverter()).thenReturn(mockIdConverter);
-    // PUT path: capture the resolved blob ID so the GET-path mock can return it.
+    // PUT: capture resolved blob ID for the GET mock.
     when(mockIdConverter.convert(any(RestRequest.class), anyString(), any(), any())).thenAnswer(invocation -> {
       FutureResult<String> futureResult = new FutureResult<>();
       String blobId = invocation.getArgument(1);
@@ -1281,14 +1277,14 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
           null, null).get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
       putCompletedLatch.await();
 
-      // GET path: idConverter resolves successfully (metadata exists), returning the put blob ID.
+      // GET: idConverter returns the put blob ID (metadata exists).
       when(mockIdConverter.convert(any(RestRequest.class), anyString())).thenAnswer(invocation -> {
         CompletableFuture<String> completableFuture = new CompletableFuture<>();
         completableFuture.complete(storedBlobId.get());
         return completableFuture;
       });
 
-      // Force every storage replica to return BlobNotFound so the router resolves to BlobDoesNotExist.
+      // All replicas reply BlobNotFound.
       layout.getMockServers()
           .forEach(mockServer -> mockServer.setServerErrorForAllRequests(ServerErrorCode.BlobNotFound));
 
@@ -1303,10 +1299,10 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
       } catch (ExecutionException ee) {
         Assert.assertTrue("Expected RouterException, got " + ee.getCause(),
             ee.getCause() instanceof RouterException);
-        Assert.assertEquals("Expected AmbryUnavailable after metadata-found-but-storage-NOT_FOUND",
+        Assert.assertEquals("Expected AmbryUnavailable",
             RouterErrorCode.AmbryUnavailable, ((RouterException) ee.getCause()).getErrorCode());
       }
-      Assert.assertEquals("Translation metric should have incremented exactly once", 1L,
+      Assert.assertEquals("Translation metric should be 1", 1L,
           routerMetrics.namedBlobMetadataExistsButStorageNotFoundCount.getCount());
     } finally {
       if (router != null) {
@@ -1316,11 +1312,7 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
     }
   }
 
-  /**
-   * Regression: when the named blob metadata itself is not found, the response still
-   * surfaces as RestServiceErrorCode.NotFound. The translation must only kick in after
-   * idConverter has resolved metadata successfully.
-   */
+  /** Regression: idConverter NotFound stays as NotFound (translation only fires after success). */
   @Test
   public void testNamedBlobMetadataNotFoundStillReturnsNotFound() throws Exception {
     Properties props = getNonBlockingRouterProperties(localDcName);
@@ -1339,7 +1331,7 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
         mockIdConverterFactory);
 
     try {
-      // assertClosed in tearDown exercises putBlob; ensure operation params are populated.
+      // tearDown's assertClosed calls putBlob; populate params.
       setOperationParams();
       RestRequest getRequest =
           createNamedBlobRestRequest(RestMethod.GET, "accountName", "containerName", "missingBlob", false, false, false,
@@ -1356,7 +1348,7 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
         Assert.assertEquals(RestServiceErrorCode.NotFound,
             ((RestServiceException) ee.getCause()).getErrorCode());
       }
-      Assert.assertEquals("Translation metric must not increment when metadata lookup itself failed", 0L,
+      Assert.assertEquals("Translation metric should be 0", 0L,
           routerMetrics.namedBlobMetadataExistsButStorageNotFoundCount.getCount());
     } finally {
       if (router != null) {
@@ -1366,11 +1358,7 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
     }
   }
 
-  /**
-   * Translation must also fire when {@code getBlobHelper}'s notFoundCache short-circuit completes the operation.
-   * That path bypasses the per-replica storage call and synthesises BlobDoesNotExist via {@code completeOperation}
-   * rather than {@code BlobOperationCallbackWrapper}, so we cover it explicitly.
-   */
+  /** Translation also fires when getBlobHelper short-circuits via the notFoundCache. */
   @Test
   public void testNamedBlobMissingViaNotFoundCacheStillTranslatedToAmbryUnavailable() throws Exception {
     Properties props = getNonBlockingRouterProperties(localDcName);
@@ -1407,15 +1395,14 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
           null, null).get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
       putCompletedLatch.await();
 
-      // GET path: idConverter resolves successfully (metadata exists), returning the put blob ID.
+      // GET: idConverter returns the put blob ID (metadata exists).
       when(mockIdConverter.convert(any(RestRequest.class), anyString())).thenAnswer(invocation -> {
         CompletableFuture<String> completableFuture = new CompletableFuture<>();
         completableFuture.complete(storedBlobId.get());
         return completableFuture;
       });
 
-      // Pre-populate the notFoundCache for the resolved blob ID so getBlobHelper short-circuits via
-      // completeOperation(...) rather than going to the storage layer.
+      // Pre-populate notFoundCache so getBlobHelper short-circuits.
       router.getNotFoundCache().put(storedBlobId.get(), Boolean.TRUE);
 
       RestRequest getRequest =
@@ -1429,11 +1416,10 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
       } catch (ExecutionException ee) {
         Assert.assertTrue("Expected RouterException, got " + ee.getCause(),
             ee.getCause() instanceof RouterException);
-        Assert.assertEquals(
-            "notFoundCache short-circuit must also be translated to AmbryUnavailable when metadata exists",
+        Assert.assertEquals("Expected AmbryUnavailable",
             RouterErrorCode.AmbryUnavailable, ((RouterException) ee.getCause()).getErrorCode());
       }
-      Assert.assertEquals("Translation metric should have incremented exactly once", 1L,
+      Assert.assertEquals("Translation metric should be 1", 1L,
           routerMetrics.namedBlobMetadataExistsButStorageNotFoundCount.getCount());
     } finally {
       if (router != null) {

--- a/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTest.java
@@ -1242,191 +1242,119 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
   /** Storage NOT_FOUND after metadata resolves → AmbryUnavailable (retryable 503). */
   @Test
   public void testNamedBlobMissingInStorageTranslatedToAmbryUnavailable() throws Exception {
-    Properties props = getNonBlockingRouterProperties(localDcName);
-    final AtomicReference<String> storedBlobId = new AtomicReference<>();
-    CountDownLatch putCompletedLatch = new CountDownLatch(1);
-
-    IdConverterFactory mockIdConverterFactory = mock(IdConverterFactory.class);
-    IdConverter mockIdConverter = mock(IdConverter.class);
-    when(mockIdConverterFactory.getIdConverter()).thenReturn(mockIdConverter);
-    // PUT: capture resolved blob ID for the GET mock.
-    when(mockIdConverter.convert(any(RestRequest.class), anyString(), any(), any())).thenAnswer(invocation -> {
-      FutureResult<String> futureResult = new FutureResult<>();
-      String blobId = invocation.getArgument(1);
-      Callback<String> callback = invocation.getArgument(3);
-      storedBlobId.set(blobId);
-      if (callback != null) {
-        callback.onCompletion(blobId, null);
-      }
-      futureResult.done(blobId, null);
-      putCompletedLatch.countDown();
-      return futureResult;
-    });
-
-    MockServerLayout layout = new MockServerLayout(mockClusterMap);
-    setRouterWithIdConverterFactory(props, layout, new LoggingNotificationSystem(), mockIdConverterFactory);
-
+    AtomicReference<String> storedBlobId = new AtomicReference<>();
+    // PUT a named blob; subsequent GETs will resolve to its blob ID via the mock.
+    MockServerLayout layout = setUpNamedBlobAndPut(storedBlobId);
     try {
-      final String accountName = "accountName";
-      final String containerName = "containerName";
-      final String blobName = "blobName";
-      setOperationParams();
-      RestRequest putRequest =
-          createNamedBlobRestRequest(RestMethod.PUT, accountName, containerName, blobName, false, false, false, false);
-      router.putBlob(putRequest, putBlobProperties, putUserMetadata, putChannel, new PutBlobOptionsBuilder().build(),
-          null, null).get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-      putCompletedLatch.await();
-
-      // GET: idConverter returns the put blob ID (metadata exists).
-      when(mockIdConverter.convert(any(RestRequest.class), anyString())).thenAnswer(invocation -> {
-        CompletableFuture<String> completableFuture = new CompletableFuture<>();
-        completableFuture.complete(storedBlobId.get());
-        return completableFuture;
-      });
-
-      // All replicas reply BlobNotFound.
-      layout.getMockServers()
-          .forEach(mockServer -> mockServer.setServerErrorForAllRequests(ServerErrorCode.BlobNotFound));
-
-      RestRequest getRequest =
-          createNamedBlobRestRequest(RestMethod.GET, accountName, containerName, blobName, false, false, false, true);
-      Future<GetBlobResult> future = router.getBlob(getRequest, (String) getRequest.getArgs().get(BLOB_ID),
-          new GetBlobOptionsBuilder().build(), null, null);
-
-      try {
-        future.get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-        Assert.fail("Expected RouterException with AmbryUnavailable");
-      } catch (ExecutionException ee) {
-        Assert.assertTrue("Expected RouterException, got " + ee.getCause(),
-            ee.getCause() instanceof RouterException);
-        Assert.assertEquals("Expected AmbryUnavailable",
-            RouterErrorCode.AmbryUnavailable, ((RouterException) ee.getCause()).getErrorCode());
-      }
-      Assert.assertEquals("Translation metric should be 1", 1L,
-          routerMetrics.namedBlobMetadataExistsButStorageNotFoundCount.getCount());
+      // All replicas reply BlobNotFound to trigger storage-side miss.
+      layout.getMockServers().forEach(s -> s.setServerErrorForAllRequests(ServerErrorCode.BlobNotFound));
+      assertNamedBlobGetTranslatedToAmbryUnavailable("a", "c", "b");
     } finally {
-      if (router != null) {
-        router.close();
-        assertClosed();
-      }
+      if (router != null) { router.close(); assertClosed(); }
     }
   }
 
   /** Regression: idConverter NotFound stays as NotFound (translation only fires after success). */
   @Test
   public void testNamedBlobMetadataNotFoundStillReturnsNotFound() throws Exception {
-    Properties props = getNonBlockingRouterProperties(localDcName);
-
-    IdConverterFactory mockIdConverterFactory = mock(IdConverterFactory.class);
-    IdConverter mockIdConverter = mock(IdConverter.class);
-    when(mockIdConverterFactory.getIdConverter()).thenReturn(mockIdConverter);
-    when(mockIdConverter.convert(any(RestRequest.class), anyString())).thenAnswer(invocation -> {
-      CompletableFuture<String> failed = new CompletableFuture<>();
-      failed.completeExceptionally(
-          new RestServiceException("Named blob not found", RestServiceErrorCode.NotFound));
-      return failed;
-    });
-
-    setRouterWithIdConverterFactory(props, new MockServerLayout(mockClusterMap), new LoggingNotificationSystem(),
-        mockIdConverterFactory);
-
+    // Wire idConverter to fail with NotFound on the GET-path convert.
+    setUpRouterWithFailingIdConverter(
+        new RestServiceException("Named blob not found", RestServiceErrorCode.NotFound));
     try {
-      // tearDown's assertClosed calls putBlob; populate params.
-      setOperationParams();
-      RestRequest getRequest =
-          createNamedBlobRestRequest(RestMethod.GET, "accountName", "containerName", "missingBlob", false, false, false,
-              true);
-      Future<GetBlobResult> future = router.getBlob(getRequest, (String) getRequest.getArgs().get(BLOB_ID),
-          new GetBlobOptionsBuilder().build(), null, null);
-
-      try {
-        future.get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-        Assert.fail("Expected RestServiceException with NotFound");
-      } catch (ExecutionException ee) {
-        Assert.assertTrue("Expected RestServiceException, got " + ee.getCause(),
-            ee.getCause() instanceof RestServiceException);
-        Assert.assertEquals(RestServiceErrorCode.NotFound,
-            ((RestServiceException) ee.getCause()).getErrorCode());
-      }
-      Assert.assertEquals("Translation metric should be 0", 0L,
-          routerMetrics.namedBlobMetadataExistsButStorageNotFoundCount.getCount());
+      setOperationParams(); // tearDown's assertClosed calls putBlob; populate params.
+      RestServiceException cause = (RestServiceException) expectGetFailure("a", "c", "b").getCause();
+      Assert.assertEquals(RestServiceErrorCode.NotFound, cause.getErrorCode());
+      Assert.assertEquals(0L, routerMetrics.namedBlobMetadataExistsButStorageNotFoundCount.getCount());
     } finally {
-      if (router != null) {
-        router.close();
-        assertClosed();
-      }
+      if (router != null) { router.close(); assertClosed(); }
     }
   }
 
   /** Translation also fires when getBlobHelper short-circuits via the notFoundCache. */
   @Test
   public void testNamedBlobMissingViaNotFoundCacheStillTranslatedToAmbryUnavailable() throws Exception {
-    Properties props = getNonBlockingRouterProperties(localDcName);
-    final AtomicReference<String> storedBlobId = new AtomicReference<>();
-    CountDownLatch putCompletedLatch = new CountDownLatch(1);
-
-    IdConverterFactory mockIdConverterFactory = mock(IdConverterFactory.class);
-    IdConverter mockIdConverter = mock(IdConverter.class);
-    when(mockIdConverterFactory.getIdConverter()).thenReturn(mockIdConverter);
-    when(mockIdConverter.convert(any(RestRequest.class), anyString(), any(), any())).thenAnswer(invocation -> {
-      FutureResult<String> futureResult = new FutureResult<>();
-      String blobId = invocation.getArgument(1);
-      Callback<String> callback = invocation.getArgument(3);
-      storedBlobId.set(blobId);
-      if (callback != null) {
-        callback.onCompletion(blobId, null);
-      }
-      futureResult.done(blobId, null);
-      putCompletedLatch.countDown();
-      return futureResult;
-    });
-
-    setRouterWithIdConverterFactory(props, new MockServerLayout(mockClusterMap), new LoggingNotificationSystem(),
-        mockIdConverterFactory);
-
+    AtomicReference<String> storedBlobId = new AtomicReference<>();
+    // PUT a named blob; subsequent GETs will resolve to its blob ID via the mock.
+    setUpNamedBlobAndPut(storedBlobId);
     try {
-      final String accountName = "accountName";
-      final String containerName = "containerName";
-      final String blobName = "blobName";
-      setOperationParams();
-      RestRequest putRequest =
-          createNamedBlobRestRequest(RestMethod.PUT, accountName, containerName, blobName, false, false, false, false);
-      router.putBlob(putRequest, putBlobProperties, putUserMetadata, putChannel, new PutBlobOptionsBuilder().build(),
-          null, null).get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-      putCompletedLatch.await();
-
-      // GET: idConverter returns the put blob ID (metadata exists).
-      when(mockIdConverter.convert(any(RestRequest.class), anyString())).thenAnswer(invocation -> {
-        CompletableFuture<String> completableFuture = new CompletableFuture<>();
-        completableFuture.complete(storedBlobId.get());
-        return completableFuture;
-      });
-
       // Pre-populate notFoundCache so getBlobHelper short-circuits.
       router.getNotFoundCache().put(storedBlobId.get(), Boolean.TRUE);
-
-      RestRequest getRequest =
-          createNamedBlobRestRequest(RestMethod.GET, accountName, containerName, blobName, false, false, false, true);
-      Future<GetBlobResult> future = router.getBlob(getRequest, (String) getRequest.getArgs().get(BLOB_ID),
-          new GetBlobOptionsBuilder().build(), null, null);
-
-      try {
-        future.get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-        Assert.fail("Expected RouterException with AmbryUnavailable");
-      } catch (ExecutionException ee) {
-        Assert.assertTrue("Expected RouterException, got " + ee.getCause(),
-            ee.getCause() instanceof RouterException);
-        Assert.assertEquals("Expected AmbryUnavailable",
-            RouterErrorCode.AmbryUnavailable, ((RouterException) ee.getCause()).getErrorCode());
-      }
-      Assert.assertEquals("Translation metric should be 1", 1L,
-          routerMetrics.namedBlobMetadataExistsButStorageNotFoundCount.getCount());
+      assertNamedBlobGetTranslatedToAmbryUnavailable("a", "c", "b");
     } finally {
-      if (router != null) {
-        router.close();
-        assertClosed();
-      }
+      if (router != null) { router.close(); assertClosed(); }
     }
+  }
+
+  /** Wire a mock IdConverter, set up the router, PUT a named blob {@code /a/c/b}, and stub the
+   *  GET-path {@code convert(RestRequest, String)} to return the resolved blob ID. */
+  private MockServerLayout setUpNamedBlobAndPut(AtomicReference<String> storedBlobId) throws Exception {
+    CountDownLatch putLatch = new CountDownLatch(1);
+    // Wire a mock IdConverterFactory + IdConverter.
+    IdConverterFactory factory = mock(IdConverterFactory.class);
+    IdConverter mockIdConverter = mock(IdConverter.class);
+    when(factory.getIdConverter()).thenReturn(mockIdConverter);
+    // PUT-path stub: capture the resolved blob ID into storedBlobId and signal the latch.
+    when(mockIdConverter.convert(any(RestRequest.class), anyString(), any(), any())).thenAnswer(inv -> {
+      FutureResult<String> f = new FutureResult<>();
+      String id = inv.getArgument(1);
+      Callback<String> cb = inv.getArgument(3);
+      storedBlobId.set(id);
+      if (cb != null) {
+        cb.onCompletion(id, null);
+      }
+      f.done(id, null);
+      putLatch.countDown();
+      return f;
+    });
+    // Build the router with the mock factory.
+    MockServerLayout layout = new MockServerLayout(mockClusterMap);
+    setRouterWithIdConverterFactory(getNonBlockingRouterProperties(localDcName), layout,
+        new LoggingNotificationSystem(), factory);
+    // PUT a named blob /a/c/b, then wait for the convert mock to have run.
+    setOperationParams();
+    router.putBlob(createNamedBlobRestRequest(RestMethod.PUT, "a", "c", "b", false, false, false, false),
+        putBlobProperties, putUserMetadata, putChannel, new PutBlobOptionsBuilder().build(), null, null)
+        .get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    putLatch.await();
+    // GET-path stub: resolve the named blob path back to the captured blob ID.
+    when(mockIdConverter.convert(any(RestRequest.class), anyString()))
+        .thenAnswer(inv -> CompletableFuture.completedFuture(storedBlobId.get()));
+    return layout;
+  }
+
+  /** Set up the router with an IdConverter whose GET-path convert fails with {@code failure}. */
+  private void setUpRouterWithFailingIdConverter(Exception failure) throws Exception {
+    // Wire a mock IdConverterFactory + IdConverter.
+    IdConverterFactory factory = mock(IdConverterFactory.class);
+    IdConverter mockIdConverter = mock(IdConverter.class);
+    when(factory.getIdConverter()).thenReturn(mockIdConverter);
+    // GET-path stub: fail with the given exception.
+    CompletableFuture<String> failed = new CompletableFuture<>();
+    failed.completeExceptionally(failure);
+    when(mockIdConverter.convert(any(RestRequest.class), anyString())).thenReturn(failed);
+    // Build the router with the mock factory.
+    setRouterWithIdConverterFactory(getNonBlockingRouterProperties(localDcName),
+        new MockServerLayout(mockClusterMap), new LoggingNotificationSystem(), factory);
+  }
+
+  /** GET {@code /named/{account}/{container}/{blob}} expecting failure; returns the wrapping ExecutionException. */
+  private ExecutionException expectGetFailure(String account, String container, String blob) throws Exception {
+    RestRequest get = createNamedBlobRestRequest(RestMethod.GET, account, container, blob, false, false, false, true);
+    try {
+      router.getBlob(get, (String) get.getArgs().get(BLOB_ID), new GetBlobOptionsBuilder().build(), null, null)
+          .get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+      throw new AssertionError("Expected failure");
+    } catch (ExecutionException ee) {
+      return ee;
+    }
+  }
+
+  /** Verify a named-blob GET surfaces as AmbryUnavailable and increments the translation metric. */
+  private void assertNamedBlobGetTranslatedToAmbryUnavailable(String account, String container, String blob)
+      throws Exception {
+    Assert.assertEquals(RouterErrorCode.AmbryUnavailable,
+        ((RouterException) expectGetFailure(account, container, blob).getCause()).getErrorCode());
+    Assert.assertEquals(1L, routerMetrics.namedBlobMetadataExistsButStorageNotFoundCount.getCount());
   }
 
   /**

--- a/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTest.java
@@ -54,6 +54,8 @@ import com.github.ambry.rest.MockRestRequest;
 import com.github.ambry.rest.RequestPath;
 import com.github.ambry.rest.RestMethod;
 import com.github.ambry.rest.RestRequest;
+import com.github.ambry.rest.RestServiceErrorCode;
+import com.github.ambry.rest.RestServiceException;
 import com.github.ambry.rest.RestUtils;
 import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.store.StoreKey;
@@ -1229,6 +1231,133 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
       Assert.assertNotNull("Blob properties should not be null", getBlobResult.getBlobInfo().getBlobProperties());
       Assert.assertNotNull("User metadata should not be null", getBlobResult.getBlobInfo().getUserMetadata());
 
+    } finally {
+      if (router != null) {
+        router.close();
+        assertClosed();
+      }
+    }
+  }
+
+  /**
+   * When idConverter resolves named blob metadata successfully but the storage layer
+   * returns BlobNotFound, the router translates the response to AmbryUnavailable so
+   * the response surfaces as a retryable 503 rather than an authoritative 404.
+   */
+  @Test
+  public void testNamedBlobMissingInStorageTranslatedToAmbryUnavailable() throws Exception {
+    Properties props = getNonBlockingRouterProperties(localDcName);
+    final AtomicReference<String> storedBlobId = new AtomicReference<>();
+    CountDownLatch putCompletedLatch = new CountDownLatch(1);
+
+    IdConverterFactory mockIdConverterFactory = mock(IdConverterFactory.class);
+    IdConverter mockIdConverter = mock(IdConverter.class);
+    when(mockIdConverterFactory.getIdConverter()).thenReturn(mockIdConverter);
+    // PUT path: capture the resolved blob ID so the GET-path mock can return it.
+    when(mockIdConverter.convert(any(RestRequest.class), anyString(), any(), any())).thenAnswer(invocation -> {
+      FutureResult<String> futureResult = new FutureResult<>();
+      String blobId = invocation.getArgument(1);
+      Callback<String> callback = invocation.getArgument(3);
+      storedBlobId.set(blobId);
+      if (callback != null) {
+        callback.onCompletion(blobId, null);
+      }
+      futureResult.done(blobId, null);
+      putCompletedLatch.countDown();
+      return futureResult;
+    });
+
+    MockServerLayout layout = new MockServerLayout(mockClusterMap);
+    setRouterWithIdConverterFactory(props, layout, new LoggingNotificationSystem(), mockIdConverterFactory);
+
+    try {
+      final String accountName = "accountName";
+      final String containerName = "containerName";
+      final String blobName = "blobName";
+      setOperationParams();
+      RestRequest putRequest =
+          createNamedBlobRestRequest(RestMethod.PUT, accountName, containerName, blobName, false, false, false, false);
+      router.putBlob(putRequest, putBlobProperties, putUserMetadata, putChannel, new PutBlobOptionsBuilder().build(),
+          null, null).get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+      putCompletedLatch.await();
+
+      // GET path: idConverter resolves successfully (metadata exists), returning the put blob ID.
+      when(mockIdConverter.convert(any(RestRequest.class), anyString())).thenAnswer(invocation -> {
+        CompletableFuture<String> completableFuture = new CompletableFuture<>();
+        completableFuture.complete(storedBlobId.get());
+        return completableFuture;
+      });
+
+      // Force every storage replica to return BlobNotFound so the router resolves to BlobDoesNotExist.
+      layout.getMockServers()
+          .forEach(mockServer -> mockServer.setServerErrorForAllRequests(ServerErrorCode.BlobNotFound));
+
+      RestRequest getRequest =
+          createNamedBlobRestRequest(RestMethod.GET, accountName, containerName, blobName, false, false, false, true);
+      Future<GetBlobResult> future = router.getBlob(getRequest, (String) getRequest.getArgs().get(BLOB_ID),
+          new GetBlobOptionsBuilder().build(), null, null);
+
+      try {
+        future.get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        Assert.fail("Expected RouterException with AmbryUnavailable");
+      } catch (ExecutionException ee) {
+        Assert.assertTrue("Expected RouterException, got " + ee.getCause(),
+            ee.getCause() instanceof RouterException);
+        Assert.assertEquals("Expected AmbryUnavailable after metadata-found-but-storage-NOT_FOUND",
+            RouterErrorCode.AmbryUnavailable, ((RouterException) ee.getCause()).getErrorCode());
+      }
+      Assert.assertEquals("Translation metric should have incremented exactly once", 1L,
+          routerMetrics.namedBlobMetadataExistsButStorageNotFoundCount.getCount());
+    } finally {
+      if (router != null) {
+        router.close();
+        assertClosed();
+      }
+    }
+  }
+
+  /**
+   * Regression: when the named blob metadata itself is not found, the response still
+   * surfaces as RestServiceErrorCode.NotFound. The translation must only kick in after
+   * idConverter has resolved metadata successfully.
+   */
+  @Test
+  public void testNamedBlobMetadataNotFoundStillReturnsNotFound() throws Exception {
+    Properties props = getNonBlockingRouterProperties(localDcName);
+
+    IdConverterFactory mockIdConverterFactory = mock(IdConverterFactory.class);
+    IdConverter mockIdConverter = mock(IdConverter.class);
+    when(mockIdConverterFactory.getIdConverter()).thenReturn(mockIdConverter);
+    when(mockIdConverter.convert(any(RestRequest.class), anyString())).thenAnswer(invocation -> {
+      CompletableFuture<String> failed = new CompletableFuture<>();
+      failed.completeExceptionally(
+          new RestServiceException("Named blob not found", RestServiceErrorCode.NotFound));
+      return failed;
+    });
+
+    setRouterWithIdConverterFactory(props, new MockServerLayout(mockClusterMap), new LoggingNotificationSystem(),
+        mockIdConverterFactory);
+
+    try {
+      // assertClosed in tearDown exercises putBlob; ensure operation params are populated.
+      setOperationParams();
+      RestRequest getRequest =
+          createNamedBlobRestRequest(RestMethod.GET, "accountName", "containerName", "missingBlob", false, false, false,
+              true);
+      Future<GetBlobResult> future = router.getBlob(getRequest, (String) getRequest.getArgs().get(BLOB_ID),
+          new GetBlobOptionsBuilder().build(), null, null);
+
+      try {
+        future.get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        Assert.fail("Expected RestServiceException with NotFound");
+      } catch (ExecutionException ee) {
+        Assert.assertTrue("Expected RestServiceException, got " + ee.getCause(),
+            ee.getCause() instanceof RestServiceException);
+        Assert.assertEquals(RestServiceErrorCode.NotFound,
+            ((RestServiceException) ee.getCause()).getErrorCode());
+      }
+      Assert.assertEquals("Translation metric must not increment when metadata lookup itself failed", 0L,
+          routerMetrics.namedBlobMetadataExistsButStorageNotFoundCount.getCount());
     } finally {
       if (router != null) {
         router.close();

--- a/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTest.java
@@ -1367,6 +1367,83 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
   }
 
   /**
+   * Translation must also fire when {@code getBlobHelper}'s notFoundCache short-circuit completes the operation.
+   * That path bypasses the per-replica storage call and synthesises BlobDoesNotExist via {@code completeOperation}
+   * rather than {@code BlobOperationCallbackWrapper}, so we cover it explicitly.
+   */
+  @Test
+  public void testNamedBlobMissingViaNotFoundCacheStillTranslatedToAmbryUnavailable() throws Exception {
+    Properties props = getNonBlockingRouterProperties(localDcName);
+    final AtomicReference<String> storedBlobId = new AtomicReference<>();
+    CountDownLatch putCompletedLatch = new CountDownLatch(1);
+
+    IdConverterFactory mockIdConverterFactory = mock(IdConverterFactory.class);
+    IdConverter mockIdConverter = mock(IdConverter.class);
+    when(mockIdConverterFactory.getIdConverter()).thenReturn(mockIdConverter);
+    when(mockIdConverter.convert(any(RestRequest.class), anyString(), any(), any())).thenAnswer(invocation -> {
+      FutureResult<String> futureResult = new FutureResult<>();
+      String blobId = invocation.getArgument(1);
+      Callback<String> callback = invocation.getArgument(3);
+      storedBlobId.set(blobId);
+      if (callback != null) {
+        callback.onCompletion(blobId, null);
+      }
+      futureResult.done(blobId, null);
+      putCompletedLatch.countDown();
+      return futureResult;
+    });
+
+    setRouterWithIdConverterFactory(props, new MockServerLayout(mockClusterMap), new LoggingNotificationSystem(),
+        mockIdConverterFactory);
+
+    try {
+      final String accountName = "accountName";
+      final String containerName = "containerName";
+      final String blobName = "blobName";
+      setOperationParams();
+      RestRequest putRequest =
+          createNamedBlobRestRequest(RestMethod.PUT, accountName, containerName, blobName, false, false, false, false);
+      router.putBlob(putRequest, putBlobProperties, putUserMetadata, putChannel, new PutBlobOptionsBuilder().build(),
+          null, null).get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+      putCompletedLatch.await();
+
+      // GET path: idConverter resolves successfully (metadata exists), returning the put blob ID.
+      when(mockIdConverter.convert(any(RestRequest.class), anyString())).thenAnswer(invocation -> {
+        CompletableFuture<String> completableFuture = new CompletableFuture<>();
+        completableFuture.complete(storedBlobId.get());
+        return completableFuture;
+      });
+
+      // Pre-populate the notFoundCache for the resolved blob ID so getBlobHelper short-circuits via
+      // completeOperation(...) rather than going to the storage layer.
+      router.getNotFoundCache().put(storedBlobId.get(), Boolean.TRUE);
+
+      RestRequest getRequest =
+          createNamedBlobRestRequest(RestMethod.GET, accountName, containerName, blobName, false, false, false, true);
+      Future<GetBlobResult> future = router.getBlob(getRequest, (String) getRequest.getArgs().get(BLOB_ID),
+          new GetBlobOptionsBuilder().build(), null, null);
+
+      try {
+        future.get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        Assert.fail("Expected RouterException with AmbryUnavailable");
+      } catch (ExecutionException ee) {
+        Assert.assertTrue("Expected RouterException, got " + ee.getCause(),
+            ee.getCause() instanceof RouterException);
+        Assert.assertEquals(
+            "notFoundCache short-circuit must also be translated to AmbryUnavailable when metadata exists",
+            RouterErrorCode.AmbryUnavailable, ((RouterException) ee.getCause()).getErrorCode());
+      }
+      Assert.assertEquals("Translation metric should have incremented exactly once", 1L,
+          routerMetrics.namedBlobMetadataExistsButStorageNotFoundCount.getCount());
+    } finally {
+      if (router != null) {
+        router.close();
+        assertClosed();
+      }
+    }
+  }
+
+  /**
    * Test named blob stitch after we move id converter into router.
    */
   @Test


### PR DESCRIPTION
## Summary

Return HTTP 503 instead of 404 when a `named_blobs_v2` row exists but every storage replica
returns `BlobNotFound` for the resolved blob ID. A wrong 404 is treated as authoritative and
triggers downstream cache/index invalidations; 503 is retryable and self-correcting.

Internal ticket: AMBRY-14247.

## Behavior change

**Old flow:** both "row missing" and "metadata exists but storage NOT_FOUND" terminate at HTTP 404.
The two failure modes are indistinguishable.

<img width="173" height="308" alt="image" src="https://github.com/user-attachments/assets/02b03611-4c7f-4018-9b2f-3325316dd128" />

**New flow:** the metadata-found-but-storage-missing branch is translated to `AmbryUnavailable`
(→ HTTP 503). Metadata-not-found still returns 404. Success path unchanged.

<img width="158" height="359" alt="image" src="https://github.com/user-attachments/assets/12679044-de1b-49c8-a7c6-4abf03900986" />

## Implementation

- `NonBlockingRouter.getBlob(RestRequest, ...)` wraps the post-`idConverter` callback to translate
  `BlobDoesNotExist` → `AmbryUnavailable`. Existing `RestServiceErrorCode` mapping handles the
  rest (`AmbryUnavailable → ServiceUnavailable → 503`).
- New counter `NonBlockingRouter.NamedBlobMetadataExistsButStorageNotFoundCount` for observability.
- Bonus: fix pre-existing operations-counter underflow in the same method's
  `idConverter`-failure branch (latent since PR #3152).

## Testing Done

Three new parameterized tests in `NonBlockingRouterTest` (4 configs × 3 tests = 12 runs, all pass):

- `testNamedBlobMissingInStorageTranslatedToAmbryUnavailable` — live storage NOT_FOUND → AmbryUnavailable.
- `testNamedBlobMetadataNotFoundStillReturnsNotFound` — regression: metadata-not-found stays 404.
- `testNamedBlobMissingViaNotFoundCacheStillTranslatedToAmbryUnavailable` — cache short-circuit path also translated.

```
./gradlew :ambry-router:test \
  --tests "com.github.ambry.router.NonBlockingRouterTest.testNamedBlob*"
```

## Risk

- Read-path-only, backward compatible at the HTTP layer (503 strictly safer than 404 — retryable).
- Removes the implicit 404 circuit-breaker → potential retry-storm amplification on the inconsistency
  path. New counter makes the rate observable.
