### PR TITLE
Fix wrong-variable logging in resource-release IOException catch

### DIFF
--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestService.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestService.java
@@ -529,7 +529,7 @@ class FrontendRestRequestService implements RestRequestService {
           responseBody.close();
         } catch (IOException ioe) {
           frontendMetrics.resourceReleaseError.inc();
-          logger.error("Error closing ReadableStreamChannel", e);
+          logger.error("Error closing ReadableStreamChannel", ioe);
         }
       }
     }


### PR DESCRIPTION
**JIRA:** [ACTIONITEM-16798](https://linkedin.atlassian.net/browse/ACTIONITEM-16798)

## Summary

Fix wrong-variable logging in `FrontendRestRequestService.submitResponse`'s response-body close catch. Caught from an internal swallowed-exception audit; flagged as P0 because it loses diagnostic information for resource-leak failures.

## The bug

```java
} catch (Exception e) {                                 // ← outer catch, `e` = submission failure
  frontendMetrics.responseSubmissionError.inc();
  // ...
  if (responseBody != null) {
    try {
      responseBody.close();
    } catch (IOException ioe) {                         // ← inner catch, `ioe` = close failure
      frontendMetrics.resourceReleaseError.inc();
      logger.error("Error closing ReadableStreamChannel", e);  // ← logs `e` (submission), not `ioe` (close)
    }
  }
}
```

The inner `catch (IOException ioe)` declares `ioe` but the log statement passes `e` from the enclosing outer catch. Two unrelated failures:
- `e`: original `responseHandler.handleResponse(...)` submission failure
- `ioe`: the actual `responseBody.close()` IOException during cleanup

The metric `resourceReleaseError` increments correctly, but the log message *"Error closing ReadableStreamChannel"* carries the submission failure's stack trace instead of the close failure's. Operators investigating leaked-channel symptoms see the unrelated submission exception and investigate the wrong subsystem; the real close failure is invisible.

## The fix

One-character change: log `ioe` instead of `e` so the message and the stack trace agree about what failed.

## Question for reviewers

Should we add a metric here? `frontendMetrics.resourceReleaseError` already counts these failures, so the metric coverage is fine — the missing piece was diagnostic content in the log. With this fix, the existing metric + corrected log gives operators both "how often" (counter) and "why" (stack trace). No new metric needed unless we want a separate counter to distinguish IOException-on-close from other resource-release failures (currently the metric covers any close failure path).

## Testing Done

- Verified the diff compiles (`./gradlew :ambry-frontend:compileJava`).
- No behavior change on the success path; the only change is which exception object SLF4J attaches to the error log when the catch fires.

## Risk Assessment

- **Backward compatibility**: log content only — no behavior or wire-format change.
- **Blast radius**: limited to the log line in this one catch block.
- **Read/write path**: unaffected.
- **Durability**: no change.

### Durability Risk Checklist
- [ ] Write path
- [ ] Metadata
- [ ] Ordering / Atomicity
- [ ] Callback semantics
- [ ] Resource cleanup
- [ ] Retries / Idempotency
- [ ] Partial failures
- [ ] Corruption handling

All unchecked — pure log-content fix.

## Rollout / Backout Plan

- Standard rollout. Log lines from this catch will start carrying the correct exception class once deployed.
- Backout: revert this PR; logs return to attaching the outer submission exception.

## Related

Companion to #3252 (same audit, same wrong-variable bug pattern, different file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

