### PR TITLE
Make named blob cleaner delay configurable

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/FrontendConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/FrontendConfig.java
@@ -50,6 +50,8 @@ public class FrontendConfig {
   public static final String CONTAINER_METRICS_ENABLED_GET_REQUEST_TYPES =
       PREFIX + "container.metrics.enabled.get.request.types";
   public static final String LIST_MAX_RESULTS = PREFIX + "list.max.results";
+  public static final String NAMED_BLOB_CLEANUP_CONTAINER_DELAY_SECONDS =
+      PREFIX + "named.blob.cleanup.container.delay.seconds";
 
   // Default values
   private static final String DEFAULT_ENDPOINT = "http://localhost:1174";
@@ -94,6 +96,15 @@ public class FrontendConfig {
   @Config("frontend.named.blob.cleanup.seconds")
   @Default("60 * 60 * 24 * 7")
   public final int namedBlobCleanupSeconds;
+
+  /**
+   * The optional delay in seconds between eligible containers within one named blob cleanup run. This is separate from
+   * {@link #namedBlobCleanupSeconds}, which controls the interval between full cleanup runs. A value of 0 disables the
+   * inter-container delay.
+   */
+  @Config(NAMED_BLOB_CLEANUP_CONTAINER_DELAY_SECONDS)
+  @Default("0")
+  public final int namedBlobCleanupContainerDelaySeconds;
 
 
   /**
@@ -323,6 +334,8 @@ public class FrontendConfig {
     optionsValiditySeconds = verifiableProperties.getLong("frontend.options.validity.seconds", 24 * 60 * 60);
     enableNamedBlobCleanupTask = verifiableProperties.getBoolean("frontend.enable.named.blob.cleanup.task", false);
     namedBlobCleanupSeconds = verifiableProperties.getInt("frontend.named.blob.cleanup.seconds", 60 * 60 * 24 * 7);
+    namedBlobCleanupContainerDelaySeconds =
+        verifiableProperties.getIntInRange(NAMED_BLOB_CLEANUP_CONTAINER_DELAY_SECONDS, 0, 0, Integer.MAX_VALUE);
     permanentNamedBlobInitialPutTtl =
         verifiableProperties.getLong("permanent.named.blob.initial.put.ttl", 25 * 60 * 60);
     optionsAllowMethods =

--- a/ambry-api/src/test/java/com/github/ambry/config/FrontendConfigTest.java
+++ b/ambry-api/src/test/java/com/github/ambry/config/FrontendConfigTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.ambry.config;
+
+import java.util.Properties;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+/**
+ * Tests for {@link FrontendConfig}.
+ */
+public class FrontendConfigTest {
+
+  @Test
+  public void testNamedBlobCleanupContainerDelaySeconds() {
+    Properties properties = new Properties();
+    FrontendConfig config = new FrontendConfig(new VerifiableProperties(properties));
+    Assert.assertEquals("The inter-container delay should be disabled by default", 0,
+        config.namedBlobCleanupContainerDelaySeconds);
+
+    properties.setProperty(FrontendConfig.NAMED_BLOB_CLEANUP_CONTAINER_DELAY_SECONDS, "17");
+    config = new FrontendConfig(new VerifiableProperties(properties));
+    Assert.assertEquals("The configured inter-container delay should be used", 17,
+        config.namedBlobCleanupContainerDelaySeconds);
+  }
+
+  @Test
+  public void testNamedBlobCleanupContainerDelaySecondsRejectsNegativeValue() {
+    Properties properties = new Properties();
+    properties.setProperty(FrontendConfig.NAMED_BLOB_CLEANUP_CONTAINER_DELAY_SECONDS, "-1");
+    try {
+      new FrontendConfig(new VerifiableProperties(properties));
+      Assert.fail("A negative inter-container delay should be rejected");
+    } catch (IllegalArgumentException ignored) {
+    }
+  }
+}

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestService.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestService.java
@@ -254,7 +254,9 @@ class FrontendRestRequestService implements RestRequestService {
     s3GetHandler =
         new S3GetHandler(s3ListHandler, s3MultipartUploadHandler, getBlobHandler, securityService, frontendMetrics,
             accountAndContainerInjector);
-    namedBlobsCleanupRunner = new NamedBlobsCleanupRunner(router, namedBlobDb, accountService);
+    namedBlobsCleanupRunner =
+        new NamedBlobsCleanupRunner(router, namedBlobDb, accountService,
+            frontendConfig.namedBlobCleanupContainerDelaySeconds);
     if (frontendConfig.enableNamedBlobCleanupTask) {
       namedBlobsCleanupScheduler = Utils.newScheduler(1, "named-blobs-cleanup-", false);
       int initialDelayInSeconds = random.nextInt(frontendConfig.namedBlobCleanupSeconds);

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobsCleanupRunner.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/NamedBlobsCleanupRunner.java
@@ -19,6 +19,8 @@ import com.github.ambry.named.NamedBlobDb;
 import com.github.ambry.named.StaleNamedBlob;
 import com.github.ambry.router.Router;
 import com.github.ambry.router.RouterErrorCode;
+import com.github.ambry.utils.SystemTime;
+import com.github.ambry.utils.Time;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -40,11 +42,28 @@ public class NamedBlobsCleanupRunner implements Runnable {
   private static final Logger logger = LoggerFactory.getLogger(NamedBlobsCleanupRunner.class);
   private final AccountService accountService;
   private final String smallestASCII = "\0";
+  private final int containerDelaySeconds;
+  private final Time time;
 
   public NamedBlobsCleanupRunner(Router router, NamedBlobDb namedBlobDb, AccountService accountService) {
+    this(router, namedBlobDb, accountService, 0);
+  }
+
+  public NamedBlobsCleanupRunner(Router router, NamedBlobDb namedBlobDb, AccountService accountService,
+      int containerDelaySeconds) {
+    this(router, namedBlobDb, accountService, containerDelaySeconds, SystemTime.getInstance());
+  }
+
+  NamedBlobsCleanupRunner(Router router, NamedBlobDb namedBlobDb, AccountService accountService,
+      int containerDelaySeconds, Time time) {
+    if (containerDelaySeconds < 0) {
+      throw new IllegalArgumentException("containerDelaySeconds must not be negative");
+    }
     this.router = router;
     this.namedBlobDb = namedBlobDb;
     this.accountService = accountService;
+    this.containerDelaySeconds = containerDelaySeconds;
+    this.time = time;
   }
 
   @Override
@@ -57,9 +76,20 @@ public class NamedBlobsCleanupRunner implements Runnable {
       combinedContainers.addAll(inactiveContainers);
       List<StaleNamedBlob> batchStaleBlobs = Collections.emptyList();
       NamedBlobDb.StaleBlobsWithLatestBlobName staleBlobsWithLatestBlobName;
+      boolean processedContainer = false;
       for (Container container : combinedContainers) {
         if (container.getNamedBlobMode() == Container.NamedBlobMode.DISABLED) {
           continue;
+        }
+        if (processedContainer && containerDelaySeconds > 0) {
+          try {
+            logger.info("Waiting {} seconds before cleaning container {}", containerDelaySeconds, container.getId());
+            time.sleep(TimeUnit.SECONDS.toMillis(containerDelaySeconds));
+          } catch (InterruptedException e) {
+            logger.info("Named blob cleanup interrupted before container {}; stopping cleanup run", container.getId());
+            Thread.currentThread().interrupt();
+            return;
+          }
         }
         logger.info("Started the cleaner for container: {}", container.getId());
         // set blobName to be "\0" since it is the lowest ASCII value and everything is greater than it
@@ -93,12 +123,8 @@ public class NamedBlobsCleanupRunner implements Runnable {
 
           blobName = staleBlobsWithLatestBlobName.getLatestBlob();
         } while (staleBlobsWithLatestBlobName.getLatestBlob() != null);
-        try {
-          logger.info("Finished cleaning container {}. Sleeping for 7 days before next container...", container.getId());
-          Thread.sleep(604800000); // 7 days
-        } catch (InterruptedException e) {
-          logger.error("Sleep interrupted after container cleanup", e);
-        }
+        logger.info("Finished cleaning container {}", container.getId());
+        processedContainer = true;
       }
       logger.info("Named Blobs Cleanup Runner is completed");
     } catch (ExecutionException e) {

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/NamedBlobsCleanupRunnerTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/NamedBlobsCleanupRunnerTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2026 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.ambry.frontend;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.github.ambry.account.AccountService;
+import com.github.ambry.account.Container;
+import com.github.ambry.named.NamedBlobDb;
+import com.github.ambry.router.Router;
+import com.github.ambry.utils.MockTime;
+import com.github.ambry.utils.Time;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+
+
+/**
+ * Tests for {@link NamedBlobsCleanupRunner}.
+ */
+public class NamedBlobsCleanupRunnerTest {
+
+  private static final String FIRST_BLOB_NAME = "\0";
+
+  @Test
+  public void testZeroDelayProcessesAllEligibleContainers() {
+    Container activeContainer = mockContainer((short) 1, Container.NamedBlobMode.OPTIONAL);
+    Container inactiveContainer = mockContainer((short) 2, Container.NamedBlobMode.NO_UPDATE);
+    Container disabledContainer = mockContainer((short) 3, Container.NamedBlobMode.DISABLED);
+    AccountService accountService = mock(AccountService.class);
+    when(accountService.getContainersByStatus(Container.ContainerStatus.ACTIVE)).thenReturn(
+        new HashSet<>(Arrays.asList(activeContainer, disabledContainer)));
+    when(accountService.getContainersByStatus(Container.ContainerStatus.INACTIVE)).thenReturn(
+        Collections.singleton(inactiveContainer));
+    NamedBlobDb namedBlobDb = mockNamedBlobDb();
+    MockTime time = new MockTime();
+
+    new NamedBlobsCleanupRunner(mock(Router.class), namedBlobDb, accountService, 0, time).run();
+
+    verify(namedBlobDb).pullStaleBlobs(activeContainer, FIRST_BLOB_NAME);
+    verify(namedBlobDb).pullStaleBlobs(inactiveContainer, FIRST_BLOB_NAME);
+    verify(namedBlobDb, never()).pullStaleBlobs(disabledContainer, FIRST_BLOB_NAME);
+    assertEquals("A zero delay should not advance time", 0, time.milliseconds());
+  }
+
+  @Test
+  public void testConfiguredDelayOccursOnlyBetweenEligibleContainers() {
+    int containerDelaySeconds = 7;
+    Container firstActiveContainer = mockContainer((short) 1, Container.NamedBlobMode.OPTIONAL);
+    Container secondActiveContainer = mockContainer((short) 2, Container.NamedBlobMode.NO_UPDATE);
+    Container inactiveContainer = mockContainer((short) 3, Container.NamedBlobMode.OPTIONAL);
+    Container disabledContainer = mockContainer((short) 4, Container.NamedBlobMode.DISABLED);
+    AccountService accountService = mock(AccountService.class);
+    when(accountService.getContainersByStatus(Container.ContainerStatus.ACTIVE)).thenReturn(
+        new HashSet<>(Arrays.asList(firstActiveContainer, secondActiveContainer, disabledContainer)));
+    when(accountService.getContainersByStatus(Container.ContainerStatus.INACTIVE)).thenReturn(
+        Collections.singleton(inactiveContainer));
+    NamedBlobDb namedBlobDb = mockNamedBlobDb();
+    MockTime time = new MockTime();
+
+    new NamedBlobsCleanupRunner(mock(Router.class), namedBlobDb, accountService, containerDelaySeconds, time).run();
+
+    verify(namedBlobDb).pullStaleBlobs(firstActiveContainer, FIRST_BLOB_NAME);
+    verify(namedBlobDb).pullStaleBlobs(secondActiveContainer, FIRST_BLOB_NAME);
+    verify(namedBlobDb).pullStaleBlobs(inactiveContainer, FIRST_BLOB_NAME);
+    verify(namedBlobDb, never()).pullStaleBlobs(disabledContainer, FIRST_BLOB_NAME);
+    assertEquals("Three eligible containers should result in two delays",
+        TimeUnit.SECONDS.toMillis(2L * containerDelaySeconds), time.milliseconds());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testNegativeDelayRejected() {
+    new NamedBlobsCleanupRunner(mock(Router.class), mock(NamedBlobDb.class), mock(AccountService.class), -1,
+        new MockTime());
+  }
+
+  @Test
+  public void testInterruptedDelayStopsCleanupRun() throws Exception {
+    Container firstContainer = mockContainer((short) 1, Container.NamedBlobMode.OPTIONAL);
+    Container secondContainer = mockContainer((short) 2, Container.NamedBlobMode.OPTIONAL);
+    AccountService accountService = mock(AccountService.class);
+    when(accountService.getContainersByStatus(Container.ContainerStatus.ACTIVE)).thenReturn(
+        new HashSet<>(Arrays.asList(firstContainer, secondContainer)));
+    when(accountService.getContainersByStatus(Container.ContainerStatus.INACTIVE)).thenReturn(Collections.emptySet());
+    NamedBlobDb namedBlobDb = mockNamedBlobDb();
+    Time time = mock(Time.class);
+    doThrow(new InterruptedException("test interruption")).when(time).sleep(TimeUnit.SECONDS.toMillis(1));
+
+    try {
+      new NamedBlobsCleanupRunner(mock(Router.class), namedBlobDb, accountService, 1, time).run();
+
+      verify(namedBlobDb, times(1)).pullStaleBlobs(any(Container.class), eq(FIRST_BLOB_NAME));
+      assertTrue("The interrupt status should be restored", Thread.currentThread().isInterrupted());
+    } finally {
+      Thread.interrupted();
+    }
+  }
+
+  private NamedBlobDb mockNamedBlobDb() {
+    NamedBlobDb namedBlobDb = mock(NamedBlobDb.class);
+    when(namedBlobDb.pullStaleBlobs(any(Container.class), eq(FIRST_BLOB_NAME))).thenReturn(
+        CompletableFuture.completedFuture(
+            new NamedBlobDb.StaleBlobsWithLatestBlobName(Collections.emptyList(), null)));
+    return namedBlobDb;
+  }
+
+  private Container mockContainer(short id, Container.NamedBlobMode namedBlobMode) {
+    Container container = mock(Container.class);
+    when(container.getId()).thenReturn(id);
+    when(container.getNamedBlobMode()).thenReturn(namedBlobMode);
+    return container;
+  }
+}


### PR DESCRIPTION
## Summary

The named-blob cleaner currently sleeps seven days after every eligible container, so one scheduled sweep can take months and restart from an earlier container after a host replacement.

- Add `frontend.named.blob.cleanup.container.delay.seconds`, defaulting to `0`, so each scheduled run processes all eligible containers without a hardcoded pause.
- Preserve optional throttling: positive values wait only between eligible containers, not after the final container or for disabled containers.
- Stop the cleanup run safely if an inter-container wait is interrupted.

This change only makes the cleaner process containers sooner. It does not change which blobs are deleted or the safety order: delete the Ambry blob first, then mark its MySQL mapping deleted. The main risk is increased load while clearing the backlog, not deleting different data; operators can set a positive delay if throttling is required.

## Testing Done

- [x] Local code review completed
- Focused configuration and runner unit tests passed.
- `ambry-api` and `ambry-frontend` builds passed with `enforceObjectMapperUsage` excluded; the unfiltered build is blocked by the existing `HostThrottleConfig.java` violation.

🤖 Generated with [GitHub Copilot CLI](https://docs.github.com/copilot/github-copilot-cli)
