### PR TITLE
DatasetDao: map JDBC driver NPE on versionSchema column read to NotFound

### DIFF
--- a/ambry-account/src/main/java/com/github/ambry/account/mysql/DatasetDao.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/mysql/DatasetDao.java
@@ -38,6 +38,8 @@ import java.util.Map;
 import com.github.ambry.account.DatasetVersionRecord;
 import com.github.ambry.protocol.DatasetVersionState;
 import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static com.github.ambry.account.Dataset.VersionSchema.*;
 import static com.github.ambry.mysql.MySqlDataAccessor.OperationType.*;
@@ -45,6 +47,7 @@ import static com.github.ambry.utils.Utils.*;
 
 
 public class DatasetDao {
+  private static final Logger logger = LoggerFactory.getLogger(DatasetDao.class);
   private final MySqlDataAccessor dataAccessor;
   private final MySqlAccountServiceConfig mySqlAccountServiceConfig;
   private final ObjectMapper objectMapper = JsonUtil.newObjectMapper();
@@ -1850,31 +1853,36 @@ public class DatasetDao {
             "Dataset expired for account: " + accountId + " container: " + containerId + " dataset: " + datasetName,
             AccountServiceErrorCode.Deleted);
       }
+      int versionSchemaOrdinal;
       try {
-        versionSchema = Dataset.VersionSchema.values()[resultSet.getInt(VERSION_SCHEMA)];
-        retentionPolicy = resultSet.getObject(RETENTION_POLICY, String.class);
-        retentionCount = resultSet.getObject(RETENTION_COUNT, Integer.class);
-        retentionTimeInSeconds = resultSet.getObject(RETENTION_TIME_IN_SECONDS, Long.class);
-        String userTagsInJson = resultSet.getString(USER_TAGS);
-        if (userTagsInJson != null) {
-          try {
-            userTags = objectMapper.readValue(userTagsInJson, Map.class);
-          } catch (IOException e) {
-            throw new AccountServiceException("Fail to deserialize user tags : " + userTagsInJson,
-                AccountServiceErrorCode.BadRequest);
-          }
-        }
+        versionSchemaOrdinal = resultSet.getInt(VERSION_SCHEMA);
       } catch (NullPointerException e) {
         // mysql-connector-java 8.0.21 (see gradle/dependency-versions.gradle) can throw NPE
         // from ResultSetImpl.findColumn -> getInt when the row state is unexpected. Observed
         // in prod 2026-04-29 on /named/<account>/<container>/<dataset>, where
         // it surfaced as HTTP 500 instead of 404. No fix is called out in the 8.0.x release
-        // notes; revisit when bumping the connector. This path is MySQL-only — Ambry's
+        // notes; revisit when bumping the connector. This path is MySQL-only -- Ambry's
         // dataset metadata does not run against TiDB. Map to NotFound so the frontend
-        // translates it to 404.
+        // translates it to 404, and emit a metric + warn log so on-call still has a signal.
+        metrics.datasetRowReadNpeCount.inc();
+        logger.warn("Dataset row read NPE for account={} container={} dataset={}", accountId, containerId, datasetName,
+            e);
         throw new AccountServiceException(
             "Dataset row could not be read for account: " + accountId + " container: " + containerId + " dataset: "
                 + datasetName, AccountServiceErrorCode.NotFound);
+      }
+      versionSchema = Dataset.VersionSchema.values()[versionSchemaOrdinal];
+      retentionPolicy = resultSet.getObject(RETENTION_POLICY, String.class);
+      retentionCount = resultSet.getObject(RETENTION_COUNT, Integer.class);
+      retentionTimeInSeconds = resultSet.getObject(RETENTION_TIME_IN_SECONDS, Long.class);
+      String userTagsInJson = resultSet.getString(USER_TAGS);
+      if (userTagsInJson != null) {
+        try {
+          userTags = objectMapper.readValue(userTagsInJson, Map.class);
+        } catch (IOException e) {
+          throw new AccountServiceException("Fail to deserialize user tags : " + userTagsInJson,
+              AccountServiceErrorCode.BadRequest);
+        }
       }
     } finally {
       //If result set is not created in a try-with-resources block, it needs to be closed in a finally block.

--- a/ambry-account/src/main/java/com/github/ambry/account/mysql/DatasetDao.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/mysql/DatasetDao.java
@@ -1850,18 +1850,31 @@ public class DatasetDao {
             "Dataset expired for account: " + accountId + " container: " + containerId + " dataset: " + datasetName,
             AccountServiceErrorCode.Deleted);
       }
-      versionSchema = Dataset.VersionSchema.values()[resultSet.getInt(VERSION_SCHEMA)];
-      retentionPolicy = resultSet.getObject(RETENTION_POLICY, String.class);
-      retentionCount = resultSet.getObject(RETENTION_COUNT, Integer.class);
-      retentionTimeInSeconds = resultSet.getObject(RETENTION_TIME_IN_SECONDS, Long.class);
-      String userTagsInJson = resultSet.getString(USER_TAGS);
-      if (userTagsInJson != null) {
-        try {
-          userTags = objectMapper.readValue(userTagsInJson, Map.class);
-        } catch (IOException e) {
-          throw new AccountServiceException("Fail to deserialize user tags : " + userTagsInJson,
-              AccountServiceErrorCode.BadRequest);
+      try {
+        versionSchema = Dataset.VersionSchema.values()[resultSet.getInt(VERSION_SCHEMA)];
+        retentionPolicy = resultSet.getObject(RETENTION_POLICY, String.class);
+        retentionCount = resultSet.getObject(RETENTION_COUNT, Integer.class);
+        retentionTimeInSeconds = resultSet.getObject(RETENTION_TIME_IN_SECONDS, Long.class);
+        String userTagsInJson = resultSet.getString(USER_TAGS);
+        if (userTagsInJson != null) {
+          try {
+            userTags = objectMapper.readValue(userTagsInJson, Map.class);
+          } catch (IOException e) {
+            throw new AccountServiceException("Fail to deserialize user tags : " + userTagsInJson,
+                AccountServiceErrorCode.BadRequest);
+          }
         }
+      } catch (NullPointerException e) {
+        // mysql-connector-java 8.0.21 (see gradle/dependency-versions.gradle) can throw NPE
+        // from ResultSetImpl.findColumn -> getInt when the row state is unexpected. Observed
+        // in prod 2026-04-29 on /named/<account>/<container>/<dataset>, where
+        // it surfaced as HTTP 500 instead of 404. No fix is called out in the 8.0.x release
+        // notes; revisit when bumping the connector. This path is MySQL-only — Ambry's
+        // dataset metadata does not run against TiDB. Map to NotFound so the frontend
+        // translates it to 404.
+        throw new AccountServiceException(
+            "Dataset row could not be read for account: " + accountId + " container: " + containerId + " dataset: "
+                + datasetName, AccountServiceErrorCode.NotFound);
       }
     } finally {
       //If result set is not created in a try-with-resources block, it needs to be closed in a finally block.

--- a/ambry-account/src/main/java/com/github/ambry/account/mysql/DatasetDao.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/mysql/DatasetDao.java
@@ -1931,7 +1931,18 @@ public class DatasetDao {
             "Version Schema not found for account: " + accountId + " container: " + containerId + " dataset: "
                 + datasetName, AccountServiceErrorCode.NotFound);
       }
-      versionSchema = Dataset.VersionSchema.values()[resultSet.getInt(VERSION_SCHEMA)];
+      int versionSchemaOrdinal;
+      try {
+        versionSchemaOrdinal = resultSet.getInt(VERSION_SCHEMA);
+      } catch (NullPointerException e) {
+        // Same JDBC driver bug as executeGetDatasetStatement -- see comment there for details.
+        // Not observed on this path in prod, but the call shape is identical so guard symmetrically.
+        metrics.datasetRowReadNpeCount.inc();
+        throw new AccountServiceException(
+            "Version Schema row could not be read for account: " + accountId + " container: " + containerId
+                + " dataset: " + datasetName, AccountServiceErrorCode.NotFound);
+      }
+      versionSchema = Dataset.VersionSchema.values()[versionSchemaOrdinal];
     } finally {
       //If result set is not created in a try-with-resources block, it needs to be closed in a finally block.
       closeQuietly(resultSet);

--- a/ambry-account/src/main/java/com/github/ambry/account/mysql/DatasetDao.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/mysql/DatasetDao.java
@@ -38,8 +38,6 @@ import java.util.Map;
 import com.github.ambry.account.DatasetVersionRecord;
 import com.github.ambry.protocol.DatasetVersionState;
 import java.util.Set;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static com.github.ambry.account.Dataset.VersionSchema.*;
 import static com.github.ambry.mysql.MySqlDataAccessor.OperationType.*;
@@ -47,7 +45,6 @@ import static com.github.ambry.utils.Utils.*;
 
 
 public class DatasetDao {
-  private static final Logger logger = LoggerFactory.getLogger(DatasetDao.class);
   private final MySqlDataAccessor dataAccessor;
   private final MySqlAccountServiceConfig mySqlAccountServiceConfig;
   private final ObjectMapper objectMapper = JsonUtil.newObjectMapper();
@@ -1863,10 +1860,9 @@ public class DatasetDao {
         // it surfaced as HTTP 500 instead of 404. No fix is called out in the 8.0.x release
         // notes; revisit when bumping the connector. This path is MySQL-only -- Ambry's
         // dataset metadata does not run against TiDB. Map to NotFound so the frontend
-        // translates it to 404, and emit a metric + warn log so on-call still has a signal.
+        // translates it to 404; the dedicated metric below is the on-call signal (the
+        // existing AccountAndContainerInjector error log already names the dataset).
         metrics.datasetRowReadNpeCount.inc();
-        logger.warn("Dataset row read NPE for account={} container={} dataset={}", accountId, containerId, datasetName,
-            e);
         throw new AccountServiceException(
             "Dataset row could not be read for account: " + accountId + " container: " + containerId + " dataset: "
                 + datasetName, AccountServiceErrorCode.NotFound);

--- a/ambry-account/src/test/java/com/github/ambry/account/mysql/DatasetDaoTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/mysql/DatasetDaoTest.java
@@ -86,4 +86,45 @@ public class DatasetDaoTest {
     assertEquals("datasetRowReadNpeCount should increment by 1", npeCountBefore + 1,
         metrics.datasetRowReadNpeCount.getCount());
   }
+
+  /**
+   * Same JDBC NPE class as {@link #testGetDatasetMapsJdbcNpeOnVersionSchemaToNotFound}, but
+   * exercising the {@code executeGetVersionSchema} path used by version-mutation flows
+   * (delete/list/ttl-update). Not observed in prod, but the call shape is identical so the
+   * mapping should be symmetric.
+   */
+  @Test
+  public void testDeleteDatasetVersionMapsJdbcNpeOnVersionSchemaToNotFound() throws Exception {
+    Connection mockConnection = mock(Connection.class);
+    MySqlMetrics metrics = new MySqlMetrics(DatasetDao.class, new MetricRegistry());
+    MySqlDataAccessor dataAccessor = getDataAccessor(mockConnection, metrics);
+    PreparedStatement mockGetVersionSchemaStatement = mock(PreparedStatement.class);
+    // getVersionSchemaSql is "select versionSchema from Datasets where ..." -- match on the table.
+    when(mockConnection.prepareStatement(contains("from " + DatasetDao.DATASET_TABLE))).thenReturn(
+        mockGetVersionSchemaStatement);
+
+    ResultSet mockResultSet = mock(ResultSet.class);
+    when(mockResultSet.next()).thenReturn(true);
+    when(mockResultSet.getInt(eq(DatasetDao.VERSION_SCHEMA))).thenThrow(new NullPointerException());
+    when(mockGetVersionSchemaStatement.executeQuery()).thenReturn(mockResultSet);
+
+    Properties props = new Properties();
+    props.setProperty(MySqlAccountServiceConfig.DB_INFO, "");
+    MySqlAccountServiceConfig config = new MySqlAccountServiceConfig(new VerifiableProperties(props));
+    DatasetDao dao = new DatasetDao(dataAccessor, config, metrics);
+
+    long npeCountBefore = metrics.datasetRowReadNpeCount.getCount();
+    try {
+      dao.deleteDatasetVersion(1, 2, "ds", "v1");
+      fail("Expected AccountServiceException");
+    } catch (AccountServiceException e) {
+      assertEquals(AccountServiceErrorCode.NotFound, e.getErrorCode());
+      String message = e.getMessage();
+      assertTrue("message should include accountId, got: " + message, message.contains("account: 1"));
+      assertTrue("message should include containerId, got: " + message, message.contains("container: 2"));
+      assertTrue("message should include datasetName, got: " + message, message.contains("dataset: ds"));
+    }
+    assertEquals("datasetRowReadNpeCount should increment by 1", npeCountBefore + 1,
+        metrics.datasetRowReadNpeCount.getCount());
+  }
 }

--- a/ambry-account/src/test/java/com/github/ambry/account/mysql/DatasetDaoTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/mysql/DatasetDaoTest.java
@@ -26,11 +26,10 @@ import java.sql.ResultSet;
 import java.sql.Timestamp;
 import java.util.Properties;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import static com.github.ambry.account.mysql.AccountDaoTest.getDataAccessor;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
@@ -39,19 +38,19 @@ import static org.mockito.Mockito.when;
 
 
 /** Unit test for {@link DatasetDao}. */
-@RunWith(MockitoJUnitRunner.class)
 public class DatasetDaoTest {
 
   /**
    * Regression for prod incident on 2026-04-29: a NPE thrown from the MySQL JDBC driver
-   * while reading a dataset row column (ResultSetImpl.findColumn -> getInt) surfaced as
-   * HTTP 500 from {@code GET /named/<account>/<container>/<dataset>}
-   * because the exception bubbled past {@link DatasetDao#executeGetDatasetStatement}
-   * uncaught. Verify the catch translates it into {@link AccountServiceException} with
-   * {@link AccountServiceErrorCode#NotFound} so callers map it to 404.
+   * while reading the {@code versionSchema} column (ResultSetImpl.findColumn -> getInt)
+   * surfaced as HTTP 500 from {@code GET /named/<account>/<container>/<dataset>}
+   * because the exception bubbled past {@link DatasetDao#getDataset} uncaught. Verify the
+   * narrow catch translates it into {@link AccountServiceException} with
+   * {@link AccountServiceErrorCode#NotFound}, increments the operability counter, and
+   * keeps the dataset identifiers in the exception message.
    */
   @Test
-  public void testGetDatasetMapsJdbcNpeToNotFound() throws Exception {
+  public void testGetDatasetMapsJdbcNpeOnVersionSchemaToNotFound() throws Exception {
     Connection mockConnection = mock(Connection.class);
     MySqlMetrics metrics = new MySqlMetrics(DatasetDao.class, new MetricRegistry());
     MySqlDataAccessor dataAccessor = getDataAccessor(mockConnection, metrics);
@@ -61,7 +60,7 @@ public class DatasetDaoTest {
 
     ResultSet mockResultSet = mock(ResultSet.class);
     when(mockResultSet.next()).thenReturn(true);
-    // Future-dated deletion ts so the deleted-check passes and we reach the column reads.
+    // Future-dated deletion ts so the deleted-check passes and we reach the column read.
     when(mockResultSet.getTimestamp(eq(DatasetDao.DELETED_TS))).thenReturn(
         new Timestamp(System.currentTimeMillis() + 60_000L));
     // Reproduce the JDBC driver NPE seen in prod.
@@ -73,11 +72,18 @@ public class DatasetDaoTest {
     MySqlAccountServiceConfig config = new MySqlAccountServiceConfig(new VerifiableProperties(props));
     DatasetDao dao = new DatasetDao(dataAccessor, config, metrics);
 
+    long npeCountBefore = metrics.datasetRowReadNpeCount.getCount();
     try {
       dao.getDataset(1, 2, "acct", "cont", "ds");
       fail("Expected AccountServiceException");
     } catch (AccountServiceException e) {
       assertEquals(AccountServiceErrorCode.NotFound, e.getErrorCode());
+      String message = e.getMessage();
+      assertTrue("message should include accountId, got: " + message, message.contains("1"));
+      assertTrue("message should include containerId, got: " + message, message.contains("2"));
+      assertTrue("message should include datasetName, got: " + message, message.contains("ds"));
     }
+    assertEquals("datasetRowReadNpeCount should increment by 1", npeCountBefore + 1,
+        metrics.datasetRowReadNpeCount.getCount());
   }
 }

--- a/ambry-account/src/test/java/com/github/ambry/account/mysql/DatasetDaoTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/mysql/DatasetDaoTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.account.mysql;
+
+import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.account.AccountServiceErrorCode;
+import com.github.ambry.account.AccountServiceException;
+import com.github.ambry.config.MySqlAccountServiceConfig;
+import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.mysql.MySqlDataAccessor;
+import com.github.ambry.mysql.MySqlMetrics;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+import java.util.Properties;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static com.github.ambry.account.mysql.AccountDaoTest.getDataAccessor;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+/** Unit test for {@link DatasetDao}. */
+@RunWith(MockitoJUnitRunner.class)
+public class DatasetDaoTest {
+
+  /**
+   * Regression for prod incident on 2026-04-29: a NPE thrown from the MySQL JDBC driver
+   * while reading a dataset row column (ResultSetImpl.findColumn -> getInt) surfaced as
+   * HTTP 500 from {@code GET /named/<account>/<container>/<dataset>}
+   * because the exception bubbled past {@link DatasetDao#executeGetDatasetStatement}
+   * uncaught. Verify the catch translates it into {@link AccountServiceException} with
+   * {@link AccountServiceErrorCode#NotFound} so callers map it to 404.
+   */
+  @Test
+  public void testGetDatasetMapsJdbcNpeToNotFound() throws Exception {
+    Connection mockConnection = mock(Connection.class);
+    MySqlMetrics metrics = new MySqlMetrics(DatasetDao.class, new MetricRegistry());
+    MySqlDataAccessor dataAccessor = getDataAccessor(mockConnection, metrics);
+    PreparedStatement mockGetDatasetStatement = mock(PreparedStatement.class);
+    when(mockConnection.prepareStatement(contains("from " + DatasetDao.DATASET_TABLE))).thenReturn(
+        mockGetDatasetStatement);
+
+    ResultSet mockResultSet = mock(ResultSet.class);
+    when(mockResultSet.next()).thenReturn(true);
+    // Future-dated deletion ts so the deleted-check passes and we reach the column reads.
+    when(mockResultSet.getTimestamp(eq(DatasetDao.DELETED_TS))).thenReturn(
+        new Timestamp(System.currentTimeMillis() + 60_000L));
+    // Reproduce the JDBC driver NPE seen in prod.
+    when(mockResultSet.getInt(eq(DatasetDao.VERSION_SCHEMA))).thenThrow(new NullPointerException());
+    when(mockGetDatasetStatement.executeQuery()).thenReturn(mockResultSet);
+
+    Properties props = new Properties();
+    props.setProperty(MySqlAccountServiceConfig.DB_INFO, "");
+    MySqlAccountServiceConfig config = new MySqlAccountServiceConfig(new VerifiableProperties(props));
+    DatasetDao dao = new DatasetDao(dataAccessor, config, metrics);
+
+    try {
+      dao.getDataset(1, 2, "acct", "cont", "ds");
+      fail("Expected AccountServiceException");
+    } catch (AccountServiceException e) {
+      assertEquals(AccountServiceErrorCode.NotFound, e.getErrorCode());
+    }
+  }
+}

--- a/ambry-mysql/src/main/java/com/github/ambry/mysql/MySqlMetrics.java
+++ b/ambry-mysql/src/main/java/com/github/ambry/mysql/MySqlMetrics.java
@@ -42,6 +42,7 @@ public class MySqlMetrics {
   public static final String CONNECTION_SUCCESS_COUNT = "ConnectionSuccessCount";
   public static final String CONNECTION_FAILURE_COUNT = "ConnectionFailureCount";
   public static final String CONSTRUCT_RETENTION_POLICY_FAILURE_COUNT = "ConstructRetentionPolicyFailureCount";
+  public static final String DATASET_ROW_READ_NPE_COUNT = "DatasetRowReadNpeCount";
 
   public final Histogram writeTimeMs;
   public final Counter writeSuccessCount;
@@ -67,6 +68,7 @@ public class MySqlMetrics {
   public final Counter connectionFailureCount;
 
   public final Counter constructRetentionPolicyFailureCount;
+  public final Counter datasetRowReadNpeCount;
 
   public MySqlMetrics(Class<?> clazz, MetricRegistry metricRegistry) {
     writeTimeMs = metricRegistry.histogram(MetricRegistry.name(clazz, WRITE_TIME_MSEC));
@@ -88,5 +90,6 @@ public class MySqlMetrics {
     connectionFailureCount = metricRegistry.counter(MetricRegistry.name(clazz, CONNECTION_FAILURE_COUNT));
     constructRetentionPolicyFailureCount =
         metricRegistry.counter(MetricRegistry.name(clazz, CONSTRUCT_RETENTION_POLICY_FAILURE_COUNT));
+    datasetRowReadNpeCount = metricRegistry.counter(MetricRegistry.name(clazz, DATASET_ROW_READ_NPE_COUNT));
   }
 }


### PR DESCRIPTION
## Summary

A dataset GET request returned HTTP 500 in prod (2026-04-29) because mysql-connector-java 8.0.21 threw `NullPointerException` from `ResultSetImpl.findColumn -> getInt` while reading the `versionSchema` column, and the exception bubbled past `executeGetDatasetStatement` uncaught.

- Wrap the `resultSet.getInt(VERSION_SCHEMA)` call with a narrow `NullPointerException` catch and translate it to `AccountServiceException(NotFound)`. `AccountAndContainerInjector` already maps `AccountServiceErrorCode.NotFound` -> `RestServiceErrorCode.NotFound` (HTTP 404).
- Apply the same narrow catch to `executeGetVersionSchema`, which makes the identical JDBC call from the version-mutation paths (`deleteDatasetVersion`, `deleteDatasetVersionForDatasetDelete`, `getAllValidVersionForDatasetDeletion`, `listAllValidDatasetVersions`). Not observed in prod on those paths, but the call shape is identical -- guard symmetrically.
- Add `MySqlMetrics.datasetRowReadNpeCount` so on-call can distinguish JDBC-driver NotFounds from legitimate ones on dashboards.
- The catch is intentionally narrow (only `getInt(VERSION_SCHEMA)`, not `objectMapper.readValue` or enum-ordinal indexing) so unrelated NPEs aren't masked as NotFound.
- Comment in the catch points at `gradle/dependency-versions.gradle` and asks the next person bumping mysql-connector-java to revisit.

## Durability Risk

Read-only / metadata-mutation paths; no blob data is at risk and no replication semantics change. Mapping a transient driver NPE to NotFound is semantically slightly off (the row exists) but the GET dataset caller (`AccountAndContainerInjector.setTargetDatasetAndVersionInRestRequestIfNeeded`) does not branch on the response to do destructive create-if-missing. On the version-mutation paths, a transient NPE surfacing as NotFound is the same outcome a genuinely missing version would produce.

## Testing Done

- [x] `DatasetDaoTest.testGetDatasetMapsJdbcNpeOnVersionSchemaToNotFound` -- drives `getDataset`, asserts NotFound, identifier propagation in the exception message, and `datasetRowReadNpeCount` increment.
- [x] `DatasetDaoTest.testDeleteDatasetVersionMapsJdbcNpeOnVersionSchemaToNotFound` -- drives `deleteDatasetVersion`, asserts the same on the `executeGetVersionSchema` path.
- [x] `./gradlew :ambry-account:test --tests DatasetDaoTest` -- 2/2 PASSED.
