### PR TITLE
Distribute lagging replicas across replica groups to reduce head-of-line blocking

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/ReplicationConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/ReplicationConfig.java
@@ -29,6 +29,7 @@ public class ReplicationConfig {
   public static final String REPLICATION_MODEL_ACROSS_DATACENTERS = "replication.model.across.datacenters";
   public static final String REPLICATION_ENABLE_CONTINUOUS_REPLICATION = "replication.enable.continuous.replication";
   public static final String REPLICATION_GROUP_ITERATION_LIMIT = "replication.group.iteration.limit";
+  public static final String REPLICATION_SPREAD_LAGGERS_ACROSS_CHUNKS = "replication.spread.laggers.across.chunks";
   public static final String REPLICATION_STANDBY_WAIT_TIMEOUT_TO_TRIGGER_CROSS_COLO_FETCH_SECONDS =
       "replication.standby.wait.timeout.to.trigger.cross.colo.fetch.seconds";
 
@@ -69,6 +70,16 @@ public class ReplicationConfig {
   @Config(REPLICATION_GROUP_ITERATION_LIMIT)
   @Default("1")
   public final int replicationGroupIterationLimit;
+
+  /**
+   * Continuous replication only — no-op when {@code replication.enable.continuous.replication=false}.
+   * When true, replicas within each per-remote-DataNode chunking pass are sorted by remote lag in bytes
+   * (descending), then round-robin distributed into chunks of at most
+   * {@code replicationMaxPartitionCountPerRequest}. When false, replicas are sliced sequentially.
+   */
+  @Config(REPLICATION_SPREAD_LAGGERS_ACROSS_CHUNKS)
+  @Default("false")
+  public final boolean replicationSpreadLaggersAcrossChunks;
 
   /**
    * The number of replica threads on each server that runs the replication protocol for intra dc replication
@@ -407,6 +418,8 @@ public class ReplicationConfig {
         verifiableProperties.getBoolean(REPLICATION_ENABLE_CONTINUOUS_REPLICATION, false);
     replicationGroupIterationLimit =
         verifiableProperties.getIntInRange(REPLICATION_GROUP_ITERATION_LIMIT, 1, 1, 10000000);
+    replicationSpreadLaggersAcrossChunks =
+        verifiableProperties.getBoolean(REPLICATION_SPREAD_LAGGERS_ACROSS_CHUNKS, false);
     replicationNumOfIntraDCReplicaThreads =
         verifiableProperties.getInt("replication.no.of.intra.dc.replica.threads", 1);
     replicationNumOfInterDCReplicaThreads =

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -2319,7 +2319,8 @@ public class ReplicaThread implements Runnable {
 
         DataNodeTracker dataNodeTracker =
             new DataNodeTracker(remoteHost, remoteReplicasPerNode, maxReplicaCountPerRequest, currentStartGroupId, time,
-                threadThrottleDurationMs);
+                threadThrottleDurationMs, replicationConfig.replicationSpreadLaggersAcrossChunks,
+                RemoteReplicaInfo::getRemoteLagFromLocalInBytes);
         logger.trace("Thread name: {} for datanode {} create datanode tracker {}", threadName, remoteHost,
             dataNodeTracker);
 

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -2318,9 +2318,8 @@ public class ReplicaThread implements Runnable {
         List<RemoteReplicaInfo> remoteReplicasPerNode = entry.getValue();
 
         DataNodeTracker dataNodeTracker =
-            new DataNodeTracker(remoteHost, remoteReplicasPerNode, maxReplicaCountPerRequest, currentStartGroupId, time,
-                threadThrottleDurationMs, replicationConfig.replicationSpreadLaggersAcrossChunks,
-                RemoteReplicaInfo::getRemoteLagFromLocalInBytes);
+            new DataNodeTracker(remoteHost, remoteReplicasPerNode, currentStartGroupId, time, threadThrottleDurationMs,
+                replicationConfig, RemoteReplicaInfo::getRemoteLagFromLocalInBytes);
         logger.trace("Thread name: {} for datanode {} create datanode tracker {}", threadName, remoteHost,
             dataNodeTracker);
 

--- a/ambry-replication/src/main/java/com/github/ambry/replication/continuous/DataNodeTracker.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/continuous/DataNodeTracker.java
@@ -14,6 +14,7 @@
 package com.github.ambry.replication.continuous;
 
 import com.github.ambry.clustermap.DataNodeId;
+import com.github.ambry.config.ReplicationConfig;
 import com.github.ambry.replication.RemoteReplicaInfo;
 import com.github.ambry.replication.ReplicaThread;
 import com.github.ambry.utils.Time;
@@ -45,29 +46,33 @@ public class DataNodeTracker {
    * All group trackers have consecutive group id.
    * @param dataNodeId remote host for which to create datanode tracker
    * @param remoteReplicas remote replicas for this data node
-   * @param maxActiveGroupSize maximum count of replicas in active groups
    * @param startGroupId group id from which we can start and increment and generate unique group id for each group
    * @param time Ambry time
-   * @param replicaThrottleDurationMs throttle duration for replicas
-   * @param spreadLaggersAcrossChunks if true, sort by remote lag DESC and round-robin distribute into chunks
-   *                                  instead of sequential slicing, so the top laggers do not co-locate in
-   *                                  one chunk. See
-   *                                  {@link com.github.ambry.config.ReplicationConfig#REPLICATION_SPREAD_LAGGERS_ACROSS_CHUNKS}.
+   * @param replicaThrottleDurationMs throttle duration for replicas. Lane-specific
+   *                                  (inter vs intra DC); resolved once by the owning {@link ReplicaThread}
+   *                                  and passed in as a primitive so lane logic doesn't leak into this class.
+   * @param replicationConfig replication config. Reads
+   *                          {@link ReplicationConfig#replicationMaxPartitionCountPerRequest} for the
+   *                          per-chunk replica cap and
+   *                          {@link ReplicationConfig#replicationSpreadLaggersAcrossChunks} for whether
+   *                          the chunking pass sorts and round-robins instead of slicing sequentially.
    * @param lagExtractor function that returns a replica's remote-lag-in-bytes; used as the sort key when
-   *                    {@code spreadLaggersAcrossChunks} is true. Supplied by the caller so the chunking
-   *                    helper does not need access to package-private state on {@link RemoteReplicaInfo}.
+   *                    {@link ReplicationConfig#replicationSpreadLaggersAcrossChunks} is true. Supplied by the
+   *                    caller so the chunking helper does not need access to package-private state on
+   *                    {@link RemoteReplicaInfo}.
    */
-  public DataNodeTracker(DataNodeId dataNodeId, List<RemoteReplicaInfo> remoteReplicas, int maxActiveGroupSize,
-      int startGroupId, Time time, long replicaThrottleDurationMs, boolean spreadLaggersAcrossChunks,
+  public DataNodeTracker(DataNodeId dataNodeId, List<RemoteReplicaInfo> remoteReplicas, int startGroupId, Time time,
+      long replicaThrottleDurationMs, ReplicationConfig replicationConfig,
       ToLongFunction<RemoteReplicaInfo> lagExtractor) {
     this.dataNodeId = dataNodeId;
     this.activeGroupTrackers = new ArrayList<>();
 
     int currentGroupId = startGroupId;
 
-    // for this data node break a larger array of remote replicas to smaller multiple arrays of maxActiveGroupSize
+    // for this data node break a larger array of remote replicas to smaller multiple arrays
     List<List<RemoteReplicaInfo>> remoteReplicaSegregatedList =
-        chunkReplicas(remoteReplicas, maxActiveGroupSize, spreadLaggersAcrossChunks, lagExtractor);
+        chunkReplicas(remoteReplicas, replicationConfig.replicationMaxPartitionCountPerRequest,
+            replicationConfig.replicationSpreadLaggersAcrossChunks, lagExtractor);
 
     // for each of smaller array of remote replicas create active group trackers with consecutive group ids
     for (List<RemoteReplicaInfo> remoteReplicaList : remoteReplicaSegregatedList) {

--- a/ambry-replication/src/main/java/com/github/ambry/replication/continuous/DataNodeTracker.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/continuous/DataNodeTracker.java
@@ -21,7 +21,10 @@ import com.github.ambry.utils.Utils;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.function.ToLongFunction;
 import java.util.stream.Collectors;
 
 
@@ -46,9 +49,17 @@ public class DataNodeTracker {
    * @param startGroupId group id from which we can start and increment and generate unique group id for each group
    * @param time Ambry time
    * @param replicaThrottleDurationMs throttle duration for replicas
+   * @param spreadLaggersAcrossChunks if true, sort by remote lag DESC and round-robin distribute into chunks
+   *                                  instead of sequential slicing, so the top laggers do not co-locate in
+   *                                  one chunk. See
+   *                                  {@link com.github.ambry.config.ReplicationConfig#REPLICATION_SPREAD_LAGGERS_ACROSS_CHUNKS}.
+   * @param lagExtractor function that returns a replica's remote-lag-in-bytes; used as the sort key when
+   *                    {@code spreadLaggersAcrossChunks} is true. Supplied by the caller so the chunking
+   *                    helper does not need access to package-private state on {@link RemoteReplicaInfo}.
    */
   public DataNodeTracker(DataNodeId dataNodeId, List<RemoteReplicaInfo> remoteReplicas, int maxActiveGroupSize,
-      int startGroupId, Time time, long replicaThrottleDurationMs) {
+      int startGroupId, Time time, long replicaThrottleDurationMs, boolean spreadLaggersAcrossChunks,
+      ToLongFunction<RemoteReplicaInfo> lagExtractor) {
     this.dataNodeId = dataNodeId;
     this.activeGroupTrackers = new ArrayList<>();
 
@@ -56,8 +67,7 @@ public class DataNodeTracker {
 
     // for this data node break a larger array of remote replicas to smaller multiple arrays of maxActiveGroupSize
     List<List<RemoteReplicaInfo>> remoteReplicaSegregatedList =
-        maxActiveGroupSize > 0 ? Utils.partitionList(remoteReplicas, maxActiveGroupSize)
-            : Collections.singletonList(remoteReplicas);
+        chunkReplicas(remoteReplicas, maxActiveGroupSize, spreadLaggersAcrossChunks, lagExtractor);
 
     // for each of smaller array of remote replicas create active group trackers with consecutive group ids
     for (List<RemoteReplicaInfo> remoteReplicaList : remoteReplicaSegregatedList) {
@@ -146,5 +156,43 @@ public class DataNodeTracker {
   public String toString() {
     return "DataNodeTracker :[" + dataNodeId.toString() + " " + activeGroupTrackers.toString() + " "
         + standByGroupTracker.toString() + "]";
+  }
+
+  /**
+   * Splits {@code remoteReplicas} into chunks of at most {@code maxActiveGroupSize}. When {@code spread}
+   * is false, replicas are sliced sequentially via {@link Utils#partitionList}. When true, replicas are
+   * first sorted by {@code lagExtractor} descending, then round-robin distributed across chunks so that
+   * the top laggers land in different chunks. When {@code maxActiveGroupSize <= 0}, returns a single
+   * chunk containing all replicas.
+   *
+   * Package-private for test access; do not call from outside {@link DataNodeTracker}.
+   */
+  static List<List<RemoteReplicaInfo>> chunkReplicas(List<RemoteReplicaInfo> remoteReplicas, int maxActiveGroupSize,
+      boolean spread, ToLongFunction<RemoteReplicaInfo> lagExtractor) {
+    if (maxActiveGroupSize <= 0) {
+      return Collections.singletonList(remoteReplicas);
+    }
+    if (!spread || remoteReplicas.isEmpty()) {
+      return Utils.partitionList(remoteReplicas, maxActiveGroupSize);
+    }
+    List<RemoteReplicaInfo> sorted = new ArrayList<>(remoteReplicas);
+    // Snapshot lag once per replica before sorting. Re-reading inside the comparator is unsafe:
+    // the underlying field is mutated by other threads and can trip TimSort's contract check.
+    // IdentityHashMap because RemoteReplicaInfo overrides equals() without hashCode().
+    Map<RemoteReplicaInfo, Long> lagSnapshot = new IdentityHashMap<>(sorted.size());
+    for (RemoteReplicaInfo r : sorted) {
+      lagSnapshot.put(r, lagExtractor.applyAsLong(r));
+    }
+    sorted.sort((a, b) -> Long.compare(lagSnapshot.get(b), lagSnapshot.get(a)));
+    int chunkCount = (sorted.size() + maxActiveGroupSize - 1) / maxActiveGroupSize;
+    List<List<RemoteReplicaInfo>> chunks = new ArrayList<>(chunkCount);
+    for (int chunk = 0; chunk < chunkCount; chunk++) {
+      List<RemoteReplicaInfo> bucket = new ArrayList<>(maxActiveGroupSize);
+      for (int j = chunk; j < sorted.size(); j += chunkCount) {
+        bucket.add(sorted.get(j));
+      }
+      chunks.add(bucket);
+    }
+    return chunks;
   }
 }

--- a/ambry-replication/src/test/java/com/github/ambry/replication/continuous/DataNodeTrackerTest.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/continuous/DataNodeTrackerTest.java
@@ -1,0 +1,296 @@
+/**
+ * Copyright 2026 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.replication.continuous;
+
+import com.github.ambry.clustermap.PartitionId;
+import com.github.ambry.clustermap.ReplicaId;
+import com.github.ambry.replication.RemoteReplicaInfo;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.ToLongFunction;
+import java.util.stream.Collectors;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+
+/**
+ * Tests for {@link DataNodeTracker#chunkReplicas}. Covers both the legacy sequential-slice path
+ * (flag off) and the sort-by-lag + round-robin path (flag on). Scope is intentionally limited to
+ * the chunking helper; the {@link DataNodeTracker} constructor's only added behavior is "call
+ * {@code chunkReplicas} with the right args" and is exercised through {@code ReplicaThread} tests.
+ *
+ * Lag values for mock replicas are stored in a side-channel {@link #lagOf} map; the lag extractor
+ * passed to {@code chunkReplicas} reads from this map. This avoids the test having to invoke the
+ * package-private {@code RemoteReplicaInfo.getRemoteLagFromLocalInBytes()} from a different package.
+ */
+public class DataNodeTrackerTest {
+
+  private final Map<RemoteReplicaInfo, Long> lagOf = new HashMap<>();
+  private final ToLongFunction<RemoteReplicaInfo> extractor = lagOf::get;
+
+  /** Flag off: behavior matches sequential slicing via {@code Utils.partitionList}. */
+  @Test
+  public void testChunkReplicasSpreadDisabledIsSequentialSlice() {
+    // 7 replicas, max chunk size 3 → expect [[0,1,2],[3,4,5],[6]] in input order.
+    List<RemoteReplicaInfo> replicas = makeReplicas(7, i -> 0L);  // lags don't matter when spread=false
+
+    List<List<RemoteReplicaInfo>> chunks = DataNodeTracker.chunkReplicas(replicas, 3, false, extractor);
+
+    assertEquals(3, chunks.size());
+    assertEquals(replicas.subList(0, 3), chunks.get(0));
+    assertEquals(replicas.subList(3, 6), chunks.get(1));
+    assertEquals(replicas.subList(6, 7), chunks.get(2));
+  }
+
+  /** Flag on: top laggers land in distinct chunks. */
+  @Test
+  public void testChunkReplicasSpreadDistributesLaggersAcrossChunks() {
+    // 6 replicas, lags [10, 20, 30, 40, 50, 60], max chunk size 3 → 2 chunks.
+    // After sort DESC: [60,50,40,30,20,10] → round-robin: chunk0=[60,40,20], chunk1=[50,30,10].
+    // Both top laggers (60 and 50) MUST be in different chunks.
+    List<RemoteReplicaInfo> replicas = makeReplicas(6, i -> 10L * (i + 1));
+
+    List<List<RemoteReplicaInfo>> chunks = DataNodeTracker.chunkReplicas(replicas, 3, true, extractor);
+
+    assertEquals(2, chunks.size());
+    assertEquals("Each chunk should be at most 3 replicas", 3, chunks.get(0).size());
+    assertEquals(3, chunks.get(1).size());
+    // Verify the top two laggers are not co-located.
+    assertNotEquals("Top two laggers must land in different chunks", findChunk(chunks, 60L), findChunk(chunks, 50L));
+    // Verify each chunk's lag composition matches the round-robin pattern.
+    assertEquals(Arrays.asList(60L, 40L, 20L), lagsOf(chunks.get(0)));
+    assertEquals(Arrays.asList(50L, 30L, 10L), lagsOf(chunks.get(1)));
+  }
+
+  /** Flag on: equal-lag replicas keep their input order (Java's stable sort). */
+  @Test
+  public void testChunkReplicasSpreadStableSortOnEqualLags() {
+    // 6 replicas all with lag=0 and known partition-id order. After a stable sort by lag DESC,
+    // their relative order must be unchanged. Round-robin into 2 chunks of size 3 then gives
+    // chunk0=[p0,p2,p4], chunk1=[p1,p3,p5].
+    long[] lags = new long[]{0, 0, 0, 0, 0, 0};
+    String[] partitionIds = new String[]{"p0", "p1", "p2", "p3", "p4", "p5"};
+
+    List<List<RemoteReplicaInfo>> chunks =
+        DataNodeTracker.chunkReplicas(makeReplicasWithIds(lags, partitionIds), 3, true, extractor);
+
+    assertEquals(2, chunks.size());
+    assertEquals(Arrays.asList("p0", "p2", "p4"), partitionPathsOf(chunks.get(0)));
+    assertEquals(Arrays.asList("p1", "p3", "p5"), partitionPathsOf(chunks.get(1)));
+  }
+
+  /** Empty input: returns zero chunks, matching {@code Utils.partitionList}'s behavior. */
+  @Test
+  public void testChunkReplicasEmptyList() {
+    assertTrue(DataNodeTracker.chunkReplicas(Collections.emptyList(), 3, false, extractor).isEmpty());
+    assertTrue("Spread path must match sequential path for empty input",
+        DataNodeTracker.chunkReplicas(Collections.emptyList(), 3, true, extractor).isEmpty());
+  }
+
+  /** Flag on, single replica: returns one chunk with that replica. */
+  @Test
+  public void testChunkReplicasSpreadSingleReplica() {
+    List<RemoteReplicaInfo> replicas = makeReplicas(1, i -> 42L);
+
+    List<List<RemoteReplicaInfo>> chunks = DataNodeTracker.chunkReplicas(replicas, 3, true, extractor);
+
+    assertEquals(1, chunks.size());
+    assertEquals(1, chunks.get(0).size());
+    assertEquals(42L, (long) lagOf.get(chunks.get(0).get(0)));
+  }
+
+  /** Flag on, max chunk size >= list size: returns one chunk containing all replicas (sorted). */
+  @Test
+  public void testChunkReplicasSpreadSingleChunkWhenMaxExceedsSize() {
+    List<RemoteReplicaInfo> replicas = makeReplicas(3, i -> (long) i);  // lags 0, 1, 2
+
+    List<List<RemoteReplicaInfo>> chunks = DataNodeTracker.chunkReplicas(replicas, 10, true, extractor);
+
+    assertEquals(1, chunks.size());
+    // Sorted DESC: lags should be [2, 1, 0].
+    assertEquals(Arrays.asList(2L, 1L, 0L), lagsOf(chunks.get(0)));
+  }
+
+  /** maxActiveGroupSize <= 0: matches legacy fallback (single chunk with all replicas, unchanged order). */
+  @Test
+  public void testChunkReplicasNonPositiveMaxReturnsSingleChunk() {
+    List<RemoteReplicaInfo> replicas = makeReplicas(5, i -> 10L);
+
+    List<List<RemoteReplicaInfo>> chunksSpreadOff = DataNodeTracker.chunkReplicas(replicas, 0, false, extractor);
+    List<List<RemoteReplicaInfo>> chunksSpreadOn = DataNodeTracker.chunkReplicas(replicas, 0, true, extractor);
+
+    assertEquals(1, chunksSpreadOff.size());
+    assertEquals(replicas, chunksSpreadOff.get(0));
+    assertEquals("max<=0 takes the same single-chunk fallback regardless of spread flag", 1, chunksSpreadOn.size());
+    assertEquals(replicas, chunksSpreadOn.get(0));
+  }
+
+  /**
+   * Conservation: every input replica appears exactly once across all chunks (no drops, no duplicates).
+   * The cycle iteration depends on this — losing a replica would silently skip replication progress.
+   */
+  @Test
+  public void testChunkReplicasConservesAllReplicas() {
+    List<RemoteReplicaInfo> replicas = makeReplicas(11, i -> (long) (i * 7));
+
+    for (boolean spread : new boolean[]{false, true}) {
+      for (int maxSize : new int[]{1, 2, 3, 5, 11, 100}) {
+        List<List<RemoteReplicaInfo>> chunks = DataNodeTracker.chunkReplicas(replicas, maxSize, spread, extractor);
+        Set<RemoteReplicaInfo> flattened = chunks.stream().flatMap(List::stream).collect(Collectors.toSet());
+        long totalCount = chunks.stream().mapToLong(List::size).sum();
+        String tag = "spread=" + spread + " maxSize=" + maxSize;
+        assertEquals(tag + ": total replica count must equal input size", replicas.size(), totalCount);
+        assertEquals(tag + ": all input replicas must be present, no duplicates",
+            new HashSet<>(replicas), flattened);
+      }
+    }
+  }
+
+  /**
+   * Chunk size cap: every chunk respects {@code maxActiveGroupSize} for awkward sizes that don't
+   * divide evenly (N=10, M=3 → 4 chunks of 3/3/2/2; N=7, M=2 → 4 chunks of 2/2/2/1; etc).
+   */
+  @Test
+  public void testChunkReplicasRespectsMaxSizeForAwkwardSizes() {
+    int[][] cases = new int[][]{{10, 3}, {7, 2}, {13, 4}, {5, 2}, {1, 1}};
+    for (int[] c : cases) {
+      int n = c[0], m = c[1];
+      List<RemoteReplicaInfo> replicas = makeReplicas(n, i -> (long) i);
+      for (boolean spread : new boolean[]{false, true}) {
+        List<List<RemoteReplicaInfo>> chunks = DataNodeTracker.chunkReplicas(replicas, m, spread, extractor);
+        for (int i = 0; i < chunks.size(); i++) {
+          assertTrue("N=" + n + " M=" + m + " spread=" + spread + " chunk[" + i + "].size=" + chunks.get(i).size(),
+              chunks.get(i).size() <= m);
+        }
+        int expectedChunkCount = (int) Math.ceil((double) n / m);
+        assertEquals("N=" + n + " M=" + m + " spread=" + spread + ": chunk count",
+            expectedChunkCount, chunks.size());
+      }
+    }
+  }
+
+  /**
+   * Lag is snapshotted before sorting, so {@link RemoteReplicaInfo#getRemoteLagFromLocalInBytes} is
+   * read exactly once per replica regardless of sort cost. Production-availability regression guard:
+   * a previous version of the helper read the extractor from inside the comparator, which would
+   * (a) call the extractor O(N log N) times instead of N, and (b) under concurrent mutation of the
+   * underlying field by another thread, could observe inconsistent lag values across compares and
+   * trigger {@code TimSort: Comparison method violates its general contract!}, killing the cycle.
+   *
+   * Verifies the snapshot pattern directly: the extractor is called exactly {@code replicas.size()}
+   * times. If anyone reverts the snapshot, the call count balloons to the sort's comparison budget
+   * and this test fails — a deterministic guard that doesn't rely on TimSort's best-effort
+   * inconsistency detection.
+   */
+  @Test
+  public void testChunkReplicasCallsExtractorOncePerReplica() {
+    List<RemoteReplicaInfo> replicas = makeReplicas(100, i -> (long) i);
+    int[] callCount = {0};
+    ToLongFunction<RemoteReplicaInfo> countingExtractor = r -> {
+      callCount[0]++;
+      return lagOf.get(r);
+    };
+
+    List<List<RemoteReplicaInfo>> chunks = DataNodeTracker.chunkReplicas(replicas, 5, true, countingExtractor);
+
+    assertEquals("Snapshot must read extractor exactly once per replica; inline-in-comparator would "
+        + "be O(N log N). Observed " + callCount[0] + " calls for " + replicas.size() + " replicas.",
+        replicas.size(), callCount[0]);
+    // Conservation still holds.
+    Set<RemoteReplicaInfo> flat = chunks.stream().flatMap(List::stream).collect(Collectors.toSet());
+    assertEquals(new HashSet<>(replicas), flat);
+  }
+
+  /** Negative lag values sort highest (most behind), still without exception. */
+  @Test
+  public void testChunkReplicasSpreadHandlesNegativeAndZeroLag() {
+    // Note: lag can momentarily be negative if totalBytesReadFromLocalStore briefly exceeds
+    // localStore size (pre-existing edge case in RemoteReplicaInfo). Verify sort is total and stable.
+    List<RemoteReplicaInfo> replicas = new ArrayList<>();
+    replicas.add(makeReplica(0L, "a"));
+    replicas.add(makeReplica(-5L, "b"));
+    replicas.add(makeReplica(100L, "c"));
+    replicas.add(makeReplica(0L, "d"));
+
+    List<List<RemoteReplicaInfo>> chunks = DataNodeTracker.chunkReplicas(replicas, 2, true, extractor);
+
+    // Sorted DESC: [100, 0(a), 0(d), -5]. Round-robin into 2 chunks: chunk0=[100, 0(d)], chunk1=[0(a), -5].
+    assertEquals(2, chunks.size());
+    assertEquals(Arrays.asList(100L, 0L), lagsOf(chunks.get(0)));
+    assertEquals(Arrays.asList(0L, -5L), lagsOf(chunks.get(1)));
+  }
+
+  // ---- helpers ----
+
+  private interface LagFn {
+    long lag(int i);
+  }
+
+  /** Creates {@code count} mock RemoteReplicaInfos with sequential partition ids "0".."count-1". */
+  private List<RemoteReplicaInfo> makeReplicas(int count, LagFn lagFn) {
+    List<RemoteReplicaInfo> out = new ArrayList<>(count);
+    for (int i = 0; i < count; i++) {
+      out.add(makeReplica(lagFn.lag(i), Integer.toString(i)));
+    }
+    return out;
+  }
+
+  private List<RemoteReplicaInfo> makeReplicasWithIds(long[] lags, String[] partitionIds) {
+    assertEquals(lags.length, partitionIds.length);
+    List<RemoteReplicaInfo> out = new ArrayList<>(lags.length);
+    for (int i = 0; i < lags.length; i++) {
+      out.add(makeReplica(lags[i], partitionIds[i]));
+    }
+    return out;
+  }
+
+  private RemoteReplicaInfo makeReplica(long lag, String partitionIdPath) {
+    PartitionId partitionId = mock(PartitionId.class);
+    when(partitionId.toPathString()).thenReturn(partitionIdPath);
+    ReplicaId replicaId = mock(ReplicaId.class);
+    when(replicaId.getPartitionId()).thenReturn(partitionId);
+    RemoteReplicaInfo replica = mock(RemoteReplicaInfo.class);
+    when(replica.getReplicaId()).thenReturn(replicaId);
+    lagOf.put(replica, lag);
+    return replica;
+  }
+
+  private int findChunk(List<List<RemoteReplicaInfo>> chunks, long lag) {
+    for (int i = 0; i < chunks.size(); i++) {
+      for (RemoteReplicaInfo r : chunks.get(i)) {
+        if (lagOf.get(r) == lag) {
+          return i;
+        }
+      }
+    }
+    fail("Lag " + lag + " not found in any chunk");
+    return -1;
+  }
+
+  private List<Long> lagsOf(List<RemoteReplicaInfo> chunk) {
+    return chunk.stream().map(lagOf::get).collect(Collectors.toList());
+  }
+
+  private static List<String> partitionPathsOf(List<RemoteReplicaInfo> chunk) {
+    return chunk.stream().map(r -> r.getReplicaId().getPartitionId().toPathString()).collect(Collectors.toList());
+  }
+}


### PR DESCRIPTION
## Summary
Adds an opt-in mode that, before forming the per-cycle replica groups for `ReplicaMetadataRequest`s, sorts replicas by remote lag (descending) and round-robin distributes them, so the top laggers no longer co-locate in the same group. Eliminates head-of-line blocking inside a replica group's iteration.

> **Terminology**: this description uses "replica group" for the per-cycle set of replicas that share a `ReplicaMetadataRequest` (`RemoteReplicaGroup` in code). The code historically calls these "chunks" — see `chunkReplicas`, `replication.spread.laggers.across.chunks`. Same thing, two names.

Gated by `replication.spread.laggers.across.chunks`, default `false`. With the flag off, behavior is byte-identical to today.

## Motivation / Context

Tracking: ACTIONITEM-19683 (LinkedIn internal). Design doc: [linkedin-multiproduct/AmbryLi#3485](https://github.com/linkedin-multiproduct/AmbryLi/pull/3485) (internal — §3.5 covers the spread mechanism, §4.6 the implementation, §4.7 the rollout plan; this OSS PR implements §3.5/§4.6).

In continuous replication, each `ReplicaThread` partitions its per-DataNode replica list into groups of `replicationMaxPartitionCountPerRequest` via sequential slicing (`Utils.partitionList`). The order replicas appear is essentially arbitrary, so when multiple ambient laggers exist in the same thread, several can land in one replica group. That group's iteration is then gated by whichever member has the most data to fetch — head-of-line blocking even when no operator action is happening.

Spread mode sorts by lag descending and round-robins into replica groups: when laggers ≤ group count, at most one lagger lands in any one group.

## Testing Done

- New `DataNodeTrackerTest` (11 cases):
  - Flag-off path matches `Utils.partitionList` byte-for-byte
  - Flag-on path distributes top laggers across distinct replica groups
  - Stable sort on equal lags (input ordering preserved)
  - Empty list, single replica, `maxSize >= size`, `maxSize <= 0` edge cases
  - **Conservation invariant** exhaustively (spread on/off × maxSize ∈ {1,2,3,5,11,100}): every input replica appears exactly once across all groups
  - **Group size cap** for awkward sizes (N=10/M=3, N=7/M=2, N=13/M=4, N=5/M=2, N=1/M=1)
  - Negative/zero lag values sort correctly
  - **Concurrent-write snapshot regression test**: asserts the extractor is called exactly once per replica (catches a future revert of the snapshot-before-sort fix)
- Full `:ambry-replication:test` suite green (278 tests)
- `:ambry-api:test` suite green
- Build commands: `./gradlew :ambry-replication:test :ambry-api:test`

## Risk Assessment

- **Read-path-only.** Touches replica-grouping strategy (which peers we fetch from, in what grouping). No write path, no metadata, no atomicity, no callback semantics, no resource lifecycle, no schema.
- **Backward compatible.** Default-off; flag-off path is byte-identical to today.
- **Worst case if the grouping has a bug:** lopsided groups → slower replication, no data loss.
- **Concurrency.** The sort snapshots lag once per replica into an `IdentityHashMap` before sorting — re-reading the lag field inside the comparator would be unsafe (non-volatile, mutated by other threads) and could trip TimSort's contract check. Regression test asserts the snapshot pattern is used.
- **Durability invariants preserved.** No write-path code touched.

## Observability / Ops Impact
No new metrics, sensors, or log statements. Existing per-cycle and per-replica replication metrics (`InterColoOneCycleReplicationTime`, `IntraColoOneCycleReplicationTime`, `maxReplicaLagFromLocalInBytes`) are the monitoring surface for rollout — these already publish in all server fabrics.

## Rollout / Backout Plan

- Default `false`. Code change is a no-op until a fabric flips the flag in its config.
- Recommended ramp: enable in one fabric, observe `InterColoOneCycleReplicationTime` p95/p99 and `maxReplicaLagFromLocalInBytes` peaks over a baking window, then ramp to remaining fabrics.
- Backout: flip the flag back to `false` — no state cleanup, no code revert needed.

## AI Usage
Implementation and tests authored with Claude Code (Opus 4.7). Iterated on a separate Claude reviewer instance over 5 rounds; surfaced and fixed a concurrent-write race in the sort (snapshot via `IdentityHashMap`) before this commit.