### PR TITLE
Add per-datacenter MySQL connection-failure counter

### DIFF
--- a/ambry-named-mysql/src/main/java/com/github/ambry/named/MySqlNamedBlobDb.java
+++ b/ambry-named-mysql/src/main/java/com/github/ambry/named/MySqlNamedBlobDb.java
@@ -42,11 +42,16 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.SQLNonTransientConnectionException;
+import java.sql.SQLTransientConnectionException;
 import java.sql.Timestamp;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -559,18 +564,54 @@ public class MySqlNamedBlobDb implements NamedBlobDb {
     }
 
     /**
-     * SQLSTATE class "08" is the ISO/SQL "Connection exception" class — it covers
-     * 08001 (unable to establish), 08003 (connection does not exist), 08006 (connection failure),
-     * and 08S01 (MySQL communication link failure / {@code CommunicationsException}).
-     * Checking SQLSTATE rather than {@code instanceof CommunicationsException} keeps this
-     * vendor-neutral and resilient to MySQL connector class-name changes.
+     * Whether the given throwable represents a JDBC connection failure (vs. any other SQL error).
+     *
+     * <p>Three independent positive signals, all spec-defined as connection-class:
+     * <ol>
+     *   <li>{@link SQLNonTransientConnectionException} — JDBC's non-transient connection-failure
+     *       subclass; MySQL {@code CommunicationsException} extends this.</li>
+     *   <li>{@link SQLTransientConnectionException} — JDBC's transient connection-failure subclass;
+     *       HikariCP wraps pool-acquisition timeouts as this.</li>
+     *   <li>{@link SQLException#getSQLState()} starting with {@code "08"} — ISO/SQL "Connection
+     *       exception" class (08001/08003/08004/08006/08007/08S01).</li>
+     * </ol>
+     *
+     * <p>The walk traverses both {@link Throwable#getCause()} and {@link SQLException#getNextException()}
+     * so wrapped/chained variants (e.g. RuntimeException-wrapped, Hikari-wrapped, batch error chains)
+     * are detected. SQLSTATE "40*" (transaction rollback), "57*" (operator intervention), and other
+     * adjacent classes are intentionally NOT counted — those are not connection failures.
      */
     private static boolean isConnectionFailure(Throwable t) {
-      if (!(t instanceof SQLException)) {
+      if (t == null) {
         return false;
       }
-      String state = ((SQLException) t).getSQLState();
-      return state != null && state.startsWith("08");
+      Set<Throwable> seen = Collections.newSetFromMap(new IdentityHashMap<>());
+      Deque<Throwable> stack = new ArrayDeque<>();
+      stack.push(t);
+      while (!stack.isEmpty()) {
+        Throwable cur = stack.pop();
+        if (!seen.add(cur)) {
+          continue;
+        }
+        if (cur instanceof SQLNonTransientConnectionException || cur instanceof SQLTransientConnectionException) {
+          return true;
+        }
+        if (cur instanceof SQLException) {
+          String state = ((SQLException) cur).getSQLState();
+          if (state != null && state.startsWith("08")) {
+            return true;
+          }
+          SQLException next = ((SQLException) cur).getNextException();
+          if (next != null) {
+            stack.push(next);
+          }
+        }
+        Throwable cause = cur.getCause();
+        if (cause != null) {
+          stack.push(cause);
+        }
+      }
+      return false;
     }
 
     <T> void executeTransaction(Container container, boolean autoCommit, Transaction<T> transaction,

--- a/ambry-named-mysql/src/main/java/com/github/ambry/named/MySqlNamedBlobDb.java
+++ b/ambry-named-mysql/src/main/java/com/github/ambry/named/MySqlNamedBlobDb.java
@@ -516,7 +516,9 @@ public class MySqlNamedBlobDb implements NamedBlobDb {
     private final String activeCountMetricName;
     private final String rejectedCountMetricName;
     private final String enqueueWaitTimeMetricName;
+    private final String connectionFailureCountMetricName;
     private final Counter rejectedCount;
+    private final Counter connectionFailureCount;
     private final Histogram enqueueWaitTimeInMs;
     private final int maxPendingTransactions;
 
@@ -540,16 +542,35 @@ public class MySqlNamedBlobDb implements NamedBlobDb {
           MetricRegistry.name(MySqlNamedBlobDb.class, prefix + "NamedBlobTransactionRejectedCount." + datacenter);
       this.enqueueWaitTimeMetricName =
           MetricRegistry.name(MySqlNamedBlobDb.class, prefix + "NamedBlobEnqueueWaitTimeInMs." + datacenter);
+      this.connectionFailureCountMetricName =
+          MetricRegistry.name(MySqlNamedBlobDb.class, prefix + "NamedBlobDBConnectionFailureCount." + datacenter);
       // remove() before register() guards against duplicate-key errors when a previous instance
       // (e.g. a test) registered the same metric name and was not closed.
       registry.remove(queueSizeMetricName);
       registry.remove(activeCountMetricName);
       registry.remove(rejectedCountMetricName);
       registry.remove(enqueueWaitTimeMetricName);
+      registry.remove(connectionFailureCountMetricName);
       registry.register(queueSizeMetricName, (Gauge<Integer>) () -> executor.getQueue().size());
       registry.register(activeCountMetricName, (Gauge<Integer>) () -> executor.getActiveCount());
       this.rejectedCount = registry.counter(rejectedCountMetricName);
       this.enqueueWaitTimeInMs = registry.histogram(enqueueWaitTimeMetricName);
+      this.connectionFailureCount = registry.counter(connectionFailureCountMetricName);
+    }
+
+    /**
+     * SQLSTATE class "08" is the ISO/SQL "Connection exception" class — it covers
+     * 08001 (unable to establish), 08003 (connection does not exist), 08006 (connection failure),
+     * and 08S01 (MySQL communication link failure / {@code CommunicationsException}).
+     * Checking SQLSTATE rather than {@code instanceof CommunicationsException} keeps this
+     * vendor-neutral and resilient to MySQL connector class-name changes.
+     */
+    private static boolean isConnectionFailure(Throwable t) {
+      if (!(t instanceof SQLException)) {
+        return false;
+      }
+      String state = ((SQLException) t).getSQLState();
+      return state != null && state.startsWith("08");
     }
 
     <T> void executeTransaction(Container container, boolean autoCommit, Transaction<T> transaction,
@@ -577,6 +598,9 @@ public class MySqlNamedBlobDb implements NamedBlobDb {
             }
             callback.onCompletion(result, null);
           } catch (Exception e) {
+            if (isConnectionFailure(e)) {
+              connectionFailureCount.inc();
+            }
             callback.onCompletion(null, e);
           }
         });
@@ -609,6 +633,9 @@ public class MySqlNamedBlobDb implements NamedBlobDb {
             }
             callback.onCompletion(result, null);
           } catch (Exception e) {
+            if (isConnectionFailure(e)) {
+              connectionFailureCount.inc();
+            }
             callback.onCompletion(null, e);
           }
         });
@@ -652,6 +679,7 @@ public class MySqlNamedBlobDb implements NamedBlobDb {
       registry.remove(activeCountMetricName);
       registry.remove(rejectedCountMetricName);
       registry.remove(enqueueWaitTimeMetricName);
+      registry.remove(connectionFailureCountMetricName);
     }
   }
 

--- a/ambry-named-mysql/src/test/java/com/github/ambry/named/MySqlNamedBlobDbTest.java
+++ b/ambry-named-mysql/src/test/java/com/github/ambry/named/MySqlNamedBlobDbTest.java
@@ -176,7 +176,63 @@ public class MySqlNamedBlobDbTest {
             .containsKey("com.github.ambry.named.MySqlNamedBlobDb.NamedBlobTransactionRejectedCount." + dc));
         assertTrue("enqueue-wait histogram missing for datacenter " + dc, registry.getHistograms()
             .containsKey("com.github.ambry.named.MySqlNamedBlobDb.NamedBlobEnqueueWaitTimeInMs." + dc));
+        assertTrue("connection-failure counter missing for datacenter " + dc, registry.getCounters()
+            .containsKey("com.github.ambry.named.MySqlNamedBlobDb.NamedBlobDBConnectionFailureCount." + dc));
       }
+    } finally {
+      db.close();
+    }
+  }
+
+  /**
+   * Verify that {@code NamedBlobDBConnectionFailureCount.<dc>} increments when a query fails with a
+   * SQLSTATE 08* exception (connection-class failure, e.g. MySQL CommunicationsException) and does
+   * NOT increment for other SQLException types or non-connection SQLSTATEs.
+   */
+  @Test
+  public void testConnectionFailureCounterIncrementsOnSqlState08() throws Exception {
+    MetricRegistry registry = new MetricRegistry();
+    Metrics metrics = new Metrics(registry, "");
+    MySqlNamedBlobDb db =
+        new MySqlNamedBlobDb(accountService, buildSmallPoolConfig(1, 1, 100), dataSourceFactory, localDatacenter,
+            metrics);
+    try {
+      String metricName =
+          "com.github.ambry.named.MySqlNamedBlobDb.NamedBlobDBConnectionFailureCount." + localDatacenter;
+      Counter counter = registry.getCounters().get(metricName);
+      assertNotNull("connection-failure counter not registered for " + localDatacenter, counter);
+
+      // SQLSTATE 08S01 — MySQL "Communication link failure" (CommunicationsException).
+      SQLException communicationLinkFailure = new SQLException("Communications link failure", "08S01", 0);
+      dataSourceFactory.triggerQueryExecutionError(localDatacenter, communicationLinkFailure);
+      TestUtils.assertException(ExecutionException.class,
+          () -> db.get(account.getName(), container.getName(), "blobName").get(),
+          e -> Assert.assertEquals(communicationLinkFailure, e.getCause()));
+      assertEquals("counter should increment on SQLSTATE 08S01", 1L, counter.getCount());
+
+      // SQLSTATE 42000 — syntax-class error. Must not increment.
+      SQLException syntaxError = new SQLException("syntax error", "42000", 1064);
+      dataSourceFactory.triggerQueryExecutionError(localDatacenter, syntaxError);
+      TestUtils.assertException(ExecutionException.class,
+          () -> db.get(account.getName(), container.getName(), "blobName").get(),
+          e -> Assert.assertEquals(syntaxError, e.getCause()));
+      assertEquals("counter must not increment on non-connection SQLSTATE", 1L, counter.getCount());
+
+      // SQLSTATE 08006 — generic "connection failure", should also count.
+      SQLException connectionFailure = new SQLException("connection failure", "08006", 0);
+      dataSourceFactory.triggerQueryExecutionError(localDatacenter, connectionFailure);
+      TestUtils.assertException(ExecutionException.class,
+          () -> db.get(account.getName(), container.getName(), "blobName").get(),
+          e -> Assert.assertEquals(connectionFailure, e.getCause()));
+      assertEquals("counter should increment on any SQLSTATE 08*", 2L, counter.getCount());
+
+      // SQLException with null SQLSTATE — must not increment (defensive).
+      SQLException nullState = new SQLException("no state");
+      dataSourceFactory.triggerQueryExecutionError(localDatacenter, nullState);
+      TestUtils.assertException(ExecutionException.class,
+          () -> db.get(account.getName(), container.getName(), "blobName").get(),
+          e -> Assert.assertEquals(nullState, e.getCause()));
+      assertEquals("counter must not increment when SQLSTATE is null", 2L, counter.getCount());
     } finally {
       db.close();
     }
@@ -203,6 +259,8 @@ public class MySqlNamedBlobDbTest {
           .containsKey("com.github.ambry.named.MySqlNamedBlobDb.NamedBlobTransactionRejectedCount." + dc));
       assertFalse("enqueue-wait histogram for " + dc + " should be removed after close", registry.getHistograms()
           .containsKey("com.github.ambry.named.MySqlNamedBlobDb.NamedBlobEnqueueWaitTimeInMs." + dc));
+      assertFalse("connection-failure counter for " + dc + " should be removed after close", registry.getCounters()
+          .containsKey("com.github.ambry.named.MySqlNamedBlobDb.NamedBlobDBConnectionFailureCount." + dc));
     }
   }
 

--- a/ambry-named-mysql/src/test/java/com/github/ambry/named/MySqlNamedBlobDbTest.java
+++ b/ambry-named-mysql/src/test/java/com/github/ambry/named/MySqlNamedBlobDbTest.java
@@ -39,6 +39,8 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.SQLNonTransientConnectionException;
+import java.sql.SQLTransientConnectionException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -233,6 +235,58 @@ public class MySqlNamedBlobDbTest {
           () -> db.get(account.getName(), container.getName(), "blobName").get(),
           e -> Assert.assertEquals(nullState, e.getCause()));
       assertEquals("counter must not increment when SQLSTATE is null", 2L, counter.getCount());
+
+      // Direct SQLNonTransientConnectionException (mimics MySQL CommunicationsException) — counts via type.
+      SQLException directNonTransient = new SQLNonTransientConnectionException("communications failure");
+      dataSourceFactory.triggerQueryExecutionError(localDatacenter, directNonTransient);
+      TestUtils.assertException(ExecutionException.class,
+          () -> db.get(account.getName(), container.getName(), "blobName").get(),
+          e -> Assert.assertEquals(directNonTransient, e.getCause()));
+      assertEquals("counter should increment on SQLNonTransientConnectionException", 3L, counter.getCount());
+
+      // Direct SQLTransientConnectionException (mimics HikariCP pool-timeout shape) — counts via type.
+      SQLException directTransient = new SQLTransientConnectionException("pool timeout");
+      dataSourceFactory.triggerQueryExecutionError(localDatacenter, directTransient);
+      TestUtils.assertException(ExecutionException.class,
+          () -> db.get(account.getName(), container.getName(), "blobName").get(),
+          e -> Assert.assertEquals(directTransient, e.getCause()));
+      assertEquals("counter should increment on SQLTransientConnectionException", 4L, counter.getCount());
+
+      // SQLSTATE 40001 (deadlock) — adjacent rollback class, NOT a connection failure.
+      SQLException deadlock = new SQLException("deadlock", "40001", 1213);
+      dataSourceFactory.triggerQueryExecutionError(localDatacenter, deadlock);
+      TestUtils.assertException(ExecutionException.class,
+          () -> db.get(account.getName(), container.getName(), "blobName").get(),
+          e -> Assert.assertEquals(deadlock, e.getCause()));
+      assertEquals("counter must not increment on SQLSTATE 40001 (deadlock)", 4L, counter.getCount());
+
+      // Outer SQLException with no SQLSTATE, cause = SQLException with 08006 — counts via getCause walk.
+      SQLException wrappedConnFailure = new SQLException("wrapper, no state");
+      wrappedConnFailure.initCause(new SQLException("inner conn failure", "08006"));
+      dataSourceFactory.triggerQueryExecutionError(localDatacenter, wrappedConnFailure);
+      TestUtils.assertException(ExecutionException.class,
+          () -> db.get(account.getName(), container.getName(), "blobName").get(),
+          e -> Assert.assertEquals(wrappedConnFailure, e.getCause()));
+      assertEquals("counter should increment when 08* is in cause chain", 5L, counter.getCount());
+
+      // Outer 99999 with getNextException() = 08006 — counts via next-exception chain.
+      SQLException withNext = new SQLException("outer", "99999");
+      withNext.setNextException(new SQLException("next conn failure", "08006"));
+      dataSourceFactory.triggerQueryExecutionError(localDatacenter, withNext);
+      TestUtils.assertException(ExecutionException.class,
+          () -> db.get(account.getName(), container.getName(), "blobName").get(),
+          e -> Assert.assertEquals(withNext, e.getCause()));
+      assertEquals("counter should increment when 08* reachable via getNextException", 6L, counter.getCount());
+
+      // Outer SQLException with no SQLSTATE, cause = SQLNonTransientConnectionException — counts via cause walk to type.
+      SQLException wrappedTyped = new SQLException("wrapper, no state");
+      wrappedTyped.initCause(new SQLNonTransientConnectionException("inner typed"));
+      dataSourceFactory.triggerQueryExecutionError(localDatacenter, wrappedTyped);
+      TestUtils.assertException(ExecutionException.class,
+          () -> db.get(account.getName(), container.getName(), "blobName").get(),
+          e -> Assert.assertEquals(wrappedTyped, e.getCause()));
+      assertEquals("counter should increment when typed connection exception is in cause chain", 7L,
+          counter.getCount());
     } finally {
       db.close();
     }


### PR DESCRIPTION
## Summary
- New per-datacenter Dropwizard counter `NamedBlobDBConnectionFailureCount.<datacenter>` registered in `MySqlNamedBlobDb.TransactionExecutor`.
- Increments when a transaction fails with a `SQLException` whose SQLSTATE starts with `"08"` — the ISO/SQL "Connection exception" class.
- Covers `08001`, `08003`, `08006`, and `08S01` (MySQL `CommunicationsException`).

## Motivation / Context
We saw a single `ambry-frontend` host lose MySQL connectivity to the named-blob DB for 67 minutes. Every query failed with `com.mysql.cj.jdbc.exceptions.CommunicationsException` (SQLSTATE `08S01`, `java.io.EOFException` root cause from `NativeProtocol.checkErrorMessage`).

The existing `NamedBlobDBListErrorCount` counter does increment for these errors via the `instanceof SQLException` check in `executeTransactionAsync`'s `finalCallback`, but it mixes connection-class failures with syntax errors, deadlocks, deserialization issues, and every other `SQLException` subclass. An on-call dashboard can't distinguish "the network/pool is broken" from "a query is malformed."

The new counter is registered alongside the existing per-DC metrics already produced by `TransactionExecutor` (`NamedBlobTransactionRejectedCount`, `TransactionExecutorQueueSize`, `TransactionExecutorActiveCount`, `NamedBlobEnqueueWaitTimeInMs`), so it inherits per-DC granularity for free.

The plan is to emit the metrics, and use this to catch individual host level connectivity error, and force a restart



## Testing Done

`./gradlew :ambry-named-mysql:test --rerun-tasks`: 11 tests, 11 passed, 0 failed.

New / extended tests:

- **`testConnectionFailureCounterIncrementsOnSqlState08` (new)** — exercises four cases via the existing `MockDataSourceFactory.triggerQueryExecutionError` plumbing:
  - SQLSTATE `08S01` (MySQL `CommunicationsException`) → counter increments
  - SQLSTATE `08006` (generic connection failure) → counter increments
  - SQLSTATE `42000` (syntax error) → counter does NOT increment (negative case, ensures no over-counting)
  - `SQLException` with `null` SQLSTATE → counter does NOT increment (defensive)
- **`testTransactionExecutorMetricsRegistered` (extended)** — asserts the new counter is registered for every writeable DC on construction.
- **`testTransactionExecutorGaugesRemovedOnClose` (extended)** — asserts the counter is deregistered on `close()` to prevent leakage / duplicate-registration on re-instantiation.

## Risk Assessment

- **Backward compatibility:** purely additive. New metric appears under a new name; no existing metric is renamed, removed, or changed in behavior. No public API changes.
- **Blast radius:** every JVM that constructs a `MySqlNamedBlobDb` (frontend, ace-tool). Each transaction failure now incurs one extra `instanceof` + null-check + `String.startsWith("08")`. Negligible.
- **Durability:** none. No effect on read/write/delete paths or callback semantics — the counter increment happens *before* the existing `callback.onCompletion(null, e)` call and does not alter what the caller observes.
- **Backout:** revert this commit. No persistent state, no schema changes.

### Durability checklist (per repo guidelines)

- [ ] Write path — no
- [ ] Metadata — no
- [ ] Ordering / Atomicity — no
- [ ] Callback semantics — no (increment runs before callback; exception still propagated unchanged)
- [ ] Resource cleanup — counter is removed in `close()` alongside the existing per-DC metrics
- [ ] Retries / Idempotency — n/a (counter only)
- [ ] Partial failures — n/a
- [ ] Corruption handling — n/a

## Observability / Ops Impact

- New metric: `com.github.ambry.named.MySqlNamedBlobDb.NamedBlobDBConnectionFailureCount.<datacenter>` (and `…secondary.NamedBlobDBConnectionFailureCount.<datacenter>` when constructed with the `secondary.` prefix).
- LinkedIn-side sensor wiring (AmbrySensors) is required separately to surface this in RRD/OTEL — same as the other per-DC metrics added in #3230. That wiring will be a follow-up PR in `AmbryLI`.

## Rollout / Backout Plan

- Standard rolling deploy. Each host begins emitting the new counter as it restarts; no migration or coordination needed.
- Backout: revert. No persistent effects.

## AI Usage

Drafted with Claude Code (counter wiring, SQLSTATE check, test cases). Author reviewed the SQLSTATE choice (vendor-neutral standard vs. `instanceof CommunicationsException`), the increment placement (before callback, in both `executeTransaction` and `executeTransactionGeneric`), and verified test coverage on the negative cases.