### PR TITLE
Fix NPE in NettyResponseChannel when root cause exception has null message

### DIFF
--- a/ambry-rest/src/main/java/com/github/ambry/rest/NettyResponseChannel.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/NettyResponseChannel.java
@@ -589,9 +589,12 @@ class NettyResponseChannel implements RestResponseChannel {
       errorResponseStatus = ResponseStatus.getResponseStatus(restServiceErrorCode);
       status = getHttpResponseStatus(errorResponseStatus);
       if (shouldSendFailureReason(status, restServiceException)) {
-        errReason = new String(
-            Utils.getRootCause(cause).getMessage().replaceAll("[\n\t\r]", " ").getBytes(StandardCharsets.US_ASCII),
-            StandardCharsets.US_ASCII);
+        String rootMessage = Utils.getRootCause(cause).getMessage();
+        if (rootMessage != null) {
+          errReason = new String(
+              rootMessage.replaceAll("[\n\t\r]", " ").getBytes(StandardCharsets.US_ASCII),
+              StandardCharsets.US_ASCII);
+        }
       }
       if (restServiceException.shouldIncludeExceptionMetadataInResponse()) {
         errHeaders = restServiceException.getExceptionHeadersMap();

--- a/ambry-rest/src/test/java/com/github/ambry/rest/NettyResponseChannelTest.java
+++ b/ambry-rest/src/test/java/com/github/ambry/rest/NettyResponseChannelTest.java
@@ -463,6 +463,27 @@ public class NettyResponseChannelTest {
   }
 
   /**
+   * Tests that no NPE occurs when the root cause of a RestServiceException has a null message (e.g.,
+   * {@link java.util.concurrent.TimeoutException} created by {@link java.util.concurrent.CompletableFuture#orTimeout}).
+   */
+  @Test
+  public void setFailureReasonNullMessageNoNpeTest() throws Exception {
+    HttpRequest request =
+        createRequestWithHeaders(HttpMethod.GET, TestingUri.SetFailureReasonInResponseWithNullMessage.toString());
+    HttpUtil.setKeepAlive(request, false);
+
+    EmbeddedChannel channel = createEmbeddedChannel();
+    channel.writeInbound(request);
+
+    HttpResponse response = channel.readOutbound();
+    assertEquals(HttpResponseStatus.SERVICE_UNAVAILABLE, response.status());
+    // No FAILURE_REASON_HEADER when root cause message is null — no NPE should be thrown
+    assertFalse("Should not have failure reason header when root message is null",
+        response.headers().contains(NettyResponseChannel.FAILURE_REASON_HEADER));
+    assertFalse("Channel not closed on the server", channel.isActive());
+  }
+
+  /**
    * Sends null input to {@link NettyResponseChannel#setHeader(String, Object)} (through
    * {@link MockNettyMessageProcessor}) and tests for reaction.
    */
@@ -1340,6 +1361,11 @@ enum TestingUri {
    */
   SetFailureReasonInResponseWithException,
   /**
+   * When this request is received, a RestServiceException whose root cause has a null message is used on
+   * onResponseComplete. Verifies no NPE when the root cause message is null.
+   */
+  SetFailureReasonInResponseWithNullMessage,
+  /**
    * Catch all TestingUri.
    */
   Unknown;
@@ -1583,6 +1609,12 @@ class MockNettyMessageProcessor extends SimpleChannelInboundHandler<HttpObject> 
       case SetFailureReasonInResponseWithException:
         request.setArg(RestUtils.InternalKeys.SEND_FAILURE_REASON, Boolean.TRUE);
         restResponseChannel.onResponseComplete(new Exception(TestingUri.SetFailureReasonInResponse.toString()));
+        break;
+      case SetFailureReasonInResponseWithNullMessage:
+        request.setArg(RestUtils.InternalKeys.SEND_FAILURE_REASON, Boolean.TRUE);
+        // TimeoutException() with no message simulates CompletableFuture.orTimeout() behavior
+        restResponseChannel.onResponseComplete(new RestServiceException("outer message",
+            new TimeoutException(), RestServiceErrorCode.ServiceUnavailable));
         break;
     }
   }


### PR DESCRIPTION
# Problem & Solution Overview

`CompletableFuture.orTimeout()` constructs a `TimeoutException` with **no message** (`new TimeoutException()`). When this exception is the root cause of a `RestServiceException`, `Utils.getRootCause(cause).getMessage()` returns `null`, causing an NPE in `NettyResponseChannel.getErrorResponse()` at line 593.

This fires when `shouldSendFailureReason` returns true — i.e. when the request has `SEND_FAILURE_REASON=true` (set by `NamedBlobPutHandler`, `S3MultipartUploadPartHandler`, and `UndeleteHandler`). Any named blob PUT whose ID conversion times out will hit this path, logging a spurious NPE stack trace on top of the 503.

**Fix:** null-check the root cause message before using it. If null, `errReason` stays `null` and no `FAILURE_REASON_HEADER` is set — same behavior as when `shouldSendFailureReason` returns false.

# Testing Done
- Added `setFailureReasonNullMessageNoNpeTest` in `NettyResponseChannelTest`: wraps a bare `new TimeoutException()` (no message) inside a `RestServiceException` with `SEND_FAILURE_REASON=true`, sends through embedded channel, asserts 503 response with no NPE and no `FAILURE_REASON_HEADER`.
- Existing `setFailureReasonInResponseTest` still passes.

# Notes for Reviewers
Root cause of null message: `CompletableFuture.orTimeout()` JDK source calls `new TimeoutException()` with no string argument. The NPE only fires on the `shouldSendFailureReason=true` code path.

# Author Checklist
- [x] For significant code changes - code is LiX'ed and/or completely backwards compatible.
- [x] For added/changed user-exposed functionality - appropriate documentation has been added.
- [ ] If necessary, new metrics and/or alerts have been added.
- [x] If a high-risk change, I've articulated what to look out for in the sections above.