### PR TITLE
Map BlobDeletedPermanently to BlobDoesNotExist (HTTP 404)

### DIFF
--- a/ambry-router/src/main/java/com/github/ambry/router/UndeleteOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/UndeleteOperation.java
@@ -365,7 +365,7 @@ public class UndeleteOperation {
       case BlobAlreadyUndeleted:
         return RouterErrorCode.BlobUndeleted;
       case BlobDeletedPermanently:
-        return RouterErrorCode.BlobDeleted;
+        return RouterErrorCode.BlobDoesNotExist;
       case BlobLifeVersionConflict:
         return RouterErrorCode.LifeVersionConflict;
       default:

--- a/ambry-router/src/test/java/com/github/ambry/router/UndeleteManagerTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/UndeleteManagerTest.java
@@ -294,7 +294,7 @@ public class UndeleteManagerTest {
 
   /**
    * Failure tests when servers return BlobDeletedPermanently because the blob has been compacted.
-   * The router should surface this as RouterErrorCode.BlobDeleted.
+   * The router should surface this as RouterErrorCode.BlobDoesNotExist.
    * @throws Exception
    */
   @Test
@@ -311,7 +311,7 @@ public class UndeleteManagerTest {
         server.setServerErrorForAllRequests(ServerErrorCode.BlobDeletedPermanently);
       }
 
-      executeOpAndVerify(Collections.singleton(blobId), RouterErrorCode.BlobDeleted);
+      executeOpAndVerify(Collections.singleton(blobId), RouterErrorCode.BlobDoesNotExist);
       serverLayout.getMockServers().forEach(server -> server.resetServerErrors());
     }
   }


### PR DESCRIPTION
## Summary
Fast-follow to #3236. Per Ambry convention, BlobDeleted (410) means deleted-but-still-on-disk and recoverable; BlobDoesNotExist (404) means purged-from-disk, indistinguishable from never-existed. A compacted blob fits the latter.


## Testing Done
Ran ./gradlew :ambry-router:test --tests "com.github.ambry.router.UndeleteManagerTest" — all 13 tests pass.