### PR TITLE
Avoid per-poll ConcurrentHashMap KeyIterator allocation in operation managers

### DIFF
--- a/ambry-router/src/main/java/com/github/ambry/router/DeleteManager.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/DeleteManager.java
@@ -117,20 +117,23 @@ class DeleteManager {
     long startTime = time.milliseconds();
     requestRegistrationCallback.setRequestsToSend(requestsToSend);
     requestRegistrationCallback.setRequestsToDrop(requestsToDrop);
-    for (DeleteOperation op : deleteOperations) {
-      boolean exceptionEncountered = false;
-      try {
-        op.poll(requestRegistrationCallback);
-      } catch (Exception e) {
-        exceptionEncountered = true;
-        op.setOperationException(new RouterException("Delete poll encountered unexpected error", e,
-            RouterErrorCode.UnexpectedInternalError));
-      }
-      if (exceptionEncountered || op.isOperationComplete()) {
-        if (deleteOperations.remove(op)) {
-          // In order to ensure that an operation is completed only once, call onComplete() only at the place where the
-          // operation actually gets removed from the set of operations. See comment within close().
-          onComplete(op);
+    // Iterating allocates a KeyIterator even when the set is empty; skip when no ops are in flight.
+    if (!deleteOperations.isEmpty()) {
+      for (DeleteOperation op : deleteOperations) {
+        boolean exceptionEncountered = false;
+        try {
+          op.poll(requestRegistrationCallback);
+        } catch (Exception e) {
+          exceptionEncountered = true;
+          op.setOperationException(new RouterException("Delete poll encountered unexpected error", e,
+              RouterErrorCode.UnexpectedInternalError));
+        }
+        if (exceptionEncountered || op.isOperationComplete()) {
+          if (deleteOperations.remove(op)) {
+            // In order to ensure that an operation is completed only once, call onComplete() only at the place where the
+            // operation actually gets removed from the set of operations. See comment within close().
+            onComplete(op);
+          }
         }
       }
     }

--- a/ambry-router/src/main/java/com/github/ambry/router/GetManager.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/GetManager.java
@@ -202,15 +202,18 @@ class GetManager {
     long startTime = time.milliseconds();
     requestRegistrationCallback.setRequestsToSend(requestsToSend);
     requestRegistrationCallback.setRequestsToDrop(requestsToDrop);
-    for (GetOperation op : getOperations) {
-      try {
-        op.poll(requestRegistrationCallback);
-        if (op.isOperationComplete()) {
-          remove(op);
+    // Iterating allocates a KeyIterator even when the set is empty; skip when no ops are in flight.
+    if (!getOperations.isEmpty()) {
+      for (GetOperation op : getOperations) {
+        try {
+          op.poll(requestRegistrationCallback);
+          if (op.isOperationComplete()) {
+            remove(op);
+          }
+        } catch (Exception e) {
+          removeAndAbort(op,
+              new RouterException("Get poll encountered unexpected error", e, RouterErrorCode.UnexpectedInternalError));
         }
-      } catch (Exception e) {
-        removeAndAbort(op,
-            new RouterException("Get poll encountered unexpected error", e, RouterErrorCode.UnexpectedInternalError));
       }
     }
     routerMetrics.getManagerPollTimeMs.update(time.milliseconds() - startTime);

--- a/ambry-router/src/main/java/com/github/ambry/router/PutManager.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/PutManager.java
@@ -227,17 +227,20 @@ class PutManager {
     long startTime = time.milliseconds();
     requestRegistrationCallback.setRequestsToSend(requestsToSend);
     requestRegistrationCallback.setRequestsToDrop(requestsToDrop);
-    for (PutOperation op : putOperations) {
-      try {
-        op.poll(requestRegistrationCallback);
-      } catch (Exception e) {
-        op.setOperationExceptionAndComplete(
-            new RouterException("Put poll encountered unexpected error", e, RouterErrorCode.UnexpectedInternalError));
-      }
-      if (op.isOperationComplete() && putOperations.remove(op)) {
-        // In order to ensure that an operation is completed only once, call onComplete() only at the place where the
-        // operation actually gets removed from the set of operations. See comment within closePendingOperations().
-        onComplete(op);
+    // Iterating allocates a KeyIterator even when the set is empty; skip when no ops are in flight.
+    if (!putOperations.isEmpty()) {
+      for (PutOperation op : putOperations) {
+        try {
+          op.poll(requestRegistrationCallback);
+        } catch (Exception e) {
+          op.setOperationExceptionAndComplete(
+              new RouterException("Put poll encountered unexpected error", e, RouterErrorCode.UnexpectedInternalError));
+        }
+        if (op.isOperationComplete() && putOperations.remove(op)) {
+          // In order to ensure that an operation is completed only once, call onComplete() only at the place where the
+          // operation actually gets removed from the set of operations. See comment within closePendingOperations().
+          onComplete(op);
+        }
       }
     }
     routerMetrics.putManagerPollTimeMs.update(time.milliseconds() - startTime);

--- a/ambry-router/src/main/java/com/github/ambry/router/ReplicateBlobManager.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/ReplicateBlobManager.java
@@ -107,20 +107,23 @@ class ReplicateBlobManager {
     long startTime = time.milliseconds();
     requestRegistrationCallback.setRequestsToSend(requestsToSend);
     requestRegistrationCallback.setRequestsToDrop(requestsToDrop);
-    for (ReplicateBlobOperation op : replicateBlobOperations) {
-      boolean exceptionEncountered = false;
-      try {
-        op.poll(requestRegistrationCallback);
-      } catch (Exception e) {
-        exceptionEncountered = true;
-        op.setOperationException(new RouterException("ReplicateBlob poll encountered unexpected error", e,
-            RouterErrorCode.UnexpectedInternalError));
-      }
-      if (exceptionEncountered || op.isOperationComplete()) {
-        if (replicateBlobOperations.remove(op)) {
-          // In order to ensure that an operation is completed only once, call onComplete() only at the place where the
-          // operation actually gets removed from the set of operations. See comment within close().
-          onComplete(op);
+    // Iterating allocates a KeyIterator even when the set is empty; skip when no ops are in flight.
+    if (!replicateBlobOperations.isEmpty()) {
+      for (ReplicateBlobOperation op : replicateBlobOperations) {
+        boolean exceptionEncountered = false;
+        try {
+          op.poll(requestRegistrationCallback);
+        } catch (Exception e) {
+          exceptionEncountered = true;
+          op.setOperationException(new RouterException("ReplicateBlob poll encountered unexpected error", e,
+              RouterErrorCode.UnexpectedInternalError));
+        }
+        if (exceptionEncountered || op.isOperationComplete()) {
+          if (replicateBlobOperations.remove(op)) {
+            // In order to ensure that an operation is completed only once, call onComplete() only at the place where the
+            // operation actually gets removed from the set of operations. See comment within close().
+            onComplete(op);
+          }
         }
       }
     }

--- a/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateManager.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateManager.java
@@ -155,20 +155,23 @@ class TtlUpdateManager {
     long startTime = time.milliseconds();
     requestRegistrationCallback.setRequestsToSend(requestsToSend);
     requestRegistrationCallback.setRequestsToDrop(requestsToDrop);
-    for (TtlUpdateOperation op : ttlUpdateOperations) {
-      boolean exceptionEncountered = false;
-      try {
-        op.poll(requestRegistrationCallback);
-      } catch (Exception e) {
-        exceptionEncountered = true;
-        op.setOperationException(
-            new RouterException("TTL poll encountered unexpected error", e, RouterErrorCode.UnexpectedInternalError));
-      }
-      if (exceptionEncountered || op.isOperationComplete()) {
-        if (ttlUpdateOperations.remove(op)) {
-          // In order to ensure that an operation is completed only once, call onComplete() only at the place where the
-          // operation actually gets removed from the set of operations. See comment within close().
-          onComplete(op);
+    // Iterating allocates a KeyIterator even when the set is empty; skip when no ops are in flight.
+    if (!ttlUpdateOperations.isEmpty()) {
+      for (TtlUpdateOperation op : ttlUpdateOperations) {
+        boolean exceptionEncountered = false;
+        try {
+          op.poll(requestRegistrationCallback);
+        } catch (Exception e) {
+          exceptionEncountered = true;
+          op.setOperationException(
+              new RouterException("TTL poll encountered unexpected error", e, RouterErrorCode.UnexpectedInternalError));
+        }
+        if (exceptionEncountered || op.isOperationComplete()) {
+          if (ttlUpdateOperations.remove(op)) {
+            // In order to ensure that an operation is completed only once, call onComplete() only at the place where the
+            // operation actually gets removed from the set of operations. See comment within close().
+            onComplete(op);
+          }
         }
       }
     }

--- a/ambry-router/src/main/java/com/github/ambry/router/UndeleteManager.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/UndeleteManager.java
@@ -158,20 +158,23 @@ public class UndeleteManager {
     long startTime = time.milliseconds();
     requestRegistrationCallback.setRequestsToSend(requestsToSend);
     requestRegistrationCallback.setRequestsToDrop(requestsToDrop);
-    for (UndeleteOperation op : undeleteOperations) {
-      boolean exceptionEncountered = false;
-      try {
-        op.poll(requestRegistrationCallback);
-      } catch (Exception e) {
-        exceptionEncountered = true;
-        op.setOperationException(new RouterException("Undelete poll encountered unexpected error", e,
-            RouterErrorCode.UnexpectedInternalError));
-      }
-      if (exceptionEncountered || op.isOperationComplete()) {
-        if (undeleteOperations.remove(op)) {
-          // In order to ensure that an operation is completed only once, call onComplete() only at the place where the
-          // operation actually gets removed from the set of operations. See comment within close().
-          onComplete(op);
+    // Iterating allocates a KeyIterator even when the set is empty; skip when no ops are in flight.
+    if (!undeleteOperations.isEmpty()) {
+      for (UndeleteOperation op : undeleteOperations) {
+        boolean exceptionEncountered = false;
+        try {
+          op.poll(requestRegistrationCallback);
+        } catch (Exception e) {
+          exceptionEncountered = true;
+          op.setOperationException(new RouterException("Undelete poll encountered unexpected error", e,
+              RouterErrorCode.UnexpectedInternalError));
+        }
+        if (exceptionEncountered || op.isOperationComplete()) {
+          if (undeleteOperations.remove(op)) {
+            // In order to ensure that an operation is completed only once, call onComplete() only at the place where the
+            // operation actually gets removed from the set of operations. See comment within close().
+            onComplete(op);
+          }
         }
       }
     }


### PR DESCRIPTION
## What

Guard the per-`poll()` iteration of each operation manager's in-flight operation set with `isEmpty()`, so the enhanced-for loop does not allocate a `ConcurrentHashMap$KeyIterator` when the set is empty.

## Why

Each operation manager (`GetManager`, `PutManager`, `DeleteManager`, `TtlUpdateManager`, `UndeleteManager`, `ReplicateBlobManager`) stores its in-flight operations in a `ConcurrentHashMap.newKeySet()` and iterates it once per `poll()` with an enhanced-for loop. The for-each calls `.iterator()`, and `ConcurrentHashMap.KeySetView.iterator()` allocates a `KeyIterator` **unconditionally** — even for an empty set — before `hasNext()` returns false:

```java
public Iterator<K> iterator() {
    Node<K,V>[] t;
    ConcurrentHashMap<K,V> m = map;
    int f = (t = m.table) == null ? 0 : t.length;
    return new KeyIterator<K,V>(t, f, 0, f, m);  // allocated even when empty
}
```

The `RequestResponseHandler` poll loop runs continuously across all six managers, so an idle or lightly-loaded router allocates a throwaway iterator per manager per poll. Heap analysis of a busy frontend showed tens of millions of these short-lived `ConcurrentHashMap$KeyIterator` objects as the dominant young-gen garbage, inflating GC frequency.

Guarding with `!operations.isEmpty()` skips the `.iterator()` call in the empty case; `isEmpty()` checks the map count and allocates nothing.

## Behavior

No behavior change — an empty set's for-each is already a no-op, so the guard only removes the wasted allocation. When operations are present the loop runs exactly as before.

## Testing Done

- `./gradlew :ambry-router:compileJava` — BUILD SUCCESSFUL.
- `./gradlew :ambry-router:test --tests GetManagerTest --tests PutManagerTest --tests DeleteManagerTest --tests TtlUpdateManagerTest --tests UndeleteManagerTest` — **201 tests, 201 passed, 0 failed**.