### PR TITLE
Gate named-blob 404->503 translation behind a config kill switch

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
@@ -130,6 +130,8 @@ public class RouterConfig {
   public static final String ROUTER_STORE_KEY_CONVERTER_FACTORY = "router.store.key.converter.factory";
   public static final String ROUTER_UNAVAILABLE_DUE_TO_OFFLINE_REPLICAS = "router.unavailable.due.to.offline.replicas";
   public static final String ROUTER_NOT_FOUND_CACHE_TTL_IN_MS = "router.not.found.cache.ttl.in.ms";
+  public static final String ROUTER_NAMED_BLOB_TRANSLATE_NOT_FOUND_TO_UNAVAILABLE_ENABLED =
+      "router.named.blob.translate.not.found.to.unavailable.enabled";
   public static final String ROUTER_UPDATE_OP_METADATA_RELIANCE_TIMESTAMP_IN_MS =
       "router.update.op.metadata.reliance.timestamp.in.ms";
   public static final String ROUTER_UNAVAILABLE_DUE_TO_SUCCESS_COUNT_IS_NON_ZERO_FOR_DELETE =
@@ -647,6 +649,17 @@ public class RouterConfig {
   @Default("15*1000")
   public final long routerNotFoundCacheTtlInMs;
 
+  /**
+   * If {@code true}, when a named blob's metadata row exists but storage replicas return
+   * {@link com.github.ambry.router.RouterErrorCode#BlobDoesNotExist}, the router translates the
+   * error to {@link com.github.ambry.router.RouterErrorCode#AmbryUnavailable} (retryable 503)
+   * instead of letting it surface as an authoritative 404. Acts as a kill switch for the
+   * behavior added in PR #3234 / AMBRY-14247.
+   */
+  @Config(ROUTER_NAMED_BLOB_TRANSLATE_NOT_FOUND_TO_UNAVAILABLE_ENABLED)
+  @Default("true")
+  public final boolean routerNamedBlobTranslateNotFoundToUnavailableEnabled;
+
   public static final String ROUTER_BLOB_METADATA_CACHE_ID = "router.blob.metadata.cache.id";
   @Config(ROUTER_BLOB_METADATA_CACHE_ID)
   public final String routerBlobMetadataCacheId;
@@ -935,6 +948,8 @@ public class RouterConfig {
         verifiableProperties.getString(OPERATION_CONTROLLER, "com.github.ambry.router.OperationController");
     routerNotFoundCacheTtlInMs = verifiableProperties.getLongInRange(ROUTER_NOT_FOUND_CACHE_TTL_IN_MS, 15 * 1000L, 0,
         ROUTER_NOT_FOUND_CACHE_MAX_TTL_IN_MS);
+    routerNamedBlobTranslateNotFoundToUnavailableEnabled =
+        verifiableProperties.getBoolean(ROUTER_NAMED_BLOB_TRANSLATE_NOT_FOUND_TO_UNAVAILABLE_ENABLED, true);
     routerUpdateOpMetadataRelianceTimestampInMs =
         verifiableProperties.getLong(ROUTER_UPDATE_OP_METADATA_RELIANCE_TIMESTAMP_IN_MS,
             DEFAULT_ROUTER_UPDATE_OP_METADATA_RELIANCE_TIMESTAMP_IN_MS);

--- a/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouter.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouter.java
@@ -351,6 +351,9 @@ public class NonBlockingRouter implements Router {
     if (e instanceof RouterException
         && ((RouterException) e).getErrorCode() == RouterErrorCode.BlobDoesNotExist) {
       routerMetrics.namedBlobMetadataExistsButStorageNotFoundCount.inc();
+      if (!routerConfig.routerNamedBlobTranslateNotFoundToUnavailableEnabled) {
+        return e;
+      }
       logger.warn("Named blob metadata exists but storage returned BlobNotFound for blob {}; "
           + "translating to AmbryUnavailable (retryable 503)", resolvedBlobId);
       return new RouterException(

--- a/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTest.java
@@ -1270,6 +1270,24 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
     }
   }
 
+  /** With the gating config disabled, storage NOT_FOUND surfaces as BlobDoesNotExist (no translation). */
+  @Test
+  public void testNamedBlobMissingInStorageNotTranslatedWhenConfigDisabled() throws Exception {
+    AtomicReference<String> storedBlobId = new AtomicReference<>();
+    Properties props = getNonBlockingRouterProperties(localDcName);
+    props.setProperty("router.named.blob.translate.not.found.to.unavailable.enabled", "false");
+    MockServerLayout layout = setUpNamedBlobAndPut(storedBlobId, props);
+    try {
+      layout.getMockServers().forEach(s -> s.setServerErrorForAllRequests(ServerErrorCode.BlobNotFound));
+      Assert.assertEquals(RouterErrorCode.BlobDoesNotExist,
+          ((RouterException) expectGetFailure("a", "c", "b").getCause()).getErrorCode());
+      // Metric still increments for observability even when translation is disabled.
+      Assert.assertEquals(1L, routerMetrics.namedBlobMetadataExistsButStorageNotFoundCount.getCount());
+    } finally {
+      if (router != null) { router.close(); assertClosed(); }
+    }
+  }
+
   /** Translation also fires when getBlobHelper short-circuits via the notFoundCache. */
   @Test
   public void testNamedBlobMissingViaNotFoundCacheStillTranslatedToAmbryUnavailable() throws Exception {
@@ -1288,6 +1306,12 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
   /** Wire a mock IdConverter, set up the router, PUT a named blob {@code /a/c/b}, and stub the
    *  GET-path {@code convert(RestRequest, String)} to return the resolved blob ID. */
   private MockServerLayout setUpNamedBlobAndPut(AtomicReference<String> storedBlobId) throws Exception {
+    return setUpNamedBlobAndPut(storedBlobId, getNonBlockingRouterProperties(localDcName));
+  }
+
+  /** Variant of {@link #setUpNamedBlobAndPut(AtomicReference)} that accepts custom router properties. */
+  private MockServerLayout setUpNamedBlobAndPut(AtomicReference<String> storedBlobId, Properties props)
+      throws Exception {
     CountDownLatch putLatch = new CountDownLatch(1);
     // Wire a mock IdConverterFactory + IdConverter.
     IdConverterFactory factory = mock(IdConverterFactory.class);
@@ -1308,8 +1332,7 @@ public class NonBlockingRouterTest extends NonBlockingRouterTestBase {
     });
     // Build the router with the mock factory.
     MockServerLayout layout = new MockServerLayout(mockClusterMap);
-    setRouterWithIdConverterFactory(getNonBlockingRouterProperties(localDcName), layout,
-        new LoggingNotificationSystem(), factory);
+    setRouterWithIdConverterFactory(props, layout, new LoggingNotificationSystem(), factory);
     // PUT a named blob /a/c/b, then wait for the convert mock to have run.
     setOperationParams();
     router.putBlob(createNamedBlobRestRequest(RestMethod.PUT, "a", "c", "b", false, false, false, false),


### PR DESCRIPTION
## Summary

PR #3234 (AMBRY-14247) changed the named-blob GET path to translate `BlobDoesNotExist` -> `AmbryUnavailable` (HTTP 503) when the named-blob metadata row exists but every storage replica returns `BlobNotFound`. The PR's own risk note flags potential retry-storm amplification on the inconsistency path, since the implicit 404 circuit-breaker is removed.

This adds a kill switch so the behavior can be disabled per-cluster without a code rollback.

- New config `router.named.blob.translate.not.found.to.unavailable.enabled` (default `true`, preserves current behavior).
- When `false`, `NonBlockingRouter.translateNamedBlobMissingInStorage` returns the original `BlobDoesNotExist` unchanged.
- The observability counter `namedBlobMetadataExistsButStorageNotFoundCount` still increments when the config is disabled so the underlying event rate remains visible during/after a rollback.

## Testing Done

- Added `testNamedBlobMissingInStorageNotTranslatedWhenConfigDisabled` which sets the config to `false`, drives storage to `BlobNotFound`, and asserts the surfaced error is `BlobDoesNotExist` while the counter still increments.
- Overloaded `setUpNamedBlobAndPut` to accept custom `Properties`; existing call sites unchanged.
- Existing three named-blob translation tests still pass under default config (`true`).
- Ran the full parameterized suite:
  ```
  ./gradlew :ambry-router:test --tests "com.github.ambry.router.NonBlockingRouterTest.testNamedBlob*"
  ```
  24 tests passed (4 parameterized configs x 6 tests).

## Risk

Default is unchanged behavior, so this is a no-op rollout. Setting the new flag to `false` restores the pre-#3234 behavior (404 surfaces to clients) on the inconsistency path only; the metric remains visible either way.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>