### PR TITLE
Set stable Hikari poolName per JDBC endpoint for observability

### DIFF
--- a/ambry-mysql/src/main/java/com/github/ambry/accountstats/AccountStatsMySqlStoreFactory.java
+++ b/ambry-mysql/src/main/java/com/github/ambry/accountstats/AccountStatsMySqlStoreFactory.java
@@ -98,6 +98,8 @@ public class AccountStatsMySqlStoreFactory implements AccountStatsStoreFactory {
     hikariConfig.addDataSourceProperty("useServerPrepStmts", "true");
     hikariConfig.addDataSourceProperty(REWRITE_BATCHED_STATEMENTS_LITERAL,
         String.valueOf(accountStatsMySqlConfig.enableRewriteBatchedStatement));
+    hikariConfig.setPoolName(String.format("ambry-account-stats-%s-%04x", dbEndpoint.getDatacenter(),
+        dbEndpoint.getUrl().hashCode() & 0xFFFF));
     hikariConfig.setMetricRegistry(registry);
     return new HikariDataSource(hikariConfig);
   }

--- a/ambry-mysql/src/main/java/com/github/ambry/repair/MysqlRepairRequestsDbFactory.java
+++ b/ambry-mysql/src/main/java/com/github/ambry/repair/MysqlRepairRequestsDbFactory.java
@@ -93,6 +93,8 @@ public class MysqlRepairRequestsDbFactory implements RepairRequestsDbFactory {
     hikariConfig.addDataSourceProperty("prepStmtCacheSize", "250");
     hikariConfig.addDataSourceProperty("prepStmtCacheSqlLimit", "2048");
     hikariConfig.addDataSourceProperty("useServerPrepStmts", "true");
+    hikariConfig.setPoolName(String.format("ambry-repair-requests-%s-%04x", dbEndpoint.getDatacenter(),
+        dbEndpoint.getUrl().hashCode() & 0xFFFF));
     hikariConfig.setMetricRegistry(metrics);
     return new HikariDataSource(hikariConfig);
   }

--- a/ambry-named-mysql/src/main/java/com/github/ambry/named/MySqlNamedBlobDbFactory.java
+++ b/ambry-named-mysql/src/main/java/com/github/ambry/named/MySqlNamedBlobDbFactory.java
@@ -88,6 +88,8 @@ public class MySqlNamedBlobDbFactory implements NamedBlobDbFactory {
     if (!config.transactionIsolationLevel.equals(TransactionIsolationLevel.TRANSACTION_NONE)) {
       hikariConfig.setTransactionIsolation(config.transactionIsolationLevel.name());
     }
+    hikariConfig.setPoolName(String.format("ambry-named-blob-%s-%04x", dbEndpoint.getDatacenter(),
+        dbEndpoint.getUrl().hashCode() & 0xFFFF));
     hikariConfig.setMetricRegistry(metricRegistry);
     return new HikariDataSource(hikariConfig);
   }


### PR DESCRIPTION
## Summary
- Add `HikariConfig.setPoolName(...)` to the three factories that already wire `setMetricRegistry`, so each pool publishes its Dropwizard metrics under a stable, predictable name across JVM restarts.
- Pool name format: `<family>-<datacenter>-<urlHash>`
  - `ambry-named-blob-<dc>-<hash>` in `MySqlNamedBlobDbFactory`
  - `ambry-repair-requests-<dc>-<hash>` in `MysqlRepairRequestsDbFactory`
  - `ambry-account-stats-<dc>-<hash>` in `AccountStatsMySqlStoreFactory`

## Motivation / Context
HikariCP's `CodaHaleMetricsTracker` keys all of its metrics off `poolName` (e.g. `<poolName>.pool.PendingConnections`). When `setPoolName` is not set, Hikari falls back to `generatePoolName()` which produces `HikariPool-1`, `HikariPool-2`, ... — a counter incremented per JVM that varies with initialization order. That makes the metrics unsubscribable from any stable dashboard or alert.

A recent production incident on ambry-frontend lasted ~67 minutes on a single host, driven by transient loss of MySQL connectivity to the named-blob DB. Hikari was emitting `PendingConnections` and `ConnectionTimeoutRate` the whole time, but those metrics weren't surfaced because consumers couldn't bind to a stable name. Per-pool, per-DC observability would have caught the single-host pool exhaustion immediately and distinguished it from a fleet-wide DB issue.

The two components of the new pool name solve two distinct collision problems:
- **`<datacenter>` component:** `MySqlNamedBlobDb.java:202-211` creates one `HikariDataSource` per writeable DC in the same JVM. Without per-DC differentiation, the second pool's `Gauge` registration in `CodaHaleMetricsTracker` would throw `IllegalArgumentException("A metric named ... already exists")` and crash frontend startup.
- **`<urlHash>` component:** `CompositeMysqlNamedBlobDb` instantiates two `MySqlNamedBlobDb` instances in the same JVM (primary + secondary). They typically share DCs but point to different MySQL endpoints. Without the URL hash, primary and secondary would also collide.

## Testing Done
- Compiled the changed modules: `./gradlew :ambry-named-mysql:compileJava :ambry-mysql:compileJava :ambry-mysql:compileTestJava :ambry-named-mysql:compileTestJava` — clean.
- The change is purely a label addition before `setMetricRegistry` — no behavior change in connection lifecycle, query path, or shutdown.

## Risk Assessment
- **Backward compatibility:** existing consumers reading `HikariPool-N.pool.*` will see those metrics disappear and `<family>-<dc>-<hash>.pool.*` appear in their place. There are no known existing consumers — the metrics were effectively unobservable until now.
- **Blast radius:** every JVM that initializes one of these three factories. Same code path as today plus one extra string assignment.
- **Durability:** none. No effect on data path, write/read semantics, or recovery behavior.
- **Backout:** revert this commit. No persistent state, no schema, no on-disk format affected.

## Observability / Ops Impact
- New metric names appear under the new pool-name prefixes (HikariCP publishes Wait, Usage, ConnectionCreation, ConnectionTimeoutRate, TotalConnections, IdleConnections, ActiveConnections, PendingConnections, MaxConnections, MinConnections per pool).
- LinkedIn-side sensor subscriptions will be added in a follow-up to surface these to RRD/OTEL dashboards.

## Rollout / Backout Plan
- Standard rolling deploy. Each host begins emitting under the new names as it restarts; old `HikariPool-N` series stop being produced.
- Backout: revert.

## AI Usage
Drafted with Claude Code; commit text and PR description reviewed by author.