### PR TITLE
Add dedicated metric for 5xx server errors per operation

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/rest/RestRequestMetrics.java
+++ b/ambry-api/src/main/java/com/github/ambry/rest/RestRequestMetrics.java
@@ -44,6 +44,10 @@ public class RestRequestMetrics {
   static final String UNSATISFIED_REQUEST_COUNT_SUFFIX = "UnsatisfiedRequestCount";
   static final String SATISFIED_REQUEST_COUNT_SUFFIX = "SatisfiedRequestCount";
 
+  // Tracked separately from UNSATISFIED_REQUEST_COUNT_SUFFIX so that alerts can be configured on 5xx server errors
+  // specifically, without being diluted by requests that are unsatisfied for other reasons (e.g. missed thresholds).
+  static final String SERVER_ERROR_COUNT_SUFFIX = "ServerErrorCount";
+
   static final String THROUGHPUT_SUFFIX = "Throughput";
 
   final Histogram nioRequestProcessingTimeInMs;
@@ -62,6 +66,7 @@ public class RestRequestMetrics {
   final Counter operationCount;
   final Counter unsatisfiedRequestCount;
   final Counter satisfiedRequestCount;
+  final Counter serverErrorCount;
 
   final Histogram throughput;
 
@@ -107,6 +112,8 @@ public class RestRequestMetrics {
         metricRegistry.counter(MetricRegistry.name(ownerClass, requestType + UNSATISFIED_REQUEST_COUNT_SUFFIX));
     satisfiedRequestCount =
         metricRegistry.counter(MetricRegistry.name(ownerClass, requestType + SATISFIED_REQUEST_COUNT_SUFFIX));
+    serverErrorCount =
+        metricRegistry.counter(MetricRegistry.name(ownerClass, requestType + SERVER_ERROR_COUNT_SUFFIX));
 
     throughput = metricRegistry.histogram(MetricRegistry.name(ownerClass, requestType + THROUGHPUT_SUFFIX));
   }

--- a/ambry-api/src/main/java/com/github/ambry/rest/RestRequestMetricsTracker.java
+++ b/ambry-api/src/main/java/com/github/ambry/rest/RestRequestMetricsTracker.java
@@ -58,6 +58,7 @@ public class RestRequestMetricsTracker {
   private ContainerMetrics containerMetrics;
   private boolean failed = false;
   private boolean satisfied = true;
+  private boolean serverError = false;
   private ResponseStatus responseStatus = ResponseStatus.Ok;
 
   private long bytesTransferred = 0;
@@ -216,6 +217,24 @@ public class RestRequestMetricsTracker {
   }
 
   /**
+   * Marks that the request resulted in a server error (5xx response) so that a metric dedicated to server errors
+   * can be tracked. This is tracked separately from {@link #markUnsatisfied()} so that alerts can be set up on 5xx
+   * responses specifically, without being diluted by requests that are unsatisfied for other reasons (e.g. missed
+   * performance thresholds).
+   */
+  public void markServerError() {
+    serverError = true;
+  }
+
+  /**
+   * Return whether the rest request resulted in a server error (5xx response) or not.
+   * @return {@code true} if the request resulted in a server error.
+   */
+  public boolean isServerError() {
+    return serverError;
+  }
+
+  /**
    * @param responseStatus the {@link ResponseStatus} to be used for certain count metrics.
    */
   public void setResponseStatus(ResponseStatus responseStatus) {
@@ -281,6 +300,9 @@ public class RestRequestMetricsTracker {
           metrics.satisfiedRequestCount.inc();
         } else {
           metrics.unsatisfiedRequestCount.inc();
+        }
+        if (serverError) {
+          metrics.serverErrorCount.inc();
         }
 
         // Only add throughput metrics when the request is successful and bytes were actually transfered over the wire.

--- a/ambry-api/src/test/java/com/github/ambry/rest/RestRequestMetricsTrackerTest.java
+++ b/ambry-api/src/test/java/com/github/ambry/rest/RestRequestMetricsTrackerTest.java
@@ -54,6 +54,63 @@ public class RestRequestMetricsTrackerTest {
   }
 
   /**
+   * Tests that {@link RestRequestMetricsTracker#markServerError()} increments a metric that is separate and
+   * independent from the unsatisfied/satisfied request count metrics tracked via
+   * {@link RestRequestMetricsTracker#markUnsatisfied()}.
+   */
+  @Test
+  public void markServerErrorTest() {
+    // server error marked, request otherwise satisfied (mirrors requests unsatisfied only due to a 5xx response).
+    serverErrorTest(true, true);
+    // server error marked and request also marked unsatisfied (mirrors requests unsatisfied due to 5xx AND missed
+    // thresholds).
+    serverErrorTest(true, false);
+    // no server error, request satisfied.
+    serverErrorTest(false, true);
+    // no server error, request unsatisfied (e.g. missed thresholds on a non-5xx response).
+    serverErrorTest(false, false);
+  }
+
+  /**
+   * Tests recording of the server error metric in combination with the satisfied/unsatisfied request metrics.
+   * @param induceServerError if {@code true}, {@link RestRequestMetricsTracker#markServerError()} is called.
+   * @param satisfied if {@code true}, the request is left in its default satisfied state; if {@code false},
+   *                  {@link RestRequestMetricsTracker#markUnsatisfied()} is called.
+   */
+  private void serverErrorTest(boolean induceServerError, boolean satisfied) {
+    MetricRegistry metricRegistry = new MetricRegistry();
+    RestRequestMetricsTracker.setDefaults(metricRegistry);
+    String testRequestType = "ServerErrorTest";
+    RestRequestMetricsTracker requestMetrics = new RestRequestMetricsTracker();
+    RestRequestMetrics restRequestMetrics = new RestRequestMetrics(getClass(), testRequestType, metricRegistry);
+    requestMetrics.injectMetrics(restRequestMetrics);
+
+    assertFalse("Request should not be a server error by default", requestMetrics.isServerError());
+    if (induceServerError) {
+      requestMetrics.markServerError();
+    }
+    if (!satisfied) {
+      requestMetrics.markUnsatisfied();
+    }
+    assertEquals("isServerError() does not reflect markServerError() call", induceServerError,
+        requestMetrics.isServerError());
+    assertEquals("isSatisfied() should be unaffected by markServerError()", satisfied, requestMetrics.isSatisfied());
+
+    requestMetrics.recordMetrics();
+
+    String metricPrefix = getClass().getCanonicalName() + "." + testRequestType;
+    long expectedServerErrorCount = induceServerError ? 1 : 0;
+    assertEquals("Server error count metric value is not as expected", expectedServerErrorCount,
+        metricRegistry.getCounters().get(metricPrefix + RestRequestMetrics.SERVER_ERROR_COUNT_SUFFIX).getCount());
+    assertEquals("Satisfied request count metric value is not as expected", satisfied ? 1 : 0,
+        metricRegistry.getCounters().get(metricPrefix + RestRequestMetrics.SATISFIED_REQUEST_COUNT_SUFFIX).getCount());
+    assertEquals("Unsatisfied request count metric value is not as expected", satisfied ? 0 : 1,
+        metricRegistry.getCounters()
+            .get(metricPrefix + RestRequestMetrics.UNSATISFIED_REQUEST_COUNT_SUFFIX)
+            .getCount());
+  }
+
+  /**
    * Tests reaction to bad calls to {@link RestRequestMetricsTracker.NioMetricsTracker#markRequestCompleted()} and
    * {@link RestRequestMetricsTracker.ScalingMetricsTracker#markRequestCompleted()}
    */

--- a/ambry-rest/src/main/java/com/github/ambry/rest/NettyResponseChannel.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/NettyResponseChannel.java
@@ -481,6 +481,11 @@ class NettyResponseChannel implements RestResponseChannel {
       restRequestMetricsTracker.markUnsatisfied();
       logUnsatisfiedRequest(requestPerfToCheck);
     }
+    if (responseStatus.isServerError()) {
+      // Track 5xx responses via a dedicated per-operation metric (separate from the unsatisfied request count)
+      // so that alerts can be configured specifically on server errors.
+      restRequestMetricsTracker.markServerError();
+    }
     restRequestMetricsTracker.recordMetrics();
   }
 

--- a/ambry-rest/src/test/java/com/github/ambry/rest/NettyResponseChannelTest.java
+++ b/ambry-rest/src/test/java/com/github/ambry/rest/NettyResponseChannelTest.java
@@ -1217,6 +1217,8 @@ public class NettyResponseChannelTest {
     } else {
       assertFalse(httpRequest.method() + " request should be unsatisfied", MockNettyRequest.mockTracker.isSatisfied());
     }
+    assertEquals(httpRequest.method() + " request server error tracking is incorrect", expectedStatus.code() >= 500,
+        MockNettyRequest.mockTracker.isServerError());
   }
 }
 


### PR DESCRIPTION
## Summary

Previously, a 5xx response and a request that missed its performance thresholds were both tracked under the same unsatisfiedRequestCount metric in NettyResponseChannel#evaluatePerformanceAndUpdateMetrics. This made it impossible to alert specifically on server errors without also triggering on slow-but-successful requests.

Add RestRequestMetrics#serverErrorCount (per operation, following the same naming/registration pattern as satisfiedRequestCount / unsatisfiedRequestCount) and RestRequestMetricsTracker#markServerError() to track it independently. NettyResponseChannel now calls markServerError() whenever responseStatus.isServerError() is true, in addition to the existing markUnsatisfied() logic, so alerts can be configured on 5xx rate per operation.

## Testing Done
unit test