### PR TITLE
Return HTTP 410 for undelete on permanently deleted blob

### DIFF
--- a/ambry-router/src/main/java/com/github/ambry/router/UndeleteOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/UndeleteOperation.java
@@ -364,6 +364,8 @@ public class UndeleteOperation {
         return RouterErrorCode.BlobNotDeleted;
       case BlobAlreadyUndeleted:
         return RouterErrorCode.BlobUndeleted;
+      case BlobDeletedPermanently:
+        return RouterErrorCode.BlobDeleted;
       case BlobLifeVersionConflict:
         return RouterErrorCode.LifeVersionConflict;
       default:

--- a/ambry-router/src/test/java/com/github/ambry/router/UndeleteManagerTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/UndeleteManagerTest.java
@@ -293,6 +293,30 @@ public class UndeleteManagerTest {
   }
 
   /**
+   * Failure tests when servers return BlobDeletedPermanently because the blob has been compacted.
+   * The router should surface this as RouterErrorCode.BlobDeleted.
+   * @throws Exception
+   */
+  @Test
+  public void blobDeletedPermanentlyTest() throws Exception {
+    HashMap<String, List<MockServer>> dcToMockServers = new HashMap<>();
+    serverLayout.getMockServers()
+        .forEach(server -> dcToMockServers.computeIfAbsent(server.getDataCenter(), k -> new ArrayList()).add(server));
+    String dc = new ArrayList<>(dcToMockServers.keySet()).get(0);
+    List<MockServer> servers = dcToMockServers.get(dc);
+    for (String blobId : blobIds) {
+      deleteBlobInAllServer(blobId);
+
+      for (MockServer server : servers.subList(0, 2)) {
+        server.setServerErrorForAllRequests(ServerErrorCode.BlobDeletedPermanently);
+      }
+
+      executeOpAndVerify(Collections.singleton(blobId), RouterErrorCode.BlobDeleted);
+      serverLayout.getMockServers().forEach(server -> server.resetServerErrors());
+    }
+  }
+
+  /**
    * Failure tests when undelete request is rejected due to quota compliance.
    * @throws Exception
    */


### PR DESCRIPTION
## Summary
Add a case for BlobDeletedPermanently in UndeleteOperation.processServerError, mapping it to RouterErrorCode.BlobDeleted so the frontend returns HTTP 410 Gone. Previously this server error code had no case in the switch and fell through to the default UnexpectedInternalError, surfacing as HTTP 500. A 410 (or any 4xx) is the correct semantic since the blob has been compacted and the undelete request can never succeed; clients should not retry.

## Testing Done
Added blobDeletedPermanentlyTest in UndeleteManagerTest. Tests pass `./gradlew :ambry-router:test --tests "com.github.ambry.router.UndeleteManagerTest"`