### PR TITLE
Admin API for partition replication priority

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/ServerConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/ServerConfig.java
@@ -96,6 +96,13 @@ public class ServerConfig {
   public final boolean serverHandleForceDeleteRequestEnabled;
 
   /**
+   * True to enable ambry server handling UpdateReplicationPriority and ListReplicationPriority admin requests.
+   */
+  @Config("server.handle.replication.priority.request.enabled")
+  @Default("false")
+  public final boolean serverHandleReplicationPriorityRequestEnabled;
+
+  /**
    * True to enable replicateBlob to replicate tombstone
    */
   @Config("server.replicate.tombstone.enabled")
@@ -183,6 +190,8 @@ public class ServerConfig {
         verifiableProperties.getBoolean("server.handle.undelete.request.enabled", false);
     serverHandleForceDeleteRequestEnabled =
         verifiableProperties.getBoolean("server.handle.force.delete.request.enabled", false);
+    serverHandleReplicationPriorityRequestEnabled =
+        verifiableProperties.getBoolean("server.handle.replication.priority.request.enabled", false);
     serverReplicateTombstoneEnabled = verifiableProperties.getBoolean("server.replicate.tombstone.enabled", false);
     serverEnableBlobPartitionJourneyLogs =
         verifiableProperties.getBoolean("server.enable.blob.partition.journey.logs", false);

--- a/ambry-api/src/main/java/com/github/ambry/replication/PriorityEntry.java
+++ b/ambry-api/src/main/java/com/github/ambry/replication/PriorityEntry.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.replication;
+
+import com.github.ambry.clustermap.PartitionId;
+
+
+/**
+ * A single {@code (partition, boost, isInterColo)} entry in a replication-priority snapshot.
+ *
+ * <p>{@code boost} is the fetchSize weight currently applied to this partition: each cycle the
+ * thread divides its total fetch budget in proportion to per-replica weights, so a partition
+ * with {@code boost=N} gets roughly {@code N}× the per-cycle bytes of a normal replica
+ * (implicit weight {@code 1}). {@code isInterColo=true} means the entry came from a
+ * cross-datacenter ReplicaThread pool; {@code false} means the intra-datacenter pool.
+ *
+ * <p>Lives in {@code ambry-api} so the {@link ReplicationAPI#listAllPriorityPartitions()} default
+ * can return {@code List<PriorityEntry>} without {@code ambry-api} taking a dependency on
+ * {@code ambry-protocol}.
+ */
+public class PriorityEntry {
+  private final PartitionId partitionId;
+  private final int boost;
+  private final boolean isInterColo;
+
+  public PriorityEntry(PartitionId partitionId, int boost, boolean isInterColo) {
+    this.partitionId = partitionId;
+    this.boost = boost;
+    this.isInterColo = isInterColo;
+  }
+
+  public PartitionId getPartitionId() {
+    return partitionId;
+  }
+
+  public int getBoost() {
+    return boost;
+  }
+
+  public boolean isInterColo() {
+    return isInterColo;
+  }
+
+  @Override
+  public String toString() {
+    return "PriorityEntry[" + partitionId + ", boost=" + boost + ", isInterColo=" + isInterColo + "]";
+  }
+}

--- a/ambry-api/src/main/java/com/github/ambry/replication/ReplicationAPI.java
+++ b/ambry-api/src/main/java/com/github/ambry/replication/ReplicationAPI.java
@@ -55,4 +55,48 @@ public interface ReplicationAPI {
    * @return The lag in bytes that the remote replica is behind the local store
    */
   long getRemoteReplicaLagFromLocalInBytes(PartitionId partitionId, String hostName, String replicaPath);
+
+  /**
+   * Boost the per-cycle fetch budget for the listed partitions by {@code boost} on every replica
+   * thread on this server. Implementations that do not support a priority API should leave the
+   * default that throws {@link UnsupportedOperationException}.
+   * @param partitions partitions to prioritize
+   * @param boost positive boost factor
+   */
+  default void prioritizePartitions(List<PartitionId> partitions, int boost) {
+    throw new UnsupportedOperationException(
+        "Priority API not supported on " + getClass().getName());
+  }
+
+  /**
+   * Remove priority entries for the listed partitions on every replica thread on this server.
+   * An empty list wipes ALL priority entries — that branch is only reachable from a handler
+   * that has explicitly validated the operator's wipe-all intent (otherwise we'd risk silent
+   * wipe-all from an operator typo).
+   * @param partitions partitions to unset; empty list ⇒ wipe all
+   */
+  default void unsetPriorityPartitions(List<PartitionId> partitions) {
+    throw new UnsupportedOperationException(
+        "Priority API not supported on " + getClass().getName());
+  }
+
+  /**
+   * @param partition the partition to look up
+   * @return true if this server is registered to replicate {@code partition}.
+   */
+  default boolean hostsPartition(PartitionId partition) {
+    throw new UnsupportedOperationException(
+        "Priority API not supported on " + getClass().getName());
+  }
+
+  /**
+   * @return a deterministically-ordered snapshot of priority entries across every
+   *         {@code ReplicaThread} on this server, one entry per (partition, thread) pair, tagged
+   *         with the thread's {@code isInterColo} flag. Implementations without a priority API
+   *         leave the default that throws {@link UnsupportedOperationException}.
+   */
+  default List<PriorityEntry> listAllPriorityPartitions() {
+    throw new UnsupportedOperationException(
+        "Priority API not supported on " + getClass().getName());
+  }
 }

--- a/ambry-commons/src/main/java/com/github/ambry/commons/ServerMetrics.java
+++ b/ambry-commons/src/main/java/com/github/ambry/commons/ServerMetrics.java
@@ -211,11 +211,11 @@ public class ServerMetrics {
   public final Histogram forceDeleteResponseSendTimeInMs;
   public final Histogram forceDeleteRequestTotalTimeInMs;
 
-  public final Histogram setReplicationPriorityRequestQueueTimeInMs;
-  public final Histogram setReplicationPriorityRequestProcessingTimeInMs;
-  public final Histogram setReplicationPriorityResponseQueueTimeInMs;
-  public final Histogram setReplicationPriorityResponseSendTimeInMs;
-  public final Histogram setReplicationPriorityRequestTotalTimeInMs;
+  public final Histogram updateReplicationPriorityRequestQueueTimeInMs;
+  public final Histogram updateReplicationPriorityRequestProcessingTimeInMs;
+  public final Histogram updateReplicationPriorityResponseQueueTimeInMs;
+  public final Histogram updateReplicationPriorityResponseSendTimeInMs;
+  public final Histogram updateReplicationPriorityRequestTotalTimeInMs;
 
   public final Histogram listReplicationPriorityRequestQueueTimeInMs;
   public final Histogram listReplicationPriorityRequestProcessingTimeInMs;
@@ -256,7 +256,7 @@ public class ServerMetrics {
   public final Meter healthCheckRequestRate;
   public final Meter blobIndexRequestRate;
   public final Meter forceDeleteRequestRate;
-  public final Meter setReplicationPriorityRequestRate;
+  public final Meter updateReplicationPriorityRequestRate;
   public final Meter listReplicationPriorityRequestRate;
 
   public final Meter putBlobDroppedRate;
@@ -279,7 +279,7 @@ public class ServerMetrics {
   public final Meter healthCheckDroppedRate;
   public final Meter blobIndexDroppedRate;
   public final Meter forceDeleteDroppedRate;
-  public final Meter setReplicationPriorityDroppedRate;
+  public final Meter updateReplicationPriorityDroppedRate;
   public final Meter listReplicationPriorityDroppedRate;
 
   public final Meter totalRequestDroppedRate;
@@ -646,16 +646,16 @@ public class ServerMetrics {
     forceDeleteRequestTotalTimeInMs =
         registry.histogram(MetricRegistry.name(requestClass, "ForceDeleteRequestTotalTimeInMs"));
 
-    setReplicationPriorityRequestQueueTimeInMs =
-        registry.histogram(MetricRegistry.name(requestClass, "SetReplicationPriorityRequestQueueTimeInMs"));
-    setReplicationPriorityRequestProcessingTimeInMs =
-        registry.histogram(MetricRegistry.name(requestClass, "SetReplicationPriorityRequestProcessingTimeInMs"));
-    setReplicationPriorityResponseQueueTimeInMs =
-        registry.histogram(MetricRegistry.name(requestClass, "SetReplicationPriorityResponseQueueTimeInMs"));
-    setReplicationPriorityResponseSendTimeInMs =
-        registry.histogram(MetricRegistry.name(requestClass, "SetReplicationPriorityResponseSendTimeInMs"));
-    setReplicationPriorityRequestTotalTimeInMs =
-        registry.histogram(MetricRegistry.name(requestClass, "SetReplicationPriorityRequestTotalTimeInMs"));
+    updateReplicationPriorityRequestQueueTimeInMs =
+        registry.histogram(MetricRegistry.name(requestClass, "UpdateReplicationPriorityRequestQueueTimeInMs"));
+    updateReplicationPriorityRequestProcessingTimeInMs =
+        registry.histogram(MetricRegistry.name(requestClass, "UpdateReplicationPriorityRequestProcessingTimeInMs"));
+    updateReplicationPriorityResponseQueueTimeInMs =
+        registry.histogram(MetricRegistry.name(requestClass, "UpdateReplicationPriorityResponseQueueTimeInMs"));
+    updateReplicationPriorityResponseSendTimeInMs =
+        registry.histogram(MetricRegistry.name(requestClass, "UpdateReplicationPriorityResponseSendTimeInMs"));
+    updateReplicationPriorityRequestTotalTimeInMs =
+        registry.histogram(MetricRegistry.name(requestClass, "UpdateReplicationPriorityRequestTotalTimeInMs"));
 
     listReplicationPriorityRequestQueueTimeInMs =
         registry.histogram(MetricRegistry.name(requestClass, "ListReplicationPriorityRequestQueueTimeInMs"));
@@ -709,8 +709,8 @@ public class ServerMetrics {
     healthCheckRequestRate = registry.meter(MetricRegistry.name(requestClass, "HealthCheckRequestRate"));
     blobIndexRequestRate = registry.meter(MetricRegistry.name(requestClass, "BlobIndexRequestRate"));
     forceDeleteRequestRate = registry.meter(MetricRegistry.name(requestClass, "ForceDeleteRequestRate"));
-    setReplicationPriorityRequestRate =
-        registry.meter(MetricRegistry.name(requestClass, "SetReplicationPriorityRequestRate"));
+    updateReplicationPriorityRequestRate =
+        registry.meter(MetricRegistry.name(requestClass, "UpdateReplicationPriorityRequestRate"));
     listReplicationPriorityRequestRate =
         registry.meter(MetricRegistry.name(requestClass, "ListReplicationPriorityRequestRate"));
 
@@ -736,8 +736,8 @@ public class ServerMetrics {
     healthCheckDroppedRate = registry.meter(MetricRegistry.name(requestClass, "HealthCheckDroppedRate"));
     blobIndexDroppedRate = registry.meter(MetricRegistry.name(requestClass, "BlobIndexDroppedRate"));
     forceDeleteDroppedRate = registry.meter(MetricRegistry.name(requestClass, "ForceDeleteDroppedRate"));
-    setReplicationPriorityDroppedRate =
-        registry.meter(MetricRegistry.name(requestClass, "SetReplicationPriorityDroppedRate"));
+    updateReplicationPriorityDroppedRate =
+        registry.meter(MetricRegistry.name(requestClass, "UpdateReplicationPriorityDroppedRate"));
     listReplicationPriorityDroppedRate =
         registry.meter(MetricRegistry.name(requestClass, "ListReplicationPriorityDroppedRate"));
 

--- a/ambry-commons/src/main/java/com/github/ambry/commons/ServerMetrics.java
+++ b/ambry-commons/src/main/java/com/github/ambry/commons/ServerMetrics.java
@@ -211,6 +211,18 @@ public class ServerMetrics {
   public final Histogram forceDeleteResponseSendTimeInMs;
   public final Histogram forceDeleteRequestTotalTimeInMs;
 
+  public final Histogram setReplicationPriorityRequestQueueTimeInMs;
+  public final Histogram setReplicationPriorityRequestProcessingTimeInMs;
+  public final Histogram setReplicationPriorityResponseQueueTimeInMs;
+  public final Histogram setReplicationPriorityResponseSendTimeInMs;
+  public final Histogram setReplicationPriorityRequestTotalTimeInMs;
+
+  public final Histogram listReplicationPriorityRequestQueueTimeInMs;
+  public final Histogram listReplicationPriorityRequestProcessingTimeInMs;
+  public final Histogram listReplicationPriorityResponseQueueTimeInMs;
+  public final Histogram listReplicationPriorityResponseSendTimeInMs;
+  public final Histogram listReplicationPriorityRequestTotalTimeInMs;
+
   public final Histogram blobSizeInBytes;
   public final Histogram blobUserMetadataSizeInBytes;
 
@@ -244,6 +256,8 @@ public class ServerMetrics {
   public final Meter healthCheckRequestRate;
   public final Meter blobIndexRequestRate;
   public final Meter forceDeleteRequestRate;
+  public final Meter setReplicationPriorityRequestRate;
+  public final Meter listReplicationPriorityRequestRate;
 
   public final Meter putBlobDroppedRate;
   public final Meter getBlobDroppedRate;
@@ -265,6 +279,8 @@ public class ServerMetrics {
   public final Meter healthCheckDroppedRate;
   public final Meter blobIndexDroppedRate;
   public final Meter forceDeleteDroppedRate;
+  public final Meter setReplicationPriorityDroppedRate;
+  public final Meter listReplicationPriorityDroppedRate;
 
   public final Meter totalRequestDroppedRate;
 
@@ -630,6 +646,28 @@ public class ServerMetrics {
     forceDeleteRequestTotalTimeInMs =
         registry.histogram(MetricRegistry.name(requestClass, "ForceDeleteRequestTotalTimeInMs"));
 
+    setReplicationPriorityRequestQueueTimeInMs =
+        registry.histogram(MetricRegistry.name(requestClass, "SetReplicationPriorityRequestQueueTimeInMs"));
+    setReplicationPriorityRequestProcessingTimeInMs =
+        registry.histogram(MetricRegistry.name(requestClass, "SetReplicationPriorityRequestProcessingTimeInMs"));
+    setReplicationPriorityResponseQueueTimeInMs =
+        registry.histogram(MetricRegistry.name(requestClass, "SetReplicationPriorityResponseQueueTimeInMs"));
+    setReplicationPriorityResponseSendTimeInMs =
+        registry.histogram(MetricRegistry.name(requestClass, "SetReplicationPriorityResponseSendTimeInMs"));
+    setReplicationPriorityRequestTotalTimeInMs =
+        registry.histogram(MetricRegistry.name(requestClass, "SetReplicationPriorityRequestTotalTimeInMs"));
+
+    listReplicationPriorityRequestQueueTimeInMs =
+        registry.histogram(MetricRegistry.name(requestClass, "ListReplicationPriorityRequestQueueTimeInMs"));
+    listReplicationPriorityRequestProcessingTimeInMs =
+        registry.histogram(MetricRegistry.name(requestClass, "ListReplicationPriorityRequestProcessingTimeInMs"));
+    listReplicationPriorityResponseQueueTimeInMs =
+        registry.histogram(MetricRegistry.name(requestClass, "ListReplicationPriorityResponseQueueTimeInMs"));
+    listReplicationPriorityResponseSendTimeInMs =
+        registry.histogram(MetricRegistry.name(requestClass, "ListReplicationPriorityResponseSendTimeInMs"));
+    listReplicationPriorityRequestTotalTimeInMs =
+        registry.histogram(MetricRegistry.name(requestClass, "ListReplicationPriorityRequestTotalTimeInMs"));
+
     blobSizeInBytes = registry.histogram(MetricRegistry.name(requestClass, "BlobSize"));
     blobUserMetadataSizeInBytes = registry.histogram(MetricRegistry.name(requestClass, "BlobUserMetadataSize"));
 
@@ -671,6 +709,10 @@ public class ServerMetrics {
     healthCheckRequestRate = registry.meter(MetricRegistry.name(requestClass, "HealthCheckRequestRate"));
     blobIndexRequestRate = registry.meter(MetricRegistry.name(requestClass, "BlobIndexRequestRate"));
     forceDeleteRequestRate = registry.meter(MetricRegistry.name(requestClass, "ForceDeleteRequestRate"));
+    setReplicationPriorityRequestRate =
+        registry.meter(MetricRegistry.name(requestClass, "SetReplicationPriorityRequestRate"));
+    listReplicationPriorityRequestRate =
+        registry.meter(MetricRegistry.name(requestClass, "ListReplicationPriorityRequestRate"));
 
     putBlobDroppedRate = registry.meter(MetricRegistry.name(requestClass, "PutBlobDroppedRate"));
     getBlobDroppedRate = registry.meter(MetricRegistry.name(requestClass, "GetBlobDroppedRate"));
@@ -694,6 +736,10 @@ public class ServerMetrics {
     healthCheckDroppedRate = registry.meter(MetricRegistry.name(requestClass, "HealthCheckDroppedRate"));
     blobIndexDroppedRate = registry.meter(MetricRegistry.name(requestClass, "BlobIndexDroppedRate"));
     forceDeleteDroppedRate = registry.meter(MetricRegistry.name(requestClass, "ForceDeleteDroppedRate"));
+    setReplicationPriorityDroppedRate =
+        registry.meter(MetricRegistry.name(requestClass, "SetReplicationPriorityDroppedRate"));
+    listReplicationPriorityDroppedRate =
+        registry.meter(MetricRegistry.name(requestClass, "ListReplicationPriorityDroppedRate"));
 
     totalRequestDroppedRate = registry.meter(MetricRegistry.name(requestClass, "TotalRequestDroppedRate"));
 

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/AdminRequestOrResponseType.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/AdminRequestOrResponseType.java
@@ -21,5 +21,5 @@ package com.github.ambry.protocol;
  */
 public enum AdminRequestOrResponseType {
   TriggerCompaction, RequestControl, ReplicationControl, CatchupStatus, BlobStoreControl, HealthCheck, BlobIndex, ForceDelete,
-  SetReplicationPriority, ListReplicationPriority
+  UpdateReplicationPriority, ListReplicationPriority
 }

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/AdminRequestOrResponseType.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/AdminRequestOrResponseType.java
@@ -20,5 +20,6 @@ package com.github.ambry.protocol;
  * requests/responses
  */
 public enum AdminRequestOrResponseType {
-  TriggerCompaction, RequestControl, ReplicationControl, CatchupStatus, BlobStoreControl, HealthCheck, BlobIndex, ForceDelete
+  TriggerCompaction, RequestControl, ReplicationControl, CatchupStatus, BlobStoreControl, HealthCheck, BlobIndex, ForceDelete,
+  SetReplicationPriority, ListReplicationPriority
 }

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/ListReplicationPriorityAdminRequest.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/ListReplicationPriorityAdminRequest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.protocol;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+
+
+/**
+ * Admin request that reads the current replication-priority snapshot for a single storage node.
+ * Carries no additional body fields beyond the {@link AdminRequest} parent — the server returns
+ * every priority entry held in memory at handler-invocation time.
+ */
+public class ListReplicationPriorityAdminRequest extends AdminRequest {
+  private static final short VERSION_V1 = 1;
+
+  private final long sizeInBytes;
+
+  /**
+   * Reads from a stream and constructs a {@link ListReplicationPriorityAdminRequest}.
+   * @param stream the stream to read from
+   * @param adminRequest the {@link AdminRequest} containing common header fields
+   * @return the {@link ListReplicationPriorityAdminRequest} constructed from {@code stream}
+   * @throws IOException if there is any problem reading from the stream
+   */
+  public static ListReplicationPriorityAdminRequest readFrom(DataInputStream stream, AdminRequest adminRequest)
+      throws IOException {
+    Short versionId = stream.readShort();
+    if (!versionId.equals(VERSION_V1)) {
+      throw new IllegalStateException("Unrecognized version for ListReplicationPriorityAdminRequest: " + versionId);
+    }
+    return new ListReplicationPriorityAdminRequest(adminRequest);
+  }
+
+  public ListReplicationPriorityAdminRequest(AdminRequest adminRequest) {
+    super(AdminRequestOrResponseType.ListReplicationPriority, adminRequest.getPartitionId(),
+        adminRequest.getCorrelationId(), adminRequest.getClientId());
+    // parent size + version
+    sizeInBytes = super.sizeInBytes() + Short.BYTES;
+  }
+
+  @Override
+  public long sizeInBytes() {
+    return sizeInBytes;
+  }
+
+  @Override
+  public String toString() {
+    return "ListReplicationPriorityAdminRequest[ClientId=" + clientId + ", CorrelationId=" + correlationId + "]";
+  }
+
+  @Override
+  protected void prepareBuffer() {
+    super.prepareBuffer();
+    bufferToSend.writeShort(VERSION_V1);
+  }
+}

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/ListReplicationPriorityAdminResponse.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/ListReplicationPriorityAdminResponse.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2026 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.protocol;
+
+import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.clustermap.PartitionId;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+
+/**
+ * Admin response for {@link ListReplicationPriorityAdminRequest}. Carries a snapshot of
+ * priority entries held by every {@link com.github.ambry.replication.ReplicaThread} on the
+ * target storage node at handler-invocation time.
+ *
+ * Each {@link PriorityEntry} carries an {@code isInterColo} flag indicating whether the entry
+ * came from the inter-colo (cross-datacenter) replication thread pool or the intra-colo pool.
+ * The current design applies priorities to both pools by default, so the same partition
+ * typically appears twice in the response — once per pool.
+ */
+public class ListReplicationPriorityAdminResponse extends AdminResponse {
+  private static final short VERSION_V1 = 1;
+
+  private final List<PriorityEntry> entries;
+  private final long sizeInBytes;
+
+  public static ListReplicationPriorityAdminResponse readFrom(DataInputStream stream, ClusterMap clusterMap)
+      throws IOException {
+    AdminResponse adminResponse = AdminResponse.readFrom(stream);
+    Short versionId = stream.readShort();
+    if (!versionId.equals(VERSION_V1)) {
+      throw new IllegalStateException("Unrecognized version for ListReplicationPriorityAdminResponse: " + versionId);
+    }
+    int numEntries = stream.readInt();
+    List<PriorityEntry> entries = new ArrayList<>(numEntries);
+    for (int i = 0; i < numEntries; i++) {
+      PartitionId partitionId = clusterMap.getPartitionIdFromStream(stream);
+      int boost = stream.readInt();
+      boolean isInterColo = stream.readByte() != 0;
+      entries.add(new PriorityEntry(partitionId, boost, isInterColo));
+    }
+    return new ListReplicationPriorityAdminResponse(entries, adminResponse);
+  }
+
+  public ListReplicationPriorityAdminResponse(List<PriorityEntry> entries, AdminResponse adminResponse) {
+    super(adminResponse.getCorrelationId(), adminResponse.getClientId(), adminResponse.getError());
+    this.entries = Collections.unmodifiableList(new ArrayList<>(entries));
+    this.sizeInBytes = computeSizeInBytes();
+  }
+
+  public List<PriorityEntry> getEntries() {
+    return entries;
+  }
+
+  @Override
+  public long sizeInBytes() {
+    return sizeInBytes;
+  }
+
+  @Override
+  public String toString() {
+    return "ListReplicationPriorityAdminResponse[ClientId=" + clientId + ", CorrelationId=" + correlationId
+        + ", Entries=" + entries + "]";
+  }
+
+  @Override
+  protected void prepareBuffer() {
+    super.prepareBuffer();
+    bufferToSend.writeShort(VERSION_V1);
+    bufferToSend.writeInt(entries.size());
+    for (PriorityEntry entry : entries) {
+      bufferToSend.writeBytes(entry.getPartitionId().getBytes());
+      bufferToSend.writeInt(entry.getBoost());
+      bufferToSend.writeByte(entry.isInterColo() ? (byte) 1 : (byte) 0);
+    }
+  }
+
+  private long computeSizeInBytes() {
+    // parent + version + num-entries
+    long size = super.sizeInBytes() + Short.BYTES + Integer.BYTES;
+    for (PriorityEntry entry : entries) {
+      size += entry.getPartitionId().getBytes().length;  // partition id
+      size += Integer.BYTES;                              // boost
+      size += Byte.BYTES;                                 // isInterColo flag
+    }
+    return size;
+  }
+
+  /**
+   * A single (partition, boost, isInterColo) entry in the priority snapshot.
+   *
+   * <p>{@code boost} is the fetchSize weight currently applied to this partition: each cycle the
+   * thread divides its total fetch budget in proportion to per-replica weights, so a partition
+   * with {@code boost=N} gets roughly {@code N}× the per-cycle bytes of a normal replica
+   * (implicit weight {@code 1}). {@code isInterColo=true} means the entry came from a
+   * cross-datacenter ReplicaThread pool; {@code false} means the intra-datacenter pool.
+   */
+  public static class PriorityEntry {
+    private final PartitionId partitionId;
+    private final int boost;
+    private final boolean isInterColo;
+
+    public PriorityEntry(PartitionId partitionId, int boost, boolean isInterColo) {
+      this.partitionId = partitionId;
+      this.boost = boost;
+      this.isInterColo = isInterColo;
+    }
+
+    public PartitionId getPartitionId() {
+      return partitionId;
+    }
+
+    public int getBoost() {
+      return boost;
+    }
+
+    public boolean isInterColo() {
+      return isInterColo;
+    }
+
+    @Override
+    public String toString() {
+      return "PriorityEntry[" + partitionId + ", boost=" + boost + ", isInterColo=" + isInterColo + "]";
+    }
+  }
+}

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/ListReplicationPriorityAdminResponse.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/ListReplicationPriorityAdminResponse.java
@@ -15,6 +15,7 @@ package com.github.ambry.protocol;
 
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.PartitionId;
+import com.github.ambry.replication.PriorityEntry;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -34,8 +35,11 @@ import java.util.List;
  */
 public class ListReplicationPriorityAdminResponse extends AdminResponse {
   private static final short VERSION_V1 = 1;
+  // Wire-level sanity bound; the operator-facing cap is enforced at the handler.
+  private static final int MAX_ENTRIES_ON_WIRE = 10000;
 
   private final List<PriorityEntry> entries;
+  private final byte[][] partitionIdBytes;
   private final long sizeInBytes;
 
   public static ListReplicationPriorityAdminResponse readFrom(DataInputStream stream, ClusterMap clusterMap)
@@ -46,6 +50,9 @@ public class ListReplicationPriorityAdminResponse extends AdminResponse {
       throw new IllegalStateException("Unrecognized version for ListReplicationPriorityAdminResponse: " + versionId);
     }
     int numEntries = stream.readInt();
+    if (numEntries < 0 || numEntries > MAX_ENTRIES_ON_WIRE) {
+      throw new IOException("ListReplicationPriorityAdminResponse numEntries out of range: " + numEntries);
+    }
     List<PriorityEntry> entries = new ArrayList<>(numEntries);
     for (int i = 0; i < numEntries; i++) {
       PartitionId partitionId = clusterMap.getPartitionIdFromStream(stream);
@@ -59,6 +66,10 @@ public class ListReplicationPriorityAdminResponse extends AdminResponse {
   public ListReplicationPriorityAdminResponse(List<PriorityEntry> entries, AdminResponse adminResponse) {
     super(adminResponse.getCorrelationId(), adminResponse.getClientId(), adminResponse.getError());
     this.entries = Collections.unmodifiableList(new ArrayList<>(entries));
+    this.partitionIdBytes = new byte[this.entries.size()][];
+    for (int i = 0; i < this.entries.size(); i++) {
+      this.partitionIdBytes[i] = this.entries.get(i).getPartitionId().getBytes();
+    }
     this.sizeInBytes = computeSizeInBytes();
   }
 
@@ -82,8 +93,9 @@ public class ListReplicationPriorityAdminResponse extends AdminResponse {
     super.prepareBuffer();
     bufferToSend.writeShort(VERSION_V1);
     bufferToSend.writeInt(entries.size());
-    for (PriorityEntry entry : entries) {
-      bufferToSend.writeBytes(entry.getPartitionId().getBytes());
+    for (int i = 0; i < entries.size(); i++) {
+      PriorityEntry entry = entries.get(i);
+      bufferToSend.writeBytes(partitionIdBytes[i]);
       bufferToSend.writeInt(entry.getBoost());
       bufferToSend.writeByte(entry.isInterColo() ? (byte) 1 : (byte) 0);
     }
@@ -92,49 +104,10 @@ public class ListReplicationPriorityAdminResponse extends AdminResponse {
   private long computeSizeInBytes() {
     // parent + version + num-entries
     long size = super.sizeInBytes() + Short.BYTES + Integer.BYTES;
-    for (PriorityEntry entry : entries) {
-      size += entry.getPartitionId().getBytes().length;  // partition id
-      size += Integer.BYTES;                              // boost
-      size += Byte.BYTES;                                 // isInterColo flag
+    for (int i = 0; i < entries.size(); i++) {
+      // partition id + boost + isInterColo flag
+      size += partitionIdBytes[i].length + Integer.BYTES + Byte.BYTES;
     }
     return size;
-  }
-
-  /**
-   * A single (partition, boost, isInterColo) entry in the priority snapshot.
-   *
-   * <p>{@code boost} is the fetchSize weight currently applied to this partition: each cycle the
-   * thread divides its total fetch budget in proportion to per-replica weights, so a partition
-   * with {@code boost=N} gets roughly {@code N}× the per-cycle bytes of a normal replica
-   * (implicit weight {@code 1}). {@code isInterColo=true} means the entry came from a
-   * cross-datacenter ReplicaThread pool; {@code false} means the intra-datacenter pool.
-   */
-  public static class PriorityEntry {
-    private final PartitionId partitionId;
-    private final int boost;
-    private final boolean isInterColo;
-
-    public PriorityEntry(PartitionId partitionId, int boost, boolean isInterColo) {
-      this.partitionId = partitionId;
-      this.boost = boost;
-      this.isInterColo = isInterColo;
-    }
-
-    public PartitionId getPartitionId() {
-      return partitionId;
-    }
-
-    public int getBoost() {
-      return boost;
-    }
-
-    public boolean isInterColo() {
-      return isInterColo;
-    }
-
-    @Override
-    public String toString() {
-      return "PriorityEntry[" + partitionId + ", boost=" + boost + ", isInterColo=" + isInterColo + "]";
-    }
   }
 }

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/SetReplicationPriorityAdminRequest.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/SetReplicationPriorityAdminRequest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2026 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.protocol;
+
+import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.clustermap.PartitionId;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+
+/**
+ * Admin request that sets, or clears, replication priority for a set of partitions on a single
+ * storage node.
+ *
+ * <p>{@code boost} is an integer weight applied to the prioritized partition's per-iteration
+ * fetchSize. Each cycle, the thread's total fetch budget is divided among all replicas in
+ * proportion to their weights: a non-priority replica has weight {@code 1}, so a partition set
+ * with {@code boost=N} gets roughly {@code N}× the per-cycle bytes of a normal replica. The
+ * server rejects {@code boost < 1} when {@code clear=false}.
+ *
+ * <p>Wire semantics:
+ * <ul>
+ *   <li>{@code clear=false}: set each listed partition's boost to {@code boost}.</li>
+ *   <li>{@code clear=true} with a non-empty partition list: remove only the listed partitions.</li>
+ *   <li>{@code clear=true} with an empty partition list: clear all priorities on this host.
+ *       The frontend's request-shape guard prevents the "clear everywhere with no operator
+ *       intent" footgun by requiring either {@code servers} or {@code partitions} on the API.</li>
+ * </ul>
+ */
+public class SetReplicationPriorityAdminRequest extends AdminRequest {
+  private static final short VERSION_V1 = 1;
+
+  private final List<PartitionId> partitionIds;
+  private final int boost;
+  private final boolean clear;
+  private final long sizeInBytes;
+
+  /**
+   * Reads from a stream and constructs a {@link SetReplicationPriorityAdminRequest}.
+   * @param stream the stream to read from
+   * @param clusterMap the cluster map used to resolve partition ids
+   * @param adminRequest the {@link AdminRequest} containing common header fields
+   * @return the {@link SetReplicationPriorityAdminRequest} constructed from {@code stream}
+   * @throws IOException if there is any problem reading from the stream
+   */
+  public static SetReplicationPriorityAdminRequest readFrom(DataInputStream stream, ClusterMap clusterMap,
+      AdminRequest adminRequest) throws IOException {
+    Short versionId = stream.readShort();
+    if (!versionId.equals(VERSION_V1)) {
+      throw new IllegalStateException("Unrecognized version for SetReplicationPriorityAdminRequest: " + versionId);
+    }
+    boolean clear = stream.readByte() == 1;
+    int boost = stream.readInt();
+    int numPartitions = stream.readInt();
+    List<PartitionId> partitionIds = new ArrayList<>(numPartitions);
+    for (int i = 0; i < numPartitions; i++) {
+      partitionIds.add(clusterMap.getPartitionIdFromStream(stream));
+    }
+    return new SetReplicationPriorityAdminRequest(partitionIds, boost, clear, adminRequest);
+  }
+
+  /**
+   * @param partitionIds partitions targeted by the operation
+   * @param boost fetchSize weight applied to each listed partition when {@code clear} is false
+   *              (must be {@code >= 1}; normal replicas have implicit weight {@code 1}); ignored
+   *              when {@code clear} is true
+   * @param clear if true, remove the listed partitions (or all, if the list is empty); if false, set their boost
+   * @param adminRequest the parent {@link AdminRequest} for common header fields
+   */
+  public SetReplicationPriorityAdminRequest(List<PartitionId> partitionIds, int boost, boolean clear,
+      AdminRequest adminRequest) {
+    super(AdminRequestOrResponseType.SetReplicationPriority, adminRequest.getPartitionId(),
+        adminRequest.getCorrelationId(), adminRequest.getClientId());
+    this.partitionIds = partitionIds;
+    this.boost = boost;
+    this.clear = clear;
+    sizeInBytes = computeSizeInBytes();
+  }
+
+  public List<PartitionId> getPartitionIds() {
+    return Collections.unmodifiableList(partitionIds);
+  }
+
+  public int getBoost() {
+    return boost;
+  }
+
+  public boolean shouldClear() {
+    return clear;
+  }
+
+  @Override
+  public long sizeInBytes() {
+    return sizeInBytes;
+  }
+
+  @Override
+  public String toString() {
+    return "SetReplicationPriorityAdminRequest[ClientId=" + clientId + ", CorrelationId=" + correlationId + ", Clear="
+        + clear + ", Boost=" + boost + ", Partitions=" + partitionIds + "]";
+  }
+
+  @Override
+  protected void prepareBuffer() {
+    super.prepareBuffer();
+    bufferToSend.writeShort(VERSION_V1);
+    bufferToSend.writeByte(clear ? (byte) 1 : 0);
+    bufferToSend.writeInt(boost);
+    bufferToSend.writeInt(partitionIds.size());
+    for (PartitionId partitionId : partitionIds) {
+      bufferToSend.writeBytes(partitionId.getBytes());
+    }
+  }
+
+  private long computeSizeInBytes() {
+    // parent size + version + clear-byte + boost + num-partitions
+    long size = super.sizeInBytes() + Short.BYTES + Byte.BYTES + Integer.BYTES + Integer.BYTES;
+    for (PartitionId partitionId : partitionIds) {
+      size += partitionId.getBytes().length;
+    }
+    return size;
+  }
+}

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/UpdateReplicationPriorityAdminRequest.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/UpdateReplicationPriorityAdminRequest.java
@@ -23,71 +23,89 @@ import java.util.List;
 
 
 /**
- * Admin request that sets, or clears, replication priority for a set of partitions on a single
+ * Admin request that sets, unsets, or wipes-all replication priority for partitions on a single
  * storage node.
  *
  * <p>{@code boost} is an integer weight applied to the prioritized partition's per-iteration
  * fetchSize. Each cycle, the thread's total fetch budget is divided among all replicas in
  * proportion to their weights: a non-priority replica has weight {@code 1}, so a partition set
  * with {@code boost=N} gets roughly {@code N}× the per-cycle bytes of a normal replica. The
- * server rejects {@code boost < 1} when {@code clear=false}.
+ * server rejects {@code boost < 1} on the {@link Action#SET} path.
  *
- * <p>Wire semantics:
+ * <p>Wire semantics — exactly one {@link Action} per request; the server rejects any partition-list
+ * shape that does not match the action:
  * <ul>
- *   <li>{@code clear=false}: set each listed partition's boost to {@code boost}.</li>
- *   <li>{@code clear=true} with a non-empty partition list: remove only the listed partitions.</li>
- *   <li>{@code clear=true} with an empty partition list: clear all priorities on this host.
- *       The frontend's request-shape guard prevents the "clear everywhere with no operator
- *       intent" footgun by requiring either {@code servers} or {@code partitions} on the API.</li>
+ *   <li>{@link Action#SET} (non-empty partitions): set each listed partition's boost to {@code
+ *       boost}.</li>
+ *   <li>{@link Action#UNSET} (non-empty partitions): remove only the listed partitions from the
+ *       priority table.</li>
+ *   <li>{@link Action#UNSET_ALL} (empty partitions): wipe ALL priority entries on this host.</li>
  * </ul>
+ * The split between {@link Action#UNSET} and {@link Action#UNSET_ALL} is explicit so an operator
+ * typo that sends an empty partition list cannot accidentally wipe everything.
  */
-public class SetReplicationPriorityAdminRequest extends AdminRequest {
+public class UpdateReplicationPriorityAdminRequest extends AdminRequest {
   private static final short VERSION_V1 = 1;
+  // Wire-level sanity bound; handler enforces a tighter operator-facing cap.
+  private static final int MAX_PARTITIONS_ON_WIRE = 10000;
+
+  /** The action this request performs. Append only — wire encoding is ordinal-based. */
+  public enum Action {
+    SET, UNSET, UNSET_ALL
+  }
 
   private final List<PartitionId> partitionIds;
   private final int boost;
-  private final boolean clear;
+  private final Action action;
   private final long sizeInBytes;
 
   /**
-   * Reads from a stream and constructs a {@link SetReplicationPriorityAdminRequest}.
+   * Reads from a stream and constructs a {@link UpdateReplicationPriorityAdminRequest}.
    * @param stream the stream to read from
    * @param clusterMap the cluster map used to resolve partition ids
    * @param adminRequest the {@link AdminRequest} containing common header fields
-   * @return the {@link SetReplicationPriorityAdminRequest} constructed from {@code stream}
+   * @return the {@link UpdateReplicationPriorityAdminRequest} constructed from {@code stream}
    * @throws IOException if there is any problem reading from the stream
    */
-  public static SetReplicationPriorityAdminRequest readFrom(DataInputStream stream, ClusterMap clusterMap,
+  public static UpdateReplicationPriorityAdminRequest readFrom(DataInputStream stream, ClusterMap clusterMap,
       AdminRequest adminRequest) throws IOException {
     Short versionId = stream.readShort();
     if (!versionId.equals(VERSION_V1)) {
-      throw new IllegalStateException("Unrecognized version for SetReplicationPriorityAdminRequest: " + versionId);
+      throw new IllegalStateException("Unrecognized version for UpdateReplicationPriorityAdminRequest: " + versionId);
     }
-    boolean clear = stream.readByte() == 1;
+    Action action = Action.values()[stream.readShort()];
     int boost = stream.readInt();
     int numPartitions = stream.readInt();
+    if (numPartitions < 0 || numPartitions > MAX_PARTITIONS_ON_WIRE) {
+      throw new IOException("UpdateReplicationPriorityAdminRequest numPartitions out of range: " + numPartitions);
+    }
     List<PartitionId> partitionIds = new ArrayList<>(numPartitions);
     for (int i = 0; i < numPartitions; i++) {
-      partitionIds.add(clusterMap.getPartitionIdFromStream(stream));
+      PartitionId partitionId = clusterMap.getPartitionIdFromStream(stream);
+      if (partitionId == null) {
+        throw new IOException("Failed to resolve partition id at index " + i);
+      }
+      partitionIds.add(partitionId);
     }
-    return new SetReplicationPriorityAdminRequest(partitionIds, boost, clear, adminRequest);
+    return new UpdateReplicationPriorityAdminRequest(partitionIds, boost, action, adminRequest);
   }
 
   /**
    * @param partitionIds partitions targeted by the operation
-   * @param boost fetchSize weight applied to each listed partition when {@code clear} is false
+   * @param boost fetchSize weight applied to each listed partition on the {@link Action#SET} path
    *              (must be {@code >= 1}; normal replicas have implicit weight {@code 1}); ignored
-   *              when {@code clear} is true
-   * @param clear if true, remove the listed partitions (or all, if the list is empty); if false, set their boost
+   *              on the {@link Action#UNSET} / {@link Action#UNSET_ALL} paths
+   * @param action the {@link Action} to perform; the partition-list shape must match (see class
+   *               javadoc)
    * @param adminRequest the parent {@link AdminRequest} for common header fields
    */
-  public SetReplicationPriorityAdminRequest(List<PartitionId> partitionIds, int boost, boolean clear,
+  public UpdateReplicationPriorityAdminRequest(List<PartitionId> partitionIds, int boost, Action action,
       AdminRequest adminRequest) {
-    super(AdminRequestOrResponseType.SetReplicationPriority, adminRequest.getPartitionId(),
+    super(AdminRequestOrResponseType.UpdateReplicationPriority, adminRequest.getPartitionId(),
         adminRequest.getCorrelationId(), adminRequest.getClientId());
     this.partitionIds = partitionIds;
     this.boost = boost;
-    this.clear = clear;
+    this.action = action;
     sizeInBytes = computeSizeInBytes();
   }
 
@@ -99,8 +117,8 @@ public class SetReplicationPriorityAdminRequest extends AdminRequest {
     return boost;
   }
 
-  public boolean shouldClear() {
-    return clear;
+  public Action getAction() {
+    return action;
   }
 
   @Override
@@ -110,15 +128,15 @@ public class SetReplicationPriorityAdminRequest extends AdminRequest {
 
   @Override
   public String toString() {
-    return "SetReplicationPriorityAdminRequest[ClientId=" + clientId + ", CorrelationId=" + correlationId + ", Clear="
-        + clear + ", Boost=" + boost + ", Partitions=" + partitionIds + "]";
+    return "UpdateReplicationPriorityAdminRequest[ClientId=" + clientId + ", CorrelationId=" + correlationId + ", Action="
+        + action + ", Boost=" + boost + ", Partitions=" + partitionIds + "]";
   }
 
   @Override
   protected void prepareBuffer() {
     super.prepareBuffer();
     bufferToSend.writeShort(VERSION_V1);
-    bufferToSend.writeByte(clear ? (byte) 1 : 0);
+    bufferToSend.writeShort((short) action.ordinal());
     bufferToSend.writeInt(boost);
     bufferToSend.writeInt(partitionIds.size());
     for (PartitionId partitionId : partitionIds) {
@@ -127,8 +145,8 @@ public class SetReplicationPriorityAdminRequest extends AdminRequest {
   }
 
   private long computeSizeInBytes() {
-    // parent size + version + clear-byte + boost + num-partitions
-    long size = super.sizeInBytes() + Short.BYTES + Byte.BYTES + Integer.BYTES + Integer.BYTES;
+    // parent size + version + action + boost + num-partitions
+    long size = super.sizeInBytes() + Short.BYTES + Short.BYTES + Integer.BYTES + Integer.BYTES;
     for (PartitionId partitionId : partitionIds) {
       size += partitionId.getBytes().length;
     }

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/UpdateReplicationPriorityAdminRequest.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/UpdateReplicationPriorityAdminRequest.java
@@ -46,8 +46,8 @@ import java.util.List;
  */
 public class UpdateReplicationPriorityAdminRequest extends AdminRequest {
   private static final short VERSION_V1 = 1;
-  // Wire-level sanity bound; handler enforces a tighter operator-facing cap.
-  private static final int MAX_PARTITIONS_ON_WIRE = 10000;
+  // Realistic priority lists are dozens, not hundreds.
+  public static final int MAX_PARTITIONS_PER_REQUEST = 256;
 
   /** The action this request performs. Append only — wire encoding is ordinal-based. */
   public enum Action {
@@ -76,7 +76,7 @@ public class UpdateReplicationPriorityAdminRequest extends AdminRequest {
     Action action = Action.values()[stream.readShort()];
     int boost = stream.readInt();
     int numPartitions = stream.readInt();
-    if (numPartitions < 0 || numPartitions > MAX_PARTITIONS_ON_WIRE) {
+    if (numPartitions < 0 || numPartitions > MAX_PARTITIONS_PER_REQUEST) {
       throw new IOException("UpdateReplicationPriorityAdminRequest numPartitions out of range: " + numPartitions);
     }
     List<PartitionId> partitionIds = new ArrayList<>(numPartitions);

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/UpdateReplicationPriorityAdminRequest.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/UpdateReplicationPriorityAdminRequest.java
@@ -49,9 +49,30 @@ public class UpdateReplicationPriorityAdminRequest extends AdminRequest {
   // Realistic priority lists are dozens, not hundreds.
   public static final int MAX_PARTITIONS_PER_REQUEST = 256;
 
-  /** The action this request performs. Append only — wire encoding is ordinal-based. */
+  /** The action this request performs. Wire values are explicit so reordering enum constants in code does not silently break the wire format. */
   public enum Action {
-    SET, UNSET, UNSET_ALL
+    SET((short) 0),
+    UNSET((short) 1),
+    UNSET_ALL((short) 2);
+
+    private final short wireValue;
+
+    Action(short wireValue) {
+      this.wireValue = wireValue;
+    }
+
+    public short getWireValue() {
+      return wireValue;
+    }
+
+    public static Action fromWireValue(short v) throws IOException {
+      for (Action a : values()) {
+        if (a.wireValue == v) {
+          return a;
+        }
+      }
+      throw new IOException("Unknown Action wire value: " + v);
+    }
   }
 
   private final List<PartitionId> partitionIds;
@@ -73,7 +94,7 @@ public class UpdateReplicationPriorityAdminRequest extends AdminRequest {
     if (!versionId.equals(VERSION_V1)) {
       throw new IllegalStateException("Unrecognized version for UpdateReplicationPriorityAdminRequest: " + versionId);
     }
-    Action action = Action.values()[stream.readShort()];
+    Action action = Action.fromWireValue(stream.readShort());
     int boost = stream.readInt();
     int numPartitions = stream.readInt();
     if (numPartitions < 0 || numPartitions > MAX_PARTITIONS_PER_REQUEST) {
@@ -136,7 +157,7 @@ public class UpdateReplicationPriorityAdminRequest extends AdminRequest {
   protected void prepareBuffer() {
     super.prepareBuffer();
     bufferToSend.writeShort(VERSION_V1);
-    bufferToSend.writeShort((short) action.ordinal());
+    bufferToSend.writeShort(action.getWireValue());
     bufferToSend.writeInt(boost);
     bufferToSend.writeInt(partitionIds.size());
     for (PartitionId partitionId : partitionIds) {

--- a/ambry-protocol/src/test/java/com/github/ambry/protocol/RequestResponseTest.java
+++ b/ambry-protocol/src/test/java/com/github/ambry/protocol/RequestResponseTest.java
@@ -1510,6 +1510,23 @@ public class RequestResponseTest {
   }
 
   /**
+   * Pins {@link UpdateReplicationPriorityAdminRequest.Action#fromWireValue} on bad inputs: every
+   * non-mapped short throws {@link IOException} rather than silently aliasing to a wrong action or
+   * crashing with {@code ArrayIndexOutOfBoundsException}.
+   */
+  @Test
+  public void updateReplicationPriorityActionWireValueRejectsUnknown() {
+    for (short bad : new short[]{(short) -1, (short) 3, Short.MAX_VALUE, Short.MIN_VALUE}) {
+      try {
+        UpdateReplicationPriorityAdminRequest.Action.fromWireValue(bad);
+        Assert.fail("fromWireValue(" + bad + ") should have thrown IOException");
+      } catch (IOException expected) {
+        // expected
+      }
+    }
+  }
+
+  /**
    * Tests the ser/de of {@link ListReplicationPriorityAdminRequest} — body-less, just the marker.
    */
   @Test

--- a/ambry-protocol/src/test/java/com/github/ambry/protocol/RequestResponseTest.java
+++ b/ambry-protocol/src/test/java/com/github/ambry/protocol/RequestResponseTest.java
@@ -32,6 +32,7 @@ import com.github.ambry.replication.FindToken;
 import com.github.ambry.replication.FindTokenFactory;
 import com.github.ambry.replication.FindTokenHelper;
 import com.github.ambry.replication.FindTokenType;
+import com.github.ambry.replication.PriorityEntry;
 import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.store.FileInfo;
 import com.github.ambry.store.LogInfo;
@@ -1490,19 +1491,22 @@ public class RequestResponseTest {
   }
 
   /**
-   * Tests the ser/de of {@link SetReplicationPriorityAdminRequest} across set, clear-list, and
-   * clear-all wire shapes; verifies fields round-trip intact.
+   * Tests the ser/de of {@link UpdateReplicationPriorityAdminRequest} across all
+   * {@link UpdateReplicationPriorityAdminRequest.Action} values; verifies fields round-trip intact.
    */
   @Test
-  public void setReplicationPriorityAdminRequestTest() throws IOException {
+  public void updateReplicationPriorityAdminRequestTest() throws IOException {
     MockClusterMap clusterMap = new MockClusterMap();
     List<PartitionId> partitions = clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS);
-    // Set: non-empty partition list, boost > 1, clear=false
-    doSetReplicationPriorityAdminRequestTest(clusterMap, partitions.subList(0, Math.min(3, partitions.size())), 8, false);
-    // Clear targeted: non-empty list, clear=true
-    doSetReplicationPriorityAdminRequestTest(clusterMap, partitions.subList(0, Math.min(2, partitions.size())), 1, true);
-    // Clear-all: empty list, clear=true
-    doSetReplicationPriorityAdminRequestTest(clusterMap, Collections.emptyList(), 1, true);
+    // SET: non-empty partition list, boost > 1
+    doUpdateReplicationPriorityAdminRequestTest(clusterMap, partitions.subList(0, Math.min(3, partitions.size())), 8,
+        UpdateReplicationPriorityAdminRequest.Action.SET);
+    // UNSET: non-empty list
+    doUpdateReplicationPriorityAdminRequestTest(clusterMap, partitions.subList(0, Math.min(2, partitions.size())), 1,
+        UpdateReplicationPriorityAdminRequest.Action.UNSET);
+    // UNSET_ALL: empty list
+    doUpdateReplicationPriorityAdminRequestTest(clusterMap, Collections.emptyList(), 1,
+        UpdateReplicationPriorityAdminRequest.Action.UNSET_ALL);
   }
 
   /**
@@ -1539,40 +1543,40 @@ public class RequestResponseTest {
     doListReplicationPriorityAdminResponseTest(clusterMap, Collections.emptyList());
     // Single entry
     doListReplicationPriorityAdminResponseTest(clusterMap, Collections.singletonList(
-        new ListReplicationPriorityAdminResponse.PriorityEntry(partitions.get(0), 4, false)));
+        new PriorityEntry(partitions.get(0), 4, false)));
     // Mixed intra/inter-colo, multiple entries
-    List<ListReplicationPriorityAdminResponse.PriorityEntry> entries = new ArrayList<>();
-    entries.add(new ListReplicationPriorityAdminResponse.PriorityEntry(partitions.get(0), 8, false));
-    entries.add(new ListReplicationPriorityAdminResponse.PriorityEntry(partitions.get(1), 16, true));
-    entries.add(new ListReplicationPriorityAdminResponse.PriorityEntry(partitions.get(2), 1, false));
+    List<PriorityEntry> entries = new ArrayList<>();
+    entries.add(new PriorityEntry(partitions.get(0), 8, false));
+    entries.add(new PriorityEntry(partitions.get(1), 16, true));
+    entries.add(new PriorityEntry(partitions.get(2), 1, false));
     doListReplicationPriorityAdminResponseTest(clusterMap, entries);
   }
 
-  private void doSetReplicationPriorityAdminRequestTest(MockClusterMap clusterMap, List<PartitionId> partitions,
-      int boost, boolean clear) throws IOException {
+  private void doUpdateReplicationPriorityAdminRequestTest(MockClusterMap clusterMap, List<PartitionId> partitions,
+      int boost, UpdateReplicationPriorityAdminRequest.Action action) throws IOException {
     int correlationId = 1234;
-    String clientId = "set-priority-client";
+    String clientId = "update-priority-client";
     AdminRequest adminRequest =
-        new AdminRequest(AdminRequestOrResponseType.SetReplicationPriority, null, correlationId, clientId);
-    SetReplicationPriorityAdminRequest setRequest =
-        new SetReplicationPriorityAdminRequest(partitions, boost, clear, adminRequest);
-    DataInputStream requestStream = serAndPrepForRead(setRequest, -1, true);
+        new AdminRequest(AdminRequestOrResponseType.UpdateReplicationPriority, null, correlationId, clientId);
+    UpdateReplicationPriorityAdminRequest updateRequest =
+        new UpdateReplicationPriorityAdminRequest(partitions, boost, action, adminRequest);
+    DataInputStream requestStream = serAndPrepForRead(updateRequest, -1, true);
     AdminRequest deserializedAdminRequest =
         deserAdminRequestAndVerify(requestStream, clusterMap, correlationId, clientId,
-            AdminRequestOrResponseType.SetReplicationPriority, null);
-    SetReplicationPriorityAdminRequest deserialized =
-        SetReplicationPriorityAdminRequest.readFrom(requestStream, clusterMap, deserializedAdminRequest);
-    Assert.assertEquals("clear flag", clear, deserialized.shouldClear());
+            AdminRequestOrResponseType.UpdateReplicationPriority, null);
+    UpdateReplicationPriorityAdminRequest deserialized =
+        UpdateReplicationPriorityAdminRequest.readFrom(requestStream, clusterMap, deserializedAdminRequest);
+    Assert.assertEquals("action", action, deserialized.getAction());
     Assert.assertEquals("boost", boost, deserialized.getBoost());
     Assert.assertEquals("partition count", partitions.size(), deserialized.getPartitionIds().size());
     for (int i = 0; i < partitions.size(); i++) {
       Assert.assertEquals("partition[" + i + "]", partitions.get(i), deserialized.getPartitionIds().get(i));
     }
-    setRequest.release();
+    updateRequest.release();
   }
 
   private void doListReplicationPriorityAdminResponseTest(MockClusterMap clusterMap,
-      List<ListReplicationPriorityAdminResponse.PriorityEntry> entries) throws IOException {
+      List<PriorityEntry> entries) throws IOException {
     int correlationId = 4242;
     String clientId = "list-priority-client";
     AdminResponse baseResponse = new AdminResponse(correlationId, clientId, ServerErrorCode.NoError);
@@ -1584,8 +1588,8 @@ public class RequestResponseTest {
     Assert.assertEquals("clientId", clientId, deserialized.getClientId());
     Assert.assertEquals("entry count", entries.size(), deserialized.getEntries().size());
     for (int i = 0; i < entries.size(); i++) {
-      ListReplicationPriorityAdminResponse.PriorityEntry expected = entries.get(i);
-      ListReplicationPriorityAdminResponse.PriorityEntry actual = deserialized.getEntries().get(i);
+      PriorityEntry expected = entries.get(i);
+      PriorityEntry actual = deserialized.getEntries().get(i);
       Assert.assertEquals("entry[" + i + "].partition", expected.getPartitionId(), actual.getPartitionId());
       Assert.assertEquals("entry[" + i + "].boost", expected.getBoost(), actual.getBoost());
       Assert.assertEquals("entry[" + i + "].isInterColo", expected.isInterColo(), actual.isInterColo());

--- a/ambry-protocol/src/test/java/com/github/ambry/protocol/RequestResponseTest.java
+++ b/ambry-protocol/src/test/java/com/github/ambry/protocol/RequestResponseTest.java
@@ -70,6 +70,7 @@ import java.util.List;
 import java.util.Map;
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -1486,6 +1487,110 @@ public class RequestResponseTest {
     doReplicationControlAdminRequestTest(origins, true);
     doReplicationControlAdminRequestTest(origins, false);
     doReplicationControlAdminRequestTest(Collections.emptyList(), true);
+  }
+
+  /**
+   * Tests the ser/de of {@link SetReplicationPriorityAdminRequest} across set, clear-list, and
+   * clear-all wire shapes; verifies fields round-trip intact.
+   */
+  @Test
+  public void setReplicationPriorityAdminRequestTest() throws IOException {
+    MockClusterMap clusterMap = new MockClusterMap();
+    List<PartitionId> partitions = clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS);
+    // Set: non-empty partition list, boost > 1, clear=false
+    doSetReplicationPriorityAdminRequestTest(clusterMap, partitions.subList(0, Math.min(3, partitions.size())), 8, false);
+    // Clear targeted: non-empty list, clear=true
+    doSetReplicationPriorityAdminRequestTest(clusterMap, partitions.subList(0, Math.min(2, partitions.size())), 1, true);
+    // Clear-all: empty list, clear=true
+    doSetReplicationPriorityAdminRequestTest(clusterMap, Collections.emptyList(), 1, true);
+  }
+
+  /**
+   * Tests the ser/de of {@link ListReplicationPriorityAdminRequest} — body-less, just the marker.
+   */
+  @Test
+  public void listReplicationPriorityAdminRequestTest() throws IOException {
+    MockClusterMap clusterMap = new MockClusterMap();
+    int correlationId = 4321;
+    String clientId = "list-client";
+    AdminRequest adminRequest =
+        new AdminRequest(AdminRequestOrResponseType.ListReplicationPriority, null, correlationId, clientId);
+    ListReplicationPriorityAdminRequest listRequest = new ListReplicationPriorityAdminRequest(adminRequest);
+    DataInputStream requestStream = serAndPrepForRead(listRequest, -1, true);
+    AdminRequest deserializedAdminRequest =
+        deserAdminRequestAndVerify(requestStream, clusterMap, correlationId, clientId,
+            AdminRequestOrResponseType.ListReplicationPriority, null);
+    ListReplicationPriorityAdminRequest deserialized =
+        ListReplicationPriorityAdminRequest.readFrom(requestStream, deserializedAdminRequest);
+    Assert.assertNotNull(deserialized);
+    listRequest.release();
+  }
+
+  /**
+   * Tests the ser/de of {@link ListReplicationPriorityAdminResponse} across empty, intra-colo only,
+   * and mixed intra/inter-colo entry lists.
+   */
+  @Test
+  public void listReplicationPriorityAdminResponseTest() throws IOException {
+    MockClusterMap clusterMap = new MockClusterMap();
+    List<PartitionId> partitions = clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS);
+    Assume.assumeTrue("Need at least 3 partitions for this test", partitions.size() >= 3);
+    // Empty entries
+    doListReplicationPriorityAdminResponseTest(clusterMap, Collections.emptyList());
+    // Single entry
+    doListReplicationPriorityAdminResponseTest(clusterMap, Collections.singletonList(
+        new ListReplicationPriorityAdminResponse.PriorityEntry(partitions.get(0), 4, false)));
+    // Mixed intra/inter-colo, multiple entries
+    List<ListReplicationPriorityAdminResponse.PriorityEntry> entries = new ArrayList<>();
+    entries.add(new ListReplicationPriorityAdminResponse.PriorityEntry(partitions.get(0), 8, false));
+    entries.add(new ListReplicationPriorityAdminResponse.PriorityEntry(partitions.get(1), 16, true));
+    entries.add(new ListReplicationPriorityAdminResponse.PriorityEntry(partitions.get(2), 1, false));
+    doListReplicationPriorityAdminResponseTest(clusterMap, entries);
+  }
+
+  private void doSetReplicationPriorityAdminRequestTest(MockClusterMap clusterMap, List<PartitionId> partitions,
+      int boost, boolean clear) throws IOException {
+    int correlationId = 1234;
+    String clientId = "set-priority-client";
+    AdminRequest adminRequest =
+        new AdminRequest(AdminRequestOrResponseType.SetReplicationPriority, null, correlationId, clientId);
+    SetReplicationPriorityAdminRequest setRequest =
+        new SetReplicationPriorityAdminRequest(partitions, boost, clear, adminRequest);
+    DataInputStream requestStream = serAndPrepForRead(setRequest, -1, true);
+    AdminRequest deserializedAdminRequest =
+        deserAdminRequestAndVerify(requestStream, clusterMap, correlationId, clientId,
+            AdminRequestOrResponseType.SetReplicationPriority, null);
+    SetReplicationPriorityAdminRequest deserialized =
+        SetReplicationPriorityAdminRequest.readFrom(requestStream, clusterMap, deserializedAdminRequest);
+    Assert.assertEquals("clear flag", clear, deserialized.shouldClear());
+    Assert.assertEquals("boost", boost, deserialized.getBoost());
+    Assert.assertEquals("partition count", partitions.size(), deserialized.getPartitionIds().size());
+    for (int i = 0; i < partitions.size(); i++) {
+      Assert.assertEquals("partition[" + i + "]", partitions.get(i), deserialized.getPartitionIds().get(i));
+    }
+    setRequest.release();
+  }
+
+  private void doListReplicationPriorityAdminResponseTest(MockClusterMap clusterMap,
+      List<ListReplicationPriorityAdminResponse.PriorityEntry> entries) throws IOException {
+    int correlationId = 4242;
+    String clientId = "list-priority-client";
+    AdminResponse baseResponse = new AdminResponse(correlationId, clientId, ServerErrorCode.NoError);
+    ListReplicationPriorityAdminResponse response = new ListReplicationPriorityAdminResponse(entries, baseResponse);
+    DataInputStream responseStream = serAndPrepForRead(response, -1, false);
+    ListReplicationPriorityAdminResponse deserialized =
+        ListReplicationPriorityAdminResponse.readFrom(responseStream, clusterMap);
+    Assert.assertEquals("correlationId", correlationId, deserialized.getCorrelationId());
+    Assert.assertEquals("clientId", clientId, deserialized.getClientId());
+    Assert.assertEquals("entry count", entries.size(), deserialized.getEntries().size());
+    for (int i = 0; i < entries.size(); i++) {
+      ListReplicationPriorityAdminResponse.PriorityEntry expected = entries.get(i);
+      ListReplicationPriorityAdminResponse.PriorityEntry actual = deserialized.getEntries().get(i);
+      Assert.assertEquals("entry[" + i + "].partition", expected.getPartitionId(), actual.getPartitionId());
+      Assert.assertEquals("entry[" + i + "].boost", expected.getBoost(), actual.getBoost());
+      Assert.assertEquals("entry[" + i + "].isInterColo", expected.isInterColo(), actual.isInterColo());
+    }
+    response.release();
   }
 
   @Test

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -2444,6 +2444,14 @@ public class ReplicaThread implements Runnable {
     }
 
     /**
+     * Package-private accessor for tests pinning the per-cycle budget math
+     * (see {@code RemoteReplicaGroupPollerTest.baseFetchSizeBudgetConservation}).
+     */
+    long getCurrentCycleBaseFetchSize() {
+      return currentCycleBaseFetchSize;
+    }
+
+    /**
      * Creates Data node trackers for every data node
      * Every datanode tracker has active groups and standby group
      * For each data node tracker, only one stand by group is present to reduce cross colo requests

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -140,11 +140,10 @@ public class ReplicaThread implements Runnable {
   /**
    * Per-thread map of partitions whose replicas are currently boosted in the per-cycle fetch-budget
    * distribution. Mutated by admin handler threads (via {@link #prioritizePartitions} /
-   * {@link #clearPriorityPartitions}) and read by the replication thread once per cycle in
-   * {@link RemoteReplicaGroupPoller#fillDataNodeTrackers()} (which snapshots before use).
+   * {@link #unsetPriorityPartitions}) and read by the replication thread in
+   * {@link RemoteReplicaGroupPoller#fillDataNodeTrackers()}.
    *
    * Concurrent because admin threads can mutate while the replication thread is iterating.
-   * Snapshot-then-use means the replication thread never observes a partial mutation.
    *
    * The map is empty by default — its absence is a no-op for chunking behavior.
    */
@@ -308,7 +307,7 @@ public class ReplicaThread implements Runnable {
    * budget after redistribution. Repeated calls overwrite previous boosts; the per-thread map is
    * bounded by partition count.
    *
-   * <p>Callers MUST validate that the chosen boost will not exceed the HTTP/2 max-content-length
+   * <p>Callers MUST validate that the chosen boost will not exceed the wire-layer max-content-length
    * cap given the current fetch-size baseline and max blob size. The check lives in the admin
    * handler so this method does not need {@code RouterConfig} / {@code NetworkConfig} dependencies.
    *
@@ -329,21 +328,21 @@ public class ReplicaThread implements Runnable {
   }
 
   /**
-   * Clear replication priority on this thread. When {@code partitions} is empty, removes ALL priority
-   * entries on this thread (per-host clear-all). When non-empty, removes only the listed partitions.
-   * Frontend-layer guards ensure the "empty list" case is only reachable when the operator
-   * explicitly sent {@code clear=true} with no partition list.
+   * Unset replication priority on this thread. When {@code partitions} is empty, removes ALL priority
+   * entries on this thread (per-host wipe-all). When non-empty, removes only the listed partitions.
+   * Admin-handler guards ensure the empty-list case is only reachable when the operator explicitly
+   * sent {@code unsetAll=true} on the wire — never from an unset request with an empty partition list.
    *
-   * @param partitions partitions to clear; empty list ⇒ clear all
+   * @param partitions partitions to unset; empty list ⇒ wipe all on this thread
    */
-  public void clearPriorityPartitions(List<PartitionId> partitions) {
+  public void unsetPriorityPartitions(List<PartitionId> partitions) {
     if (partitions.isEmpty()) {
-      int cleared = priorityPartitions.size();
+      int unsetCount = priorityPartitions.size();
       priorityPartitions.clear();
-      logger.info("Cleared all {} replication priorities on thread {}", cleared, getName());
+      logger.info("Unset all {} replication priorities on thread {}", unsetCount, getName());
     } else {
       partitions.forEach(priorityPartitions::remove);
-      logger.info("Cleared replication priorities for {} partitions on thread {}", partitions.size(), getName());
+      logger.info("Unset replication priorities for {} partitions on thread {}", partitions.size(), getName());
     }
     terminateCycleAndWake();
   }
@@ -1339,17 +1338,17 @@ public class ReplicaThread implements Runnable {
     if (allLocalStoreInBootstrap && !replicatingFromRemoteColo) {
       baseline = replicationConfig.replicationFetchSizeInBytesForBootstrapIntraColo;
       logger.trace(
-          "All local stores are at bootstrap mode, and this is intro colo replication, set the fetch size baseline to {}",
+          "All local stores are at bootstrap mode, and this is intra colo replication, set the fetch size baseline to {}",
           baseline);
     } else if (baseFetchSize > 0) {
       baseline = baseFetchSize;
     } else {
       baseline = replicationConfig.replicationFetchSizeInBytes;
     }
-    long fetchSize = (long) weight * baseline;
+    long perReplicaFetchSize = (long) weight * baseline;
     return new ReplicaMetadataRequest(correlationIdGenerator.incrementAndGet(),
         "replication-metadata-" + dataNodeId.getHostname() + "[" + dataNodeId.getDatacenterName() + "]",
-        replicaMetadataRequestInfoList, fetchSize, replicationConfig.replicaMetadataRequestVersion);
+        replicaMetadataRequestInfoList, perReplicaFetchSize, replicationConfig.replicaMetadataRequestVersion);
   }
 
   /**

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -80,12 +80,15 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.ToLongFunction;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -134,6 +137,18 @@ public class ReplicaThread implements Runnable {
   private final Predicate<MessageInfo> skipPredicate;
   private final int continuousReplicationGroupIterationLimit;
   private volatile boolean terminateCurrentContinuousReplicationCycle = false;
+  /**
+   * Per-thread map of partitions whose replicas are currently boosted in the per-cycle fetch-budget
+   * distribution. Mutated by admin handler threads (via {@link #prioritizePartitions} /
+   * {@link #clearPriorityPartitions}) and read by the replication thread once per cycle in
+   * {@link RemoteReplicaGroupPoller#fillDataNodeTrackers()} (which snapshots before use).
+   *
+   * Concurrent because admin threads can mutate while the replication thread is iterating.
+   * Snapshot-then-use means the replication thread never observes a partial mutation.
+   *
+   * The map is empty by default — its absence is a no-op for chunking behavior.
+   */
+  private final ConcurrentHashMap<PartitionId, Integer> priorityPartitions = new ConcurrentHashMap<>();
   private volatile boolean allDisabled = false;
   private final ReplicationManager.LeaderBasedReplicationAdmin leaderBasedReplicationAdmin;
   protected Thread thread;
@@ -266,6 +281,105 @@ public class ReplicaThread implements Runnable {
       terminateCurrentContinuousReplicationCycle = true;
       lock.unlock();
     }
+  }
+
+  /**
+   * Returns true when {@code infos} is non-empty AND every replica is {@link ReplicaStatus#ACTIVE}
+   * AND has remote lag strictly less than {@code syncedLagThreshold}. Empty {@code infos} returns
+   * false so a priority partition with no replicas in this thread is never auto-pruned here.
+   */
+  static boolean shouldAutoPrunePriority(List<RemoteReplicaInfo> infos, long syncedLagThreshold,
+      Function<RemoteReplicaInfo, ReplicaStatus> statusFn, ToLongFunction<RemoteReplicaInfo> lagFn) {
+    if (infos.isEmpty()) {
+      return false;
+    }
+    for (RemoteReplicaInfo r : infos) {
+      if (statusFn.apply(r) != ReplicaStatus.ACTIVE || lagFn.applyAsLong(r) >= syncedLagThreshold) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Boost the per-cycle fetch budget for the listed partitions by {@code boost}. Each priority
+   * partition is segregated into its own singleton chunk; the chunk's per-iteration metadata
+   * fetchSize is {@code boost × baseFetchSize}, where {@code baseFetchSize} is the per-replica
+   * budget after redistribution. Repeated calls overwrite previous boosts; the per-thread map is
+   * bounded by partition count.
+   *
+   * <p>Callers MUST validate that the chosen boost will not exceed the HTTP/2 max-content-length
+   * cap given the current fetch-size baseline and max blob size. The check lives in the admin
+   * handler so this method does not need {@code RouterConfig} / {@code NetworkConfig} dependencies.
+   *
+   * @param partitions partitions to prioritize; empty list is a no-op
+   * @param boost weight applied on top of the per-replica budget. Must be {@code >= 1}; the admin
+   *              handler rejects smaller values at the boundary, so this method does not re-validate.
+   */
+  public void prioritizePartitions(List<PartitionId> partitions, int boost) {
+    if (partitions.isEmpty()) {
+      return;
+    }
+    for (PartitionId id : partitions) {
+      priorityPartitions.put(id, boost);
+    }
+    terminateCycleAndWake();
+    logger.info("Set replication priority for {} partitions on thread {} to boost {}",
+        partitions.size(), getName(), boost);
+  }
+
+  /**
+   * Clear replication priority on this thread. When {@code partitions} is empty, removes ALL priority
+   * entries on this thread (per-host clear-all). When non-empty, removes only the listed partitions.
+   * Frontend-layer guards ensure the "empty list" case is only reachable when the operator
+   * explicitly sent {@code clear=true} with no partition list.
+   *
+   * @param partitions partitions to clear; empty list ⇒ clear all
+   */
+  public void clearPriorityPartitions(List<PartitionId> partitions) {
+    if (partitions.isEmpty()) {
+      int cleared = priorityPartitions.size();
+      priorityPartitions.clear();
+      logger.info("Cleared all {} replication priorities on thread {}", cleared, getName());
+    } else {
+      partitions.forEach(priorityPartitions::remove);
+      logger.info("Cleared replication priorities for {} partitions on thread {}", partitions.size(), getName());
+    }
+    terminateCycleAndWake();
+  }
+
+  /**
+   * End any in-flight continuous replication cycle and wake the thread if it is parked, so an
+   * operator-driven priority change takes effect this round instead of waiting for a natural cycle
+   * boundary. Signal is unconditional — cheap, and robust against future additions to the
+   * park-condition set.
+   */
+  private void terminateCycleAndWake() {
+    lock.lock();
+    try {
+      terminateCurrentContinuousReplicationCycle = true;
+      pauseCondition.signal();
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  /**
+   * @return a snapshot of {@code (partitionId, boost)} entries held in this thread's priority map.
+   *         The snapshot may briefly include entries that an admin handler is concurrently removing;
+   *         that is fine for the operator list view (best-effort, weakly consistent).
+   */
+  public Map<PartitionId, Integer> listPriorityPartitions() {
+    // ConcurrentHashMap.entrySet() is weakly consistent — safe to iterate without external sync.
+    return new HashMap<>(priorityPartitions);
+  }
+
+  /**
+   * @return true if this thread replicates from a remote datacenter (inter-colo), false if intra-colo.
+   *         Used to tag {@link #listPriorityPartitions} entries with their {@code isInterColo} flag.
+   */
+  public boolean isReplicatingFromRemoteColo() {
+    return replicatingFromRemoteColo;
   }
 
   /**
@@ -1187,6 +1301,26 @@ public class ReplicaThread implements Runnable {
    */
   ReplicaMetadataRequest createReplicaMetadataRequest(List<RemoteReplicaInfo> replicasToReplicatePerNode,
       DataNodeId remoteNode) {
+    return createReplicaMetadataRequest(replicasToReplicatePerNode, remoteNode, /*weight*/ 1, /*baseFetchSize*/ 0L);
+  }
+
+  /**
+   * Variant that takes the per-chunk {@code weight} and {@code baseFetchSize} computed in
+   * {@code fillDataNodeTrackers} when continuous replication is enabled. Used so priority chunks
+   * (with their boost) get a correspondingly larger per-iteration fetchSize.
+   *
+   * fetchSize selection (in this order):
+   * <ul>
+   *   <li>If the call is intra-colo bootstrap, the bootstrap baseline replaces the per-cycle
+   *       baseline (preserves existing bootstrap behavior).</li>
+   *   <li>Otherwise, if {@code baseFetchSize > 0}, use that (continuous-mode per-cycle budget).</li>
+   *   <li>Otherwise, fall back to {@code replicationConfig.replicationFetchSizeInBytes} (legacy
+   *       and non-continuous path).</li>
+   * </ul>
+   * The chosen baseline is then multiplied by {@code weight}.
+   */
+  ReplicaMetadataRequest createReplicaMetadataRequest(List<RemoteReplicaInfo> replicasToReplicatePerNode,
+      DataNodeId remoteNode, int weight, long baseFetchSize) {
     boolean allLocalStoreInBootstrap = true;
     List<ReplicaMetadataRequestInfo> replicaMetadataRequestInfoList = new ArrayList<>();
     for (RemoteReplicaInfo remoteReplicaInfo : replicasToReplicatePerNode) {
@@ -1201,13 +1335,18 @@ public class ReplicaThread implements Runnable {
         allLocalStoreInBootstrap = false;
       }
     }
-    long fetchSize = replicationConfig.replicationFetchSizeInBytes;
+    long baseline;
     if (allLocalStoreInBootstrap && !replicatingFromRemoteColo) {
-      fetchSize = replicationConfig.replicationFetchSizeInBytesForBootstrapIntraColo;
+      baseline = replicationConfig.replicationFetchSizeInBytesForBootstrapIntraColo;
       logger.trace(
-          "All local stores are at bootstrap mode, and this is intro colo replication, set the fetch size to {}",
-          fetchSize);
+          "All local stores are at bootstrap mode, and this is intro colo replication, set the fetch size baseline to {}",
+          baseline);
+    } else if (baseFetchSize > 0) {
+      baseline = baseFetchSize;
+    } else {
+      baseline = replicationConfig.replicationFetchSizeInBytes;
     }
+    long fetchSize = (long) weight * baseline;
     return new ReplicaMetadataRequest(correlationIdGenerator.incrementAndGet(),
         "replication-metadata-" + dataNodeId.getHostname() + "[" + dataNodeId.getDatacenterName() + "]",
         replicaMetadataRequestInfoList, fetchSize, replicationConfig.replicaMetadataRequestVersion);
@@ -2286,6 +2425,10 @@ public class ReplicaThread implements Runnable {
   class RemoteReplicaGroupPoller {
     private final List<DataNodeTracker> dataNodeTrackers;
     private boolean allReplicasCaughtUpEarly;
+    // Per-cycle base fetch size. Computed once at the end of fillDataNodeTrackers and read in
+    // fillActiveGroups when constructing each RemoteReplicaGroup; identical for every chunk in the
+    // cycle, so a single scalar on the poller is the single source of truth.
+    private long currentCycleBaseFetchSize;
 
     RemoteReplicaGroupPoller() {
       dataNodeTrackers = new ArrayList<>();
@@ -2307,25 +2450,75 @@ public class ReplicaThread implements Runnable {
      * For each data node tracker, only one stand by group is present to reduce cross colo requests
      * Active groups have maximum {@link #maxReplicaCountPerRequest}  preassigned replicas
      * Across all datanode tracker group ids are unique
+     *
+     * Priority handling:
+     * <ol>
+     *   <li>Auto-prune priority entries whose replicas in this thread are all caught up. Pruning is
+     *       thread-scope; entries whose replicas live in other threads are left alone.</li>
+     *   <li>Snapshot the pruned priority map for use during chunking.</li>
+     *   <li>Per DataNode: priority replicas become singleton {@code ActiveGroupTracker}s
+     *       (weight = boost); remaining replicas go through normal chunking.</li>
+     *   <li>Compute the per-cycle {@code baseFetchSize} so total budget matches the legacy
+     *       {@code replicasInThread × replicationFetchSizeInBytes}.</li>
+     * </ol>
+     *
+     * <p>Priorities on cross-colo follower replicas never auto-prune and must be cleared
+     * explicitly: under leader-based replication these replicas stay STANDBY (waiting on intra-colo
+     * delivery from the local leader) and never reach ACTIVE, so the auto-prune predicate never
+     * fires for them.
      */
     private void fillDataNodeTrackers() {
       Map<DataNodeId, List<RemoteReplicaInfo>> dataNodeToRemoteReplicaInfo = selectReplicas(getRemoteReplicaInfos());
 
-      int currentStartGroupId = 0;
+      // Auto-prune caught-up priority entries.
+      if (!priorityPartitions.isEmpty()) {
+        Map<PartitionId, List<RemoteReplicaInfo>> byPartition = dataNodeToRemoteReplicaInfo.values().stream()
+            .flatMap(List::stream)
+            .collect(Collectors.groupingBy(r -> r.getReplicaId().getPartitionId()));
+        // If remaining lag is below the per-iteration budget, the next ACTIVE iteration closes the
+        // gap. Strict lag == 0 would rarely fire on write-active partitions.
+        long syncedLagThreshold = replicationConfig.replicationFetchSizeInBytes;
+        priorityPartitions.entrySet().removeIf(e -> {
+          List<RemoteReplicaInfo> infos = byPartition.getOrDefault(e.getKey(), Collections.emptyList());
+          if (!shouldAutoPrunePriority(infos, syncedLagThreshold, ReplicaThread.this::getReplicaStatus,
+              RemoteReplicaInfo::getRemoteLagFromLocalInBytes)) {
+            return false;
+          }
+          logger.info("Auto-pruning priority for partition {} on thread {}: all {} replicas caught up",
+              e.getKey(), threadName, infos.size());
+          return true;
+        });
+      }
 
+      Map<PartitionId, Integer> prioritySnapshot = priorityPartitions.isEmpty() ? null : new HashMap<>(priorityPartitions);
+
+      int currentStartGroupId = 0;
+      long replicasInThread = 0;
+      long totalWeightedReplicas = 0;
       for (Map.Entry<DataNodeId, List<RemoteReplicaInfo>> entry : dataNodeToRemoteReplicaInfo.entrySet()) {
         DataNodeId remoteHost = entry.getKey();
         List<RemoteReplicaInfo> remoteReplicasPerNode = entry.getValue();
 
         DataNodeTracker dataNodeTracker =
             new DataNodeTracker(remoteHost, remoteReplicasPerNode, currentStartGroupId, time, threadThrottleDurationMs,
-                replicationConfig, RemoteReplicaInfo::getRemoteLagFromLocalInBytes);
+                replicationConfig, RemoteReplicaInfo::getRemoteLagFromLocalInBytes, prioritySnapshot);
         logger.trace("Thread name: {} for datanode {} create datanode tracker {}", threadName, remoteHost,
             dataNodeTracker);
 
         dataNodeTrackers.add(dataNodeTracker);
         currentStartGroupId = dataNodeTracker.getMaxGroupId() + 1;
+        replicasInThread += remoteReplicasPerNode.size();
+        for (ActiveGroupTracker g : dataNodeTracker.getActiveGroupTrackers()) {
+          totalWeightedReplicas += (long) g.getReplicaCount() * g.getWeight();
+        }
       }
+
+      // baseFetchSize divides total budget across all weighted replicas; fall back to the per-replica
+      // baseline when the thread has no replicas.
+      long totalBudget = replicasInThread * replicationConfig.replicationFetchSizeInBytes;
+      currentCycleBaseFetchSize = totalWeightedReplicas > 0
+          ? totalBudget / totalWeightedReplicas
+          : replicationConfig.replicationFetchSizeInBytes;
     }
 
     /**
@@ -2464,7 +2657,8 @@ public class ReplicaThread implements Runnable {
 
           RemoteReplicaGroup remoteReplicaGroup = new RemoteReplicaGroup(
               activeReplicaTrackers.stream().map(ReplicaTracker::getRemoteReplicaInfo).collect(Collectors.toList()),
-              dataNodeTracker.getDataNodeId(), false, activeGroupTracker.getGroupId());
+              dataNodeTracker.getDataNodeId(), false, activeGroupTracker.getGroupId(),
+              activeGroupTracker.getWeight(), currentCycleBaseFetchSize);
 
           activeGroupTracker.startIteration(remoteReplicaGroup, activeReplicaTrackers);
           logger.trace("Thread name: {} Created active remote replica group for group tracker {} ", threadName,
@@ -2602,6 +2796,17 @@ public class ReplicaThread implements Runnable {
     private final DataNodeId remoteDataNode;
     private final boolean isNonProgressStandbyReplicaGroup;
     private final int id;
+    /**
+     * Fetch-size weight inherited from the originating {@link ActiveGroupTracker}. 1 for normal
+     * chunks and the non-continuous path; equal to the operator-supplied boost for priority chunks.
+     */
+    private final int weight;
+    /**
+     * Per-cycle base fetch-size inherited from the originating {@link ActiveGroupTracker}. 0 means
+     * "fall back to replicationFetchSizeInBytes" — used by the non-continuous path and standby
+     * groups (which don't carry a per-cycle budget).
+     */
+    private final long baseFetchSize;
     private ReplicaGroupReplicationState state;
     private Exception exception = null;
     private long replicaMetadataRequestStartTimeMs;
@@ -2622,10 +2827,23 @@ public class ReplicaThread implements Runnable {
      */
     public RemoteReplicaGroup(List<RemoteReplicaInfo> remoteReplicaInfos, DataNodeId dataNodeId,
         boolean isNonProgressStandbyReplicaGroup, int id) {
+      this(remoteReplicaInfos, dataNodeId, isNonProgressStandbyReplicaGroup, id, /*weight*/ 1, /*baseFetchSize*/ 0L);
+    }
+
+    /**
+     * Constructor variant that carries the originating chunk's {@code weight} and
+     * {@code baseFetchSize}. Used by the continuous-replication active-chunk path so the per-cycle
+     * fetch-budget split (including priority boosts) is honored when this group's metadata request
+     * is built.
+     */
+    public RemoteReplicaGroup(List<RemoteReplicaInfo> remoteReplicaInfos, DataNodeId dataNodeId,
+        boolean isNonProgressStandbyReplicaGroup, int id, int weight, long baseFetchSize) {
       this.remoteReplicaInfos = remoteReplicaInfos;
       this.remoteDataNode = dataNodeId;
       this.isNonProgressStandbyReplicaGroup = isNonProgressStandbyReplicaGroup;
       this.id = id;
+      this.weight = weight;
+      this.baseFetchSize = baseFetchSize;
       storeKeysConversionLog = new ArrayList<>();
       finishTime = 0;
       if (isNonProgressStandbyReplicaGroup) {
@@ -2711,7 +2929,8 @@ public class ReplicaThread implements Runnable {
         // When the state is STARTED, we will send the ReplicaMetadataRequest out.
         replicaMetadataRequestStartTimeMs = time.milliseconds();
         exchangeMetadataStartTimeInMs = replicaMetadataRequestStartTimeMs;
-        ReplicaMetadataRequest request = createReplicaMetadataRequest(remoteReplicaInfos, remoteDataNode);
+        ReplicaMetadataRequest request = createReplicaMetadataRequest(remoteReplicaInfos, remoteDataNode, weight,
+            baseFetchSize);
         RequestInfo requestInfo =
             new RequestInfo(remoteDataNode.getHostname(), port, request, remoteReplicaInfos.get(0).getReplicaId(), null,
                 time.milliseconds(), timeout, timeout);

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
@@ -29,7 +29,6 @@ import com.github.ambry.config.StoreConfig;
 import com.github.ambry.network.NetworkClient;
 import com.github.ambry.network.NetworkClientFactory;
 import com.github.ambry.notification.NotificationSystem;
-import com.github.ambry.protocol.ListReplicationPriorityAdminResponse;
 import com.github.ambry.server.StoreManager;
 import com.github.ambry.store.MessageInfo;
 import com.github.ambry.store.Store;
@@ -45,6 +44,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -186,6 +186,7 @@ public abstract class ReplicationEngine implements ReplicationAPI {
    * <p>The per-thread auto-prune in {@code fillDataNodeTrackers} removes entries once their
    * partitions catch up.
    */
+  @Override
   public void prioritizePartitions(List<PartitionId> partitions, int boost) {
     for (List<ReplicaThread> pool : replicaThreadPoolByDc.values()) {
       for (ReplicaThread replicaThread : pool) {
@@ -194,15 +195,23 @@ public abstract class ReplicationEngine implements ReplicationAPI {
     }
   }
 
+  @Override
+  public boolean hostsPartition(PartitionId partition) {
+    return partitionToPartitionInfo.containsKey(partition);
+  }
+
   /**
-   * Fans out a priority-clear call to every {@link ReplicaThread} pool. An empty {@code partitions}
-   * list clears all priorities on this host — only reachable when the frontend explicitly sent
-   * {@code clear=true} with no partition list.
+   * Fans out a priority-unset call to every {@link ReplicaThread} pool. A non-empty list unsets
+   * only the listed partitions; an empty list WIPES ALL priorities on this host. The empty-list
+   * branch must only be reached from a handler that has explicitly validated wipe-all intent
+   * (the admin layer requires {@code unsetAll=true} on the wire); routing an unvalidated empty
+   * list here would risk silent wipe-all.
    */
-  public void clearPriorityPartitions(List<PartitionId> partitions) {
+  @Override
+  public void unsetPriorityPartitions(List<PartitionId> partitions) {
     for (List<ReplicaThread> pool : replicaThreadPoolByDc.values()) {
       for (ReplicaThread replicaThread : pool) {
-        replicaThread.clearPriorityPartitions(partitions);
+        replicaThread.unsetPriorityPartitions(partitions);
       }
     }
   }
@@ -212,16 +221,20 @@ public abstract class ReplicationEngine implements ReplicationAPI {
    * prioritized on multiple threads (typical, since priorities are mirrored across pools) appears
    * once per thread, each entry tagged with its {@code isInterColo} flag.
    */
-  public List<ListReplicationPriorityAdminResponse.PriorityEntry> listAllPriorityPartitions() {
-    List<ListReplicationPriorityAdminResponse.PriorityEntry> entries = new ArrayList<>();
+  @Override
+  public List<PriorityEntry> listAllPriorityPartitions() {
+    List<PriorityEntry> entries = new ArrayList<>();
     for (List<ReplicaThread> pool : replicaThreadPoolByDc.values()) {
       for (ReplicaThread thread : pool) {
         boolean isInterColo = thread.isReplicatingFromRemoteColo();
         for (Map.Entry<PartitionId, Integer> e : thread.listPriorityPartitions().entrySet()) {
-          entries.add(new ListReplicationPriorityAdminResponse.PriorityEntry(e.getKey(), e.getValue(), isInterColo));
+          entries.add(new PriorityEntry(e.getKey(), e.getValue(), isInterColo));
         }
       }
     }
+    entries.sort(Comparator
+        .comparing((PriorityEntry e) -> e.getPartitionId().toPathString())
+        .thenComparing(PriorityEntry::isInterColo));
     return entries;
   }
 

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
@@ -29,6 +29,7 @@ import com.github.ambry.config.StoreConfig;
 import com.github.ambry.network.NetworkClient;
 import com.github.ambry.network.NetworkClientFactory;
 import com.github.ambry.notification.NotificationSystem;
+import com.github.ambry.protocol.ListReplicationPriorityAdminResponse;
 import com.github.ambry.server.StoreManager;
 import com.github.ambry.store.MessageInfo;
 import com.github.ambry.store.Store;
@@ -176,6 +177,53 @@ public abstract class ReplicationEngine implements ReplicationAPI {
    * @throws ReplicationException
    */
   public abstract void start() throws ReplicationException;
+
+  /**
+   * Fans out a priority-set call to every {@link ReplicaThread} pool on this node. Each
+   * {@code ReplicaThread} that holds replicas of any listed partition will treat them as priority;
+   * threads without those replicas pass them through but they have no effect there.
+   *
+   * <p>The per-thread auto-prune in {@code fillDataNodeTrackers} removes entries once their
+   * partitions catch up.
+   */
+  public void prioritizePartitions(List<PartitionId> partitions, int boost) {
+    for (List<ReplicaThread> pool : replicaThreadPoolByDc.values()) {
+      for (ReplicaThread replicaThread : pool) {
+        replicaThread.prioritizePartitions(partitions, boost);
+      }
+    }
+  }
+
+  /**
+   * Fans out a priority-clear call to every {@link ReplicaThread} pool. An empty {@code partitions}
+   * list clears all priorities on this host — only reachable when the frontend explicitly sent
+   * {@code clear=true} with no partition list.
+   */
+  public void clearPriorityPartitions(List<PartitionId> partitions) {
+    for (List<ReplicaThread> pool : replicaThreadPoolByDc.values()) {
+      for (ReplicaThread replicaThread : pool) {
+        replicaThread.clearPriorityPartitions(partitions);
+      }
+    }
+  }
+
+  /**
+   * Snapshot priority entries across every {@link ReplicaThread} on this node. A partition that is
+   * prioritized on multiple threads (typical, since priorities are mirrored across pools) appears
+   * once per thread, each entry tagged with its {@code isInterColo} flag.
+   */
+  public List<ListReplicationPriorityAdminResponse.PriorityEntry> listAllPriorityPartitions() {
+    List<ListReplicationPriorityAdminResponse.PriorityEntry> entries = new ArrayList<>();
+    for (List<ReplicaThread> pool : replicaThreadPoolByDc.values()) {
+      for (ReplicaThread thread : pool) {
+        boolean isInterColo = thread.isReplicatingFromRemoteColo();
+        for (Map.Entry<PartitionId, Integer> e : thread.listPriorityPartitions().entrySet()) {
+          entries.add(new ListReplicationPriorityAdminResponse.PriorityEntry(e.getKey(), e.getValue(), isInterColo));
+        }
+      }
+    }
+    return entries;
+  }
 
   /**
    * Enable/Disable replication for given partitions if all origins are involved,

--- a/ambry-replication/src/main/java/com/github/ambry/replication/continuous/ActiveGroupTracker.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/continuous/ActiveGroupTracker.java
@@ -20,14 +20,28 @@ import java.util.stream.Collectors;
 /**
  * This class tracks for a current state for Active groups for a continuous replication cycle.
  * Active group tracker have preassigned replicas and from these replicas only we create active remote replica groups
- * Any remote replica group created for this tracker has replicas with ACTIVE state only
+ * Any remote replica group created for this tracker has replicas with ACTIVE state only.
+ *
+ * Each tracker carries a {@code weight} used to compute its share of the per-cycle fetch budget:
+ * a chunk's metadata-request fetchSize is {@code weight * baseFetchSize}, where {@code baseFetchSize}
+ * is the per-cycle scalar held on {@link com.github.ambry.replication.ReplicaThread}'s
+ * {@code RemoteReplicaGroupPoller}. Priority chunks are segregated into singleton groups with
+ * {@code weight = boost} and {@code isPriority = true}; normal chunks get {@code weight = 1}.
  */
 public class ActiveGroupTracker extends GroupTracker {
   private final List<ReplicaTracker> preAssignedReplicas;
+  private final boolean priority;
+  private final int weight;
 
   public ActiveGroupTracker(int groupId, List<ReplicaTracker> preAssignedReplicas) {
+    this(groupId, preAssignedReplicas, false, 1);
+  }
+
+  public ActiveGroupTracker(int groupId, List<ReplicaTracker> preAssignedReplicas, boolean priority, int weight) {
     super(groupId);
     this.preAssignedReplicas = preAssignedReplicas;
+    this.priority = priority;
+    this.weight = weight;
   }
 
   public List<ReplicaTracker> getPreAssignedReplicas() {
@@ -40,8 +54,34 @@ public class ActiveGroupTracker extends GroupTracker {
         .collect(Collectors.toList());
   }
 
+  /**
+   * @return number of replicas pre-assigned to this group; used by the per-cycle fetch-budget
+   * denominator in {@code ReplicaThread.fillDataNodeTrackers}.
+   */
+  public int getReplicaCount() {
+    return preAssignedReplicas.size();
+  }
+
+  /**
+   * @return true if this group was segregated to a single replica because that replica's partition
+   * is a current priority entry; false for normal chunks.
+   */
+  public boolean isPriority() {
+    return priority;
+  }
+
+  /**
+   * @return the multiplier applied to the cycle's {@code baseFetchSize} when computing this
+   * group's per-iteration metadata fetchSize. Priority groups carry the operator-supplied boost;
+   * normal groups carry 1.
+   */
+  public int getWeight() {
+    return weight;
+  }
+
   @Override
   public String toString() {
-    return "ActiveGroupTracker :[" + super.toString() + " " + preAssignedReplicas.toString() + "]";
+    return "ActiveGroupTracker :[" + super.toString() + " " + preAssignedReplicas.toString() + " priority="
+        + priority + " weight=" + weight + "]";
   }
 }

--- a/ambry-replication/src/main/java/com/github/ambry/replication/continuous/DataNodeTracker.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/continuous/DataNodeTracker.java
@@ -14,6 +14,7 @@
 package com.github.ambry.replication.continuous;
 
 import com.github.ambry.clustermap.DataNodeId;
+import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.config.ReplicationConfig;
 import com.github.ambry.replication.RemoteReplicaInfo;
 import com.github.ambry.replication.ReplicaThread;
@@ -60,18 +61,41 @@ public class DataNodeTracker {
    *                    {@link ReplicationConfig#replicationSpreadLaggersAcrossChunks} is true. Supplied by the
    *                    caller so the chunking helper does not need access to package-private state on
    *                    {@link RemoteReplicaInfo}.
+   * @param prioritySnapshot a per-cycle snapshot of priority entries (partition id → boost). Replicas
+   *                        for partitions in this map are segregated into singleton chunks tagged
+   *                        {@code isPriority=true, weight=boost}; the remaining replicas go through
+   *                        normal chunking. {@code null} or empty disables priority segregation.
    */
   public DataNodeTracker(DataNodeId dataNodeId, List<RemoteReplicaInfo> remoteReplicas, int startGroupId, Time time,
       long replicaThrottleDurationMs, ReplicationConfig replicationConfig,
-      ToLongFunction<RemoteReplicaInfo> lagExtractor) {
+      ToLongFunction<RemoteReplicaInfo> lagExtractor, Map<PartitionId, Integer> prioritySnapshot) {
     this.dataNodeId = dataNodeId;
     this.activeGroupTrackers = new ArrayList<>();
 
     int currentGroupId = startGroupId;
 
-    // for this data node break a larger array of remote replicas to smaller multiple arrays
+    // Split priority replicas (those whose partition is in prioritySnapshot) from the rest.
+    // Each priority replica becomes its own singleton chunk with weight = boost.
+    List<RemoteReplicaInfo> nonPriorityReplicas;
+    if (prioritySnapshot == null || prioritySnapshot.isEmpty()) {
+      nonPriorityReplicas = remoteReplicas;
+    } else {
+      nonPriorityReplicas = new ArrayList<>(remoteReplicas.size());
+      for (RemoteReplicaInfo r : remoteReplicas) {
+        Integer boost = prioritySnapshot.get(r.getReplicaId().getPartitionId());
+        if (boost != null) {
+          activeGroupTrackers.add(new ActiveGroupTracker(currentGroupId++,
+              Collections.singletonList(new ReplicaTracker(r, time, replicaThrottleDurationMs)),
+              /*priority*/ true, /*weight*/ boost));
+        } else {
+          nonPriorityReplicas.add(r);
+        }
+      }
+    }
+
+    // for this data node break the remaining replicas into chunks
     List<List<RemoteReplicaInfo>> remoteReplicaSegregatedList =
-        chunkReplicas(remoteReplicas, replicationConfig.replicationMaxPartitionCountPerRequest,
+        chunkReplicas(nonPriorityReplicas, replicationConfig.replicationMaxPartitionCountPerRequest,
             replicationConfig.replicationSpreadLaggersAcrossChunks, lagExtractor);
 
     // for each of smaller array of remote replicas create active group trackers with consecutive group ids
@@ -85,6 +109,16 @@ public class DataNodeTracker {
 
     // standby group id has maximum group id
     standByGroupTracker = new StandByGroupTracker(currentGroupId);
+  }
+
+  /**
+   * Convenience constructor for callers without priority logic (priority snapshot is empty).
+   */
+  public DataNodeTracker(DataNodeId dataNodeId, List<RemoteReplicaInfo> remoteReplicas, int startGroupId, Time time,
+      long replicaThrottleDurationMs, ReplicationConfig replicationConfig,
+      ToLongFunction<RemoteReplicaInfo> lagExtractor) {
+    this(dataNodeId, remoteReplicas, startGroupId, time, replicaThrottleDurationMs, replicationConfig, lagExtractor,
+        /*prioritySnapshot*/ null);
   }
 
   /**

--- a/ambry-replication/src/test/java/com/github/ambry/replication/RemoteReplicaGroupPollerTest.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/RemoteReplicaGroupPollerTest.java
@@ -18,6 +18,7 @@ import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.clustermap.MockHelixParticipant;
 import com.github.ambry.clustermap.PartitionId;
+import com.github.ambry.clustermap.ReplicaState;
 import com.github.ambry.commons.BlobIdFactory;
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.ReplicationConfig;
@@ -37,6 +38,7 @@ import com.github.ambry.store.Store;
 import com.github.ambry.utils.Pair;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -486,5 +488,206 @@ public class RemoteReplicaGroupPollerTest extends ReplicationTestHelper {
 
     Assert.assertTrue("There should be no inflight groups", inflightGroups.isEmpty());
     Assert.assertFalse("All replicas haven't caught up early", poller.allReplicasCaughtUpEarly());
+  }
+
+  /**
+   * Pins the per-cycle budget math in {@code fillDataNodeTrackers}:
+   * <pre>
+   *   totalBudget   = replicasInThread * replicationFetchSizeInBytes
+   *   baseFetchSize = totalWeightedReplicas > 0
+   *                       ? totalBudget / totalWeightedReplicas
+   *                       : replicationFetchSizeInBytes
+   * </pre>
+   * Covers three cases on the same intra-colo thread:
+   * <ol>
+   *   <li>no priorities ⇒ baseFetchSize == replicationFetchSizeInBytes,
+   *       total bytes-in-flight == replicasInThread × replicationFetchSizeInBytes</li>
+   *   <li>one priority with boost=B ⇒ baseFetchSize == (N × config) / (1×B + (N-1)×1);
+   *       priority chunk requests B × baseFetchSize, normal chunks request 1 × baseFetchSize each;
+   *       total bytes-in-flight stays bounded by the no-priority budget (allow rounding)</li>
+   *   <li>zero weighted replicas (replicasInThread == 0) ⇒ baseFetchSize falls back to
+   *       replicationFetchSizeInBytes</li>
+   * </ol>
+   * Verified through the package-private accessor on {@code RemoteReplicaGroupPoller} plus
+   * {@code ActiveGroupTracker.getWeight()/getReplicaCount()}.
+   */
+  @Test
+  public void baseFetchSizeBudgetConservation() {
+    ReplicaThread replicaThread = intraColoReplicaThread;
+    long fetchConfig = replicationConfig.replicationFetchSizeInBytes;
+
+    // ---- Case 1: pure normal case (no priorities). ----
+    RemoteReplicaGroupPoller pollerNoPriority = replicaThread.new RemoteReplicaGroupPoller();
+    long replicasInThread = pollerNoPriority.getDataNodeTrackers().stream()
+        .flatMap(t -> t.getActiveGroupTrackers().stream())
+        .mapToLong(ActiveGroupTracker::getReplicaCount)
+        .sum();
+    Assert.assertTrue("test setup must have at least one replica", replicasInThread > 0);
+    Assert.assertEquals("baseFetchSize equals fetchConfig when no priorities", fetchConfig,
+        pollerNoPriority.getCurrentCycleBaseFetchSize());
+    long totalNoPriorityBytes = sumChunkFetchBytes(pollerNoPriority, fetchConfig);
+    Assert.assertEquals("no-priority total bytes = replicasInThread × fetchConfig",
+        replicasInThread * fetchConfig, totalNoPriorityBytes);
+
+    // ---- Case 2: one priority with boost=B. ----
+    // Pick the first replica's partition as the priority target. To defeat the auto-prune predicate
+    // (which fires when every priority replica is ACTIVE AND lag < threshold), put the replica in
+    // backoff so getReplicaStatus returns OFFLINE. The priority entry then survives into chunking.
+    int boost = 4;
+    RemoteReplicaInfo priorityReplica = replicaThread.getRemoteReplicaInfos().values().stream()
+        .flatMap(Collection::stream)
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("no replicas to prioritize"));
+    PartitionId priorityPartition = priorityReplica.getReplicaId().getPartitionId();
+    long savedBackoff = priorityReplica.getReEnableReplicationTime();
+    priorityReplica.setReEnableReplicationTime(time.milliseconds() + 60_000L);
+    try {
+      replicaThread.prioritizePartitions(Collections.singletonList(priorityPartition), boost);
+
+      RemoteReplicaGroupPoller pollerWithPriority = replicaThread.new RemoteReplicaGroupPoller();
+      long priorityReplicaCount = pollerWithPriority.getDataNodeTrackers().stream()
+          .flatMap(t -> t.getActiveGroupTrackers().stream())
+          .filter(ActiveGroupTracker::isPriority)
+          .mapToLong(ActiveGroupTracker::getReplicaCount)
+          .sum();
+      long normalReplicaCount = pollerWithPriority.getDataNodeTrackers().stream()
+          .flatMap(t -> t.getActiveGroupTrackers().stream())
+          .filter(g -> !g.isPriority())
+          .mapToLong(ActiveGroupTracker::getReplicaCount)
+          .sum();
+      Assert.assertTrue("priority partition should produce at least one priority chunk",
+          priorityReplicaCount >= 1);
+      Assert.assertEquals("priority + normal replicas == replicasInThread",
+          replicasInThread, priorityReplicaCount + normalReplicaCount);
+
+      long totalWeighted = priorityReplicaCount * boost + normalReplicaCount;
+      long expectedBase = (replicasInThread * fetchConfig) / totalWeighted;
+      Assert.assertEquals("baseFetchSize = totalBudget / totalWeightedReplicas",
+          expectedBase, pollerWithPriority.getCurrentCycleBaseFetchSize());
+
+      // Per-chunk fetchSize from poller's view: weight × baseFetchSize. Verify priority chunks get
+      // boost×base and normal chunks get base. Use that to assert budget conservation.
+      long totalPriorityBytes = pollerWithPriority.getDataNodeTrackers().stream()
+          .flatMap(t -> t.getActiveGroupTrackers().stream())
+          .filter(ActiveGroupTracker::isPriority)
+          .mapToLong(g -> (long) g.getReplicaCount() * g.getWeight() * expectedBase)
+          .sum();
+      long totalNormalBytes = pollerWithPriority.getDataNodeTrackers().stream()
+          .flatMap(t -> t.getActiveGroupTrackers().stream())
+          .filter(g -> !g.isPriority())
+          .mapToLong(g -> (long) g.getReplicaCount() * g.getWeight() * expectedBase)
+          .sum();
+      long totalPriorityCycleBytes = totalPriorityBytes + totalNormalBytes;
+      Assert.assertTrue("priority-cycle total bytes (" + totalPriorityCycleBytes
+              + ") must be bounded by no-priority budget (" + totalNoPriorityBytes + "); diff is integer-division slack",
+          totalPriorityCycleBytes <= totalNoPriorityBytes);
+      // Slack must be strictly less than one fully weighted unit (integer-division floor).
+      Assert.assertTrue("slack < totalWeighted (one floor unit)",
+          totalNoPriorityBytes - totalPriorityCycleBytes < totalWeighted);
+    } finally {
+      replicaThread.unsetPriorityPartitions(Collections.emptyList()); // wipe all on this thread
+      priorityReplica.setReEnableReplicationTime(savedBackoff);
+    }
+
+    // ---- Case 3: zero-replica edge case (no replicas → no weighted denominator → fall back to fetchConfig). ----
+    Map<DataNodeId, List<RemoteReplicaInfo>> snapshot = replicaThread.getRemoteReplicaInfos();
+    List<RemoteReplicaInfo> allReplicas = snapshot.values().stream()
+        .flatMap(Collection::stream)
+        .collect(Collectors.toList());
+    try {
+      allReplicas.forEach(replicaThread::removeRemoteReplicaInfo);
+      Assert.assertTrue("after removal, thread has no replicas",
+          replicaThread.getRemoteReplicaInfos().values().stream().allMatch(List::isEmpty));
+      RemoteReplicaGroupPoller emptyPoller = replicaThread.new RemoteReplicaGroupPoller();
+      Assert.assertEquals("baseFetchSize falls back to fetchConfig when totalWeightedReplicas == 0",
+          fetchConfig, emptyPoller.getCurrentCycleBaseFetchSize());
+    } finally {
+      allReplicas.forEach(replicaThread::addRemoteReplicaInfo);
+    }
+  }
+
+  /**
+   * Pins the per-replica fetchSize selection in {@code createReplicaMetadataRequest(replicas, node, weight, base)}.
+   * Four cases pulled apart from the chunking path:
+   * <ol>
+   *   <li>{@code weight=1, baseFetchSize=0} ⇒ no priority redistribution active, falls back to
+   *       {@code replicationFetchSizeInBytes}</li>
+   *   <li>{@code weight=1, baseFetchSize=X} ⇒ {@code X}</li>
+   *   <li>{@code weight=B, baseFetchSize=X} ⇒ {@code B * X} (boost multiplies through)</li>
+   *   <li>Bootstrap intra-colo path: all local stores in BOOTSTRAP, intra-colo thread ⇒ baseline
+   *       switches to {@code replicationFetchSizeInBytesForBootstrapIntraColo} regardless of
+   *       {@code baseFetchSize}; weight still multiplies through</li>
+   * </ol>
+   */
+  @Test
+  public void createReplicaMetadataRequestFetchSizeMath() {
+    ReplicaThread replicaThread = intraColoReplicaThread;
+    long fetchConfig = replicationConfig.replicationFetchSizeInBytes;
+    long bootstrapFetchConfig = replicationConfig.replicationFetchSizeInBytesForBootstrapIntraColo;
+
+    Map.Entry<DataNodeId, List<RemoteReplicaInfo>> entry =
+        replicaThread.getRemoteReplicaInfos().entrySet().iterator().next();
+    DataNodeId remoteNode = entry.getKey();
+    List<RemoteReplicaInfo> replicas = entry.getValue();
+    Assert.assertFalse("test setup must give us replicas", replicas.isEmpty());
+
+    // Snapshot starting states so we can restore after the bootstrap-case test.
+    Map<RemoteReplicaInfo, ReplicaState> originalStates = new HashMap<>();
+    for (RemoteReplicaInfo r : replicas) {
+      originalStates.put(r, r.getLocalStore().getCurrentState());
+    }
+    // Force at least one local store out of BOOTSTRAP so the non-bootstrap cases hit the
+    // baseFetchSize / fallback branches (the bootstrap branch fires only when *all* are BOOTSTRAP).
+    replicas.get(0).getLocalStore().setCurrentState(ReplicaState.STANDBY);
+    try {
+      // Case 1: weight=1, baseFetchSize=0 ⇒ fallback to fetchConfig.
+      Assert.assertEquals("weight=1, base=0 ⇒ fetchConfig", fetchConfig,
+          replicaThread.createReplicaMetadataRequest(replicas, remoteNode, /*weight*/ 1, /*baseFetchSize*/ 0L)
+              .getMaxTotalSizeOfEntriesInBytes());
+
+      // Case 2: weight=1, baseFetchSize=X ⇒ X.
+      long base = 4096L;
+      Assert.assertEquals("weight=1, base=X ⇒ X", base,
+          replicaThread.createReplicaMetadataRequest(replicas, remoteNode, /*weight*/ 1, base)
+              .getMaxTotalSizeOfEntriesInBytes());
+
+      // Case 3: weight=B, baseFetchSize=X ⇒ B × X.
+      int boost = 7;
+      Assert.assertEquals("weight=B, base=X ⇒ B × X", boost * base,
+          replicaThread.createReplicaMetadataRequest(replicas, remoteNode, boost, base)
+              .getMaxTotalSizeOfEntriesInBytes());
+
+      // Case 4: bootstrap intra-colo path: all local stores in BOOTSTRAP, baseline switches to
+      // bootstrap baseline regardless of baseFetchSize; weight still multiplies through.
+      // The intra-colo thread satisfies !replicatingFromRemoteColo.
+      for (RemoteReplicaInfo r : replicas) {
+        r.getLocalStore().setCurrentState(ReplicaState.BOOTSTRAP);
+      }
+      Assert.assertEquals("bootstrap intra-colo: weight=1 ⇒ bootstrap baseline (baseFetchSize ignored)",
+          bootstrapFetchConfig,
+          replicaThread.createReplicaMetadataRequest(replicas, remoteNode, /*weight*/ 1, base)
+              .getMaxTotalSizeOfEntriesInBytes());
+      Assert.assertEquals("bootstrap intra-colo: weight=B ⇒ B × bootstrap baseline",
+          boost * bootstrapFetchConfig,
+          replicaThread.createReplicaMetadataRequest(replicas, remoteNode, boost, base)
+              .getMaxTotalSizeOfEntriesInBytes());
+    } finally {
+      // Restore original local store states so other parameterized runs are unaffected.
+      originalStates.forEach((r, s) -> r.getLocalStore().setCurrentState(s));
+    }
+  }
+
+  /**
+   * Sums per-cycle bytes-in-flight: for each chunk, {@code replicaCount × weight × baseFetchSize}
+   * where the baseline equals {@code fetchConfig} when no priorities are active (case-1 invariant).
+   */
+  private static long sumChunkFetchBytes(RemoteReplicaGroupPoller poller, long baseline) {
+    long bytes = 0;
+    for (DataNodeTracker t : poller.getDataNodeTrackers()) {
+      for (ActiveGroupTracker g : t.getActiveGroupTrackers()) {
+        bytes += (long) g.getReplicaCount() * g.getWeight() * baseline;
+      }
+    }
+    return bytes;
   }
 }

--- a/ambry-replication/src/test/java/com/github/ambry/replication/RemoteReplicaGroupPollerTest.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/RemoteReplicaGroupPollerTest.java
@@ -590,20 +590,17 @@ public class RemoteReplicaGroupPollerTest extends ReplicationTestHelper {
     }
 
     // ---- Case 3: zero-replica edge case (no replicas → no weighted denominator → fall back to fetchConfig). ----
+    // No fixture restore: @Before rebuilds the storageManager + replicaThread between runs.
     Map<DataNodeId, List<RemoteReplicaInfo>> snapshot = replicaThread.getRemoteReplicaInfos();
     List<RemoteReplicaInfo> allReplicas = snapshot.values().stream()
         .flatMap(Collection::stream)
         .collect(Collectors.toList());
-    try {
-      allReplicas.forEach(replicaThread::removeRemoteReplicaInfo);
-      Assert.assertTrue("after removal, thread has no replicas",
-          replicaThread.getRemoteReplicaInfos().values().stream().allMatch(List::isEmpty));
-      RemoteReplicaGroupPoller emptyPoller = replicaThread.new RemoteReplicaGroupPoller();
-      Assert.assertEquals("baseFetchSize falls back to fetchConfig when totalWeightedReplicas == 0",
-          fetchConfig, emptyPoller.getCurrentCycleBaseFetchSize());
-    } finally {
-      allReplicas.forEach(replicaThread::addRemoteReplicaInfo);
-    }
+    allReplicas.forEach(replicaThread::removeRemoteReplicaInfo);
+    Assert.assertTrue("after removal, thread has no replicas",
+        replicaThread.getRemoteReplicaInfos().values().stream().allMatch(List::isEmpty));
+    RemoteReplicaGroupPoller emptyPoller = replicaThread.new RemoteReplicaGroupPoller();
+    Assert.assertEquals("baseFetchSize falls back to fetchConfig when totalWeightedReplicas == 0",
+        fetchConfig, emptyPoller.getCurrentCycleBaseFetchSize());
   }
 
   /**

--- a/ambry-replication/src/test/java/com/github/ambry/replication/ReplicaThreadPriorityAutoPruneTest.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/ReplicaThreadPriorityAutoPruneTest.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright 2026 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.replication;
+
+import com.github.ambry.replication.continuous.ReplicaStatus;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.ToLongFunction;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+
+/**
+ * Unit tests for {@link ReplicaThread#shouldAutoPrunePriority}. The predicate is
+ * {@code status == ACTIVE && lag < threshold}: prune only when the priority replica is healthy AND
+ * caught up. Do NOT prune on transient outage (OFFLINE with stale low lag) — the operator's bias
+ * should persist across the outage and resume once the peer recovers.
+ */
+public class ReplicaThreadPriorityAutoPruneTest {
+
+  private final Map<RemoteReplicaInfo, ReplicaStatus> statuses = new HashMap<>();
+  private final Map<RemoteReplicaInfo, Long> lags = new HashMap<>();
+  private final Function<RemoteReplicaInfo, ReplicaStatus> statusFn = statuses::get;
+  private final ToLongFunction<RemoteReplicaInfo> lagFn = lags::get;
+
+  /** All replicas ACTIVE with lag below threshold ⇒ prune. */
+  @Test
+  public void testPruneWhenAllActiveAndBelowThreshold() {
+    List<RemoteReplicaInfo> infos = Arrays.asList(
+        mockReplicaInfo(ReplicaStatus.ACTIVE, 100L),
+        mockReplicaInfo(ReplicaStatus.ACTIVE, 200L));
+
+    assertTrue("ACTIVE + lag < threshold ⇒ prune",
+        ReplicaThread.shouldAutoPrunePriority(infos, 1000L, statusFn, lagFn));
+  }
+
+  /** Lag at threshold (exclusive) ⇒ do NOT prune. */
+  @Test
+  public void testNoPruneWhenLagAtThreshold() {
+    List<RemoteReplicaInfo> infos = Collections.singletonList(mockReplicaInfo(ReplicaStatus.ACTIVE, 1000L));
+
+    assertFalse("lag == threshold should NOT prune (strict less-than)",
+        ReplicaThread.shouldAutoPrunePriority(infos, 1000L, statusFn, lagFn));
+  }
+
+  /** Any replica with lag >= threshold ⇒ do NOT prune. */
+  @Test
+  public void testNoPruneWhenOneReplicaStillLagging() {
+    List<RemoteReplicaInfo> infos = Arrays.asList(
+        mockReplicaInfo(ReplicaStatus.ACTIVE, 100L),
+        mockReplicaInfo(ReplicaStatus.ACTIVE, 5000L));
+
+    assertFalse("one lagging replica blocks prune (all-or-nothing)",
+        ReplicaThread.shouldAutoPrunePriority(infos, 1000L, statusFn, lagFn));
+  }
+
+  /**
+   * Replica is OFFLINE with stale-but-low cached lag ⇒ do NOT prune. This is the bug-fix scenario:
+   * with the original predicate (OFFLINE && lag < threshold) the priority would be silently dropped
+   * on transient outage, losing the operator's bias when the peer recovers.
+   */
+  @Test
+  public void testNoPruneWhenOfflineWithStaleLag() {
+    List<RemoteReplicaInfo> infos = Collections.singletonList(mockReplicaInfo(ReplicaStatus.OFFLINE, 100L));
+
+    assertFalse("OFFLINE with stale low lag must NOT prune — operator bias must persist across outage",
+        ReplicaThread.shouldAutoPrunePriority(infos, 1000L, statusFn, lagFn));
+  }
+
+  /** Any replica with non-ACTIVE status blocks prune (mixed-state ACTIVE + STANDBY example). */
+  @Test
+  public void testNoPruneWhenAnyReplicaNotActive() {
+    for (ReplicaStatus nonActive : new ReplicaStatus[]{ReplicaStatus.UNKNOWN, ReplicaStatus.OFFLINE,
+        ReplicaStatus.STANDBY, ReplicaStatus.STANDBY_TIMED_OUT_ON_NO_PROGRESS}) {
+      statuses.clear();
+      lags.clear();
+      List<RemoteReplicaInfo> infos = Arrays.asList(
+          mockReplicaInfo(ReplicaStatus.ACTIVE, 100L),
+          mockReplicaInfo(nonActive, 100L));
+
+      assertFalse("status " + nonActive + " on any replica blocks prune",
+          ReplicaThread.shouldAutoPrunePriority(infos, 1000L, statusFn, lagFn));
+    }
+  }
+
+  /** Single replica, ACTIVE with lag below threshold ⇒ prune. */
+  @Test
+  public void testPruneWhenSingleActiveBelowThreshold() {
+    List<RemoteReplicaInfo> infos = Collections.singletonList(mockReplicaInfo(ReplicaStatus.ACTIVE, 0L));
+
+    assertTrue("singleton ACTIVE replica below threshold ⇒ prune",
+        ReplicaThread.shouldAutoPrunePriority(infos, 1000L, statusFn, lagFn));
+  }
+
+  /** Zero lag is the canonical "fully caught up" case. */
+  @Test
+  public void testPruneWhenZeroLagActive() {
+    List<RemoteReplicaInfo> infos = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      infos.add(mockReplicaInfo(ReplicaStatus.ACTIVE, 0L));
+    }
+
+    assertTrue("all replicas at zero lag and ACTIVE ⇒ prune",
+        ReplicaThread.shouldAutoPrunePriority(infos, 1L, statusFn, lagFn));
+  }
+
+  /**
+   * Empty list returns false: a priority partition with no replicas in this thread is not a
+   * candidate for auto-prune here (some other thread that owns the replicas decides). Pins the
+   * self-defending behavior so the call site doesn't have to gate on emptiness separately.
+   */
+  @Test
+  public void testEmptyListReturnsFalse() {
+    assertFalse("empty list ⇒ not a prune candidate (defended inside the predicate)",
+        ReplicaThread.shouldAutoPrunePriority(Collections.emptyList(), 1000L, statusFn, lagFn));
+  }
+
+  private RemoteReplicaInfo mockReplicaInfo(ReplicaStatus status, long lag) {
+    RemoteReplicaInfo info = mock(RemoteReplicaInfo.class);
+    statuses.put(info, status);
+    lags.put(info, lag);
+    return info;
+  }
+}

--- a/ambry-replication/src/test/java/com/github/ambry/replication/continuous/DataNodeTrackerTest.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/continuous/DataNodeTrackerTest.java
@@ -13,9 +13,14 @@
  */
 package com.github.ambry.replication.continuous;
 
+import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.clustermap.ReplicaId;
+import com.github.ambry.config.ReplicationConfig;
+import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.replication.RemoteReplicaInfo;
+import com.github.ambry.utils.MockTime;
+import com.github.ambry.utils.Time;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -23,6 +28,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.function.ToLongFunction;
 import java.util.stream.Collectors;
@@ -237,6 +243,159 @@ public class DataNodeTrackerTest {
     assertEquals(2, chunks.size());
     assertEquals(Arrays.asList(100L, 0L), lagsOf(chunks.get(0)));
     assertEquals(Arrays.asList(0L, -5L), lagsOf(chunks.get(1)));
+  }
+
+  // ---- constructor tests (priority ctor + lifecycle) ----
+
+  /** Null prioritySnapshot ⇒ identical to no-priority ctor: every chunk is a normal-weight non-priority chunk. */
+  @Test
+  public void testCtorNullPrioritySnapshotMatchesNoPriorityCtor() {
+    List<RemoteReplicaInfo> replicas = makeReplicas(5, i -> 0L);
+    DataNodeTracker withNull = new DataNodeTracker(mockDataNode(), replicas, 0, new MockTime(), 1L,
+        buildConfig(/*maxChunk*/ 3, /*spread*/ false), extractor, null);
+    DataNodeTracker plain = new DataNodeTracker(mockDataNode(), replicas, 0, new MockTime(), 1L,
+        buildConfig(/*maxChunk*/ 3, /*spread*/ false), extractor);
+
+    assertEquals(plain.getActiveGroupTrackers().size(), withNull.getActiveGroupTrackers().size());
+    for (int i = 0; i < plain.getActiveGroupTrackers().size(); i++) {
+      ActiveGroupTracker a = plain.getActiveGroupTrackers().get(i);
+      ActiveGroupTracker b = withNull.getActiveGroupTrackers().get(i);
+      assertEquals("group[" + i + "] priority", a.isPriority(), b.isPriority());
+      assertEquals("group[" + i + "] weight", a.getWeight(), b.getWeight());
+      assertEquals("group[" + i + "] size", a.getReplicaCount(), b.getReplicaCount());
+    }
+  }
+
+  /** Empty prioritySnapshot is equivalent to null. */
+  @Test
+  public void testCtorEmptyPrioritySnapshotSkipsPriorityPath() {
+    List<RemoteReplicaInfo> replicas = makeReplicas(4, i -> 0L);
+    DataNodeTracker tracker = new DataNodeTracker(mockDataNode(), replicas, 0, new MockTime(), 1L,
+        buildConfig(2, false), extractor, Collections.emptyMap());
+
+    // 4 replicas, max chunk size 2 ⇒ 2 chunks, all non-priority weight=1.
+    assertEquals(2, tracker.getActiveGroupTrackers().size());
+    for (ActiveGroupTracker g : tracker.getActiveGroupTrackers()) {
+      assertFalse("no priority groups", g.isPriority());
+      assertEquals("weight=1", 1, g.getWeight());
+    }
+  }
+
+  /** One priority partition ⇒ one singleton priority chunk + normal chunks for the rest. */
+  @Test
+  public void testCtorPrioritySnapshotProducesSingletonPriorityChunk() {
+    List<RemoteReplicaInfo> replicas = makeReplicas(5, i -> 0L);
+    PartitionId priorityPartition = replicas.get(2).getReplicaId().getPartitionId();
+    Map<PartitionId, Integer> snapshot = new HashMap<>();
+    snapshot.put(priorityPartition, 8);
+
+    DataNodeTracker tracker = new DataNodeTracker(mockDataNode(), replicas, 0, new MockTime(), 1L,
+        buildConfig(/*maxChunk*/ 10, /*spread*/ false), extractor, snapshot);
+
+    // Expect 1 singleton priority chunk + 1 normal chunk holding the other 4 replicas.
+    assertEquals(2, tracker.getActiveGroupTrackers().size());
+    ActiveGroupTracker priorityChunk = tracker.getActiveGroupTrackers().get(0);
+    ActiveGroupTracker normalChunk = tracker.getActiveGroupTrackers().get(1);
+    assertTrue("first chunk is priority", priorityChunk.isPriority());
+    assertEquals("priority weight=boost", 8, priorityChunk.getWeight());
+    assertEquals("priority chunk is singleton", 1, priorityChunk.getReplicaCount());
+    assertFalse("second chunk is non-priority", normalChunk.isPriority());
+    assertEquals("non-priority weight=1", 1, normalChunk.getWeight());
+    assertEquals("non-priority chunk holds remaining 4", 4, normalChunk.getReplicaCount());
+  }
+
+  /** Multiple priorities + non-priorities + chunk overflow: every priority gets its own chunk; rest are chunked. */
+  @Test
+  public void testCtorMultiplePrioritiesAndChunkSplit() {
+    List<RemoteReplicaInfo> replicas = makeReplicas(7, i -> 0L);
+    PartitionId p1 = replicas.get(0).getReplicaId().getPartitionId();
+    PartitionId p2 = replicas.get(3).getReplicaId().getPartitionId();
+    Map<PartitionId, Integer> snapshot = new HashMap<>();
+    snapshot.put(p1, 4);
+    snapshot.put(p2, 16);
+
+    DataNodeTracker tracker = new DataNodeTracker(mockDataNode(), replicas, 0, new MockTime(), 1L,
+        buildConfig(/*maxChunk*/ 3, /*spread*/ false), extractor, snapshot);
+
+    // 7 replicas: 2 priority + 5 non-priority. Non-priority split into chunks of 3 ⇒ 3 chunks (3, 2).
+    // Total: 2 priority singletons + 2 non-priority chunks = 4 chunks.
+    assertEquals(4, tracker.getActiveGroupTrackers().size());
+    int priorityCount = 0;
+    int normalCount = 0;
+    int totalReplicaCount = 0;
+    for (ActiveGroupTracker g : tracker.getActiveGroupTrackers()) {
+      totalReplicaCount += g.getReplicaCount();
+      if (g.isPriority()) {
+        priorityCount++;
+        assertEquals("priority chunk is singleton", 1, g.getReplicaCount());
+        assertTrue("priority weight 4 or 16", g.getWeight() == 4 || g.getWeight() == 16);
+      } else {
+        normalCount++;
+        assertEquals("non-priority weight=1", 1, g.getWeight());
+        assertTrue("non-priority chunk size <= 3", g.getReplicaCount() <= 3);
+      }
+    }
+    assertEquals("2 priority chunks", 2, priorityCount);
+    assertEquals("2 non-priority chunks (5 replicas split 3+2)", 2, normalCount);
+    assertEquals("conservation: 7 replicas total", 7, totalReplicaCount);
+  }
+
+  /** Group IDs are unique and sequential across priority + non-priority chunks; standby ID is max+1. */
+  @Test
+  public void testCtorGroupIdsSequentialAndUnique() {
+    List<RemoteReplicaInfo> replicas = makeReplicas(6, i -> 0L);
+    PartitionId p = replicas.get(0).getReplicaId().getPartitionId();
+    Map<PartitionId, Integer> snapshot = new HashMap<>();
+    snapshot.put(p, 4);
+
+    int startGroupId = 100;
+    DataNodeTracker tracker = new DataNodeTracker(mockDataNode(), replicas, startGroupId, new MockTime(), 1L,
+        buildConfig(3, false), extractor, snapshot);
+
+    Set<Integer> ids = new HashSet<>();
+    int expectedId = startGroupId;
+    for (ActiveGroupTracker g : tracker.getActiveGroupTrackers()) {
+      assertEquals("group ids assigned sequentially from startGroupId", expectedId, g.getGroupId());
+      ids.add(g.getGroupId());
+      expectedId++;
+    }
+    assertEquals("all group ids are unique", tracker.getActiveGroupTrackers().size(), ids.size());
+    assertEquals("standby group id is max+1", expectedId, tracker.getStandByGroupTracker().getGroupId());
+  }
+
+  /** Priority entry for a partition NOT in this DataNode's slice produces no chunk for it. */
+  @Test
+  public void testCtorPriorityEntryWithoutMatchingReplicaProducesNoChunk() {
+    List<RemoteReplicaInfo> replicas = makeReplicas(3, i -> 0L);
+    Map<PartitionId, Integer> snapshot = new HashMap<>();
+    // Use a fresh partition id not present in any replica.
+    PartitionId orphan = mock(PartitionId.class);
+    when(orphan.toPathString()).thenReturn("orphan");
+    snapshot.put(orphan, 8);
+
+    DataNodeTracker tracker = new DataNodeTracker(mockDataNode(), replicas, 0, new MockTime(), 1L,
+        buildConfig(3, false), extractor, snapshot);
+
+    // Should be one normal chunk; no priority chunks (orphan has no replicas in this slice).
+    assertEquals(1, tracker.getActiveGroupTrackers().size());
+    assertFalse("no priority chunks", tracker.getActiveGroupTrackers().get(0).isPriority());
+    assertEquals("conservation: 3 replicas", 3, tracker.getActiveGroupTrackers().get(0).getReplicaCount());
+  }
+
+  /** Build a minimal ReplicationConfig for tests with chunk size + spread flag overrides. */
+  private static ReplicationConfig buildConfig(int maxPartitionCountPerRequest, boolean spreadLaggersAcrossChunks) {
+    Properties properties = new Properties();
+    properties.setProperty("replication.max.partition.count.per.request",
+        String.valueOf(maxPartitionCountPerRequest));
+    properties.setProperty(ReplicationConfig.REPLICATION_SPREAD_LAGGERS_ACROSS_CHUNKS,
+        String.valueOf(spreadLaggersAcrossChunks));
+    return new ReplicationConfig(new VerifiableProperties(properties));
+  }
+
+  private static DataNodeId mockDataNode() {
+    DataNodeId dataNodeId = mock(DataNodeId.class);
+    when(dataNodeId.toString()).thenReturn("mock-datanode");
+    return dataNodeId;
   }
 
   // ---- helpers ----

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryRequests.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryRequests.java
@@ -2524,6 +2524,30 @@ public class AmbryRequests implements RequestAPI {
             metrics.totalRequestDroppedRate.mark();
           }
           break;
+        case SetReplicationPriority:
+          metrics.setReplicationPriorityRequestQueueTimeInMs.update(requestQueueTime);
+          metrics.setReplicationPriorityRequestRate.mark();
+          metrics.setReplicationPriorityRequestProcessingTimeInMs.update(requestProcessingTime);
+          responseQueueTimeHistogram = metrics.setReplicationPriorityResponseQueueTimeInMs;
+          responseSendTimeHistogram = metrics.setReplicationPriorityResponseSendTimeInMs;
+          requestTotalTimeHistogram = metrics.setReplicationPriorityRequestTotalTimeInMs;
+          if (isRequestDropped) {
+            metrics.setReplicationPriorityDroppedRate.mark();
+            metrics.totalRequestDroppedRate.mark();
+          }
+          break;
+        case ListReplicationPriority:
+          metrics.listReplicationPriorityRequestQueueTimeInMs.update(requestQueueTime);
+          metrics.listReplicationPriorityRequestRate.mark();
+          metrics.listReplicationPriorityRequestProcessingTimeInMs.update(requestProcessingTime);
+          responseQueueTimeHistogram = metrics.listReplicationPriorityResponseQueueTimeInMs;
+          responseSendTimeHistogram = metrics.listReplicationPriorityResponseSendTimeInMs;
+          requestTotalTimeHistogram = metrics.listReplicationPriorityRequestTotalTimeInMs;
+          if (isRequestDropped) {
+            metrics.listReplicationPriorityDroppedRate.mark();
+            metrics.totalRequestDroppedRate.mark();
+          }
+          break;
       }
     }
 

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryRequests.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryRequests.java
@@ -2524,15 +2524,15 @@ public class AmbryRequests implements RequestAPI {
             metrics.totalRequestDroppedRate.mark();
           }
           break;
-        case SetReplicationPriority:
-          metrics.setReplicationPriorityRequestQueueTimeInMs.update(requestQueueTime);
-          metrics.setReplicationPriorityRequestRate.mark();
-          metrics.setReplicationPriorityRequestProcessingTimeInMs.update(requestProcessingTime);
-          responseQueueTimeHistogram = metrics.setReplicationPriorityResponseQueueTimeInMs;
-          responseSendTimeHistogram = metrics.setReplicationPriorityResponseSendTimeInMs;
-          requestTotalTimeHistogram = metrics.setReplicationPriorityRequestTotalTimeInMs;
+        case UpdateReplicationPriority:
+          metrics.updateReplicationPriorityRequestQueueTimeInMs.update(requestQueueTime);
+          metrics.updateReplicationPriorityRequestRate.mark();
+          metrics.updateReplicationPriorityRequestProcessingTimeInMs.update(requestProcessingTime);
+          responseQueueTimeHistogram = metrics.updateReplicationPriorityResponseQueueTimeInMs;
+          responseSendTimeHistogram = metrics.updateReplicationPriorityResponseSendTimeInMs;
+          requestTotalTimeHistogram = metrics.updateReplicationPriorityRequestTotalTimeInMs;
           if (isRequestDropped) {
-            metrics.setReplicationPriorityDroppedRate.mark();
+            metrics.updateReplicationPriorityDroppedRate.mark();
             metrics.totalRequestDroppedRate.mark();
           }
           break;

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryServer.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryServer.java
@@ -515,8 +515,7 @@ public class AmbryServer {
             AmbryRequests repairRequests =
                 new AmbryServerRequests(storageManager, localChannel, clusterMap, nodeId, registry, metrics,
                     findTokenHelper, notificationSystem, replicationManager, storeKeyFactory, serverConfig,
-                    diskManagerConfig, storeKeyConverterFactory, statsManager, clusterParticipant,
-                    connectionPool);
+                    diskManagerConfig, storeKeyConverterFactory, statsManager, clusterParticipant, connectionPool);
             // Right now we only open single thread for the repairHandlerPool
             repairHandlerPool = new RequestHandlerPool(1, localChannel, repairRequests, "Repair-");
             // start the repairRequestSender. It sends requests through the localChannel to the repairHandlerPool

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryServerRequests.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryServerRequests.java
@@ -44,11 +44,16 @@ import com.github.ambry.protocol.BlobStoreControlAdminRequest;
 import com.github.ambry.protocol.CatchupStatusAdminRequest;
 import com.github.ambry.protocol.CatchupStatusAdminResponse;
 import com.github.ambry.protocol.ForceDeleteAdminRequest;
+import com.github.ambry.protocol.ListReplicationPriorityAdminRequest;
+import com.github.ambry.protocol.ListReplicationPriorityAdminResponse;
 import com.github.ambry.protocol.ReplicationControlAdminRequest;
 import com.github.ambry.protocol.RequestControlAdminRequest;
 import com.github.ambry.protocol.RequestOrResponseType;
+import com.github.ambry.protocol.SetReplicationPriorityAdminRequest;
 import com.github.ambry.replication.FindTokenHelper;
+import com.github.ambry.replication.ReplicaThread;
 import com.github.ambry.replication.ReplicationAPI;
+import com.github.ambry.replication.ReplicationEngine;
 import com.github.ambry.replication.ReplicationManager;
 import com.github.ambry.store.BlobStore;
 import com.github.ambry.store.DiskHealthStatus;
@@ -228,6 +233,12 @@ public class AmbryServerRequests extends AmbryRequests {
         case ForceDelete:
           response = handleForceDeleteRequest(requestStream, adminRequest);
           break;
+        case SetReplicationPriority:
+          response = handleSetReplicationPriorityRequest(requestStream, adminRequest);
+          break;
+        case ListReplicationPriority:
+          response = handleListReplicationPriorityRequest(requestStream, adminRequest);
+          break;
       }
     } catch (Exception e) {
       logger.error("Unknown exception for admin request {}", adminRequest, e);
@@ -246,6 +257,13 @@ public class AmbryServerRequests extends AmbryRequests {
         case ForceDelete:
           response = new AdminResponse(adminRequest.getCorrelationId(), adminRequest.getClientId(),
               ServerErrorCode.UnknownError);
+          break;
+        case ListReplicationPriority:
+          // Client deserializer expects a typed response; the inner handler builds one normally but if
+          // we land in this catch the client would otherwise fail to parse the bare AdminResponse.
+          response = new ListReplicationPriorityAdminResponse(Collections.emptyList(),
+              new AdminResponse(adminRequest.getCorrelationId(), adminRequest.getClientId(),
+                  ServerErrorCode.UnknownError));
           break;
       }
     } finally {
@@ -599,6 +617,78 @@ public class AmbryServerRequests extends AmbryRequests {
       logger.error("ForceDeleteAdminRequest Unexpected error when handleForceDeleteRequest", e);
     }
     return new AdminResponse(correlationId, clientId, ServerErrorCode.UnknownError);
+  }
+
+  /**
+   * Handles {@link AdminRequestOrResponseType#SetReplicationPriority} — set, or clear, replication
+   * priority for a set of partitions on this storage node by fanning out to every
+   * {@link ReplicaThread} pool managed by the {@link ReplicationEngine}.
+   *
+   * Admission check (HTTP/2 max-content-length cap) is NOT done here — it lives in the frontend
+   * layer where {@code RouterConfig} and {@code NetworkConfig} are reachable. Server trusts the
+   * boost.
+   */
+  private AdminResponse handleSetReplicationPriorityRequest(DataInputStream requestStream, AdminRequest adminRequest) {
+    final int correlationId = adminRequest.getCorrelationId();
+    final String clientId = adminRequest.getClientId();
+    SetReplicationPriorityAdminRequest setRequest;
+    try {
+      setRequest = SetReplicationPriorityAdminRequest.readFrom(requestStream, clusterMap, adminRequest);
+    } catch (Exception e) {
+      logger.error("Failed to deserialize SetReplicationPriorityAdminRequest", e);
+      return new AdminResponse(correlationId, clientId, ServerErrorCode.BadRequest);
+    }
+    // Boundary validation: reject boost < 1 on the set path so operators get a typed error instead of
+    // a silent clamp deep in ReplicaThread. (clear=true ignores the boost field.)
+    if (!setRequest.shouldClear() && setRequest.getBoost() < 1) {
+      logger.warn("Rejecting SetReplicationPriority clientId={} boost={} — must be >= 1", clientId,
+          setRequest.getBoost());
+      return new AdminResponse(correlationId, clientId, ServerErrorCode.BadRequest);
+    }
+    if (!(replicationEngine instanceof ReplicationEngine)) {
+      logger.error("ReplicationEngine instance does not support priority operations");
+      return new AdminResponse(correlationId, clientId, ServerErrorCode.UnknownError);
+    }
+    ReplicationEngine engine = (ReplicationEngine) replicationEngine;
+    // Audit log: per-host operator actions should be traceable to a clientId.
+    logger.info("SetReplicationPriority clientId={} clear={} boost={} partitions={}", clientId, setRequest.shouldClear(),
+        setRequest.getBoost(), setRequest.getPartitionIds());
+    try {
+      if (setRequest.shouldClear()) {
+        engine.clearPriorityPartitions(setRequest.getPartitionIds());
+      } else {
+        engine.prioritizePartitions(setRequest.getPartitionIds(), setRequest.getBoost());
+      }
+      return new AdminResponse(correlationId, clientId, ServerErrorCode.NoError);
+    } catch (Exception e) {
+      logger.error("SetReplicationPriorityAdminRequest failed", e);
+      return new AdminResponse(correlationId, clientId, ServerErrorCode.UnknownError);
+    }
+  }
+
+  /**
+   * Handles {@link AdminRequestOrResponseType#ListReplicationPriority} — returns a snapshot of every
+   * priority entry currently held by any {@link ReplicaThread} on this host. The {@code isInterColo}
+   * flag on each entry is derived from {@link ReplicaThread#isReplicatingFromRemoteColo()}.
+   */
+  private AdminResponse handleListReplicationPriorityRequest(DataInputStream requestStream, AdminRequest adminRequest) {
+    final int correlationId = adminRequest.getCorrelationId();
+    final String clientId = adminRequest.getClientId();
+    try {
+      ListReplicationPriorityAdminRequest.readFrom(requestStream, adminRequest);
+    } catch (Exception e) {
+      logger.error("Failed to deserialize ListReplicationPriorityAdminRequest", e);
+      AdminResponse base = new AdminResponse(correlationId, clientId, ServerErrorCode.BadRequest);
+      return new ListReplicationPriorityAdminResponse(Collections.emptyList(), base);
+    }
+    if (!(replicationEngine instanceof ReplicationEngine)) {
+      logger.error("ReplicationEngine instance does not support priority list");
+      AdminResponse base = new AdminResponse(correlationId, clientId, ServerErrorCode.UnknownError);
+      return new ListReplicationPriorityAdminResponse(Collections.emptyList(), base);
+    }
+    ReplicationEngine engine = (ReplicationEngine) replicationEngine;
+    AdminResponse base = new AdminResponse(correlationId, clientId, ServerErrorCode.NoError);
+    return new ListReplicationPriorityAdminResponse(engine.listAllPriorityPartitions(), base);
   }
 
   /**

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryServerRequests.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryServerRequests.java
@@ -636,6 +636,10 @@ public class AmbryServerRequests extends AmbryRequests {
       AdminRequest adminRequest) {
     final int correlationId = adminRequest.getCorrelationId();
     final String clientId = adminRequest.getClientId();
+    if (!serverConfig.serverHandleReplicationPriorityRequestEnabled) {
+      logger.warn("UpdateReplicationPriority request is disabled");
+      return new AdminResponse(correlationId, clientId, ServerErrorCode.BadRequest);
+    }
     UpdateReplicationPriorityAdminRequest updateRequest;
     try {
       updateRequest = UpdateReplicationPriorityAdminRequest.readFrom(requestStream, clusterMap, adminRequest);
@@ -735,6 +739,11 @@ public class AmbryServerRequests extends AmbryRequests {
   private AdminResponse handleListReplicationPriorityRequest(DataInputStream requestStream, AdminRequest adminRequest) {
     final int correlationId = adminRequest.getCorrelationId();
     final String clientId = adminRequest.getClientId();
+    if (!serverConfig.serverHandleReplicationPriorityRequestEnabled) {
+      logger.warn("ListReplicationPriority request is disabled");
+      AdminResponse base = new AdminResponse(correlationId, clientId, ServerErrorCode.BadRequest);
+      return new ListReplicationPriorityAdminResponse(Collections.emptyList(), base);
+    }
     try {
       ListReplicationPriorityAdminRequest.readFrom(requestStream, adminRequest);
     } catch (Exception e) {

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryServerRequests.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryServerRequests.java
@@ -108,8 +108,6 @@ public class AmbryServerRequests extends AmbryRequests {
   private final ClusterParticipant clusterParticipant;
   // Defensive cap; the precise wire-layer limit is enforced on the frontend.
   private static final int MAX_PRIORITY_BOOST = 1024;
-  // Defensive cap; realistic priority lists are dozens, not hundreds.
-  private static final int MAX_PRIORITY_PARTITIONS_PER_REQUEST = 256;
   private final ConcurrentHashMap<RequestOrResponseType, Set<PartitionId>> requestsDisableInfo =
       new ConcurrentHashMap<>();
   private final ObjectMapper objectMapper = JsonUtil.newObjectMapper();
@@ -645,9 +643,9 @@ public class AmbryServerRequests extends AmbryRequests {
       logger.error("Failed to deserialize UpdateReplicationPriorityAdminRequest", e);
       return new AdminResponse(correlationId, clientId, ServerErrorCode.BadRequest);
     }
-    if (updateRequest.getPartitionIds().size() > MAX_PRIORITY_PARTITIONS_PER_REQUEST) {
+    if (updateRequest.getPartitionIds().size() > UpdateReplicationPriorityAdminRequest.MAX_PARTITIONS_PER_REQUEST) {
       logger.warn("Rejecting UpdateReplicationPriority clientId={} — partition list size {} exceeds cap {}",
-          clientId, updateRequest.getPartitionIds().size(), MAX_PRIORITY_PARTITIONS_PER_REQUEST);
+          clientId, updateRequest.getPartitionIds().size(), UpdateReplicationPriorityAdminRequest.MAX_PARTITIONS_PER_REQUEST);
       return new AdminResponse(correlationId, clientId, ServerErrorCode.BadRequest);
     }
     final UpdateReplicationPriorityAdminRequest.Action action = updateRequest.getAction();

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryServerRequests.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryServerRequests.java
@@ -49,7 +49,7 @@ import com.github.ambry.protocol.ListReplicationPriorityAdminResponse;
 import com.github.ambry.protocol.ReplicationControlAdminRequest;
 import com.github.ambry.protocol.RequestControlAdminRequest;
 import com.github.ambry.protocol.RequestOrResponseType;
-import com.github.ambry.protocol.SetReplicationPriorityAdminRequest;
+import com.github.ambry.protocol.UpdateReplicationPriorityAdminRequest;
 import com.github.ambry.replication.FindTokenHelper;
 import com.github.ambry.replication.ReplicaThread;
 import com.github.ambry.replication.ReplicationAPI;
@@ -72,6 +72,7 @@ import com.github.ambry.utils.SystemTime;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -105,6 +106,10 @@ public class AmbryServerRequests extends AmbryRequests {
   private final DiskManagerConfig diskManagerConfig;
   private final StatsManager statsManager;
   private final ClusterParticipant clusterParticipant;
+  // Defensive cap; the precise wire-layer limit is enforced on the frontend.
+  private static final int MAX_PRIORITY_BOOST = 1024;
+  // Defensive cap; realistic priority lists are dozens, not hundreds.
+  private static final int MAX_PRIORITY_PARTITIONS_PER_REQUEST = 256;
   private final ConcurrentHashMap<RequestOrResponseType, Set<PartitionId>> requestsDisableInfo =
       new ConcurrentHashMap<>();
   private final ObjectMapper objectMapper = JsonUtil.newObjectMapper();
@@ -233,8 +238,8 @@ public class AmbryServerRequests extends AmbryRequests {
         case ForceDelete:
           response = handleForceDeleteRequest(requestStream, adminRequest);
           break;
-        case SetReplicationPriority:
-          response = handleSetReplicationPriorityRequest(requestStream, adminRequest);
+        case UpdateReplicationPriority:
+          response = handleUpdateReplicationPriorityRequest(requestStream, adminRequest);
           break;
         case ListReplicationPriority:
           response = handleListReplicationPriorityRequest(requestStream, adminRequest);
@@ -620,48 +625,106 @@ public class AmbryServerRequests extends AmbryRequests {
   }
 
   /**
-   * Handles {@link AdminRequestOrResponseType#SetReplicationPriority} — set, or clear, replication
-   * priority for a set of partitions on this storage node by fanning out to every
+   * Handles {@link AdminRequestOrResponseType#UpdateReplicationPriority} — set, unset, or wipe all
+   * replication priorities for partitions on this storage node by fanning out to every
    * {@link ReplicaThread} pool managed by the {@link ReplicationEngine}.
    *
-   * Admission check (HTTP/2 max-content-length cap) is NOT done here — it lives in the frontend
-   * layer where {@code RouterConfig} and {@code NetworkConfig} are reachable. Server trusts the
-   * boost.
+   * <p>The handler validates that the partition-list shape matches the wire-level
+   * {@link UpdateReplicationPriorityAdminRequest.Action}: SET and UNSET require a non-empty list;
+   * UNSET_ALL requires an empty list. Mismatches are rejected with
+   * {@link ServerErrorCode#BadRequest} so we never reach the engine with a malformed request.
    */
-  private AdminResponse handleSetReplicationPriorityRequest(DataInputStream requestStream, AdminRequest adminRequest) {
+  private AdminResponse handleUpdateReplicationPriorityRequest(DataInputStream requestStream,
+      AdminRequest adminRequest) {
     final int correlationId = adminRequest.getCorrelationId();
     final String clientId = adminRequest.getClientId();
-    SetReplicationPriorityAdminRequest setRequest;
+    UpdateReplicationPriorityAdminRequest updateRequest;
     try {
-      setRequest = SetReplicationPriorityAdminRequest.readFrom(requestStream, clusterMap, adminRequest);
+      updateRequest = UpdateReplicationPriorityAdminRequest.readFrom(requestStream, clusterMap, adminRequest);
     } catch (Exception e) {
-      logger.error("Failed to deserialize SetReplicationPriorityAdminRequest", e);
+      logger.error("Failed to deserialize UpdateReplicationPriorityAdminRequest", e);
       return new AdminResponse(correlationId, clientId, ServerErrorCode.BadRequest);
     }
-    // Boundary validation: reject boost < 1 on the set path so operators get a typed error instead of
-    // a silent clamp deep in ReplicaThread. (clear=true ignores the boost field.)
-    if (!setRequest.shouldClear() && setRequest.getBoost() < 1) {
-      logger.warn("Rejecting SetReplicationPriority clientId={} boost={} — must be >= 1", clientId,
-          setRequest.getBoost());
+    if (updateRequest.getPartitionIds().size() > MAX_PRIORITY_PARTITIONS_PER_REQUEST) {
+      logger.warn("Rejecting UpdateReplicationPriority clientId={} — partition list size {} exceeds cap {}",
+          clientId, updateRequest.getPartitionIds().size(), MAX_PRIORITY_PARTITIONS_PER_REQUEST);
       return new AdminResponse(correlationId, clientId, ServerErrorCode.BadRequest);
     }
-    if (!(replicationEngine instanceof ReplicationEngine)) {
-      logger.error("ReplicationEngine instance does not support priority operations");
-      return new AdminResponse(correlationId, clientId, ServerErrorCode.UnknownError);
+    final UpdateReplicationPriorityAdminRequest.Action action = updateRequest.getAction();
+    final boolean empty = updateRequest.getPartitionIds().isEmpty();
+    switch (action) {
+      case SET:
+        if (empty) {
+          logger.warn("Rejecting UpdateReplicationPriority clientId={} — SET requires non-empty partition list",
+              clientId);
+          return new AdminResponse(correlationId, clientId, ServerErrorCode.BadRequest);
+        }
+        break;
+      case UNSET:
+        if (empty) {
+          logger.warn(
+              "Rejecting UpdateReplicationPriority clientId={} — UNSET requires non-empty partition list; use UNSET_ALL to wipe all",
+              clientId);
+          return new AdminResponse(correlationId, clientId, ServerErrorCode.BadRequest);
+        }
+        break;
+      case UNSET_ALL:
+        if (!empty) {
+          logger.warn("Rejecting UpdateReplicationPriority clientId={} — UNSET_ALL requires empty partition list",
+              clientId);
+          return new AdminResponse(correlationId, clientId, ServerErrorCode.BadRequest);
+        }
+        break;
     }
-    ReplicationEngine engine = (ReplicationEngine) replicationEngine;
-    // Audit log: per-host operator actions should be traceable to a clientId.
-    logger.info("SetReplicationPriority clientId={} clear={} boost={} partitions={}", clientId, setRequest.shouldClear(),
-        setRequest.getBoost(), setRequest.getPartitionIds());
+    if (action == UpdateReplicationPriorityAdminRequest.Action.SET && updateRequest.getBoost() < 1) {
+      logger.warn("Rejecting UpdateReplicationPriority clientId={} boost={} — must be >= 1", clientId,
+          updateRequest.getBoost());
+      return new AdminResponse(correlationId, clientId, ServerErrorCode.BadRequest);
+    }
+    if (action == UpdateReplicationPriorityAdminRequest.Action.SET
+        && updateRequest.getBoost() > MAX_PRIORITY_BOOST) {
+      logger.warn("Rejecting UpdateReplicationPriority clientId={} boost={} — exceeds cap={}",
+          clientId, updateRequest.getBoost(), MAX_PRIORITY_BOOST);
+      return new AdminResponse(correlationId, clientId, ServerErrorCode.BadRequest);
+    }
+    if (action == UpdateReplicationPriorityAdminRequest.Action.SET) {
+      // All-or-nothing. A null partitionId means ClusterMap couldn't resolve; treat as unknown.
+      List<PartitionId> unknownPartitions = new ArrayList<>();
+      for (PartitionId partitionId : updateRequest.getPartitionIds()) {
+        if (partitionId == null || !replicationEngine.hostsPartition(partitionId)) {
+          unknownPartitions.add(partitionId);
+        }
+      }
+      if (!unknownPartitions.isEmpty()) {
+        logger.warn(
+            "Rejecting UpdateReplicationPriority clientId={} — {} partition(s) not hosted on this server: {}",
+            clientId, unknownPartitions.size(), unknownPartitions);
+        return new AdminResponse(correlationId, clientId, ServerErrorCode.BadRequest);
+      }
+    }
     try {
-      if (setRequest.shouldClear()) {
-        engine.clearPriorityPartitions(setRequest.getPartitionIds());
-      } else {
-        engine.prioritizePartitions(setRequest.getPartitionIds(), setRequest.getBoost());
+      switch (action) {
+        case UNSET_ALL:
+          logger.info("UpdateReplicationPriority clientId={} UNSET_ALL — wiping ALL priorities on this host", clientId);
+          replicationEngine.unsetPriorityPartitions(Collections.emptyList());
+          break;
+        case UNSET:
+          logger.info("UpdateReplicationPriority clientId={} UNSET partitions={}", clientId,
+              updateRequest.getPartitionIds());
+          replicationEngine.unsetPriorityPartitions(updateRequest.getPartitionIds());
+          break;
+        case SET:
+          logger.info("UpdateReplicationPriority clientId={} SET boost={} partitions={}", clientId,
+              updateRequest.getBoost(), updateRequest.getPartitionIds());
+          replicationEngine.prioritizePartitions(updateRequest.getPartitionIds(), updateRequest.getBoost());
+          break;
       }
       return new AdminResponse(correlationId, clientId, ServerErrorCode.NoError);
+    } catch (UnsupportedOperationException e) {
+      logger.error("UpdateReplicationPriorityAdminRequest not supported by replication engine impl", e);
+      return new AdminResponse(correlationId, clientId, ServerErrorCode.BadRequest);
     } catch (Exception e) {
-      logger.error("SetReplicationPriorityAdminRequest failed", e);
+      logger.error("UpdateReplicationPriorityAdminRequest failed", e);
       return new AdminResponse(correlationId, clientId, ServerErrorCode.UnknownError);
     }
   }
@@ -681,14 +744,14 @@ public class AmbryServerRequests extends AmbryRequests {
       AdminResponse base = new AdminResponse(correlationId, clientId, ServerErrorCode.BadRequest);
       return new ListReplicationPriorityAdminResponse(Collections.emptyList(), base);
     }
-    if (!(replicationEngine instanceof ReplicationEngine)) {
-      logger.error("ReplicationEngine instance does not support priority list");
+    try {
+      AdminResponse base = new AdminResponse(correlationId, clientId, ServerErrorCode.NoError);
+      return new ListReplicationPriorityAdminResponse(replicationEngine.listAllPriorityPartitions(), base);
+    } catch (UnsupportedOperationException e) {
+      logger.error("ListReplicationPriorityAdminRequest not supported by replication engine impl", e);
       AdminResponse base = new AdminResponse(correlationId, clientId, ServerErrorCode.UnknownError);
       return new ListReplicationPriorityAdminResponse(Collections.emptyList(), base);
     }
-    ReplicationEngine engine = (ReplicationEngine) replicationEngine;
-    AdminResponse base = new AdminResponse(correlationId, clientId, ServerErrorCode.NoError);
-    return new ListReplicationPriorityAdminResponse(engine.listAllPriorityPartitions(), base);
   }
 
   /**

--- a/ambry-server/src/test/java/com/github/ambry/server/AmbryServerRequestsTest.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/AmbryServerRequestsTest.java
@@ -65,7 +65,6 @@ import com.github.ambry.protocol.DeleteRequest;
 import com.github.ambry.protocol.GetOption;
 import com.github.ambry.protocol.GetRequest;
 import com.github.ambry.protocol.GetResponse;
-import com.github.ambry.protocol.ListReplicationPriorityAdminResponse;
 import com.github.ambry.protocol.PartitionRequestInfo;
 import com.github.ambry.protocol.PartitionResponseInfo;
 import com.github.ambry.protocol.PutRequest;
@@ -81,11 +80,12 @@ import com.github.ambry.protocol.RequestControlAdminRequest;
 import com.github.ambry.protocol.RequestOrResponse;
 import com.github.ambry.protocol.RequestOrResponseType;
 import com.github.ambry.protocol.Response;
-import com.github.ambry.protocol.SetReplicationPriorityAdminRequest;
 import com.github.ambry.protocol.TtlUpdateRequest;
 import com.github.ambry.protocol.UndeleteRequest;
+import com.github.ambry.protocol.UpdateReplicationPriorityAdminRequest;
 import com.github.ambry.replication.BackupCheckerThread;
 import com.github.ambry.replication.FindTokenHelper;
+import com.github.ambry.replication.PriorityEntry;
 import com.github.ambry.replication.MockConnectionPool;
 import com.github.ambry.replication.MockFindTokenHelper;
 import com.github.ambry.replication.MockHost;
@@ -447,39 +447,61 @@ public class AmbryServerRequestsTest extends ReplicationTestHelper {
   }
 
   /**
-   * Boundary validation: {@link AdminRequestOrResponseType#SetReplicationPriority} with
-   * {@code clear=false} and {@code boost < 1} must be rejected with
-   * {@link ServerErrorCode#BadRequest} before reaching the {@code ReplicationEngine}.
+   * Boundary validation: {@link AdminRequestOrResponseType#UpdateReplicationPriority} on the SET path
+   * with {@code boost < 1} must be rejected with {@link ServerErrorCode#BadRequest} before
+   * reaching the {@code ReplicationEngine}.
    */
   @Test
-  public void setReplicationPriorityRejectsBoostBelowOne() throws InterruptedException, IOException {
+  public void updateReplicationPriorityRejectsBoostBelowOne() throws InterruptedException, IOException {
     PartitionId id = clusterMap.getWritablePartitionIds(DEFAULT_PARTITION_CLASS).get(0);
     int correlationId = TestUtils.RANDOM.nextInt();
     String clientId = TestUtils.getRandomString(10);
     AdminRequest adminRequest =
-        new AdminRequest(AdminRequestOrResponseType.SetReplicationPriority, null, correlationId, clientId);
-    SetReplicationPriorityAdminRequest setRequest =
-        new SetReplicationPriorityAdminRequest(Collections.singletonList(id), /*boost*/ 0, /*clear*/ false, adminRequest);
-    Response response = sendRequestGetResponse(setRequest, ServerErrorCode.BadRequest);
+        new AdminRequest(AdminRequestOrResponseType.UpdateReplicationPriority, null, correlationId, clientId);
+    UpdateReplicationPriorityAdminRequest updateRequest =
+        new UpdateReplicationPriorityAdminRequest(Collections.singletonList(id), /*boost*/ 0,
+            UpdateReplicationPriorityAdminRequest.Action.SET, adminRequest);
+    Response response = sendRequestGetResponse(updateRequest, ServerErrorCode.BadRequest);
     assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
     response.release();
   }
 
   /**
-   * Boundary validation: when {@code clear=true}, the {@code boost} field is ignored, so
-   * {@code boost=0} should NOT trigger the BadRequest path. The request reaches the engine and
-   * succeeds (no priorities to clear in the mock setup).
+   * Boundary validation: reject Set requests whose boost exceeds the HTTP/2 admission cap.
+   * Mirrors the below-one test — a typed BadRequest instead of letting the request reach
+   * ReplicaThread.
    */
   @Test
-  public void setReplicationPriorityClearIgnoresBoost() throws InterruptedException, IOException {
+  public void updateReplicationPriorityRejectsBoostAboveCap() throws InterruptedException, IOException {
     PartitionId id = clusterMap.getWritablePartitionIds(DEFAULT_PARTITION_CLASS).get(0);
     int correlationId = TestUtils.RANDOM.nextInt();
     String clientId = TestUtils.getRandomString(10);
     AdminRequest adminRequest =
-        new AdminRequest(AdminRequestOrResponseType.SetReplicationPriority, null, correlationId, clientId);
-    SetReplicationPriorityAdminRequest clearRequest =
-        new SetReplicationPriorityAdminRequest(Collections.singletonList(id), /*boost*/ 0, /*clear*/ true, adminRequest);
-    Response response = sendRequestGetResponse(clearRequest, ServerErrorCode.NoError);
+        new AdminRequest(AdminRequestOrResponseType.UpdateReplicationPriority, null, correlationId, clientId);
+    UpdateReplicationPriorityAdminRequest updateRequest =
+        new UpdateReplicationPriorityAdminRequest(Collections.singletonList(id), Integer.MAX_VALUE,
+            UpdateReplicationPriorityAdminRequest.Action.SET, adminRequest);
+    Response response = sendRequestGetResponse(updateRequest, ServerErrorCode.BadRequest);
+    assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
+    response.release();
+  }
+
+  /**
+   * Boundary validation: on the UNSET path, the {@code boost} field is ignored, so {@code boost=0}
+   * should NOT trigger the BadRequest path. The request reaches the engine and succeeds (no
+   * priorities to unset in the mock setup; unset of an unknown-to-engine partition is a no-op).
+   */
+  @Test
+  public void updateReplicationPriorityUnsetIgnoresBoost() throws InterruptedException, IOException {
+    PartitionId id = clusterMap.getWritablePartitionIds(DEFAULT_PARTITION_CLASS).get(0);
+    int correlationId = TestUtils.RANDOM.nextInt();
+    String clientId = TestUtils.getRandomString(10);
+    AdminRequest adminRequest =
+        new AdminRequest(AdminRequestOrResponseType.UpdateReplicationPriority, null, correlationId, clientId);
+    UpdateReplicationPriorityAdminRequest unsetRequest =
+        new UpdateReplicationPriorityAdminRequest(Collections.singletonList(id), /*boost*/ 0,
+            UpdateReplicationPriorityAdminRequest.Action.UNSET, adminRequest);
+    Response response = sendRequestGetResponse(unsetRequest, ServerErrorCode.NoError);
     assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
     response.release();
   }
@@ -504,7 +526,7 @@ public class AmbryServerRequestsTest extends ReplicationTestHelper {
     assertTrue("p2 probe should produce at least one entry", expectedP2 >= 1);
     try {
       replicationManager.prioritizePartitions(Arrays.asList(p1, p2), boost);
-      List<ListReplicationPriorityAdminResponse.PriorityEntry> entries =
+      List<PriorityEntry> entries =
           replicationManager.listAllPriorityPartitions();
       // Bulk set on both partitions should produce the sum of each probe's count (priorities
       // mirror across every thread that has the partition's replicas, so a regression that
@@ -514,17 +536,17 @@ public class AmbryServerRequestsTest extends ReplicationTestHelper {
       long p2Count = entries.stream().filter(e -> e.getPartitionId().equals(p2)).count();
       assertEquals("p1 entry count", expectedP1, p1Count);
       assertEquals("p2 entry count", expectedP2, p2Count);
-      for (ListReplicationPriorityAdminResponse.PriorityEntry entry : entries) {
+      for (PriorityEntry entry : entries) {
         assertEquals("boost mismatch for " + entry, boost, entry.getBoost());
       }
       // Sanity: both isInterColo branches should be exercised because the engine mirrors priorities
       // across intra-colo AND inter-colo thread pools.
       boolean sawIntra = entries.stream().anyMatch(e -> !e.isInterColo());
-      boolean sawInter = entries.stream().anyMatch(ListReplicationPriorityAdminResponse.PriorityEntry::isInterColo);
+      boolean sawInter = entries.stream().anyMatch(PriorityEntry::isInterColo);
       assertTrue("expected at least one intra-colo entry", sawIntra);
       assertTrue("expected at least one inter-colo entry", sawInter);
     } finally {
-      replicationManager.clearPriorityPartitions(Collections.emptyList());
+      replicationManager.unsetPriorityPartitions(Collections.emptyList());
     }
     assertTrue("List should be empty after clear-all", replicationManager.listAllPriorityPartitions().isEmpty());
   }
@@ -540,6 +562,199 @@ public class AmbryServerRequestsTest extends ReplicationTestHelper {
   }
 
   /**
+   * {@link ReplicationEngine#listAllPriorityPartitions()} must return entries in a deterministic
+   * order so operators diffing successive list outputs don't see false-positive reorderings driven
+   * by HashMap / pool-iteration order. Order is (partitionPathString asc, isInterColo asc).
+   */
+  @Test
+  public void listAllPriorityPartitionsResultsAreOrderedDeterministically() {
+    List<? extends PartitionId> writable = clusterMap.getWritablePartitionIds(DEFAULT_PARTITION_CLASS);
+    assertTrue("Need >= 3 partitions for this test", writable.size() >= 3);
+    // Set in arbitrary order (reverse of natural sort) to make sure the ordering comes from the
+    // sort step, not insertion order.
+    PartitionId p0 = writable.get(0);
+    PartitionId p1 = writable.get(1);
+    PartitionId p2 = writable.get(2);
+    try {
+      replicationManager.prioritizePartitions(Collections.singletonList(p2), 7);
+      replicationManager.prioritizePartitions(Collections.singletonList(p0), 3);
+      replicationManager.prioritizePartitions(Collections.singletonList(p1), 5);
+      // Compare by (path, isInterColo, boost) triples — PriorityEntry doesn't override equals().
+      List<String> first = serializeKeys(replicationManager.listAllPriorityPartitions());
+      List<String> second = serializeKeys(replicationManager.listAllPriorityPartitions());
+      // Round-trip property: two consecutive list calls produce equal sequences.
+      assertEquals("consecutive list calls must produce equal sequences", first, second);
+      // Sort property: entries are sorted by partition path string (then isInterColo).
+      List<String> expectedSorted = new ArrayList<>(first);
+      Collections.sort(expectedSorted);
+      assertEquals("list output must be sorted by (partition path, isInterColo)", expectedSorted, first);
+    } finally {
+      replicationManager.unsetPriorityPartitions(Collections.emptyList());
+    }
+  }
+
+  private static List<String> serializeKeys(List<PriorityEntry> entries) {
+    List<String> out = new ArrayList<>(entries.size());
+    for (PriorityEntry e : entries) {
+      // Path first, then isInterColo flag, then boost — keyed in the same precedence order the
+      // engine sorts on so a naive String.sort() produces the same order as the engine.
+      out.add(e.getPartitionId().toPathString() + "|" + e.isInterColo() + "|" + e.getBoost());
+    }
+    return out;
+  }
+
+  /**
+   * Boundary validation building block: {@link ReplicationEngine#hostsPartition} must
+   * report true for a partition the cluster map says belongs here, and false for a fabricated
+   * partition for which no PartitionInfo is registered. The admin handler uses this to reject
+   * {@link AdminRequestOrResponseType#UpdateReplicationPriority} requests for partitions not on this
+   * server (operator-typo guard).
+   */
+  @Test
+  public void updateReplicationPriorityRejectsUnknownPartition() {
+    PartitionId known = clusterMap.getWritablePartitionIds(DEFAULT_PARTITION_CLASS).get(0);
+    PartitionId unknown = new MockPartitionId(Long.MAX_VALUE, DEFAULT_PARTITION_CLASS);
+    assertTrue("Known partition should be registered with a PartitionInfo",
+        replicationManager.hostsPartition(known));
+    assertFalse("Fabricated partition must NOT be registered",
+        replicationManager.hostsPartition(unknown));
+    // No priority entries should have been created merely by checking presence.
+    assertTrue("hostsPartition must not mutate state",
+        replicationManager.listAllPriorityPartitions().isEmpty());
+  }
+
+  /**
+   * Unset path is unchanged: unsetting a partition that no {@link ReplicaThread} hosts is a no-op
+   * at the engine level — no exception, no state changes. Pins the invariant that the admin
+   * handler validates partition existence ONLY on the set path: a future refactor that starts
+   * rejecting unsets with unknown partitions would break the operator mental model (unsetting
+   * nonexistent state is harmless).
+   */
+  @Test
+  public void updateReplicationPriorityUnsetAcceptsUnknownPartition() {
+    PartitionId unknown = new MockPartitionId(Long.MAX_VALUE, DEFAULT_PARTITION_CLASS);
+    assertFalse("Test setup: unknown partition should not be hosted on any thread",
+        replicationManager.hostsPartition(unknown));
+    // No-op unset on an unknown partition must not throw, must not change state.
+    replicationManager.unsetPriorityPartitions(Collections.singletonList(unknown));
+    assertTrue("Unset-of-unknown should not produce any priority entries",
+        replicationManager.listAllPriorityPartitions().isEmpty());
+  }
+
+  /**
+   * Defensive cap: an UpdateReplicationPriority request whose partition-list size exceeds
+   * {@code MAX_PRIORITY_PARTITIONS_PER_REQUEST} must be rejected with {@link ServerErrorCode#BadRequest}
+   * before any further validation runs.
+   */
+  @Test
+  public void updateReplicationPriorityRejectsOversizedPartitionList() throws InterruptedException, IOException {
+    // Cap is 256; produce 257 distinct (and intentionally fabricated) partitions to exceed it. We
+    // fabricate so the test does not depend on the mock cluster map containing 257 partitions.
+    final int oversized = 257;
+    List<PartitionId> partitions = new ArrayList<>(oversized);
+    for (int i = 0; i < oversized; i++) {
+      partitions.add(new MockPartitionId(i, DEFAULT_PARTITION_CLASS));
+    }
+    int correlationId = TestUtils.RANDOM.nextInt();
+    String clientId = TestUtils.getRandomString(10);
+    AdminRequest adminRequest =
+        new AdminRequest(AdminRequestOrResponseType.UpdateReplicationPriority, null, correlationId, clientId);
+    UpdateReplicationPriorityAdminRequest updateRequest =
+        new UpdateReplicationPriorityAdminRequest(partitions, /*boost*/ 4,
+            UpdateReplicationPriorityAdminRequest.Action.SET, adminRequest);
+    Response response = sendRequestGetResponse(updateRequest, ServerErrorCode.BadRequest);
+    assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
+    response.release();
+  }
+
+  /**
+   * Strict action validation: {@link UpdateReplicationPriorityAdminRequest.Action#UNSET} with an
+   * empty partition list is malformed — operators must use
+   * {@link UpdateReplicationPriorityAdminRequest.Action#UNSET_ALL} to wipe all priorities. Rejected
+   * with BadRequest.
+   */
+  @Test
+  public void updateReplicationPriorityRejectsUnsetWithEmptyList() throws InterruptedException, IOException {
+    int correlationId = TestUtils.RANDOM.nextInt();
+    String clientId = TestUtils.getRandomString(10);
+    AdminRequest adminRequest =
+        new AdminRequest(AdminRequestOrResponseType.UpdateReplicationPriority, null, correlationId, clientId);
+    UpdateReplicationPriorityAdminRequest updateRequest =
+        new UpdateReplicationPriorityAdminRequest(Collections.emptyList(), /*boost*/ 1,
+            UpdateReplicationPriorityAdminRequest.Action.UNSET, adminRequest);
+    Response response = sendRequestGetResponse(updateRequest, ServerErrorCode.BadRequest);
+    assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
+    response.release();
+  }
+
+  /**
+   * Strict action validation: {@link UpdateReplicationPriorityAdminRequest.Action#UNSET_ALL} with a
+   * non-empty partition list is malformed — operators must use
+   * {@link UpdateReplicationPriorityAdminRequest.Action#UNSET} for specific partitions. Rejected
+   * with BadRequest.
+   */
+  @Test
+  public void updateReplicationPriorityRejectsUnsetAllWithNonEmptyList() throws InterruptedException, IOException {
+    PartitionId id = clusterMap.getWritablePartitionIds(DEFAULT_PARTITION_CLASS).get(0);
+    int correlationId = TestUtils.RANDOM.nextInt();
+    String clientId = TestUtils.getRandomString(10);
+    AdminRequest adminRequest =
+        new AdminRequest(AdminRequestOrResponseType.UpdateReplicationPriority, null, correlationId, clientId);
+    UpdateReplicationPriorityAdminRequest updateRequest =
+        new UpdateReplicationPriorityAdminRequest(Collections.singletonList(id), /*boost*/ 1,
+            UpdateReplicationPriorityAdminRequest.Action.UNSET_ALL, adminRequest);
+    Response response = sendRequestGetResponse(updateRequest, ServerErrorCode.BadRequest);
+    assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
+    response.release();
+  }
+
+  /**
+   * Strict action validation: {@link UpdateReplicationPriorityAdminRequest.Action#SET} with an empty
+   * partition list is malformed — SET must target at least one partition. Rejected with
+   * BadRequest. Also subsumes the old "no action specified, empty list" malformed case, which
+   * under the enum encoding collapses to SET-with-empty-list.
+   */
+  @Test
+  public void updateReplicationPriorityRejectsSetWithEmptyList() throws InterruptedException, IOException {
+    int correlationId = TestUtils.RANDOM.nextInt();
+    String clientId = TestUtils.getRandomString(10);
+    AdminRequest adminRequest =
+        new AdminRequest(AdminRequestOrResponseType.UpdateReplicationPriority, null, correlationId, clientId);
+    UpdateReplicationPriorityAdminRequest updateRequest =
+        new UpdateReplicationPriorityAdminRequest(Collections.emptyList(), /*boost*/ 1,
+            UpdateReplicationPriorityAdminRequest.Action.SET, adminRequest);
+    Response response = sendRequestGetResponse(updateRequest, ServerErrorCode.BadRequest);
+    assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
+    response.release();
+  }
+
+  /**
+   * Positive: {@link UpdateReplicationPriorityAdminRequest.Action#UNSET_ALL} with empty partition
+   * list dispatches to engine wipe-all. The pre-populated priorities are wiped after the request
+   * completes successfully.
+   */
+  @Test
+  public void updateReplicationPriorityAcceptsUnsetAll() throws InterruptedException, IOException {
+    PartitionId id = clusterMap.getWritablePartitionIds(DEFAULT_PARTITION_CLASS).get(0);
+    // Seed a priority so the wipe-all path has something observable to wipe.
+    replicationManager.prioritizePartitions(Collections.singletonList(id), /*boost*/ 4);
+    assertFalse("Test setup: priority should be present before wipe-all",
+        replicationManager.listAllPriorityPartitions().isEmpty());
+    int correlationId = TestUtils.RANDOM.nextInt();
+    String clientId = TestUtils.getRandomString(10);
+    AdminRequest adminRequest =
+        new AdminRequest(AdminRequestOrResponseType.UpdateReplicationPriority, null, correlationId, clientId);
+    UpdateReplicationPriorityAdminRequest updateRequest =
+        new UpdateReplicationPriorityAdminRequest(Collections.emptyList(), /*boost*/ 1,
+            UpdateReplicationPriorityAdminRequest.Action.UNSET_ALL, adminRequest);
+    Response response = sendRequestGetResponse(updateRequest, ServerErrorCode.NoError);
+    assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
+    response.release();
+    assertTrue("After UNSET_ALL, listAllPriorityPartitions should be empty",
+        replicationManager.listAllPriorityPartitions().isEmpty());
+  }
+
+  /**
    * Set priority on a single partition, observe the resulting entry count (= number of threads
    * holding the partition), then clear. Used to derive the expected fan-out without depending on
    * cluster-map placement details.
@@ -549,7 +764,7 @@ public class AmbryServerRequestsTest extends ReplicationTestHelper {
       replicationManager.prioritizePartitions(Collections.singletonList(partition), boost);
       return replicationManager.listAllPriorityPartitions().size();
     } finally {
-      replicationManager.clearPriorityPartitions(Collections.emptyList());
+      replicationManager.unsetPriorityPartitions(Collections.emptyList());
     }
   }
 

--- a/ambry-server/src/test/java/com/github/ambry/server/AmbryServerRequestsTest.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/AmbryServerRequestsTest.java
@@ -65,6 +65,7 @@ import com.github.ambry.protocol.DeleteRequest;
 import com.github.ambry.protocol.GetOption;
 import com.github.ambry.protocol.GetRequest;
 import com.github.ambry.protocol.GetResponse;
+import com.github.ambry.protocol.ListReplicationPriorityAdminResponse;
 import com.github.ambry.protocol.PartitionRequestInfo;
 import com.github.ambry.protocol.PartitionResponseInfo;
 import com.github.ambry.protocol.PutRequest;
@@ -80,6 +81,7 @@ import com.github.ambry.protocol.RequestControlAdminRequest;
 import com.github.ambry.protocol.RequestOrResponse;
 import com.github.ambry.protocol.RequestOrResponseType;
 import com.github.ambry.protocol.Response;
+import com.github.ambry.protocol.SetReplicationPriorityAdminRequest;
 import com.github.ambry.protocol.TtlUpdateRequest;
 import com.github.ambry.protocol.UndeleteRequest;
 import com.github.ambry.replication.BackupCheckerThread;
@@ -442,6 +444,113 @@ public class AmbryServerRequestsTest extends ReplicationTestHelper {
     sendAndVerifyReplicationControlRequest(Collections.emptyList(), false,
         clusterMap.getWritablePartitionIds(DEFAULT_PARTITION_CLASS).get(0), ServerErrorCode.UnknownError);
     // PartitionUnknown is hard to simulate without betraying knowledge of the internals of MockClusterMap.
+  }
+
+  /**
+   * Boundary validation: {@link AdminRequestOrResponseType#SetReplicationPriority} with
+   * {@code clear=false} and {@code boost < 1} must be rejected with
+   * {@link ServerErrorCode#BadRequest} before reaching the {@code ReplicationEngine}.
+   */
+  @Test
+  public void setReplicationPriorityRejectsBoostBelowOne() throws InterruptedException, IOException {
+    PartitionId id = clusterMap.getWritablePartitionIds(DEFAULT_PARTITION_CLASS).get(0);
+    int correlationId = TestUtils.RANDOM.nextInt();
+    String clientId = TestUtils.getRandomString(10);
+    AdminRequest adminRequest =
+        new AdminRequest(AdminRequestOrResponseType.SetReplicationPriority, null, correlationId, clientId);
+    SetReplicationPriorityAdminRequest setRequest =
+        new SetReplicationPriorityAdminRequest(Collections.singletonList(id), /*boost*/ 0, /*clear*/ false, adminRequest);
+    Response response = sendRequestGetResponse(setRequest, ServerErrorCode.BadRequest);
+    assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
+    response.release();
+  }
+
+  /**
+   * Boundary validation: when {@code clear=true}, the {@code boost} field is ignored, so
+   * {@code boost=0} should NOT trigger the BadRequest path. The request reaches the engine and
+   * succeeds (no priorities to clear in the mock setup).
+   */
+  @Test
+  public void setReplicationPriorityClearIgnoresBoost() throws InterruptedException, IOException {
+    PartitionId id = clusterMap.getWritablePartitionIds(DEFAULT_PARTITION_CLASS).get(0);
+    int correlationId = TestUtils.RANDOM.nextInt();
+    String clientId = TestUtils.getRandomString(10);
+    AdminRequest adminRequest =
+        new AdminRequest(AdminRequestOrResponseType.SetReplicationPriority, null, correlationId, clientId);
+    SetReplicationPriorityAdminRequest clearRequest =
+        new SetReplicationPriorityAdminRequest(Collections.singletonList(id), /*boost*/ 0, /*clear*/ true, adminRequest);
+    Response response = sendRequestGetResponse(clearRequest, ServerErrorCode.NoError);
+    assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
+    response.release();
+  }
+
+  /**
+   * Bulk set + engine aggregation: {@link ReplicationEngine#prioritizePartitions(List, int)}
+   * persists every listed partition on every {@link ReplicaThread}, and
+   * {@link ReplicationEngine#listAllPriorityPartitions()} walks every thread and surfaces them.
+   * Also pins the per-partition entry cardinality and the {@code isInterColo} tagging path.
+   */
+  @Test
+  public void prioritizePartitionsBulkPersistsAndListAggregates() {
+    List<? extends PartitionId> writable = clusterMap.getWritablePartitionIds(DEFAULT_PARTITION_CLASS);
+    assertTrue("Need >= 2 partitions for this test", writable.size() >= 2);
+    PartitionId p1 = writable.get(0);
+    PartitionId p2 = writable.get(1);
+    int boost = 4;
+    // Probe each partition's fan-out separately — placement could be asymmetric in principle.
+    int expectedP1 = probePartitionFanOut(p1, boost);
+    int expectedP2 = probePartitionFanOut(p2, boost);
+    assertTrue("p1 probe should produce at least one entry", expectedP1 >= 1);
+    assertTrue("p2 probe should produce at least one entry", expectedP2 >= 1);
+    try {
+      replicationManager.prioritizePartitions(Arrays.asList(p1, p2), boost);
+      List<ListReplicationPriorityAdminResponse.PriorityEntry> entries =
+          replicationManager.listAllPriorityPartitions();
+      // Bulk set on both partitions should produce the sum of each probe's count (priorities
+      // mirror across every thread that has the partition's replicas, so a regression that
+      // silently dropped one thread's entries would show up here).
+      assertEquals("entry cardinality should be sum of per-partition probes", expectedP1 + expectedP2, entries.size());
+      long p1Count = entries.stream().filter(e -> e.getPartitionId().equals(p1)).count();
+      long p2Count = entries.stream().filter(e -> e.getPartitionId().equals(p2)).count();
+      assertEquals("p1 entry count", expectedP1, p1Count);
+      assertEquals("p2 entry count", expectedP2, p2Count);
+      for (ListReplicationPriorityAdminResponse.PriorityEntry entry : entries) {
+        assertEquals("boost mismatch for " + entry, boost, entry.getBoost());
+      }
+      // Sanity: both isInterColo branches should be exercised because the engine mirrors priorities
+      // across intra-colo AND inter-colo thread pools.
+      boolean sawIntra = entries.stream().anyMatch(e -> !e.isInterColo());
+      boolean sawInter = entries.stream().anyMatch(ListReplicationPriorityAdminResponse.PriorityEntry::isInterColo);
+      assertTrue("expected at least one intra-colo entry", sawIntra);
+      assertTrue("expected at least one inter-colo entry", sawInter);
+    } finally {
+      replicationManager.clearPriorityPartitions(Collections.emptyList());
+    }
+    assertTrue("List should be empty after clear-all", replicationManager.listAllPriorityPartitions().isEmpty());
+  }
+
+  /**
+   * Empty partition list is a no-op: no entries get written and the LIST output stays empty.
+   */
+  @Test
+  public void prioritizePartitionsEmptyListIsNoOp() {
+    replicationManager.prioritizePartitions(Collections.emptyList(), 4);
+    assertTrue("Empty bulk set should not create entries",
+        replicationManager.listAllPriorityPartitions().isEmpty());
+  }
+
+  /**
+   * Set priority on a single partition, observe the resulting entry count (= number of threads
+   * holding the partition), then clear. Used to derive the expected fan-out without depending on
+   * cluster-map placement details.
+   */
+  private int probePartitionFanOut(PartitionId partition, int boost) {
+    try {
+      replicationManager.prioritizePartitions(Collections.singletonList(partition), boost);
+      return replicationManager.listAllPriorityPartitions().size();
+    } finally {
+      replicationManager.clearPriorityPartitions(Collections.emptyList());
+    }
   }
 
   /**

--- a/ambry-server/src/test/java/com/github/ambry/server/AmbryServerRequestsTest.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/AmbryServerRequestsTest.java
@@ -243,6 +243,7 @@ public class AmbryServerRequestsTest extends ReplicationTestHelper {
     properties.setProperty("server.validate.request.based.on.store.state",
         Boolean.toString(validateRequestOnStoreState));
     properties.setProperty("server.handle.undelete.request.enabled", Boolean.toString(handleUndeleteRequestEnabled));
+    properties.setProperty("server.handle.replication.priority.request.enabled", "true");
     properties.setProperty("clustermap.dcs.zk.connect.strings", zkJson.toString(2));
     properties.setProperty("num.io.threads", "1");
     properties.setProperty("queued.max.requests", "1");


### PR DESCRIPTION
## Summary

Design doc: [linkedin-multiproduct/AmbryLi#3485](https://github.com/linkedin-multiproduct/AmbryLi/pull/3485)

Adds an admin API for boosting a partition's per-cycle replication fetch budget, so operators can accelerate catch-up on selected partitions during recovery from a lag incident (e.g. ACTIONITEM-19683 / incident-10927). Server-side implementation only; the AmbryLI frontend REST endpoint + fan-out is a separate PR.

## What's in this PR

**Wire protocol** (additive, append-only enums)
- `AdminRequestOrResponseType.UpdateReplicationPriority`, `.ListReplicationPriority`
- `UpdateReplicationPriorityAdminRequest` — partition list + boost + `Action` (`SET` / `UNSET` / `UNSET_ALL`). Action has explicit wire values (`SET=0, UNSET=1, UNSET_ALL=2`) and `fromWireValue(short)` throws `IOException` on unknown inputs, so a reorder of the enum can't silently corrupt the wire format.
- `ListReplicationPriorityAdminRequest` / `ListReplicationPriorityAdminResponse` — response carries `(partitionId, boost, isInterColo)` per priority entry per `ReplicaThread`. `PriorityEntry` lives in `ambry-api` so all four priority methods sit on the `ReplicationAPI` interface as `default`-throws (no `instanceof ReplicationEngine` casts at call sites).
- `ReplicationEngine.listAllPriorityPartitions()` aggregates priorities across every thread, tagging each entry with its colo.

**Replication thread**
- `priorityPartitions: ConcurrentHashMap<PartitionId, Integer>` per thread, written by admin handlers and read once per cycle in `fillDataNodeTrackers` (snapshotted to avoid CME).
- `fillDataNodeTrackers` auto-prunes entries whose replicas in this thread are all `ACTIVE` and below the per-iteration lag threshold (`shouldAutoPrunePriority` predicate).
- Priority replicas split into singleton `ActiveGroupTracker`s with `weight = boost`; the per-cycle `baseFetchSize` is computed as `totalBudget / Σ(replicaCount × weight)` so the legacy per-thread budget is preserved.
- Existing intra-colo bootstrap branch in `createReplicaMetadataRequest` is preserved unchanged; the weight multiplier composes on top.

**Server**
- `AmbryServerRequests` admin handlers for the two new RPC types.
- **API gate**: `server.handle.replication.priority.request.enabled` (default `false`, mirrors the existing `server.handle.{undelete,force.delete}.request.enabled` gates). Both handlers reject with `BadRequest` + `warn` log when closed. Lets us ship the OSS binary to every fabric before the cfg2 flip enables the API per fabric, and remains as a per-fabric kill switch post-rollout. **Rollout sequence**: ship OSS → bump AmbryLI → flip cfg2 per fabric.
- **Validation at the handler boundary** (rejected with `BadRequest` before reaching the engine):
  - Partition list size cap: `UpdateReplicationPriorityAdminRequest.MAX_PARTITIONS_PER_REQUEST = 256`, enforced both at wire-deserialization and in the handler.
  - Defensive boost cap: `MAX_PRIORITY_BOOST = 1024` on the server (the precise wire-layer cap derived from HTTP/2 max-content-length is the frontend's job).
  - `Action`-aware partition-list shape: `SET`/`UNSET` require non-empty list, `UNSET_ALL` requires empty.
  - `SET` only: every partition must be hosted on this server (`ReplicationEngine.hostsPartition()`, O(1) via `partitionToPartitionInfo`); unknown partitions reject the whole request.
- Dedicated metric fields in `ServerMetrics` for both new types; `AmbryRequests` dispatch updated.

## Risk

- **Read-path only.** Touches replica-grouping shape and metadata-request `fetchSize` math. No write path, no schema, no atomicity boundary, no resource lifecycle, no callback semantics.
- **Default-off API gate.** Until cfg2 flips on a fabric, every request is rejected at the handler boundary — no engine-level state change is possible.
- **Wire protocol additions are enum-append.** Older servers reply with `UnknownError` per existing dispatcher behavior. `Action.fromWireValue` rejects unknown values on the wire.
- **`priorityPartitions` defaults empty** ⇒ chunking shape and fetchSize math are byte-identical to today on every thread until an operator sets a priority.
- **Concurrency**: `priorityPartitions` is a `ConcurrentHashMap`; the replication thread snapshots it once per cycle and works off the snapshot.

## Testing Done

- `RequestResponseTest` (extended): wire round-trip for `SET` / `UNSET` / `UNSET_ALL`, list-marker, list-response with mixed `isInterColo` values; new `updateReplicationPriorityActionWireValueRejectsUnknown` pins `IOException` for bad `Action` wire values (`-1, 3, Short.MAX_VALUE, Short.MIN_VALUE`).
- `DataNodeTrackerTest` (extended): 6 ctor cases for the priority chunking path — null/empty snapshot, single & multi priority, conservation invariant (every replica appears exactly once), group-id sequencing, orphan partitions.
- `ReplicaThreadPriorityAutoPruneTest` (new, 8 cases): `ACTIVE + lag < threshold ⇒ prune`; threshold boundary; one-lagging-replica blocks prune; `OFFLINE` with stale-low-lag must NOT prune (operator's bias persists across transient outage); any non-`ACTIVE` blocks; empty list returns false (self-defending predicate).
- `RemoteReplicaGroupPollerTest` (new):
  - `baseFetchSizeBudgetConservation` (3 cases) — pure-normal vs one-priority vs zero-replica; total cycle bytes ≤ no-priority budget.
  - `createReplicaMetadataRequestFetchSizeMath` (4 cases) — `weight × baseFetchSize` math, zero-base fallback, bootstrap intra-colo path composes with weight.
- `AmbryServerRequestsTest` (extended):
  - `updateReplicationPriorityRejectsBoostBelowOne` / `updateReplicationPriorityRejectsBoostAboveCap` — handler-layer boost validation.
  - `updateReplicationPriorityUnsetIgnoresBoost` — `UNSET` path skips boost validation.
  - `updateReplicationPriorityRejects*PartitionListShape` — `SET`/`UNSET` empty-list and `UNSET_ALL` non-empty-list rejections.
  - `updateReplicationPriorityRejectsPartitionsNotHostedOnThisServer` — `SET` on a partition not on this server rejects the whole request.
  - `updateReplicationPriorityRejectsOversizedPartitionList` — list-size cap defense.
  - `updateReplicationPriorityAcceptsUnsetAll` — wipe-all dispatches to engine.
  - `prioritizePartitionsBulkPersistsAndListAggregates` — bulk set + `listAllPriorityPartitions` walks every thread; pins per-partition cardinality + both `isInterColo` branches.
  - Test setup flips the new config gate on so the priority tests still exercise the handler path.
- Build: `JAVA_HOME=$(/usr/libexec/java_home -v 11) ./gradlew :ambry-replication:test :ambry-protocol:test :ambry-server:test --tests 'com.github.ambry.server.AmbryServerRequestsTest'` — all green.

## Observability / Ops

- Dedicated metrics: `UpdateReplicationPriorityRequestRate`, `UpdateReplicationPriorityRequestProcessingTimeInMs`, … (5 histograms + 1 rate + 1 dropped-rate per RPC type). Mirrors the pattern of every other admin type.
- Audit log: each successful `UpdateReplicationPriority` / `ListReplicationPriority` invocation logs `clientId` (+ action / boost / partitions for Update) at INFO so per-host operator actions are traceable. Rejections at the handler boundary log at WARN.

## AI Usage

Implementation and tests authored with Claude Code (Opus 4.7).
