### PR TITLE
Emit metrics on helix expected total capacity

### DIFF
--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
@@ -1122,6 +1122,13 @@ public class HelixClusterManager implements ClusterMap {
     return result;
   }
 
+  int getResourceExpectedTotalDiskCapacityUsage(String resource) {
+    String dcName = clusterMapConfig.clusterMapDatacenterName;
+    String tag = dcToResourceNameToTag.get(dcName).get(resource);
+    int replicationFactor = dcToTagToResourceProperty.get(dcName).get(tag).replicationFactor;
+    return getResourceExpectedTotalDiskCapacityUsage(resource, replicationFactor);
+  }
+
   int getResourceTotalDiskCapacityUsage(String resource) {
     // call this method to fill up the partition capacity map from resource config
     String dcName = clusterMapConfig.clusterMapDatacenterName;

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManagerMetrics.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManagerMetrics.java
@@ -366,6 +366,12 @@ class HelixClusterManagerMetrics {
       registry.gauge(MetricRegistry.name(HelixClusterManager.class, "Resource_" + resource + "_TotalDiskCapacityUsage"),
           () -> resourceTotalDiskCapacityUsage);
 
+      Gauge<Integer> resourceExpectedTotalDiskCapacityUsage =
+          () -> helixClusterManager.getResourceExpectedTotalDiskCapacityUsage(resource);
+      registry.gauge(MetricRegistry.name(HelixClusterManager.class,
+          "Resource_" + resource + "_ExpectedTotalDiskCapacityUsage"),
+          () -> resourceExpectedTotalDiskCapacityUsage);
+
       Gauge<Integer> resourceNumberOfPartitions = () -> helixClusterManager.getNumberOfPartitionsInResource(resource);
       registry.gauge(MetricRegistry.name(HelixClusterManager.class, "Resource_" + resource + "_NumberOfPartitions"),
           () -> resourceNumberOfPartitions);

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixClusterManagerTest.java
@@ -1368,9 +1368,12 @@ public class HelixClusterManagerTest {
     String resourceName = resourceNames.get(0);
     String totalInstanceMetricName =
         MetricRegistry.name(HelixClusterManager.class, "Resource_" + resourceName + "_TotalInstanceCount");
+    String expectedCapacityMetricName =
+        MetricRegistry.name(HelixClusterManager.class, "Resource_" + resourceName + "_ExpectedTotalDiskCapacityUsage");
     // Make sure that we don't have any FULL AUTO related metrics
     MetricRegistry registry = helixClusterManager.getMetricRegistry();
     assertFalse(registry.getGauges().keySet().contains(totalInstanceMetricName));
+    assertFalse(registry.getGauges().keySet().contains(expectedCapacityMetricName));
 
     // Update the IdealState to CUSTOMIZED mode, this would keep all local data node as they were.
     IdealState idealState = helixCluster.getResourceIdealState(resourceName, localDc);
@@ -1383,6 +1386,7 @@ public class HelixClusterManagerTest {
           helixClusterManager.isDataNodeInFullAutoMode(dataNode));
     }
     assertFalse(registry.getGauges().keySet().contains(totalInstanceMetricName));
+    assertFalse(registry.getGauges().keySet().contains(expectedCapacityMetricName));
 
     // Now update resource to have a tag
     final String instanceGroupTag = "TAG_1000000";
@@ -1393,6 +1397,7 @@ public class HelixClusterManagerTest {
           helixClusterManager.isDataNodeInFullAutoMode(dataNode));
     }
     assertFalse(registry.getGauges().keySet().contains(totalInstanceMetricName));
+    assertFalse(registry.getGauges().keySet().contains(expectedCapacityMetricName));
 
     // Now update data node to have the same tag
     for (DataNode dataNode : allLocalDcDataNodes) {
@@ -1412,6 +1417,7 @@ public class HelixClusterManagerTest {
       assertTrue("Should be in FULL_AUTO mode", helixClusterManager.isDataNodeInFullAutoMode(dataNode));
     }
     assertTrue(registry.getGauges().keySet().contains(totalInstanceMetricName));
+    assertTrue(registry.getGauges().keySet().contains(expectedCapacityMetricName));
 
     // Now update data node to have another tag
     for (DataNode dataNode : allLocalDcDataNodes) {
@@ -1445,6 +1451,7 @@ public class HelixClusterManagerTest {
     idealState.setRebalanceMode(IdealState.RebalanceMode.SEMI_AUTO);
     helixCluster.refreshIdealState();
     assertFalse(registry.getGauges().keySet().contains(totalInstanceMetricName));
+    assertFalse(registry.getGauges().keySet().contains(expectedCapacityMetricName));
     for (DataNode dataNode : allLocalDcDataNodes) {
       String instanceName = ClusterMapUtils.getInstanceName(dataNode.getHostname(), dataNode.getPort());
       InstanceConfig instanceConfig =


### PR DESCRIPTION
## Summary
Right now we are using the helix clique total capacity to gauge the total remaining capacity left on a clique. Total capacity can fluctuate during rebalancing. Expected capacity will be a more accurate number to gauge a clique's headroom



## Testing Done
add unit tests
