### PR TITLE
Log force-delete failures inside AmbryRequests.maybeForceDelete

### DIFF
--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryRequests.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryRequests.java
@@ -1175,9 +1175,11 @@ public class AmbryRequests implements RequestAPI {
           // Blob might have been replicated while we were force deleting it. Try normal delete now
           store.delete(Collections.singletonList(info));
         } catch (StoreException ex) {
+          logger.error("Force-delete fallback delete failed for blob {}", info.getStoreKey().getID(), ex);
           serverErrorCode = ErrorMapping.getStoreErrorMapping(ex.getErrorCode());
         }
       } else {
+        logger.error("Force-delete failed for blob {}", info.getStoreKey().getID(), e);
         serverErrorCode = ErrorMapping.getStoreErrorMapping(e.getErrorCode());
       }
     }


### PR DESCRIPTION
**JIRA:** [ACTIONITEM-16798](https://linkedin.atlassian.net/browse/ACTIONITEM-16798)

## Summary

`AmbryRequests.maybeForceDelete` has two catch blocks (one outer, one
inner-retry-after-AlreadyExist) that previously consumed the
`StoreException` purely for its `getErrorCode()` and returned a mapped
`ServerErrorCode` — without logging the exception or its stack trace.

The caller (`handleDeleteRequest`) does log a Store exception, but it logs
the *outer* `e` (the `IDNotFound` that triggered the force-delete branch),
not the maybeForceDelete-internal one. So when a force-delete itself failed
in production, the operator log read "Store exception on a delete with
error code IDNotFound" — pointing at the wrong cause, and with the actual
failure's stack trace dropped entirely.

This change adds a `logger.error(...)` at each catch site with the blob's
`StoreKey.getID()` and the exception passed as the last argument so SLF4J
prints the full stack trace.

The two distinct messages distinguish the two failure paths:
- `"Force-delete failed for blob {}"` — `forceDelete` itself failed for a
  non-`AlreadyExist` reason.
- `"Force-delete fallback delete failed for blob {}"` — `forceDelete`
  returned `AlreadyExist`, the fallback `store.delete(...)` then also failed.

ERROR level matches the surrounding `handleDeleteRequest` discipline at
L519-521, which logs unexpected `StoreException`s at ERROR. CLAUDE.md's
log-level rubric also calls for ERROR on \"unexpected failures requiring
attention,\" which both sites are.

## Testing Done

- \`./gradlew :ambry-server:compileJava\` — clean.
- \`./gradlew :ambry-server:test --tests \"com.github.ambry.server.AmbryServerRequestsTest\"\` — 118 passed, 6 skipped, 0 failed.

## Durability risk analysis

No write/metadata/ordering paths touched. Pure observability change inside
the force-delete-retry helper. Behavior is byte-identical except for two
new log lines on the two failure paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
