### PR TITLE
Add SetReplicationPriority/ListReplicationPriority operations to ServerAdminTool

### DIFF
--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/UpdateReplicationPriorityAdminRequest.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/UpdateReplicationPriorityAdminRequest.java
@@ -48,6 +48,8 @@ public class UpdateReplicationPriorityAdminRequest extends AdminRequest {
   private static final short VERSION_V1 = 1;
   // Realistic priority lists are dozens, not hundreds.
   public static final int MAX_PARTITIONS_PER_REQUEST = 256;
+  // Defensive cap on the boost weight; the precise fetch-size-derived limit is enforced at the frontend.
+  public static final int MAX_PRIORITY_BOOST = 1024;
 
   /** The action this request performs. Wire values are explicit so reordering enum constants in code does not silently break the wire format. */
   public enum Action {

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryServerRequests.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryServerRequests.java
@@ -106,8 +106,6 @@ public class AmbryServerRequests extends AmbryRequests {
   private final DiskManagerConfig diskManagerConfig;
   private final StatsManager statsManager;
   private final ClusterParticipant clusterParticipant;
-  // Defensive cap; the precise wire-layer limit is enforced on the frontend.
-  private static final int MAX_PRIORITY_BOOST = 1024;
   private final ConcurrentHashMap<RequestOrResponseType, Set<PartitionId>> requestsDisableInfo =
       new ConcurrentHashMap<>();
   private final ObjectMapper objectMapper = JsonUtil.newObjectMapper();
@@ -684,9 +682,9 @@ public class AmbryServerRequests extends AmbryRequests {
       return new AdminResponse(correlationId, clientId, ServerErrorCode.BadRequest);
     }
     if (action == UpdateReplicationPriorityAdminRequest.Action.SET
-        && updateRequest.getBoost() > MAX_PRIORITY_BOOST) {
+        && updateRequest.getBoost() > UpdateReplicationPriorityAdminRequest.MAX_PRIORITY_BOOST) {
       logger.warn("Rejecting UpdateReplicationPriority clientId={} boost={} — exceeds cap={}",
-          clientId, updateRequest.getBoost(), MAX_PRIORITY_BOOST);
+          clientId, updateRequest.getBoost(), UpdateReplicationPriorityAdminRequest.MAX_PRIORITY_BOOST);
       return new AdminResponse(correlationId, clientId, ServerErrorCode.BadRequest);
     }
     if (action == UpdateReplicationPriorityAdminRequest.Action.SET) {

--- a/ambry-tools/src/main/java/com/github/ambry/tools/admin/ReplicationPriorityAdminHelper.java
+++ b/ambry-tools/src/main/java/com/github/ambry/tools/admin/ReplicationPriorityAdminHelper.java
@@ -65,13 +65,6 @@ public class ReplicationPriorityAdminHelper {
   private static final String CLIENT_ID = "ServerAdminTool";
   private static final Logger LOGGER = LoggerFactory.getLogger(ReplicationPriorityAdminHelper.class);
 
-  /**
-   * Defensive cap on the boost weight (the server enforces the precise fetch-size-derived limit). Mirrors,
-   * and must stay in sync with, the server's {@code AmbryServerRequests.MAX_PRIORITY_BOOST}.
-   */
-  @VisibleForTesting
-  static final int MAX_BOOST = 1024;
-
   private final ClusterMap clusterMap;
   private final Sender sender;
   private final AtomicInteger correlationId = new AtomicInteger(0);
@@ -151,8 +144,10 @@ public class ReplicationPriorityAdminHelper {
       if (empty) {
         throw new IllegalArgumentException("SET (clear=false) requires a non-empty partition list");
       }
-      if (boost < 1 || boost > MAX_BOOST) {
-        throw new IllegalArgumentException("boost must be in [1, " + MAX_BOOST + "] for SET; got " + boost);
+      if (boost < 1 || boost > UpdateReplicationPriorityAdminRequest.MAX_PRIORITY_BOOST) {
+        throw new IllegalArgumentException(
+            "boost must be in [1, " + UpdateReplicationPriorityAdminRequest.MAX_PRIORITY_BOOST + "] for SET; got "
+                + boost);
       }
       if (partitionIds.size() > UpdateReplicationPriorityAdminRequest.MAX_PARTITIONS_PER_REQUEST) {
         throw new IllegalArgumentException(
@@ -251,7 +246,13 @@ public class ReplicationPriorityAdminHelper {
     }
 
     if (!serversProvided) {
-      // servers omitted -> fan out to every fabric host hosting any requested partition.
+      // servers omitted -> every fabric host hosting a requested partition; reject if none do (e.g. a mistyped
+      // --fabric) rather than silently doing nothing.
+      if (fabricHostSubset.isEmpty()) {
+        throw new IllegalArgumentException(
+            "None of the requested partitions are hosted in fabric(s) " + fabricSet
+                + "; nothing to do (check --fabric and --partition.ids)");
+      }
       return fabricHostSubset;
     }
 
@@ -563,7 +564,10 @@ public class ReplicationPriorityAdminHelper {
     Map<DataNodeId, List<PriorityEntry>> hostEntries = new LinkedHashMap<>();
     Map<DataNodeId, String> failures = new LinkedHashMap<>();
     FanOutSummary summary = fanOut(hosts, "ListReplicationPriority", host -> {
-      List<PriorityEntry> entries = listReplicationPriority(host);
+      // A replica-less node (spare/draining) hosts no partitions, so it has no priorities. Report it as empty/OK
+      // rather than contacting it (which would surface a healthy node as an error).
+      List<PriorityEntry> entries =
+          clusterMap.getReplicaIds(host).isEmpty() ? Collections.emptyList() : listReplicationPriority(host);
       hostEntries.put(host, entries);
     }, failures);
     System.out.println(buildListResultJson(hosts, hostEntries, failures, partitionFilter, summary).toString(2));
@@ -737,6 +741,9 @@ public class ReplicationPriorityAdminHelper {
         buildUpdateRequest(partitionIds, boost, action, correlationId.incrementAndGet());
     PartitionId replicaResolutionPartition = resolveReplicaPartition(partitionIds);
     ResponseInfo response = sender.send(dataNodeId, replicaResolutionPartition, updateRequest);
+    if (response == null) {
+      throw new IOException("Null response from " + dataNodeId + " — possible network-layer failure");
+    }
     try {
       AdminResponse adminResponse = AdminResponse.readFrom(new NettyByteBufDataInputStream(response.content()));
       return adminResponse.getError();
@@ -760,6 +767,9 @@ public class ReplicationPriorityAdminHelper {
     ListReplicationPriorityAdminRequest listRequest = new ListReplicationPriorityAdminRequest(adminRequest);
     // Partition-agnostic request: pass null so getReplicaFromNode picks any replica on the node.
     ResponseInfo response = sender.send(dataNodeId, null, listRequest);
+    if (response == null) {
+      throw new IOException("Null response from " + dataNodeId + " — possible network-layer failure");
+    }
     try {
       ListReplicationPriorityAdminResponse adminResponse =
           ListReplicationPriorityAdminResponse.readFrom(new NettyByteBufDataInputStream(response.content()),

--- a/ambry-tools/src/main/java/com/github/ambry/tools/admin/ReplicationPriorityAdminHelper.java
+++ b/ambry-tools/src/main/java/com/github/ambry/tools/admin/ReplicationPriorityAdminHelper.java
@@ -1,0 +1,776 @@
+/**
+ * Copyright 2026 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.tools.admin;
+
+import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.clustermap.DataNodeId;
+import com.github.ambry.clustermap.PartitionId;
+import com.github.ambry.clustermap.ReplicaId;
+import com.github.ambry.network.ResponseInfo;
+import com.github.ambry.network.SendWithCorrelationId;
+import com.github.ambry.protocol.AdminRequest;
+import com.github.ambry.protocol.AdminRequestOrResponseType;
+import com.github.ambry.protocol.AdminResponse;
+import com.github.ambry.protocol.ListReplicationPriorityAdminRequest;
+import com.github.ambry.protocol.ListReplicationPriorityAdminResponse;
+import com.github.ambry.protocol.UpdateReplicationPriorityAdminRequest;
+import com.github.ambry.replication.PriorityEntry;
+import com.github.ambry.server.ServerErrorCode;
+import com.github.ambry.utils.NettyByteBufDataInputStream;
+import com.github.ambry.utils.Utils;
+import com.google.common.annotations.VisibleForTesting;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Performs the {@code SetReplicationPriority} and {@code ListReplicationPriority} admin operations on behalf of
+ * {@link ServerAdminTool}.
+ *
+ * <p>{@code SetReplicationPriority} marks a set of partitions as replication priorities — or clears them — so the
+ * receiving servers bias their replication scheduler toward those partitions until they catch up.
+ * {@code ListReplicationPriority} reports the priorities currently in effect. Both operations are scoped to a
+ * single fabric and fan out to the servers in that fabric that host the partitions (optionally narrowed to
+ * specific servers); a set/clear sends each host only the partitions it actually holds.
+ *
+ * <p>This class owns no network client: it resolves targets from the {@link ClusterMap}, builds the wire requests,
+ * and delegates the send to {@link ServerAdminTool} via the {@link Sender} interface. Per-host failures are
+ * isolated and reported rather than aborting the operation, and each operation's result is written as JSON to
+ * stdout.
+ */
+public class ReplicationPriorityAdminHelper {
+  private static final String CLIENT_ID = "ServerAdminTool";
+  private static final Logger LOGGER = LoggerFactory.getLogger(ReplicationPriorityAdminHelper.class);
+
+  /**
+   * Defensive cap on the boost weight (the server enforces the precise fetch-size-derived limit). Mirrors,
+   * and must stay in sync with, the server's {@code AmbryServerRequests.MAX_PRIORITY_BOOST}.
+   */
+  @VisibleForTesting
+  static final int MAX_BOOST = 1024;
+
+  private final ClusterMap clusterMap;
+  private final Sender sender;
+  private final AtomicInteger correlationId = new AtomicInteger(0);
+
+  /**
+   * The transport interface this helper uses to send a built request to a single host and receive the raw response.
+   * Implemented in production by {@code ServerAdminTool#sendRequestGetResponse}; the signature matches it exactly
+   * so a method reference satisfies it.
+   */
+  @FunctionalInterface
+  public interface Sender {
+    /**
+     * Sends {@code request} to {@code node} and returns the raw response.
+     * @param node the target {@link DataNodeId}.
+     * @param partitionForReplicaResolution the partition used only to pick a replica on the node; may be
+     *                                       {@code null} for partition-agnostic requests.
+     * @param request the request to send.
+     * @return the {@link ResponseInfo}.
+     * @throws TimeoutException if the response was not received in time.
+     */
+    ResponseInfo send(DataNodeId node, PartitionId partitionForReplicaResolution, SendWithCorrelationId request)
+        throws TimeoutException;
+  }
+
+  /**
+   * The per-host unit of work for {@link #fanOut}. A thrown checked exception is isolated to that host (counted as
+   * that host's failure) and does not abort the others. Both the set/clear and list paths supply a {@code work}
+   * lambda; the set path's lambda turns a non-{@code NoError} {@link ServerErrorCode} into an
+   * {@link IOException} so error-code and transport failures funnel through the same isolation.
+   */
+  @VisibleForTesting
+  @FunctionalInterface
+  interface HostWork {
+    /**
+     * Performs the per-host work.
+     * @param host the target host.
+     * @throws IOException on a transport/parse/server-error failure (isolated per host by {@link #fanOut}).
+     * @throws TimeoutException if the host did not respond in time (isolated per host by {@link #fanOut}).
+     */
+    void run(DataNodeId host) throws IOException, TimeoutException;
+  }
+
+  /**
+   * @param clusterMap the {@link ClusterMap} to resolve fabrics/hosts/partitions against.
+   * @param sender the transport interface used to send each built request.
+   */
+  public ReplicationPriorityAdminHelper(ClusterMap clusterMap, Sender sender) {
+    this.clusterMap = clusterMap;
+    this.sender = sender;
+  }
+
+  /**
+   * Derives the {@link UpdateReplicationPriorityAdminRequest.Action} from the {@code clear} flag and the
+   * partition list, validating the partition-list shape and {@code boost} against the same rules the
+   * server enforces. Pure function — no I/O — so every branch is unit-testable.
+   *
+   * <ul>
+   *   <li>{@code clear=false}, non-empty partitions → {@link UpdateReplicationPriorityAdminRequest.Action#SET}
+   *       (empty partitions rejected).</li>
+   *   <li>{@code clear=true}, non-empty partitions → {@link UpdateReplicationPriorityAdminRequest.Action#UNSET}.</li>
+   *   <li>{@code clear=true}, empty partitions → {@link UpdateReplicationPriorityAdminRequest.Action#UNSET_ALL}
+   *       (the "servers required, no partitions" case — the servers requirement is enforced separately in
+   *       {@link #resolveTargetHostPartitions}; the action itself is partition-agnostic).</li>
+   * </ul>
+   *
+   * @param clear whether this is a clear (unset) operation.
+   * @param partitionIds the partitions targeted (may be empty).
+   * @param boost the boost weight (only meaningful on the SET path).
+   * @return the resolved {@link UpdateReplicationPriorityAdminRequest.Action}.
+   * @throws IllegalArgumentException if the partition-list shape or boost is invalid for the action.
+   */
+  @VisibleForTesting
+  static UpdateReplicationPriorityAdminRequest.Action resolveAction(boolean clear, List<PartitionId> partitionIds,
+      int boost) {
+    boolean empty = partitionIds.isEmpty();
+    if (!clear) {
+      if (empty) {
+        throw new IllegalArgumentException("SET (clear=false) requires a non-empty partition list");
+      }
+      if (boost < 1 || boost > MAX_BOOST) {
+        throw new IllegalArgumentException("boost must be in [1, " + MAX_BOOST + "] for SET; got " + boost);
+      }
+      if (partitionIds.size() > UpdateReplicationPriorityAdminRequest.MAX_PARTITIONS_PER_REQUEST) {
+        throw new IllegalArgumentException(
+            "partition list size " + partitionIds.size() + " exceeds cap "
+                + UpdateReplicationPriorityAdminRequest.MAX_PARTITIONS_PER_REQUEST);
+      }
+      return UpdateReplicationPriorityAdminRequest.Action.SET;
+    }
+    // clear == true
+    if (empty) {
+      return UpdateReplicationPriorityAdminRequest.Action.UNSET_ALL;
+    }
+    if (partitionIds.size() > UpdateReplicationPriorityAdminRequest.MAX_PARTITIONS_PER_REQUEST) {
+      throw new IllegalArgumentException(
+          "partition list size " + partitionIds.size() + " exceeds cap "
+              + UpdateReplicationPriorityAdminRequest.MAX_PARTITIONS_PER_REQUEST);
+    }
+    return UpdateReplicationPriorityAdminRequest.Action.UNSET;
+  }
+
+  /**
+   * Resolves, for a fabric-scoped SET/UNSET/UNSET_ALL operation, the ordered map from each target host to the
+   * subset of the requested partitions that host actually carries. Priority ops are ALWAYS fabric-scoped:
+   * {@code fabrics} must be non-empty (an empty list is rejected). Pure function (reads only the
+   * {@link ClusterMap}) so it is unit-testable against a controlled cluster layout.
+   *
+   * <p>Why a per-host subset rather than the full list to every host: for SET, the server handler is
+   * all-or-nothing — it rejects the ENTIRE request with {@code BadRequest} if the receiving host does not
+   * carry every listed partition (see {@code AmbryServerRequests.handleUpdateReplicationPriorityRequest}'s
+   * {@code hostsPartition} check, which is gated on {@code action == SET}). Since Ambry spreads each partition
+   * across only a subset of nodes per datacenter, a host that carries {@code p1} but not {@code p2} would
+   * reject {@code {p1,p2}}. Sending each host only the partitions it hosts avoids those spurious rejections.
+   * For UNSET the server does NOT validate hosting, so this is not a server requirement there; we apply the
+   * same per-host subset deliberately as a harmless refinement (a host only clears priorities for partitions
+   * it actually carries; clearing a non-present one would be a no-op).
+   *
+   * <p>The {@code (action, servers)} combinations map as follows:
+   * <ul>
+   *   <li>SET / UNSET, {@code servers} empty: each replica-hosting node (in {@code fabrics}) of any listed
+   *       partition mapped to exactly the listed partitions it hosts (de-duplicated, first-seen order); hosts
+   *       with no hosted partition are omitted.</li>
+   *   <li>SET / UNSET, {@code servers} non-empty: same per-host subset, but restricted to the listed servers,
+   *       after validating each server is in the fabric(s) AND hosts at least one requested partition
+   *       (any failure rejects the whole request, no partial success).</li>
+   *   <li>UNSET_ALL ({@code servers} REQUIRED, no partitions): each listed server (validated in-fabric) mapped
+   *       to an empty list. An empty {@code servers} for UNSET_ALL is rejected.</li>
+   * </ul>
+   *
+   * @param clusterMap the {@link ClusterMap} to resolve against.
+   * @param fabrics the datacenter names to fan out to (REQUIRED — non-empty).
+   * @param servers the operator-supplied host narrowing (may be empty for SET/UNSET; REQUIRED for UNSET_ALL).
+   * @param partitionIds the partitions involved (empty for UNSET_ALL).
+   * @param action the resolved {@link UpdateReplicationPriorityAdminRequest.Action} (SET / UNSET / UNSET_ALL).
+   * @return an ordered map from target {@link DataNodeId} to the partitions to send that host.
+   * @throws IllegalArgumentException if {@code fabrics} is empty, a fabric is unknown, a listed server fails
+   *                                  validation, or UNSET_ALL is given with no servers.
+   */
+  @VisibleForTesting
+  static Map<DataNodeId, List<PartitionId>> resolveTargetHostPartitions(ClusterMap clusterMap, List<String> fabrics,
+      List<String> servers, List<PartitionId> partitionIds, UpdateReplicationPriorityAdminRequest.Action action) {
+    if (fabrics.isEmpty()) {
+      throw new IllegalArgumentException(
+          "--fabric is REQUIRED for SetReplicationPriority (no implicit cluster-wide default); specify the "
+              + "target fabric explicitly");
+    }
+    Set<String> fabricSet = validateAndCollectFabrics(clusterMap, fabrics);
+    boolean serversProvided = !servers.isEmpty();
+    Map<DataNodeId, List<PartitionId>> hostPartitions = new LinkedHashMap<>();
+
+    if (action == UpdateReplicationPriorityAdminRequest.Action.UNSET_ALL) {
+      // clear=true, partitions empty -> servers REQUIRED. No partition-hosting check (no partitions).
+      if (!serversProvided) {
+        throw new IllegalArgumentException(
+            "Clear with no partitions (UNSET_ALL) requires --servers; refusing to clear all priorities "
+                + "across whole fabric(s)");
+      }
+      for (String server : servers) {
+        DataNodeId node = resolveServerInFabrics(clusterMap, server, fabricSet);
+        hostPartitions.put(node, Collections.emptyList());
+      }
+      return hostPartitions;
+    }
+
+    // SET / UNSET. Build the per-host hosted-subset map over the fabric(s).
+    Map<DataNodeId, List<PartitionId>> fabricHostSubset = new LinkedHashMap<>();
+    for (PartitionId partitionId : partitionIds) {
+      for (ReplicaId replicaId : partitionId.getReplicaIds()) {
+        DataNodeId node = replicaId.getDataNodeId();
+        if (fabricSet.contains(node.getDatacenterName())) {
+          List<PartitionId> forHost = fabricHostSubset.computeIfAbsent(node, n -> new ArrayList<>());
+          if (!forHost.contains(partitionId)) {
+            forHost.add(partitionId);
+          }
+        }
+      }
+    }
+
+    if (!serversProvided) {
+      // servers omitted -> fan out to every fabric host hosting any requested partition.
+      return fabricHostSubset;
+    }
+
+    // servers provided -> validate each is in-fabric AND hosts at least one requested partition;
+    // ANY failure rejects the WHOLE request (no partial).
+    for (String server : servers) {
+      DataNodeId node = resolveServerInFabrics(clusterMap, server, fabricSet);
+      List<PartitionId> hosted = fabricHostSubset.get(node);
+      if (hosted == null || hosted.isEmpty()) {
+        throw new IllegalArgumentException(
+            "Server " + server + " hosts none of the requested partitions in the given fabric(s); whole request "
+                + "rejected (no partial success)");
+      }
+      hostPartitions.put(node, hosted);
+    }
+    return hostPartitions;
+  }
+
+  /**
+   * Resolves a single operator-supplied server hostname to its {@link DataNodeId}, validating that it exists
+   * and lives in one of the requested fabrics. Used by both the set/clear and list paths so the
+   * "server must be in fabric" rule is enforced uniformly.
+   * @param clusterMap the {@link ClusterMap} to resolve against.
+   * @param hostname the operator-supplied hostname.
+   * @param fabricSet the requested fabric(s).
+   * @return the resolved {@link DataNodeId}.
+   * @throws IllegalArgumentException if the host is unknown or not in any requested fabric.
+   */
+  private static DataNodeId resolveServerInFabrics(ClusterMap clusterMap, String hostname, Set<String> fabricSet) {
+    DataNodeId resolved = null;
+    for (DataNodeId node : clusterMap.getDataNodeIds()) {
+      if (node.getHostname().equals(hostname)) {
+        resolved = node;
+        break;
+      }
+    }
+    if (resolved == null) {
+      throw new IllegalArgumentException("Unknown server (no data node with hostname): " + hostname);
+    }
+    if (!fabricSet.contains(resolved.getDatacenterName())) {
+      throw new IllegalArgumentException(
+          "Server " + hostname + " is in fabric " + resolved.getDatacenterName() + ", not in the requested fabric(s) "
+              + fabricSet);
+    }
+    return resolved;
+  }
+
+  /**
+   * Resolves the set of target hosts for the partition-agnostic List operation. Unlike set/clear, List
+   * does NOT require {@code fabrics}: when both {@code fabrics} and {@code servers} are empty it fans out to
+   * EVERY host in the cluster. When {@code servers} is supplied it restricts to those hosts (validated against
+   * the requested fabric(s) if any were given, else any fabric). Pure function (reads only the
+   * {@link ClusterMap}) so it is unit-testable against a {@code MockClusterMap}.
+   *
+   * @param clusterMap the {@link ClusterMap} to resolve against.
+   * @param fabrics the datacenter names to scope to (optional; empty = whole cluster).
+   * @param servers the host narrowing (optional; empty = all hosts in scope).
+   * @return the de-duplicated list of target {@link DataNodeId}s, first-seen order.
+   * @throws IllegalArgumentException if a fabric is unknown, or a listed server is unknown / out of fabric scope.
+   */
+  @VisibleForTesting
+  static List<DataNodeId> resolveTargetHosts(ClusterMap clusterMap, List<String> fabrics, List<String> servers) {
+    Set<String> fabricSet = fabrics.isEmpty() ? allFabrics(clusterMap) : validateAndCollectFabrics(clusterMap, fabrics);
+    LinkedHashSet<DataNodeId> hosts = new LinkedHashSet<>();
+    if (!servers.isEmpty()) {
+      for (String server : servers) {
+        hosts.add(resolveServerInFabrics(clusterMap, server, fabricSet));
+      }
+      return new ArrayList<>(hosts);
+    }
+    for (DataNodeId node : clusterMap.getDataNodeIds()) {
+      if (fabricSet.contains(node.getDatacenterName())) {
+        hosts.add(node);
+      }
+    }
+    return new ArrayList<>(hosts);
+  }
+
+  /** Returns every datacenter (fabric) name present in the cluster map. */
+  private static Set<String> allFabrics(ClusterMap clusterMap) {
+    Set<String> dcs = new LinkedHashSet<>();
+    for (DataNodeId node : clusterMap.getDataNodeIds()) {
+      dcs.add(node.getDatacenterName());
+    }
+    return dcs;
+  }
+
+  /**
+   * Validates that every requested fabric exists in the cluster map and returns the fabric set (preserving
+   * the requested order).
+   * @param clusterMap the {@link ClusterMap} to resolve against.
+   * @param fabrics the requested datacenter names.
+   * @return the de-duplicated set of fabrics.
+   * @throws IllegalArgumentException if any requested fabric is not a known datacenter.
+   */
+  private static Set<String> validateAndCollectFabrics(ClusterMap clusterMap, List<String> fabrics) {
+    Set<String> knownDcs = new LinkedHashSet<>();
+    for (DataNodeId node : clusterMap.getDataNodeIds()) {
+      knownDcs.add(node.getDatacenterName());
+    }
+    for (String fabric : fabrics) {
+      if (!knownDcs.contains(fabric)) {
+        throw new IllegalArgumentException("Unknown fabric (datacenter): " + fabric + "; known: " + knownDcs);
+      }
+    }
+    return new LinkedHashSet<>(fabrics);
+  }
+
+  /**
+   * Parses the raw {@code partition.ids} config string into resolved {@link PartitionId}s. Comma-splitting,
+   * blank-token skipping, and per-token trimming are delegated to {@link Utils#splitString(String, String,
+   * java.util.function.Function, java.util.Collection)} (so stray/trailing commas and surrounding spaces do not
+   * produce a spurious "Partition Id is not valid" error). An unknown/unresolvable id is a hard error.
+   * @param partitionIdsRaw the raw comma-separated config value (the default-empty config {@code ""} yields an
+   *                        empty list).
+   * @param clusterMap the {@link ClusterMap} to resolve against.
+   * @return the resolved {@link PartitionId}s (possibly empty).
+   * @throws IllegalArgumentException if any non-blank token does not resolve to a known partition.
+   */
+  @VisibleForTesting
+  static List<PartitionId> parsePartitionIds(String partitionIdsRaw, ClusterMap clusterMap) {
+    List<PartitionId> partitionIds = new ArrayList<>();
+    for (String token : splitTrimmed(partitionIdsRaw)) {
+      partitionIds.add(ServerAdminTool.getPartitionIdFromStr(token, clusterMap));
+    }
+    return partitionIds;
+  }
+
+  /**
+   * Splits a raw comma-separated config value into trimmed, non-blank tokens via
+   * {@link Utils#splitString(String, String, java.util.function.Function, java.util.Collection)} (the filter
+   * trims each token and drops it if blank). The default-empty config {@code ""} yields an empty list.
+   * @param raw the raw comma-separated config value.
+   * @return the cleaned token list (possibly empty).
+   */
+  private static List<String> splitTrimmed(String raw) {
+    List<String> tokens = new ArrayList<>();
+    Utils.splitString(raw, ",", token -> {
+      String trimmed = token.trim();
+      return trimmed.isEmpty() ? null : trimmed;
+    }, tokens);
+    return tokens;
+  }
+
+  /**
+   * Drives a {@code SetReplicationPriority} operation: resolves the action and fabric-scoped target
+   * hosts (optionally narrowed by {@code servers}), enforces the {@code maxFanoutTotal} ceiling, fans the
+   * request out to each host (per-host failure does not abort the others), and prints the JSON result
+   * body to stdout. Admissibility failures (missing fabric, bad servers, boost out of range, fan-out cap
+   * exceeded, clear-with-neither) propagate as {@link IllegalArgumentException} so the caller exits non-zero
+   * WITHOUT printing a results body.
+   * @param partitionIdsRaw the raw {@code partition.ids} config value.
+   * @param boost the boost weight (only meaningful on the SET path).
+   * @param clear whether this is a clear (unset) operation.
+   * @param fabricConfig the raw single {@code fabric} config value.
+   * @param serversRaw the raw {@code servers} config value.
+   * @param maxFanoutTotal the configured {@code partitions × hosts} ceiling.
+   */
+  public void runSetReplicationPriority(String partitionIdsRaw, int boost, boolean clear, String fabricConfig,
+      String serversRaw, int maxFanoutTotal) {
+    List<PartitionId> partitionIds = parsePartitionIds(partitionIdsRaw, clusterMap);
+    UpdateReplicationPriorityAdminRequest.Action action = resolveAction(clear, partitionIds, boost);
+    List<String> fabrics = toFabricList(fabricConfig);
+    List<String> servers = splitTrimmed(serversRaw);
+    // Each host gets only the requested partitions it actually carries. For SET this avoids the server's
+    // all-or-nothing rejection; for UNSET the server doesn't validate hosting, so it's a harmless refinement.
+    Map<DataNodeId, List<PartitionId>> hostPartitions =
+        resolveTargetHostPartitions(clusterMap, fabrics, servers, partitionIds, action);
+    // maxFanoutTotal admission guard: partitions × resolvedHosts. UNSET_ALL carries no partitions, so its
+    // fan-out cost is one unit per host (each host clears its whole map in one request).
+    int partitionFactor = partitionIds.isEmpty() ? 1 : partitionIds.size();
+    checkMaxFanoutTotal(partitionFactor, hostPartitions.size(), maxFanoutTotal);
+    // boost is only meaningful for SET; for UNSET/UNSET_ALL the server ignores it, so don't log a misleading value.
+    String boostToken = action == UpdateReplicationPriorityAdminRequest.Action.SET ? "boost=" + boost : "boost=n/a";
+    LOGGER.info("SetReplicationPriority action={} {} partitions={} targeting {} host(s) (maxFanoutTotal={})", action,
+        boostToken, partitionIds, hostPartitions.size(), maxFanoutTotal);
+    Map<DataNodeId, String> failures = new LinkedHashMap<>();
+    FanOutSummary summary = fanOut(new ArrayList<>(hostPartitions.keySet()), action.toString(),
+        host -> sendSetForHost(host, hostPartitions.get(host), boost, action), failures);
+    System.out.println(buildSetResultJson(hostPartitions.keySet(), failures, summary).toString(2));
+  }
+
+  /**
+   * Sends a single host its {@code SET}/{@code UNSET}/{@code UNSET_ALL} request and converts a non-success
+   * {@link ServerErrorCode} into an {@link IOException} so {@link #fanOut} can treat error codes and transport
+   * failures uniformly (both count as that host's failure).
+   * @param host the target host.
+   * @param partitionsForHost the partitions to send this host (the subset it actually carries).
+   * @param boost the boost weight (only meaningful for {@code SET}).
+   * @param action the {@link UpdateReplicationPriorityAdminRequest.Action} to perform.
+   * @throws IOException on a transport/parse failure, or when the host returns a non-{@code NoError} code.
+   * @throws TimeoutException if the host did not respond in time.
+   */
+  private void sendSetForHost(DataNodeId host, List<PartitionId> partitionsForHost, int boost,
+      UpdateReplicationPriorityAdminRequest.Action action) throws IOException, TimeoutException {
+    ServerErrorCode errorCode = updateReplicationPriority(host, partitionsForHost, boost, action);
+    if (errorCode != ServerErrorCode.NoError) {
+      throw new IOException("ServerErrorCode: " + errorCode);
+    }
+  }
+
+  /**
+   * Builds the {@link UpdateReplicationPriorityAdminRequest} sent to a single host. The partition list, boost,
+   * and action are carried in the typed request body; the wrapping {@link AdminRequest} is built with a
+   * {@code null} partition (the server reads partitions from the typed body, not the header). Pure function so
+   * the wire-request shape is unit-testable without a network.
+   * @param partitionIds the partitions to operate on (empty for {@code UNSET_ALL}).
+   * @param boost the boost weight (only meaningful for {@code SET}).
+   * @param action the {@link UpdateReplicationPriorityAdminRequest.Action} to perform.
+   * @param correlationId the correlation id for the wrapping {@link AdminRequest}.
+   * @return the constructed {@link UpdateReplicationPriorityAdminRequest}.
+   */
+  @VisibleForTesting
+  static UpdateReplicationPriorityAdminRequest buildUpdateRequest(List<PartitionId> partitionIds, int boost,
+      UpdateReplicationPriorityAdminRequest.Action action, int correlationId) {
+    AdminRequest adminRequest =
+        new AdminRequest(AdminRequestOrResponseType.UpdateReplicationPriority, null, correlationId, CLIENT_ID);
+    return new UpdateReplicationPriorityAdminRequest(partitionIds, boost, action, adminRequest);
+  }
+
+  /**
+   * Chooses which partition (if any) to use for replica resolution when sending to a single host. For a
+   * single-partition list the replica is resolved precisely; otherwise (UNSET_ALL / multi-partition) any
+   * replica on the node is fine since the request is not bound to one partition, so {@code null} is returned
+   * and {@code getReplicaFromNode} picks any replica on the node. Pure function so it is unit-testable.
+   * @param partitionIds the partitions in the request (may be empty).
+   * @return the single partition to resolve against, or {@code null} for the empty/multi-partition cases.
+   */
+  @VisibleForTesting
+  static PartitionId resolveReplicaPartition(List<PartitionId> partitionIds) {
+    return partitionIds.size() == 1 ? partitionIds.get(0) : null;
+  }
+
+  /**
+   * Runs {@code work} against each host, isolating per-host failures: one host's thrown {@link IOException} or
+   * {@link TimeoutException} does not abort the others. Records each failing host's error message in
+   * {@code failures} (insertion-ordered) so the caller can emit the per-host {@code status:"error"} JSON, and
+   * returns the {@code requested/succeeded/failed} counts. Used by both the set/clear path (whose {@code work}
+   * lambda turns a non-{@code NoError} {@link ServerErrorCode} into an {@link IOException}) and the list path.
+   * @param hosts the target hosts, in fan-out order.
+   * @param operationName the operation name (for logging only).
+   * @param work the per-host unit of work (a thrown exception counts as a failure for that host only).
+   * @param failures populated with each failing host's error message.
+   * @return the {@link FanOutSummary} of the fan-out.
+   */
+  @VisibleForTesting
+  static FanOutSummary fanOut(List<DataNodeId> hosts, String operationName, HostWork work,
+      Map<DataNodeId, String> failures) {
+    int succeeded = 0;
+    for (DataNodeId host : hosts) {
+      try {
+        work.run(host);
+        succeeded++;
+        LOGGER.info("{}: {} succeeded", host, operationName);
+      } catch (Exception e) {
+        // Deliberately broad: this is the per-host failure-isolation boundary, so it must catch EVERY way a
+        // single host can fail without aborting the others. That includes the checked IOException/TimeoutException
+        // the work lambdas declare AND unchecked failures from the transport — notably the unreachable/errored-host
+        // case, where ServerAdminTool.sendRequestGetResponse throws an unchecked IllegalStateException. The
+        // narrow-exception guideline does not apply here precisely because the contract is "isolate any per-host
+        // failure".
+        failures.put(host, e.getClass().getSimpleName() + ": " + e.getMessage());
+        LOGGER.error("{}: {} failed", host, operationName, e);
+      }
+    }
+    return new FanOutSummary(hosts.size(), succeeded);
+  }
+
+  /** Immutable summary of a per-host fan-out: how many hosts were targeted, succeeded, and failed. */
+  @VisibleForTesting
+  static final class FanOutSummary {
+    final int requested;
+    final int succeeded;
+    final int failed;
+
+    FanOutSummary(int requested, int succeeded) {
+      this.requested = requested;
+      this.succeeded = succeeded;
+      this.failed = requested - succeeded;
+    }
+  }
+
+  /**
+   * Drives a {@code ListReplicationPriority} operation: resolves target hosts (every host in the
+   * cluster, or the {@code fabric}/{@code servers}-scoped subset — {@code fabric} is NOT required for
+   * list), enforces the {@code maxFanoutTotal} ceiling against the resolved host count (list is
+   * partition-agnostic, so the partition factor is 1), queries each (per-host failure does not abort the
+   * others), applies the optional {@code partition.ids} filter, and prints the JSON response body to stdout.
+   * @param partitionIdsRaw the raw {@code partition.ids} config value (optional post-fan-out filter).
+   * @param fabricConfig the raw single {@code fabric} config value (optional scope).
+   * @param serversRaw the raw {@code servers} config value (optional scope).
+   * @param maxFanoutTotal the configured host-count ceiling (an unscoped whole-cluster list above this is
+   *                       rejected before any host is contacted).
+   */
+  public void runListReplicationPriority(String partitionIdsRaw, String fabricConfig, String serversRaw,
+      int maxFanoutTotal) {
+    List<String> fabrics = toFabricList(fabricConfig);
+    List<String> servers = splitTrimmed(serversRaw);
+    List<DataNodeId> hosts = resolveTargetHosts(clusterMap, fabrics, servers);
+    // List is partition-agnostic, so its fan-out cost is one unit per host. Guard against an unscoped
+    // whole-cluster list contacting every node above the cap.
+    checkMaxFanoutTotal(1, hosts.size(), maxFanoutTotal);
+    // Optional partition filter applied at the tool after fan-out. Empty = no filter.
+    Set<PartitionId> partitionFilter = new LinkedHashSet<>(parsePartitionIds(partitionIdsRaw, clusterMap));
+    LOGGER.info("ListReplicationPriority targeting {} host(s){}", hosts.size(),
+        partitionFilter.isEmpty() ? "" : " (filtering to partitions=" + partitionFilter + ")");
+
+    // Per-host outcome accumulators, kept in fan-out order for a stable JSON results[] array.
+    Map<DataNodeId, List<PriorityEntry>> hostEntries = new LinkedHashMap<>();
+    Map<DataNodeId, String> failures = new LinkedHashMap<>();
+    FanOutSummary summary = fanOut(hosts, "ListReplicationPriority", host -> {
+      List<PriorityEntry> entries = listReplicationPriority(host);
+      hostEntries.put(host, entries);
+    }, failures);
+    System.out.println(buildListResultJson(hosts, hostEntries, failures, partitionFilter, summary).toString(2));
+  }
+
+  /**
+   * Builds the set/clear JSON response body: {@code {summary:{requested,succeeded,failed}, results:[...]}}.
+   * Each host appears once in {@code results}; a host in {@code failures} gets {@code status:"error"} with its
+   * {@code error} message, otherwise {@code status:"ok"}. Pure function so the shape is unit-testable.
+   * @param hosts the hosts that were targeted (insertion order preserved for stable output).
+   * @param failures per-host error messages for the hosts that failed.
+   * @param summary the {@link FanOutSummary} counts.
+   * @return the assembled {@link JSONObject}.
+   */
+  @VisibleForTesting
+  static JSONObject buildSetResultJson(Set<DataNodeId> hosts, Map<DataNodeId, String> failures,
+      FanOutSummary summary) {
+    JSONObject root = new JSONObject();
+    JSONObject summaryJson = new JSONObject();
+    summaryJson.put("requested", summary.requested);
+    summaryJson.put("succeeded", summary.succeeded);
+    summaryJson.put("failed", summary.failed);
+    root.put("summary", summaryJson);
+    JSONArray results = new JSONArray();
+    for (DataNodeId host : hosts) {
+      JSONObject hostJson = new JSONObject();
+      hostJson.put("host", host.getHostname());
+      String error = failures.get(host);
+      if (error == null) {
+        hostJson.put("status", "ok");
+      } else {
+        hostJson.put("status", "error");
+        hostJson.put("error", error);
+      }
+      results.put(hostJson);
+    }
+    root.put("results", results);
+    return root;
+  }
+
+  /**
+   * Builds the list JSON response body:
+   * {@code {summary:{queriedHosts,hostsWithPriorities,uniquePartitions}, partitions:[...], servers:[...],
+   * results:[{host,status,priorities:[{partitionId,boost,interColo}]}|{host,status:error,error}]}}.
+   * The server returns one {@link PriorityEntry} per ReplicaThread holding the partition, so a partition can
+   * legitimately appear multiple times on one host (e.g. one intra-colo entry with {@code interColo=false} and
+   * one or more inter-colo entries with {@code interColo=true}); each entry is emitted as its own row in the
+   * order the server returned them, never collapsed. {@code partitions} is the dedup of DISTINCT partition ids
+   * across hosts (a partition counts once even if it has both an intra and an inter entry); {@code servers} is
+   * the hosts whose (post-filter) priority list is non-empty; error hosts are excluded from both derived lists
+   * but appear in {@code results} with {@code status:"error"}. Pure function so the shape is unit-testable.
+   * @param hosts the queried hosts, in fan-out order.
+   * @param hostEntries the raw per-host entries returned (absent for hosts that errored).
+   * @param failures per-host error messages for hosts that failed.
+   * @param partitionFilter the optional partition filter (empty = keep all).
+   * @param summary the {@link FanOutSummary} counts.
+   * @return the assembled {@link JSONObject}.
+   */
+  @VisibleForTesting
+  static JSONObject buildListResultJson(List<DataNodeId> hosts, Map<DataNodeId, List<PriorityEntry>> hostEntries,
+      Map<DataNodeId, String> failures, Set<PartitionId> partitionFilter, FanOutSummary summary) {
+    JSONArray results = new JSONArray();
+    Set<Long> uniquePartitions = new LinkedHashSet<>();
+    List<String> serversWithPriorities = new ArrayList<>();
+    int hostsWithPriorities = 0;
+    for (DataNodeId host : hosts) {
+      JSONObject hostJson = new JSONObject();
+      hostJson.put("host", host.getHostname());
+      String error = failures.get(host);
+      if (error != null) {
+        hostJson.put("status", "error");
+        hostJson.put("error", error);
+        results.put(hostJson);
+        continue;
+      }
+      hostJson.put("status", "ok");
+      JSONArray priorities = new JSONArray();
+      for (PriorityEntry entry : hostEntries.getOrDefault(host, Collections.emptyList())) {
+        PartitionId partitionId = entry.getPartitionId();
+        if (!partitionFilter.isEmpty() && !partitionFilter.contains(partitionId)) {
+          continue;
+        }
+        JSONObject rowJson = new JSONObject();
+        rowJson.put("partitionId", partitionId.getId());
+        rowJson.put("boost", entry.getBoost());
+        rowJson.put("interColo", entry.isInterColo());
+        priorities.put(rowJson);
+        uniquePartitions.add(partitionId.getId());
+      }
+      hostJson.put("priorities", priorities);
+      results.put(hostJson);
+      if (priorities.length() > 0) {
+        hostsWithPriorities++;
+        serversWithPriorities.add(host.getHostname());
+      }
+    }
+    JSONObject root = new JSONObject();
+    JSONObject summaryJson = new JSONObject();
+    summaryJson.put("queriedHosts", summary.requested);
+    summaryJson.put("hostsWithPriorities", hostsWithPriorities);
+    summaryJson.put("uniquePartitions", uniquePartitions.size());
+    root.put("summary", summaryJson);
+    JSONArray partitionsJson = new JSONArray();
+    for (Long partition : uniquePartitions) {
+      partitionsJson.put(partition.longValue());
+    }
+    root.put("partitions", partitionsJson);
+    JSONArray serversJson = new JSONArray();
+    for (String server : serversWithPriorities) {
+      serversJson.put(server);
+    }
+    root.put("servers", serversJson);
+    root.put("results", results);
+    return root;
+  }
+
+  /**
+   * Enforces the {@code maxFanoutTotal} ceiling: rejects if {@code partitionFactor × resolvedHosts}
+   * exceeds the cap, BEFORE any host is contacted.
+   * @param partitionFactor the per-host partition multiplier (partition count, or 1 for UNSET_ALL / list).
+   * @param resolvedHosts the number of hosts the request resolved to.
+   * @param maxFanoutTotal the configured ceiling.
+   * @throws IllegalArgumentException if the product exceeds {@code maxFanoutTotal}.
+   */
+  @VisibleForTesting
+  static void checkMaxFanoutTotal(int partitionFactor, int resolvedHosts, int maxFanoutTotal) {
+    long total = (long) partitionFactor * resolvedHosts;
+    if (total > maxFanoutTotal) {
+      throw new IllegalArgumentException(
+          "partitions × resolvedHosts = " + partitionFactor + " × " + resolvedHosts + " = " + total
+              + " exceeds maxFanoutTotal=" + maxFanoutTotal + "; raise --max.fanout.total to override");
+    }
+  }
+
+  /**
+   * Converts the raw single {@code fabric} config value into a clean list: trimmed and (if non-blank)
+   * wrapped in a singleton list so the downstream list-based resolvers still apply the "fabric required",
+   * "fabric must be a known DC", and "server must be in fabric" rules. Only one fabric may be specified per
+   * invocation (scope/blast-radius control), so a comma-separated value is rejected. A blank value yields an
+   * empty list (no fabric scope). Genuinely unknown fabrics are still rejected downstream in
+   * {@link #resolveTargetHostPartitions} / {@link #resolveTargetHosts}.
+   * @param fabric the raw config value (a single fabric name, or empty).
+   * @return the cleaned single-element fabric list, or empty if no fabric was given.
+   * @throws IllegalArgumentException if {@code fabric} contains a comma (more than one fabric requested).
+   */
+  @VisibleForTesting
+  static List<String> toFabricList(String fabric) {
+    if (fabric.contains(",")) {
+      throw new IllegalArgumentException(
+          "only one fabric may be specified per invocation; run one fabric at a time (got: " + fabric + ")");
+    }
+    String trimmed = fabric.trim();
+    return trimmed.isEmpty() ? Collections.emptyList() : Collections.singletonList(trimmed);
+  }
+
+  /**
+   * Sends an {@link UpdateReplicationPriorityAdminRequest} to {@code dataNodeId}. The partition list, boost,
+   * and action are carried in the typed request body; the wrapping {@link AdminRequest} is built with a
+   * {@code null} partition (the server reads partitions from the typed body, not the header).
+   * @param dataNodeId the {@link DataNodeId} to contact.
+   * @param partitionIds the partitions to operate on (empty for {@code UNSET_ALL}).
+   * @param boost the boost weight (only meaningful for {@code SET}).
+   * @param action the {@link UpdateReplicationPriorityAdminRequest.Action} to perform.
+   * @return the {@link ServerErrorCode} that is returned.
+   * @throws IOException if the response could not be read or parsed.
+   * @throws TimeoutException if the host did not respond in time.
+   */
+  private ServerErrorCode updateReplicationPriority(DataNodeId dataNodeId, List<PartitionId> partitionIds, int boost,
+      UpdateReplicationPriorityAdminRequest.Action action) throws IOException, TimeoutException {
+    UpdateReplicationPriorityAdminRequest updateRequest =
+        buildUpdateRequest(partitionIds, boost, action, correlationId.incrementAndGet());
+    PartitionId replicaResolutionPartition = resolveReplicaPartition(partitionIds);
+    ResponseInfo response = sender.send(dataNodeId, replicaResolutionPartition, updateRequest);
+    try {
+      AdminResponse adminResponse = AdminResponse.readFrom(new NettyByteBufDataInputStream(response.content()));
+      return adminResponse.getError();
+    } finally {
+      response.release();
+    }
+  }
+
+  /**
+   * Sends a {@link ListReplicationPriorityAdminRequest} to {@code dataNodeId} and returns the priority
+   * snapshot held by the host's replication engine.
+   * @param dataNodeId the {@link DataNodeId} to contact.
+   * @return the list of {@link PriorityEntry}s the host reports.
+   * @throws IOException if the response could not be read or parsed, or the host returned a server error.
+   * @throws TimeoutException if the host did not respond in time.
+   */
+  private List<PriorityEntry> listReplicationPriority(DataNodeId dataNodeId) throws IOException, TimeoutException {
+    AdminRequest adminRequest =
+        new AdminRequest(AdminRequestOrResponseType.ListReplicationPriority, null, correlationId.incrementAndGet(),
+            CLIENT_ID);
+    ListReplicationPriorityAdminRequest listRequest = new ListReplicationPriorityAdminRequest(adminRequest);
+    // Partition-agnostic request: pass null so getReplicaFromNode picks any replica on the node.
+    ResponseInfo response = sender.send(dataNodeId, null, listRequest);
+    try {
+      ListReplicationPriorityAdminResponse adminResponse =
+          ListReplicationPriorityAdminResponse.readFrom(new NettyByteBufDataInputStream(response.content()),
+              clusterMap);
+      ServerErrorCode errorCode = adminResponse.getError();
+      if (errorCode != ServerErrorCode.NoError) {
+        throw new IOException("ListReplicationPriority from " + dataNodeId + " returned server error " + errorCode);
+      }
+      return adminResponse.getEntries();
+    } finally {
+      response.release();
+    }
+  }
+}

--- a/ambry-tools/src/main/java/com/github/ambry/tools/admin/ServerAdminTool.java
+++ b/ambry-tools/src/main/java/com/github/ambry/tools/admin/ServerAdminTool.java
@@ -317,8 +317,11 @@ public class ServerAdminTool implements Closeable {
       numReplicasCaughtUpPerPartition =
           verifiableProperties.getShortInRange("num.replicas.caught.up.per.partition", Short.MAX_VALUE, (short) 0,
               Short.MAX_VALUE);
-      storeControlRequestType =
-          BlobStoreControlAction.valueOf(verifiableProperties.getString("store.control.request.type", "StartStore"));
+      // Required for BlobStoreControl (defaulting it could silently start stores the operator didn't intend);
+      // other ops ignore it, so default it there to avoid failing config construction over an unrelated key.
+      storeControlRequestType = BlobStoreControlAction.valueOf(typeOfOperation == Operation.BlobStoreControl
+          ? verifiableProperties.getString("store.control.request.type")
+          : verifiableProperties.getString("store.control.request.type", "StartStore"));
       boost = verifiableProperties.getInt("boost", 2);
       clear = verifiableProperties.getBoolean("clear", false);
       fabric = verifiableProperties.getString("fabric", "");

--- a/ambry-tools/src/main/java/com/github/ambry/tools/admin/ServerAdminTool.java
+++ b/ambry-tools/src/main/java/com/github/ambry/tools/admin/ServerAdminTool.java
@@ -88,6 +88,7 @@ import org.slf4j.LoggerFactory;
  * 2. Triggering of compaction of a particular partition on a particular node.
  * 3. Get catchup status of peers for a particular blob.
  * 4. Stop/Start a particular blob store via BlobStoreControl operation.
+ * 5. Set/clear/list replication priority for partitions across whole fabrics.
  */
 public class ServerAdminTool implements Closeable {
   private static final int POLL_TIMEOUT_MS = 10;
@@ -113,7 +114,9 @@ public class ServerAdminTool implements Closeable {
     RequestControl,
     ReplicationControl,
     CatchupStatus,
-    BlobStoreControl
+    BlobStoreControl,
+    SetReplicationPriority,
+    ListReplicationPriority
   }
 
   /**
@@ -239,6 +242,52 @@ public class ServerAdminTool implements Closeable {
     final BlobStoreControlAction storeControlRequestType;
 
     /**
+     * The fetchSize weight to apply to each listed partition when setting replication priority.
+     * Applicable for: SetReplicationPriority (when {@code clear=false}).
+     */
+    @Config("boost")
+    @Default("2")
+    final int boost;
+
+    /**
+     * If {@code true}, clears (unsets) replication priority instead of setting it. With a non-empty
+     * partition list this unsets only those partitions; with an empty partition list it wipes ALL
+     * priorities on the target host(s).
+     * Applicable for: SetReplicationPriority
+     */
+    @Config("clear")
+    @Default("false")
+    final boolean clear;
+
+    /**
+     * The single datacenter (fabric) name to scope the operation to (one fabric per invocation, for
+     * scope/blast-radius control). REQUIRED for {@code SetReplicationPriority} (no implicit cluster-wide
+     * default); optional for {@code ListReplicationPriority} (omitted = whole cluster).
+     * Applicable for: SetReplicationPriority,ListReplicationPriority
+     */
+    @Config("fabric")
+    @Default("")
+    final String fabric;
+
+    /**
+     * Optional comma separated list of hostnames to narrow the fan-out to (omitted = all hosts in the
+     * requested fabric(s)). Each listed host must be in the fabric(s) and host a requested partition.
+     * Applicable for: SetReplicationPriority,ListReplicationPriority
+     */
+    @Config("servers")
+    @Default("")
+    final String servers;
+
+    /**
+     * Reject the request if {@code partitions × resolvedHosts} exceeds this.
+     * Catches typos / runaway scripts before any host is contacted.
+     * Applicable for: SetReplicationPriority,ListReplicationPriority
+     */
+    @Config("max.fanout.total")
+    @Default("1000")
+    final int maxFanoutTotal;
+
+    /**
      * Path of the file where the data from certain operations will output. For example, the blob from GetBlob and the
      * user metadata from GetUserMetadata will be written into this file.
      */
@@ -269,7 +318,12 @@ public class ServerAdminTool implements Closeable {
           verifiableProperties.getShortInRange("num.replicas.caught.up.per.partition", Short.MAX_VALUE, (short) 0,
               Short.MAX_VALUE);
       storeControlRequestType =
-          BlobStoreControlAction.valueOf(verifiableProperties.getString("store.control.request.type"));
+          BlobStoreControlAction.valueOf(verifiableProperties.getString("store.control.request.type", "StartStore"));
+      boost = verifiableProperties.getInt("boost", 2);
+      clear = verifiableProperties.getBoolean("clear", false);
+      fabric = verifiableProperties.getString("fabric", "");
+      servers = verifiableProperties.getString("servers", "");
+      maxFanoutTotal = verifiableProperties.getIntInRange("max.fanout.total", 1000, 1, Integer.MAX_VALUE);
       dataOutputFilePath = verifiableProperties.getString("data.output.file.path", "/tmp/ambryResult.out");
     }
   }
@@ -293,8 +347,12 @@ public class ServerAdminTool implements Closeable {
       throw new IllegalStateException("Could not create " + file);
     }
     FileOutputStream outputFileStream = new FileOutputStream(config.dataOutputFilePath);
+    // The replication-priority ops do their own fabric-scoped host resolution, so they skip the single
+    // --hostname target node that all other ops require.
+    boolean isReplicationPriorityOp = config.typeOfOperation == Operation.SetReplicationPriority
+        || config.typeOfOperation == Operation.ListReplicationPriority;
     DataNodeId dataNodeId = clusterMap.getDataNodeId(config.hostname, config.port);
-    if (dataNodeId == null) {
+    if (dataNodeId == null && !isReplicationPriorityOp) {
       throw new IllegalArgumentException(
           "Could not find a data node corresponding to " + config.hostname + ":" + config.port);
     }
@@ -445,6 +503,20 @@ public class ServerAdminTool implements Closeable {
           LOGGER.error("There were no partitions provided to be controlled (Start/Stop)");
         }
         break;
+      case SetReplicationPriority: {
+        ReplicationPriorityAdminHelper priorityHelper =
+            new ReplicationPriorityAdminHelper(clusterMap, serverAdminTool::sendRequestGetResponse);
+        priorityHelper.runSetReplicationPriority(String.join(",", config.partitionIds), config.boost, config.clear,
+            config.fabric, config.servers, config.maxFanoutTotal);
+        break;
+      }
+      case ListReplicationPriority: {
+        ReplicationPriorityAdminHelper priorityHelper =
+            new ReplicationPriorityAdminHelper(clusterMap, serverAdminTool::sendRequestGetResponse);
+        priorityHelper.runListReplicationPriority(String.join(",", config.partitionIds), config.fabric, config.servers,
+            config.maxFanoutTotal);
+        break;
+      }
       default:
         throw new IllegalStateException("Recognized but unsupported operation: " + config.typeOfOperation);
     }
@@ -872,8 +944,9 @@ public class ServerAdminTool implements Closeable {
    * @return the response as a {@link ResponseInfo} if the response was successfully received. {@code null} otherwise.
    * @throws TimeoutException
    */
-  private ResponseInfo sendRequestGetResponse(DataNodeId dataNodeId, PartitionId partitionId,
-      SendWithCorrelationId request) throws TimeoutException {
+  // Package-private (was private) so it can be passed as the transport function to ReplicationPriorityAdminHelper.
+  ResponseInfo sendRequestGetResponse(DataNodeId dataNodeId, PartitionId partitionId, SendWithCorrelationId request)
+      throws TimeoutException {
     ReplicaId replicaId = ToolRequestResponseUtil.getReplicaFromNode(dataNodeId, partitionId, clusterMap);
     String hostname = dataNodeId.getHostname();
     Port port = dataNodeId.getPortToConnectTo();

--- a/ambry-tools/src/main/java/com/github/ambry/tools/util/ToolRequestResponseUtil.java
+++ b/ambry-tools/src/main/java/com/github/ambry/tools/util/ToolRequestResponseUtil.java
@@ -24,6 +24,7 @@ import com.github.ambry.utils.NettyByteBufDataInputStream;
 import com.github.ambry.utils.Pair;
 import java.io.DataInputStream;
 import java.io.InputStream;
+import java.util.List;
 
 
 public class ToolRequestResponseUtil {
@@ -65,7 +66,11 @@ public class ToolRequestResponseUtil {
       }
     } else {
       // pick any replica on this node
-      replicaToReturn = clusterMap.getReplicaIds(dataNodeId).get(0);
+      List<? extends ReplicaId> replicaIds = clusterMap.getReplicaIds(dataNodeId);
+      if (replicaIds.isEmpty()) {
+        throw new IllegalStateException("Node " + dataNodeId + " hosts no replicas; cannot resolve a replica for it");
+      }
+      replicaToReturn = replicaIds.get(0);
     }
     return replicaToReturn;
   }

--- a/ambry-tools/src/test/java/com/github/ambry/tools/admin/ReplicationPriorityAdminHelperTest.java
+++ b/ambry-tools/src/test/java/com/github/ambry/tools/admin/ReplicationPriorityAdminHelperTest.java
@@ -1,0 +1,850 @@
+/**
+ * Copyright 2026 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.tools.admin;
+
+import com.github.ambry.clustermap.DataNodeId;
+import com.github.ambry.clustermap.MockClusterMap;
+import com.github.ambry.clustermap.MockDataNodeId;
+import com.github.ambry.clustermap.MockPartitionId;
+import com.github.ambry.clustermap.PartitionId;
+import com.github.ambry.clustermap.ReplicaId;
+import com.github.ambry.protocol.AdminRequestOrResponseType;
+import com.github.ambry.protocol.UpdateReplicationPriorityAdminRequest;
+import com.github.ambry.replication.PriorityEntry;
+import com.github.ambry.server.ServerErrorCode;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+/**
+ * Unit tests for the pure (no-I/O) logic of {@link ReplicationPriorityAdminHelper}'s replication-priority
+ * operations: action resolution + the clear table, fabric-required host resolution with optional
+ * {@code --servers} narrowing
+ * (whole-request rejection on a bad server), the {@code maxFanoutTotal} admission guard, per-host fan-out
+ * failure isolation, the set/clear JSON response shape, and the list response shape (one raw row per
+ * server-returned entry, with the {@code interColo} flag from {@link PriorityEntry#isInterColo()}).
+ *
+ * <p>The send/parse round-trip against a live server is exercised by the server-side admin integration suite
+ * (see {@code AmbryServerRequests} handling of {@code UpdateReplicationPriority}/{@code ListReplicationPriority});
+ * it is intentionally not duplicated here because this test deliberately avoids standing up an embedded server.
+ */
+public class ReplicationPriorityAdminHelperTest {
+  private MockClusterMap clusterMap;
+  private List<PartitionId> partitions;
+
+  @Before
+  public void setUp() throws Exception {
+    // Default ctor: 9 nodes across DC1/DC2/DC3 (3 per dc). Every default partition has a replica on every node;
+    // additionally a "special" partition is hosted on only a SUBSET of nodes (3 in the local dc, 2 elsewhere),
+    // which lets us exercise the per-host partition-subset fan-out below.
+    clusterMap = new MockClusterMap();
+    // MockClusterMap names every node "localhost" (distinguishing only by port), but --servers and the JSON
+    // output key on unique hostnames (as in prod). Give each node a unique hostname so the
+    // hostname-based server resolution and host-keyed JSON are exercised realistically.
+    int hostIndex = 0;
+    for (DataNodeId node : clusterMap.getDataNodeIds()) {
+      ((MockDataNodeId) node).setHostname(node.getDatacenterName() + "-host" + hostIndex++ + ".test");
+    }
+    partitions = new ArrayList<>(clusterMap.getAllPartitionIds(null));
+    assertFalse("Expected the mock cluster map to have partitions", partitions.isEmpty());
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    if (clusterMap != null) {
+      clusterMap.cleanup();
+    }
+  }
+
+  /**
+   * Asserts that {@code runnable} throws {@link IllegalArgumentException}. JUnit 4.12 (this repo's version)
+   * has no {@code Assert.assertThrows}, so this provides the same affordance.
+   * @param runnable the code expected to throw.
+   */
+  private static void assertThrowsIae(Runnable runnable) {
+    try {
+      runnable.run();
+      fail("Expected IllegalArgumentException to be thrown");
+    } catch (IllegalArgumentException expected) {
+      // expected
+    }
+  }
+
+  // ---- resolveAction ----
+
+  @Test
+  public void testResolveActionSet() {
+    assertEquals(UpdateReplicationPriorityAdminRequest.Action.SET,
+        ReplicationPriorityAdminHelper.resolveAction(false, Collections.singletonList(partitions.get(0)), 8));
+  }
+
+  @Test
+  public void testResolveActionSetEmptyPartitionsRejected() {
+    // clear=false requires non-empty partitions.
+    assertThrowsIae(() -> ReplicationPriorityAdminHelper.resolveAction(false, Collections.emptyList(), 8));
+  }
+
+  @Test
+  public void testResolveActionSetBoostTooLowRejected() {
+    assertThrowsIae(
+        () -> ReplicationPriorityAdminHelper.resolveAction(false, Collections.singletonList(partitions.get(0)), 0));
+  }
+
+  @Test
+  public void testResolveActionSetBoostTooHighRejected() {
+    assertThrowsIae(() -> ReplicationPriorityAdminHelper.resolveAction(false,
+        Collections.singletonList(partitions.get(0)), ReplicationPriorityAdminHelper.MAX_BOOST + 1));
+  }
+
+  @Test
+  public void testResolveActionSetBoostAtCapAccepted() {
+    assertEquals(UpdateReplicationPriorityAdminRequest.Action.SET, ReplicationPriorityAdminHelper.resolveAction(false,
+        Collections.singletonList(partitions.get(0)), ReplicationPriorityAdminHelper.MAX_BOOST));
+  }
+
+  @Test
+  public void testResolveActionUnset() {
+    // clear=true, non-empty partitions -> UNSET.
+    assertEquals(UpdateReplicationPriorityAdminRequest.Action.UNSET,
+        ReplicationPriorityAdminHelper.resolveAction(true, Collections.singletonList(partitions.get(0)), 1));
+  }
+
+  @Test
+  public void testResolveActionUnsetAll() {
+    // clear=true, empty partitions -> UNSET_ALL (servers requirement enforced in host resolution).
+    assertEquals(UpdateReplicationPriorityAdminRequest.Action.UNSET_ALL,
+        ReplicationPriorityAdminHelper.resolveAction(true, Collections.emptyList(), 1));
+  }
+
+  @Test
+  public void testResolveActionTooManyPartitionsRejected() {
+    assertThrowsIae(() -> ReplicationPriorityAdminHelper.resolveAction(false, tooManyPartitions(), 8));
+  }
+
+  @Test
+  public void testResolveActionUnsetTooManyPartitionsRejected() {
+    assertThrowsIae(() -> ReplicationPriorityAdminHelper.resolveAction(true, tooManyPartitions(), 1));
+  }
+
+  // ---- resolveTargetHostPartitions: fabric REQUIRED ----
+
+  @Test
+  public void testResolveTargetHostPartitionsFabricRequired() {
+    // fabric REQUIRED for SetReplicationPriority -> missing fabric is a hard error.
+    assertThrowsIae(
+        () -> ReplicationPriorityAdminHelper.resolveTargetHostPartitions(clusterMap, Collections.emptyList(),
+            Collections.emptyList(), Collections.singletonList(partitions.get(0)),
+            UpdateReplicationPriorityAdminRequest.Action.SET));
+  }
+
+  @Test
+  public void testResolveTargetHostPartitionsUnknownFabricRejected() {
+    assertThrowsIae(
+        () -> ReplicationPriorityAdminHelper.resolveTargetHostPartitions(clusterMap,
+            Collections.singletonList("DC-nope"), Collections.emptyList(), Collections.singletonList(partitions.get(0)),
+            UpdateReplicationPriorityAdminRequest.Action.SET));
+  }
+
+  // ---- resolveTargetHostPartitions: SET/UNSET fabric fan-out, per-host subset ----
+
+  @Test
+  public void testResolveTargetHostPartitionsFabricSetSinglePartition() {
+    // SET on one default partition scoped to DC1: every DC1 host hosting it gets exactly [that partition].
+    PartitionId partition = partitions.get(0);
+    Map<DataNodeId, List<PartitionId>> hostPartitions =
+        ReplicationPriorityAdminHelper.resolveTargetHostPartitions(clusterMap, Collections.singletonList("DC1"),
+            Collections.emptyList(), Collections.singletonList(partition),
+            UpdateReplicationPriorityAdminRequest.Action.SET);
+    Set<DataNodeId> expectedHosts = nodesOfPartitionInDcs(partition, Collections.singleton("DC1"));
+    assertEquals(expectedHosts, hostPartitions.keySet());
+    for (Map.Entry<DataNodeId, List<PartitionId>> entry : hostPartitions.entrySet()) {
+      assertEquals("DC1", entry.getKey().getDatacenterName());
+      assertEquals(Collections.singletonList(partition), entry.getValue());
+    }
+  }
+
+  @Test
+  public void testResolveTargetHostPartitionsFabricSetSendsOnlyHostedSubset() {
+    // The crux of the all-or-nothing bug fix: when a partition is NOT on every node, each host must receive only
+    // the subset of the requested partitions it actually hosts.
+    PartitionId defaultPartition = firstDefaultPartition();
+    PartitionId specialPartition = clusterMap.getSpecialPartition();
+    assertNotNull("Mock cluster map must have a special partition for this test", specialPartition);
+
+    Set<DataNodeId> defaultHostsDc2 = nodesOfPartitionInDcs(defaultPartition, Collections.singleton("DC2"));
+    Set<DataNodeId> specialHostsDc2 = nodesOfPartitionInDcs(specialPartition, Collections.singleton("DC2"));
+    assertTrue("Expected the special partition to be on fewer DC2 nodes than the default partition",
+        specialHostsDc2.size() < defaultHostsDc2.size());
+
+    List<PartitionId> requested = Arrays.asList(defaultPartition, specialPartition);
+    Map<DataNodeId, List<PartitionId>> hostPartitions =
+        ReplicationPriorityAdminHelper.resolveTargetHostPartitions(clusterMap, Collections.singletonList("DC2"),
+            Collections.emptyList(), requested, UpdateReplicationPriorityAdminRequest.Action.SET);
+
+    assertEquals(defaultHostsDc2, hostPartitions.keySet());
+    for (Map.Entry<DataNodeId, List<PartitionId>> entry : hostPartitions.entrySet()) {
+      DataNodeId host = entry.getKey();
+      List<PartitionId> forHost = entry.getValue();
+      if (specialHostsDc2.contains(host)) {
+        assertEquals("Host carrying both partitions must receive both, in request order",
+            Arrays.asList(defaultPartition, specialPartition), forHost);
+      } else {
+        assertEquals("Host carrying only the default partition must receive only it (not the special one)",
+            Collections.singletonList(defaultPartition), forHost);
+      }
+    }
+  }
+
+  @Test
+  public void testResolveTargetHostPartitionsFabricSetScopedToOneFabricExcludesOtherDcs() {
+    // SET scoped to DC3 only: hosts in OTHER datacenters (DC1/DC2) must be excluded even though they host the
+    // same partition. This is the single-fabric scoping / blast-radius guarantee.
+    PartitionId partition = partitions.get(0);
+    Map<DataNodeId, List<PartitionId>> hostPartitions =
+        ReplicationPriorityAdminHelper.resolveTargetHostPartitions(clusterMap, Collections.singletonList("DC3"),
+            Collections.emptyList(), Collections.singletonList(partition),
+            UpdateReplicationPriorityAdminRequest.Action.SET);
+    Set<DataNodeId> expectedHosts = nodesOfPartitionInDcs(partition, Collections.singleton("DC3"));
+    assertEquals(expectedHosts, hostPartitions.keySet());
+    for (Map.Entry<DataNodeId, List<PartitionId>> entry : hostPartitions.entrySet()) {
+      assertEquals("Only DC3 hosts may be targeted", "DC3", entry.getKey().getDatacenterName());
+      assertEquals(Collections.singletonList(partition), entry.getValue());
+    }
+  }
+
+  @Test
+  public void testResolveTargetHostPartitionsFabricUnsetSendsOnlyHostedSubset() {
+    PartitionId defaultPartition = firstDefaultPartition();
+    PartitionId specialPartition = clusterMap.getSpecialPartition();
+    assertNotNull(specialPartition);
+    Set<DataNodeId> specialHostsDc2 = nodesOfPartitionInDcs(specialPartition, Collections.singleton("DC2"));
+
+    Map<DataNodeId, List<PartitionId>> hostPartitions =
+        ReplicationPriorityAdminHelper.resolveTargetHostPartitions(clusterMap, Collections.singletonList("DC2"),
+            Collections.emptyList(), Arrays.asList(defaultPartition, specialPartition),
+            UpdateReplicationPriorityAdminRequest.Action.UNSET);
+    for (Map.Entry<DataNodeId, List<PartitionId>> entry : hostPartitions.entrySet()) {
+      if (specialHostsDc2.contains(entry.getKey())) {
+        assertTrue(entry.getValue().contains(specialPartition));
+      } else {
+        assertFalse("A host not hosting the special partition must not be sent it",
+            entry.getValue().contains(specialPartition));
+      }
+    }
+  }
+
+  // ---- clear semantics: servers narrowing + validation ----
+
+  @Test
+  public void testResolveTargetHostPartitionsServersNarrowsSet() {
+    // clear=false, partitions non-empty, servers given -> restrict SET to those servers.
+    PartitionId partition = partitions.get(0);
+    List<DataNodeId> dc1Hosts = new ArrayList<>(nodesOfPartitionInDcs(partition, Collections.singleton("DC1")));
+    DataNodeId chosen = dc1Hosts.get(0);
+    Map<DataNodeId, List<PartitionId>> hostPartitions =
+        ReplicationPriorityAdminHelper.resolveTargetHostPartitions(clusterMap, Collections.singletonList("DC1"),
+            Collections.singletonList(chosen.getHostname()), Collections.singletonList(partition),
+            UpdateReplicationPriorityAdminRequest.Action.SET);
+    assertEquals(Collections.singleton(chosen), hostPartitions.keySet());
+    assertEquals(Collections.singletonList(partition), hostPartitions.get(chosen));
+  }
+
+  @Test
+  public void testResolveTargetHostPartitionsServerOutOfFabricRejectsWholeRequest() {
+    // a server NOT in the requested fabric rejects the WHOLE request.
+    PartitionId partition = partitions.get(0);
+    DataNodeId dc2Host = new ArrayList<>(nodesOfPartitionInDcs(partition, Collections.singleton("DC2"))).get(0);
+    assertThrowsIae(
+        () -> ReplicationPriorityAdminHelper.resolveTargetHostPartitions(clusterMap, Collections.singletonList("DC1"),
+            Collections.singletonList(dc2Host.getHostname()), Collections.singletonList(partition),
+            UpdateReplicationPriorityAdminRequest.Action.SET));
+  }
+
+  @Test
+  public void testResolveTargetHostPartitionsServerNotHostingPartitionRejectsWholeRequest() {
+    // a server in-fabric but hosting NONE of the requested partitions rejects the WHOLE request.
+    PartitionId specialPartition = clusterMap.getSpecialPartition();
+    assertNotNull(specialPartition);
+    Set<DataNodeId> specialHostsDc2 = nodesOfPartitionInDcs(specialPartition, Collections.singleton("DC2"));
+    // Find a DC2 node that does NOT host the special partition.
+    DataNodeId nonHostingDc2 = null;
+    for (DataNodeId node : clusterMap.getDataNodeIds()) {
+      if ("DC2".equals(node.getDatacenterName()) && !specialHostsDc2.contains(node)) {
+        nonHostingDc2 = node;
+        break;
+      }
+    }
+    assertNotNull("Expected a DC2 node not hosting the special partition", nonHostingDc2);
+    final DataNodeId badServer = nonHostingDc2;
+    assertThrowsIae(
+        () -> ReplicationPriorityAdminHelper.resolveTargetHostPartitions(clusterMap, Collections.singletonList("DC2"),
+            Collections.singletonList(badServer.getHostname()), Collections.singletonList(specialPartition),
+            UpdateReplicationPriorityAdminRequest.Action.SET));
+  }
+
+  @Test
+  public void testResolveTargetHostPartitionsUnknownServerRejected() {
+    assertThrowsIae(
+        () -> ReplicationPriorityAdminHelper.resolveTargetHostPartitions(clusterMap, Collections.singletonList("DC1"),
+            Collections.singletonList("no-such-host"), Collections.singletonList(partitions.get(0)),
+            UpdateReplicationPriorityAdminRequest.Action.SET));
+  }
+
+  @Test
+  public void testResolveTargetHostPartitionsUnsetAllServersRequiredEmptyLists() {
+    // clear=true, partitions empty, servers non-empty -> UNSET_ALL on those servers (empty lists).
+    List<DataNodeId> dc1Nodes = new ArrayList<>(allNodesInDcs(Collections.singleton("DC1")));
+    DataNodeId a = dc1Nodes.get(0);
+    DataNodeId b = dc1Nodes.get(1);
+    Map<DataNodeId, List<PartitionId>> hostPartitions =
+        ReplicationPriorityAdminHelper.resolveTargetHostPartitions(clusterMap, Collections.singletonList("DC1"),
+            Arrays.asList(a.getHostname(), b.getHostname()), Collections.emptyList(),
+            UpdateReplicationPriorityAdminRequest.Action.UNSET_ALL);
+    assertEquals(new HashSet<>(Arrays.asList(a, b)), hostPartitions.keySet());
+    for (List<PartitionId> forHost : hostPartitions.values()) {
+      assertTrue("UNSET_ALL sends an empty partition list to each host", forHost.isEmpty());
+    }
+  }
+
+  @Test
+  public void testResolveTargetHostPartitionsUnsetAllNoServersRejected() {
+    // clear=true, partitions empty, servers empty -> REJECT.
+    assertThrowsIae(
+        () -> ReplicationPriorityAdminHelper.resolveTargetHostPartitions(clusterMap, Collections.singletonList("DC1"),
+            Collections.emptyList(), Collections.emptyList(),
+            UpdateReplicationPriorityAdminRequest.Action.UNSET_ALL));
+  }
+
+  @Test
+  public void testResolveTargetHostPartitionsClearPartitionsAndServersIntersection() {
+    // clear=true, partitions non-empty, servers non-empty -> intersection (UNSET on those servers).
+    PartitionId partition = partitions.get(0);
+    List<DataNodeId> dc1Hosts = new ArrayList<>(nodesOfPartitionInDcs(partition, Collections.singleton("DC1")));
+    DataNodeId chosen = dc1Hosts.get(0);
+    Map<DataNodeId, List<PartitionId>> hostPartitions =
+        ReplicationPriorityAdminHelper.resolveTargetHostPartitions(clusterMap, Collections.singletonList("DC1"),
+            Collections.singletonList(chosen.getHostname()), Collections.singletonList(partition),
+            UpdateReplicationPriorityAdminRequest.Action.UNSET);
+    assertEquals(Collections.singleton(chosen), hostPartitions.keySet());
+    assertEquals(Collections.singletonList(partition), hostPartitions.get(chosen));
+  }
+
+  // ---- resolveTargetHosts (List path: partition-agnostic, fabric NOT required) ----
+
+  @Test
+  public void testResolveTargetHostsListNoFabricNoServersWholeCluster() {
+    // list with neither fabric nor servers -> every host in the cluster.
+    List<DataNodeId> hosts =
+        ReplicationPriorityAdminHelper.resolveTargetHosts(clusterMap, Collections.emptyList(), Collections.emptyList());
+    assertEquals(new HashSet<>(clusterMap.getDataNodeIds()), new HashSet<>(hosts));
+  }
+
+  @Test
+  public void testResolveTargetHostsListFabricScoped() {
+    // List scoped to a single fabric (DC1): exactly the DC1 hosts, no DC2/DC3 hosts.
+    List<DataNodeId> hosts = ReplicationPriorityAdminHelper.resolveTargetHosts(clusterMap,
+        Collections.singletonList("DC1"), Collections.emptyList());
+    assertEquals(allNodesInDcs(Collections.singleton("DC1")), new HashSet<>(hosts));
+  }
+
+  @Test
+  public void testResolveTargetHostsListServersScoped() {
+    List<DataNodeId> nodes = clusterMap.getDataNodeIds();
+    DataNodeId a = nodes.get(0);
+    DataNodeId b = nodes.get(1);
+    List<DataNodeId> hosts = ReplicationPriorityAdminHelper.resolveTargetHosts(clusterMap, Collections.emptyList(),
+        Arrays.asList(a.getHostname(), b.getHostname()));
+    assertEquals(Arrays.asList(a, b), hosts);
+  }
+
+  @Test
+  public void testResolveTargetHostsListUnknownFabricRejected() {
+    assertThrowsIae(() -> ReplicationPriorityAdminHelper.resolveTargetHosts(clusterMap,
+        Collections.singletonList("DC-nope"), Collections.emptyList()));
+  }
+
+  @Test
+  public void testResolveTargetHostsListServerOutOfFabricScopeRejected() {
+    DataNodeId dc2Host = null;
+    for (DataNodeId node : clusterMap.getDataNodeIds()) {
+      if ("DC2".equals(node.getDatacenterName())) {
+        dc2Host = node;
+        break;
+      }
+    }
+    assertNotNull(dc2Host);
+    final DataNodeId server = dc2Host;
+    assertThrowsIae(() -> ReplicationPriorityAdminHelper.resolveTargetHosts(clusterMap,
+        Collections.singletonList("DC1"), Collections.singletonList(server.getHostname())));
+  }
+
+  @Test
+  public void testResolveTargetHostsListUnknownServerRejected() {
+    assertThrowsIae(() -> ReplicationPriorityAdminHelper.resolveTargetHosts(clusterMap, Collections.emptyList(),
+        Collections.singletonList("no-such-host")));
+  }
+
+  // ---- request construction: buildUpdateRequest + resolveReplicaPartition ----
+
+  @Test
+  public void testBuildUpdateRequestWrapsWithNullPartitionAndCarriesTypedBody() {
+    PartitionId p0 = partitions.get(0);
+    PartitionId p1 = partitions.get(1);
+    List<PartitionId> ids = Arrays.asList(p0, p1);
+    UpdateReplicationPriorityAdminRequest request =
+        ReplicationPriorityAdminHelper.buildUpdateRequest(ids, 8, UpdateReplicationPriorityAdminRequest.Action.SET, 42);
+    assertNull("Wrapping AdminRequest partition must be null", request.getPartitionId());
+    assertEquals(AdminRequestOrResponseType.UpdateReplicationPriority, request.getType());
+    assertEquals(UpdateReplicationPriorityAdminRequest.Action.SET, request.getAction());
+    assertEquals(8, request.getBoost());
+    assertEquals(ids, request.getPartitionIds());
+  }
+
+  @Test
+  public void testBuildUpdateRequestUnsetAllAction() {
+    UpdateReplicationPriorityAdminRequest request =
+        ReplicationPriorityAdminHelper.buildUpdateRequest(Collections.emptyList(), 1,
+            UpdateReplicationPriorityAdminRequest.Action.UNSET_ALL, 7);
+    assertNull(request.getPartitionId());
+    assertEquals(UpdateReplicationPriorityAdminRequest.Action.UNSET_ALL, request.getAction());
+    assertTrue(request.getPartitionIds().isEmpty());
+  }
+
+  @Test
+  public void testResolveReplicaPartitionSingleReturnsThatPartition() {
+    PartitionId p0 = partitions.get(0);
+    assertSame(p0, ReplicationPriorityAdminHelper.resolveReplicaPartition(Collections.singletonList(p0)));
+  }
+
+  @Test
+  public void testResolveReplicaPartitionMultiReturnsNull() {
+    assertNull(
+        ReplicationPriorityAdminHelper.resolveReplicaPartition(Arrays.asList(partitions.get(0), partitions.get(1))));
+  }
+
+  @Test
+  public void testResolveReplicaPartitionEmptyReturnsNull() {
+    assertNull(ReplicationPriorityAdminHelper.resolveReplicaPartition(Collections.emptyList()));
+  }
+
+  // ---- parsePartitionIds ----
+
+  @Test
+  public void testParsePartitionIdsValid() {
+    String s0 = partitions.get(0).toPathString();
+    String s1 = partitions.get(1).toPathString();
+    List<PartitionId> parsed = ReplicationPriorityAdminHelper.parsePartitionIds(s0 + "," + s1, clusterMap);
+    assertEquals(Arrays.asList(partitions.get(0), partitions.get(1)), parsed);
+  }
+
+  @Test
+  public void testParsePartitionIdsDefaultEmptyConfigYieldsEmptyList() {
+    assertTrue(ReplicationPriorityAdminHelper.parsePartitionIds("", clusterMap).isEmpty());
+  }
+
+  @Test
+  public void testParsePartitionIdsTrimsAndSkipsBlanks() {
+    String s0 = partitions.get(0).toPathString();
+    // Surrounding spaces and stray/empty tokens (leading/trailing/repeated commas) must be ignored.
+    List<PartitionId> parsed = ReplicationPriorityAdminHelper.parsePartitionIds(" " + s0 + " ,,  ", clusterMap);
+    assertEquals(Collections.singletonList(partitions.get(0)), parsed);
+  }
+
+  @Test
+  public void testParsePartitionIdsUnknownThrows() {
+    assertThrowsIae(() -> ReplicationPriorityAdminHelper.parsePartitionIds("999999999", clusterMap));
+  }
+
+  // ---- toFabricList ----
+
+  @Test
+  public void testToFabricListSingleFabric() {
+    assertEquals(Collections.singletonList("DC1"), ReplicationPriorityAdminHelper.toFabricList("DC1"));
+  }
+
+  @Test
+  public void testToFabricListDefaultEmptyConfigYieldsEmptyList() {
+    assertTrue(ReplicationPriorityAdminHelper.toFabricList("").isEmpty());
+  }
+
+  @Test
+  public void testToFabricListTrimsWhitespace() {
+    assertEquals(Collections.singletonList("DC1"), ReplicationPriorityAdminHelper.toFabricList("  DC1 "));
+  }
+
+  @Test
+  public void testToFabricListBlankAfterTrimYieldsEmptyList() {
+    assertTrue(ReplicationPriorityAdminHelper.toFabricList("   ").isEmpty());
+  }
+
+  @Test
+  public void testToFabricListCommaSeparatedRejected() {
+    // Only one fabric may be specified per invocation; a comma-separated value is a hard error.
+    assertThrowsIae(() -> ReplicationPriorityAdminHelper.toFabricList("DC1,DC2"));
+  }
+
+  // ---- checkMaxFanoutTotal ----
+
+  @Test
+  public void testCheckMaxFanoutTotalUnderCapAccepted() {
+    ReplicationPriorityAdminHelper.checkMaxFanoutTotal(10, 100, 1000);  // exactly at cap is fine
+    ReplicationPriorityAdminHelper.checkMaxFanoutTotal(1, 1, 1000);
+  }
+
+  @Test
+  public void testCheckMaxFanoutTotalOverCapRejected() {
+    assertThrowsIae(() -> ReplicationPriorityAdminHelper.checkMaxFanoutTotal(11, 100, 1000));  // 1100 > 1000
+  }
+
+  @Test
+  public void testRunListReplicationPriorityOverCapUnscopedListRejected() {
+    // An unscoped (no fabric, no servers) list resolves to EVERY host in the cluster. With a cap below the
+    // cluster size it must be rejected (hard error) before any host is contacted -- list is partition-agnostic,
+    // so the fan-out cost is one unit per host.
+    int clusterSize = clusterMap.getDataNodeIds().size();
+    assertTrue("Need a multi-host cluster for this test", clusterSize > 1);
+    // sender that fails the test if it is ever invoked -- the cap must short-circuit before any send.
+    ReplicationPriorityAdminHelper.Sender sender = (node, partition, request) -> {
+      throw new AssertionError("No host should be contacted when the fan-out cap is exceeded");
+    };
+    ReplicationPriorityAdminHelper helper = new ReplicationPriorityAdminHelper(clusterMap, sender);
+    assertThrowsIae(() -> helper.runListReplicationPriority("", "", "", clusterSize - 1));
+  }
+
+  // ---- fanOut: per-host failure isolation + failure recording ----
+
+  @Test
+  public void testFanOutIsolatesPerHostFailuresAndRecordsErrors() {
+    List<DataNodeId> hosts = new ArrayList<>(clusterMap.getDataNodeIds());
+    assertTrue("Need at least 3 hosts for this test", hosts.size() >= 3);
+    DataNodeId errorCodeHost = hosts.get(0);
+    DataNodeId throwingHost = hosts.get(1);
+    List<DataNodeId> visited = new ArrayList<>();
+    // The set path's work lambda turns a non-NoError ServerErrorCode into an IOException; model that here so a
+    // returned error and a thrown transport failure both funnel through fanOut's per-host isolation.
+    ReplicationPriorityAdminHelper.HostWork work = host -> {
+      visited.add(host);
+      if (host.equals(errorCodeHost)) {
+        throw new java.io.IOException("ServerErrorCode: " + ServerErrorCode.UnknownError);
+      }
+      if (host.equals(throwingHost)) {
+        throw new java.util.concurrent.TimeoutException("simulated transport timeout");
+      }
+    };
+    Map<DataNodeId, String> failures = new LinkedHashMap<>();
+    ReplicationPriorityAdminHelper.FanOutSummary summary =
+        ReplicationPriorityAdminHelper.fanOut(hosts, "SET", work, failures);
+    assertEquals(hosts, visited);
+    assertEquals(hosts.size(), summary.requested);
+    assertEquals(hosts.size() - 2, summary.succeeded);
+    assertEquals(2, summary.failed);
+    // The two failing hosts are recorded with their error text; the rest are not.
+    assertEquals(new HashSet<>(Arrays.asList(errorCodeHost, throwingHost)), failures.keySet());
+    assertTrue(failures.get(errorCodeHost).contains("UnknownError"));
+    assertTrue(failures.get(throwingHost).contains("simulated transport timeout"));
+  }
+
+  @Test
+  public void testFanOutIsolatesUncheckedTransportFailure() {
+    // The transport (ServerAdminTool.sendRequestGetResponse) throws an unchecked IllegalStateException for an
+    // unreachable/errored host. That must be isolated to the offending host like any other per-host failure:
+    // the rest of the fan-out continues and succeeds, and the down host is counted as failed with its message.
+    List<DataNodeId> hosts = new ArrayList<>(clusterMap.getDataNodeIds());
+    assertTrue("Need at least 3 hosts for this test", hosts.size() >= 3);
+    DataNodeId downHost = hosts.get(1);
+    List<DataNodeId> visited = new ArrayList<>();
+    ReplicationPriorityAdminHelper.HostWork work = host -> {
+      visited.add(host);
+      if (host.equals(downHost)) {
+        // Mirror the transport's unchecked failure for a host that is down / returned a transport error.
+        throw new IllegalStateException(host.getHostname() + ": Encountered error while trying to send request");
+      }
+    };
+    Map<DataNodeId, String> failures = new LinkedHashMap<>();
+    ReplicationPriorityAdminHelper.FanOutSummary summary =
+        ReplicationPriorityAdminHelper.fanOut(hosts, "SET", work, failures);
+    // (a) every remaining host was still attempted (and the down host did not abort the loop).
+    assertEquals(hosts, visited);
+    assertEquals(hosts.size(), summary.requested);
+    assertEquals(hosts.size() - 1, summary.succeeded);
+    assertEquals(1, summary.failed);
+    // (b) only the down host is recorded as failed, with its IllegalStateException message captured.
+    assertEquals(Collections.singleton(downHost), failures.keySet());
+    assertTrue(failures.get(downHost).contains("IllegalStateException"));
+    assertTrue(failures.get(downHost).contains("Encountered error while trying to send request"));
+  }
+
+  @Test
+  public void testFanOutVisitsEveryHostInOrderOnAllSuccess() {
+    List<DataNodeId> hosts = new ArrayList<>(clusterMap.getDataNodeIds());
+    assertTrue("Need at least 2 hosts for this test", hosts.size() >= 2);
+    List<DataNodeId> visited = new ArrayList<>();
+    Map<DataNodeId, String> failures = new LinkedHashMap<>();
+    ReplicationPriorityAdminHelper.FanOutSummary summary =
+        ReplicationPriorityAdminHelper.fanOut(hosts, "ListReplicationPriority", visited::add, failures);
+    assertEquals(hosts, visited);
+    assertEquals(hosts.size(), summary.requested);
+    assertEquals(hosts.size(), summary.succeeded);
+    assertEquals(0, summary.failed);
+    assertTrue(failures.isEmpty());
+  }
+
+  // ---- set/clear JSON response shape ----
+
+  @Test
+  public void testBuildSetResultJsonShape() {
+    List<DataNodeId> nodes = clusterMap.getDataNodeIds();
+    DataNodeId ok1 = nodes.get(0);
+    DataNodeId ok2 = nodes.get(1);
+    DataNodeId bad = nodes.get(2);
+    Map<DataNodeId, List<PartitionId>> hostPartitions = new LinkedHashMap<>();
+    hostPartitions.put(ok1, Collections.singletonList(partitions.get(0)));
+    hostPartitions.put(ok2, Collections.singletonList(partitions.get(0)));
+    hostPartitions.put(bad, Collections.singletonList(partitions.get(0)));
+    Map<DataNodeId, String> failures = new LinkedHashMap<>();
+    failures.put(bad, "ServerErrorCode: BadRequest");
+    ReplicationPriorityAdminHelper.FanOutSummary summary = new ReplicationPriorityAdminHelper.FanOutSummary(3, 2);
+
+    JSONObject json = ReplicationPriorityAdminHelper.buildSetResultJson(hostPartitions.keySet(), failures, summary);
+    JSONObject summaryJson = json.getJSONObject("summary");
+    assertEquals(3, summaryJson.getInt("requested"));
+    assertEquals(2, summaryJson.getInt("succeeded"));
+    assertEquals(1, summaryJson.getInt("failed"));
+
+    JSONArray results = json.getJSONArray("results");
+    assertEquals(3, results.length());
+    Map<String, JSONObject> byHost = indexByHost(results);
+    assertEquals("ok", byHost.get(ok1.getHostname()).getString("status"));
+    assertEquals("ok", byHost.get(ok2.getHostname()).getString("status"));
+    JSONObject badJson = byHost.get(bad.getHostname());
+    assertEquals("error", badJson.getString("status"));
+    assertEquals("ServerErrorCode: BadRequest", badJson.getString("error"));
+    assertFalse("ok hosts must not carry an error field", byHost.get(ok1.getHostname()).has("error"));
+  }
+
+  // ---- list JSON response shape (raw per-entry interColo) ----
+
+  @Test
+  public void testBuildListResultJsonInterColoFalseOnly() {
+    PartitionId p = partitions.get(0);
+    DataNodeId host = clusterMap.getDataNodeIds().get(0);
+    Map<DataNodeId, List<PriorityEntry>> hostEntries = new LinkedHashMap<>();
+    hostEntries.put(host, Collections.singletonList(new PriorityEntry(p, 4, /*isInterColo*/ false)));
+    JSONObject json = ReplicationPriorityAdminHelper.buildListResultJson(Collections.singletonList(host), hostEntries,
+        Collections.emptyMap(), Collections.emptySet(), new ReplicationPriorityAdminHelper.FanOutSummary(1, 1));
+    JSONArray priorities = indexByHost(json.getJSONArray("results")).get(host.getHostname()).getJSONArray("priorities");
+    assertEquals(1, priorities.length());
+    assertEquals(p.getId(), priorities.getJSONObject(0).getLong("partitionId"));
+    assertEquals(4, priorities.getJSONObject(0).getInt("boost"));
+    assertFalse(priorities.getJSONObject(0).getBoolean("interColo"));
+    assertEquals(1, json.getJSONObject("summary").getInt("uniquePartitions"));
+  }
+
+  @Test
+  public void testBuildListResultJsonInterColoTrueOnly() {
+    PartitionId p = partitions.get(0);
+    DataNodeId host = clusterMap.getDataNodeIds().get(0);
+    Map<DataNodeId, List<PriorityEntry>> hostEntries = new LinkedHashMap<>();
+    hostEntries.put(host, Collections.singletonList(new PriorityEntry(p, 7, /*isInterColo*/ true)));
+    JSONObject json = ReplicationPriorityAdminHelper.buildListResultJson(Collections.singletonList(host), hostEntries,
+        Collections.emptyMap(), Collections.emptySet(), new ReplicationPriorityAdminHelper.FanOutSummary(1, 1));
+    JSONArray priorities = indexByHost(json.getJSONArray("results")).get(host.getHostname()).getJSONArray("priorities");
+    assertEquals(1, priorities.length());
+    assertEquals(7, priorities.getJSONObject(0).getInt("boost"));
+    assertTrue(priorities.getJSONObject(0).getBoolean("interColo"));
+  }
+
+  @Test
+  public void testBuildListResultJsonPartitionWithBothIntraAndInterEntriesYieldsTwoRows() {
+    // The SAME partition is returned twice by the server (one intra-colo entry, one inter-colo entry). These
+    // must NOT be collapsed: both appear as their own row, and the partition counts once in uniquePartitions.
+    PartitionId p = partitions.get(0);
+    DataNodeId host = clusterMap.getDataNodeIds().get(0);
+    Map<DataNodeId, List<PriorityEntry>> hostEntries = new LinkedHashMap<>();
+    hostEntries.put(host, Arrays.asList(
+        new PriorityEntry(p, 5, /*isInterColo*/ false),
+        new PriorityEntry(p, 5, /*isInterColo*/ true)));
+    JSONObject json = ReplicationPriorityAdminHelper.buildListResultJson(Collections.singletonList(host), hostEntries,
+        Collections.emptyMap(), Collections.emptySet(), new ReplicationPriorityAdminHelper.FanOutSummary(1, 1));
+    JSONArray priorities = indexByHost(json.getJSONArray("results")).get(host.getHostname()).getJSONArray("priorities");
+    assertEquals("both entries are kept as separate rows", 2, priorities.length());
+    Set<Boolean> interColoSeen = new HashSet<>();
+    for (int i = 0; i < priorities.length(); i++) {
+      assertEquals(p.getId(), priorities.getJSONObject(i).getLong("partitionId"));
+      interColoSeen.add(priorities.getJSONObject(i).getBoolean("interColo"));
+    }
+    assertEquals("both an interColo=false and interColo=true row present",
+        new HashSet<>(Arrays.asList(false, true)), interColoSeen);
+    assertEquals("partition counts once despite two rows", 1,
+        json.getJSONObject("summary").getInt("uniquePartitions"));
+  }
+
+  @Test
+  public void testBuildListResultJsonShapeSummaryPartitionsServersResults() {
+    PartitionId p0 = partitions.get(0);
+    PartitionId p1 = partitions.get(1);
+    List<DataNodeId> nodes = clusterMap.getDataNodeIds();
+    DataNodeId hostWithPriorities = nodes.get(0);
+    DataNodeId hostEmpty = nodes.get(1);  // queried, no priorities
+    DataNodeId hostError = nodes.get(2);  // errored
+    List<DataNodeId> hosts = Arrays.asList(hostWithPriorities, hostEmpty, hostError);
+
+    Map<DataNodeId, List<PriorityEntry>> hostEntries = new LinkedHashMap<>();
+    hostEntries.put(hostWithPriorities, Arrays.asList(
+        new PriorityEntry(p0, 4, false),
+        new PriorityEntry(p0, 4, true),
+        new PriorityEntry(p1, 9, true)));   // p1 inter-only
+    hostEntries.put(hostEmpty, Collections.emptyList());
+    Map<DataNodeId, String> failures = new LinkedHashMap<>();
+    failures.put(hostError, "IOException: timeout");
+    ReplicationPriorityAdminHelper.FanOutSummary summary = new ReplicationPriorityAdminHelper.FanOutSummary(3, 2);
+
+    JSONObject json = ReplicationPriorityAdminHelper.buildListResultJson(hosts, hostEntries, failures,
+        Collections.emptySet(), summary);
+
+    JSONObject summaryJson = json.getJSONObject("summary");
+    assertEquals(3, summaryJson.getInt("queriedHosts"));
+    assertEquals(1, summaryJson.getInt("hostsWithPriorities"));
+    assertEquals("two distinct partition ids despite three entries", 2, summaryJson.getInt("uniquePartitions"));
+
+    // partitions[] = dedup of DISTINCT partition ids with at least one entry.
+    Set<Long> partitionIds = new HashSet<>();
+    JSONArray partitionsArr = json.getJSONArray("partitions");
+    for (int i = 0; i < partitionsArr.length(); i++) {
+      partitionIds.add(partitionsArr.getLong(i));
+    }
+    assertEquals(new HashSet<>(Arrays.asList(p0.getId(), p1.getId())), partitionIds);
+
+    // servers[] = hosts with non-empty priorities (excludes empty + errored).
+    JSONArray serversArr = json.getJSONArray("servers");
+    assertEquals(1, serversArr.length());
+    assertEquals(hostWithPriorities.getHostname(), serversArr.getString(0));
+
+    // results[]: per-host raw view, one row per server-returned entry.
+    Map<String, JSONObject> byHost = indexByHost(json.getJSONArray("results"));
+    assertEquals(3, byHost.size());
+    JSONObject hostJson = byHost.get(hostWithPriorities.getHostname());
+    assertEquals("ok", hostJson.getString("status"));
+    JSONArray priorities = hostJson.getJSONArray("priorities");
+    assertEquals("all three entries are emitted as rows", 3, priorities.length());
+    // p0 contributes both an interColo=false and an interColo=true row.
+    Set<Boolean> p0InterColo = new HashSet<>();
+    JSONObject p1Row = null;
+    for (int i = 0; i < priorities.length(); i++) {
+      JSONObject row = priorities.getJSONObject(i);
+      if (row.getLong("partitionId") == p0.getId()) {
+        assertEquals(4, row.getInt("boost"));
+        p0InterColo.add(row.getBoolean("interColo"));
+      } else {
+        p1Row = row;
+      }
+    }
+    assertEquals(new HashSet<>(Arrays.asList(false, true)), p0InterColo);
+    assertNotNull(p1Row);
+    assertEquals(9, p1Row.getInt("boost"));
+    assertTrue(p1Row.getBoolean("interColo"));
+
+    JSONObject emptyHostJson = byHost.get(hostEmpty.getHostname());
+    assertEquals("ok", emptyHostJson.getString("status"));
+    assertEquals(0, emptyHostJson.getJSONArray("priorities").length());
+
+    JSONObject errorHostJson = byHost.get(hostError.getHostname());
+    assertEquals("error", errorHostJson.getString("status"));
+    assertEquals("IOException: timeout", errorHostJson.getString("error"));
+    assertFalse("errored host has no priorities array", errorHostJson.has("priorities"));
+  }
+
+  @Test
+  public void testBuildListResultJsonPartitionFilterApplied() {
+    PartitionId kept = partitions.get(0);
+    PartitionId dropped = partitions.get(1);
+    DataNodeId host = clusterMap.getDataNodeIds().get(0);
+    Map<DataNodeId, List<PriorityEntry>> hostEntries = new LinkedHashMap<>();
+    hostEntries.put(host, Arrays.asList(new PriorityEntry(kept, 2, false), new PriorityEntry(dropped, 3, false)));
+    JSONObject json = ReplicationPriorityAdminHelper.buildListResultJson(Collections.singletonList(host), hostEntries,
+        Collections.emptyMap(), Collections.singleton(kept), new ReplicationPriorityAdminHelper.FanOutSummary(1, 1));
+    assertEquals(1, json.getJSONObject("summary").getInt("uniquePartitions"));
+    JSONArray partitionsArr = json.getJSONArray("partitions");
+    assertEquals(1, partitionsArr.length());
+    assertEquals(kept.getId(), partitionsArr.getLong(0));
+    // The dropped partition's row must not survive the filter.
+    JSONArray priorities = indexByHost(json.getJSONArray("results")).get(host.getHostname()).getJSONArray("priorities");
+    assertEquals(1, priorities.length());
+    assertEquals(kept.getId(), priorities.getJSONObject(0).getLong("partitionId"));
+  }
+
+  // ---- helpers ----
+
+  private List<PartitionId> tooManyPartitions() {
+    List<PartitionId> many = new ArrayList<>();
+    PartitionId p = partitions.get(0);
+    for (int i = 0; i < UpdateReplicationPriorityAdminRequest.MAX_PARTITIONS_PER_REQUEST + 1; i++) {
+      many.add(p);
+    }
+    return many;
+  }
+
+  private PartitionId firstDefaultPartition() {
+    MockPartitionId special = clusterMap.getSpecialPartition();
+    for (PartitionId p : partitions) {
+      if (special == null || !p.equals(special)) {
+        return p;
+      }
+    }
+    throw new IllegalStateException("No default partition found");
+  }
+
+  private Set<DataNodeId> nodesOfPartitionInDcs(PartitionId partition, Set<String> dcs) {
+    Set<DataNodeId> nodes = new HashSet<>();
+    for (ReplicaId r : partition.getReplicaIds()) {
+      DataNodeId node = r.getDataNodeId();
+      if (dcs.contains(node.getDatacenterName())) {
+        nodes.add(node);
+      }
+    }
+    return nodes;
+  }
+
+  private Set<DataNodeId> allNodesInDcs(Set<String> dcs) {
+    Set<DataNodeId> nodes = new HashSet<>();
+    for (DataNodeId node : clusterMap.getDataNodeIds()) {
+      if (dcs.contains(node.getDatacenterName())) {
+        nodes.add(node);
+      }
+    }
+    return nodes;
+  }
+
+  private static Map<String, JSONObject> indexByHost(JSONArray results) {
+    Map<String, JSONObject> byHost = new LinkedHashMap<>();
+    for (int i = 0; i < results.length(); i++) {
+      JSONObject o = results.getJSONObject(i);
+      byHost.put(o.getString("host"), o);
+    }
+    return byHost;
+  }
+}

--- a/ambry-tools/src/test/java/com/github/ambry/tools/admin/ReplicationPriorityAdminHelperTest.java
+++ b/ambry-tools/src/test/java/com/github/ambry/tools/admin/ReplicationPriorityAdminHelperTest.java
@@ -23,6 +23,9 @@ import com.github.ambry.protocol.AdminRequestOrResponseType;
 import com.github.ambry.protocol.UpdateReplicationPriorityAdminRequest;
 import com.github.ambry.replication.PriorityEntry;
 import com.github.ambry.server.ServerErrorCode;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -117,13 +120,13 @@ public class ReplicationPriorityAdminHelperTest {
   @Test
   public void testResolveActionSetBoostTooHighRejected() {
     assertThrowsIae(() -> ReplicationPriorityAdminHelper.resolveAction(false,
-        Collections.singletonList(partitions.get(0)), ReplicationPriorityAdminHelper.MAX_BOOST + 1));
+        Collections.singletonList(partitions.get(0)), UpdateReplicationPriorityAdminRequest.MAX_PRIORITY_BOOST + 1));
   }
 
   @Test
   public void testResolveActionSetBoostAtCapAccepted() {
     assertEquals(UpdateReplicationPriorityAdminRequest.Action.SET, ReplicationPriorityAdminHelper.resolveAction(false,
-        Collections.singletonList(partitions.get(0)), ReplicationPriorityAdminHelper.MAX_BOOST));
+        Collections.singletonList(partitions.get(0)), UpdateReplicationPriorityAdminRequest.MAX_PRIORITY_BOOST));
   }
 
   @Test
@@ -255,6 +258,19 @@ public class ReplicationPriorityAdminHelperTest {
             entry.getValue().contains(specialPartition));
       }
     }
+  }
+
+  @Test
+  public void testResolveTargetHostPartitionsSetNoHostsInFabricRejected() throws Exception {
+    // SET (no --servers) scoped to a fabric where NONE of the requested partitions has a replica must be rejected,
+    // not silently resolve to zero hosts (a requested=0 no-op that's easy to mistake for success, e.g. a mistyped
+    // --fabric). Symmetric to the --servers "hosts none of the requested partitions" rejection. A freshly added DC
+    // hosts no existing partition, giving us a known-but-empty fabric for the requested partition.
+    clusterMap.createNewDataNodes(1, "DC-empty");
+    assertThrowsIae(
+        () -> ReplicationPriorityAdminHelper.resolveTargetHostPartitions(clusterMap,
+            Collections.singletonList("DC-empty"), Collections.emptyList(),
+            Collections.singletonList(partitions.get(0)), UpdateReplicationPriorityAdminRequest.Action.SET));
   }
 
   // ---- clear semantics: servers narrowing + validation ----
@@ -797,7 +813,83 @@ public class ReplicationPriorityAdminHelperTest {
     assertEquals(kept.getId(), priorities.getJSONObject(0).getLong("partitionId"));
   }
 
+  // ---- run* paths: null-response handling + replica-less node short-circuit ----
+
+  @Test
+  public void testRunSetReplicationPriorityNullResponseReportedAsActionableError() {
+    // sendRequestGetResponse may return null on a network-layer failure. The operator must see an actionable
+    // error for that host, NOT a bare NullPointerException (dereferencing null + a second NPE on release()).
+    ReplicationPriorityAdminHelper.Sender nullSender = (node, partition, request) -> null;
+    ReplicationPriorityAdminHelper helper = new ReplicationPriorityAdminHelper(clusterMap, nullSender);
+    JSONObject json = captureJson(
+        () -> helper.runSetReplicationPriority(partitions.get(0).toPathString(), 4, false, "DC1", "", 1000));
+    assertEquals(0, json.getJSONObject("summary").getInt("succeeded"));
+    JSONArray results = json.getJSONArray("results");
+    assertTrue("expected at least one targeted host", results.length() > 0);
+    for (int i = 0; i < results.length(); i++) {
+      assertHostErrorIsNullResponseNotNpe(results.getJSONObject(i));
+    }
+  }
+
+  @Test
+  public void testRunListReplicationPriorityNullResponseReportedAsActionableError() {
+    ReplicationPriorityAdminHelper.Sender nullSender = (node, partition, request) -> null;
+    ReplicationPriorityAdminHelper helper = new ReplicationPriorityAdminHelper(clusterMap, nullSender);
+    JSONObject json = captureJson(() -> helper.runListReplicationPriority("", "DC1", "", 1000));
+    JSONArray results = json.getJSONArray("results");
+    assertTrue("expected at least one queried host", results.length() > 0);
+    for (int i = 0; i < results.length(); i++) {
+      assertHostErrorIsNullResponseNotNpe(results.getJSONObject(i));
+    }
+  }
+
+  @Test
+  public void testRunListReplicationPriorityReplicaLessNodeReportedOkEmptyNotError() throws Exception {
+    // A fresh / spare / draining node hosts no replicas, so it can hold no priorities. It must be reported as an
+    // empty-but-OK result, never contacted over the network (which would route through getReplicaFromNode with no
+    // replica to pick and surface a healthy node as status:"error").
+    MockDataNodeId spare = clusterMap.createNewDataNodes(1, "DC-spare").get(0);
+    spare.setHostname("DC-spare-host.test");
+    ReplicationPriorityAdminHelper.Sender sender = (node, partition, request) -> {
+      throw new AssertionError("a replica-less node must not be contacted over the network");
+    };
+    ReplicationPriorityAdminHelper helper = new ReplicationPriorityAdminHelper(clusterMap, sender);
+    JSONObject json =
+        captureJson(() -> helper.runListReplicationPriority("", "", spare.getHostname(), 1000));
+    assertEquals(1, json.getJSONObject("summary").getInt("queriedHosts"));
+    assertEquals(0, json.getJSONObject("summary").getInt("hostsWithPriorities"));
+    JSONArray results = json.getJSONArray("results");
+    assertEquals(1, results.length());
+    JSONObject hostJson = results.getJSONObject(0);
+    assertEquals(spare.getHostname(), hostJson.getString("host"));
+    assertEquals("ok", hostJson.getString("status"));
+    assertEquals(0, hostJson.getJSONArray("priorities").length());
+  }
+
   // ---- helpers ----
+
+  /** Asserts a results[] entry is an error whose message is the actionable null-response IOException, not an NPE. */
+  private static void assertHostErrorIsNullResponseNotNpe(JSONObject hostJson) {
+    assertEquals("error", hostJson.getString("status"));
+    String error = hostJson.getString("error");
+    assertTrue("error should surface the null-response IOException, got: " + error, error.contains("Null response"));
+    assertFalse("must not surface a NullPointerException, got: " + error, error.contains("NullPointerException"));
+  }
+
+  /** Runs {@code runnable}, capturing what it writes to {@code System.out}, and parses it as a {@link JSONObject}. */
+  private static JSONObject captureJson(Runnable runnable) {
+    PrintStream original = System.out;
+    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    try {
+      System.setOut(new PrintStream(buffer, true, "UTF-8"));
+      runnable.run();
+      return new JSONObject(buffer.toString("UTF-8"));
+    } catch (UnsupportedEncodingException e) {
+      throw new AssertionError(e);
+    } finally {
+      System.setOut(original);
+    }
+  }
 
   private List<PartitionId> tooManyPartitions() {
     List<PartitionId> many = new ArrayList<>();

--- a/ambry-tools/src/test/java/com/github/ambry/tools/admin/ReplicationPriorityAdminHelperTest.java
+++ b/ambry-tools/src/test/java/com/github/ambry/tools/admin/ReplicationPriorityAdminHelperTest.java
@@ -40,7 +40,13 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 
 /**

--- a/ambry-tools/src/test/java/com/github/ambry/tools/util/ToolRequestResponseUtilTest.java
+++ b/ambry-tools/src/test/java/com/github/ambry/tools/util/ToolRequestResponseUtilTest.java
@@ -21,7 +21,10 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 
 /**

--- a/ambry-tools/src/test/java/com/github/ambry/tools/util/ToolRequestResponseUtilTest.java
+++ b/ambry-tools/src/test/java/com/github/ambry/tools/util/ToolRequestResponseUtilTest.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2026 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.tools.util;
+
+import com.github.ambry.clustermap.DataNodeId;
+import com.github.ambry.clustermap.MockClusterMap;
+import com.github.ambry.clustermap.MockDataNodeId;
+import com.github.ambry.clustermap.ReplicaId;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+/**
+ * Unit tests for {@link ToolRequestResponseUtil#getReplicaFromNode}, focused on the {@code partitionId == null}
+ * ("pick any replica on the node") path used by the partition-agnostic admin operations.
+ */
+public class ToolRequestResponseUtilTest {
+  private MockClusterMap clusterMap;
+
+  @Before
+  public void setUp() throws Exception {
+    clusterMap = new MockClusterMap();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    if (clusterMap != null) {
+      clusterMap.cleanup();
+    }
+  }
+
+  @Test
+  public void testNullPartitionPicksAnyReplicaOnNode() {
+    DataNodeId node = clusterMap.getDataNodeIds().get(0);
+    ReplicaId replica = ToolRequestResponseUtil.getReplicaFromNode(node, null, clusterMap);
+    assertNotNull("A node hosting replicas must resolve a replica when partitionId is null", replica);
+    assertEquals(node, replica.getDataNodeId());
+  }
+
+  @Test
+  public void testNullPartitionOnReplicaLessNodeThrowsClearError() throws Exception {
+    // A freshly added node in a new DC hosts no replicas. Resolving "any replica" on it must fail with a clear
+    // IllegalStateException, not a bare IndexOutOfBoundsException from a .get(0) on an empty list.
+    MockDataNodeId spare = clusterMap.createNewDataNodes(1, "DC-spare").get(0);
+    try {
+      ToolRequestResponseUtil.getReplicaFromNode(spare, null, clusterMap);
+      fail("Expected IllegalStateException for a replica-less node");
+    } catch (IllegalStateException expected) {
+      assertTrue("error should explain the node hosts no replicas, got: " + expected.getMessage(),
+          expected.getMessage().contains("no replicas"));
+    }
+  }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -715,8 +715,6 @@ project(':ambry-tools') {
         implementation "commons-io:commons-io:$commonsIoVersion"
         implementation "org.bouncycastle:bcpkix-jdk15on:$bouncycastleVersion"
         implementation "com.zaxxer:HikariCP:$hikariVersion"
-        implementation "com.google.guava:guava:$guavaVersion"
-        implementation "org.json:json:$jsonVersion"
         testImplementation project(path: ':ambry-clustermap', configuration: 'testArchives')
         testImplementation project(path: ':ambry-account', configuration: 'testArchives')
         testImplementation project(path: ':ambry-store', configuration: 'testArchives')

--- a/build.gradle
+++ b/build.gradle
@@ -715,6 +715,8 @@ project(':ambry-tools') {
         implementation "commons-io:commons-io:$commonsIoVersion"
         implementation "org.bouncycastle:bcpkix-jdk15on:$bouncycastleVersion"
         implementation "com.zaxxer:HikariCP:$hikariVersion"
+        implementation "com.google.guava:guava:$guavaVersion"
+        implementation "org.json:json:$jsonVersion"
         testImplementation project(path: ':ambry-clustermap', configuration: 'testArchives')
         testImplementation project(path: ':ambry-account', configuration: 'testArchives')
         testImplementation project(path: ':ambry-store', configuration: 'testArchives')


### PR DESCRIPTION
## Summary
Adds two operator CLI operations to `ServerAdminTool` for the partition
replication-priority admin API whose server side shipped in #3261:
- `SetReplicationPriority` — set (or clear) a replication-priority boost on a set of
  partitions, scoped to a single fabric, fanned out to the servers hosting them
  (optionally narrowed via `servers`).
- `ListReplicationPriority` — report the priority entries currently in effect.

The logic lives in a new `ReplicationPriorityAdminHelper`; `ServerAdminTool` stays a thin
dispatcher. The helper resolves targets from the `ClusterMap` (sending each host only the
partitions it hosts — the server SET handler is all-or-nothing on `hostsPartition`), maps
`clear` + partition/server shape to the protocol `Action` (SET/UNSET/UNSET_ALL) with the
same validation the server enforces, fans out sequentially with per-host failure isolation
bounded by `maxFanoutTotal`, and emits JSON to stdout. `list` reports each entry's raw
`interColo` flag (intra- vs inter-colo pool). Transport is reused from
`ServerAdminTool#sendRequestGetResponse` — no new network client.

## Notes / scope
- CLI ("primitive") layer. `fabric` is single-valued (one fabric per invocation, for
  blast-radius control). No write-side lane selector — a SET applies to both pools (the
  wire request has no lane field); `list` surfaces the read-side `interColo` flag.
- `boost` defaults to 2, defensive cap 1024 (server enforces the precise cap).
- `ServerAdminToolConfig` now reads `store.control.request.type` with default `StartStore`
  (aligning with the field's existing `@Default("StartStore")`) so the new ops, which don't
  set that unrelated store-control property, don't fail config construction. Behavior-
  preserving for existing ops.
- Adds `guava` (`@VisibleForTesting`) and `org.json` (JSON output) as explicit `:ambry-tools`
  deps — both already repo dependencies via shared version vars.

## Testing Done
- `./gradlew :ambry-tools:compileJava :ambry-tools:compileTestJava :ambry-tools:test
  --tests "*ServerAdminTool*" --tests "*ReplicationPriorityAdminHelper*"` →
  BUILD SUCCESSFUL, 54 tests pass (JDK 11).
- `ReplicationPriorityAdminHelperTest` (`MockClusterMap`-based, network stubbed) covers
  action resolution + the full clear-semantics table, boost bounds, single-fabric
  requirement + comma-rejection, `servers` validation (whole-request rejection),
  per-host hosted-subset resolution, `maxFanoutTotal` admission on both set and list,
  per-host failure isolation incl. an unchecked-exception (down-host) case, wire-request
  construction, and the set/clear + list JSON shapes (parsed and asserted).
- `ServerAdminTool` had no prior tool-level tests; this change adds 54 (the first for the
  tool), covering the new ops' logic with the transport stubbed via the `Sender` interface.
  The wire round-trip's two ends are already covered separately — the server-side handling
  of these admin requests in `AmbryServerRequestsTest` (#3261), and protocol serialize/parse
  in `ambry-protocol`'s tests.

## Risk
Two new admin operations + a helper class; existing `ServerAdminTool` ops unchanged except
the `store.control.request.type` default above. No wire-protocol change (protocol shipped
in #3261); transport reused, not modified.

## AI Usage
Claude Code (Opus 4.8) — implementation, multi-round adversarial review, and the
extraction/refactor. All changes reviewed and tested.
