### PR TITLE
ci: restrict workflow token to read-only access

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -18,6 +18,10 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
+
+permissions:
+  contents: read
+
 jobs:
   # ============================================================
   # Per-group unit-test jobs.


### PR DESCRIPTION
Adds `permissions: contents: read` to the GitHub Actions CI workflow.

The workflow checks out the repository, builds with Gradle, and runs unit tests. It uploads coverage to Codecov using a separate API token but does not use the GITHUB_TOKEN for any write operations. Pinning the token to read-only limits the potential for misuse if any action in the pipeline were to be compromised.