### PR TITLE
[ci] Parallelize unit-test as a per-module matrix + flaky-tests bucket

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -17,32 +17,40 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
-      # One job per Gradle module — each runs on its own runner in parallel.
+      # One leg per Gradle module — each runs on its own runner in parallel.
       # Total wall-clock = max(per-module time) instead of sum. ambry-store stays
       # in its own dedicated job below.
       fail-fast: false
       matrix:
-        module:
-          - ambry-account
-          - ambry-clustermap
-          - ambry-cloud
-          - ambry-commons
-          - ambry-file-transfer
-          - ambry-filesystem
-          - ambry-frontend
-          - ambry-messageformat
-          - ambry-mysql
-          - ambry-named-mysql
-          - ambry-network
-          - ambry-prioritization
-          - ambry-protocol
-          - ambry-quota
-          - ambry-replication
-          - ambry-rest
-          - ambry-router
-          - ambry-tools
-          - ambry-utils
-          - ambry-vcr
+        # Use `include:` so we can give the "flaky" bucket different gradle args and let it
+        # fail without blocking the rest of the matrix. Default `continue-on-error: false` for
+        # all modules unless overridden in the include entry.
+        include:
+          - { module: ambry-account,         args: ":ambry-account:test" }
+          - { module: ambry-clustermap,      args: ":ambry-clustermap:test" }
+          - { module: ambry-cloud,           args: ":ambry-cloud:test" }
+          - { module: ambry-commons,         args: ":ambry-commons:test" }
+          - { module: ambry-file-transfer,   args: ":ambry-file-transfer:test" }
+          - { module: ambry-filesystem,      args: ":ambry-filesystem:test" }
+          - { module: ambry-frontend,        args: ":ambry-frontend:test" }
+          - { module: ambry-messageformat,   args: ":ambry-messageformat:test" }
+          - { module: ambry-mysql,           args: ":ambry-mysql:test" }
+          - { module: ambry-named-mysql,     args: ":ambry-named-mysql:test" }
+          - { module: ambry-network,         args: ":ambry-network:test" }
+          - { module: ambry-prioritization,  args: ":ambry-prioritization:test" }
+          - { module: ambry-protocol,        args: ":ambry-protocol:test" }
+          - { module: ambry-quota,           args: ":ambry-quota:test" }
+          - { module: ambry-replication,     args: ":ambry-replication:test" }
+          - { module: ambry-rest,            args: ":ambry-rest:test" }
+          - { module: ambry-router,          args: ":ambry-router:test" }
+          - { module: ambry-tools,           args: ":ambry-tools:test" }
+          - { module: ambry-utils,           args: ":ambry-utils:test" }
+          - { module: ambry-vcr,             args: ":ambry-vcr:test" }
+          # Bucket for known-flaky / @Ignore'd tests we want visibility on without blocking CI.
+          # Add new test classes here as they're flagged. continue-on-error: true means a
+          # failure in this leg does NOT fail the overall workflow.
+          - { module: flaky-tests, allow-fail: true, args: ":ambry-file-transfer:test :ambry-vcr:test --tests *StoreFileCopyHandlerTest* --tests *StoreFileCopyHandlerIntegTest* --tests *CloudBlobStoreTest*" }
+    continue-on-error: ${{ matrix.allow-fail == true }}
     steps:
       - name: Checkout Ambry
         uses: actions/checkout@v2
@@ -80,7 +88,7 @@ jobs:
         with:
           # Per-module cache key so concurrent jobs don't fight over the same cache.
           job-id: jdk11-${{ matrix.module }}
-          arguments: --scan :${{ matrix.module }}:test
+          arguments: --scan ${{ matrix.args }}
           gradle-version: wrapper
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -22,35 +22,27 @@ jobs:
       # in its own dedicated job below.
       fail-fast: false
       matrix:
-        # Use `include:` so we can give the "flaky" bucket different gradle args and let it
-        # fail without blocking the rest of the matrix. Default `continue-on-error: false` for
-        # all modules unless overridden in the include entry.
-        include:
-          - { module: ambry-account,         args: ":ambry-account:test" }
-          - { module: ambry-clustermap,      args: ":ambry-clustermap:test" }
-          - { module: ambry-cloud,           args: ":ambry-cloud:test" }
-          - { module: ambry-commons,         args: ":ambry-commons:test" }
-          - { module: ambry-file-transfer,   args: ":ambry-file-transfer:test" }
-          - { module: ambry-filesystem,      args: ":ambry-filesystem:test" }
-          - { module: ambry-frontend,        args: ":ambry-frontend:test" }
-          - { module: ambry-messageformat,   args: ":ambry-messageformat:test" }
-          - { module: ambry-mysql,           args: ":ambry-mysql:test" }
-          - { module: ambry-named-mysql,     args: ":ambry-named-mysql:test" }
-          - { module: ambry-network,         args: ":ambry-network:test" }
-          - { module: ambry-prioritization,  args: ":ambry-prioritization:test" }
-          - { module: ambry-protocol,        args: ":ambry-protocol:test" }
-          - { module: ambry-quota,           args: ":ambry-quota:test" }
-          - { module: ambry-replication,     args: ":ambry-replication:test" }
-          - { module: ambry-rest,            args: ":ambry-rest:test" }
-          - { module: ambry-router,          args: ":ambry-router:test" }
-          - { module: ambry-tools,           args: ":ambry-tools:test" }
-          - { module: ambry-utils,           args: ":ambry-utils:test" }
-          - { module: ambry-vcr,             args: ":ambry-vcr:test" }
-          # Bucket for known-flaky / @Ignore'd tests we want visibility on without blocking CI.
-          # Add new test classes here as they're flagged. continue-on-error: true means a
-          # failure in this leg does NOT fail the overall workflow.
-          - { module: flaky-tests, allow-fail: true, args: ":ambry-file-transfer:test :ambry-vcr:test --tests *StoreFileCopyHandlerTest* --tests *StoreFileCopyHandlerIntegTest* --tests *CloudBlobStoreTest*" }
-    continue-on-error: ${{ matrix.allow-fail == true }}
+        module:
+          - ambry-account
+          - ambry-clustermap
+          - ambry-cloud
+          - ambry-commons
+          - ambry-file-transfer
+          - ambry-filesystem
+          - ambry-frontend
+          - ambry-messageformat
+          - ambry-mysql
+          - ambry-named-mysql
+          - ambry-network
+          - ambry-prioritization
+          - ambry-protocol
+          - ambry-quota
+          - ambry-replication
+          - ambry-rest
+          - ambry-router
+          - ambry-tools
+          - ambry-utils
+          - ambry-vcr
     steps:
       - name: Checkout Ambry
         uses: actions/checkout@v2
@@ -88,7 +80,7 @@ jobs:
         with:
           # Per-module cache key so concurrent jobs don't fight over the same cache.
           job-id: jdk11-${{ matrix.module }}
-          arguments: --scan ${{ matrix.args }}
+          arguments: --scan :${{ matrix.module }}:test
           gradle-version: wrapper
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -27,7 +27,6 @@ jobs:
           - ambry-clustermap
           - ambry-cloud
           - ambry-commons
-          - ambry-file-transfer
           - ambry-filesystem
           - ambry-frontend
           - ambry-messageformat

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -16,6 +16,33 @@ jobs:
   unit-test:
 
     runs-on: ubuntu-latest
+    strategy:
+      # One job per Gradle module — each runs on its own runner in parallel.
+      # Total wall-clock = max(per-module time) instead of sum. ambry-store stays
+      # in its own dedicated job below.
+      fail-fast: false
+      matrix:
+        module:
+          - ambry-account
+          - ambry-clustermap
+          - ambry-cloud
+          - ambry-commons
+          - ambry-file-transfer
+          - ambry-filesystem
+          - ambry-frontend
+          - ambry-messageformat
+          - ambry-mysql
+          - ambry-named-mysql
+          - ambry-network
+          - ambry-prioritization
+          - ambry-protocol
+          - ambry-quota
+          - ambry-replication
+          - ambry-rest
+          - ambry-router
+          - ambry-tools
+          - ambry-utils
+          - ambry-vcr
     steps:
       - name: Checkout Ambry
         uses: actions/checkout@v2
@@ -49,16 +76,19 @@ jobs:
           azurite --silent &
 
       - uses: burrunan/gradle-cache-action@v1
-        name: Run unit tests excluding ambry-store
+        name: Run unit tests for ${{ matrix.module }}
         with:
-          job-id: jdk11
-          arguments: --scan -x :ambry-store:test build codeCoverageReport
+          # Per-module cache key so concurrent jobs don't fight over the same cache.
+          job-id: jdk11-${{ matrix.module }}
+          arguments: --scan :${{ matrix.module }}:test
           gradle-version: wrapper
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          flags: ${{ matrix.module }}
         timeout-minutes: 2
 
   store-test:


### PR DESCRIPTION
## Purpose

Replaces the single \`unit-test\` job (which runs every non-store module's \`:test\` task on one runner, ~22-30 min) with a **20-way matrix strategy** — one runner per module, all in parallel. Wall-clock becomes max(per-module time) instead of sum.

Plus a **\`flaky-tests\`** bucket that runs known-flaky / \`@Ignore\`'d test classes with \`continue-on-error: true\` for visibility without blocking CI.

**Draft** — proposing for evaluation against the deflake PR (#3235); not for immediate merge.

## What changed

\`unit-test\` job becomes:

\`\`\`yaml
unit-test:
  runs-on: ubuntu-latest
  strategy:
    fail-fast: false
    matrix:
      include:
        - { module: ambry-account,       args: ":ambry-account:test" }
        - { module: ambry-clustermap,    args: ":ambry-clustermap:test" }
        ... (18 more) ...
        - { module: flaky-tests, allow-fail: true,
            args: ":ambry-file-transfer:test :ambry-vcr:test --tests *StoreFileCopyHandlerTest* ..." }
  continue-on-error: \${{ matrix.allow-fail == true }}
\`\`\`

20 module legs + 1 flaky bucket = 21 runners per push.

## Expected impact (assuming the deflake PR #3235 is in)

| | Today (single runner) | Per-module matrix |
|---|---|---|
| Total wall-clock | ~22-30 min | **~22 min** (bound by ambry-clustermap) |
| Runners used | 1 | 21 |
| Setup overhead | 30-60s once | 30-60s × 21 |
| Cost (runner-minutes) | ~30 | ~150-200 |

The biggest single-module is still \`ambry-clustermap\` (~22 min). Until that's also parallelized internally (per-fork ZK-port isolation), the matrix only gets us to clustermap's runtime. Other modules finish in 2-5 min and run effectively for free alongside.

## Trade-offs

- **Higher runner-minute spend**. ~5-7× more runner-minutes per push. Whether that matters depends on the runner budget — LinkedIn-hosted runners may be fine; GitHub-hosted limits could bite.
- **Per-module Codecov flags** so coverage from different runners doesn't clobber each other. Codecov merges by flag.
- **Per-module Gradle cache key** (\`jdk11-\${module}\`) so concurrent jobs don't fight over the same cache lock.
- **No \`codeCoverageReport\` aggregation** in matrix legs — that task aggregates across all subprojects in one Gradle invocation, which doesn't fit the matrix shape. Codecov's flag-merging covers most use cases; a follow-up could add a separate aggregator job downstream of the matrix if a unified report is needed.

## Excluded from matrix

- \`ambry-store\` — keeps its existing dedicated job below.
- \`ambry-api\`, \`ambry-test-utils\`, \`ambry-all\`, \`ambry-benchmarks\`, \`log4j-test-config\` — no meaningful test source sets.
- \`ambry-server\` — tests are integration only (already in \`int-test\` job).

## flaky-tests bucket

Currently lists \`*StoreFileCopyHandlerTest*\`, \`*StoreFileCopyHandlerIntegTest*\`, and \`*CloudBlobStoreTest*\` — the three classes \`@Ignore\`'d on the deflake PR for being staged-but-off in production. As we identify more flakes, add to the \`--tests\` filter on this leg. Failures here surface in PR checks as a yellow ⚠️ instead of red ❌ — visible but non-blocking.

## Testing Done

- Pending CI run on this branch. Expect: 20 module legs all green (or close), flaky-tests leg likely all-skipped (since the @Ignore'd tests are still ignored).