### PR TITLE
Cancel named-blob metadata commit when client has disconnected

### DIFF
--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbryIdConverterFactory.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbryIdConverterFactory.java
@@ -211,6 +211,17 @@ public class AmbryIdConverterFactory implements IdConverterFactory {
           });
         } else {
           Objects.requireNonNull(blobProperties, "blobProperties cannot be null.");
+          // Best-effort: if the client channel has already been closed (e.g. TCP disconnect / stream reset while
+          // router upload was still in flight), skip the metadata commit so the caller's retry can win MAX(version)
+          // in MySqlNamedBlobDb instead of being silently overwritten by this now-orphan attempt. Router chunks
+          // already uploaded will self-expire via existing chunk TTL. See RequestChannelClosed javadoc.
+          if (!restRequest.isOpen()) {
+            frontendMetrics.idConverterClientAbortedCount.inc();
+            LOGGER.info("Client disconnected before namedBlobDb.put for {}; skipping metadata commit",
+                restRequest.getUri());
+            throw new RestServiceException("Client disconnected before named-blob metadata commit",
+                RestServiceErrorCode.RequestChannelClosed);
+          }
           NamedBlobPath namedBlobPath =
               NamedBlobPath.parse(RestUtils.getRequestPath(restRequest), restRequest.getArgs());
           String blobId = RestUtils.stripSlashAndExtensionFromId(input);

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendMetrics.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendMetrics.java
@@ -241,6 +241,7 @@ public class FrontendMetrics {
   // AmbryIdConverter
   public final Histogram idConverterProcessingTimeInMs;
   public final Histogram idConversionDownstreamCallbackTimeInMs;
+  public final Counter idConverterClientAbortedCount;
 
   // GetPeersHandler
   public final Histogram getPeersProcessingTimeInMs;
@@ -687,6 +688,8 @@ public class FrontendMetrics {
         metricRegistry.histogram(MetricRegistry.name(AmbryIdConverterFactory.class, "ProcessingTimeInMs"));
     idConversionDownstreamCallbackTimeInMs =
         metricRegistry.histogram(MetricRegistry.name(AmbryIdConverterFactory.class, "DownstreamCallbackTimeInMs"));
+    idConverterClientAbortedCount =
+        metricRegistry.counter(MetricRegistry.name(AmbryIdConverterFactory.class, "ClientAbortedCount"));
     // GetPeersHandler
     getPeersProcessingTimeInMs =
         metricRegistry.histogram(MetricRegistry.name(GetPeersHandler.class, "ProcessingTimeInMs"));

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/AmbryIdConverterFactoryTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/AmbryIdConverterFactoryTest.java
@@ -260,6 +260,64 @@ public class AmbryIdConverterFactoryTest {
         restRequest.getArgs().containsKey(RestUtils.InternalKeys.NAMED_BLOB_VERSION));
   }
 
+  @Test
+  public void ambryIdConverterNamedBlobPutClientDisconnectTest() throws Exception {
+    // Best-effort race guard: when the client has already disconnected, AmbryIdConverterFactory should NOT
+    // commit named-blob metadata (namedBlobDb.put), and should surface RequestChannelClosed on both the
+    // future and callback paths, while incrementing idConverterClientAbortedCount.
+    Properties properties = new Properties();
+    VerifiableProperties verifiableProperties = new VerifiableProperties(properties);
+    IdSigningService idSigningService = mock(IdSigningService.class);
+    NamedBlobDb namedBlobDb = mock(NamedBlobDb.class);
+    MetricRegistry metricRegistry = new MetricRegistry();
+    AmbryIdConverterFactory ambryIdConverterFactory =
+        new AmbryIdConverterFactory(verifiableProperties, metricRegistry, idSigningService, namedBlobDb);
+    IdConverter idConverter = ambryIdConverterFactory.getIdConverter();
+    assertNotNull("No IdConverter returned", idConverter);
+    PartitionId partitionId = new MockPartitionId(partition, MockClusterMap.DEFAULT_PARTITION_CLASS);
+    BlobId blobId = new BlobId(BLOB_ID_V6, BlobIdType.NATIVE, dataCenterId, accountId, containerId, partitionId, false,
+        BlobDataType.DATACHUNK);
+
+    // Build a named-blob PUT request the same way ambryIdConverterNamedBlobTest does, then close it BEFORE
+    // convert(...) so restRequest.isOpen() returns false when the write branch is entered.
+    JSONObject requestData = new JSONObject();
+    JSONObject headers = new JSONObject();
+    headers.put(RestUtils.Headers.AMBRY_CONTENT_TYPE, "application/octet-stream");
+    requestData.put(MockRestRequest.REST_METHOD_KEY, RestMethod.PUT.name());
+    requestData.put(MockRestRequest.URI_KEY, NAMED_BLOB_PATH);
+    requestData.put(MockRestRequest.HEADERS_KEY, headers);
+    RestRequest restRequest = new MockRestRequest(requestData, null);
+    restRequest.setArg(RestUtils.InternalKeys.REQUEST_PATH,
+        RequestPath.parse(NAMED_BLOB_PATH, Collections.emptyMap(), Collections.emptyList(), "Ambry-test"));
+    BlobInfo blobInfo = new BlobInfo(new BlobProperties(-1, "service", accountId, containerId, false), new byte[0]);
+    restRequest.close();
+    assertFalse("Test precondition: RestRequest must be closed", restRequest.isOpen());
+
+    String metricName =
+        MetricRegistry.name(AmbryIdConverterFactory.class, "ClientAbortedCount");
+    assertTrue("ClientAbortedCount counter must be registered",
+        metricRegistry.getCounters().containsKey(metricName));
+    long beforeCount = metricRegistry.counter(metricName).getCount();
+
+    IdConversionCallback callback = new IdConversionCallback();
+    try {
+      idConverter.convert(restRequest, blobId.getID(), blobInfo.getBlobProperties(), callback).get(5, TimeUnit.SECONDS);
+      fail("ID conversion should have failed because the client disconnected");
+    } catch (ExecutionException e) {
+      RestServiceException re = (RestServiceException) e.getCause();
+      assertEquals("Unexpected RestServiceErrorCode (Future)", RestServiceErrorCode.RequestChannelClosed,
+          re.getErrorCode());
+    }
+    assertNotNull("Callback exception should be set", callback.exception);
+    assertTrue("Callback exception should be RestServiceException",
+        callback.exception instanceof RestServiceException);
+    assertEquals("Unexpected RestServiceErrorCode (Callback)", RestServiceErrorCode.RequestChannelClosed,
+        ((RestServiceException) callback.exception).getErrorCode());
+    verify(namedBlobDb, never()).put(any(), any(), any());
+    assertEquals("idConverterClientAbortedCount should have incremented by exactly 1", beforeCount + 1,
+        metricRegistry.counter(metricName).getCount());
+  }
+
   /**
    * Callback implementation for testing {@link IdConverter#convert(RestRequest, String, Callback)}.
    */

--- a/ambry-rest/src/main/java/com/github/ambry/rest/NettyMessageProcessor.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/NettyMessageProcessor.java
@@ -139,6 +139,15 @@ public class NettyMessageProcessor extends SimpleChannelInboundHandler<HttpObjec
     nettyMetrics.channelDestructionRate.mark();
     if (request != null && request.isOpen()) {
       logger.error("Request {} was aborted because the channel {} became inactive", request.getUri(), ctx.channel());
+      // Flip channelOpen=false so downstream callbacks that check restRequest.isOpen() observe the disconnect
+      // and can short-circuit best-effort work (e.g. named-blob metadata commit in AmbryIdConverterFactory).
+      // NettyRequest.close() is idempotent via channelOpen.compareAndSet(true,false), so double-close on the
+      // normal-completion path is a no-op.
+      try {
+        request.close();
+      } catch (Exception e) {
+        logger.warn("Exception while closing request {} on channelInactive", request.getUri(), e);
+      }
       onRequestAborted(Utils.convertToClientTerminationException(new ClosedChannelException()));
     } else {
       close();

--- a/ambry-rest/src/test/java/com/github/ambry/rest/NettyMessageProcessorTest.java
+++ b/ambry-rest/src/test/java/com/github/ambry/rest/NettyMessageProcessorTest.java
@@ -490,6 +490,76 @@ public class NettyMessageProcessorTest {
     compareContent(receivedContent, Collections.singletonList(content));
   }
 
+  /**
+   * Verifies that {@link NettyMessageProcessor#channelInactive} flips {@code NettyRequest.channelOpen} to
+   * false so downstream callbacks that later check {@code restRequest.isOpen()} observe the disconnect.
+   * <p>
+   * Regression: previously {@code channelInactive} only called {@code onRequestAborted(...)}, which routes
+   * an exception into the response channel but does NOT close the {@link NettyRequest}. Best-effort race
+   * guards elsewhere (e.g. named-blob metadata commit in {@code AmbryIdConverterFactory}) depend on
+   * {@code restRequest.isOpen() == false} to short-circuit; without this fix they would still run.
+   *
+   * @throws Exception
+   */
+  @Test
+  public void channelInactiveClosesInflightRequestTest() throws Exception {
+    // Custom handler that captures the RestRequest so we can inspect isOpen() after channelInactive fires.
+    CapturingRestRequestHandler capturingHandler = new CapturingRestRequestHandler();
+    capturingHandler.start();
+    try {
+      NettyMessageProcessor processor =
+          new NettyMessageProcessor(NETTY_METRICS, NETTY_CONFIG, PERFORMANCE_CONFIG, capturingHandler);
+      EmbeddedChannel channel = new EmbeddedChannel(new ChunkedWriteHandler(), processor);
+
+      // Send a PUT header only (no LastHttpContent) so the request stays in-flight when we close the channel.
+      HttpRequest httpRequest = RestTestUtils.createRequest(HttpMethod.PUT, "/", null);
+      httpRequest.headers().set(RestUtils.Headers.SERVICE_ID, "channelInactiveClosesInflightRequestTest");
+      httpRequest.headers().set(RestUtils.Headers.AMBRY_CONTENT_TYPE, "application/octet-stream");
+      channel.writeInbound(httpRequest);
+
+      RestRequest capturedRequest = capturingHandler.getCapturedRequest();
+      assertNotNull("Handler should have received the in-flight RestRequest", capturedRequest);
+      assertTrue("RestRequest must be open before channelInactive", capturedRequest.isOpen());
+
+      // Simulate the client TCP disconnect / channel becoming inactive mid-request.
+      channel.close().awaitUninterruptibly();
+
+      assertFalse("RestRequest.isOpen() must be false after channelInactive so downstream callbacks "
+          + "(e.g. named-blob metadata commit) can observe the disconnect", capturedRequest.isOpen());
+    } finally {
+      capturingHandler.shutdown();
+    }
+  }
+
+  /**
+   * {@link RestRequestHandler} that captures the first {@link RestRequest} passed to
+   * {@link #handleRequest(RestRequest, RestResponseChannel)} and does nothing else. Used by
+   * {@link #channelInactiveClosesInflightRequestTest()} to hold a reference to an in-flight request
+   * so its {@code isOpen()} state can be observed after {@code channelInactive}.
+   */
+  private static class CapturingRestRequestHandler implements RestRequestHandler {
+    private final java.util.concurrent.atomic.AtomicReference<RestRequest> captured =
+        new java.util.concurrent.atomic.AtomicReference<>();
+
+    @Override
+    public void start() {
+    }
+
+    @Override
+    public void shutdown() {
+    }
+
+    @Override
+    public void handleRequest(RestRequest restRequest, RestResponseChannel restResponseChannel) {
+      captured.compareAndSet(null, restRequest);
+      // Do NOT complete the request — leave it in-flight so channelInactive fires before completion.
+    }
+
+    RestRequest getCapturedRequest() {
+      return captured.get();
+    }
+  }
+
   // helpers
   // general
 


### PR DESCRIPTION


## Summary
Named-blob PUT race: a slow original plus a client retry can both reach MySqlNamedBlobDb.put(...) and win MAX(version) via wall-clock buildVersion, silently overwriting the retry the client saw as 200.

Best-effort fix: gate namedBlobDb.put(...) on restRequest.isOpen() in AmbryIdConverterFactory.convertId(...) (write branch) and in S3MultipartCompleteUploadHandler.routerStitchBlobCallback(...) (manual idConverter.convert call). NettyMessageProcessor.channelInactive(...) now calls request.close() before onRequestAborted(...) so the check sees the disconnect; NettyRequest.close() is idempotent via CAS.

Add Counter idConverterClientAbortedCount under AmbryIdConverterFactory to observe how often this fires.

Non-goals (kept as follow-ups): orphan router chunks (self-expire via TTL), cross-frontend clock skew, HTTP/2 stream-reset (LB-dependent), residual ms race between isOpen() and executeUpdate(). No interface, wire, or schema changes.


## Testing Done
unit tests