### PR TITLE
Replication priority: scope boosts to hosting threads, clean up on replica removal, report thread name

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/replication/PriorityEntry.java
+++ b/ambry-api/src/main/java/com/github/ambry/replication/PriorityEntry.java
@@ -33,11 +33,19 @@ public class PriorityEntry {
   private final PartitionId partitionId;
   private final int boost;
   private final boolean isInterColo;
+  private final String threadName;
 
-  public PriorityEntry(PartitionId partitionId, int boost, boolean isInterColo) {
+  /**
+   * @param partitionId the prioritized partition.
+   * @param boost the fetchSize weight applied to the partition.
+   * @param isInterColo whether the entry came from the inter-colo (cross-datacenter) thread pool.
+   * @param threadName the {@link ReplicaThread} holding this entry; may be {@code null} if unknown.
+   */
+  public PriorityEntry(PartitionId partitionId, int boost, boolean isInterColo, String threadName) {
     this.partitionId = partitionId;
     this.boost = boost;
     this.isInterColo = isInterColo;
+    this.threadName = threadName;
   }
 
   public PartitionId getPartitionId() {
@@ -52,8 +60,18 @@ public class PriorityEntry {
     return isInterColo;
   }
 
+  /**
+   * @return the name of the {@link ReplicaThread} that holds this priority entry, or {@code null} if unknown.
+   *         Two threads on the same node can each report the same partition (one entry per thread), so this
+   *         disambiguates otherwise-identical {@code (partition, boost, isInterColo)} rows.
+   */
+  public String getThreadName() {
+    return threadName;
+  }
+
   @Override
   public String toString() {
-    return "PriorityEntry[" + partitionId + ", boost=" + boost + ", isInterColo=" + isInterColo + "]";
+    return "PriorityEntry[" + partitionId + ", boost=" + boost + ", isInterColo=" + isInterColo + ", threadName="
+        + threadName + "]";
   }
 }

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/ListReplicationPriorityAdminResponse.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/ListReplicationPriorityAdminResponse.java
@@ -16,8 +16,10 @@ package com.github.ambry.protocol;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.replication.PriorityEntry;
+import com.github.ambry.utils.Utils;
 import java.io.DataInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -28,10 +30,10 @@ import java.util.List;
  * priority entries held by every {@link com.github.ambry.replication.ReplicaThread} on the
  * target storage node at handler-invocation time.
  *
- * Each {@link PriorityEntry} carries an {@code isInterColo} flag indicating whether the entry
- * came from the inter-colo (cross-datacenter) replication thread pool or the intra-colo pool.
- * The current design applies priorities to both pools by default, so the same partition
- * typically appears twice in the response — once per pool.
+ * Each {@link PriorityEntry} carries an {@code isInterColo} flag (inter-colo vs intra-colo thread pool)
+ * and the name of the holding {@link com.github.ambry.replication.ReplicaThread}. A partition can be
+ * replicated by more than one thread on a node, so it may appear once per thread; the thread name
+ * disambiguates otherwise-identical {@code (partition, boost, isInterColo)} rows.
  */
 public class ListReplicationPriorityAdminResponse extends AdminResponse {
   private static final short VERSION_V1 = 1;
@@ -40,6 +42,7 @@ public class ListReplicationPriorityAdminResponse extends AdminResponse {
 
   private final List<PriorityEntry> entries;
   private final byte[][] partitionIdBytes;
+  private final byte[][] threadNameBytes;
   private final long sizeInBytes;
 
   public static ListReplicationPriorityAdminResponse readFrom(DataInputStream stream, ClusterMap clusterMap)
@@ -58,7 +61,8 @@ public class ListReplicationPriorityAdminResponse extends AdminResponse {
       PartitionId partitionId = clusterMap.getPartitionIdFromStream(stream);
       int boost = stream.readInt();
       boolean isInterColo = stream.readByte() != 0;
-      entries.add(new PriorityEntry(partitionId, boost, isInterColo));
+      String threadName = Utils.readIntString(stream, StandardCharsets.UTF_8);
+      entries.add(new PriorityEntry(partitionId, boost, isInterColo, threadName));
     }
     return new ListReplicationPriorityAdminResponse(entries, adminResponse);
   }
@@ -67,8 +71,12 @@ public class ListReplicationPriorityAdminResponse extends AdminResponse {
     super(adminResponse.getCorrelationId(), adminResponse.getClientId(), adminResponse.getError());
     this.entries = Collections.unmodifiableList(new ArrayList<>(entries));
     this.partitionIdBytes = new byte[this.entries.size()][];
+    this.threadNameBytes = new byte[this.entries.size()][];
     for (int i = 0; i < this.entries.size(); i++) {
-      this.partitionIdBytes[i] = this.entries.get(i).getPartitionId().getBytes();
+      PriorityEntry entry = this.entries.get(i);
+      this.partitionIdBytes[i] = entry.getPartitionId().getBytes();
+      String threadName = entry.getThreadName() == null ? "" : entry.getThreadName();
+      this.threadNameBytes[i] = threadName.getBytes(StandardCharsets.UTF_8);
     }
     this.sizeInBytes = computeSizeInBytes();
   }
@@ -98,6 +106,9 @@ public class ListReplicationPriorityAdminResponse extends AdminResponse {
       bufferToSend.writeBytes(partitionIdBytes[i]);
       bufferToSend.writeInt(entry.getBoost());
       bufferToSend.writeByte(entry.isInterColo() ? (byte) 1 : (byte) 0);
+      // length-prefixed UTF-8 thread name (readable by Utils.readIntString).
+      bufferToSend.writeInt(threadNameBytes[i].length);
+      bufferToSend.writeBytes(threadNameBytes[i]);
     }
   }
 
@@ -105,8 +116,8 @@ public class ListReplicationPriorityAdminResponse extends AdminResponse {
     // parent + version + num-entries
     long size = super.sizeInBytes() + Short.BYTES + Integer.BYTES;
     for (int i = 0; i < entries.size(); i++) {
-      // partition id + boost + isInterColo flag
-      size += partitionIdBytes[i].length + Integer.BYTES + Byte.BYTES;
+      // partition id + boost + isInterColo flag + (thread-name length prefix + bytes)
+      size += partitionIdBytes[i].length + Integer.BYTES + Byte.BYTES + Integer.BYTES + threadNameBytes[i].length;
     }
     return size;
   }

--- a/ambry-protocol/src/test/java/com/github/ambry/protocol/RequestResponseTest.java
+++ b/ambry-protocol/src/test/java/com/github/ambry/protocol/RequestResponseTest.java
@@ -1560,13 +1560,34 @@ public class RequestResponseTest {
     doListReplicationPriorityAdminResponseTest(clusterMap, Collections.emptyList());
     // Single entry
     doListReplicationPriorityAdminResponseTest(clusterMap, Collections.singletonList(
-        new PriorityEntry(partitions.get(0), 4, false)));
-    // Mixed intra/inter-colo, multiple entries
+        new PriorityEntry(partitions.get(0), 4, false, "ReplicaThread-Intra-0-dc1")));
+    // Mixed intra/inter-colo, multiple entries, distinct thread names
     List<PriorityEntry> entries = new ArrayList<>();
-    entries.add(new PriorityEntry(partitions.get(0), 8, false));
-    entries.add(new PriorityEntry(partitions.get(1), 16, true));
-    entries.add(new PriorityEntry(partitions.get(2), 1, false));
+    entries.add(new PriorityEntry(partitions.get(0), 8, false, "ReplicaThread-Intra-0-dc1"));
+    entries.add(new PriorityEntry(partitions.get(1), 16, true, "ReplicaThread-Inter-1-dc2"));
+    entries.add(new PriorityEntry(partitions.get(2), 1, false, "ReplicaThread-Intra-1-dc1"));
     doListReplicationPriorityAdminResponseTest(clusterMap, entries);
+  }
+
+  /**
+   * A {@code null} thread name is serialized as an empty string and reads back as {@code ""} (never null),
+   * pinning the wire contract for entries created without a thread name.
+   */
+  @Test
+  public void listReplicationPriorityAdminResponseNullThreadNameTest() throws IOException {
+    MockClusterMap clusterMap = new MockClusterMap();
+    List<PartitionId> partitions = clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS);
+    Assume.assumeTrue("Need at least 1 partition for this test", partitions.size() >= 1);
+    AdminResponse baseResponse = new AdminResponse(7, "null-threadname-client", ServerErrorCode.NoError);
+    ListReplicationPriorityAdminResponse response = new ListReplicationPriorityAdminResponse(
+        Collections.singletonList(new PriorityEntry(partitions.get(0), 3, false, null)), baseResponse);
+    DataInputStream responseStream = serAndPrepForRead(response, -1, false);
+    ListReplicationPriorityAdminResponse deserialized =
+        ListReplicationPriorityAdminResponse.readFrom(responseStream, clusterMap);
+    Assert.assertEquals("entry count", 1, deserialized.getEntries().size());
+    Assert.assertEquals("null thread name should read back as empty string", "",
+        deserialized.getEntries().get(0).getThreadName());
+    response.release();
   }
 
   private void doUpdateReplicationPriorityAdminRequestTest(MockClusterMap clusterMap, List<PartitionId> partitions,
@@ -1610,6 +1631,7 @@ public class RequestResponseTest {
       Assert.assertEquals("entry[" + i + "].partition", expected.getPartitionId(), actual.getPartitionId());
       Assert.assertEquals("entry[" + i + "].boost", expected.getBoost(), actual.getBoost());
       Assert.assertEquals("entry[" + i + "].isInterColo", expected.isInterColo(), actual.isInterColo());
+      Assert.assertEquals("entry[" + i + "].threadName", expected.getThreadName(), actual.getThreadName());
     }
     response.release();
   }

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -319,12 +319,48 @@ public class ReplicaThread implements Runnable {
     if (partitions.isEmpty()) {
       return;
     }
-    for (PartitionId id : partitions) {
-      priorityPartitions.put(id, boost);
+    int applied = 0;
+    lock.lock();
+    try {
+      for (PartitionId id : partitions) {
+        // Only a thread that actually replicates this partition can act on a boost for it. Setting it on a
+        // thread that holds no replica of the partition is a no-op that also never auto-prunes (see the
+        // empty-infos case in shouldAutoPrunePriority), leaving a stale "ghost" entry. Skip those here.
+        if (hostsPartition(id)) {
+          priorityPartitions.put(id, boost);
+          applied++;
+        }
+      }
+    } finally {
+      lock.unlock();
     }
-    terminateCycleAndWake();
-    logger.info("Set replication priority for {} partitions on thread {} to boost {}",
-        partitions.size(), getName(), boost);
+    if (applied > 0) {
+      terminateCycleAndWake();
+      logger.info("Set replication priority for {} of {} requested partitions on thread {} to boost {}", applied,
+          partitions.size(), getName(), boost);
+    } else {
+      // Expected in the fan-out case: the engine offers every thread the full partition list and most threads
+      // host none of them. Log at debug so we don't emit N noisy INFO lines per operator request.
+      logger.debug("No hosted partitions among the {} requested for replication priority on thread {}",
+          partitions.size(), getName());
+    }
+  }
+
+  /**
+   * Whether this thread currently replicates at least one {@link RemoteReplicaInfo} of {@code partitionId}.
+   * Callers MUST hold {@link #lock} as this reads {@link #replicasToReplicateGroupedByNode}.
+   * @param partitionId the partition to check.
+   * @return {@code true} if at least one hosted remote replica belongs to {@code partitionId}.
+   */
+  private boolean hostsPartition(PartitionId partitionId) {
+    for (Set<RemoteReplicaInfo> infos : replicasToReplicateGroupedByNode.values()) {
+      for (RemoteReplicaInfo info : infos) {
+        if (info.getReplicaId().getPartitionId().equals(partitionId)) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   /**
@@ -473,6 +509,14 @@ public class ReplicaThread implements Runnable {
         } else {
           logger.info("RemoteReplicaInfo {} is removed from ReplicaThread {}.", remoteReplicaInfo, threadName);
           decreaseAssignedRemoteReplicaInfosMetric();
+          // Drop any replication priority held for this partition once its last replica leaves this thread;
+          // otherwise the entry never auto-prunes (empty-infos case) and lingers as a stale "ghost".
+          PartitionId removedPartition = remoteReplicaInfo.getReplicaId().getPartitionId();
+          if (priorityPartitions.containsKey(removedPartition) && !hostsPartition(removedPartition)) {
+            priorityPartitions.remove(removedPartition);
+            logger.info("Removed replication priority for partition {} on thread {} after its last replica was removed",
+                removedPartition, threadName);
+          }
         }
       } else {
         replicationMetrics.remoteReplicaInfoRemoveError.inc();

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
@@ -228,13 +228,14 @@ public abstract class ReplicationEngine implements ReplicationAPI {
       for (ReplicaThread thread : pool) {
         boolean isInterColo = thread.isReplicatingFromRemoteColo();
         for (Map.Entry<PartitionId, Integer> e : thread.listPriorityPartitions().entrySet()) {
-          entries.add(new PriorityEntry(e.getKey(), e.getValue(), isInterColo));
+          entries.add(new PriorityEntry(e.getKey(), e.getValue(), isInterColo, thread.getName()));
         }
       }
     }
     entries.sort(Comparator
         .comparing((PriorityEntry e) -> e.getPartitionId().toPathString())
-        .thenComparing(PriorityEntry::isInterColo));
+        .thenComparing(PriorityEntry::isInterColo)
+        .thenComparing(e -> e.getThreadName() == null ? "" : e.getThreadName()));
     return entries;
   }
 

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
@@ -235,7 +235,7 @@ public abstract class ReplicationEngine implements ReplicationAPI {
     entries.sort(Comparator
         .comparing((PriorityEntry e) -> e.getPartitionId().toPathString())
         .thenComparing(PriorityEntry::isInterColo)
-        .thenComparing(e -> e.getThreadName() == null ? "" : e.getThreadName()));
+        .thenComparing(PriorityEntry::getThreadName));
     return entries;
   }
 

--- a/ambry-replication/src/test/java/com/github/ambry/replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/ReplicationTest.java
@@ -204,6 +204,128 @@ public class ReplicationTest extends ReplicationTestHelper {
   }
 
   /**
+   * {@link ReplicaThread#prioritizePartitions} must only apply a boost to partitions this thread actually hosts.
+   * A boost on a partition with no local replica on the thread would create a "ghost" entry that never
+   * auto-prunes (see the empty-infos case of {@link ReplicaThread#shouldAutoPrunePriority}), so it must be skipped.
+   */
+  @Test
+  public void prioritizePartitionsSkipsNonHostedPartitionsTest() throws Exception {
+    MockClusterMap clusterMap = new MockClusterMap();
+    Pair<MockHost, MockHost> localAndRemoteHosts = getLocalAndRemoteHosts(clusterMap);
+    MockHost localHost = localAndRemoteHosts.getFirst();
+    MockHost remoteHost = localAndRemoteHosts.getSecond();
+    ReplicaThread replicaThread = buildReplicaThreadForPriorityTest(clusterMap, localHost, remoteHost);
+    List<RemoteReplicaInfo> remoteReplicaInfoList = localHost.getRemoteReplicaInfos(remoteHost, null);
+
+    // Host exactly one partition on this thread.
+    RemoteReplicaInfo hosted = remoteReplicaInfoList.get(0);
+    replicaThread.addRemoteReplicaInfo(hosted);
+    PartitionId hostedPartition = hosted.getReplicaId().getPartitionId();
+    PartitionId nonHostedPartition = remoteReplicaInfoList.get(1).getReplicaId().getPartitionId();
+    assertNotEquals("test needs two distinct partitions", hostedPartition, nonHostedPartition);
+
+    replicaThread.prioritizePartitions(Arrays.asList(hostedPartition, nonHostedPartition), 5);
+
+    Map<PartitionId, Integer> priorities = replicaThread.listPriorityPartitions();
+    assertEquals("only the hosted partition should be prioritized", Collections.singleton(hostedPartition),
+        priorities.keySet());
+    assertEquals("boost should match", Integer.valueOf(5), priorities.get(hostedPartition));
+  }
+
+  /**
+   * When a thread's last replica of a prioritized partition is removed, the priority entry must be dropped so it
+   * does not linger as an orphan that never auto-prunes (the empty-infos case is intentionally not pruned in the
+   * replication cycle, so cleanup happens here at removal time).
+   */
+  @Test
+  public void removeRemoteReplicaInfoClearsOrphanedPriorityTest() throws Exception {
+    MockClusterMap clusterMap = new MockClusterMap();
+    Pair<MockHost, MockHost> localAndRemoteHosts = getLocalAndRemoteHosts(clusterMap);
+    MockHost localHost = localAndRemoteHosts.getFirst();
+    MockHost remoteHost = localAndRemoteHosts.getSecond();
+    ReplicaThread replicaThread = buildReplicaThreadForPriorityTest(clusterMap, localHost, remoteHost);
+    List<RemoteReplicaInfo> remoteReplicaInfoList = localHost.getRemoteReplicaInfos(remoteHost, null);
+
+    RemoteReplicaInfo hosted = remoteReplicaInfoList.get(0);
+    replicaThread.addRemoteReplicaInfo(hosted);
+    PartitionId hostedPartition = hosted.getReplicaId().getPartitionId();
+    replicaThread.prioritizePartitions(Collections.singletonList(hostedPartition), 3);
+    assertTrue("priority should be set on the hosted partition",
+        replicaThread.listPriorityPartitions().containsKey(hostedPartition));
+
+    replicaThread.removeRemoteReplicaInfo(hosted);
+    assertFalse("priority must be cleared once the last replica of the partition is removed",
+        replicaThread.listPriorityPartitions().containsKey(hostedPartition));
+  }
+
+  /**
+   * A thread can hold multiple {@link RemoteReplicaInfo}s for the same partition (one per peer). Removing one
+   * must NOT drop the priority while another replica of the partition remains on the thread; only removing the
+   * last one clears it. Exercises the {@code && !hostsPartition(...)} guard in {@code removeRemoteReplicaInfo}.
+   */
+  @Test
+  public void removeRemoteReplicaInfoRetainsPriorityWhileAnotherReplicaRemainsTest() throws Exception {
+    MockClusterMap clusterMap = new MockClusterMap();
+    Pair<MockHost, MockHost> localAndRemoteHosts = getLocalAndRemoteHosts(clusterMap);
+    ReplicaThread replicaThread =
+        buildReplicaThreadForPriorityTest(clusterMap, localAndRemoteHosts.getFirst(), localAndRemoteHosts.getSecond());
+
+    // Two peer replicas of the SAME partition on two different remote nodes, both on this thread.
+    PartitionId partition = clusterMap.getWritablePartitionIds(null).get(0);
+    RemoteReplicaInfo peerA = mockRemoteReplicaInfoFor(partition, mock(DataNodeId.class));
+    RemoteReplicaInfo peerB = mockRemoteReplicaInfoFor(partition, mock(DataNodeId.class));
+    replicaThread.addRemoteReplicaInfo(peerA);
+    replicaThread.addRemoteReplicaInfo(peerB);
+
+    replicaThread.prioritizePartitions(Collections.singletonList(partition), 6);
+    assertTrue("priority should be set", replicaThread.listPriorityPartitions().containsKey(partition));
+
+    // Remove one peer: still hosted via the other peer -> priority RETAINED.
+    replicaThread.removeRemoteReplicaInfo(peerA);
+    assertTrue("priority must be retained while another replica of the partition remains on the thread",
+        replicaThread.listPriorityPartitions().containsKey(partition));
+
+    // Remove the last peer: no replica of the partition remains -> priority CLEARED.
+    replicaThread.removeRemoteReplicaInfo(peerB);
+    assertFalse("priority must be cleared after the last replica of the partition is removed",
+        replicaThread.listPriorityPartitions().containsKey(partition));
+  }
+
+  private RemoteReplicaInfo mockRemoteReplicaInfoFor(PartitionId partition, DataNodeId node) {
+    ReplicaId replicaId = mock(ReplicaId.class);
+    when(replicaId.getPartitionId()).thenReturn(partition);
+    when(replicaId.getDataNodeId()).thenReturn(node);
+    RemoteReplicaInfo info = mock(RemoteReplicaInfo.class);
+    when(info.getReplicaId()).thenReturn(replicaId);
+    return info;
+  }
+
+  /**
+   * Builds a bare {@link ReplicaThread} (no replicas added) for the priority unit tests above, mirroring the
+   * construction in {@link #remoteReplicaInfoAddRemoveTest()}.
+   */
+  private ReplicaThread buildReplicaThreadForPriorityTest(MockClusterMap clusterMap, MockHost localHost,
+      MockHost remoteHost) throws Exception {
+    StoreKeyFactory storeKeyFactory = Utils.getObj("com.github.ambry.commons.BlobIdFactory", clusterMap);
+    MockStoreKeyConverterFactory mockStoreKeyConverterFactory = new MockStoreKeyConverterFactory(null, null);
+    mockStoreKeyConverterFactory.setReturnInputIfAbsent(true);
+    mockStoreKeyConverterFactory.setConversionMap(new HashMap<>());
+    StoreKeyConverter storeKeyConverter = mockStoreKeyConverterFactory.getStoreKeyConverter();
+    Transformer transformer = new ValidatingTransformer(storeKeyFactory, storeKeyConverter);
+    ReplicationMetrics replicationMetrics =
+        new ReplicationMetrics(new MetricRegistry(), clusterMap.getReplicaIds(localHost.dataNodeId));
+    replicationMetrics.populateSingleColoMetrics(remoteHost.dataNodeId.getDatacenterName());
+    Map<DataNodeId, MockHost> hosts = new HashMap<>();
+    hosts.put(remoteHost.dataNodeId, remoteHost);
+    FindTokenHelper findTokenHelper = new MockFindTokenHelper(storeKeyFactory, replicationConfig);
+    MockNetworkClient networkClient = new MockNetworkClient(hosts, clusterMap, 4, findTokenHelper);
+    return new ReplicaThread("threadtest", findTokenHelper, clusterMap, new AtomicInteger(0), localHost.dataNodeId,
+        networkClient, replicationConfig, replicationMetrics, null, storeKeyConverter, transformer,
+        clusterMap.getMetricRegistry(), false, localHost.dataNodeId.getDatacenterName(),
+        new ResponseHandler(clusterMap), time, null, null, null);
+  }
+
+  /**
    * Test {@link ReplicationManager} is started successfully with empty replicas
    * @throws Exception
    */

--- a/ambry-tools/src/test/java/com/github/ambry/tools/admin/ReplicationPriorityAdminHelperTest.java
+++ b/ambry-tools/src/test/java/com/github/ambry/tools/admin/ReplicationPriorityAdminHelperTest.java
@@ -675,7 +675,7 @@ public class ReplicationPriorityAdminHelperTest {
     PartitionId p = partitions.get(0);
     DataNodeId host = clusterMap.getDataNodeIds().get(0);
     Map<DataNodeId, List<PriorityEntry>> hostEntries = new LinkedHashMap<>();
-    hostEntries.put(host, Collections.singletonList(new PriorityEntry(p, 4, /*isInterColo*/ false)));
+    hostEntries.put(host, Collections.singletonList(new PriorityEntry(p, 4, /*isInterColo*/ false, null)));
     JSONObject json = ReplicationPriorityAdminHelper.buildListResultJson(Collections.singletonList(host), hostEntries,
         Collections.emptyMap(), Collections.emptySet(), new ReplicationPriorityAdminHelper.FanOutSummary(1, 1));
     JSONArray priorities = indexByHost(json.getJSONArray("results")).get(host.getHostname()).getJSONArray("priorities");
@@ -691,7 +691,7 @@ public class ReplicationPriorityAdminHelperTest {
     PartitionId p = partitions.get(0);
     DataNodeId host = clusterMap.getDataNodeIds().get(0);
     Map<DataNodeId, List<PriorityEntry>> hostEntries = new LinkedHashMap<>();
-    hostEntries.put(host, Collections.singletonList(new PriorityEntry(p, 7, /*isInterColo*/ true)));
+    hostEntries.put(host, Collections.singletonList(new PriorityEntry(p, 7, /*isInterColo*/ true, null)));
     JSONObject json = ReplicationPriorityAdminHelper.buildListResultJson(Collections.singletonList(host), hostEntries,
         Collections.emptyMap(), Collections.emptySet(), new ReplicationPriorityAdminHelper.FanOutSummary(1, 1));
     JSONArray priorities = indexByHost(json.getJSONArray("results")).get(host.getHostname()).getJSONArray("priorities");
@@ -708,8 +708,8 @@ public class ReplicationPriorityAdminHelperTest {
     DataNodeId host = clusterMap.getDataNodeIds().get(0);
     Map<DataNodeId, List<PriorityEntry>> hostEntries = new LinkedHashMap<>();
     hostEntries.put(host, Arrays.asList(
-        new PriorityEntry(p, 5, /*isInterColo*/ false),
-        new PriorityEntry(p, 5, /*isInterColo*/ true)));
+        new PriorityEntry(p, 5, /*isInterColo*/ false, null),
+        new PriorityEntry(p, 5, /*isInterColo*/ true, null)));
     JSONObject json = ReplicationPriorityAdminHelper.buildListResultJson(Collections.singletonList(host), hostEntries,
         Collections.emptyMap(), Collections.emptySet(), new ReplicationPriorityAdminHelper.FanOutSummary(1, 1));
     JSONArray priorities = indexByHost(json.getJSONArray("results")).get(host.getHostname()).getJSONArray("priorities");
@@ -737,9 +737,9 @@ public class ReplicationPriorityAdminHelperTest {
 
     Map<DataNodeId, List<PriorityEntry>> hostEntries = new LinkedHashMap<>();
     hostEntries.put(hostWithPriorities, Arrays.asList(
-        new PriorityEntry(p0, 4, false),
-        new PriorityEntry(p0, 4, true),
-        new PriorityEntry(p1, 9, true)));   // p1 inter-only
+        new PriorityEntry(p0, 4, false, null),
+        new PriorityEntry(p0, 4, true, null),
+        new PriorityEntry(p1, 9, true, null)));   // p1 inter-only
     hostEntries.put(hostEmpty, Collections.emptyList());
     Map<DataNodeId, String> failures = new LinkedHashMap<>();
     failures.put(hostError, "IOException: timeout");
@@ -806,7 +806,7 @@ public class ReplicationPriorityAdminHelperTest {
     PartitionId dropped = partitions.get(1);
     DataNodeId host = clusterMap.getDataNodeIds().get(0);
     Map<DataNodeId, List<PriorityEntry>> hostEntries = new LinkedHashMap<>();
-    hostEntries.put(host, Arrays.asList(new PriorityEntry(kept, 2, false), new PriorityEntry(dropped, 3, false)));
+    hostEntries.put(host, Arrays.asList(new PriorityEntry(kept, 2, false, null), new PriorityEntry(dropped, 3, false, null)));
     JSONObject json = ReplicationPriorityAdminHelper.buildListResultJson(Collections.singletonList(host), hostEntries,
         Collections.emptyMap(), Collections.singleton(kept), new ReplicationPriorityAdminHelper.FanOutSummary(1, 1));
     assertEquals(1, json.getJSONObject("summary").getInt("uniquePartitions"));


### PR DESCRIPTION
## Summary
Improvements to the replication-priority admin API (#3261), surfaced by live Set/List/Clear testing on ei-ltx1 perf:

- **`prioritizePartitions` only boosts partitions the thread hosts.** Previously `ReplicationEngine.prioritizePartitions` fanned the boost to *every* `ReplicaThread`, including threads with no replica of the partition. Those entries never auto-prune (the empty-infos case in `shouldAutoPrunePriority` is intentionally not pruned), so they linger as stale "ghost" priorities until a manual unset or restart. Now a thread only accepts a boost for a partition it actually replicates (new `hostsPartition` check).
- **`removeRemoteReplicaInfo` clears an orphaned priority** once the thread's *last* replica of a partition is removed (decommission / rebalance). Guarded by `!hostsPartition` so the priority is retained while another peer replica of the same partition remains on the thread.
- **`PriorityEntry` / `ListReplicationPriorityAdminResponse` now carry the holding `ReplicaThread` name**, so otherwise-identical per-thread `List` rows (same partition / boost / isInterColo) are distinguishable.

### Wire compatibility
The thread name is appended to each entry on the existing response version (no version bump). This is safe here because the response is ephemeral (not persisted) and this request/response pair was introduced together in the same unreleased feature line — the only writer is the server and the only reader is `ServerAdminTool` (not yet merged), so there is no old-reader-vs-new-writer skew for the field. `threadName` is nullable and serialized as a length-prefixed UTF-8 string (`null` → `""`).

> The CLI surfacing of `threadName` in the `List` JSON output lands separately in #3268 (the `ServerAdminTool` lives on that branch).

## Testing Done
- New unit tests:
  - `ReplicationTest.prioritizePartitionsSkipsNonHostedPartitionsTest` — a boost targeting a non-hosted partition is skipped.
  - `ReplicationTest.removeRemoteReplicaInfoClearsOrphanedPriorityTest` — removing the last replica clears the priority.
  - `ReplicationTest.removeRemoteReplicaInfoRetainsPriorityWhileAnotherReplicaRemainsTest` — removing one of two peer replicas of a partition retains the priority; removing the last clears it (regression guard for the `!hostsPartition` check; verified by mutation — deleting the guard fails this test).
  - `RequestResponseTest.listReplicationPriorityAdminResponseTest` extended to assert `threadName` round-trips; new `...NullThreadNameTest` pins the `null` → `""` contract.
- Re-ran `AmbryServerRequestsTest` replication-priority handler tests (40), `RemoteReplicaGroupPollerTest` (14), and `ReplicaThreadPriorityAutoPruneTest` (8): all pass.

## Durability
No durability risk. This is a replication-scheduling hint (fetch-budget weight) on the read/observability path — it does not touch PUT / named-blob PUT / TTL / delete, metadata storage, or callback semantics. Removing a priority on a non-hosting thread is a no-op (that thread never fetched the partition); removing it on actual replica removal is correct.
