### PR TITLE
Fix option-4 empty-prefix LIST regression; add window-function LIST_ALL

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/frontend/NamedBlobPath.java
+++ b/ambry-api/src/main/java/com/github/ambry/frontend/NamedBlobPath.java
@@ -98,6 +98,15 @@ public class NamedBlobPath {
     path = path.startsWith("/") ? path.substring(1) : path;
     String[] splitPath = path.split("/", 4);
     String blobNamePrefix = RestUtils.getHeader(args, PREFIX_PARAM, false);
+    // S3 clients can send `prefix=` with no value, which is semantically equivalent to
+    // omitting the prefix entirely. Collapse the empty case to null so it routes to
+    // LIST_ALL_QUERY rather than LIST_WITH_PREFIX_SQL with `blob_name LIKE '%'`; under
+    // listNamedBlobsSQLOption=4 the latter produces a Window-over-full-container-scan
+    // plan that can exceed MAX_EXECUTION_TIME on large containers, while LIST_ALL_QUERY
+    // is purpose-built for the unbounded case.
+    if (blobNamePrefix != null && blobNamePrefix.isEmpty()) {
+      blobNamePrefix = null;
+    }
     boolean isBatchDelete = args.containsKey(BATCH_DELETE_QUERY_PARAM);
     boolean isGetObjectLockRequest = args.containsKey(OBJECT_LOCK_PARAM);
     // For S3 container-level operations, expected segments = 3

--- a/ambry-api/src/test/java/com/github/ambry/frontend/NamedBlobPathTest.java
+++ b/ambry-api/src/test/java/com/github/ambry/frontend/NamedBlobPathTest.java
@@ -108,4 +108,42 @@ public class NamedBlobPathTest {
       assertTrue(e.getMessage().contains("blob name"));
     }
   }
+
+  /**
+   * S3 clients can send `prefix=` with no value (an empty header). Semantically that's the same as
+   * omitting the prefix entirely. {@link NamedBlobPath#parseS3} must collapse it to null so the
+   * downstream {@code MySqlNamedBlobDb.run_list_v2} routes to LIST_ALL_QUERY instead of
+   * LIST_WITH_PREFIX_SQL with {@code blob_name LIKE '%'} (the latter produces a Window-over-full-scan
+   * plan under option 4 that can exceed MAX_EXECUTION_TIME on large containers).
+   */
+  @Test
+  public void testParseS3EmptyPrefixCollapsesToNull() throws Exception {
+    Map<String, Object> args = new HashMap<>();
+    args.put(RestUtils.InternalKeys.S3_REQUEST, "true");
+    args.put(RestUtils.InternalKeys.LIST_REQUEST, "true");
+    args.put(RestUtils.PREFIX_PARAM_NAME, "");
+    NamedBlobPath nbp = NamedBlobPath.parse("/named/account/container", args);
+    assertEquals("account", nbp.getAccountName());
+    assertEquals("container", nbp.getContainerName());
+    assertNull("Empty-string prefix should be normalized to null in parseS3", nbp.getBlobNamePrefix());
+  }
+
+  @Test
+  public void testParseS3OmittedPrefixIsNull() throws Exception {
+    Map<String, Object> args = new HashMap<>();
+    args.put(RestUtils.InternalKeys.S3_REQUEST, "true");
+    args.put(RestUtils.InternalKeys.LIST_REQUEST, "true");
+    NamedBlobPath nbp = NamedBlobPath.parse("/named/account/container", args);
+    assertNull("Omitted prefix should be null", nbp.getBlobNamePrefix());
+  }
+
+  @Test
+  public void testParseS3NonEmptyPrefixPreserved() throws Exception {
+    Map<String, Object> args = new HashMap<>();
+    args.put(RestUtils.InternalKeys.S3_REQUEST, "true");
+    args.put(RestUtils.InternalKeys.LIST_REQUEST, "true");
+    args.put(RestUtils.PREFIX_PARAM_NAME, "foo/");
+    NamedBlobPath nbp = NamedBlobPath.parse("/named/account/container", args);
+    assertEquals("foo/", nbp.getBlobNamePrefix());
+  }
 }

--- a/ambry-commons/src/main/java/com/github/ambry/commons/InMemNamedBlobDb.java
+++ b/ambry-commons/src/main/java/com/github/ambry/commons/InMemNamedBlobDb.java
@@ -100,14 +100,18 @@ public class InMemNamedBlobDb implements NamedBlobDb {
 
     TreeMap<String, List<NamedBlobRow>> allNamedBlobsInContainer = allRecords.get(accountName).get(containerName);
     NavigableMap<String, List<NamedBlobRow>> nextMap;
-    if (pageToken == null) {
+    if (pageToken != null) {
+      nextMap = allNamedBlobsInContainer.tailMap(pageToken, true);
+    } else if (blobNamePrefix != null) {
       nextMap = allNamedBlobsInContainer.tailMap(blobNamePrefix, true);
     } else {
-      nextMap = allNamedBlobsInContainer.tailMap(pageToken, true);
+      // No prefix and no continuation token: iterate all entries. Mirrors MySqlNamedBlobDb's
+      // LIST_ALL_QUERY path which is selected when blobNamePrefix == null.
+      nextMap = allNamedBlobsInContainer;
     }
     int numRecords = 0;
     for (Map.Entry<String, List<NamedBlobRow>> entry : nextMap.entrySet()) {
-      if (!entry.getKey().startsWith(blobNamePrefix)) {
+      if (blobNamePrefix != null && !entry.getKey().startsWith(blobNamePrefix)) {
         break;
       }
 

--- a/ambry-named-mysql/src/main/java/com/github/ambry/named/MySqlNamedBlobDb.java
+++ b/ambry-named-mysql/src/main/java/com/github/ambry/named/MySqlNamedBlobDb.java
@@ -114,28 +114,7 @@ public class MySqlNamedBlobDb implements NamedBlobDb {
           NAMED_BLOBS_V2, PK_MATCH, STATE_MATCH, VERSION);
 
   private final String LIST_WITH_PREFIX_SQL;
-
-  /**
-   * Similar like LIST_QUERY_V2, but this query is used when user don't provide the prefix and want to list all records.
-   */
-  // @formatter:off
-  private static final String LIST_ALL_QUERY = String.format(""
-      + "SELECT t1.blob_name, t1.blob_id, t1.version, t1.deleted_ts, t1.blob_size, t1.modified_ts "
-      + "FROM named_blobs_v2 t1 "
-      + "INNER JOIN "
-      + "(SELECT account_id, container_id, blob_name, max(version) as version "
-      + "FROM named_blobs_v2 "
-      + "WHERE (account_id, container_id) = (?, ?) AND %1$s "
-      + "  AND (deleted_ts IS NULL OR deleted_ts>%2$S) "
-      + "        GROUP BY account_id, container_id, blob_name) t2 "
-      + "ON (t1.account_id,t1.container_id,t1.blob_name,t1.version) = (t2.account_id,t2.container_id,t2.blob_name,t2.version) "
-      + "WHERE "
-      + "  CASE "
-      + "     WHEN ? IS NOT NULL THEN t1.blob_name >= ? "
-      + "     ELSE 1 "
-      + "   END "
-      + "ORDER BY t1.blob_name ASC LIMIT ?",STATE_MATCH, CURRENT_TIME);
-  // @formatter:on
+  private final String LIST_ALL_SQL;
 
   /**
    * Attempt to insert a new mapping into the database. The 'modified_ts' column in the DB will be auto-populated on
@@ -201,6 +180,7 @@ public class MySqlNamedBlobDb implements NamedBlobDb {
     this.accountService = accountService;
     this.config = config;
     this.LIST_WITH_PREFIX_SQL = getListWithPrefixSQLStatement(config);
+    this.LIST_ALL_SQL = getListAllSQLStatement(config);
     this.localDatacenter = localDatacenter;
     this.retryExecutor = new RetryExecutor(null);
     this.metricsRecoder = metricRecorder;
@@ -324,6 +304,81 @@ public class MySqlNamedBlobDb implements NamedBlobDb {
             + "    AND %1$s " // blob_state = x
             + "    AND blob_name LIKE ? " // 3
             + "    AND blob_name >= ? " // 4
+            + ") t "
+            + "WHERE version = max_version "
+            + "  AND (deleted_ts IS NULL OR deleted_ts > %2$s) "
+            + "ORDER BY blob_name "
+            + "LIMIT ?", STATE_MATCH, CURRENT_TIME); // 5
+        // @formatter:on
+      default:
+        throw new IllegalArgumentException("Invalid listNamedBlobsSQLOption: " + config.listNamedBlobsSQLOption);
+    }
+  }
+
+  /**
+   * Build the no-prefix LIST SQL. Selected by the same {@link MySqlNamedBlobDbConfig#listNamedBlobsSQLOption}
+   * knob as {@link #getListWithPrefixSQLStatement}. Options 2 and 3 share the legacy INNER-JOIN + MAX-grouped
+   * subquery shape; option 4 uses a window-function shape that mirrors LIST_WITH_PREFIX_SQL option 4.
+   *
+   * S3-handler change in linkedin/ambry#3260's follow-up normalizes empty-string prefix to null at the API
+   * layer, so any empty-prefix S3 LIST now arrives here. Option 4's LIST_WITH_PREFIX_SQL with
+   * {@code blob_name LIKE '%'} was the failure shape we are routing away from.
+   */
+  private String getListAllSQLStatement(MySqlNamedBlobDbConfig config) {
+    switch (config.listNamedBlobsSQLOption) {
+      case 2:
+      case 3:
+        /**
+         * Legacy no-prefix LIST.
+         * INNER JOIN against a MAX(version) GROUP BY subquery. Preserves the pre-option-4 behavior:
+         * the deleted_ts filter lives in the inner subquery, so a soft-deleted latest version is
+         * filtered out before MAX is computed — meaning the second-latest non-deleted version surfaces
+         * as the apparent "latest" for that blob. This semantic differs from LIST_WITH_PREFIX_SQL
+         * options 2/3/4 (which hide the blob entirely when its latest version is deleted), but is
+         * preserved here to avoid changing default behavior for fabrics still on option 2 or 3.
+         */
+        // @formatter:off
+        return String.format(""
+            + "SELECT t1.blob_name, t1.blob_id, t1.version, t1.deleted_ts, t1.blob_size, t1.modified_ts "
+            + "FROM named_blobs_v2 t1 "
+            + "INNER JOIN "
+            + "(SELECT account_id, container_id, blob_name, max(version) as version "
+            + "FROM named_blobs_v2 "
+            + "WHERE (account_id, container_id) = (?, ?) AND %1$s "
+            + "  AND (deleted_ts IS NULL OR deleted_ts>%2$S) "
+            + "        GROUP BY account_id, container_id, blob_name) t2 "
+            + "ON (t1.account_id,t1.container_id,t1.blob_name,t1.version) = (t2.account_id,t2.container_id,t2.blob_name,t2.version) "
+            + "WHERE "
+            + "  CASE "
+            + "     WHEN ? IS NOT NULL THEN t1.blob_name >= ? "
+            + "     ELSE 1 "
+            + "   END "
+            + "ORDER BY t1.blob_name ASC LIMIT ?", STATE_MATCH, CURRENT_TIME);
+        // @formatter:on
+      case 4:
+        /**
+         * No-prefix LIST, window-function variant. Single PK range scan over (account_id, container_id)
+         * with MAX(version) OVER (PARTITION BY blob_name); no INNER JOIN, no GROUP BY materialization.
+         *
+         * Correctness invariant — matches LIST_WITH_PREFIX_SQL option 4: deleted_ts predicate is applied
+         * on the OUTER select after the window operator, so a soft-deleted latest version causes the
+         * blob to be hidden entirely (rather than surfacing an older non-deleted version). This unifies
+         * the no-prefix and with-prefix LIST semantics under option 4. Operators flipping from option 3
+         * to option 4 inherit both the perf improvement and the consistent hide-latest-deleted semantic.
+         *
+         * Requires MySQL 8.0+ or TiDB (window function).
+         */
+        // @formatter:off
+        return String.format(""
+            + "SELECT blob_name, blob_id, version, deleted_ts, blob_size, modified_ts "
+            + "FROM ( "
+            + "  SELECT blob_name, blob_id, version, deleted_ts, blob_size, modified_ts, "
+            + "         MAX(version) OVER (PARTITION BY blob_name) AS max_version "
+            + "  FROM named_blobs_v2 "
+            + "  WHERE account_id = ? " // 1
+            + "    AND container_id = ? " // 2
+            + "    AND %1$s " // blob_state = x
+            + "    AND ( ? IS NULL OR blob_name >= ? ) " // 3, 4 (pageToken twice)
             + ") t "
             + "WHERE version = max_version "
             + "  AND (deleted_ts IS NULL OR deleted_ts > %2$s) "
@@ -807,7 +862,7 @@ public class MySqlNamedBlobDb implements NamedBlobDb {
   private Page<NamedBlobRecord> run_list_v2(String accountName, String containerName, String blobNamePrefix,
       String pageToken, short accountId, short containerId, Connection connection, Integer maxKeys) throws Exception {
     String query = "";
-    String queryStatement = blobNamePrefix == null ? LIST_ALL_QUERY : LIST_WITH_PREFIX_SQL;
+    String queryStatement = blobNamePrefix == null ? LIST_ALL_SQL : LIST_WITH_PREFIX_SQL;
     int maxKeysValue = maxKeys == null ? config.listMaxResults : maxKeys;
     try (PreparedStatement statement = connection.prepareStatement(queryStatement)) {
       if (blobNamePrefix == null) {


### PR DESCRIPTION
## Summary

Two related changes for the option-4 (window-function) LIST path introduced in #3260:

1. **`NamedBlobPath.parseS3`**: collapse empty-string `prefix` to `null`. S3 clients can send `prefix=` with no value, which is semantically equivalent to omitting the prefix entirely. Routing the empty case to `LIST_ALL_QUERY` avoids triggering `LIST_WITH_PREFIX_SQL` with `blob_name LIKE '%'`, which under option 4 produces a Window-over-full-container-scan plan that can exceed `MAX_EXECUTION_TIME` on large containers.
2. **`MySqlNamedBlobDb`**: gate `LIST_ALL_QUERY` behind the same `listNamedBlobsSQLOption` knob as `LIST_WITH_PREFIX_SQL`. Options 2/3 keep the existing INNER-JOIN + MAX-grouped subquery shape; option 4 adds a window-function variant matching the option-4 with-prefix plan shape and semantic.

Default `listNamedBlobsSQLOption` remains 2. Option 2 and 3 deployments are byte-identical to master.

## Motivation

After deploying option 4 (`#3260` shipped in `0.5.163`) downstream, a load/correctness suite failed `S3ListTests.testSuccessListObjectsEmptyPrefix` against a container with a substantial number of named blobs. All other S3 LIST tests passed including the prefix-filtering tests that directly exercise option 4's new SQL — the only failure was the empty-prefix case.

Tracing through the OSS code path: S3 `ListObjects` with explicit `prefix=""` arrives at `NamedBlobPath.parseS3` as `blobNamePrefix = ""` (not `null`), then through `NamedBlobListHandler.listRecursivelyInternal` into `MySqlNamedBlobDb.run_list_v2`:

```java
String queryStatement = blobNamePrefix == null ? LIST_ALL_QUERY : LIST_WITH_PREFIX_SQL;
```

`""` is not `null`, so the empty case routes to `LIST_WITH_PREFIX_SQL`. With `prefix=""`, the V4 binder produces parameters `("%", "")`, which under option 4 plans as:

- Single PK range scan over the entire `(account_id, container_id)` prefix
- `Window(MAX(version) OVER (PARTITION BY blob_name))` over the full result
- Outer `Selection` + `ORDER BY blob_name LIMIT N`

On a large enough container this exceeds a typical 5s `MAX_EXECUTION_TIME` server kill, returning 500 to the S3 SDK after 3 retries. Pre-#3260 with option 3, the same empty-prefix request also routed to `LIST_WITH_PREFIX_SQL` but used the correlated-subquery shape, whose per-row probe pattern apparently completed within the kill threshold on the same dataset.

The OSS integration matrix in #3260 (`MySqlNamedBlobDbListOperationIntegrationTest`) only exercises non-empty prefixes, so this unbounded-scan failure mode of option 4 was not caught upstream.

## What this PR changes

### `NamedBlobPath.parseS3`

```java
String blobNamePrefix = RestUtils.getHeader(args, PREFIX_PARAM, false);
+ if (blobNamePrefix != null && blobNamePrefix.isEmpty()) {
+   blobNamePrefix = null;
+ }
```

S3-only. Non-S3 callers (which use `isListRequest = blobNamePrefix != null` to detect a list request) are unchanged so they don't change list-request detection semantics.

### `MySqlNamedBlobDb.LIST_ALL_QUERY` → `LIST_ALL_SQL`

Convert from `static final` constant to an instance field initialized via `getListAllSQLStatement(config)`, mirroring the existing `LIST_WITH_PREFIX_SQL` pattern:

| Option | LIST_ALL SQL shape | Semantic |
|---|---|---|
| 2 or 3 | Existing INNER-JOIN + MAX-grouped subquery (preserved verbatim) | If latest version is soft-deleted, second-latest non-deleted surfaces |
| 4 | `MAX(version) OVER (PARTITION BY blob_name)` over single PK range scan, `deleted_ts` on OUTER select | If latest version is soft-deleted, blob is hidden entirely (matches LIST_WITH_PREFIX_SQL option 4) |

For option 2/3 deployments: **byte-identical SQL** to master. For option 4 deployments: get the window-function plan for both with-prefix and no-prefix paths, and a unified hide-latest-deleted semantic across the two paths.

### `InMemNamedBlobDb`

Handle `null` prefix to match `MySqlNamedBlobDb`'s `LIST_ALL_QUERY` path. Previously the in-memory test impl assumed non-null prefix and would NPE in `TreeMap.tailMap(null)` and `entry.getKey().startsWith(null)`. With parseS3 now normalizing empty to null, the in-memory impl needs the same null-tolerant branching.

## Compatibility

- Default `listNamedBlobsSQLOption` remains 2.
- Window function requires MySQL 8.0+ or TiDB. Already enforced by `MySqlNamedBlobDbConfig` for option 4 LIST_WITH_PREFIX; no new constraint here.
- The empty-prefix normalization is unconditional but only affects S3 callers that explicitly send `prefix=` empty.
- Option 4 deployments inherit a behavior change on the no-prefix LIST path: latest-deleted blobs now hide instead of surfacing the second-latest. This unifies the semantic between with-prefix and no-prefix LIST under option 4. Option 2/3 deployments are unaffected.

## Testing Done

- `./gradlew :ambry-api:compileJava :ambry-named-mysql:compileJava :ambry-named-mysql:compileTestJava :ambry-named-mysql:compileIntTestJava` → **BUILD SUCCESSFUL**.
- `./gradlew :ambry-api:test --tests com.github.ambry.frontend.NamedBlobPathTest` → **10/10 pass**, including 3 new cases:
  - `testParseS3EmptyPrefixCollapsesToNull`
  - `testParseS3OmittedPrefixIsNull`
  - `testParseS3NonEmptyPrefixPreserved`
- `./gradlew :ambry-named-mysql:test` → all unit tests pass.
- `./gradlew :ambry-frontend:test --tests S3ListHandlerTest` → 7/7 pass.
- `./gradlew :ambry-frontend:intTest --tests S3IntegrationTest` → 2/2 pass locally.
- The full integration matrix `MySqlNamedBlobDbListOperationIntegrationTest` already parameterizes over `listSqlOption ∈ {2, 3, 4}` and will exercise the new `LIST_ALL_SQL` variants on CI.

## Durability risk

Read-only LIST routing change. No write path, no schema, no atomicity, no callback semantics, no resource cleanup. No durability concern.