### PR TITLE
Bound named blob cleanup initial delay to prevent restart starvation

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/FrontendConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/FrontendConfig.java
@@ -52,6 +52,8 @@ public class FrontendConfig {
   public static final String LIST_MAX_RESULTS = PREFIX + "list.max.results";
   public static final String NAMED_BLOB_CLEANUP_CONTAINER_DELAY_SECONDS =
       PREFIX + "named.blob.cleanup.container.delay.seconds";
+  public static final String NAMED_BLOB_CLEANUP_INITIAL_DELAY_MAX_SECONDS =
+      PREFIX + "named.blob.cleanup.initial.delay.max.seconds";
 
   // Default values
   private static final String DEFAULT_ENDPOINT = "http://localhost:1174";
@@ -105,6 +107,18 @@ public class FrontendConfig {
   @Config(NAMED_BLOB_CLEANUP_CONTAINER_DELAY_SECONDS)
   @Default("0")
   public final int namedBlobCleanupContainerDelaySeconds;
+
+  /**
+   * Upper bound (in seconds) on the randomized initial delay before the first named blob cleanup run after startup.
+   * The actual initial delay is a random value in {@code [0, min(namedBlobCleanupSeconds, this))}. This jitters the
+   * first run across pods without letting the initial delay grow to the full cleanup interval: a large initial delay
+   * (previously up to {@link #namedBlobCleanupSeconds}, e.g. 7 days) combined with frequent pod restarts — each
+   * restart re-rolls the delay — can indefinitely postpone the cleanup from ever running. A value of 0 makes the
+   * first run start immediately.
+   */
+  @Config(NAMED_BLOB_CLEANUP_INITIAL_DELAY_MAX_SECONDS)
+  @Default("600")
+  public final int namedBlobCleanupInitialDelayMaxSeconds;
 
 
   /**
@@ -336,6 +350,8 @@ public class FrontendConfig {
     namedBlobCleanupSeconds = verifiableProperties.getInt("frontend.named.blob.cleanup.seconds", 60 * 60 * 24 * 7);
     namedBlobCleanupContainerDelaySeconds =
         verifiableProperties.getIntInRange(NAMED_BLOB_CLEANUP_CONTAINER_DELAY_SECONDS, 0, 0, Integer.MAX_VALUE);
+    namedBlobCleanupInitialDelayMaxSeconds =
+        verifiableProperties.getIntInRange(NAMED_BLOB_CLEANUP_INITIAL_DELAY_MAX_SECONDS, 600, 0, Integer.MAX_VALUE);
     permanentNamedBlobInitialPutTtl =
         verifiableProperties.getLong("permanent.named.blob.initial.put.ttl", 25 * 60 * 60);
     optionsAllowMethods =

--- a/ambry-api/src/test/java/com/github/ambry/config/FrontendConfigTest.java
+++ b/ambry-api/src/test/java/com/github/ambry/config/FrontendConfigTest.java
@@ -48,4 +48,28 @@ public class FrontendConfigTest {
     } catch (IllegalArgumentException ignored) {
     }
   }
+
+  @Test
+  public void testNamedBlobCleanupInitialDelayMaxSeconds() {
+    Properties properties = new Properties();
+    FrontendConfig config = new FrontendConfig(new VerifiableProperties(properties));
+    Assert.assertEquals("The initial delay max should default to 600 seconds", 600,
+        config.namedBlobCleanupInitialDelayMaxSeconds);
+
+    properties.setProperty(FrontendConfig.NAMED_BLOB_CLEANUP_INITIAL_DELAY_MAX_SECONDS, "42");
+    config = new FrontendConfig(new VerifiableProperties(properties));
+    Assert.assertEquals("The configured initial delay max should be used", 42,
+        config.namedBlobCleanupInitialDelayMaxSeconds);
+  }
+
+  @Test
+  public void testNamedBlobCleanupInitialDelayMaxSecondsRejectsNegativeValue() {
+    Properties properties = new Properties();
+    properties.setProperty(FrontendConfig.NAMED_BLOB_CLEANUP_INITIAL_DELAY_MAX_SECONDS, "-1");
+    try {
+      new FrontendConfig(new VerifiableProperties(properties));
+      Assert.fail("A negative initial delay max should be rejected");
+    } catch (IllegalArgumentException ignored) {
+    }
+  }
 }

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestService.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestService.java
@@ -259,7 +259,12 @@ class FrontendRestRequestService implements RestRequestService {
             frontendConfig.namedBlobCleanupContainerDelaySeconds);
     if (frontendConfig.enableNamedBlobCleanupTask) {
       namedBlobsCleanupScheduler = Utils.newScheduler(1, "named-blobs-cleanup-", false);
-      int initialDelayInSeconds = random.nextInt(frontendConfig.namedBlobCleanupSeconds);
+      // Bound the randomized initial delay: a large cleanup interval combined with frequent pod restarts (each
+      // restart re-rolls this delay) could otherwise indefinitely postpone the first cleanup run. See
+      // FrontendConfig#namedBlobCleanupInitialDelayMaxSeconds.
+      int initialDelayBoundSeconds =
+          Math.min(frontendConfig.namedBlobCleanupSeconds, frontendConfig.namedBlobCleanupInitialDelayMaxSeconds);
+      int initialDelayInSeconds = initialDelayBoundSeconds > 0 ? random.nextInt(initialDelayBoundSeconds) : 0;
       namedBlobsCleanupTask =
           namedBlobsCleanupScheduler.scheduleAtFixedRate(namedBlobsCleanupRunner, initialDelayInSeconds,
               frontendConfig.namedBlobCleanupSeconds, TimeUnit.SECONDS);


### PR DESCRIPTION
## Summary
The named blob cleanup task (`NamedBlobsCleanupRunner`) computed its first-run delay as `random.nextInt(namedBlobCleanupSeconds)` — up to the full cleanup interval (7 days by default) — and recomputed it on **every process start**. With frequent pod restarts the delay is re-rolled before it ever elapses, so the cleanup can be postponed indefinitely and effectively never run.

This caps the randomized initial delay with a new configurable upper bound, `frontend.named.blob.cleanup.initial.delay.max.seconds` (default 600s). The first run now happens shortly after startup regardless of restarts, while still jittering the start across pods. Complements #3274 (which makes a single cleanup run sweep all eligible containers).

Changes:
- `FrontendConfig`: add `namedBlobCleanupInitialDelayMaxSeconds` (default 600, validated `>= 0`).
- `FrontendRestRequestService`: initial delay is now `random.nextInt(min(namedBlobCleanupSeconds, namedBlobCleanupInitialDelayMaxSeconds))`, guarded so a bound of 0 starts the first run immediately.

## Testing Done
- [x] Local code review completed
- Added `FrontendConfigTest` coverage for the new config: default value, override, and rejection of negative values.
- `./gradlew :ambry-api:compileJava` — BUILD SUCCESSFUL.
- Ran `FrontendConfigTest` — OK (4 tests).

🤖 Generated with [GitHub Copilot CLI](https://docs.github.com/copilot/github-copilot-cli)
