### PR TITLE
Log and meter S3 batch-delete request-body parse failures

### DIFF
--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendMetrics.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendMetrics.java
@@ -265,6 +265,8 @@ public class FrontendMetrics {
   // GetReplicasHandler
   public final Counter invalidBlobIdError;
   public final Counter responseConstructionError;
+  // S3BatchDeleteHandler
+  public final Counter s3BatchDeleteRequestParseError;
   // Other
   // FrontendRestRequestService
   public final Histogram restRequestServiceStartupTimeInMs;
@@ -721,6 +723,9 @@ public class FrontendMetrics {
     invalidBlobIdError = metricRegistry.counter(MetricRegistry.name(GetReplicasHandler.class, "InvalidBlobIdError"));
     responseConstructionError =
         metricRegistry.counter(MetricRegistry.name(GetReplicasHandler.class, "ResponseConstructionError"));
+    // S3BatchDeleteHandler
+    s3BatchDeleteRequestParseError =
+        metricRegistry.counter(MetricRegistry.name(S3BatchDeleteHandler.class, "RequestParseError"));
 
     // Other
     restRequestServiceStartupTimeInMs =

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3BatchDeleteHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/s3/S3BatchDeleteHandler.java
@@ -116,6 +116,8 @@ public class S3BatchDeleteHandler extends S3BaseHandler<ReadableStreamChannel> {
           throw new RestServiceException(batchSizeErrorMessage, RestServiceErrorCode.BadRequest);
         }
       } catch (Exception e) {
+        metrics.s3BatchDeleteRequestParseError.inc();
+        logger.warn("Failed to parse S3 batch-delete request body, returning malformed-body error", e);
         S3MessagePayload.Error response = new S3MessagePayload.Error();
         response.setCode(ERR_MALFORMED_REQUEST_BODY_CODE);
         response.setMessage(ERR_MALFORMED_REQUEST_BODY_MESSAGE);

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/S3BatchDeleteHandlerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/S3BatchDeleteHandlerTest.java
@@ -71,6 +71,7 @@ public class S3BatchDeleteHandlerTest {
   private final Account account;
   private final Container container;
   private FrontendConfig frontendConfig;
+  private FrontendMetrics metrics;
   private NamedBlobPutHandler namedBlobPutHandler;
   private S3BatchDeleteHandler s3BatchDeleteHandler;
   private final NettyByteBufLeakHelper nettyByteBufLeakHelper = new NettyByteBufLeakHelper();
@@ -233,6 +234,7 @@ public class S3BatchDeleteHandlerTest {
     RestResponseChannel restResponseChannel = new MockRestResponseChannel();
     request.setArg(RestUtils.InternalKeys.REQUEST_PATH,
         RequestPath.parse(request, frontendConfig.pathPrefixesToRemove, CLUSTER_NAME));
+    long parseErrorsBefore = metrics.s3BatchDeleteRequestParseError.getCount();
     FutureResult<ReadableStreamChannel> futureResult = new FutureResult<>();
     s3BatchDeleteHandler.handle(request, restResponseChannel, futureResult::done);
     ReadableStreamChannel readableStreamChannel = futureResult.get();
@@ -245,6 +247,8 @@ public class S3BatchDeleteHandlerTest {
     assertEquals(response.getMessage(), ERR_MALFORMED_REQUEST_BODY_MESSAGE);
     assertEquals(response.getCode(), ERR_MALFORMED_REQUEST_BODY_CODE);
     assertEquals("Mismatch on status", ResponseStatus.Ok, restResponseChannel.getStatus());
+    assertEquals("Parse-error counter should increment by 1", parseErrorsBefore + 1,
+        metrics.s3BatchDeleteRequestParseError.getCount());
   }
 
   @Test
@@ -314,7 +318,7 @@ public class S3BatchDeleteHandlerTest {
     CommonTestUtils.populateRequiredRouterProps(properties);
     VerifiableProperties verifiableProperties = new VerifiableProperties(properties);
     frontendConfig = new FrontendConfig(verifiableProperties);
-    FrontendMetrics metrics = new FrontendMetrics(new MetricRegistry(), frontendConfig);
+    metrics = new FrontendMetrics(new MetricRegistry(), frontendConfig);
     AccountAndContainerInjector injector = new AccountAndContainerInjector(ACCOUNT_SERVICE, metrics, frontendConfig);
     IdSigningService idSigningService = new AmbryIdSigningService();
     AmbrySecurityServiceFactory securityServiceFactory =


### PR DESCRIPTION
**JIRA:** [ACTIONITEM-16798](https://linkedin.atlassian.net/browse/ACTIONITEM-16798)

## Summary

`S3BatchDeleteHandler.parseRequestBodyAndDeleteCallback` catches every
`Exception` thrown while validating the request body and maps it to a
generic `MalformedRequestBody` S3 error. The caught exception is never
logged, no metric is incremented, and the callback is invoked with a
`null` exception argument — so a genuine server-side bug (NPE, IO
failure, deserializer crash, etc.) is operationally indistinguishable
from a client sending malformed XML.

This change:
- Adds `FrontendMetrics.s3BatchDeleteRequestParseError` (`Counter`).
- In the catch block, increments the counter and logs the exception at
  `WARN` with `logger.warn("Failed to parse S3 batch-delete request body, returning malformed-body error", e)`.
- Leaves the S3 protocol response (200 OK with XML error body) unchanged
  — that's a protocol requirement.

## Testing Done

- `S3BatchDeleteHandlerTest.malformedXMLRequestTest` now also asserts
  the parse-error counter increments by exactly 1 when a malformed body
  fires the catch.
- All 6 tests in `S3BatchDeleteHandlerTest` pass:
  `./gradlew :ambry-frontend:test --tests "com.github.ambry.frontend.S3BatchDeleteHandlerTest"`
- `:ambry-frontend:compileJava` and `:ambry-frontend:compileTestJava` are clean.

## Durability risk analysis

No write/metadata/ordering paths touched. This is a pure observability
change in the request-validation path of an S3-compat batch delete
handler. The on-the-wire response is byte-for-byte identical to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
